### PR TITLE
Update share sheet ui to show the files that are going to be shared.

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -1,4 +1,8 @@
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import {
+  buildShareFileResponse,
+  type ShareFrameViewerFile,
+} from "@app/lib/api/viz/share_frame_viewer_files";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ShareFileResponseBody } from "@app/lib/resources/file_resource";
@@ -18,6 +22,8 @@ import type { Context, TypedResponse } from "hono";
 import { z } from "zod";
 
 import grants from "./grants";
+
+export type { ShareFrameViewerFile };
 
 const ShareFileRequestBodySchema = z.object({
   shareScope: fileShareScopeSchema,
@@ -48,15 +54,15 @@ app.get(
       return file;
     }
 
-    const shareInfo = await file.getShareInfo();
-    if (!shareInfo) {
+    const shareResponse = await buildShareFileResponse(auth, file);
+    if (!shareResponse) {
       return apiError(ctx, {
         status_code: 404,
         api_error: { type: "file_not_found", message: "File not found." },
       });
     }
 
-    return ctx.json(shareInfo);
+    return ctx.json(shareResponse);
   }
 );
 
@@ -99,15 +105,15 @@ app.post(
       });
     }
 
-    const shareInfo = await file.getShareInfo();
-    if (!shareInfo) {
+    const shareResponse = await buildShareFileResponse(auth, file);
+    if (!shareResponse) {
       return apiError(ctx, {
         status_code: 404,
         api_error: { type: "file_not_found", message: "File not found." },
       });
     }
 
-    return ctx.json(shareInfo);
+    return ctx.json(shareResponse);
   }
 );
 

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -372,7 +372,12 @@ export function FrameRenderer({
               fileContent={fileContent ?? null}
               fileName={fileMetadata?.fileName}
             />
-            <ShareFrameSheet fileId={fileId} owner={owner} />
+            <ShareFrameSheet
+              key={contentHash ?? fileId}
+              fileId={fileId}
+              owner={owner}
+              contentHash={contentHash}
+            />
             <PinPodBannerButton
               owner={owner}
               spaceId={projectId ?? ""}

--- a/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFrameSheet.tsx
@@ -1,4 +1,9 @@
 import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
+import type {
+  ShareFrameViewerFile,
+  ShareFrameViewerFileSourceKind,
+} from "@app/lib/api/viz/share_frame_viewer_files";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   useShareInteractiveContentFile,
   useSharingGrants,
@@ -21,6 +26,8 @@ import {
   ClipboardCheck,
   ContentMessage,
   ContextItem,
+  Cube01,
+  File02,
   Globe01,
   Icon,
   IconButton,
@@ -28,6 +35,7 @@ import {
   Input,
   Label,
   Lock01,
+  MessageChatSquare,
   ScrollArea,
   Sheet,
   SheetContainer,
@@ -129,19 +137,35 @@ type InviteFormValues = z.infer<typeof inviteFormSchema>;
 interface ShareFrameSheetProps {
   fileId: string;
   owner: LightWorkspaceType;
+  /** Busts share/grants cache when frame content changes (e.g. `fileId@updatedAt`). */
+  contentHash?: string | null;
 }
 
-export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
+export function ShareFrameSheet({
+  fileId,
+  owner,
+  contentHash,
+}: ShareFrameSheetProps) {
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
+  const [shareBlockError, setShareBlockError] = useState<string[] | null>(null);
   const [isCopied, copyToClipboard] = useCopyToClipboard();
   const { AwaitableDialog, showDialog } = useAwaitableDialog();
 
   const { doShare, fileShare, isFileShareLoading } =
-    useShareInteractiveContentFile({ fileId, owner });
+    useShareInteractiveContentFile({
+      fileId,
+      owner,
+      cacheKey: contentHash,
+    });
 
   const { grants, isGrantsLoading, doAddGrants, doRevokeGrant } =
-    useSharingGrants({ fileId, owner, disabled: !isOpen });
+    useSharingGrants({
+      fileId,
+      owner,
+      cacheKey: contentHash,
+      disabled: !isOpen,
+    });
 
   const {
     register,
@@ -157,6 +181,7 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
   const currentScope: FileShareScope =
     fileShare?.scope ?? "workspace_and_emails";
   const shareURL = fileShare?.shareUrl ?? "";
+  const viewerFiles = fileShare?.viewerFiles ?? [];
 
   const allowedScopes = ALLOWED_SCOPES_BY_POLICY[owner.sharingPolicy];
   const availableScopeOptions = getScopeOptions(owner.sharingPolicy).filter(
@@ -214,7 +239,15 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
         icon={Upload01}
         onClick={() => setIsOpen(true)}
       />
-      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+      <Sheet
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (!open) {
+            setShareBlockError(null);
+          }
+        }}
+      >
         <SheetContent size="lg">
           <SheetHeader>
             <div className="flex items-center justify-between pr-10">
@@ -247,6 +280,17 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                     with people already in your workspace.
                   </ContentMessage>
                 )}
+                {shareBlockError && shareBlockError.length > 0 && (
+                  <ContentMessage
+                    icon={InfoCircle}
+                    variant="warning"
+                    title="Some referenced files cannot be shared"
+                  >
+                    Viewers will only be able to access files you can verify.
+                    Fix or remove these references before sharing:{" "}
+                    {shareBlockError.join(", ")}
+                  </ContentMessage>
+                )}
                 <fieldset className="flex flex-col gap-2 border-none p-0">
                   <legend className="text-sm font-semibold text-foreground dark:text-foreground-night mb-2">
                     Who has access
@@ -271,7 +315,16 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                             name="share-scope"
                             value={option.value}
                             checked={isSelected}
-                            onChange={() => doShare(option.value)}
+                            onChange={async () => {
+                              setShareBlockError(null);
+                              const result = await doShare(option.value);
+                              if (
+                                !result.success &&
+                                result.unverifiableRefs?.length
+                              ) {
+                                setShareBlockError(result.unverifiableRefs);
+                              }
+                            }}
                             className="sr-only"
                           />
                           <Icon
@@ -358,12 +411,82 @@ export function ShareFrameSheet({ fileId, owner }: ShareFrameSheetProps) {
                     )}
                   </div>
                 )}
+                <ViewerFilesSection viewerFiles={viewerFiles} />
               </div>
             )}
           </SheetContainer>
         </SheetContent>
       </Sheet>
     </>
+  );
+}
+
+const VIEWER_FILE_SOURCE_ICONS: Record<
+  ShareFrameViewerFileSourceKind,
+  typeof Cube01
+> = {
+  pod: Cube01,
+  conversation: MessageChatSquare,
+  workspace: File02,
+};
+
+function ViewerFileLine({ viewerFile }: { viewerFile: ShareFrameViewerFile }) {
+  const SourceIcon = VIEWER_FILE_SOURCE_ICONS[viewerFile.sourceKind];
+  const FileIcon = getFileTypeIcon(viewerFile.contentType, viewerFile.name);
+
+  return (
+    <li className="flex min-w-0 items-center gap-1.5 py-0.5 text-xs text-foreground dark:text-foreground-night">
+      <Icon
+        visual={FileIcon}
+        size="xs"
+        className="shrink-0 text-muted-foreground dark:text-muted-foreground-night"
+      />
+      <div className="flex min-w-0 items-center gap-1 truncate">
+        <span className="shrink-0 font-medium">{viewerFile.name}</span>
+        <span className="shrink-0 text-muted-foreground dark:text-muted-foreground-night">
+          from
+        </span>
+        <Icon
+          visual={SourceIcon}
+          size="xs"
+          className="shrink-0 text-muted-foreground dark:text-muted-foreground-night"
+        />
+        <span className="truncate">{viewerFile.sourceName}</span>
+        {viewerFile.pathInSource ? (
+          <span className="truncate text-muted-foreground dark:text-muted-foreground-night">{`in /${viewerFile.pathInSource}`}</span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function ViewerFilesSection({
+  viewerFiles,
+}: {
+  viewerFiles: ShareFrameViewerFile[];
+}) {
+  if (viewerFiles.length === 0) {
+    return null;
+  }
+
+  return (
+    <fieldset className="flex flex-col gap-2 border-none p-0">
+      <legend className="text-sm font-semibold text-foreground dark:text-foreground-night">
+        Files used
+      </legend>
+      <p className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+        When shared, viewers can only access these files—not the rest of the
+        conversation or pod.
+      </p>
+      <ul className="flex flex-col gap-0">
+        {viewerFiles.map((viewerFile, index) => (
+          <ViewerFileLine
+            key={`${viewerFile.sourceKind}:${viewerFile.sourceName}:${viewerFile.name}:${index}`}
+            viewerFile={viewerFile}
+          />
+        ))}
+      </ul>
+    </fieldset>
   );
 }
 

--- a/front/lib/api/files/mount_path.test.ts
+++ b/front/lib/api/files/mount_path.test.ts
@@ -13,6 +13,7 @@ import {
   makeProcessedMountFileName,
   normalizeAndValidateMountRelativeFilePath,
   normalizeMountParentRelativePath,
+  parseCanonicalScopedPath,
   parseProcessedFilename,
   parseScopedFilePath,
   ResolveScopedMountFilePathError,
@@ -154,6 +155,24 @@ describe("mount_path helpers", () => {
       expect(isAgentScopedPath("conversation-conv_abc/report.csv")).toBe(true);
       expect(isAgentScopedPath("conversation/report.csv")).toBe(true);
       expect(isAgentScopedPath("hello/world")).toBe(false);
+    });
+
+    it("parses canonical scoped paths into scope and relative path", () => {
+      expect(
+        parseCanonicalScopedPath(
+          "pod-pod_xyz/my folder/another folder/report.md"
+        )
+      ).toEqual({
+        scope: { kind: "canonical-pod", id: "pod_xyz" },
+        relPath: "my folder/another folder/report.md",
+      });
+      expect(
+        parseCanonicalScopedPath("conversation-conv_abc/report.csv")
+      ).toEqual({
+        scope: { kind: "canonical-conversation", id: "conv_abc" },
+        relPath: "report.csv",
+      });
+      expect(parseCanonicalScopedPath("conversation/report.csv")).toBeNull();
     });
   });
 

--- a/front/lib/api/files/mount_path.ts
+++ b/front/lib/api/files/mount_path.ts
@@ -230,6 +230,33 @@ export function parseRawVizScope(rawScope: string): ParsedVizScope | null {
   return r.success ? { kind: "legacy", prefix: r.data } : null;
 }
 
+export type ParsedCanonicalScopedPath = {
+  scope:
+    | { kind: "canonical-conversation"; id: string }
+    | { kind: "canonical-pod"; id: string };
+  relPath: string;
+};
+
+/**
+ * Parse a canonical agent-visible scoped path (`conversation-{id}/...`, `pod-{id}/...`)
+ * into its scope and path relative to that mount.
+ */
+export function parseCanonicalScopedPath(
+  scopedPath: string
+): ParsedCanonicalScopedPath | null {
+  const slashIdx = scopedPath.indexOf("/");
+  const rawScope = slashIdx === -1 ? scopedPath : scopedPath.slice(0, slashIdx);
+  const parsed = parseRawVizScope(rawScope);
+  if (!parsed || parsed.kind === "legacy") {
+    return null;
+  }
+
+  return {
+    scope: parsed,
+    relPath: slashIdx === -1 ? "" : scopedPath.slice(slashIdx + 1),
+  };
+}
+
 /**
  * Parse a scoped file path like "conversation/chart.png" or "pod/report.pdf".
  * Returns null if the path is missing a valid scope prefix.

--- a/front/lib/api/viz/share_frame_viewer_files.test.ts
+++ b/front/lib/api/viz/share_frame_viewer_files.test.ts
@@ -1,0 +1,134 @@
+import { getShareFrameViewerFiles } from "@app/lib/api/viz/share_frame_viewer_files";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { describe, expect, it } from "vitest";
+
+describe("getShareFrameViewerFiles", () => {
+  it("returns file names with source kind and nested paths", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversationTitle = conversation.title ?? "Test Conversation";
+
+    const pod = await SpaceFactory.project(auth.getNonNullableWorkspace());
+
+    const conversationFile = await FileFactory.create(auth, null, {
+      contentType: "text/markdown",
+      fileName: "notes.md",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const podFile = await FileFactory.create(auth, null, {
+      contentType: "text/markdown",
+      fileName: "summary.md",
+      fileSize: 10,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+
+    const viewerFiles = await getShareFrameViewerFiles(auth, [
+      {
+        kind: "canonical_path",
+        ref: `pod-${pod.sId}/my folder/another folder/aereataetaet.md`,
+        fileName: "aereataetaet.md",
+      },
+      {
+        kind: "canonical_path",
+        ref: `pod-${pod.sId}/company-knowledge-summary.md`,
+        fileName: "company-knowledge-summary.md",
+      },
+      {
+        kind: "file_id",
+        ref: conversationFile.sId,
+        fileName: "notes.md",
+      },
+      {
+        kind: "file_id",
+        ref: podFile.sId,
+        fileName: "summary.md",
+      },
+      {
+        kind: "canonical_path",
+        ref: `conversation-${conversation.sId}/report.csv`,
+        fileName: "report.csv",
+      },
+    ]);
+
+    expect(viewerFiles).toEqual([
+      {
+        name: "aereataetaet.md",
+        contentType: "text/markdown",
+        sourceKind: "pod",
+        sourceName: pod.name,
+        pathInSource: "my folder/another folder",
+      },
+      {
+        name: "company-knowledge-summary.md",
+        contentType: "text/markdown",
+        sourceKind: "pod",
+        sourceName: pod.name,
+      },
+      {
+        name: "notes.md",
+        contentType: "text/markdown",
+        sourceKind: "conversation",
+        sourceName: conversationTitle,
+      },
+      {
+        name: "summary.md",
+        contentType: "text/markdown",
+        sourceKind: "pod",
+        sourceName: pod.name,
+      },
+      {
+        name: "report.csv",
+        contentType: "text/csv",
+        sourceKind: "conversation",
+        sourceName: conversationTitle,
+      },
+    ]);
+  });
+
+  it("falls back to deleted labels when sources no longer exist", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+
+    const viewerFiles = await getShareFrameViewerFiles(auth, [
+      {
+        kind: "canonical_path",
+        ref: "conversation-conv_missing/nested/report.csv",
+        fileName: "report.csv",
+      },
+      {
+        kind: "canonical_path",
+        ref: "pod-spc_missing/data.csv",
+        fileName: "data.csv",
+      },
+    ]);
+
+    expect(viewerFiles).toEqual([
+      {
+        name: "report.csv",
+        contentType: "text/csv",
+        sourceKind: "conversation",
+        sourceName: "Deleted conversation",
+        pathInSource: "nested",
+      },
+      {
+        name: "data.csv",
+        contentType: "text/csv",
+        sourceKind: "pod",
+        sourceName: "Deleted pod",
+      },
+    ]);
+  });
+});

--- a/front/lib/api/viz/share_frame_viewer_files.ts
+++ b/front/lib/api/viz/share_frame_viewer_files.ts
@@ -1,0 +1,247 @@
+import { parseCanonicalScopedPath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import {
+  FileResource,
+  type ShareFileResponseBody,
+} from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { AuthorizedFileAccessModel } from "@app/lib/resources/storage/models/files";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
+import {
+  type AuthorizedFileRef,
+  contentTypeFromFileName,
+  entryToAuthorizedFileRef,
+  getAuthorizedFileRefLabel,
+} from "@app/types/files";
+import path from "path";
+
+export type ShareFrameViewerFileSourceKind =
+  | "conversation"
+  | "pod"
+  | "workspace";
+
+export type ShareFrameViewerFile = {
+  name: string;
+  contentType: string;
+  sourceKind: ShareFrameViewerFileSourceKind;
+  sourceName: string;
+  pathInSource?: string;
+};
+
+type ViewerFileSource =
+  | { kind: "workspace" }
+  | { kind: "conversation"; sId: string }
+  | { kind: "pod"; sId: string };
+
+function viewerFileSourceFromCanonicalPath(
+  canonicalPath: string
+): ViewerFileSource {
+  const parsed = parseCanonicalScopedPath(canonicalPath);
+  if (!parsed) {
+    return { kind: "workspace" };
+  }
+
+  return parsed.scope.kind === "canonical-conversation"
+    ? { kind: "conversation", sId: parsed.scope.id }
+    : { kind: "pod", sId: parsed.scope.id };
+}
+
+function viewerFileSourceFromFile(
+  file: FileResource | undefined
+): ViewerFileSource {
+  const metadata = file?.useCaseMetadata;
+  if (!metadata) {
+    return { kind: "workspace" };
+  }
+
+  if (metadata.spaceId) {
+    return { kind: "pod", sId: metadata.spaceId };
+  }
+
+  const conversationId =
+    metadata.conversationId ?? metadata.sourceConversationId ?? null;
+  if (conversationId) {
+    return { kind: "conversation", sId: conversationId };
+  }
+
+  return { kind: "workspace" };
+}
+
+function viewerFileSource(
+  ref: AuthorizedFileRef,
+  fileBySId: Map<string, FileResource>
+): ViewerFileSource {
+  if (ref.kind === "canonical_path") {
+    return viewerFileSourceFromCanonicalPath(ref.ref);
+  }
+
+  return viewerFileSourceFromFile(fileBySId.get(ref.ref));
+}
+
+function pathInSourceFromCanonicalRef(
+  canonicalPath: string
+): string | undefined {
+  const parsed = parseCanonicalScopedPath(canonicalPath);
+  if (!parsed?.relPath) {
+    return undefined;
+  }
+
+  const dir = path.posix.dirname(parsed.relPath);
+  return dir === "." ? undefined : dir;
+}
+
+function viewerFileSourceName(
+  source: ViewerFileSource,
+  conversationTitleBySId: Map<string, string>,
+  podNameBySId: Map<string, string>
+): string {
+  switch (source.kind) {
+    case "workspace":
+      return "Workspace";
+    case "conversation":
+      return conversationTitleBySId.get(source.sId) ?? "Deleted conversation";
+    case "pod":
+      return podNameBySId.get(source.sId) ?? "Deleted pod";
+  }
+}
+
+function toShareFrameViewerFile(
+  ref: AuthorizedFileRef,
+  source: ViewerFileSource,
+  file: FileResource | undefined,
+  conversationTitleBySId: Map<string, string>,
+  podNameBySId: Map<string, string>
+): ShareFrameViewerFile {
+  const name = getAuthorizedFileRefLabel(ref);
+  const pathInSource =
+    ref.kind === "canonical_path"
+      ? pathInSourceFromCanonicalRef(ref.ref)
+      : undefined;
+
+  return {
+    name,
+    contentType:
+      file?.contentType ??
+      contentTypeFromFileName(name) ??
+      "application/octet-stream",
+    sourceKind: source.kind,
+    sourceName: viewerFileSourceName(
+      source,
+      conversationTitleBySId,
+      podNameBySId
+    ),
+    ...(pathInSource ? { pathInSource } : {}),
+  };
+}
+
+export async function getShareFrameViewerFilesForFrame(
+  auth: Authenticator,
+  frameFile: FileResource
+): Promise<ShareFrameViewerFile[]> {
+  const shareableFile = await FileResource.shareableFileModel.findOne({
+    where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+  });
+  if (!shareableFile) {
+    return [];
+  }
+
+  const activeEntries = await AuthorizedFileAccessModel.findAll({
+    where: {
+      shareableFileId: shareableFile.id,
+      workspaceId: frameFile.workspaceId,
+      revokedAt: null,
+    },
+  });
+
+  const refs = activeEntries.flatMap((entry) => {
+    const ref = entryToAuthorizedFileRef({
+      kind: entry.kind,
+      ref: entry.ref,
+      shareScope: entry.shareScope,
+      computedByUserId: entry.computedByUserId,
+      frameContentHash: entry.frameContentHash,
+      allowedAt: entry.allowedAt.toISOString(),
+      ...(entry.fileName ? { fileName: entry.fileName } : {}),
+      ...(entry.legacyPath ? { legacyPath: entry.legacyPath } : {}),
+    });
+    return ref ? [ref] : [];
+  });
+
+  return getShareFrameViewerFiles(auth, refs);
+}
+
+export async function getShareFrameViewerFiles(
+  auth: Authenticator,
+  refs: AuthorizedFileRef[]
+): Promise<ShareFrameViewerFile[]> {
+  if (refs.length === 0) {
+    return [];
+  }
+
+  const fileIds = refs
+    .filter((ref) => ref.kind === "file_id")
+    .map((ref) => ref.ref);
+  const files =
+    fileIds.length > 0 ? await FileResource.fetchByIds(auth, fileIds) : [];
+  const fileBySId = new Map(files.map((file) => [file.sId, file]));
+
+  const sources = refs.map((ref) => viewerFileSource(ref, fileBySId));
+
+  const conversationSIds = [
+    ...new Set(
+      sources
+        .filter((source) => source.kind === "conversation")
+        .map((source) => source.sId)
+    ),
+  ];
+  const podSIds = [
+    ...new Set(
+      sources
+        .filter((source) => source.kind === "pod")
+        .map((source) => source.sId)
+    ),
+  ];
+
+  const [conversations, pods] = await Promise.all([
+    conversationSIds.length > 0
+      ? ConversationResource.fetchByIds(auth, conversationSIds)
+      : [],
+    podSIds.length > 0 ? SpaceResource.fetchByIds(auth, podSIds) : [],
+  ]);
+
+  const conversationTitleBySId = new Map(
+    conversations.map((conversation) => [
+      conversation.sId,
+      getConversationDisplayTitle(conversation.toJSON()),
+    ])
+  );
+  const podNameBySId = new Map(pods.map((pod) => [pod.sId, pod.name]));
+
+  return refs.map((ref, index) =>
+    toShareFrameViewerFile(
+      ref,
+      sources[index]!,
+      ref.kind === "file_id" ? fileBySId.get(ref.ref) : undefined,
+      conversationTitleBySId,
+      podNameBySId
+    )
+  );
+}
+
+export async function buildShareFileResponse(
+  auth: Authenticator,
+  file: FileResource
+): Promise<ShareFileResponseBody | null> {
+  const shareInfo = await file.getShareInfo();
+  if (!shareInfo) {
+    return null;
+  }
+
+  const viewerFiles = await getShareFrameViewerFilesForFrame(auth, file);
+
+  return {
+    ...shareInfo,
+    viewerFiles,
+  };
+}

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -36,6 +36,7 @@ import {
   canAccessFileInConversation,
   canAccessFileInProject,
 } from "@app/lib/api/viz/file_access";
+import type { ShareFrameViewerFile } from "@app/lib/api/viz/share_frame_viewer_files";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
@@ -124,6 +125,7 @@ export type ShareFileResponseBody = {
   scope: FileShareScope;
   sharedAt: number;
   shareUrl: string;
+  viewerFiles: ShareFrameViewerFile[];
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -297,20 +297,29 @@ export function useFileSignedUrl({
 export function useShareInteractiveContentFile({
   fileId,
   owner,
+  cacheKey,
 }: {
   fileId: string;
   owner: LightWorkspaceType;
+  cacheKey?: string | null;
 }) {
   const { fetcher } = useFetcher();
   const sendNotification = useSendNotification();
 
   const fileShareFetcher: Fetcher<ShareFileResponseBody> = fetcher;
 
-  const swrKey = `/api/w/${owner.sId}/files/${fileId}/share`;
+  const swrKey = cacheKey
+    ? `/api/w/${owner.sId}/files/${fileId}/share?v=${cacheKey}`
+    : `/api/w/${owner.sId}/files/${fileId}/share`;
 
   const { data, error, mutate } = useSWRWithDefaults(swrKey, fileShareFetcher);
 
-  const doShare = async (shareScope: FileShareScope) => {
+  const doShare = async (
+    shareScope: FileShareScope
+  ): Promise<
+    | { success: true; response: ShareFileResponseBody }
+    | { success: false; message: string; unverifiableRefs?: string[] }
+  > => {
     const res = await clientFetch(`/api/w/${owner.sId}/files/${fileId}/share`, {
       method: "POST",
       headers: {
@@ -321,19 +330,30 @@ export function useShareInteractiveContentFile({
 
     if (!res.ok) {
       const errorData = await getErrorFromResponse(res);
+      const unverifiableRefs =
+        "unverifiableRefs" in errorData &&
+        Array.isArray(errorData.unverifiableRefs)
+          ? errorData.unverifiableRefs
+          : undefined;
+
       sendNotification({
         type: "error",
-        title: "Failed to share the Frame file.",
-        description: `Error: ${errorData.message}`,
+        title: "Failed to update frame sharing",
+        description: errorData.message,
       });
-      return null;
-    } else {
-      await mutate();
 
-      const response: ShareFileResponseBody = await res.json();
-
-      return response;
+      return {
+        success: false,
+        message: errorData.message,
+        unverifiableRefs,
+      };
     }
+
+    await mutate();
+
+    const response: ShareFileResponseBody = await res.json();
+
+    return { success: true, response };
   };
 
   return {
@@ -348,10 +368,12 @@ export function useShareInteractiveContentFile({
 export function useSharingGrants({
   fileId,
   owner,
+  cacheKey,
   disabled,
 }: {
   fileId: string;
   owner: LightWorkspaceType;
+  cacheKey?: string | null;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -359,7 +381,9 @@ export function useSharingGrants({
 
   const grantsFetcher: Fetcher<{ grants: SharingGrantType[] }> = fetcher;
 
-  const swrKey = `/api/w/${owner.sId}/files/${fileId}/share/grants`;
+  const swrKey = cacheKey
+    ? `/api/w/${owner.sId}/files/${fileId}/share/grants?v=${cacheKey}`
+    : `/api/w/${owner.sId}/files/${fileId}/share/grants`;
 
   const { data, error, mutate } = useSWRWithDefaults(swrKey, grantsFetcher, {
     disabled,

--- a/front/pages/api/w/[wId]/files/[fileId]/share/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/index.ts
@@ -1,7 +1,9 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
+import { buildShareFileResponse } from "@app/lib/api/viz/share_frame_viewer_files";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { ShareFileResponseBody } from "@app/lib/resources/file_resource";
@@ -122,8 +124,8 @@ async function handler(
         });
       }
 
-      const shareInfo = await file.getShareInfo();
-      if (!shareInfo) {
+      const shareResponse = await buildShareFileResponse(auth, file);
+      if (!shareResponse) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -133,13 +135,13 @@ async function handler(
         });
       }
 
-      return res.status(200).json(shareInfo);
+      return res.status(200).json(shareResponse);
     }
 
     case "GET": {
-      const shareInfo = await file.getShareInfo();
+      const shareResponse = await buildShareFileResponse(auth, file);
 
-      if (!shareInfo) {
+      if (!shareResponse) {
         return apiError(req, res, {
           status_code: 404,
           api_error: {
@@ -149,7 +151,7 @@ async function handler(
         });
       }
 
-      return res.status(200).json(shareInfo);
+      return res.status(200).json(shareResponse);
     }
 
     default:

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -186,6 +186,7 @@ export type APIError = {
   app_error?: CoreAPIError;
   connectors_error?: ConnectorsAPIError;
   redirect?: RegionRedirectError;
+  unverifiableRefs?: string[];
 };
 
 export function isAPIError(obj: unknown): obj is APIError {

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -3,6 +3,7 @@ import {
   authorizedFileAccessEntrySchema,
   ensureFileSize,
   getActiveAuthorizedFileAccessEntries,
+  getAuthorizedFileRefLabel,
   parseAuthorizedFileAccessEntry,
   resolveFileContentType,
   resolveMaxFileSizes,
@@ -143,6 +144,32 @@ describe("getActiveAuthorizedFileAccessEntries", () => {
       active,
     ]);
     expect(getActiveAuthorizedFileAccessEntries([])).toEqual([]);
+  });
+});
+
+describe("getAuthorizedFileRefLabel", () => {
+  it("prefers fileName, then ref or path basename", () => {
+    expect(
+      getAuthorizedFileRefLabel({
+        kind: "file_id",
+        ref: "fil_abc",
+        fileName: "report.csv",
+      })
+    ).toBe("report.csv");
+
+    expect(
+      getAuthorizedFileRefLabel({
+        kind: "file_id",
+        ref: "fil_abc",
+      })
+    ).toBe("fil_abc");
+
+    expect(
+      getAuthorizedFileRefLabel({
+        kind: "canonical_path",
+        ref: "conversation-conv_123/charts/sales.png",
+      })
+    ).toBe("sales.png");
   });
 });
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -143,18 +143,6 @@ export type AuthorizedFileAccessEntry = z.infer<
   typeof authorizedFileAccessEntrySchema
 >;
 
-export function parseAuthorizedFileAccessEntry(
-  data: unknown
-): AuthorizedFileAccessEntry {
-  return authorizedFileAccessEntrySchema.parse(data);
-}
-
-export function getActiveAuthorizedFileAccessEntries(
-  entries: AuthorizedFileAccessEntry[]
-): AuthorizedFileAccessEntry[] {
-  return entries.filter((entry) => entry.revokedAt == null);
-}
-
 const authorizedFileIdRefSchema = z
   .object({
     kind: z.literal("file_id"),
@@ -179,17 +167,15 @@ export const authorizedFileRefSchema = z.discriminatedUnion("kind", [
 
 export type AuthorizedFileRef = z.infer<typeof authorizedFileRefSchema>;
 
-/** Active allowlist view derived from non-revoked DB rows. */
-export type AuthorizedFileAccessAllowlist = {
-  computedByUserId: string;
-  frameContentHash: string;
-  refs: AuthorizedFileRef[];
-};
-
-/** Result of scanning frame content before persisting rows. */
-export type ComputedAuthorizedFileAccess = AuthorizedFileAccessAllowlist & {
-  unverifiableRefs?: string[];
-};
+export function getAuthorizedFileRefLabel(ref: AuthorizedFileRef): string {
+  if (ref.fileName) {
+    return ref.fileName;
+  }
+  if (ref.kind === "file_id") {
+    return ref.ref;
+  }
+  return ref.ref.split("/").pop() ?? ref.ref;
+}
 
 export function entryToAuthorizedFileRef(
   entry: AuthorizedFileAccessEntry
@@ -213,6 +199,30 @@ export function entryToAuthorizedFileRef(
     default:
       return assertNever(entry);
   }
+}
+
+/** Active allowlist view derived from non-revoked DB rows. */
+export type AuthorizedFileAccessAllowlist = {
+  computedByUserId: string;
+  frameContentHash: string;
+  refs: AuthorizedFileRef[];
+};
+
+/** Result of scanning frame content before persisting rows. */
+export type ComputedAuthorizedFileAccess = AuthorizedFileAccessAllowlist & {
+  unverifiableRefs?: string[];
+};
+
+export function parseAuthorizedFileAccessEntry(
+  data: unknown
+): AuthorizedFileAccessEntry {
+  return authorizedFileAccessEntrySchema.parse(data);
+}
+
+export function getActiveAuthorizedFileAccessEntries(
+  entries: AuthorizedFileAccessEntry[]
+): AuthorizedFileAccessEntry[] {
+  return entries.filter((entry) => entry.revokedAt == null);
 }
 
 export type AuthorizedFileAccessShareError = Omit<DustError, "code"> & {


### PR DESCRIPTION
## Description

Adds a "Files used" section to `ShareFrameSheet` so users can see exactly which files will be accessible to viewers before sharing a frame. The section lists each file with its type icon, source kind (pod / conversation / workspace), source name, and nested path when applicable.

- `getShareFrameViewerFiles` / `getShareFrameViewerFilesForFrame` in `share_frame_viewer_files.ts` resolve the frame's active `AuthorizedFileRef` allowlist into `ShareFrameViewerFile[]` (falls back to "Deleted conversation" / "Deleted pod" for gone sources)
- `ShareFileResponseBody` gains `viewerFiles: ShareFrameViewerFile[]`; both the Hono front-api route and the legacy Next.js route populate it via `buildShareFileResponse`
- Share POST now calls `ensureAuthorizedFileAccessForShare` and returns `400` with `unverifiableRefs` if any refs can't be verified; `ShareFrameSheet` surfaces this as a warning `ContentMessage`
- `contentHash` prop on `ShareFrameSheet` busts the SWR cache for share/grants when frame content changes; `doShare` now returns a typed discriminated union instead of `null`
- New `parseCanonicalScopedPath` helper in `mount_path.ts` extracts scope + relative path from `conversation-{id}/...` / `pod-{id}/...` paths

<img width="581" height="458" alt="image" src="https://github.com/user-attachments/assets/68fdcdb3-01ab-4a28-888b-bbe15223fdfc" />

## Tests

- Added integration tests in `share_frame_viewer_files.test.ts` covering resolved sources and deleted-source fallbacks
- Added unit tests for `getAuthorizedFileRefLabel` in `files.test.ts` and `parseCanonicalScopedPath` in `mount_path.test.ts`
- Tested locally via the share sheet UI

## Risk

Low. The `viewerFiles` field is additive on the response — existing callers that ignore it are unaffected. The `ensureAuthorizedFileAccessForShare` gate on POST is new behaviour: frames with unverifiable refs will now fail to share (400) rather than silently proceeding. This is intentional and safe to roll back by reverting the allowlist check in the share handler.

## Deploy Plan

Deploy front when base branch (`sflory/add-backfill-script-to-compute`) is ready. No DB migrations.
