### PR TITLE
Add: notice in tool output when editing a publicly shared frame and changing authorizedFileList.

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -137,7 +137,12 @@ export function createInteractiveContentTools(
         );
       }
 
-      const { fileResource, replacementCount, warnings } = result.value;
+      const {
+        fileResource,
+        replacementCount,
+        warnings,
+        referencedFilesChangeNotice,
+      } = result.value;
 
       const pluralS = replacementCount === 1 ? "" : "s";
       let responseText =
@@ -145,6 +150,9 @@ export function createInteractiveContentTools(
         `${replacementCount} replacement${pluralS}`;
 
       responseText += formatValidationWarningsForLLM(warnings);
+      if (referencedFilesChangeNotice) {
+        responseText += referencedFilesChangeNotice;
+      }
 
       if (_meta?.progressToken) {
         const notification: MCPProgressNotificationType =

--- a/front/lib/api/actions/servers/slideshow/tools/index.ts
+++ b/front/lib/api/actions/servers/slideshow/tools/index.ts
@@ -108,7 +108,12 @@ export function createSlideshowTools(
         return new Err(new MCPError(result.error.message, { tracked: false }));
       }
 
-      const { fileResource, replacementCount, warnings } = result.value;
+      const {
+        fileResource,
+        replacementCount,
+        warnings,
+        referencedFilesChangeNotice,
+      } = result.value;
 
       const pluralS = replacementCount === 1 ? "" : "s";
       let responseText =
@@ -116,6 +121,9 @@ export function createSlideshowTools(
         `${replacementCount} replacement${pluralS}`;
 
       responseText += formatValidationWarningsForLLM(warnings);
+      if (referencedFilesChangeNotice) {
+        responseText += referencedFilesChangeNotice;
+      }
 
       if (_meta?.progressToken) {
         const notification: MCPProgressNotificationType =

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -7,6 +7,11 @@ import {
   getFileContent,
   getUpdatedContentAndOccurrences,
 } from "@app/lib/api/files/utils";
+import {
+  diffAuthorizedFileRefs,
+  fetchShareableFileAllowlistState,
+  formatPublicShareReferencedFilesChangeNoticeForLLM,
+} from "@app/lib/api/viz/authorized_file_access";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
@@ -177,6 +182,7 @@ export async function editClientExecutableFile(
       fileResource: FileResource;
       replacementCount: number;
       warnings: ValidationWarning[];
+      referencedFilesChangeNotice: string | null;
     },
     { tracked: boolean; message: string }
   >
@@ -249,6 +255,9 @@ export async function editClientExecutableFile(
         warnings.push(...tailwindValidation.error);
       }
 
+      const beforeShareState =
+        await fetchShareableFileAllowlistState(fileResource);
+
       // Upload the updated content (version is incremented inside uploadFrameContent).
       const uploadResult = await uploadFrameContent(
         auth,
@@ -262,7 +271,25 @@ export async function editClientExecutableFile(
         });
       }
 
-      return new Ok({ fileResource, replacementCount: occurrences, warnings });
+      let referencedFilesChangeNotice: string | null = null;
+      if (beforeShareState?.shareScope === "public") {
+        const afterShareState =
+          await fetchShareableFileAllowlistState(fileResource);
+        referencedFilesChangeNotice =
+          formatPublicShareReferencedFilesChangeNoticeForLLM(
+            diffAuthorizedFileRefs(
+              beforeShareState.refs,
+              afterShareState?.refs ?? []
+            ).added
+          );
+      }
+
+      return new Ok({
+        fileResource,
+        replacementCount: occurrences,
+        warnings,
+        referencedFilesChangeNotice,
+      });
     });
   } catch (error) {
     return new Err({

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -1,7 +1,10 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
   assertVizFileAuthorized,
+  diffAuthorizedFileRefs,
   ensureAuthorizedFileAccessForShare,
+  fetchShareableFileAllowlistState,
+  formatPublicShareReferencedFilesChangeNoticeForLLM,
   readAllowlistedScopedVizFile,
   reverifyAuthorAccess,
 } from "@app/lib/api/viz/authorized_file_access";
@@ -857,5 +860,109 @@ describe("reverifyAuthorAccess", () => {
         workspace
       )
     ).toBe(false);
+  });
+});
+
+describe("public share referenced files change notice", () => {
+  it("diffAuthorizedFileRefs reports added and removed refs", () => {
+    const previous = [
+      { kind: "file_id" as const, ref: "fil_OLD0000001", fileName: "old.txt" },
+    ];
+    const next = [
+      { kind: "file_id" as const, ref: "fil_NEW0000001", fileName: "new.txt" },
+      {
+        kind: "canonical_path" as const,
+        ref: "conversation-conv_123/report.csv",
+        fileName: "report.csv",
+      },
+    ];
+
+    expect(diffAuthorizedFileRefs(previous, next)).toEqual({
+      added: [
+        { kind: "file_id", ref: "fil_NEW0000001", fileName: "new.txt" },
+        {
+          kind: "canonical_path",
+          ref: "conversation-conv_123/report.csv",
+          fileName: "report.csv",
+        },
+      ],
+      removed: [
+        { kind: "file_id", ref: "fil_OLD0000001", fileName: "old.txt" },
+      ],
+    });
+  });
+
+  it("formats a notice when new references are added", () => {
+    const notice = formatPublicShareReferencedFilesChangeNoticeForLLM([
+      { kind: "file_id", ref: "fil_NEW0000001", fileName: "data.txt" },
+    ]);
+
+    expect(notice).toContain("Public share notice");
+    expect(notice).toContain("Let the user know");
+    expect(notice).toContain("New references: data.txt");
+  });
+
+  it("returns null when references are only removed", () => {
+    expect(formatPublicShareReferencedFilesChangeNoticeForLLM([])).toBeNull();
+  });
+
+  it("fetchShareableFileAllowlistState returns the active allowlist refs", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const dataFile = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "data.txt",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    await frameFile.setShareScope(auth, "public");
+
+    const shareableFile = await FileResource.shareableFileModel.findOne({
+      where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+    });
+    expect(shareableFile).not.toBeNull();
+    await AuthorizedFileAccessModel.create({
+      workspaceId: frameFile.workspaceId,
+      shareableFileId: shareableFile!.id,
+      kind: "file_id",
+      ref: dataFile.sId,
+      fileName: "data.txt",
+      legacyPath: null,
+      shareScope: shareableFile!.shareScope,
+      computedByUserId: auth.user()!.sId,
+      frameContentHash: "hash",
+      allowedAt: new Date(),
+      revokedAt: null,
+    });
+
+    const state = await fetchShareableFileAllowlistState(frameFile);
+
+    expect(state).toEqual({
+      shareScope: "public",
+      refs: [
+        {
+          kind: "file_id",
+          ref: dataFile.sId,
+          fileName: "data.txt",
+        },
+      ],
+    });
   });
 });

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -9,10 +9,13 @@ import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import type {
-  AuthorizedFileAccessAllowlist,
-  AuthorizedFileAccessShareError,
-  ComputedAuthorizedFileAccess,
+import {
+  type AuthorizedFileAccessAllowlist,
+  type AuthorizedFileAccessShareError,
+  type AuthorizedFileRef,
+  type ComputedAuthorizedFileAccess,
+  type FileShareScope,
+  getAuthorizedFileRefLabel,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -29,6 +32,63 @@ function unverifiableFrameFileRefsShareError(
     code: "invalid_request_error",
     message: `Frame references files that cannot be verified: ${unverifiableRefs.join(", ")}`,
     unverifiableRefs,
+  };
+}
+
+function authorizedFileRefKey(ref: AuthorizedFileRef): string {
+  return `${ref.kind}:${ref.ref}`;
+}
+
+export function diffAuthorizedFileRefs(
+  previousRefs: readonly AuthorizedFileRef[],
+  nextRefs: readonly AuthorizedFileRef[]
+): { added: AuthorizedFileRef[]; removed: AuthorizedFileRef[] } {
+  const previousKeys = new Set(previousRefs.map(authorizedFileRefKey));
+  const nextKeys = new Set(nextRefs.map(authorizedFileRefKey));
+
+  return {
+    added: nextRefs.filter(
+      (ref) => !previousKeys.has(authorizedFileRefKey(ref))
+    ),
+    removed: previousRefs.filter(
+      (ref) => !nextKeys.has(authorizedFileRefKey(ref))
+    ),
+  };
+}
+
+export function formatPublicShareReferencedFilesChangeNoticeForLLM(
+  added: AuthorizedFileRef[]
+): string | null {
+  if (added.length === 0) {
+    return null;
+  }
+
+  return [
+    "\n\nPublic share notice:",
+    "This frame is shared publicly and now references new files via useFile().",
+    "Let the user know viewers with the public link may gain access to additional source files.",
+    `New references: ${added.map(getAuthorizedFileRefLabel).join(", ")}`,
+  ].join("\n");
+}
+
+export async function fetchShareableFileAllowlistState(
+  frameFile: FileResource
+): Promise<{
+  shareScope: FileShareScope;
+  refs: AuthorizedFileRef[];
+} | null> {
+  const shareableFile = await FileResource.shareableFileModel.findOne({
+    where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+  });
+  if (!shareableFile) {
+    return null;
+  }
+
+  const active = await frameFile.getActiveAuthorizedFileAccessAllowlist();
+
+  return {
+    shareScope: shareableFile.shareScope,
+    refs: active?.refs ?? [],
   };
 }
 

--- a/front/pages/api/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -10,7 +10,12 @@ import handler from "./edit-text";
 vi.mock("@app/lib/api/files/client_executable", () => ({
   editClientExecutableFile: vi.fn().mockResolvedValue({
     isErr: () => false,
-    value: { fileResource: {}, replacementCount: 1, warnings: [] },
+    value: {
+      fileResource: {},
+      replacementCount: 1,
+      warnings: [],
+      referencedFilesChangeNotice: null,
+    },
   }),
 }));
 


### PR DESCRIPTION
## Description

When an agent edits a publicly shared frame via the `interactive_content` or `slideshow` MCP tools, the frame's `authorizedFileList` may grow to include new file references. Without awareness of this, the agent never alerts the user that additional source files have become accessible via the public share link.

Added `fetchShareableFileAllowlistState`, `diffAuthorizedFileRefs`, and `formatPublicShareReferencedFilesChangeNoticeForLLM` to `authorized_file_access.ts`. In `editClientExecutableFile`, the allowlist is snapshotted before `uploadFrameContent` runs; if the frame is `public` and new refs appear in the post-upload allowlist, a `referencedFilesChangeNotice` string is appended to the tool response text in both the `interactive_content` and `slideshow` tool handlers.

<img width="738" height="513" alt="image" src="https://github.com/user-attachments/assets/24f0108b-09bd-4984-b677-5899e7d07b15" />

## Tests

- Added unit tests for `diffAuthorizedFileRefs` (added/removed diff), `formatPublicShareReferencedFilesChangeNoticeForLLM` (notice format, null on empty), and `fetchShareableFileAllowlistState` (reads active allowlist from `ShareableFileModel`) in `authorized_file_access.test.ts`.
- Updated the `edit-text.test.ts` mock to include `referencedFilesChangeNotice: null` in the mock return value.
- Tested manually by editing a publicly shared frame that references a new file and verifying the notice appears in the tool output.

## Risk

Low. The new DB read (`ShareableFileModel.findOne`) runs only when a frame file is edited, and the notice path is gated on `shareScope === "public"`. No schema changes. No impact on non-public frames.

## Deploy Plan

Deploy front.
