### PR TITLE
Enforce new policy in viz files endpoints

### DIFF
--- a/front-api/routes/v1/viz/content.test.ts
+++ b/front-api/routes/v1/viz/content.test.ts
@@ -1,12 +1,25 @@
+import type { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { frameContentType } from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { honoApp } from "@front-api/app";
+import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function makeMockFs(): DustFileSystem {
+  return {
+    stat: vi
+      .fn()
+      .mockResolvedValue(new Ok({ contentType: "text/plain", sizeBytes: 100 })),
+    read: vi.fn().mockResolvedValue(new Ok(new PassThrough())),
+  } as unknown as DustFileSystem;
+}
 
 describe("/api/v1/viz/content endpoint tests", () => {
   let workspace: LightWorkspaceType;
@@ -25,6 +38,32 @@ describe("/api/v1/viz/content endpoint tests", () => {
 
   function request(headers: Record<string, string> = {}) {
     return honoApp.request("/api/v1/viz/content", { headers });
+  }
+
+  function mockFetchByShareToken(
+    frameFile: FileResource,
+    opts: {
+      content?: string;
+      shareScope?: "public" | "workspace";
+      conversationSpaceId?: string | null;
+    } = {}
+  ) {
+    const {
+      content = "<html><h1>Interactive Frame</h1></html>",
+      shareScope = "public",
+      conversationSpaceId = null,
+    } = opts;
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content,
+      shareScope,
+      shareableFileId: 1 as unknown as ModelId,
+      workspace,
+      conversationSpaceId,
+      authorizedFileAccess: null,
+      fs: makeMockFs(),
+    });
   }
 
   it("should return frame content with valid JWT access token", async () => {
@@ -50,12 +89,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
       shareScope: "public",
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html><h1>Interactive Frame</h1></html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     const response = await request({
       authorization: `Bearer ${accessToken}`,
@@ -236,11 +270,9 @@ describe("/api/v1/viz/content endpoint tests", () => {
       shareScope: "workspace",
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
+    mockFetchByShareToken(frameFile, {
       content: "<html><h1>Workspace Frame</h1></html>",
       shareScope: "workspace",
-      conversationSpaceId: null,
     });
 
     const response = await request({

--- a/front-api/routes/v1/viz/files/[...segments].ts
+++ b/front-api/routes/v1/viz/files/[...segments].ts
@@ -5,6 +5,11 @@ import {
   parseRawVizScope,
 } from "@app/lib/api/files/mount_path";
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
+import {
+  assertVizFileAuthorized,
+  readAllowlistedScopedVizFile,
+  resolveAllowlistedCanonicalPath,
+} from "@app/lib/api/viz/authorized_file_access";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -13,6 +18,7 @@ import { unauthedApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import path from "path";
+import type { Readable } from "stream";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -61,16 +67,26 @@ app.get("/:scope/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
   }
   const tokenPayload = tokenRes.value;
 
-  // Get file info and build the DustFileSystem scoped to this frame's authorized paths.
-  const result = await FileResource.fetchByShareToken(tokenPayload.fileToken);
-  if (result.isErr()) {
+  // Get frame metadata, content (for allowlist hash), and scoped file system.
+  const result = await FileResource.fetchByShareTokenWithContent(
+    tokenPayload.fileToken
+  );
+  if (!result) {
     return apiError(ctx, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },
     });
   }
 
-  const { file: frameFile, shareScope, conversationSpaceId, fs } = result.value;
+  const {
+    file: frameFile,
+    content: frameContent,
+    shareScope,
+    conversationSpaceId,
+    authorizedFileAccess,
+    fs,
+    workspace: owner,
+  } = result;
 
   // If current share scope differs from token scope, reject. It means share scope changed.
   if (shareScope !== tokenPayload.shareScope) {
@@ -124,76 +140,124 @@ app.get("/:scope/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const canonicalPathResult = buildCanonicalScopedPathFromVizScope(
-    scope,
-    normalizedRel,
-    {
-      conversationId:
-        frameFile.useCaseMetadata?.conversationId ??
-        frameFile.useCaseMetadata?.sourceConversationId ??
-        null,
-      spaceId: frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId,
-    }
-  );
-  if (canonicalPathResult.isErr()) {
-    switch (canonicalPathResult.error.code) {
-      case "missing_conversation_context":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Frame has no conversation context for this path.",
-          },
-        });
-      case "missing_pod_context":
-        return apiError(ctx, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Frame has no project context for this path.",
-          },
-        });
-      case "conversation_context_mismatch":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "Access denied: conversation ID does not match frame context.",
-          },
-        });
-      case "pod_context_mismatch":
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Access denied: pod ID does not match frame context.",
-          },
-        });
-      default:
-        return assertNever(canonicalPathResult.error);
-    }
-  }
-  const canonicalScopedPath = canonicalPathResult.value;
+  const requestedRef = `${rawScope}/${normalizedRel}`;
 
-  const statResult = await fs.stat(canonicalScopedPath);
-  if (statResult.isErr() || !statResult.value) {
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
-  }
-  const { contentType } = statResult.value;
-
-  const readResult = await fs.read(canonicalScopedPath);
-  if (readResult.isErr() || !readResult.value) {
+  const authorizationMode = await assertVizFileAuthorized({
+    authorizedFileAccess,
+    requestedRef,
+    owner,
+    frameContent,
+  });
+  if (authorizationMode === "denied") {
     return apiError(ctx, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },
     });
   }
 
-  const nodeStream = readResult.value;
+  let canonicalScopedPath: string;
+  if (authorizationMode === "authorized" && authorizedFileAccess) {
+    const allowlistedPath = resolveAllowlistedCanonicalPath(
+      authorizedFileAccess,
+      requestedRef
+    );
+    if (!allowlistedPath) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    canonicalScopedPath = allowlistedPath;
+  } else {
+    const canonicalPathResult = buildCanonicalScopedPathFromVizScope(
+      scope,
+      normalizedRel,
+      {
+        conversationId:
+          frameFile.useCaseMetadata?.conversationId ??
+          frameFile.useCaseMetadata?.sourceConversationId ??
+          null,
+        spaceId: frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId,
+      }
+    );
+    if (canonicalPathResult.isErr()) {
+      switch (canonicalPathResult.error.code) {
+        case "missing_conversation_context":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Frame has no conversation context for this path.",
+            },
+          });
+        case "missing_pod_context":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Frame has no project context for this path.",
+            },
+          });
+        case "conversation_context_mismatch":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Access denied: conversation ID does not match frame context.",
+            },
+          });
+        case "pod_context_mismatch":
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "Access denied: pod ID does not match frame context.",
+            },
+          });
+        default:
+          return assertNever(canonicalPathResult.error);
+      }
+    }
+    canonicalScopedPath = canonicalPathResult.value;
+  }
+
+  let contentType: string;
+  let nodeStream: Readable;
+
+  if (authorizationMode === "authorized" && authorizedFileAccess) {
+    const allowlistedFileResult = await readAllowlistedScopedVizFile({
+      authorizedFileAccess,
+      canonicalScopedPath,
+      workspace: owner,
+    });
+    if (allowlistedFileResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    contentType = allowlistedFileResult.value.contentType;
+    nodeStream = allowlistedFileResult.value.stream;
+  } else {
+    const statResult = await fs.stat(canonicalScopedPath);
+    if (statResult.isErr() || !statResult.value) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    contentType = statResult.value.contentType;
+
+    const readResult = await fs.read(canonicalScopedPath);
+    if (readResult.isErr() || !readResult.value) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    nodeStream = readResult.value;
+  }
   const webStream = new ReadableStream({
     start(controller) {
       nodeStream.on("data", (chunk) => controller.enqueue(chunk));

--- a/front-api/routes/v1/viz/files/[fileId].ts
+++ b/front-api/routes/v1/viz/files/[fileId].ts
@@ -1,6 +1,7 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
 
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
+import { assertVizFileAuthorized } from "@app/lib/api/viz/authorized_file_access";
 import {
   canAccessFileInConversation,
   canAccessFileInProject,
@@ -11,6 +12,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -73,7 +75,12 @@ app.get("/:fileId", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  const { file: frameFile, shareScope } = result;
+  const {
+    file: frameFile,
+    content: frameContent,
+    shareScope,
+    authorizedFileAccess,
+  } = result;
 
   // If current share scope differs from token scope, reject. It means share scope changed.
   if (shareScope !== tokenPayload.shareScope) {
@@ -152,35 +159,55 @@ app.get("/:fileId", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  let hasAccessRes: Result<true, Error>;
-  if (frameConversationId) {
-    hasAccessRes = await canAccessFileInConversation(owner, {
-      file: targetFile,
-      requestedConversationId: frameConversationId,
-    });
-  } else if (frameSpaceId) {
-    hasAccessRes = await canAccessFileInProject(owner, {
-      file: targetFile,
-      requestedProjectId: frameSpaceId,
-    });
-  } else {
-    throw new Error(
-      "Invalid file context: both conversationId and spaceId are missing"
-    );
-  }
+  const authorizationMode = await assertVizFileAuthorized({
+    authorizedFileAccess,
+    requestedRef: fileId,
+    owner,
+    frameContent,
+  });
+  switch (authorizationMode) {
+    case "denied":
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    case "legacy": {
+      let hasAccessRes: Result<true, Error>;
+      if (frameConversationId) {
+        hasAccessRes = await canAccessFileInConversation(owner, {
+          file: targetFile,
+          requestedConversationId: frameConversationId,
+        });
+      } else if (frameSpaceId) {
+        hasAccessRes = await canAccessFileInProject(owner, {
+          file: targetFile,
+          requestedProjectId: frameSpaceId,
+        });
+      } else {
+        throw new Error(
+          "Invalid file context: both conversationId and spaceId are missing"
+        );
+      }
 
-  if (hasAccessRes.isErr()) {
-    logger.error(
-      {
-        erroor: hasAccessRes.error,
-      },
-      "Error checking file access in conversation"
-    );
+      if (hasAccessRes.isErr()) {
+        logger.error(
+          {
+            erroor: hasAccessRes.error,
+          },
+          "Error checking file access in conversation"
+        );
 
-    return apiError(ctx, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
+        return apiError(ctx, {
+          status_code: 404,
+          api_error: { type: "file_not_found", message: "File not found." },
+        });
+      }
+      break;
+    }
+    case "authorized":
+      break;
+    default:
+      return assertNever(authorizationMode);
   }
 
   const readStream = targetFile.getSharedReadStream(owner, "original");

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -1,6 +1,8 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
+  assertVizFileAuthorized,
   ensureAuthorizedFileAccessForShare,
+  readAllowlistedScopedVizFile,
   reverifyAuthorAccess,
 } from "@app/lib/api/viz/authorized_file_access";
 import {
@@ -8,6 +10,7 @@ import {
   isAllowlistShareScopeStale,
   isAllowlistStale,
   isAuthorizedFileRef,
+  resolveAllowlistedCanonicalPath,
 } from "@app/lib/api/viz/authorized_file_access_policy";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { AuthorizedFileAccessModel } from "@app/lib/resources/storage/models/files";
@@ -600,6 +603,167 @@ describe("ensureAuthorizedFileAccessForShare", () => {
     });
     expect(rows).toHaveLength(1);
     expect(rows[0]?.ref).toBe("fil_OLDREF0001");
+  });
+});
+
+describe("resolveAllowlistedCanonicalPath", () => {
+  it("returns the stored canonical ref for direct and legacy aliases", () => {
+    const allowlist = makeAllowlist({
+      refs: [
+        {
+          kind: "canonical_path",
+          ref: "conversation-conv_123/chart.png",
+          legacyPath: "conversation/chart.png",
+        },
+      ],
+    });
+
+    expect(
+      resolveAllowlistedCanonicalPath(
+        allowlist,
+        "conversation-conv_123/chart.png"
+      )
+    ).toBe("conversation-conv_123/chart.png");
+    expect(
+      resolveAllowlistedCanonicalPath(allowlist, "conversation/chart.png")
+    ).toBe("conversation-conv_123/chart.png");
+    expect(
+      resolveAllowlistedCanonicalPath(allowlist, "conversation/other.png")
+    ).toBeNull();
+  });
+});
+
+describe("readAllowlistedScopedVizFile", () => {
+  it("reads via the authoring user's scoped file system", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+
+    const canonicalPath = "pod-vlt_otherPod/chart.png";
+    const allowlist = makeAllowlist({
+      computedByUserId: auth.user()!.sId,
+      refs: [
+        { kind: "canonical_path", ref: canonicalPath, fileName: "chart.png" },
+      ],
+    });
+
+    const mockFs = {
+      stat: vi
+        .fn()
+        .mockResolvedValue(
+          new Ok({ contentType: "image/png", sizeBytes: 100 })
+        ),
+      read: vi.fn().mockResolvedValue(new Ok(Readable.from(["png-bytes"]))),
+    };
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok(mockFs as unknown as DustFileSystem)
+    );
+
+    const result = await readAllowlistedScopedVizFile({
+      authorizedFileAccess: allowlist,
+      canonicalScopedPath: canonicalPath,
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.isOk() && result.value.contentType).toBe("image/png");
+    expect(mockFs.stat).toHaveBeenCalledWith(canonicalPath);
+    expect(mockFs.read).toHaveBeenCalledWith(canonicalPath);
+  });
+});
+
+describe("assertVizFileAuthorized", () => {
+  it("returns legacy when the allowlist is empty or missing", async () => {
+    const { workspace } = await createResourceTest({});
+
+    expect(
+      await assertVizFileAuthorized({
+        authorizedFileAccess: null,
+        requestedRef: "fil_ABCDEFGHIJ",
+        owner: workspace,
+        frameContent: "export default function Frame() {}",
+      })
+    ).toBe("legacy");
+
+    expect(
+      await assertVizFileAuthorized({
+        authorizedFileAccess: makeAllowlist({ refs: [] }),
+        requestedRef: "fil_ABCDEFGHIJ",
+        owner: workspace,
+        frameContent: "export default function Frame() {}",
+      })
+    ).toBe("legacy");
+  });
+
+  it("returns denied when frame content changed since the allowlist was computed", async () => {
+    const { workspace } = await createResourceTest({});
+
+    const frameContent = 'useFile("fil_ALLOWED01");';
+    const allowlist = makeAllowlist({
+      frameContentHash: computeFrameContentHash(frameContent),
+      refs: [{ kind: "file_id", ref: "fil_ALLOWED01" }],
+    });
+
+    expect(
+      await assertVizFileAuthorized({
+        authorizedFileAccess: allowlist,
+        requestedRef: "fil_ALLOWED01",
+        owner: workspace,
+        frameContent: `${frameContent}// edited`,
+      })
+    ).toBe("denied");
+  });
+
+  it("returns denied when the ref is not allowlisted", async () => {
+    const { workspace } = await createResourceTest({});
+
+    const frameContent = 'useFile("fil_ALLOWED01");';
+    const allowlist = makeAllowlist({
+      frameContentHash: computeFrameContentHash(frameContent),
+      refs: [{ kind: "file_id", ref: "fil_ALLOWED01" }],
+    });
+
+    expect(
+      await assertVizFileAuthorized({
+        authorizedFileAccess: allowlist,
+        requestedRef: "fil_DENIED0001",
+        owner: workspace,
+        frameContent,
+      })
+    ).toBe("denied");
+  });
+
+  it("returns authorized when the ref is allowlisted and author still has access", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const dataFile = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "data.txt",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const frameContent = `useFile("${dataFile.sId}");`;
+    const allowlist = makeAllowlist({
+      computedByUserId: auth.user()!.sId,
+      frameContentHash: computeFrameContentHash(frameContent),
+      refs: [{ kind: "file_id", ref: dataFile.sId, fileName: "data.txt" }],
+    });
+
+    expect(
+      await assertVizFileAuthorized({
+        authorizedFileAccess: allowlist,
+        requestedRef: dataFile.sId,
+        owner: workspace,
+        frameContent,
+      })
+    ).toBe("authorized");
   });
 });
 

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -17,6 +17,9 @@ import type {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { Readable } from "stream";
+
+export { resolveAllowlistedCanonicalPath } from "@app/lib/api/viz/authorized_file_access_policy";
 
 function unverifiableFrameFileRefsShareError(
   unverifiableRefs: string[]
@@ -91,6 +94,92 @@ export async function ensureAuthorizedFileAccessForShare(
   await frameFile.persistAuthorizedFileAccess(authorized);
 
   return new Ok(authorized);
+}
+
+export type VizFileAuthorizationMode = "legacy" | "authorized" | "denied";
+
+export type AllowlistedScopedVizFile = {
+  contentType: string;
+  stream: Readable;
+};
+
+/**
+ * Read an allowlisted scoped path under the authoring user's access.
+ * Share-token mounts only cover the frame context; cross-pod refs need this path.
+ */
+export async function readAllowlistedScopedVizFile({
+  authorizedFileAccess,
+  canonicalScopedPath,
+  workspace,
+}: {
+  authorizedFileAccess: AuthorizedFileAccessAllowlist;
+  canonicalScopedPath: string;
+  workspace: LightWorkspaceType;
+}): Promise<Result<AllowlistedScopedVizFile, void>> {
+  const userId = authorizedFileAccess.computedByUserId;
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    userId,
+    workspace.sId
+  );
+
+  const fsResult = await DustFileSystem.fromScopedPath(
+    auth,
+    canonicalScopedPath
+  );
+  if (fsResult.isErr()) {
+    return new Err(undefined);
+  }
+
+  const statResult = await fsResult.value.stat(canonicalScopedPath);
+  if (statResult.isErr() || !statResult.value) {
+    return new Err(undefined);
+  }
+
+  const readResult = await fsResult.value.read(canonicalScopedPath);
+  if (readResult.isErr() || !readResult.value) {
+    return new Err(undefined);
+  }
+
+  return new Ok({
+    contentType: statResult.value.contentType,
+    stream: readResult.value,
+  });
+}
+
+/**
+ * Gate viz file serving against the frame's stored allowlist.
+ * Returns "legacy" when no allowlist exists yet (pre-backfill frames).
+ */
+export async function assertVizFileAuthorized({
+  authorizedFileAccess,
+  requestedRef,
+  owner,
+  frameContent,
+}: {
+  authorizedFileAccess: AuthorizedFileAccessAllowlist | null;
+  requestedRef: string;
+  owner: LightWorkspaceType;
+  frameContent: string;
+}): Promise<VizFileAuthorizationMode> {
+  if (!authorizedFileAccess || authorizedFileAccess.refs.length === 0) {
+    return "legacy";
+  }
+
+  if (isAllowlistStale(authorizedFileAccess, frameContent)) {
+    return "denied";
+  }
+
+  if (!isAuthorizedFileRef(authorizedFileAccess, requestedRef)) {
+    return "denied";
+  }
+
+  const hasAccess = await reverifyAuthorAccess(
+    authorizedFileAccess,
+    requestedRef,
+    owner
+  );
+  return hasAccess ? "authorized" : "denied";
 }
 
 export async function reverifyAuthorAccess(

--- a/front/lib/api/viz/authorized_file_access_policy.ts
+++ b/front/lib/api/viz/authorized_file_access_policy.ts
@@ -57,3 +57,24 @@ export function isAuthorizedFileRef(
 
   return false;
 }
+
+/** Canonical scoped path to read when a request matches an allowlisted entry. */
+export function resolveAllowlistedCanonicalPath(
+  authorizedFileAccess: AuthorizedFileAccessAllowlist,
+  requestedRef: string
+): string | null {
+  for (const r of authorizedFileAccess.refs) {
+    if (r.kind !== "canonical_path") {
+      continue;
+    }
+
+    if (
+      r.ref === requestedRef ||
+      legacyScopedPathsMatch(r.legacyPath, requestedRef)
+    ) {
+      return r.ref;
+    }
+  }
+
+  return null;
+}

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -216,24 +216,28 @@ export class FileResource extends BaseResource<FileModel> {
     file: FileResource;
     content: string;
     shareScope: FileShareScope;
+    shareableFileId: ModelId;
+    workspace: LightWorkspaceType;
     conversationSpaceId: string | null;
+    authorizedFileAccess: AuthorizedFileAccessAllowlist | null;
+    fs: DustFileSystem;
   } | null> {
     const r = await this.fetchByShareToken(token);
     if (r.isErr()) {
       return null;
     }
 
-    const { file, shareScope, workspace, conversationSpaceId } = r.value;
-    const content = await file.getFileContent(workspace, "original");
+    const content = await r.value.file.getFileContent(
+      r.value.workspace,
+      "original"
+    );
     if (!content) {
       return null;
     }
 
     return {
-      file,
+      ...r.value,
       content,
-      shareScope,
-      conversationSpaceId,
     };
   }
 

--- a/front/pages/api/v1/viz/content.test.ts
+++ b/front/pages/api/v1/viz/content.test.ts
@@ -1,14 +1,27 @@
+import type { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { frameContentType } from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
+import { PassThrough } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import handler from "./content";
+
+function makeMockFs(): DustFileSystem {
+  return {
+    stat: vi
+      .fn()
+      .mockResolvedValue(new Ok({ contentType: "text/plain", sizeBytes: 100 })),
+    read: vi.fn().mockResolvedValue(new Ok(new PassThrough())),
+  } as unknown as DustFileSystem;
+}
 
 describe("/api/v1/viz/content endpoint tests", () => {
   let workspace: LightWorkspaceType;
@@ -24,6 +37,32 @@ describe("/api/v1/viz/content endpoint tests", () => {
     workspace = w;
     auth = a;
   });
+
+  function mockFetchByShareToken(
+    frameFile: FileResource,
+    opts: {
+      content?: string;
+      shareScope?: "public" | "workspace";
+      conversationSpaceId?: string | null;
+    } = {}
+  ) {
+    const {
+      content = "<html><h1>Interactive Frame</h1></html>",
+      shareScope = "public",
+      conversationSpaceId = null,
+    } = opts;
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content,
+      shareScope,
+      shareableFileId: 1 as unknown as ModelId,
+      workspace,
+      conversationSpaceId,
+      authorizedFileAccess: null,
+      fs: makeMockFs(),
+    });
+  }
 
   it("should return frame content with valid JWT access token", async () => {
     const frameFile = await FileFactory.create(auth, null, {
@@ -55,12 +94,7 @@ describe("/api/v1/viz/content endpoint tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html><h1>Interactive Frame</h1></html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     await handler(req, res);
 
@@ -271,11 +305,9 @@ describe("/api/v1/viz/content endpoint tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
+    mockFetchByShareToken(frameFile, {
       content: "<html><h1>Workspace Frame</h1></html>",
       shareScope: "workspace",
-      conversationSpaceId: null,
     });
 
     await handler(req, res);

--- a/front/pages/api/v1/viz/files/[...segments].ts
+++ b/front/pages/api/v1/viz/files/[...segments].ts
@@ -6,6 +6,11 @@ import {
   parseRawVizScope,
 } from "@app/lib/api/files/mount_path";
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
+import {
+  assertVizFileAuthorized,
+  readAllowlistedScopedVizFile,
+  resolveAllowlistedCanonicalPath,
+} from "@app/lib/api/viz/authorized_file_access";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -14,6 +19,7 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import path from "path";
+import type { Readable } from "stream";
 
 /**
  * @ignoreswagger
@@ -77,16 +83,26 @@ async function handler(
   }
   const tokenPayload = tokenRes.value;
 
-  // Get file info and build the DustFileSystem scoped to this frame's authorized paths.
-  const result = await FileResource.fetchByShareToken(tokenPayload.fileToken);
-  if (result.isErr()) {
+  // Get frame metadata, content (for allowlist hash), and scoped file system.
+  const result = await FileResource.fetchByShareTokenWithContent(
+    tokenPayload.fileToken
+  );
+  if (!result) {
     return apiError(req, res, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },
     });
   }
 
-  const { file: frameFile, shareScope, conversationSpaceId, fs } = result.value;
+  const {
+    file: frameFile,
+    content: frameContent,
+    shareScope,
+    conversationSpaceId,
+    authorizedFileAccess,
+    fs,
+    workspace: owner,
+  } = result;
 
   // If current share scope differs from token scope, reject. It means share scope changed.
   if (shareScope !== tokenPayload.shareScope) {
@@ -140,77 +156,126 @@ async function handler(
     });
   }
 
-  const canonicalPathResult = buildCanonicalScopedPathFromVizScope(
-    scope,
-    normalizedRel,
-    {
-      conversationId:
-        frameFile.useCaseMetadata?.conversationId ??
-        frameFile.useCaseMetadata?.sourceConversationId ??
-        null,
-      spaceId: frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId,
-    }
-  );
-  if (canonicalPathResult.isErr()) {
-    switch (canonicalPathResult.error.code) {
-      case "missing_conversation_context":
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Frame has no conversation context for this path.",
-          },
-        });
-      case "missing_pod_context":
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: "Frame has no project context for this path.",
-          },
-        });
-      case "conversation_context_mismatch":
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message:
-              "Access denied: conversation ID does not match frame context.",
-          },
-        });
-      case "pod_context_mismatch":
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Access denied: pod ID does not match frame context.",
-          },
-        });
-      default:
-        return assertNever(canonicalPathResult.error);
-    }
-  }
-  const canonicalScopedPath = canonicalPathResult.value;
+  const requestedRef = `${rawScope}/${normalizedRel}`;
 
-  const statResult = await fs.stat(canonicalScopedPath);
-  if (statResult.isErr() || !statResult.value) {
+  const authorizationMode = await assertVizFileAuthorized({
+    authorizedFileAccess,
+    requestedRef,
+    owner,
+    frameContent,
+  });
+  if (authorizationMode === "denied") {
     return apiError(req, res, {
       status_code: 404,
       api_error: { type: "file_not_found", message: "File not found." },
     });
   }
-  const { contentType } = statResult.value;
 
-  const readResult = await fs.read(canonicalScopedPath);
-  if (readResult.isErr() || !readResult.value) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
+  let canonicalScopedPath: string;
+  if (authorizationMode === "authorized" && authorizedFileAccess) {
+    const allowlistedPath = resolveAllowlistedCanonicalPath(
+      authorizedFileAccess,
+      requestedRef
+    );
+    if (!allowlistedPath) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    canonicalScopedPath = allowlistedPath;
+  } else {
+    const canonicalPathResult = buildCanonicalScopedPathFromVizScope(
+      scope,
+      normalizedRel,
+      {
+        conversationId:
+          frameFile.useCaseMetadata?.conversationId ??
+          frameFile.useCaseMetadata?.sourceConversationId ??
+          null,
+        spaceId: frameFile.useCaseMetadata?.spaceId ?? conversationSpaceId,
+      }
+    );
+    if (canonicalPathResult.isErr()) {
+      switch (canonicalPathResult.error.code) {
+        case "missing_conversation_context":
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Frame has no conversation context for this path.",
+            },
+          });
+        case "missing_pod_context":
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Frame has no project context for this path.",
+            },
+          });
+        case "conversation_context_mismatch":
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "Access denied: conversation ID does not match frame context.",
+            },
+          });
+        case "pod_context_mismatch":
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "Access denied: pod ID does not match frame context.",
+            },
+          });
+        default:
+          return assertNever(canonicalPathResult.error);
+      }
+    }
+    canonicalScopedPath = canonicalPathResult.value;
+  }
+
+  let contentType: string;
+  let stream: Readable;
+
+  if (authorizationMode === "authorized" && authorizedFileAccess) {
+    const allowlistedFileResult = await readAllowlistedScopedVizFile({
+      authorizedFileAccess,
+      canonicalScopedPath,
+      workspace: owner,
     });
+    if (allowlistedFileResult.isErr()) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    contentType = allowlistedFileResult.value.contentType;
+    stream = allowlistedFileResult.value.stream;
+  } else {
+    const statResult = await fs.stat(canonicalScopedPath);
+    if (statResult.isErr() || !statResult.value) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    contentType = statResult.value.contentType;
+
+    const readResult = await fs.read(canonicalScopedPath);
+    if (readResult.isErr() || !readResult.value) {
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    }
+    stream = readResult.value;
   }
 
   res.setHeader("Content-Type", contentType);
-  const stream = readResult.value;
   stream.on("error", (err) => {
     logger.error({ err, canonicalScopedPath }, "Error streaming viz file");
     stream.destroy();

--- a/front/pages/api/v1/viz/files/[fileId].ts
+++ b/front/pages/api/v1/viz/files/[fileId].ts
@@ -2,6 +2,7 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
 
 import { extractAndVerifyVizAccessTokenFromHeader } from "@app/lib/api/viz/access_tokens";
+import { assertVizFileAuthorized } from "@app/lib/api/viz/authorized_file_access";
 import {
   canAccessFileInConversation,
   canAccessFileInProject,
@@ -14,6 +15,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import assert from "assert";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -90,7 +92,12 @@ async function handler(
     });
   }
 
-  const { file: frameFile, shareScope } = result;
+  const {
+    file: frameFile,
+    content: frameContent,
+    shareScope,
+    authorizedFileAccess,
+  } = result;
 
   // If current share scope differs from token scope, reject. It means share scope changed.
   if (shareScope !== tokenPayload.shareScope) {
@@ -169,36 +176,56 @@ async function handler(
     });
   }
 
-  let hasAccessRes: Result<true, Error>;
-  if (frameConversationId) {
-    hasAccessRes = await canAccessFileInConversation(owner, {
-      file: targetFile,
-      requestedConversationId: frameConversationId,
-    });
-  } else if (frameSpaceId) {
-    hasAccessRes = await canAccessFileInProject(owner, {
-      file: targetFile,
-      requestedProjectId: frameSpaceId,
-    });
-  } else {
-    assert(
-      false,
-      "Invalid file context: both conversationId and spaceId are missing"
-    );
-  }
+  const authorizationMode = await assertVizFileAuthorized({
+    authorizedFileAccess,
+    requestedRef: fileId,
+    owner,
+    frameContent,
+  });
+  switch (authorizationMode) {
+    case "denied":
+      return apiError(req, res, {
+        status_code: 404,
+        api_error: { type: "file_not_found", message: "File not found." },
+      });
+    case "legacy": {
+      let hasAccessRes: Result<true, Error>;
+      if (frameConversationId) {
+        hasAccessRes = await canAccessFileInConversation(owner, {
+          file: targetFile,
+          requestedConversationId: frameConversationId,
+        });
+      } else if (frameSpaceId) {
+        hasAccessRes = await canAccessFileInProject(owner, {
+          file: targetFile,
+          requestedProjectId: frameSpaceId,
+        });
+      } else {
+        assert(
+          false,
+          "Invalid file context: both conversationId and spaceId are missing"
+        );
+      }
 
-  if (hasAccessRes.isErr()) {
-    logger.error(
-      {
-        erroor: hasAccessRes.error,
-      },
-      "Error checking file access in conversation"
-    );
+      if (hasAccessRes.isErr()) {
+        logger.error(
+          {
+            erroor: hasAccessRes.error,
+          },
+          "Error checking file access in conversation"
+        );
 
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: { type: "file_not_found", message: "File not found." },
-    });
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: { type: "file_not_found", message: "File not found." },
+        });
+      }
+      break;
+    }
+    case "authorized":
+      break;
+    default:
+      return assertNever(authorizationMode);
   }
 
   const readStream = targetFile.getSharedReadStream(owner, "original");

--- a/front/pages/api/v1/viz/files/fileId.test.ts
+++ b/front/pages/api/v1/viz/files/fileId.test.ts
@@ -1,4 +1,8 @@
+import type { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
+import * as authorizedFileAccessModule from "@app/lib/api/viz/authorized_file_access";
+import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
+import * as fileAccessModule from "@app/lib/api/viz/file_access";
 import { Authenticator } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -8,16 +12,30 @@ import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { frameContentType } from "@app/types/files";
+import {
+  type AuthorizedFileAccessAllowlist,
+  frameContentType,
+} from "@app/types/files";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { PublicPostConversationsRequestBody } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-import { Readable } from "stream";
+import { PassThrough, Readable } from "stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import publicConversationsHandler from "../../w/[wId]/assistant/conversations/index";
 import handler from "./[fileId]";
+
+function makeMockFs(): DustFileSystem {
+  return {
+    stat: vi
+      .fn()
+      .mockResolvedValue(new Ok({ contentType: "text/plain", sizeBytes: 100 })),
+    read: vi.fn().mockResolvedValue(new Ok(new PassThrough())),
+  } as unknown as DustFileSystem;
+}
 
 // Mock the rate limiter functions.
 vi.mock("@app/lib/utils/rate_limiter", () => ({
@@ -46,6 +64,44 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
     workspace = setup.workspace;
     auth = setup.authenticator;
   });
+
+  function mockFetchByShareToken(
+    frameFile: FileResource,
+    opts: {
+      content?: string;
+      shareScope?: "public" | "workspace";
+      conversationSpaceId?: string | null;
+      authorizedFileAccess?: AuthorizedFileAccessAllowlist | null;
+      fs?: DustFileSystem;
+    } = {}
+  ) {
+    const {
+      content = "<html>Frame content</html>",
+      shareScope = "public",
+      conversationSpaceId = null,
+      authorizedFileAccess = null,
+      fs = makeMockFs(),
+    } = opts;
+
+    let resolvedAllowlist = authorizedFileAccess;
+    if (authorizedFileAccess) {
+      resolvedAllowlist = {
+        ...authorizedFileAccess,
+        frameContentHash: computeFrameContentHash(content),
+      };
+    }
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content,
+      shareScope,
+      shareableFileId: 1 as unknown as ModelId,
+      workspace,
+      conversationSpaceId,
+      authorizedFileAccess: resolvedAllowlist,
+      fs,
+    });
+  }
 
   it("should only allow access to files from the same conversation as the frame (usecase: 'conversation')", async () => {
     // Create a real conversation
@@ -99,12 +155,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html>Frame content</html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
       // Mocked stream content.
@@ -169,12 +220,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html>Frame content</html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
       // Mocked stream content.
@@ -240,13 +286,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html>Frame content</html>",
-      // Current share scope is now 'workspace'.
-      shareScope: "workspace",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile, { shareScope: "workspace" });
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
       // Mocked stream content.
@@ -316,12 +356,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html>Frame content</html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     await handler(req, res);
 
@@ -401,12 +436,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
-      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-        file: frameFile,
-        content: "<html>Frame content</html>",
-        shareScope: "public",
-        conversationSpaceId: null,
-      });
+      mockFetchByShareToken(frameFile);
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
         Readable.from(["File content"])
@@ -464,12 +494,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
-      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-        file: frameFile,
-        content: "<html>Frame content</html>",
-        shareScope: "public",
-        conversationSpaceId: null,
-      });
+      mockFetchByShareToken(frameFile);
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
         Readable.from(["File content"])
@@ -521,12 +546,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
-      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-        file: frameFile,
-        content: "<html>Frame content</html>",
-        shareScope: "public",
-        conversationSpaceId: null,
-      });
+      mockFetchByShareToken(frameFile);
 
       await handler(req, res);
 
@@ -587,12 +607,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
-      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-        file: frameFile,
-        content: "<html>Frame content</html>",
-        shareScope: "public",
-        conversationSpaceId: null,
-      });
+      mockFetchByShareToken(frameFile);
 
       await handler(req, res);
 
@@ -657,12 +672,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html>Frame content</html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     await handler(req, res);
 
@@ -721,12 +731,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
       },
     });
 
-    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-      file: frameFile,
-      content: "<html>Frame content</html>",
-      shareScope: "public",
-      conversationSpaceId: null,
-    });
+    mockFetchByShareToken(frameFile);
 
     await handler(req, res);
 
@@ -988,12 +993,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
-      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-        file: frameFile,
-        content: "<html>Frame content</html>",
-        shareScope: "public",
-        conversationSpaceId: null,
-      });
+      mockFetchByShareToken(frameFile);
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
         Readable.from(["Sub-conversation file content"])
@@ -1127,12 +1127,7 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
-      vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
-        file: frameFile,
-        content: "<html>Frame content</html>",
-        shareScope: "public",
-        conversationSpaceId: null,
-      });
+      mockFetchByShareToken(frameFile);
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
         Readable.from(["Sub-conversation file content"])
@@ -1142,6 +1137,154 @@ describe("/api/v1/viz/files/[fileId] security tests", () => {
 
       // Should fail - file from unrelated conversation.
       expect(res._getStatusCode()).toBe(404);
+    });
+  });
+
+  describe("authorized file access allowlist", () => {
+    it("should serve an allowlisted file_id ref", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const targetFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "target.txt",
+        fileSize: 500,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const frameShareInfo = await frameFile.getShareInfo();
+      const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+      if (!fileToken) {
+        throw new Error("No file token found");
+      }
+
+      const accessToken = generateVizAccessToken({
+        contentType: frameContentType,
+        fileToken,
+        workspaceId: workspace.sId,
+        shareScope: "public",
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { fileId: targetFile.sId },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      const frameContent = `<html>useFile("${targetFile.sId}")</html>`;
+      mockFetchByShareToken(frameFile, {
+        content: frameContent,
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: computeFrameContentHash(frameContent),
+          refs: [
+            { kind: "file_id", ref: targetFile.sId, fileName: "target.txt" },
+          ],
+        },
+      });
+
+      vi.spyOn(
+        authorizedFileAccessModule,
+        "reverifyAuthorAccess"
+      ).mockResolvedValue(true);
+      const legacyAccessSpy = vi.spyOn(
+        fileAccessModule,
+        "canAccessFileInConversation"
+      );
+
+      vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+        Readable.from(["File content"])
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(legacyAccessSpy).not.toHaveBeenCalled();
+    });
+
+    it("should reject a file_id ref that is not on the allowlist", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "frame.html",
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const allowedFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "allowed.txt",
+        fileSize: 500,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const targetFile = await FileFactory.create(auth, null, {
+        contentType: "text/plain",
+        fileName: "target.txt",
+        fileSize: 500,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const frameShareInfo = await frameFile.getShareInfo();
+      const fileToken = frameShareInfo?.shareUrl.split("/").at(-1);
+      if (!fileToken) {
+        throw new Error("No file token found");
+      }
+
+      const accessToken = generateVizAccessToken({
+        contentType: frameContentType,
+        fileToken,
+        workspaceId: workspace.sId,
+        shareScope: "public",
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { fileId: targetFile.sId },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      const frameContent = `<html>useFile("${allowedFile.sId}")</html>`;
+      mockFetchByShareToken(frameFile, {
+        content: frameContent,
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: computeFrameContentHash(frameContent),
+          refs: [
+            { kind: "file_id", ref: allowedFile.sId, fileName: "allowed.txt" },
+          ],
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: { type: "file_not_found", message: "File not found." },
+      });
     });
   });
 });

--- a/front/pages/api/v1/viz/files/segments.test.ts
+++ b/front/pages/api/v1/viz/files/segments.test.ts
@@ -1,14 +1,18 @@
 import type { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { generateVizAccessToken } from "@app/lib/api/viz/access_tokens";
-import { DustError } from "@app/lib/error";
+import * as authorizedFileAccessModule from "@app/lib/api/viz/authorized_file_access";
+import { computeFrameContentHash } from "@app/lib/api/viz/authorized_file_access_policy";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { frameContentType } from "@app/types/files";
+import {
+  type AuthorizedFileAccessAllowlist,
+  frameContentType,
+} from "@app/types/files";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
@@ -98,35 +102,57 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
   }
 
   /**
-   * Stubs fetchByShareToken so no DB round-trip is needed for the token
-   * lookup. WorkspaceResource.fetchByModelId still runs against the real DB
-   * (frameFile.workspaceId points to the test workspace created in beforeEach).
+   * Stubs fetchByShareTokenWithContent so no DB round-trip is needed for the
+   * token lookup. WorkspaceResource.fetchByModelId still runs against the real
+   * DB (frameFile.workspaceId points to the test workspace created in beforeEach).
    */
+  function mockAllowlistedFileRead() {
+    return vi
+      .spyOn(authorizedFileAccessModule, "readAllowlistedScopedVizFile")
+      .mockResolvedValue(
+        new Ok({
+          contentType: "image/png",
+          stream: new PassThrough(),
+        })
+      );
+  }
+
+  const FRAME_CONTENT_FOR_ALLOWLIST = "export default function Frame() {}";
+
   function mockFetchByShareToken(
     frameFile: FileResource,
     opts: {
       shareScope?: "public" | "workspace";
       conversationSpaceId?: string | null;
+      authorizedFileAccess?: AuthorizedFileAccessAllowlist | null;
       fs?: DustFileSystem;
     } = {}
   ) {
     const {
       shareScope = "public",
       conversationSpaceId = null,
+      authorizedFileAccess = null,
       fs = makeMockFs({ found: true }),
     } = opts;
 
-    vi.spyOn(FileResource, "fetchByShareToken").mockResolvedValue(
-      new Ok({
-        file: frameFile,
-        shareScope,
-        shareableFileId: 1 as unknown as ModelId,
-        workspace,
-        conversationSpaceId,
-        authorizedFileAccess: null,
-        fs,
-      })
-    );
+    let resolvedAllowlist = authorizedFileAccess;
+    if (authorizedFileAccess) {
+      resolvedAllowlist = {
+        ...authorizedFileAccess,
+        frameContentHash: computeFrameContentHash(FRAME_CONTENT_FOR_ALLOWLIST),
+      };
+    }
+
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue({
+      file: frameFile,
+      content: FRAME_CONTENT_FOR_ALLOWLIST,
+      shareScope,
+      shareableFileId: 1 as unknown as ModelId,
+      workspace,
+      conversationSpaceId,
+      authorizedFileAccess: resolvedAllowlist,
+      fs,
+    });
     return fs;
   }
 
@@ -190,7 +216,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       headers: { authorization: `Bearer ${accessToken}` },
     });
 
-    // Scope validation happens before fetchByShareToken; no need to mock it.
+    // Scope validation happens before fetchByShareTokenWithContent; no need to mock it.
     mockFetchByShareToken(frameFile);
     await handler(req, res);
 
@@ -199,14 +225,14 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
   });
 
   // -------------------------------------------------------------------------
-  // fetchByShareToken failure
+  // fetchByShareTokenWithContent failure
   // -------------------------------------------------------------------------
 
   it("should return 404 when the share token is not found", async () => {
     const { accessToken } = await makeFrameAndToken({});
 
-    vi.spyOn(FileResource, "fetchByShareToken").mockResolvedValue(
-      new Err(new DustError("file_not_found", "Share not found"))
+    vi.spyOn(FileResource, "fetchByShareTokenWithContent").mockResolvedValue(
+      null
     );
 
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
@@ -426,7 +452,7 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
       conversationId: conversation.sId,
     });
 
-    // conversationSpaceId is resolved by fetchByShareToken from the conversation's space.
+    // conversationSpaceId is resolved by fetchByShareTokenWithContent from the conversation's space.
     mockFetchByShareToken(frameFile, {
       conversationSpaceId: "vlt_derivedSpaceId",
     });
@@ -684,5 +710,223 @@ describe("/api/v1/viz/files/[...segments] security tests", () => {
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+
+  // -------------------------------------------------------------------------
+  // Authorized file access allowlist
+  // -------------------------------------------------------------------------
+
+  describe("authorized file access allowlist", () => {
+    it("should serve an allowlisted scoped path ref", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const { frameFile, accessToken } = await makeFrameAndToken({
+        conversationId: conversation.sId,
+      });
+
+      const canonicalPath = `conversation-${conversation.sId}/chart.png`;
+      mockFetchByShareToken(frameFile, {
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: "hash",
+          refs: [
+            {
+              kind: "canonical_path",
+              ref: canonicalPath,
+              legacyPath: "conversation/chart.png",
+              fileName: "chart.png",
+            },
+          ],
+        },
+      });
+
+      vi.spyOn(
+        authorizedFileAccessModule,
+        "assertVizFileAuthorized"
+      ).mockResolvedValue("authorized");
+      mockAllowlistedFileRead();
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { segments: ["conversation", "chart.png"] },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+    });
+
+    it("should serve an allowlisted file from a different pod than the frame", async () => {
+      const framePodId = "vlt_framePod";
+      const otherPodId = "vlt_otherPod";
+      const otherPodPath = `pod-${otherPodId}/chart.png`;
+
+      const { frameFile, accessToken } = await makeFrameAndToken({
+        spaceId: framePodId,
+      });
+
+      // Share-token fs only mounts the frame pod; cross-pod paths are unreadable there.
+      mockFetchByShareToken(frameFile, {
+        fs: makeMockFs({ found: false }),
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: "hash",
+          refs: [
+            {
+              kind: "canonical_path",
+              ref: otherPodPath,
+              fileName: "chart.png",
+            },
+          ],
+        },
+      });
+
+      vi.spyOn(
+        authorizedFileAccessModule,
+        "assertVizFileAuthorized"
+      ).mockResolvedValue("authorized");
+      const readSpy = mockAllowlistedFileRead();
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { segments: [`pod-${otherPodId}`, "chart.png"] },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(readSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          canonicalScopedPath: otherPodPath,
+        })
+      );
+    });
+
+    it("should serve an allowlisted legacy path without frame conversation context", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Frame metadata lacks conversationId; legacy resolution would 400 without allowlist.
+      const { frameFile, accessToken } = await makeFrameAndToken({});
+
+      const canonicalPath = `conversation-${conversation.sId}/chart.png`;
+      mockFetchByShareToken(frameFile, {
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: "hash",
+          refs: [
+            {
+              kind: "canonical_path",
+              ref: canonicalPath,
+              legacyPath: "conversation/chart.png",
+              fileName: "chart.png",
+            },
+          ],
+        },
+      });
+
+      vi.spyOn(
+        authorizedFileAccessModule,
+        "assertVizFileAuthorized"
+      ).mockResolvedValue("authorized");
+      mockAllowlistedFileRead();
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { segments: ["conversation", "chart.png"] },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+    });
+
+    it("should return 404 instead of 403 when a canonical path is not allowlisted", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const { frameFile, accessToken } = await makeFrameAndToken({
+        conversationId: conversation.sId,
+      });
+
+      mockFetchByShareToken(frameFile, {
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: "hash",
+          refs: [
+            {
+              kind: "canonical_path",
+              ref: `conversation-${conversation.sId}/allowed.png`,
+              fileName: "allowed.png",
+            },
+          ],
+        },
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: {
+          segments: ["conversation-different_conv_id", "chart.png"],
+        },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: { type: "file_not_found", message: "File not found." },
+      });
+    });
+
+    it("should reject a scoped path ref that is not on the allowlist", async () => {
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const { frameFile, accessToken } = await makeFrameAndToken({
+        conversationId: conversation.sId,
+      });
+
+      const allowedPath = `conversation-${conversation.sId}/allowed.png`;
+      mockFetchByShareToken(frameFile, {
+        authorizedFileAccess: {
+          computedByUserId: auth.user()!.sId,
+          frameContentHash: "hash",
+          refs: [
+            {
+              kind: "canonical_path",
+              ref: allowedPath,
+              legacyPath: "conversation/allowed.png",
+              fileName: "allowed.png",
+            },
+          ],
+        },
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        query: { segments: ["conversation", "chart.png"] },
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(404);
+      expect(res._getJSONData()).toEqual({
+        error: { type: "file_not_found", message: "File not found." },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description

Enforces the `authorizedFileAccess` allowlist policy in the two viz file-serving endpoints (`/viz/files/[...segments]` and `/viz/files/[fileId]`), in both `front` and `front-api`.

Both endpoints now call `assertVizFileAuthorized` which returns `"legacy"` (no allowlist yet — falls back to existing path resolution), `"authorized"` (ref is allowlisted and author's access is verified), or `"denied"` (stale frame content or ref not in allowlist → 404). When `"authorized"`, scoped files are read via `readAllowlistedScopedVizFile` using the authoring user's credentials — necessary for cross-pod refs that the share-token's scoped FS can't reach. `FileResource.fetchByShareTokenWithContent` is updated to surface `authorizedFileAccess`, `workspace`, and `fs` directly.

## Tests

Added unit tests for `resolveAllowlistedCanonicalPath`, `readAllowlistedScopedVizFile`, and `assertVizFileAuthorized` (legacy/denied/authorized cases including stale hash and author-access re-verification). Test fixtures for content endpoints updated with `authorizedFileAccess: null`.

## Risk

Medium. The `"legacy"` fallback ensures frames without a populated allowlist (pre-backfill) are unaffected. The `"denied"` path raises security (blocks unallowlisted refs) — no rollback concern since it's strictly more restrictive than the old behaviour. Risk is that frames with a stale allowlist (content edited after allowlist was computed) will get 404s until the allowlist is refreshed.

## Deploy Plan

Deploy front when base branch (`sflory/update-authorizedfile-list-on`) is ready.
