### PR TITLE
Update authorizedFile list on frames edits.

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -13,6 +13,7 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import * as dataSourcesModule from "@app/lib/api/data_sources";
 import * as fileUpsertModule from "@app/lib/api/files/upsert";
 import * as fileUtilsModule from "@app/lib/api/files/utils";
+import * as uploadFrameContentModule from "@app/lib/api/viz/upload_frame_content";
 import { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
@@ -170,6 +171,7 @@ async function createAgentMessage(
   const action = await AgentMCPActionModel.create({
     workspaceId: workspace.id,
     agentMessageId: agentMessage.id,
+    stepContentId: stepContent.id,
     mcpServerConfigurationId: generateRandomModelSId(),
     status: "succeeded",
     citationsAllocated: 0,
@@ -442,6 +444,15 @@ function mockFileContentStorage() {
     getFileContentSpy,
     uploadContentSpy,
   };
+}
+
+function mockUploadFrameContent() {
+  return vi
+    .spyOn(uploadFrameContentModule, "uploadFrameContent")
+    .mockImplementation(async (auth, file, content) => {
+      await file.uploadContent(auth, content);
+      return new Ok(undefined);
+    });
 }
 
 function mockContentNodeAttachments(nodeDataSourceViewId: number) {
@@ -996,6 +1007,7 @@ describe("createConversationFork", () => {
     const { auth } = await createPrivateApiMockRequest();
     const copyToConversationSpy = mockCopyToConversation({ copyContent: true });
     const { getFileContentSpy, uploadContentSpy } = mockFileContentStorage();
+    const uploadFrameContentSpy = mockUploadFrameContent();
     const {
       getOrCreateConversationDataSourceFromFileSpy,
       processAndUpsertToDataSourceSpy,
@@ -1143,6 +1155,7 @@ const untouched = "prefix${referencedFile.sId}suffix";`
     getOrCreateConversationDataSourceFromFileSpy.mockRestore();
     processAndUpsertToDataSourceSpy.mockRestore();
     uploadContentSpy.mockRestore();
+    uploadFrameContentSpy.mockRestore();
   }, 15_000);
 
   it("only copies attachments that existed at the selected source message", async () => {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -17,6 +17,7 @@ import {
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
+import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
@@ -393,16 +394,15 @@ async function rewriteCopiedInteractiveContentAttachmentIds(
         return;
       }
 
-      try {
-        await file.uploadContent(auth, updatedContent);
-      } catch (error) {
+      const uploadResult = await uploadFrameContent(auth, file, updatedContent);
+      if (uploadResult.isErr()) {
         logger.error(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
             parentConversationId,
             childConversationId,
             copiedFileId: file.sId,
-            error,
+            error: uploadResult.error,
           },
           "Failed to rewrite copied interactive content file ids in forked conversation."
         );

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -7,6 +7,7 @@ import {
   getFileContent,
   getUpdatedContentAndOccurrences,
 } from "@app/lib/api/files/utils";
+import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -127,7 +128,13 @@ export async function createClientExecutableFile(
     });
 
     // Upload content directly.
-    await fileResource.uploadContent(auth, content);
+    const uploadResult = await uploadFrameContent(auth, fileResource, content);
+    if (uploadResult.isErr()) {
+      return new Err({
+        message: uploadResult.error.message,
+        tracked: uploadResult.error.code === "internal_error",
+      });
+    }
 
     return new Ok({ fileResource, warnings });
   } catch (error) {
@@ -242,8 +249,18 @@ export async function editClientExecutableFile(
         warnings.push(...tailwindValidation.error);
       }
 
-      // Upload the updated content (version is incremented inside uploadContent).
-      await fileResource.uploadContent(auth, updatedContent);
+      // Upload the updated content (version is incremented inside uploadFrameContent).
+      const uploadResult = await uploadFrameContent(
+        auth,
+        fileResource,
+        updatedContent
+      );
+      if (uploadResult.isErr()) {
+        return new Err({
+          message: uploadResult.error.message,
+          tracked: uploadResult.error.code === "internal_error",
+        });
+      }
 
       return new Ok({ fileResource, replacementCount: occurrences, warnings });
     });

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -1,11 +1,15 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { reverifyAuthorAccess } from "@app/lib/api/viz/authorized_file_access";
+import {
+  ensureAuthorizedFileAccessForShare,
+  reverifyAuthorAccess,
+} from "@app/lib/api/viz/authorized_file_access";
 import {
   computeFrameContentHash,
   isAllowlistStale,
   isAuthorizedFileRef,
 } from "@app/lib/api/viz/authorized_file_access_policy";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { AuthorizedFileAccessModel } from "@app/lib/resources/storage/models/files";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -15,6 +19,7 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   type AuthorizedFileAccessAllowlist,
   frameContentType,
+  isUnverifiableFrameFileRefsShareError,
 } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
@@ -337,6 +342,181 @@ describe("computeAuthorizedFileAccess", () => {
         fileName: "report.csv",
       },
     ]);
+  });
+});
+
+describe("ensureAuthorizedFileAccessForShare", () => {
+  it("blocks sharing when static refs cannot be verified", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from('useFile("fil_ZZZZZZZZZZ");', "utf-8")])
+    );
+    vi.spyOn(FileResource, "fetchById").mockResolvedValue(null);
+
+    const result = await ensureAuthorizedFileAccessForShare(auth, frameFile);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(isUnverifiableFrameFileRefsShareError(result.error)).toBe(true);
+      if (isUnverifiableFrameFileRefsShareError(result.error)) {
+        expect(result.error.unverifiableRefs).toEqual(["fil_ZZZZZZZZZZ"]);
+      }
+    }
+
+    const shareableFile = await FileResource.shareableFileModel.findOne({
+      where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+    });
+    const rows = await AuthorizedFileAccessModel.findAll({
+      where: {
+        shareableFileId: shareableFile!.id,
+        workspaceId: frameFile.workspaceId,
+        revokedAt: null,
+      },
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("skips recompute when the active allowlist matches current content", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const frameContent = "export default function Frame() {}";
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const activeSnapshot = makeAllowlist({
+      computedByUserId: auth.user()!.sId,
+      frameContentHash: computeFrameContentHash(frameContent),
+      refs: [],
+    });
+
+    const shareableFile = await FileResource.shareableFileModel.findOne({
+      where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+    });
+    expect(shareableFile).not.toBeNull();
+    await AuthorizedFileAccessModel.create({
+      workspaceId: frameFile.workspaceId,
+      shareableFileId: shareableFile!.id,
+      kind: "file_id",
+      ref: "fil_PLACEHOLDER",
+      fileName: null,
+      legacyPath: null,
+      shareScope: shareableFile!.shareScope,
+      computedByUserId: activeSnapshot.computedByUserId,
+      frameContentHash: activeSnapshot.frameContentHash,
+      allowedAt: new Date(),
+      revokedAt: null,
+    });
+
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from(frameContent, "utf-8")])
+    );
+
+    const result = await ensureAuthorizedFileAccessForShare(auth, frameFile);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.frameContentHash).toBe(
+        activeSnapshot.frameContentHash
+      );
+      expect(result.value.computedByUserId).toBe(
+        activeSnapshot.computedByUserId
+      );
+    }
+
+    const rows = await AuthorizedFileAccessModel.findAll({
+      where: {
+        shareableFileId: shareableFile!.id,
+        workspaceId: frameFile.workspaceId,
+        revokedAt: null,
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ref).toBe("fil_PLACEHOLDER");
+  });
+
+  it("recomputes and blocks when the active allowlist is stale", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const frameContent = 'useFile("fil_ABCDEFGHIJ");';
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const shareableFile = await FileResource.shareableFileModel.findOne({
+      where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+    });
+    expect(shareableFile).not.toBeNull();
+    await AuthorizedFileAccessModel.create({
+      workspaceId: frameFile.workspaceId,
+      shareableFileId: shareableFile!.id,
+      kind: "file_id",
+      ref: "fil_OLDREF0001",
+      fileName: null,
+      legacyPath: null,
+      shareScope: shareableFile!.shareScope,
+      computedByUserId: auth.user()!.sId,
+      frameContentHash: "stale-hash",
+      allowedAt: new Date(),
+      revokedAt: null,
+    });
+
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from(frameContent, "utf-8")])
+    );
+    vi.spyOn(FileResource, "fetchById").mockResolvedValue(null);
+
+    const result = await ensureAuthorizedFileAccessForShare(auth, frameFile);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(isUnverifiableFrameFileRefsShareError(result.error)).toBe(true);
+    }
+
+    const rows = await AuthorizedFileAccessModel.findAll({
+      where: {
+        shareableFileId: shareableFile!.id,
+        workspaceId: frameFile.workspaceId,
+        revokedAt: null,
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ref).toBe("fil_OLDREF0001");
   });
 });
 

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -1,10 +1,89 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { legacyScopedPathsMatch } from "@app/lib/api/files/mount_path";
-import { isAuthorizedFileRef } from "@app/lib/api/viz/authorized_file_access_policy";
+import {
+  isAllowlistStale,
+  isAuthorizedFileRef,
+} from "@app/lib/api/viz/authorized_file_access_policy";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
-import type { AuthorizedFileAccessAllowlist } from "@app/types/files";
+import { streamToBuffer } from "@app/lib/utils/streams";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type {
+  AuthorizedFileAccessAllowlist,
+  AuthorizedFileAccessShareError,
+  ComputedAuthorizedFileAccess,
+} from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
+
+function unverifiableFrameFileRefsShareError(
+  unverifiableRefs: string[]
+): AuthorizedFileAccessShareError {
+  return {
+    name: "dust_error",
+    code: "invalid_request_error",
+    message: `Frame references files that cannot be verified: ${unverifiableRefs.join(", ")}`,
+    unverifiableRefs,
+  };
+}
+
+async function readFrameFileContent(
+  auth: Authenticator,
+  frameFile: FileResource
+): Promise<string | null> {
+  const workspace = renderLightWorkspaceType({
+    workspace: auth.getNonNullableWorkspace(),
+  });
+  const readStream = frameFile.getSharedReadStream(workspace, "original");
+  const bufferResult = await streamToBuffer(readStream);
+  if (bufferResult.isErr()) {
+    return null;
+  }
+
+  return bufferResult.value.toString("utf-8") || null;
+}
+
+/**
+ * Recomputes the allowlist when missing or stale on frame save.
+ * Blocks when any static file ref cannot be verified under the author's auth.
+ */
+export async function ensureAuthorizedFileAccessForShare(
+  auth: Authenticator,
+  frameFile: FileResource
+): Promise<
+  Result<ComputedAuthorizedFileAccess, AuthorizedFileAccessShareError>
+> {
+  const frameContent = await readFrameFileContent(auth, frameFile);
+  if (frameContent === null) {
+    return new Err({
+      name: "dust_error",
+      code: "internal_error",
+      message: `Failed to read frame content for authorized file access (file: ${frameFile.sId})`,
+    });
+  }
+
+  const active = await frameFile.getActiveAuthorizedFileAccessAllowlist();
+  const needsRecompute = !active || isAllowlistStale(active, frameContent);
+
+  if (!needsRecompute) {
+    return new Ok(active);
+  }
+
+  const authorized = await frameFile.computeAuthorizedFileAccess(auth, {
+    frameContent,
+  });
+
+  if (authorized.unverifiableRefs && authorized.unverifiableRefs.length > 0) {
+    return new Err(
+      unverifiableFrameFileRefsShareError(authorized.unverifiableRefs)
+    );
+  }
+
+  await frameFile.persistAuthorizedFileAccess(authorized);
+
+  return new Ok(authorized);
+}
 
 export async function reverifyAuthorAccess(
   authorizedFileAccess: AuthorizedFileAccessAllowlist,

--- a/front/lib/api/viz/upload_frame_content.ts
+++ b/front/lib/api/viz/upload_frame_content.ts
@@ -1,0 +1,25 @@
+import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type { AuthorizedFileAccessShareError } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Uploads frame content and refreshes the authorized file access allowlist.
+ * Keeps allowlist logic out of FileResource to avoid import cycles.
+ */
+export async function uploadFrameContent(
+  auth: Authenticator,
+  file: FileResource,
+  content: string
+): Promise<Result<void, AuthorizedFileAccessShareError>> {
+  await file.uploadContent(auth, content);
+
+  const allowlistResult = await ensureAuthorizedFileAccessForShare(auth, file);
+  if (allowlistResult.isErr()) {
+    return new Err(allowlistResult.error);
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1,4 +1,5 @@
 import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
+import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -15,7 +16,10 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { frameContentType } from "@app/types/files";
+import {
+  frameContentType,
+  isUnverifiableFrameFileRefsShareError,
+} from "@app/types/files";
 import { Readable } from "stream";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1136,6 +1140,16 @@ describe("FileResource", () => {
   });
 
   describe("authorized file access", () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      vi.spyOn(
+        FileResource.prototype,
+        "getSharedReadStream"
+      ).mockImplementation(function getSharedReadStream(this: FileResource) {
+        return Readable.from([Buffer.from(this.fileName, "utf-8")]);
+      });
+    });
+
     it("refreshAuthorizedFileAccess revokes prior rows and persists the refreshed allowlist", async () => {
       const { authenticator: auth } = await createResourceTest({});
 
@@ -1199,6 +1213,189 @@ describe("FileResource", () => {
       expect(rows[1]?.revokedAt).toBeNull();
       expect(rows[1]?.kind).toBe("unverifiable");
       expect(rows[1]?.ref).toBe("fil_ABCDEFGHIJ");
+    });
+
+    it("uploadFrameContent blocks when static refs cannot be verified", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: 'useFile("fil_ZZZZZZZZZZ");',
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      vi.spyOn(FileResource, "fetchById").mockResolvedValue(null);
+
+      const result = await uploadFrameContent(
+        auth,
+        frameFile,
+        'useFile("fil_ZZZZZZZZZZ");'
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(isUnverifiableFrameFileRefsShareError(result.error)).toBe(true);
+      }
+
+      const shareableFile = await FileResource.shareableFileModel.findOne({
+        where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+      });
+      const rows = await AuthorizedFileAccessModel.findAll({
+        where: {
+          shareableFileId: shareableFile!.id,
+          workspaceId: frameFile.workspaceId,
+          revokedAt: null,
+        },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it("uploadFrameContent updates the allowlist for verifiable refs", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const dataFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "data.txt",
+        fileSize: 10,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const frameContent = `useFile("${dataFile.sId}");`;
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: frameContent,
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const result = await uploadFrameContent(auth, frameFile, frameContent);
+      expect(result.isOk()).toBe(true);
+
+      const shareableFile = await FileResource.shareableFileModel.findOne({
+        where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+      });
+      const rows = await AuthorizedFileAccessModel.findAll({
+        where: {
+          shareableFileId: shareableFile!.id,
+          workspaceId: frameFile.workspaceId,
+          revokedAt: null,
+        },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.kind).toBe("file_id");
+      expect(rows[0]?.ref).toBe(dataFile.sId);
+      expect(rows[0]?.fileName).toBe("data.txt");
+    });
+
+    it("setShareScope updates share scope without recomputing the allowlist", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "Frame.tsx",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      await frameFile.setShareScope(auth, "public");
+
+      const shareableFile = await FileResource.shareableFileModel.findOne({
+        where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+      });
+      expect(shareableFile?.shareScope).toBe("public");
+
+      const rows = await AuthorizedFileAccessModel.findAll({
+        where: {
+          shareableFileId: shareableFile!.id,
+          workspaceId: frameFile.workspaceId,
+          revokedAt: null,
+        },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it("fetchByShareToken returns the active authorized file access allowlist", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const dataFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "data.txt",
+        fileSize: 10,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const frameContent = `useFile("${dataFile.sId}");`;
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: frameContent,
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const uploadResult = await uploadFrameContent(
+        auth,
+        frameFile,
+        frameContent
+      );
+      expect(uploadResult.isOk()).toBe(true);
+
+      const shareInfo = await frameFile.getShareInfo();
+      const token = shareInfo?.shareUrl.split("/").at(-1);
+      assert(token, "Share token should be defined");
+
+      const result = await FileResource.fetchByShareToken(token);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.authorizedFileAccess).not.toBeNull();
+        expect(result.value.authorizedFileAccess?.refs).toEqual([
+          {
+            kind: "file_id",
+            ref: dataFile.sId,
+            fileName: "data.txt",
+          },
+        ]);
+      }
     });
   });
 });

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -246,6 +246,8 @@ export class FileResource extends BaseResource<FileModel> {
         workspace: LightWorkspaceType;
         // sId of the project space the frame's conversation belongs to, if any.
         conversationSpaceId: string | null;
+        // Active allowlist for useFile() refs, if computed.
+        authorizedFileAccess: AuthorizedFileAccessAllowlist | null;
         // DustFileSystem scoped to this frame's authorized paths (conversation + pod if any).
         // Always read-only; share-token is its own authorization model.
         fs: DustFileSystem;
@@ -337,12 +339,16 @@ export class FileResource extends BaseResource<FileModel> {
       spaceId: frameSpaceId,
     });
 
+    const authorizedFileAccess =
+      await fileRes.getActiveAuthorizedFileAccessAllowlist();
+
     return new Ok({
       file: fileRes,
       workspace: renderLightWorkspaceType({ workspace }),
       shareScope: shareableFile.shareScope,
       shareableFileId: shareableFile.id,
       conversationSpaceId,
+      authorizedFileAccess,
       fs,
     });
   }

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -123,6 +123,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
         shareableFileId: 1 as unknown as ModelId,
         workspace,
         conversationSpaceId,
+        authorizedFileAccess: null,
         fs,
       })
     );

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -1,4 +1,5 @@
 // Types.
+import type { DustError } from "@app/lib/error";
 import { z } from "zod";
 
 import { assertNever } from "./shared/utils/assert_never";
@@ -212,6 +213,24 @@ export function entryToAuthorizedFileRef(
     default:
       return assertNever(entry);
   }
+}
+
+export type AuthorizedFileAccessShareError = Omit<DustError, "code"> & {
+  code: "invalid_request_error" | "internal_error";
+  unverifiableRefs?: string[];
+};
+
+export function isUnverifiableFrameFileRefsShareError(
+  error: AuthorizedFileAccessShareError
+): error is AuthorizedFileAccessShareError & {
+  code: "invalid_request_error";
+  unverifiableRefs: string[];
+} {
+  return (
+    error.code === "invalid_request_error" &&
+    Array.isArray(error.unverifiableRefs) &&
+    error.unverifiableRefs.length > 0
+  );
 }
 
 export interface SharingGrantType {


### PR DESCRIPTION
## Description

Introduces `uploadFrameContent` (`front/lib/api/viz/upload_frame_content.ts`), a thin wrapper around `file.uploadContent` that immediately calls `ensureAuthorizedFileAccessForShare` to recompute and persist the `authorizedFileAccess` allowlist. All frame save paths — `createClientExecutableFile`, `editClientExecutableFile`, and conversation fork rewrites — now go through this wrapper, so the allowlist stays in sync with the frame's actual `useFile()` refs after every edit.

`ensureAuthorizedFileAccessForShare` short-circuits when the active snapshot's content hash matches the current content, recomputes when stale, and returns `Err(AuthorizedFileAccessShareError)` (with `unverifiableRefs`) when a static ref resolves to a file that can't be verified under the author's auth. `FileResource.fetchByShareToken` now exposes the active `authorizedFileAccess` snapshot in its return type.

## Tests

Added integration tests for `ensureAuthorizedFileAccessForShare` in `authorized_file_access.test.ts` (blocks on unverifiable refs, skips recompute when fresh, recomputes when stale) and for `uploadFrameContent` in `file_resource.test.ts` (blocks when refs are unverifiable, persists allowlist for valid refs, `setShareScope` does not trigger recompute, `fetchByShareToken` returns the active snapshot).

## Risk

Low. The allowlist was already being persisted via `refreshAuthorizedFileAccess` — this PR just extends that to all frame save paths. Frame saves that reference unverifiable file IDs now fail explicitly (Result err) rather than silently succeeding with a stale allowlist. No DB migrations.

## Deploy Plan

Deploy front when base branch (`sflory/create-methods-to-compute-verify`) is ready.
