### PR TITLE
[slim-api] move spaces & data_sources API contracts out of pages/api

### DIFF
--- a/front-api/routes/v1/w/[wId]/files/fileId.test.ts
+++ b/front-api/routes/v1/w/[wId]/files/fileId.test.ts
@@ -25,7 +25,8 @@ vi.mock("@app/lib/api/files/upsert", () => ({
     .mockResolvedValue({ isErr: () => false }),
 }));
 
-vi.mock("@app/lib/api/data_sources", () => ({
+vi.mock("@app/lib/api/data_sources", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/data_sources")>()),
   getOrCreateConversationDataSourceFromFile: vi.fn().mockResolvedValue({
     isErr: () => false,
     value: { id: "test_data_source" },

--- a/front-api/routes/w/[wId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/data_source_views/index.ts
@@ -1,13 +1,9 @@
+import type { GetDataSourceViewsResponseBody } from "@app/lib/api/data_source_view";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import tags from "./tags";
-
-export type GetDataSourceViewsResponseBody = {
-  dataSourceViews: DataSourceViewType[];
-};
 
 // Mounted under /api/w/:wId/data_source_views.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/data_source_views/tags/search.ts
+++ b/front-api/routes/w/[wId]/data_source_views/tags/search.ts
@@ -1,21 +1,13 @@
 import apiConfig from "@app/lib/api/config";
+import type { PostTagSearchResponseBody } from "@app/lib/api/data_source_view_tags";
+import { PostTagSearchBodySchema } from "@app/lib/api/data_source_view_tags";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
-import type { CoreAPISearchTagsResponse } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-export type PostTagSearchResponseBody = CoreAPISearchTagsResponse;
-
-const PostTagSearchBodySchema = z.object({
-  query: z.string(),
-  queryType: z.enum(["exact", "prefix", "match"]),
-  dataSourceViewIds: z.array(z.string()),
-});
 
 // Mounted at /api/w/:wId/data_source_views/tags/search.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -5,7 +5,8 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/data_sources", () => ({
+vi.mock("@app/lib/api/data_sources", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/data_sources")>()),
   getOrCreateConversationDataSourceFromFile: vi.fn().mockResolvedValue({
     isErr: () => false,
     value: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
@@ -1,11 +1,11 @@
 import config from "@app/lib/api/config";
+import type { GetDatasetResponseBody } from "@app/lib/api/datasets";
 import { getDatasetHash } from "@app/lib/api/datasets";
 import { checkDatasetData } from "@app/lib/datasets";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { DatasetType } from "@app/types/dataset";
 import type { APIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -16,8 +16,6 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import type { Context, TypedResponse } from "hono";
 
 import { PostDatasetRequestBodySchema } from "../schemas";
-
-export type GetDatasetResponseBody = { dataset: DatasetType };
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/datasets/:name.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
@@ -1,11 +1,17 @@
 import config from "@app/lib/api/config";
-import { getDatasets } from "@app/lib/api/datasets";
+import type {
+  GetDatasetsResponseBody,
+  PostDatasetResponseBody,
+} from "@app/lib/api/datasets";
+import {
+  getDatasets,
+  PostDatasetRequestBodySchema,
+} from "@app/lib/api/datasets";
 import { checkDatasetData } from "@app/lib/datasets";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { DatasetType } from "@app/types/dataset";
 import type { APIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -14,32 +20,8 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 import type { Context, TypedResponse } from "hono";
-import { z } from "zod";
 
 import name from "./[name]";
-
-export type GetDatasetsResponseBody = {
-  datasets: DatasetType[];
-};
-
-export type PostDatasetResponseBody = {
-  dataset: DatasetType;
-};
-
-export const PostDatasetRequestBodySchema = z.object({
-  dataset: z.object({
-    name: z.string(),
-    description: z.string().nullable(),
-    data: z.array(z.record(z.string(), z.any())),
-  }),
-  schema: z.array(
-    z.object({
-      key: z.string(),
-      type: z.enum(["string", "number", "boolean", "json"]),
-      description: z.string().nullable(),
-    })
-  ),
-});
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/datasets.
 //

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -1,6 +1,6 @@
+import type { GetOrPostAppResponseBody } from "@app/lib/api/apps";
 import { softDeleteApp } from "@app/lib/api/apps";
 import { AppResource } from "@app/lib/resources/app_resource";
-import type { AppType } from "@app/types/app";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -12,10 +12,6 @@ import { z } from "zod";
 import datasets from "./datasets";
 import runs from "./runs";
 import state from "./state";
-
-export type GetOrPostAppResponseBody = {
-  app: AppType;
-};
 
 const PatchAppBodySchema = z.object({
   name: z.string(),

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,8 +1,9 @@
+import type { GetRunBlockResponseBody } from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { BlockType, RunType } from "@app/types/run";
+import type { BlockType } from "@app/types/run";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -16,10 +17,6 @@ const ParamsSchema = z.object({
   type: z.string(),
   name: z.string(),
 });
-
-export type GetRunBlockResponseBody = {
-  run: RunType | null;
-};
 
 // Mounted under
 // /api/w/:wId/spaces/:spaceId/apps/:aId/runs/:runId/blocks/:type/:name.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
@@ -1,3 +1,4 @@
+import type { PostRunCancelResponseBody } from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
@@ -13,10 +14,6 @@ const ParamsSchema = z.object({
   aId: z.string(),
   runId: z.string(),
 });
-
-export type PostRunCancelResponseBody = {
-  success: boolean;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/runs/:runId/cancel.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,6 +1,6 @@
+import type { GetRunResponseBody } from "@app/lib/api/apps";
 import { AppResource } from "@app/lib/resources/app_resource";
-import type { AppType, SpecificationType } from "@app/types/app";
-import type { RunType } from "@app/types/run";
+import type { AppType } from "@app/types/app";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -16,11 +16,6 @@ const ParamsSchema = z.object({
 import blocks from "./blocks";
 import cancel from "./cancel";
 import status from "./status";
-
-export type GetRunResponseBody = {
-  run: RunType;
-  spec: SpecificationType;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/runs/:runId.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,8 +1,8 @@
+import type { GetRunStatusResponseBody } from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RunType } from "@app/types/run";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -14,10 +14,6 @@ const ParamsSchema = z.object({
   aId: z.string(),
   runId: z.string(),
 });
-
-export type GetRunStatusResponseBody = {
-  run: RunType | null;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/runs/:runId/status.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -1,3 +1,7 @@
+import type {
+  GetRunsResponseBody,
+  PostRunsResponseBody,
+} from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
@@ -9,7 +13,6 @@ import logger from "@app/logger/logger";
 import { credentialsFromProviders } from "@app/types/api/credentials";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { APIErrorResponse } from "@app/types/error";
-import type { RunType } from "@app/types/run";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { sessionAuth } from "@front-api/middlewares/session_auth";
@@ -19,15 +22,6 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import type { Context, TypedResponse } from "hono";
 
 import runId from "./[runId]";
-
-export type GetRunsResponseBody = {
-  runs: RunType[];
-  total: number;
-};
-
-export type PostRunsResponseBody = {
-  run: RunType;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/apps/:aId/runs.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -1,8 +1,11 @@
+import type {
+  GetAppsResponseBody,
+  PostAppResponseBody,
+} from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
-import type { AppType } from "@app/types/app";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -13,14 +16,6 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
 
 import aId from "./[aId]";
-
-export type GetAppsResponseBody = {
-  apps: AppType[];
-};
-
-export type PostAppResponseBody = {
-  app: AppType;
-};
 
 const PostAppBodySchema = z.object({
   name: z.string(),

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,22 +1,13 @@
-import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import {
-  getCursorPaginationParams,
-  SortingParamsCodec,
-} from "@app/lib/api/pagination";
-import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
+  GetContentNodesOrChildrenRequestBody as ContentNodesBody,
+  getContentNodesForDataSourceView,
+} from "@app/lib/api/data_source_view";
+import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withDataSourceView } from "@front-api/middlewares/with_data_source_view";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
-
-const ContentNodesBody = z.object({
-  internalIds: z.array(z.string().nullable()).optional(),
-  parentId: z.string().optional(),
-  viewType: ContentNodesViewTypeCodec,
-  sorting: SortingParamsCodec.optional(),
-});
 
 // Mounted under
 // /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId/content-nodes.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -1,7 +1,7 @@
 import config from "@app/lib/api/config";
+import type { GetDataSourceViewDocumentResponseBody } from "@app/lib/api/data_source_view";
 import logger from "@app/logger/logger";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDocument } from "@app/types/core/data_source";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -13,10 +13,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   documentId: z.string(),
 });
-
-export type GetDataSourceViewDocumentResponseBody = {
-  document: CoreAPIDocument;
-};
 
 // Mounted under
 // /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId/documents/:documentId.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -1,11 +1,14 @@
 import config from "@app/lib/api/config";
+import type {
+  GetDataSourceViewResponseBody,
+  PatchDataSourceViewResponseBody,
+} from "@app/lib/api/data_source_view";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import logger from "@app/logger/logger";
 import { PatchDataSourceViewSchema } from "@app/types/api/public/spaces";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -17,16 +20,6 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import contentNodes from "./content-nodes";
 import documents from "./documents";
 import tables from "./tables";
-
-export type GetDataSourceViewResponseBody = {
-  dataSourceView: DataSourceViewType;
-  connector: ConnectorType | null;
-};
-
-export type PatchDataSourceViewResponseBody = {
-  dataSourceView: DataSourceViewType;
-  connector: ConnectorType | null;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
+import type { GetDataSourceViewTableResponseBody } from "@app/lib/api/tables";
 import logger from "@app/logger/logger";
-import type { CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -13,10 +13,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   tableId: z.string(),
 });
-
-export type GetDataSourceViewTableResponseBody = {
-  table: CoreAPITable;
-};
 
 // Mounted under
 // /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId/tables/:tableId.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -1,6 +1,6 @@
+import type { ListTablesResponseBody } from "@app/lib/api/data_source_view";
 import { getFlattenedContentNodesOfViewTypeForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -9,10 +9,7 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import tableId from "./[tableId]";
 import search from "./search";
 
-export type ListTablesResponseBody = {
-  tables: DataSourceViewContentNode[];
-  nextPageCursor: string | null;
-};
+export type { ListTablesResponseBody };
 
 // Mounted under /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId/tables.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
@@ -1,22 +1,15 @@
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
+import type { SearchTablesResponseBody } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import logger from "@app/logger/logger";
-import type { SearchWarningCode } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { withDataSourceView } from "@front-api/middlewares/with_data_source_view";
 import { withSpace } from "@front-api/middlewares/with_space";
-
-export type SearchTablesResponseBody = {
-  tables: DataSourceViewContentNode[];
-  nextPageCursor: string | null;
-  warningCode: SearchWarningCode | null;
-};
 
 // Mounted under
 // /api/w/:wId/spaces/:spaceId/data_source_views/:dsvId/tables/search.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -3,6 +3,10 @@ import {
   getDataSourcesUsageByCategory,
   getDataSourceViewsUsageByCategory,
 } from "@app/lib/api/agent_data_sources";
+import type {
+  GetSpaceDataSourceViewsResponseBody,
+  PostSpaceDataSourceViewsResponseBody,
+} from "@app/lib/api/data_source_view";
 import { augmentDataSourceWithConnectorDetails } from "@app/lib/api/data_sources";
 import { isManaged, isWebsite } from "@app/lib/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -10,10 +14,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { ContentSchema } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
-import type {
-  DataSourceViewsWithDetails,
-  DataSourceViewType,
-} from "@app/types/data_source_view";
+import type { DataSourceViewsWithDetails } from "@app/types/data_source_view";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -21,18 +22,6 @@ import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 
 import dsvId from "./[dsvId]";
-
-export type GetSpaceDataSourceViewsResponseBody<
-  IncludeDetails extends boolean = boolean,
-> = {
-  dataSourceViews: IncludeDetails extends true
-    ? DataSourceViewsWithDetails[]
-    : DataSourceViewType[];
-};
-
-export type PostSpaceDataSourceViewsResponseBody = {
-  dataSourceView: DataSourceViewType;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/data_source_views.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
@@ -1,7 +1,10 @@
 import config from "@app/lib/api/config";
+import type {
+  GetDataSourceConfigurationResponseBody,
+  PatchDataSourceConfigurationResponseBody,
+} from "@app/lib/api/data_sources";
 import { isWebsite } from "@app/lib/data_sources";
 import logger from "@app/logger/logger";
-import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
 import {
   ConnectorsAPI,
   UpdateConnectorConfigurationTypeSchema,
@@ -13,13 +16,6 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withDataSource } from "@front-api/middlewares/with_data_source";
 import { withSpace } from "@front-api/middlewares/with_space";
-
-export type GetDataSourceConfigurationResponseBody = {
-  configuration: ConnectorConfiguration;
-};
-
-export type PatchDataSourceConfigurationResponseBody =
-  GetDataSourceConfigurationResponseBody;
 
 // Mounted at /api/w/:wId/spaces/:spaceId/data_sources/:dsId/configuration.
 // Only Slack and Webcrawler connectors have configurations; Slack is set from

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,11 +1,10 @@
 import apiConfig from "@app/lib/api/config";
+import type { PatchDocumentResponseBody } from "@app/lib/api/data_sources";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { isManaged, isWebsite } from "@app/lib/data_sources";
 import logger from "@app/logger/logger";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types/api/public/data_sources";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPILightDocument } from "@app/types/core/data_source";
-import type { DocumentType } from "@app/types/document";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -17,10 +16,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   documentId: z.string(),
 });
-
-export type PatchDocumentResponseBody = {
-  document: DocumentType | CoreAPILightDocument;
-};
 
 // Mounted at /api/w/:wId/spaces/:spaceId/data_sources/:dsId/documents/:documentId.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -1,7 +1,6 @@
+import type { PostDocumentResponseBody } from "@app/lib/api/data_sources";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types/api/public/data_sources";
-import type { CoreAPILightDocument } from "@app/types/core/data_source";
-import type { DocumentType } from "@app/types/document";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -10,10 +9,6 @@ import { withDataSource } from "@front-api/middlewares/with_data_source";
 import { withSpace } from "@front-api/middlewares/with_space";
 
 import documentId from "./[documentId]";
-
-export type PostDocumentResponseBody = {
-  document: DocumentType | CoreAPILightDocument;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/data_sources/:dsId/documents.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -1,4 +1,5 @@
 import { upsertTable } from "@app/lib/api/data_sources";
+import type { PatchTableResponseBody } from "@app/lib/api/tables";
 import { deleteTable } from "@app/lib/api/tables";
 import { PatchDataSourceTableRequestBodySchema } from "@app/types/api/public/data_sources";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -13,10 +14,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   tableId: z.string(),
 });
-
-export type PatchTableResponseBody = {
-  table?: { table_id: string };
-};
 
 // Mounted at /api/w/:wId/spaces/:spaceId/data_sources/:dsId/tables/:tableId.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -4,8 +4,14 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
+import type {
+  PostDataSourceRequestBody,
+  PostSpaceDataSourceResponseBody,
+} from "@app/lib/api/data_sources";
 import {
   createDataSourceWithoutProvider,
+  PostDataSourceRequestBodySchema,
+  PostDataSourceWithProviderRequestBodySchema,
   registerSlackWebhookRouterEntry,
 } from "@app/lib/api/data_sources";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
@@ -30,16 +36,10 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
-import {
-  ConnectorConfigurationTypeSchema,
-  ConnectorsAPI,
-} from "@app/types/connectors/connectors_api";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { WebCrawlerConfigurationTypeSchema } from "@app/types/connectors/webcrawler";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";
-import type { DataSourceType } from "@app/types/data_source";
-import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { PlanType } from "@app/types/plan";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
@@ -51,37 +51,17 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 import type { Context } from "hono";
-import { z } from "zod";
+import type { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 import dsId from "./[dsId]";
 
-export const PostDataSourceWithProviderRequestBodySchema = z.object({
-  provider: z.enum(CONNECTOR_PROVIDERS),
-  name: z.string().optional(),
-  configuration: ConnectorConfigurationTypeSchema,
-  connectionId: z.string().optional(),
-  relatedCredentialId: z.string().optional(),
-  extraConfig: z.record(z.string(), z.string()).optional(),
-});
-
-const PostDataSourceWithoutProviderRequestBodySchema = z.object({
-  name: z.string(),
-  description: z.string().nullable(),
-});
-
-const PostDataSourceRequestBodySchema = z.union([
-  PostDataSourceWithoutProviderRequestBodySchema,
+export type { PostDataSourceRequestBody, PostSpaceDataSourceResponseBody };
+// Contract types and schemas are owned by `@app/lib/api/data_sources` and
+// re-exported here to preserve this module's public surface.
+export {
+  PostDataSourceRequestBodySchema,
   PostDataSourceWithProviderRequestBodySchema,
-]);
-
-export type PostDataSourceRequestBody = z.infer<
-  typeof PostDataSourceRequestBodySchema
->;
-
-export type PostSpaceDataSourceResponseBody = {
-  dataSource: DataSourceType;
-  dataSourceView: DataSourceViewType;
 };
 
 // Mounted under /api/w/:wId/spaces/:spaceId/data_sources.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -1,5 +1,9 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import type {
+  FileSystemEntry,
+  GetSpaceFilesResponseBody,
+  PostSpaceFolderResponseBody,
+} from "@app/lib/api/file_system/types";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { isGCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
@@ -15,14 +19,6 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import rel from "./[...rel]";
 
 export type { FileSystemEntry, GCSMountDirectoryEntry };
-
-export type GetSpaceFilesResponseBody = {
-  files: FileSystemEntry[];
-};
-
-export type PostSpaceFolderResponseBody = {
-  folder: GCSMountDirectoryEntry;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/files.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -4,6 +4,11 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type {
+  GetSpaceResponseBody,
+  PatchSpaceResponseBody,
+  SpaceCategoryInfo,
+} from "@app/lib/api/spaces";
 import { softDeleteSpaceAndLaunchScrubWorkflow } from "@app/lib/api/spaces";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -13,7 +18,6 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { PatchSpaceRequestBodySchema } from "@app/types/api/internal/spaces";
 import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
-import type { AgentsUsageType } from "@app/types/data_source";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { SpaceType } from "@app/types/space";
 import type { SpaceUserType } from "@app/types/user";
@@ -40,35 +44,6 @@ import projectTasks from "./project_tasks";
 import searchConversations from "./search_conversations";
 import star from "./star";
 import webhookSourceViews from "./webhook_source_views";
-
-export type SpaceCategoryInfo = {
-  usage: AgentsUsageType;
-  count: number;
-};
-
-export type RichSpaceType = SpaceType & {
-  categories: { [key: string]: SpaceCategoryInfo };
-  canWrite: boolean;
-  canRead: boolean;
-  isMember: boolean;
-  members: SpaceUserType[];
-  isEditor: boolean;
-  // Useful in case of projects
-  description: string | null;
-  archivedAt: number | null;
-  /** Background todo suggestions from project activity (project spaces only). */
-  todoGenerationEnabled: boolean;
-  lastTodoAnalysisAt: number | null;
-  pinnedFramePath: string | null;
-};
-
-export type GetSpaceResponseBody = {
-  space: RichSpaceType;
-};
-
-export type PatchSpaceResponseBody = {
-  space: SpaceType;
-};
 
 export type DeleteSpaceResponseBody = {
   space: SpaceType;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -1,6 +1,5 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
@@ -8,6 +7,10 @@ import {
 import { getActiveAdminEmails } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import type {
+  GetMCPServerViewsResponseBody,
+  PostMCPServerViewResponseBody,
+} from "@app/lib/resources/mcp_server_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -24,16 +27,6 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
 import svId from "./[svId]";
 import notActivated from "./not_activated";
-
-export type GetMCPServerViewsResponseBody = {
-  success: boolean;
-  serverViews: MCPServerViewType[];
-};
-
-export type PostMCPServerViewResponseBody = {
-  success: boolean;
-  serverView: MCPServerViewType;
-};
 
 const GetQueryParamsSchema = z.object({
   availability: z

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -1,15 +1,10 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { GetMCPServerViewsNotActivatedResponseBody } from "@app/lib/api/mcp";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
 import differenceWith from "lodash/differenceWith";
-
-export type GetMCPServerViewsNotActivatedResponseBody = {
-  success: boolean;
-  serverViews: MCPServerViewType[];
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/mcp_views/not_activated.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { PatchSpaceMembersRequestBodySchema } from "@app/lib/api/spaces/members";
 import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
@@ -12,30 +13,8 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
 
-const PatchSpaceMembersRequestBodySchema = z.intersection(
-  z.object({
-    isRestricted: z.boolean(),
-    name: z.string(),
-  }),
-  z.discriminatedUnion("managementMode", [
-    z.object({
-      memberIds: z.array(z.string()),
-      managementMode: z.literal("manual"),
-      editorIds: z.array(z.string()),
-    }),
-    z.object({
-      groupIds: z.array(z.string()),
-      managementMode: z.literal("group"),
-      editorGroupIds: z.array(z.string()),
-    }),
-  ])
-);
-
-export type PatchSpaceMembersRequestBodyType = z.infer<
-  typeof PatchSpaceMembersRequestBodySchema
->;
+export type { PatchSpaceMembersRequestBodyType } from "@app/lib/api/spaces/members";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/members.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -1,50 +1,21 @@
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   addContentNodeToProject,
+  type GetProjectContextResponseBody,
   listProjectContextAttachments,
+  PostProjectContextContentNodeBodySchema,
+  type PostProjectContextContentNodeFragment,
+  type PostProjectContextContentNodeResponseBody,
 } from "@app/lib/api/projects/context";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { ContentNodeType } from "@app/types/core/content_node";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
 
 import contentNodes from "./content_nodes";
 import files from "./files";
-
-export type GetProjectContextResponseBody = {
-  attachments: ConversationAttachmentType[];
-};
-
-export type PostProjectContextContentNodeResponseBody = {
-  contentFragments: PostProjectContextContentNodeFragment[];
-  errors: Array<{ index: number; message: string }>;
-};
-
-const PostProjectContextContentNodeItemSchema = z.object({
-  title: z.string().min(1, "title is required"),
-  nodeId: z.string().min(1, "nodeId is required"),
-  nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
-  url: z.string().nullable().optional(),
-  supersededContentFragmentId: z.string().nullable().optional(),
-});
-
-const PostProjectContextContentNodeBodySchema = z.object({
-  items: z.array(PostProjectContextContentNodeItemSchema),
-});
-
-export type PostProjectContextContentNodeFragment = {
-  sId: string;
-  title: string;
-  contentType: string;
-  nodeId: string;
-  nodeDataSourceViewId: string;
-  nodeType: ContentNodeType;
-};
 
 /** Lowercase + strip separators so "Hello World 4" matches query "helloworld". */
 function normalizeAttachmentSearchKey(s: string): string {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,3 +1,7 @@
+import type {
+  GetPodMetadataResponseBody,
+  PatchPodMetadataResponseBody,
+} from "@app/lib/api/projects/metadata";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import {
@@ -6,20 +10,11 @@ import {
   stopProjectTodoWorkflow,
 } from "@app/temporal/project_task/client";
 import { PatchPodMetadataBodySchema } from "@app/types/api/internal/spaces";
-import type { PodMetadataType } from "@app/types/project_metadata";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-
-export type GetPodMetadataResponseBody = {
-  projectMetadata: PodMetadataType | null;
-};
-
-export type PatchPodMetadataResponseBody = {
-  projectMetadata: PodMetadataType;
-};
 
 // Mounted under /api/w/:wId/spaces/:spaceId/project_metadata. All routes
 // require the space to be a project; this is checked inline per handler.

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -1,24 +1,14 @@
+import type {
+  GetUserPodNotificationPreferenceResponseBody,
+  PatchUserPodNotificationPreferenceResponseBody,
+} from "@app/lib/api/projects/preferences";
+import { PatchUserPodNotificationPreferenceBodySchema } from "@app/lib/api/projects/preferences";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
-import type { UserPodNotificationPreference } from "@app/types/notification_preferences";
-import { NOTIFICATION_CONDITION_OPTIONS } from "@app/types/notification_preferences";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
-
-export type GetUserPodNotificationPreferenceResponseBody = {
-  userProjectNotificationPreference: UserPodNotificationPreference | null;
-};
-
-export type PatchUserPodNotificationPreferenceResponseBody = {
-  userProjectNotificationPreference: UserPodNotificationPreference | null;
-};
-
-const PatchUserPodNotificationPreferenceBodySchema = z.object({
-  preference: z.enum(NOTIFICATION_CONDITION_OPTIONS),
-});
 
 // Mounted under /api/w/:wId/spaces/:spaceId/project_notification_preferences.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
@@ -1,27 +1,10 @@
+import { BulkActionsBodySchema } from "@app/lib/api/projects/tasks";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
-import { POD_TASK_STATUSES } from "@app/types/project_task";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
-
-const BulkActionsBodySchema = z.discriminatedUnion("action", [
-  z.object({
-    action: z.literal("set_status"),
-    taskIds: z.array(z.string().min(1)).min(1).max(200),
-    status: z.enum(POD_TASK_STATUSES),
-  }),
-  z.object({
-    action: z.literal("approve_agent_suggestion"),
-    taskIds: z.array(z.string().min(1)).min(1).max(200),
-  }),
-  z.object({
-    action: z.literal("reject_agent_suggestion"),
-    taskIds: z.array(z.string().min(1)).min(1).max(200),
-  }),
-]);
 
 // Mounted under /api/w/:wId/spaces/:spaceId/project_tasks/bulk-actions.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -1,3 +1,4 @@
+import type { SearchConversationsResponseBody } from "@app/lib/api/projects/search";
 import { searchProjectConversations } from "@app/lib/api/projects/search";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -8,10 +9,6 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
-
-export type SearchConversationsResponseBody = {
-  conversations: ConversationWithoutContentType[];
-};
 
 const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.1;
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/star.ts
@@ -1,21 +1,11 @@
+import type { PostUserPodStarResponseBody } from "@app/lib/api/projects/preferences";
+import { PostUserPodStarBodySchema } from "@app/lib/api/projects/preferences";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
-
-export type PostUserPodStarResponseBody = {
-  sId: string;
-  spaceId: string;
-  userId: string;
-  isStarred: boolean;
-};
-
-const PostUserPodStarBodySchema = z.object({
-  starred: z.boolean(),
-});
 
 // Mounted under /api/w/:wId/spaces/:spaceId/star.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -1,29 +1,18 @@
+import type {
+  GetWebhookSourceViewsResponseBody,
+  PostWebhookSourceViewResponseBody,
+} from "@app/lib/api/webhook_source";
+import { PostWebhookSourceViewBodySchema } from "@app/lib/api/webhook_source";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import type { SpaceKind } from "@app/types/space";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
-import { z } from "zod";
 
 import webhookSourceViewId from "./[webhookSourceViewId]";
-
-export type GetWebhookSourceViewsResponseBody = {
-  success: boolean;
-  webhookSourceViews: WebhookSourceViewType[];
-};
-
-export type PostWebhookSourceViewResponseBody = {
-  success: boolean;
-  webhookSourceView: WebhookSourceViewType;
-};
-
-const PostWebhookSourceViewBodySchema = z.object({
-  webhookSourceId: z.string(),
-});
 
 // Mounted under /api/w/:wId/spaces/:spaceId/webhook_source_views.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/check-name.ts
+++ b/front-api/routes/w/[wId]/spaces/check-name.ts
@@ -1,11 +1,8 @@
+import type { CheckNameResponseBody } from "@app/lib/api/spaces";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type CheckNameResponseBody = {
-  available: boolean;
-};
 
 // Mounted under /api/w/:wId/spaces/check-name.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/index.test.ts
@@ -6,7 +6,8 @@ const { mockCreateSpaceAndGroup } = vi.hoisted(() => ({
   mockCreateSpaceAndGroup: vi.fn(),
 }));
 
-vi.mock("@app/lib/api/spaces", () => ({
+vi.mock("@app/lib/api/spaces", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/spaces")>()),
   createSpaceAndGroup: mockCreateSpaceAndGroup,
 }));
 

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -4,7 +4,15 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
-import { createSpaceAndGroup } from "@app/lib/api/spaces";
+import type {
+  GetSpacesResponseBody,
+  PostSpaceRequestBodyType,
+  PostSpacesResponseBody,
+} from "@app/lib/api/spaces";
+import {
+  createSpaceAndGroup,
+  PostSpaceRequestBodySchema,
+} from "@app/lib/api/spaces";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -13,40 +21,15 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
 import spaceId from "./[spaceId]";
 import checkName from "./check-name";
 import projectsLookup from "./projects-lookup";
 import searchProjects from "./search_projects";
 
-const PostSpaceRequestBodySchema = z.intersection(
-  z.object({
-    isRestricted: z.boolean(),
-    name: z.string(),
-    spaceKind: z.enum(["regular", "project"]),
-  }),
-  z.discriminatedUnion("managementMode", [
-    z.object({
-      memberIds: z.array(z.string()),
-      managementMode: z.literal("manual"),
-    }),
-    z.object({
-      groupIds: z.array(z.string()),
-      managementMode: z.literal("group"),
-    }),
-  ])
-);
-
-export type PostSpaceRequestBodyType = z.infer<
-  typeof PostSpaceRequestBodySchema
->;
-
-export type GetSpacesResponseBody = {
-  spaces: (SpaceType | PodType)[];
-};
-
-export type PostSpacesResponseBody = {
-  space: SpaceType;
+export type {
+  GetSpacesResponseBody,
+  PostSpaceRequestBodyType,
+  PostSpacesResponseBody,
 };
 
 // Mounted under /api/w/:wId/spaces. workspaceAuth is applied by the parent

--- a/front-api/routes/w/[wId]/spaces/projects-lookup.ts
+++ b/front-api/routes/w/[wId]/spaces/projects-lookup.ts
@@ -1,13 +1,11 @@
-import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import {
+  enrichProjectsWithMetadata,
+  type SpacesLookupResponseBody,
+} from "@app/lib/api/projects/list";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { PodType } from "@app/types/space";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type SpacesLookupResponseBody = {
-  spaces: PodType[];
-};
 
 // Mounted under /api/w/:wId/spaces/projects-lookup.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/spaces/search_projects.ts
+++ b/front-api/routes/w/[wId]/spaces/search_projects.ts
@@ -1,17 +1,13 @@
 import { getPaginationParams } from "@app/lib/api/pagination";
-import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import {
+  enrichProjectsWithMetadata,
+  type SearchProjectsResponseBody,
+} from "@app/lib/api/projects/list";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import type { PodType } from "@app/types/space";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type SearchProjectsResponseBody = {
-  spaces: Array<PodType & { isMember: boolean }>;
-  hasMore: boolean;
-  lastValue: string | null;
-};
 
 // Mounted under /api/w/:wId/spaces/search_projects.
 const app = workspaceApp();

--- a/front/components/agent_builder/shared/tables.ts
+++ b/front/components/agent_builder/shared/tables.ts
@@ -1,10 +1,10 @@
-import type { FetcherWithBodyFn } from "@app/lib/swr/fetcher";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import type {
   GetContentNodesOrChildrenRequestBodyType,
   GetDataSourceViewContentNodes,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
+} from "@app/lib/api/data_source_view";
+import type { FetcherWithBodyFn } from "@app/lib/swr/fetcher";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { LightContentNode } from "@app/types/api/public/spaces";
 import type { DataSourceType } from "@app/types/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -13,6 +13,10 @@ import type {
   PostTriggersRequestBody,
 } from "@app/lib/api/assistant/configuration/triggers";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import type {
+  GetContentNodesOrChildrenRequestBodyType,
+  GetDataSourceViewContentNodes,
+} from "@app/lib/api/data_source_view";
 import { clientFetch } from "@app/lib/egress/client";
 import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
 import type { FetcherWithBodyFn } from "@app/lib/swr/fetcher";
@@ -23,10 +27,6 @@ import {
 } from "@app/lib/tracking";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import datadogLogger from "@app/logger/datadogLogger";
-import type {
-  GetContentNodesOrChildrenRequestBodyType,
-  GetDataSourceViewContentNodes,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
 import type {
   DataSourcesConfigurationsCodecType,
   PostOrPatchAgentConfigurationRequestBody,

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -15,6 +15,10 @@ import {
   usePodConversationsSummary,
 } from "@app/hooks/conversations";
 import { useTaskDiffAnimations } from "@app/hooks/useTaskDiffAnimations";
+import type {
+  BulkActionsBody,
+  GetPodTasksResponseBody,
+} from "@app/lib/api/projects/tasks";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { comparePodTaskAssignees } from "@app/lib/project_task/display_order";
@@ -29,8 +33,6 @@ import {
 } from "@app/lib/swr/pods";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { BulkActionsBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions";
-import type { GetPodTasksResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import {
   POD_TASK_UNASSIGNED_GROUP_KEY,

--- a/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
+++ b/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
@@ -1,5 +1,5 @@
+import type { GetNotionWebhookConfigResponseBody } from "@app/lib/api/data_sources/managed_notion";
 import { clientFetch } from "@app/lib/egress/client";
-import type { GetNotionWebhookConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config";
 import type { DataSourceType } from "@app/types/data_source";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { NotificationType } from "@dust-tt/sparkle";

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -11,10 +11,10 @@ import { usePodUnreadConversationIds } from "@app/hooks/conversations";
 import type { PodConversationListFilter } from "@app/hooks/conversations/usePodConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchPodConversations } from "@app/hooks/useSearchPodConversations";
+import type { GetSpaceResponseBody } from "@app/lib/api/spaces";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type {
   ConversationWithoutContentType,
   LightConversationType,

--- a/front/components/pod/conversation/PodPinnedBanner.tsx
+++ b/front/components/pod/conversation/PodPinnedBanner.tsx
@@ -1,11 +1,11 @@
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import { useScopedPodUiPreferences } from "@app/hooks/useScopedUIPreferences";
+import type { RichSpaceType } from "@app/lib/api/spaces";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useFileContent } from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
 import logger from "@app/logger/logger";
-import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -5,6 +5,7 @@ import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettings
 import { SuggestedTasksGenerationTile } from "@app/components/pod/settings/SuggestedTasksGenerationTile";
 import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useArchivePod } from "@app/hooks/useArchivePod";
+import type { RichSpaceType } from "@app/lib/api/spaces";
 import {
   useCheckPodName,
   usePodMetadata,
@@ -13,7 +14,6 @@ import {
 import { useSpaceInfo, useUpdateSpace } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
-import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { PatchPodMetadataBodyType } from "@app/types/api/internal/spaces";
 import { PatchPodMetadataBodySchema } from "@app/types/api/internal/spaces";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/components/pod/settings/SuggestedTasksGenerationTile.tsx
+++ b/front/components/pod/settings/SuggestedTasksGenerationTile.tsx
@@ -1,10 +1,10 @@
 import { FirstSyncTaskLookbackForm } from "@app/components/assistant/conversation/space/FirstSyncTaskLookbackForm";
 import { ConfirmContext } from "@app/components/Confirm";
 import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettingsOptionLabel";
+import type { RichSpaceType } from "@app/lib/api/spaces";
 import type { InitialTasksSyncLookbackValue } from "@app/lib/project_task/analyze_document/types";
 import { useUpdatePodMetadata } from "@app/lib/swr/pods";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Chip,

--- a/front/components/shared/labels/types.ts
+++ b/front/components/shared/labels/types.ts
@@ -1,5 +1,5 @@
+import type { MicrosoftSensitivityLabel } from "@app/lib/api/data_classification_labels";
 import type { MicrosoftAllowedLabel } from "@app/lib/models/workspace_sensitivity_label_config";
-import type { MicrosoftSensitivityLabel } from "@app/pages/api/w/[wId]/data-classification-labels";
 
 export type SensitivityLabelSource =
   | { dataSourceId: string; internalMCPServerId?: never }

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -3,6 +3,7 @@ import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_sour
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PostDataSourceRequestBody } from "@app/lib/api/data_sources";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
@@ -23,7 +24,6 @@ import {
   trackEvent,
   withTracking,
 } from "@app/lib/tracking";
-import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
   ConnectorProvider,
   ConnectorType,

--- a/front/components/spaces/ConfirmDeleteSpaceDialog.tsx
+++ b/front/components/spaces/ConfirmDeleteSpaceDialog.tsx
@@ -1,5 +1,5 @@
+import type { SpaceCategoryInfo } from "@app/lib/api/spaces";
 import { getSpaceName } from "@app/lib/spaces";
-import type { SpaceCategoryInfo } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { SpaceType } from "@app/types/space";
 import {
   Button,

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -3,6 +3,7 @@ import type { SearchMemberType } from "@app/components/members/MemberSelectionTa
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
+import type { SpaceCategoryInfo } from "@app/lib/api/spaces";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
@@ -12,7 +13,6 @@ import {
   useSpaceInfo,
   useUpdateSpace,
 } from "@app/lib/swr/spaces";
-import type { SpaceCategoryInfo } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { GroupType } from "@app/types/groups";
 import type { PlanType } from "@app/types/plan";
 import type { SpaceType } from "@app/types/space";

--- a/front/components/spaces/SpaceCreateAppModal.tsx
+++ b/front/components/spaces/SpaceCreateAppModal.tsx
@@ -1,9 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PostAppResponseBody } from "@app/lib/api/apps";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useApps } from "@app/lib/swr/apps";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
-import type { PostAppResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import type { APIError } from "@app/types/error";
 import type { SpaceType } from "@app/types/space";

--- a/front/components/workspace/settings/BotToggle.tsx
+++ b/front/components/workspace/settings/BotToggle.tsx
@@ -1,9 +1,9 @@
 import { updateConnectorConnectionId } from "@app/components/data_source/ConnectorPermissionsModal";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PostDataSourceRequestBody } from "@app/lib/api/data_sources";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig, useToggleChatBot } from "@app/lib/swr/connectors";
-import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type { ConnectorProvider, DataSourceType } from "@app/types/data_source";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { OAuthProvider, OAuthUseCase } from "@app/types/oauth/lib";

--- a/front/hooks/useSearchPodConversations.ts
+++ b/front/hooks/useSearchPodConversations.ts
@@ -1,6 +1,6 @@
 import { useDebounce } from "@app/hooks/useDebounce";
+import type { SearchConversationsResponseBody } from "@app/lib/api/projects/search";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { SearchConversationsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/search_conversations";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";

--- a/front/hooks/useSearchPods.ts
+++ b/front/hooks/useSearchPods.ts
@@ -1,9 +1,9 @@
+import type { SearchProjectsResponseBody } from "@app/lib/api/projects/lookup";
 import {
   emptyArray,
   useFetcher,
   useSWRInfiniteWithDefaults,
 } from "@app/lib/swr/swr";
-import type { SearchProjectsResponseBody } from "@app/pages/api/w/[wId]/spaces/search_projects";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -30,6 +30,10 @@ const DISABLE_QUERIES = false;
 
 export type DataSourcesUsageByAgent = Record<ModelId, AgentsUsageType | null>;
 
+export type GetDataSourceUsageResponseBody = {
+  usage: AgentsUsageType;
+};
+
 const AGENT_CONFIG_PATH =
   '"agent_mcp_server_configuration->agent_configuration"';
 

--- a/front/lib/api/apps.ts
+++ b/front/lib/api/apps.ts
@@ -4,7 +4,9 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
+import type { RunType } from "@app/types/run";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -12,6 +14,44 @@ import type { LightWorkspaceType } from "@app/types/user";
 type AppDeploymentCheck = {
   appId: string;
   appHash: string;
+};
+
+export type GetAppsResponseBody = {
+  apps: AppType[];
+};
+
+export type PostAppResponseBody = {
+  app: AppType;
+};
+
+export type GetOrPostAppResponseBody = {
+  app: AppType;
+};
+
+export type GetRunsResponseBody = {
+  runs: RunType[];
+  total: number;
+};
+
+export type PostRunsResponseBody = {
+  run: RunType;
+};
+
+export type GetRunResponseBody = {
+  run: RunType;
+  spec: SpecificationType;
+};
+
+export type GetRunBlockResponseBody = {
+  run: RunType | null;
+};
+
+export type PostRunCancelResponseBody = {
+  success: boolean;
+};
+
+export type GetRunStatusResponseBody = {
+  run: RunType | null;
 };
 
 export async function softDeleteApp(

--- a/front/lib/api/data_classification_labels.ts
+++ b/front/lib/api/data_classification_labels.ts
@@ -18,6 +18,11 @@ export type MicrosoftSensitivityLabel = {
   name: string;
 };
 
+export type DataClassificationLabelsResponseBody = {
+  labels: MicrosoftSensitivityLabel[];
+  allowedLabels: MicrosoftAllowedLabel[];
+};
+
 const AllowedLabelsConfigSchema = z.array(z.string());
 
 export function parseAllowedLabelsConfig(

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -8,6 +8,7 @@ import type {
   CursorPaginationParams,
   SortingParams,
 } from "@app/lib/api/pagination";
+import { SortingParamsCodec } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -15,17 +16,24 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { PatchDataSourceViewType } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
+import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
-import type { CoreAPIDatasourceViewFilter } from "@app/types/core/core_api";
+import type {
+  CoreAPIDatasourceViewFilter,
+  SearchWarningCode,
+} from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { AgentsUsageType } from "@app/types/data_source";
+import type { CoreAPIDocument } from "@app/types/core/data_source";
+import type { AgentsUsageType, ConnectorType } from "@app/types/data_source";
 import type {
   DataSourceViewContentNode,
+  DataSourceViewsWithDetails,
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
 
 const DEFAULT_PAGINATION_LIMIT = 1000;
 const CORE_MAX_PAGE_SIZE = 1000;
@@ -363,3 +371,66 @@ export async function listDataSourceViewsWithUsage(
     { concurrency: 4 }
   );
 }
+
+// Contract types for the data source view API endpoints. These are the
+// request/response body shapes shared between the Next handlers under
+// `pages/api/.../data_source_views/*` and their Hono counterparts under
+// `front-api/routes/.../data_source_views/*`.
+
+export type GetDataSourceViewsResponseBody = {
+  dataSourceViews: DataSourceViewType[];
+};
+
+export type GetSpaceDataSourceViewsResponseBody<
+  IncludeDetails extends boolean = boolean,
+> = {
+  dataSourceViews: IncludeDetails extends true
+    ? DataSourceViewsWithDetails[]
+    : DataSourceViewType[];
+};
+
+export type PostSpaceDataSourceViewsResponseBody = {
+  dataSourceView: DataSourceViewType;
+};
+
+export type GetDataSourceViewResponseBody = {
+  dataSourceView: DataSourceViewType;
+  connector: ConnectorType | null;
+};
+
+export type PatchDataSourceViewResponseBody = {
+  dataSourceView: DataSourceViewType;
+  connector: ConnectorType | null;
+};
+
+export const GetContentNodesOrChildrenRequestBody = z.object({
+  internalIds: z.array(z.string().nullable()).optional(),
+  parentId: z.string().optional(),
+  viewType: ContentNodesViewTypeCodec,
+  sorting: SortingParamsCodec.optional(),
+});
+export type GetContentNodesOrChildrenRequestBodyType = z.infer<
+  typeof GetContentNodesOrChildrenRequestBody
+>;
+
+export type GetDataSourceViewContentNodes = {
+  nodes: DataSourceViewContentNode[];
+  total: number;
+  totalIsAccurate: boolean;
+  nextPageCursor: string | null;
+};
+
+export type GetDataSourceViewDocumentResponseBody = {
+  document: CoreAPIDocument;
+};
+
+export type ListTablesResponseBody = {
+  tables: DataSourceViewContentNode[];
+  nextPageCursor: string | null;
+};
+
+export type SearchTablesResponseBody = {
+  tables: DataSourceViewContentNode[];
+  nextPageCursor: string | null;
+  warningCode: SearchWarningCode | null;
+};

--- a/front/lib/api/data_source_view_tags.ts
+++ b/front/lib/api/data_source_view_tags.ts
@@ -1,0 +1,12 @@
+import type { CoreAPISearchTagsResponse } from "@app/types/core/core_api";
+import { z } from "zod";
+
+export const PostTagSearchBodySchema = z.object({
+  query: z.string(),
+  queryType: z.enum(["exact", "prefix", "match"]),
+  dataSourceViewIds: z.array(z.string()),
+});
+
+export type PostTagSearchBody = z.infer<typeof PostTagSearchBodySchema>;
+
+export type PostTagSearchResponseBody = CoreAPISearchTagsResponse;

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -37,7 +37,11 @@ import type { FrontDataSourceDocumentSectionType } from "@app/types/api/public/d
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import type { AdminCommandType } from "@app/types/connectors/admin/cli";
-import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
+import {
+  ConnectorConfigurationTypeSchema,
+  ConnectorsAPI,
+} from "@app/types/connectors/connectors_api";
 import type { CoreAPIError, CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import type {
@@ -56,7 +60,12 @@ import type {
   DataSourceWithConnectorDetailsType,
   WithConnector,
 } from "@app/types/data_source";
-import { isDataSourceNameValid } from "@app/types/data_source";
+import {
+  CONNECTOR_PROVIDERS,
+  isDataSourceNameValid,
+} from "@app/types/data_source";
+import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { DocumentType } from "@app/types/document";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { PlanType } from "@app/types/plan";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
@@ -74,7 +83,53 @@ import type {
 } from "@dust-tt/client";
 import assert from "assert";
 import type { Transaction } from "sequelize";
+import { z } from "zod";
 import { ConversationResource } from "../resources/conversation_resource";
+
+// Contract types for the spaces data source endpoints (Next + Hono).
+
+export const PostDataSourceWithProviderRequestBodySchema = z.object({
+  provider: z.enum(CONNECTOR_PROVIDERS),
+  name: z.string().optional(),
+  configuration: ConnectorConfigurationTypeSchema,
+  connectionId: z.string().optional(), // Required for some providers
+  relatedCredentialId: z.string().optional(), // Required for private integrations
+  extraConfig: z.record(z.string(), z.string()).optional(), // Used by slack private integrations
+});
+
+const PostDataSourceWithoutProviderRequestBodySchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+});
+
+export const PostDataSourceRequestBodySchema = z.union([
+  PostDataSourceWithoutProviderRequestBodySchema,
+  PostDataSourceWithProviderRequestBodySchema,
+]);
+
+export type PostDataSourceRequestBody = z.infer<
+  typeof PostDataSourceRequestBodySchema
+>;
+
+export type PostSpaceDataSourceResponseBody = {
+  dataSource: DataSourceType;
+  dataSourceView: DataSourceViewType;
+};
+
+export type GetDataSourceConfigurationResponseBody = {
+  configuration: ConnectorConfiguration;
+};
+
+export type PatchDataSourceConfigurationResponseBody =
+  GetDataSourceConfigurationResponseBody;
+
+export type PostDocumentResponseBody = {
+  document: DocumentType | CoreAPILightDocument;
+};
+
+export type PatchDocumentResponseBody = {
+  document: DocumentType | CoreAPILightDocument;
+};
 
 const CORE_UNKNOWN_DATA_SOURCE_DELETE_ERROR_PREFIX =
   "Failed to delete data source (error: Unknown DataSource: ";

--- a/front/lib/api/data_sources/bot_data_sources.ts
+++ b/front/lib/api/data_sources/bot_data_sources.ts
@@ -1,0 +1,7 @@
+import type { DataSourceType } from "@app/types/data_source";
+
+export type GetBotDataSourcesResponseBody = {
+  slackBotDataSource: DataSourceType | null;
+  microsoftBotDataSource: DataSourceType | null;
+  discordBotDataSource: DataSourceType | null;
+};

--- a/front/lib/api/data_sources/managed_config.ts
+++ b/front/lib/api/data_sources/managed_config.ts
@@ -1,0 +1,11 @@
+// Contract types and schemas for the managed data source config endpoints.
+
+import { z } from "zod";
+
+export type GetOrPostManagedDataSourceConfigResponseBody = {
+  configValue: string;
+};
+
+export const PostManagedDataSourceConfigRequestBodySchema = z.object({
+  configValue: z.string(),
+});

--- a/front/lib/api/data_sources/managed_notion.ts
+++ b/front/lib/api/data_sources/managed_notion.ts
@@ -1,0 +1,4 @@
+export type GetNotionWebhookConfigResponseBody = {
+  webhookUrl: string;
+  verificationToken: string | null;
+};

--- a/front/lib/api/data_sources/managed_permissions.ts
+++ b/front/lib/api/data_sources/managed_permissions.ts
@@ -1,6 +1,10 @@
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
-import type { ContentNode } from "@app/types/connectors/connectors_api";
+import type {
+  ConnectorPermission,
+  ContentNode,
+  ContentNodeWithParent,
+} from "@app/types/connectors/connectors_api";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
 import type { Result } from "@app/types/shared/result";
@@ -25,6 +29,16 @@ export type ManagedPermissionsError =
   | { type: "connector_rate_limit" }
   | { type: "connector_authorization_error" }
   | { type: "internal_error" };
+
+export type GetDataSourcePermissionsResponseBody<
+  T extends ConnectorPermission = ConnectorPermission,
+> = {
+  resources: (T extends "read" ? ContentNodeWithParent : ContentNode)[];
+};
+
+export type SetDataSourcePermissionsResponseBody = {
+  success: true;
+};
 
 export async function getManagedDataSourcePermissions(
   connectorId: string,

--- a/front/lib/api/data_sources/request_access.ts
+++ b/front/lib/api/data_sources/request_access.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const PostRequestAccessBodySchema = z.object({
+  emailMessage: z.string(),
+  dataSourceId: z.string(),
+});
+
+export type PostRequestAccessBody = z.infer<typeof PostRequestAccessBodySchema>;

--- a/front/lib/api/datasets.ts
+++ b/front/lib/api/datasets.ts
@@ -6,6 +6,32 @@ import logger from "@app/logger/logger";
 import type { AppType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { DatasetSchema, DatasetType } from "@app/types/dataset";
+import { z } from "zod";
+
+export type GetDatasetsResponseBody = {
+  datasets: DatasetType[];
+};
+
+export type PostDatasetResponseBody = {
+  dataset: DatasetType;
+};
+
+export type GetDatasetResponseBody = { dataset: DatasetType };
+
+export const PostDatasetRequestBodySchema = z.object({
+  dataset: z.object({
+    name: z.string(),
+    description: z.string().nullable(),
+    data: z.array(z.record(z.string(), z.any())),
+  }),
+  schema: z.array(
+    z.object({
+      key: z.string(),
+      type: z.enum(["string", "number", "boolean", "json"]),
+      description: z.string().nullable(),
+    })
+  ),
+});
 
 export async function getDatasets(
   auth: Authenticator,

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -8,6 +8,8 @@
  * sandbox mount point, backward-compat aliases, and per-mount permissions.
  */
 
+import type { GCSMountDirectoryEntry } from "@app/lib/api/files/gcs_mount/files";
+
 export type FileSystemMountKind = "conversation" | "pod";
 
 /** Canonical scoped-path prefixes (include the trailing dash). */
@@ -92,3 +94,11 @@ export class DustFileSystemError extends Error {
     this.name = "DustFileSystemError";
   }
 }
+
+export type GetSpaceFilesResponseBody = {
+  files: FileSystemEntry[];
+};
+
+export type PostSpaceFolderResponseBody = {
+  folder: GCSMountDirectoryEntry;
+};

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -22,6 +22,7 @@ import logger from "@app/logger/logger";
 import type { CoreAPIDataSourceDocumentSection } from "@app/types/core/data_source";
 import type {
   AllSupportedFileContentType,
+  FileType,
   FileUseCase,
 } from "@app/types/files";
 import {
@@ -40,6 +41,20 @@ import {
   isSupportedPlainTextContentType,
   // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 } from "@dust-tt/client";
+
+export interface UpsertFileToDataSourceRequestBody {
+  fileId: string;
+  upsertArgs?:
+    | Pick<UpsertDocumentArgs, "document_id" | "title" | "tags">
+    | Pick<
+        UpsertTableArgs,
+        "name" | "title" | "description" | "tags" | "tableId"
+      >;
+}
+
+export interface UpsertFileToDataSourceResponseBody {
+  file: FileType;
+}
 
 // Upload to dataSource
 const upsertDocumentToDatasource: ProcessingFunction = async (

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -162,3 +162,8 @@ export type MCPServerTypeWithViews = MCPServerType & {
 };
 
 export type DeveloperSecretSelectionType = "required" | "optional";
+
+export type GetMCPServerViewsNotActivatedResponseBody = {
+  success: boolean;
+  serverViews: MCPServerViewType[];
+};

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -41,6 +41,38 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { Op } from "sequelize";
+import { z } from "zod";
+
+/** GET: project context (file-backed + content-node fragments). */
+export type GetProjectContextResponseBody = {
+  attachments: ConversationAttachmentType[];
+};
+
+export const PostProjectContextContentNodeItemSchema = z.object({
+  title: z.string().min(1, "title is required"),
+  nodeId: z.string().min(1, "nodeId is required"),
+  nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
+  url: z.string().nullable().optional(),
+  supersededContentFragmentId: z.string().nullable().optional(),
+});
+
+export const PostProjectContextContentNodeBodySchema = z.object({
+  items: z.array(PostProjectContextContentNodeItemSchema),
+});
+
+export type PostProjectContextContentNodeFragment = {
+  sId: string;
+  title: string;
+  contentType: string;
+  nodeId: string;
+  nodeDataSourceViewId: string;
+  nodeType: ContentNodeType;
+};
+
+export type PostProjectContextContentNodeResponseBody = {
+  contentFragments: PostProjectContextContentNodeFragment[];
+  errors: Array<{ index: number; message: string }>;
+};
 
 /**
  * Folder internal id under which conversation transcripts are indexed in the dust_project

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -3,6 +3,16 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { PodType, SpaceType } from "@app/types/space";
 
+export type SpacesLookupResponseBody = {
+  spaces: PodType[];
+};
+
+export type SearchProjectsResponseBody = {
+  spaces: Array<PodType & { isMember: boolean }>;
+  hasMore: boolean;
+  lastValue: string | null;
+};
+
 /**
  * Spaces the user is a member of, with project metadata loaded, excluding
  * archived projects.

--- a/front/lib/api/projects/lookup.ts
+++ b/front/lib/api/projects/lookup.ts
@@ -1,0 +1,4 @@
+export type {
+  SearchProjectsResponseBody,
+  SpacesLookupResponseBody,
+} from "@app/lib/api/projects/list";

--- a/front/lib/api/projects/metadata.ts
+++ b/front/lib/api/projects/metadata.ts
@@ -1,0 +1,9 @@
+import type { PodMetadataType } from "@app/types/project_metadata";
+
+export type GetPodMetadataResponseBody = {
+  projectMetadata: PodMetadataType | null;
+};
+
+export type PatchPodMetadataResponseBody = {
+  projectMetadata: PodMetadataType;
+};

--- a/front/lib/api/projects/preferences.ts
+++ b/front/lib/api/projects/preferences.ts
@@ -1,0 +1,28 @@
+import {
+  NOTIFICATION_CONDITION_OPTIONS,
+  type UserPodNotificationPreference,
+} from "@app/types/notification_preferences";
+import { z } from "zod";
+
+export type PostUserPodStarResponseBody = {
+  sId: string;
+  spaceId: string;
+  userId: string;
+  isStarred: boolean;
+};
+
+export const PostUserPodStarBodySchema = z.object({
+  starred: z.boolean(),
+});
+
+export type GetUserPodNotificationPreferenceResponseBody = {
+  userProjectNotificationPreference: UserPodNotificationPreference | null;
+};
+
+export type PatchUserPodNotificationPreferenceResponseBody = {
+  userProjectNotificationPreference: UserPodNotificationPreference | null;
+};
+
+export const PatchUserPodNotificationPreferenceBodySchema = z.object({
+  preference: z.enum(NOTIFICATION_CONDITION_OPTIONS),
+});

--- a/front/lib/api/projects/search.ts
+++ b/front/lib/api/projects/search.ts
@@ -8,11 +8,28 @@ import { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+export const SearchConversationsQuerySchema = z.object({
+  query: z.string().min(1, "Query parameter is required and cannot be empty"),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1, "Limit must be at least 1")
+    .max(100, "Limit must be at most 100")
+    .optional()
+    .default(10),
+});
+
+export type SearchConversationsResponseBody = {
+  conversations: ConversationWithoutContentType[];
+};
 
 export interface SearchProjectConversationsOptions {
   query: string;

--- a/front/lib/api/projects/tasks.ts
+++ b/front/lib/api/projects/tasks.ts
@@ -1,0 +1,84 @@
+// Shared contract types and schemas for the project_tasks API endpoints.
+// Imported by both the Next.js handlers (front/pages/api/...) and their Hono
+// counterparts (front-api/routes/...) so there is a single source of truth.
+import type { PodTaskType } from "@app/types/project_task";
+import { POD_TASK_STATUSES } from "@app/types/project_task";
+import { z } from "zod";
+
+export const PatchProjectTaskBodySchema = z
+  .object({
+    text: z
+      .string()
+      .min(1, "Text cannot be empty.")
+      .max(256, "Text must be at most 256 characters.")
+      .optional(),
+    status: z.enum(POD_TASK_STATUSES).optional(),
+    assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
+  })
+  .refine(
+    (data) =>
+      data.text !== undefined ||
+      data.status !== undefined ||
+      data.assigneeUserId !== undefined,
+    {
+      message:
+        "At least one of text, status, or assigneeUserId must be provided.",
+    }
+  );
+
+export interface PatchPodTaskResponseBody {
+  task: PodTaskType;
+}
+
+export type DeletePodTaskResponseBody = never;
+
+export const PostStartPodTaskBodySchema = z.object({
+  customMessage: z.string().optional(),
+  agentConfigurationId: z.string().optional(),
+});
+
+export interface PostStartPodTaskResponseBody {
+  task: PodTaskType;
+}
+
+export type BulkActionsResponse = {
+  success: boolean;
+};
+
+export const BulkActionsBodySchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("set_status"),
+    taskIds: z.array(z.string().min(1)).min(1).max(200),
+    status: z.enum(POD_TASK_STATUSES),
+  }),
+  z.object({
+    action: z.literal("approve_agent_suggestion"),
+    taskIds: z.array(z.string().min(1)).min(1).max(200),
+  }),
+  z.object({
+    action: z.literal("reject_agent_suggestion"),
+    taskIds: z.array(z.string().min(1)).min(1).max(200),
+  }),
+]);
+
+export type BulkActionsBody = z.infer<typeof BulkActionsBodySchema>;
+
+export const PostPodTaskBodySchema = z.object({
+  text: z
+    .string()
+    .trim()
+    .min(1, "Text is required.")
+    .max(256, "Text must be at most 256 characters."),
+  /** Omit to assign to the current user; pass `null` for unassigned (or the sole assignable member if the pod has exactly one). */
+  assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
+});
+
+export interface GetPodTasksResponseBody {
+  tasks: PodTaskType[];
+  lastReadAt: string | null;
+  viewerUserId: string | null;
+}
+
+export interface PostPodTaskResponseBody {
+  task: PodTaskType;
+}

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -21,6 +21,15 @@ import { recomputeIndents, restoreTripleBackticks } from "../specification";
 
 export type RunTrace = [[BlockType, string], TraceType[][]];
 
+export type {
+  GetRunBlockResponseBody,
+  GetRunResponseBody,
+  GetRunStatusResponseBody,
+  GetRunsResponseBody,
+  PostRunCancelResponseBody,
+  PostRunsResponseBody,
+} from "@app/lib/api/apps";
+
 /**
  * Walks an app-run's `block_execution` traces and emits one `RunUsageType` per trace that carries
  * `meta.token_usage`, attaching the block's provider/model and the computed cost in micro-USD.

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -36,9 +36,78 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { PodType, SpaceType } from "@app/types/space";
+import type { SpaceUserType } from "@app/types/user";
 import assert from "assert";
 import uniq from "lodash/uniq";
 import { Op } from "sequelize";
+import { z } from "zod";
+
+// Contract types and schemas for the spaces API endpoints (shared between the
+// Next handlers under `pages/api/w/[wId]/spaces` and their Hono counterparts).
+
+export const PostSpaceRequestBodySchema = z.intersection(
+  z.object({
+    isRestricted: z.boolean(),
+    name: z.string(),
+    spaceKind: z.enum(["regular", "project"]),
+  }),
+  z.discriminatedUnion("managementMode", [
+    z.object({
+      memberIds: z.array(z.string()),
+      managementMode: z.literal("manual"),
+    }),
+    z.object({
+      groupIds: z.array(z.string()),
+      managementMode: z.literal("group"),
+    }),
+  ])
+);
+
+export type PostSpaceRequestBodyType = z.infer<
+  typeof PostSpaceRequestBodySchema
+>;
+
+export type GetSpacesResponseBody = {
+  spaces: (SpaceType | PodType)[];
+};
+
+export type PostSpacesResponseBody = {
+  space: SpaceType;
+};
+
+export type SpaceCategoryInfo = {
+  usage: AgentsUsageType;
+  count: number;
+};
+
+export type RichSpaceType = SpaceType & {
+  categories: { [key: string]: SpaceCategoryInfo };
+  canWrite: boolean;
+  canRead: boolean;
+  isMember: boolean;
+  members: SpaceUserType[];
+  isEditor: boolean;
+  // Useful in case of projects
+  description: string | null;
+  archivedAt: number | null;
+  /** Background todo suggestions from project activity (project spaces only). */
+  todoGenerationEnabled: boolean;
+  lastTodoAnalysisAt: number | null;
+  pinnedFramePath: string | null;
+};
+
+export type GetSpaceResponseBody = {
+  space: RichSpaceType;
+};
+
+export type PatchSpaceResponseBody = {
+  space: SpaceType;
+};
+
+export type CheckNameResponseBody = {
+  available: boolean;
+};
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,

--- a/front/lib/api/spaces/members.ts
+++ b/front/lib/api/spaces/members.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const PatchSpaceMembersRequestBodySchema = z.intersection(
+  z.object({
+    isRestricted: z.boolean(),
+    name: z.string(),
+  }),
+  z.discriminatedUnion("managementMode", [
+    z.object({
+      memberIds: z.array(z.string()),
+      managementMode: z.literal("manual"),
+      editorIds: z.array(z.string()),
+    }),
+    z.object({
+      groupIds: z.array(z.string()),
+      managementMode: z.literal("group"),
+      editorGroupIds: z.array(z.string()),
+    }),
+  ])
+);
+
+export type PatchSpaceMembersRequestBodyType = z.infer<
+  typeof PatchSpaceMembersRequestBodySchema
+>;

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -10,6 +10,14 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 
+export type PatchTableResponseBody = {
+  table?: { table_id: string };
+};
+
+export type GetDataSourceViewTableResponseBody = {
+  table: CoreAPITable;
+};
+
 type NotFoundError = {
   type: "table_not_found" | "file_not_found";
   message: string;

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -20,10 +20,26 @@ import type {
   WebhookSourceForAdminType,
   WebhookSourceType,
   WebhookSourceViewForAdminType,
+  WebhookSourceViewType,
 } from "@app/types/triggers/webhooks";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
+import { z } from "zod";
+
+export type GetWebhookSourceViewsResponseBody = {
+  success: boolean;
+  webhookSourceViews: WebhookSourceViewType[];
+};
+
+export type PostWebhookSourceViewResponseBody = {
+  success: boolean;
+  webhookSourceView: WebhookSourceViewType;
+};
+
+export const PostWebhookSourceViewBodySchema = z.object({
+  webhookSourceId: z.string(),
+});
 
 /**
  * Deletes a webhook source and all related entities (views, triggers, requests).

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -1,5 +1,5 @@
+import type { PostRequestAccessBody } from "@app/lib/api/data_sources/request_access";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PostRequestAccessBody } from "@app/pages/api/w/[wId]/data_sources/request_access";
 import type { PostRequestFeatureAccessBody } from "@app/pages/api/w/[wId]/labs/request_access";
 import type { PostRequestActionsAccessBody } from "@app/pages/api/w/[wId]/mcp/request_access";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -51,6 +51,7 @@ import type {
   Transaction,
 } from "sequelize";
 import { Op } from "sequelize";
+import { z } from "zod";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -66,6 +67,24 @@ export type MCPServerViewCreationResult = {
   view: MCPServerViewResource;
   affectedAgents?: AffectedAgent[];
 };
+
+export type GetMCPServerViewsResponseBody = {
+  success: boolean;
+  serverViews: MCPServerViewType[];
+};
+
+export type PostMCPServerViewResponseBody = {
+  success: boolean;
+  serverView: MCPServerViewType;
+};
+
+export const PostMCPServerViewQueryParamsSchema = z.object({
+  mcpServerId: z.string(),
+});
+
+export type PostMCPServersQueryParams = z.infer<
+  typeof PostMCPServerViewQueryParamsSchema
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel> {

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,16 +1,20 @@
+import type {
+  GetAppsResponseBody,
+  GetOrPostAppResponseBody,
+} from "@app/lib/api/apps";
+import type {
+  GetRunBlockResponseBody,
+  GetRunResponseBody,
+  GetRunStatusResponseBody,
+  GetRunsResponseBody,
+  PostRunCancelResponseBody,
+} from "@app/lib/api/run";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
-import type { GetAppsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps";
-import type { GetOrPostAppResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]";
-import type { GetRunsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs";
-import type { GetRunResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]";
-import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]";
-import type { PostRunCancelResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel";
-import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status";
 import type { AppType } from "@app/types/app";
 import type { RunRunType } from "@app/types/run";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -1,4 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/lib/api/data_sources/managed_config";
+import type { GetDataSourcePermissionsResponseBody } from "@app/lib/api/data_sources/managed_permissions";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -6,8 +8,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]";
-import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 import type {
   ConnectorPermission,
   ContentNode,

--- a/front/lib/swr/data_classification_labels.ts
+++ b/front/lib/swr/data_classification_labels.ts
@@ -1,8 +1,8 @@
 import type { SensitivityLabelSource } from "@app/components/shared/labels/types";
+import type { DataClassificationLabelsResponseBody } from "@app/lib/api/data_classification_labels";
 import { clientFetch } from "@app/lib/egress/client";
 import type { MicrosoftAllowedLabel } from "@app/lib/models/workspace_sensitivity_label_config";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { DataClassificationLabelsResponseBody } from "@app/pages/api/w/[wId]/data-classification-labels";
 import type { LightWorkspaceType } from "@app/types/user";
 
 function buildKey(

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -1,4 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetDataSourceViewDocumentResponseBody } from "@app/lib/api/data_source_view";
+import type {
+  PatchDocumentResponseBody,
+  PostDocumentResponseBody,
+} from "@app/lib/api/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
@@ -6,9 +11,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { GetDataSourceViewDocumentResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]";
-import type { PostDocumentResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents";
-import type { PatchDocumentResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";
 import type {
   PatchDataSourceDocumentRequestBody,
   PostDataSourceDocumentRequestBody,

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -1,4 +1,12 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  ListTablesResponseBody,
+  SearchTablesResponseBody,
+} from "@app/lib/api/data_source_view";
+import type {
+  GetDataSourceViewTableResponseBody,
+  PatchTableResponseBody,
+} from "@app/lib/api/tables";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
@@ -7,10 +15,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { ListTablesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables";
-import type { GetDataSourceViewTableResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]";
-import type { SearchTablesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search";
-import type { PatchTableResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]";
 import type { PatchDataSourceTableRequestBody } from "@app/types/api/public/data_sources";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -1,4 +1,11 @@
 import type {
+  GetContentNodesOrChildrenRequestBodyType,
+  GetDataSourceViewContentNodes,
+  GetDataSourceViewsResponseBody,
+} from "@app/lib/api/data_source_view";
+import type { PostTagSearchBody } from "@app/lib/api/data_source_view_tags";
+import type { GetDataSourceConfigurationResponseBody } from "@app/lib/api/data_sources";
+import type {
   CursorPaginationParams,
   SortingParams,
 } from "@app/lib/api/pagination";
@@ -9,13 +16,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { GetDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/data_source_views";
-import type { PostTagSearchBody } from "@app/pages/api/w/[wId]/data_source_views/tags/search";
-import type {
-  GetContentNodesOrChildrenRequestBodyType,
-  GetDataSourceViewContentNodes,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes";
-import type { GetDataSourceConfigurationResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";

--- a/front/lib/swr/data_sources.ts
+++ b/front/lib/swr/data_sources.ts
@@ -1,6 +1,6 @@
+import type { GetDataSourceUsageResponseBody } from "@app/lib/api/agent_data_sources";
+import type { GetBotDataSourcesResponseBody } from "@app/lib/api/data_sources/bot_data_sources";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetDataSourceUsageResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/usage";
-import type { GetBotDataSourcesResponseBody } from "@app/pages/api/w/[wId]/data_sources/bot-data-sources";
 import type { GetPostNotionSyncResponseBody } from "@app/types/api/internal/spaces";
 import type { DataSourceType } from "@app/types/data_source";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -1,6 +1,8 @@
+import type {
+  GetDatasetResponseBody,
+  GetDatasetsResponseBody,
+} from "@app/lib/api/datasets";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetDatasetsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets";
-import type { GetDatasetResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]";
 import type { AppType } from "@app/types/app";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -1,6 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
 import config from "@app/lib/api/config";
+import type {
+  UpsertFileToDataSourceRequestBody,
+  UpsertFileToDataSourceResponseBody,
+} from "@app/lib/api/files/upsert";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
@@ -9,10 +13,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type {
-  UpsertFileToDataSourceRequestBody,
-  UpsertFileToDataSourceResponseBody,
-} from "@app/pages/api/w/[wId]/data_sources/[dsId]/files";
 import type { ShareFileResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]/share";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type {

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -8,6 +8,7 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
+  GetMCPServerViewsNotActivatedResponseBody,
   MCPServerType,
   MCPServerTypeWithViews,
   MCPServerViewType,
@@ -18,6 +19,7 @@ import type {
   MCPServerConnectionConnectionType,
   MCPServerConnectionType,
 } from "@app/lib/resources/mcp_server_connection_resource";
+import type { GetMCPServerViewsResponseBody } from "@app/lib/resources/mcp_server_view_resource";
 import { useSpaceInfo, useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
@@ -46,8 +48,6 @@ import type {
   PatchMCPServerViewBody,
   PatchMCPServerViewResponseBody,
 } from "@app/pages/api/w/[wId]/mcp/views/[viewId]";
-import type { GetMCPServerViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/mcp_views";
-import type { GetMCPServerViewsNotActivatedResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isAPIErrorResponse } from "@app/types/error";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -6,6 +6,30 @@ import {
 import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  FileSystemEntry,
+  GetSpaceFilesResponseBody,
+} from "@app/lib/api/file_system/types";
+import type {
+  GetProjectContextResponseBody,
+  PostProjectContextContentNodeResponseBody as PostPodContextContentNodeResponseBody,
+} from "@app/lib/api/projects/context";
+import type {
+  GetPodMetadataResponseBody,
+  PatchPodMetadataResponseBody,
+} from "@app/lib/api/projects/metadata";
+import type {
+  GetUserPodNotificationPreferenceResponseBody,
+  PatchUserPodNotificationPreferenceResponseBody,
+  PostUserPodStarResponseBody,
+} from "@app/lib/api/projects/preferences";
+import type {
+  GetPodTasksResponseBody,
+  PatchPodTaskResponseBody,
+  PostPodTaskResponseBody,
+  PostStartPodTaskResponseBody,
+} from "@app/lib/api/projects/tasks";
+import type { CheckNameResponseBody } from "@app/lib/api/spaces";
 import { clientFetch } from "@app/lib/egress/client";
 import { flattenPodTasksWithStableAssigneeOrder } from "@app/lib/project_task/display_order";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
@@ -17,30 +41,6 @@ import {
 } from "@app/lib/swr/swr";
 import type { PostSeedInitialPodTasksResponseBody } from "@app/pages/api/w/[wId]/pods/[podId]/tasks/seed";
 import type { GetWorkspacePodTaskResponseBody } from "@app/pages/api/w/[wId]/project_tasks/[taskSId]/index";
-import type {
-  FileSystemEntry,
-  GetSpaceFilesResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/files";
-import type {
-  GetProjectContextResponseBody,
-  PostProjectContextContentNodeResponseBody as PostPodContextContentNodeResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_context";
-import type {
-  GetPodMetadataResponseBody,
-  PatchPodMetadataResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_metadata";
-import type {
-  GetUserPodNotificationPreferenceResponseBody,
-  PatchUserPodNotificationPreferenceResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences";
-import type { PatchPodTaskResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index";
-import type { PostStartPodTaskResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/start";
-import type {
-  GetPodTasksResponseBody,
-  PostPodTaskResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index";
-import type { PostUserPodStarResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/star";
-import type { CheckNameResponseBody } from "@app/pages/api/w/[wId]/spaces/check-name";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type { PatchPodMetadataBodyType } from "@app/types/api/internal/spaces";
 import type {

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetDataSourcePermissionsResponseBody } from "@app/lib/api/data_sources/managed_permissions";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -12,7 +13,6 @@ import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { PostPokeStripeCustomerCurrencyResponseBody } from "@app/pages/api/poke/stripe/customers/currency";
 import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
 import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
-import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { DataSourceType } from "@app/types/data_source";
 import {

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1,8 +1,22 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type {
+  GetDataSourceViewResponseBody,
+  GetSpaceDataSourceViewsResponseBody,
+} from "@app/lib/api/data_source_view";
+import type { PostSpaceDataSourceResponseBody } from "@app/lib/api/data_sources";
+import type {
   CursorPaginationParams,
   SortingParams,
 } from "@app/lib/api/pagination";
+import type { SpacesLookupResponseBody } from "@app/lib/api/projects/lookup";
+import type {
+  GetSpaceResponseBody,
+  GetSpacesResponseBody,
+  PatchSpaceResponseBody,
+  PostSpaceRequestBodyType,
+  PostSpacesResponseBody,
+} from "@app/lib/api/spaces";
+import type { PatchSpaceMembersRequestBodyType } from "@app/lib/api/spaces/members";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import { getSpaceName } from "@app/lib/spaces";
@@ -17,20 +31,6 @@ import type {
   DataSourceContentNode,
   PostWorkspaceSearchResponseBody,
 } from "@app/pages/api/w/[wId]/search";
-import type {
-  GetSpacesResponseBody,
-  PostSpaceRequestBodyType,
-  PostSpacesResponseBody,
-} from "@app/pages/api/w/[wId]/spaces";
-import type {
-  GetSpaceResponseBody,
-  PatchSpaceResponseBody,
-} from "@app/pages/api/w/[wId]/spaces/[spaceId]";
-import type { GetSpaceDataSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views";
-import type { GetDataSourceViewResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]";
-import type { PostSpaceDataSourceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
-import type { PatchSpaceMembersRequestBodyType } from "@app/pages/api/w/[wId]/spaces/[spaceId]/members";
-import type { SpacesLookupResponseBody } from "@app/pages/api/w/[wId]/spaces/projects-lookup";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetWebhookSourceViewsResponseBody } from "@app/lib/api/webhook_source";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -7,7 +8,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetWebhookRequestsResponseBody } from "@app/lib/triggers/webhook";
-import type { GetWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views";
 import type {
   GetWebhookSourcesResponseBody,
   PostWebhookSourcesBody,

--- a/front/pages/api/v1/w/[wId]/files/fileId.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/fileId.test.ts
@@ -45,7 +45,8 @@ vi.mock("@app/lib/api/files/upsert", () => ({
     .mockResolvedValue({ isErr: () => false }),
 }));
 
-vi.mock("@app/lib/api/data_sources", () => ({
+vi.mock("@app/lib/api/data_sources", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/data_sources")>()),
   getOrCreateConversationDataSourceFromFile: vi.fn().mockResolvedValue({
     isErr: () => false,
     value: { id: "test_data_source" },

--- a/front/pages/api/w/[wId]/data-classification-labels.ts
+++ b/front/pages/api/w/[wId]/data-classification-labels.ts
@@ -3,6 +3,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import {
+  type DataClassificationLabelsResponseBody,
   getMicrosoftSensitivityLabels,
   type MicrosoftSensitivityLabel,
   parseAllowedLabelsConfig,
@@ -50,11 +51,6 @@ function resolveSourceErrorToApiError(
 // Re-exported so existing consumers (`components/shared/labels/types.ts`)
 // keep importing from the route file.
 export type { MicrosoftSensitivityLabel };
-
-export type DataClassificationLabelsResponseBody = {
-  labels: MicrosoftSensitivityLabel[];
-  allowedLabels: MicrosoftAllowedLabel[];
-};
 
 const SourceSchema = z
   .object({

--- a/front/pages/api/w/[wId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/data_source_views/index.ts
@@ -1,16 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetDataSourceViewsResponseBody } from "@app/lib/api/data_source_view";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetDataSourceViewsResponseBody = {
-  dataSourceViews: DataSourceViewType[];
-};
+export type { GetDataSourceViewsResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_source_views/tags/search.ts
+++ b/front/pages/api/w/[wId]/data_source_views/tags/search.ts
@@ -2,26 +2,16 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
+import type { PostTagSearchResponseBody } from "@app/lib/api/data_source_view_tags";
+import { PostTagSearchBodySchema } from "@app/lib/api/data_source_view_tags";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { CoreAPISearchTagsResponse } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostTagSearchBodySchema = z.object({
-  query: z.string(),
-  queryType: z.enum(["exact", "prefix", "match"]),
-  dataSourceViewIds: z.array(z.string()),
-});
-
-export type PostTagSearchBody = z.infer<typeof PostTagSearchBodySchema>;
-
-export type PostTagSearchResponseBody = CoreAPISearchTagsResponse;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/files.ts
@@ -2,9 +2,9 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type {
-  UpsertDocumentArgs,
-  UpsertTableArgs,
-} from "@app/lib/api/data_sources";
+  UpsertFileToDataSourceRequestBody,
+  UpsertFileToDataSourceResponseBody,
+} from "@app/lib/api/files/upsert";
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -14,19 +14,10 @@ import type { APIErrorType, WithAPIErrorResponse } from "@app/types/error";
 import type { FileType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export interface UpsertFileToDataSourceRequestBody {
-  fileId: string;
-  upsertArgs?:
-    | Pick<UpsertDocumentArgs, "document_id" | "title" | "tags">
-    | Pick<
-        UpsertTableArgs,
-        "name" | "title" | "description" | "tags" | "tableId"
-      >;
-}
-
-export interface UpsertFileToDataSourceResponseBody {
-  file: FileType;
-}
+export type {
+  UpsertFileToDataSourceRequestBody,
+  UpsertFileToDataSourceResponseBody,
+};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -2,6 +2,8 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { GetOrPostManagedDataSourceConfigResponseBody } from "@app/lib/api/data_sources/managed_config";
+import { PostManagedDataSourceConfigRequestBodySchema } from "@app/lib/api/data_sources/managed_config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
@@ -9,16 +11,7 @@ import { apiError } from "@app/logger/withlogging";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostManagedDataSourceConfigRequestBodySchema = z.object({
-  configValue: z.string(),
-});
-
-export type GetOrPostManagedDataSourceConfigResponseBody = {
-  configValue: string;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/notion/webhook_config.ts
@@ -2,6 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { GetNotionWebhookConfigResponseBody } from "@app/lib/api/data_sources/managed_notion";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
@@ -9,11 +10,6 @@ import { apiError } from "@app/logger/withlogging";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetNotionWebhookConfigResponseBody = {
-  webhookUrl: string;
-  verificationToken: string | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type {
+  GetDataSourcePermissionsResponseBody,
+  SetDataSourcePermissionsResponseBody,
+} from "@app/lib/api/data_sources/managed_permissions";
 import {
   getManagedDataSourcePermissions,
   ManagedPermissionsQuerySchema,
@@ -10,11 +14,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  ConnectorPermission,
-  ContentNode,
-  ContentNodeWithParent,
-} from "@app/types/connectors/connectors_api";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -30,16 +29,6 @@ const SetConnectorPermissionsRequestBodySchema = z.object({
     })
   ),
 });
-
-export type GetDataSourcePermissionsResponseBody<
-  T extends ConnectorPermission = ConnectorPermission,
-> = {
-  resources: (T extends "read" ? ContentNodeWithParent : ContentNode)[];
-};
-
-export type SetDataSourcePermissionsResponseBody = {
-  success: true;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/usage.ts
@@ -1,17 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+import type { GetDataSourceUsageResponseBody } from "@app/lib/api/agent_data_sources";
 import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { AgentsUsageType } from "@app/types/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetDataSourceUsageResponseBody = {
-  usage: AgentsUsageType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/bot-data-sources.ts
+++ b/front/pages/api/w/[wId]/data_sources/bot-data-sources.ts
@@ -1,18 +1,12 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetBotDataSourcesResponseBody } from "@app/lib/api/data_sources/bot_data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { DataSourceType } from "@app/types/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetBotDataSourcesResponseBody = {
-  slackBotDataSource: DataSourceType | null;
-  microsoftBotDataSource: DataSourceType | null;
-  discordBotDataSource: DataSourceType | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/data_sources/request_access.ts
+++ b/front/pages/api/w/[wId]/data_sources/request_access.ts
@@ -2,6 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { PostRequestAccessBodySchema } from "@app/lib/api/data_sources/request_access";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -10,15 +11,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { escape } from "html-escaper";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostRequestAccessBodySchema = z.object({
-  emailMessage: z.string(),
-  dataSourceId: z.string(),
-});
-
-export type PostRequestAccessBody = z.infer<typeof PostRequestAccessBodySchema>;
 
 const MAX_ACCESS_REQUESTS_PER_DAY = 30;
 

--- a/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.test.ts
@@ -7,7 +7,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import handler from "./index";
 
 // Mock the data sources functions to avoid actual upserting
-vi.mock("@app/lib/api/data_sources", () => ({
+vi.mock("@app/lib/api/data_sources", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/data_sources")>()),
   getOrCreateConversationDataSourceFromFile: vi.fn().mockResolvedValue({
     isErr: () => false,
     value: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.ts
@@ -2,7 +2,11 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { getDatasetHash } from "@app/lib/api/datasets";
+import type { GetDatasetResponseBody } from "@app/lib/api/datasets";
+import {
+  getDatasetHash,
+  PostDatasetRequestBodySchema,
+} from "@app/lib/api/datasets";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
@@ -12,14 +16,9 @@ import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { DatasetType } from "@app/types/dataset";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-import { PostDatasetRequestBodySchema } from "..";
-
-export type GetDatasetResponseBody = { dataset: DatasetType };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.ts
@@ -2,7 +2,14 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
-import { getDatasets } from "@app/lib/api/datasets";
+import type {
+  GetDatasetsResponseBody,
+  PostDatasetResponseBody,
+} from "@app/lib/api/datasets";
+import {
+  getDatasets,
+  PostDatasetRequestBodySchema,
+} from "@app/lib/api/datasets";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { checkDatasetData } from "@app/lib/datasets";
@@ -12,34 +19,9 @@ import { DatasetModel } from "@app/lib/resources/storage/models/apps";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { DatasetType } from "@app/types/dataset";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetDatasetsResponseBody = {
-  datasets: DatasetType[];
-};
-
-export type PostDatasetResponseBody = {
-  dataset: DatasetType;
-};
-
-export const PostDatasetRequestBodySchema = z.object({
-  dataset: z.object({
-    name: z.string(),
-    description: z.string().nullable(),
-    data: z.array(z.record(z.string(), z.any())),
-  }),
-  schema: z.array(
-    z.object({
-      key: z.string(),
-      type: z.enum(["string", "number", "boolean", "json"]),
-      description: z.string().nullable(),
-    })
-  ),
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+import type { GetOrPostAppResponseBody } from "@app/lib/api/apps";
 import { softDeleteApp } from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
@@ -7,16 +8,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { AppType } from "@app/types/app";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetOrPostAppResponseBody = {
-  app: AppType;
-};
 
 const PatchAppBodySchema = z.object({
   name: z.string(),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,5 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
+import type { GetRunBlockResponseBody } from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
@@ -10,17 +12,13 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { BlockType, RunType } from "@app/types/run";
+import type { BlockType } from "@app/types/run";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export const config = {
   api: {
     responseLimit: "8mb",
   },
-};
-
-export type GetRunBlockResponseBody = {
-  run: RunType | null;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
@@ -1,5 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
+import type { PostRunCancelResponseBody } from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
@@ -12,10 +14,6 @@ import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PostRunCancelResponseBody = {
-  success: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,5 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
+import type { GetRunResponseBody } from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { getRun } from "@app/lib/api/run";
@@ -7,15 +9,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { SpecificationType } from "@app/types/app";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { RunType } from "@app/types/run";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetRunResponseBody = {
-  run: RunType;
-  spec: SpecificationType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,5 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
+import type { GetRunStatusResponseBody } from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
@@ -10,12 +12,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { RunType } from "@app/types/run";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetRunStatusResponseBody = {
-  run: RunType | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -1,5 +1,10 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
+import type {
+  GetRunsResponseBody,
+  PostRunsResponseBody,
+} from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
@@ -16,17 +21,7 @@ import { apiError } from "@app/logger/withlogging";
 import { credentialsFromProviders } from "@app/types/api/credentials";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { RunType } from "@app/types/run";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetRunsResponseBody = {
-  runs: RunType[];
-  total: number;
-};
-
-export type PostRunsResponseBody = {
-  run: RunType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -1,5 +1,9 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+import type {
+  GetAppsResponseBody,
+  PostAppResponseBody,
+} from "@app/lib/api/apps";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
@@ -9,18 +13,10 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { AppType } from "@app/types/app";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetAppsResponseBody = {
-  apps: AppType[];
-};
-export type PostAppResponseBody = {
-  app: AppType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -1,38 +1,27 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
+import type {
+  GetContentNodesOrChildrenRequestBodyType,
+  GetDataSourceViewContentNodes,
+} from "@app/lib/api/data_source_view";
 import {
-  getCursorPaginationParams,
-  SortingParamsCodec,
-} from "@app/lib/api/pagination";
+  GetContentNodesOrChildrenRequestBody,
+  getContentNodesForDataSourceView,
+} from "@app/lib/api/data_source_view";
+import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
-import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-const GetContentNodesOrChildrenRequestBody = z.object({
-  internalIds: z.array(z.string().nullable()).optional(),
-  parentId: z.string().optional(),
-  viewType: ContentNodesViewTypeCodec,
-  sorting: SortingParamsCodec.optional(),
-});
-export type GetContentNodesOrChildrenRequestBodyType = z.infer<
-  typeof GetContentNodesOrChildrenRequestBody
->;
-
-export type GetDataSourceViewContentNodes = {
-  nodes: DataSourceViewContentNode[];
-  total: number;
-  totalIsAccurate: boolean;
-  nextPageCursor: string | null;
+export type {
+  GetContentNodesOrChildrenRequestBodyType,
+  GetDataSourceViewContentNodes,
 };
 
 // This endpoints serves two purposes:

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -2,13 +2,13 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
+import type { GetDataSourceViewDocumentResponseBody } from "@app/lib/api/data_source_view";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDocument } from "@app/types/core/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -22,9 +22,7 @@ export const config = {
   },
 };
 
-export type GetDataSourceViewDocumentResponseBody = {
-  document: CoreAPIDocument;
-};
+export type { GetDataSourceViewDocumentResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -138,6 +138,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type {
+  GetDataSourceViewResponseBody,
+  PatchDataSourceViewResponseBody,
+} from "@app/lib/api/data_source_view";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -148,20 +152,12 @@ import { apiError } from "@app/logger/withlogging";
 import { PatchDataSourceViewSchema } from "@app/types/api/public/spaces";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
-export type PatchDataSourceViewResponseBody = {
-  dataSourceView: DataSourceViewType;
-};
-
-export type GetDataSourceViewResponseBody = {
-  dataSourceView: DataSourceViewType;
-  connector: ConnectorType | null;
-};
+export type { GetDataSourceViewResponseBody, PatchDataSourceViewResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -3,18 +3,16 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { GetDataSourceViewTableResponseBody } from "@app/lib/api/tables";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetDataSourceViewTableResponseBody = {
-  table: CoreAPITable;
-};
+export type { GetDataSourceViewTableResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -1,20 +1,17 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { ListTablesResponseBody } from "@app/lib/api/data_source_view";
 import { getFlattenedContentNodesOfViewTypeForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type ListTablesResponseBody = {
-  tables: DataSourceViewContentNode[];
-  nextPageCursor: string | null;
-};
+export type { ListTablesResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
@@ -3,24 +3,19 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
+import type { SearchTablesResponseBody } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { SearchWarningCode } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
-import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type SearchTablesResponseBody = {
-  tables: DataSourceViewContentNode[];
-  nextPageCursor: string | null;
-  warningCode: SearchWarningCode | null;
-};
+export type { SearchTablesResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -111,6 +111,10 @@ import {
   getDataSourceViewsUsageByCategory,
 } from "@app/lib/api/agent_data_sources";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetSpaceDataSourceViewsResponseBody,
+  PostSpaceDataSourceViewsResponseBody,
+} from "@app/lib/api/data_source_view";
 import { augmentDataSourceWithConnectorDetails } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -122,24 +126,13 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import { ContentSchema } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
-import type {
-  DataSourceViewsWithDetails,
-  DataSourceViewType,
-} from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
-export type GetSpaceDataSourceViewsResponseBody<
-  IncludeDetails extends boolean = boolean,
-> = {
-  dataSourceViews: IncludeDetails extends true
-    ? DataSourceViewsWithDetails[]
-    : DataSourceViewType[];
-};
-
-type PostSpaceDataSourceViewsResponseBody = {
-  dataSourceView: DataSourceViewType;
+export type {
+  GetSpaceDataSourceViewsResponseBody,
+  PostSpaceDataSourceViewsResponseBody,
 };
 
 const PostDataSourceViewSchema = ContentSchema;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type {
+  GetDataSourceConfigurationResponseBody,
+  PatchDataSourceConfigurationResponseBody,
+} from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { isWebsite } from "@app/lib/data_sources";
@@ -9,7 +13,6 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
 import {
   ConnectorsAPI,
   UpdateConnectorConfigurationTypeSchema,
@@ -17,13 +20,6 @@ import {
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-export type GetDataSourceConfigurationResponseBody = {
-  configuration: ConnectorConfiguration;
-};
-
-export type PatchDataSourceConfigurationResponseBody =
-  GetDataSourceConfigurationResponseBody;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -2,6 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
+import type { PatchDocumentResponseBody } from "@app/lib/api/data_sources";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,8 +13,6 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types/api/public/data_sources";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPILightDocument } from "@app/types/core/data_source";
-import type { DocumentType } from "@app/types/document";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
@@ -26,10 +25,6 @@ export const config = {
       sizeLimit: "16mb",
     },
   },
-};
-
-export type PatchDocumentResponseBody = {
-  document: DocumentType | CoreAPILightDocument;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { PostDocumentResponseBody } from "@app/lib/api/data_sources";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,8 +9,6 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types/api/public/data_sources";
-import type { CoreAPILightDocument } from "@app/types/core/data_source";
-import type { DocumentType } from "@app/types/document";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
@@ -22,10 +21,6 @@ export const config = {
       sizeLimit: "16mb",
     },
   },
-};
-
-export type PostDocumentResponseBody = {
-  document: DocumentType | CoreAPILightDocument;
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -3,6 +3,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { upsertTable } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { PatchTableResponseBody } from "@app/lib/api/tables";
 import { deleteTable } from "@app/lib/api/tables";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -13,10 +14,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-export type PatchTableResponseBody = {
-  table?: { table_id: string };
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -7,8 +7,11 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { PostSpaceDataSourceResponseBody } from "@app/lib/api/data_sources";
 import {
   createDataSourceWithoutProvider,
+  PostDataSourceRequestBodySchema,
+  type PostDataSourceWithProviderRequestBodySchema,
   registerSlackWebhookRouterEntry,
 } from "@app/lib/api/data_sources";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
@@ -35,16 +38,10 @@ import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
-import {
-  ConnectorConfigurationTypeSchema,
-  ConnectorsAPI,
-} from "@app/types/connectors/connectors_api";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { WebCrawlerConfigurationTypeSchema } from "@app/types/connectors/webcrawler";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";
-import type { DataSourceType } from "@app/types/data_source";
-import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PlanType } from "@app/types/plan";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
@@ -52,36 +49,8 @@ import { sendUserOperationMessage } from "@app/types/shared/user_operation";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
+import type { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostDataSourceWithProviderRequestBodySchema = z.object({
-  provider: z.enum(CONNECTOR_PROVIDERS),
-  name: z.string().optional(),
-  configuration: ConnectorConfigurationTypeSchema,
-  connectionId: z.string().optional(), // Required for some providers
-  relatedCredentialId: z.string().optional(), // Required for private integrations
-  extraConfig: z.record(z.string(), z.string()).optional(), // Used by slack private integrations
-});
-
-const PostDataSourceWithoutProviderRequestBodySchema = z.object({
-  name: z.string(),
-  description: z.string().nullable(),
-});
-
-const PostDataSourceRequestBodySchema = z.union([
-  PostDataSourceWithoutProviderRequestBodySchema,
-  PostDataSourceWithProviderRequestBodySchema,
-]);
-
-export type PostDataSourceRequestBody = z.infer<
-  typeof PostDataSourceRequestBodySchema
->;
-
-export type PostSpaceDataSourceResponseBody = {
-  dataSource: DataSourceType;
-  dataSourceView: DataSourceViewType;
-};
 
 async function handler(
   req: NextApiRequest,
@@ -157,9 +126,7 @@ async function handler(
           res,
         });
       } else {
-        const body = bodyValidation.data as z.infer<
-          typeof PostDataSourceWithoutProviderRequestBodySchema
-        >;
+        const body = bodyValidation.data;
         const r = await createDataSourceWithoutProvider(auth, {
           plan,
           owner,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -2,7 +2,11 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import type {
+  FileSystemEntry,
+  GetSpaceFilesResponseBody,
+  PostSpaceFolderResponseBody,
+} from "@app/lib/api/file_system/types";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { isGCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
@@ -18,14 +22,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
 export type { FileSystemEntry, GCSMountDirectoryEntry };
-
-export type GetSpaceFilesResponseBody = {
-  files: FileSystemEntry[];
-};
-
-export type PostSpaceFolderResponseBody = {
-  folder: GCSMountDirectoryEntry;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -189,6 +189,11 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type {
+  GetSpaceResponseBody,
+  PatchSpaceResponseBody,
+  SpaceCategoryInfo,
+} from "@app/lib/api/spaces";
 import { softDeleteSpaceAndLaunchScrubWorkflow } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -201,42 +206,12 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import { PatchSpaceRequestBodySchema } from "@app/types/api/internal/spaces";
 import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
-import type { AgentsUsageType } from "@app/types/data_source";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { SpaceType } from "@app/types/space";
 import type { SpaceUserType } from "@app/types/user";
 import uniqBy from "lodash/uniqBy";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-export type SpaceCategoryInfo = {
-  usage: AgentsUsageType;
-  count: number;
-};
-
-export type RichSpaceType = SpaceType & {
-  categories: { [key: string]: SpaceCategoryInfo };
-  canWrite: boolean;
-  canRead: boolean;
-  isMember: boolean;
-  members: SpaceUserType[];
-  isEditor: boolean;
-  // Useful in case of projects
-  description: string | null;
-  archivedAt: number | null;
-  /** Background todo suggestions from project activity (project spaces only). */
-  todoGenerationEnabled: boolean;
-  lastTodoAnalysisAt: number | null;
-  pinnedFramePath: string | null;
-};
-export type GetSpaceResponseBody = {
-  space: RichSpaceType;
-};
-
-export type PatchSpaceResponseBody = {
-  space: SpaceType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -3,7 +3,6 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { sendMCPGlobalSharingReconfigurationEmail } from "@app/lib/api/email";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
@@ -12,7 +11,14 @@ import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { getActiveAdminEmails } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type {
+  GetMCPServerViewsResponseBody,
+  PostMCPServerViewResponseBody,
+} from "@app/lib/resources/mcp_server_view_resource";
+import {
+  MCPServerViewResource,
+  PostMCPServerViewQueryParamsSchema,
+} from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -25,27 +31,11 @@ import type { SpaceKind } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-export type GetMCPServerViewsResponseBody = {
-  success: boolean;
-  serverViews: MCPServerViewType[];
-};
-
-export type PostMCPServerViewResponseBody = {
-  success: boolean;
-  serverView: MCPServerViewType;
-};
-
 const GetQueryParamsSchema = z.object({
   availability: z
     .enum(["manual", "auto", "auto_hidden_builder", "all"])
     .optional(),
 });
-
-const PostQueryParamsSchema = z.object({
-  mcpServerId: z.string(),
-});
-
-export type PostMCPServersQueryParams = z.infer<typeof PostQueryParamsSchema>;
 
 async function notifyWorkspaceAdminsAboutAffectedAgents(
   auth: Authenticator,
@@ -206,7 +196,7 @@ async function handler(
       });
     }
     case "POST": {
-      const r = PostQueryParamsSchema.safeParse(req.body);
+      const r = PostMCPServerViewQueryParamsSchema.safeParse(req.body);
 
       if (!r.success) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { GetMCPServerViewsNotActivatedResponseBody } from "@app/lib/api/mcp";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -11,11 +11,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
 import differenceWith from "lodash/differenceWith";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetMCPServerViewsNotActivatedResponseBody = {
-  success: boolean;
-  serverViews: MCPServerViewType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import { PatchSpaceMembersRequestBodySchema } from "@app/lib/api/spaces/members";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
@@ -18,35 +19,11 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { SpaceType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 interface PatchSpaceMembersResponseBody {
   space: SpaceType;
 }
-
-const PatchSpaceMembersRequestBodySchema = z.intersection(
-  z.object({
-    isRestricted: z.boolean(),
-    name: z.string(),
-  }),
-  z.discriminatedUnion("managementMode", [
-    z.object({
-      memberIds: z.array(z.string()),
-      managementMode: z.literal("manual"),
-      editorIds: z.array(z.string()),
-    }),
-    z.object({
-      groupIds: z.array(z.string()),
-      managementMode: z.literal("group"),
-      editorGroupIds: z.array(z.string()),
-    }),
-  ])
-);
-
-export type PatchSpaceMembersRequestBodyType = z.infer<
-  typeof PatchSpaceMembersRequestBodySchema
->;
 
 export async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_context/index.ts
@@ -1,51 +1,22 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   addContentNodeToProject,
+  type GetProjectContextResponseBody,
   listProjectContextAttachments,
+  PostProjectContextContentNodeBodySchema,
+  type PostProjectContextContentNodeFragment,
+  type PostProjectContextContentNodeResponseBody,
 } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
-import type { ContentNodeType } from "@app/types/core/content_node";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-/** GET: project context (file-backed + content-node fragments). */
-export type GetProjectContextResponseBody = {
-  attachments: ConversationAttachmentType[];
-};
-
-const PostProjectContextContentNodeItemSchema = z.object({
-  title: z.string().min(1, "title is required"),
-  nodeId: z.string().min(1, "nodeId is required"),
-  nodeDataSourceViewId: z.string().min(1, "nodeDataSourceViewId is required"),
-  url: z.string().nullable().optional(),
-  supersededContentFragmentId: z.string().nullable().optional(),
-});
-
-const PostProjectContextContentNodeBodySchema = z.object({
-  items: z.array(PostProjectContextContentNodeItemSchema),
-});
-
-export type PostProjectContextContentNodeFragment = {
-  sId: string;
-  title: string;
-  contentType: string;
-  nodeId: string;
-  nodeDataSourceViewId: string;
-  nodeType: ContentNodeType;
-};
-
-export type PostProjectContextContentNodeResponseBody = {
-  contentFragments: PostProjectContextContentNodeFragment[];
-  errors: Array<{ index: number; message: string }>;
-};
 
 const ProjectContextQuerySchema = z.object({
   spaceId: z.string(),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,6 +1,10 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetPodMetadataResponseBody,
+  PatchPodMetadataResponseBody,
+} from "@app/lib/api/projects/metadata";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -14,16 +18,7 @@ import {
 } from "@app/temporal/project_task/client";
 import { PatchPodMetadataBodySchema } from "@app/types/api/internal/spaces";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PodMetadataType } from "@app/types/project_metadata";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPodMetadataResponseBody = {
-  projectMetadata: PodMetadataType | null;
-};
-
-export type PatchPodMetadataResponseBody = {
-  projectMetadata: PodMetadataType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_notification_preferences.ts
@@ -108,30 +108,23 @@
  */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetUserPodNotificationPreferenceResponseBody,
+  PatchUserPodNotificationPreferenceResponseBody,
+} from "@app/lib/api/projects/preferences";
+import { PatchUserPodNotificationPreferenceBodySchema } from "@app/lib/api/projects/preferences";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import {
-  NOTIFICATION_CONDITION_OPTIONS,
-  type UserPodNotificationPreference,
-} from "@app/types/notification_preferences";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
-export type GetUserPodNotificationPreferenceResponseBody = {
-  userProjectNotificationPreference: UserPodNotificationPreference | null;
+export type {
+  GetUserPodNotificationPreferenceResponseBody,
+  PatchUserPodNotificationPreferenceResponseBody,
 };
-
-export type PatchUserPodNotificationPreferenceResponseBody = {
-  userProjectNotificationPreference: UserPodNotificationPreference | null;
-};
-
-const PatchUserProjectNotificationPreferenceBodySchema = z.object({
-  preference: z.enum(NOTIFICATION_CONDITION_OPTIONS),
-});
 
 async function handler(
   req: NextApiRequest,
@@ -178,7 +171,7 @@ async function handler(
 
     case "PATCH": {
       const bodyValidation =
-        PatchUserProjectNotificationPreferenceBodySchema.safeParse(req.body);
+        PatchUserPodNotificationPreferenceBodySchema.safeParse(req.body);
 
       if (!bodyValidation.success) {
         const errorMessage = bodyValidation.error.errors

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.ts
@@ -1,43 +1,19 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  DeletePodTaskResponseBody,
+  PatchPodTaskResponseBody,
+} from "@app/lib/api/projects/tasks";
+import { PatchProjectTaskBodySchema } from "@app/lib/api/projects/tasks";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { POD_TASK_STATUSES, type PodTaskType } from "@app/types/project_task";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
-
-const PatchProjectTaskBodySchema = z
-  .object({
-    text: z
-      .string()
-      .min(1, "Text cannot be empty.")
-      .max(256, "Text must be at most 256 characters.")
-      .optional(),
-    status: z.enum(POD_TASK_STATUSES).optional(),
-    assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
-  })
-  .refine(
-    (data) =>
-      data.text !== undefined ||
-      data.status !== undefined ||
-      data.assigneeUserId !== undefined,
-    {
-      message:
-        "At least one of text, status, or assigneeUserId must be provided.",
-    }
-  );
-
-export interface PatchPodTaskResponseBody {
-  task: PodTaskType;
-}
-
-export type DeletePodTaskResponseBody = never;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/start.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/start.ts
@@ -1,25 +1,16 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { PostStartPodTaskResponseBody } from "@app/lib/api/projects/tasks";
+import { PostStartPodTaskBodySchema } from "@app/lib/api/projects/tasks";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { startAgentForProjectTask } from "@app/lib/project_task/start_agent";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { APIErrorType, WithAPIErrorResponse } from "@app/types/error";
-import type { PodTaskType } from "@app/types/project_task";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
-
-export interface PostStartPodTaskResponseBody {
-  task: PodTaskType;
-}
-
-const PostStartPodTaskBodySchema = z.object({
-  customMessage: z.string().optional(),
-  agentConfigurationId: z.string().optional(),
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/bulk-actions.ts
@@ -1,39 +1,17 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { BulkActionsResponse } from "@app/lib/api/projects/tasks";
+import { BulkActionsBodySchema } from "@app/lib/api/projects/tasks";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import { POD_TASK_STATUSES } from "@app/types/project_task";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type BulkActionsResponse = {
-  success: boolean;
-};
-
-const BulkActionsBodySchema = z.discriminatedUnion("action", [
-  z.object({
-    action: z.literal("set_status"),
-    taskIds: z.array(z.string().min(1)).min(1).max(200),
-    status: z.enum(POD_TASK_STATUSES),
-  }),
-  z.object({
-    action: z.literal("approve_agent_suggestion"),
-    taskIds: z.array(z.string().min(1)).min(1).max(200),
-  }),
-  z.object({
-    action: z.literal("reject_agent_suggestion"),
-    taskIds: z.array(z.string().min(1)).min(1).max(200),
-  }),
-]);
-
-export type BulkActionsBody = z.infer<typeof BulkActionsBodySchema>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_tasks/index.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetPodTasksResponseBody,
+  PostPodTaskResponseBody,
+} from "@app/lib/api/projects/tasks";
+import { PostPodTaskBodySchema } from "@app/lib/api/projects/tasks";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -21,7 +26,6 @@ import {
 import type { ModelId } from "@app/types/shared/model_id";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
 function parseSingleQueryValue(
   value: NextApiRequest["query"][string] | undefined
@@ -52,26 +56,6 @@ function parseProjectTasksPeopleMode(
     return "mine";
   }
   return "all";
-}
-
-export interface GetPodTasksResponseBody {
-  tasks: PodTaskType[];
-  lastReadAt: string | null;
-  viewerUserId: string | null;
-}
-
-const PostPodTaskBodySchema = z.object({
-  text: z
-    .string()
-    .trim()
-    .min(1, "Text is required.")
-    .max(256, "Text must be at most 256 characters."),
-  /** Omit to assign to the current user; pass `null` for unassigned (or the sole assignable member if the pod has exactly one). */
-  assigneeUserId: z.union([z.string().min(1), z.null()]).optional(),
-});
-
-export interface PostPodTaskResponseBody {
-  task: PodTaskType;
 }
 
 async function handler(

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -1,7 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { searchProjectConversations } from "@app/lib/api/projects/search";
+import type { SearchConversationsResponseBody } from "@app/lib/api/projects/search";
+import {
+  SearchConversationsQuerySchema,
+  searchProjectConversations,
+} from "@app/lib/api/projects/search";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -11,25 +15,9 @@ import { apiError } from "@app/logger/withlogging";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.1;
-
-export type SearchConversationsResponseBody = {
-  conversations: ConversationWithoutContentType[];
-};
-
-const SearchConversationsQuerySchema = z.object({
-  query: z.string().min(1, "Query parameter is required and cannot be empty"),
-  limit: z.coerce
-    .number()
-    .int()
-    .min(1, "Limit must be at least 1")
-    .max(100, "Limit must be at most 100")
-    .optional()
-    .default(10),
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/star.ts
@@ -3,6 +3,8 @@
  * @ignoreswagger
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { PostUserPodStarResponseBody } from "@app/lib/api/projects/preferences";
+import { PostUserPodStarBodySchema } from "@app/lib/api/projects/preferences";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -10,19 +12,7 @@ import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PostUserPodStarResponseBody = {
-  sId: string;
-  spaceId: string;
-  userId: string;
-  isStarred: boolean;
-};
-
-const PostUserPodStarBodySchema = z.object({
-  starred: z.boolean(),
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -2,30 +2,19 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type {
+  GetWebhookSourceViewsResponseBody,
+  PostWebhookSourceViewResponseBody,
+} from "@app/lib/api/webhook_source";
+import { PostWebhookSourceViewBodySchema } from "@app/lib/api/webhook_source";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { SpaceKind } from "@app/types/space";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetWebhookSourceViewsResponseBody = {
-  success: boolean;
-  webhookSourceViews: WebhookSourceViewType[];
-};
-
-export type PostWebhookSourceViewResponseBody = {
-  success: boolean;
-  webhookSourceView: WebhookSourceViewType;
-};
-
-const postWebhookSourceViewBodySchema = z.object({
-  webhookSourceId: z.string(),
-});
 
 async function handler(
   req: NextApiRequest,
@@ -52,7 +41,7 @@ async function handler(
       });
     }
     case "POST": {
-      const parseResult = postWebhookSourceViewBodySchema.safeParse(req.body);
+      const parseResult = PostWebhookSourceViewBodySchema.safeParse(req.body);
 
       if (!parseResult.success) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/spaces/check-name.ts
+++ b/front/pages/api/w/[wId]/spaces/check-name.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { CheckNameResponseBody } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -11,10 +12,6 @@ import z from "zod";
 const CheckNameQuerySchema = z.object({
   name: z.string().min(1),
 });
-
-export type CheckNameResponseBody = {
-  available: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/index.test.ts
@@ -6,7 +6,8 @@ const { mockCreateSpaceAndGroup } = vi.hoisted(() => ({
   mockCreateSpaceAndGroup: vi.fn(),
 }));
 
-vi.mock("@app/lib/api/spaces", () => ({
+vi.mock("@app/lib/api/spaces", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/spaces")>()),
   createSpaceAndGroup: mockCreateSpaceAndGroup,
 }));
 

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -111,7 +111,14 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
-import { createSpaceAndGroup } from "@app/lib/api/spaces";
+import type {
+  GetSpacesResponseBody,
+  PostSpacesResponseBody,
+} from "@app/lib/api/spaces";
+import {
+  createSpaceAndGroup,
+  PostSpaceRequestBodySchema,
+} from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
@@ -120,38 +127,7 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { PodType, SpaceType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PostSpaceRequestBodySchema = z.intersection(
-  z.object({
-    isRestricted: z.boolean(),
-    name: z.string(),
-    spaceKind: z.enum(["regular", "project"]),
-  }),
-  z.discriminatedUnion("managementMode", [
-    z.object({
-      memberIds: z.array(z.string()),
-      managementMode: z.literal("manual"),
-    }),
-    z.object({
-      groupIds: z.array(z.string()),
-      managementMode: z.literal("group"),
-    }),
-  ])
-);
-
-export type PostSpaceRequestBodyType = z.infer<
-  typeof PostSpaceRequestBodySchema
->;
-
-export type GetSpacesResponseBody = {
-  spaces: (SpaceType | PodType)[];
-};
-
-export type PostSpacesResponseBody = {
-  space: SpaceType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/projects-lookup.ts
+++ b/front/pages/api/w/[wId]/spaces/projects-lookup.ts
@@ -1,22 +1,20 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import {
+  enrichProjectsWithMetadata,
+  type SpacesLookupResponseBody,
+} from "@app/lib/api/projects/list";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PodType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
 import z from "zod";
 
 const SpacesLookupQuerySchema = z.object({
   ids: z.union([z.string(), z.array(z.string())]),
 });
-
-export type SpacesLookupResponseBody = {
-  spaces: PodType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/spaces/search_projects.ts
+++ b/front/pages/api/w/[wId]/spaces/search_projects.ts
@@ -2,21 +2,17 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
-import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import {
+  enrichProjectsWithMetadata,
+  type SearchProjectsResponseBody,
+} from "@app/lib/api/projects/list";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { PodType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type SearchProjectsResponseBody = {
-  spaces: Array<PodType & { isMember: boolean }>;
-  hasMore: boolean;
-  lastValue: string | null;
-};
 
 async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Description

Relocates **spaces / data_sources / data_source_views / data-classification** contract types (and zod schemas) out of the Next handlers into `lib/api` homes (`spaces.ts`, `data_sources*`, `data_source_view.ts`, `apps.ts`, `tables.ts`, `datasets.ts`, `projects/*`, `files/*`, etc.). Next handlers, Hono routes, and client code all import from `lib`.

## Tests

Pure type/schema **relocation** with no behavior change, so existing functional tests cover these routes. `npx tsgo --noEmit` is green on both `front` and `front-api`, and `biome` passes. Where a relocated zod schema is consumed at module scope (`validate("json", …)`), the affected `vi.mock(...)` test helpers were switched to `importOriginal` so the real schema is preserved.

## Risk

Low. Types and zod schemas are moved into `lib/api` homes that both the Next handlers and the Hono routes import from — a single source of truth, no duplication, no runtime logic touched. Fully revertable by reverting the commit.

## Deploy Plan

No migration or special steps. ⚠️ This PR makes Next-only edits on modules whose Hono route had no duplicate, so it needs the **`skip-migration-check`** label (BACK17). Merge the stack bottom-up.
