### PR TITLE
[slim-api] move poke API contracts out of pages/api

### DIFF
--- a/front-api/routes/poke/auth-context.ts
+++ b/front-api/routes/poke/auth-context.ts
@@ -1,11 +1,6 @@
-import type { UserType } from "@app/types/user";
+import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/lib/api/poke/auth_context";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetPokeNoWorkspaceAuthContextResponseType = {
-  user: UserType;
-  isSuperUser: true;
-};
 
 // Mounted at /api/poke/auth-context. pokeAuth is applied by the parent poke
 // sub-app, so ctx.get("auth") is always available here and the user is a

--- a/front-api/routes/poke/cache.ts
+++ b/front-api/routes/poke/cache.ts
@@ -1,3 +1,8 @@
+import type {
+  DeletePokeCacheResponseBody,
+  GetPokeCacheResponseBody,
+  RedisCacheResult,
+} from "@app/lib/api/poke/cache";
 import { runOnRedis, runOnRedisCache } from "@app/lib/api/redis";
 import logger from "@app/logger/logger";
 import {
@@ -9,25 +14,6 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import type { Context } from "hono";
-
-export interface RedisCacheResult {
-  value: unknown | null;
-  ttlSeconds: number;
-}
-
-export type RedisInstance = "cache" | "stream";
-
-export type GetPokeCacheResponseBody = {
-  key: string;
-  cacheRedis: RedisCacheResult;
-  streamRedis: RedisCacheResult;
-};
-
-export type DeletePokeCacheResponseBody = {
-  key: string;
-  redisInstance: RedisInstance;
-  deleted: true;
-};
 
 // Mounted at /api/poke/cache. pokeAuth is applied by the parent poke sub-app.
 const app = pokeApp();

--- a/front-api/routes/poke/global-agent-feedbacks/index.ts
+++ b/front-api/routes/poke/global-agent-feedbacks/index.ts
@@ -1,12 +1,7 @@
-import type { GlobalAgentFeedbackItem } from "@app/lib/api/poke/global_agent_feedbacks";
+import type { GetGlobalAgentFeedbacksResponseBody } from "@app/lib/api/poke/global_agent_feedbacks";
 import { listGlobalAgentFeedbacks } from "@app/lib/api/poke/global_agent_feedbacks";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export interface GetGlobalAgentFeedbacksResponseBody {
-  feedbacks: GlobalAgentFeedbackItem[];
-  hasMore: boolean;
-}
 
 // Mounted at /api/poke/global-agent-feedbacks. pokeAuth is applied by the
 // parent poke sub-app.

--- a/front-api/routes/poke/kill.ts
+++ b/front-api/routes/poke/kill.ts
@@ -1,4 +1,5 @@
-import type { KillSwitchType } from "@app/lib/poke/types";
+import type { GetKillSwitchesResponseBody } from "@app/lib/api/poke/kill";
+import { KillSwitchTypeSchema } from "@app/lib/api/poke/kill";
 import { isKillSwitchType } from "@app/lib/poke/types";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { pokeApp } from "@front-api/middlewares/ctx";
@@ -6,16 +7,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
-import { z } from "zod";
-
-export type GetKillSwitchesResponseBody = {
-  killSwitches: KillSwitchType[];
-};
-
-const KillSwitchTypeSchema = z.object({
-  enabled: z.boolean(),
-  type: z.string(),
-});
 
 // Mounted at /api/poke/kill. pokeAuth is applied by the parent poke sub-app.
 const app = pokeApp();

--- a/front-api/routes/poke/metronome/packages.ts
+++ b/front-api/routes/poke/metronome/packages.ts
@@ -1,13 +1,7 @@
-import {
-  listMetronomePackages,
-  type MetronomePackageSummary,
-} from "@app/lib/metronome/client";
+import type { GetPokeMetronomePackagesResponseBody } from "@app/lib/api/poke/metronome";
+import { listMetronomePackages } from "@app/lib/metronome/client";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetPokeMetronomePackagesResponseBody = {
-  packages: MetronomePackageSummary[];
-};
 
 // Mounted at /api/poke/metronome/packages. pokeAuth is applied by the parent
 // poke sub-app.

--- a/front-api/routes/poke/plans.ts
+++ b/front-api/routes/poke/plans.ts
@@ -1,3 +1,8 @@
+import type {
+  GetPokePlansResponseBody,
+  UpsertPokePlanResponseBody,
+} from "@app/lib/api/poke/plans";
+import { PlanTypeSchema } from "@app/lib/api/poke/plans";
 import { MAX_DOCUMENT_UPSERT_SIZE_MB } from "@app/lib/data_sources";
 import { PlanModel } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
@@ -7,64 +12,6 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-export type GetPokePlansResponseBody = {
-  plans: PlanType[];
-};
-
-export type UpsertPokePlanResponseBody = {
-  plan: PlanType;
-};
-
-export const PlanTypeSchema = z.object({
-  code: z.string(),
-  name: z.string(),
-  limits: z.object({
-    assistant: z.object({
-      isSlackBotAllowed: z.boolean(),
-      maxMessages: z.number(),
-      maxMessagesTimeframe: z.enum(["day", "lifetime"]),
-      isDeepDiveAllowed: z.boolean(),
-    }),
-    capabilities: z.object({
-      images: z.object({
-        maxImagesPerWeek: z.number(),
-      }),
-    }),
-    connections: z.object({
-      isConfluenceAllowed: z.boolean(),
-      isSlackAllowed: z.boolean(),
-      isNotionAllowed: z.boolean(),
-      isGoogleDriveAllowed: z.boolean(),
-      isGithubAllowed: z.boolean(),
-      isIntercomAllowed: z.boolean(),
-      isWebCrawlerAllowed: z.boolean(),
-      isSalesforceAllowed: z.boolean(),
-    }),
-    dataSources: z.object({
-      count: z.number(),
-      documents: z.object({
-        count: z.number(),
-        sizeMb: z.number(),
-      }),
-    }),
-    users: z.object({
-      maxUsers: z.number(),
-      maxFreeUsers: z.number(),
-      maxLifetimeFreeUsers: z.number(),
-      isSSOAllowed: z.boolean(),
-      isSCIMAllowed: z.boolean(),
-    }),
-    vaults: z.object({
-      maxVaults: z.number(),
-    }),
-    canUseProduct: z.boolean(),
-  }),
-  trialPeriodDays: z.number(),
-  isByok: z.boolean(),
-  isAuditLogsAllowed: z.boolean(),
-});
 
 // Mounted at /api/poke/plans. pokeAuth is applied by the parent poke sub-app.
 const app = pokeApp();

--- a/front-api/routes/poke/plugins/[pluginId]/async-args.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/async-args.ts
@@ -1,19 +1,12 @@
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import type { PokeGetPluginAsyncArgsResponseBody } from "@app/lib/api/poke/plugins/async_args";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
-import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
 import { supportedResourceTypes } from "@app/types/poke/plugins";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface PokeGetPluginAsyncArgsResponseBody {
-  asyncArgs: Record<
-    string,
-    string | number | boolean | AsyncEnumValues | EnumValues
-  >;
-}
 
 const AsyncArgsQuerySchema = z.object({
   resourceType: z.enum(supportedResourceTypes),

--- a/front-api/routes/poke/plugins/[pluginId]/manifest.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/manifest.ts
@@ -1,17 +1,9 @@
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import type {
-  PluginArgs,
-  PluginManifest,
-  SupportedResourceType,
-} from "@app/types/poke/plugins";
+import type { PokeGetPluginDetailsResponseBody } from "@app/lib/api/poke/plugins/manifest";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface PokeGetPluginDetailsResponseBody {
-  manifest: PluginManifest<PluginArgs, SupportedResourceType>;
-}
 
 const ParamsSchema = z.object({
   pluginId: z.string(),

--- a/front-api/routes/poke/plugins/[pluginId]/run.ts
+++ b/front-api/routes/poke/plugins/[pluginId]/run.ts
@@ -1,5 +1,5 @@
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import type { PluginResponse } from "@app/lib/api/poke/types";
+import type { PokeRunPluginResponseBody } from "@app/lib/api/poke/plugins/run";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
@@ -27,10 +27,6 @@ const RunPluginQuerySchema = z.object({
 const ParamsSchema = z.object({
   pluginId: z.string(),
 });
-
-export interface PokeRunPluginResponseBody {
-  result: PluginResponse;
-}
 
 // Mounted at /api/poke/plugins/:pluginId/run.
 //

--- a/front-api/routes/poke/plugins/index.ts
+++ b/front-api/routes/poke/plugins/index.ts
@@ -1,5 +1,5 @@
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import type { PluginListItem } from "@app/lib/api/poke/types";
+import type { PokeListPluginsForScopeResponseBody } from "@app/lib/api/poke/plugins/list";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
 import { isSupportedResourceType } from "@app/types/poke/plugins";
@@ -10,10 +10,6 @@ import { z } from "zod";
 
 import pluginId from "./[pluginId]";
 import runs from "./runs";
-
-export interface PokeListPluginsForScopeResponseBody {
-  plugins: PluginListItem[];
-}
 
 const ListPluginsQuerySchema = z.object({
   resourceType: z.string().refine(isSupportedResourceType, {

--- a/front-api/routes/poke/plugins/runs.ts
+++ b/front-api/routes/poke/plugins/runs.ts
@@ -1,14 +1,10 @@
+import type { PokeListPluginRunsResponseBody } from "@app/lib/api/poke/plugin_manager";
 import { Authenticator } from "@app/lib/auth";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
-import type { PluginRunType } from "@app/types/poke/plugins";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface PokeListPluginRunsResponseBody {
-  pluginRuns: PluginRunType[];
-}
 
 const ListPluginRunsQuerySchema = z.object({
   workspaceId: z.string().optional(),

--- a/front-api/routes/poke/production-checks/[checkName]/history.ts
+++ b/front-api/routes/poke/production-checks/[checkName]/history.ts
@@ -1,16 +1,14 @@
+import type { GetCheckHistoryResponseBody } from "@app/lib/api/poke/production_checks";
 import {
   getCheckHistoryRuns,
   getRegisteredCheck,
 } from "@app/lib/api/poke/production_checks";
-import type { CheckHistoryRun } from "@app/types/production_checks";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-export type GetCheckHistoryResponseBody = {
-  runs: CheckHistoryRun[];
-};
+export type { GetCheckHistoryResponseBody };
 
 const ParamsSchema = z.object({
   checkName: z.string(),

--- a/front-api/routes/poke/production-checks/index.ts
+++ b/front-api/routes/poke/production-checks/index.ts
@@ -1,14 +1,10 @@
+import type { GetProductionChecksResponseBody } from "@app/lib/api/poke/production_checks";
 import { getCheckSummaries } from "@app/lib/api/poke/production_checks";
-import type { CheckSummary } from "@app/types/production_checks";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import checkName from "./[checkName]";
 import run from "./run";
-
-export type GetProductionChecksResponseBody = {
-  checks: CheckSummary[];
-};
 
 // Mounted at /api/poke/production-checks.
 const app = pokeApp();

--- a/front-api/routes/poke/region.ts
+++ b/front-api/routes/poke/region.ts
@@ -1,13 +1,9 @@
+import type { GetRegionResponseType } from "@app/lib/api/regions/config";
 import { config } from "@app/lib/api/regions/config";
 import type { RegionType } from "@app/types/region";
 import { SUPPORTED_REGIONS } from "@app/types/region";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetRegionResponseType = {
-  region: RegionType;
-  regionUrls: Record<RegionType, string>;
-};
 
 // Mounted at /api/poke/region. pokeAuth is applied by the parent poke sub-app.
 const app = pokeApp();

--- a/front-api/routes/poke/sandbox_kill/images.ts
+++ b/front-api/routes/poke/sandbox_kill/images.ts
@@ -1,10 +1,9 @@
-import { getRegisteredImages } from "@app/lib/api/sandbox/image";
+import {
+  getRegisteredImages,
+  type SandboxKillImagesResponseBody,
+} from "@app/lib/api/sandbox/image";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export interface SandboxKillImagesResponseBody {
-  images: Array<{ baseImage: string; version: string }>;
-}
 
 // Mounted at /api/poke/sandbox_kill/images.
 const app = pokeApp();

--- a/front-api/routes/poke/sandbox_kill/request.ts
+++ b/front-api/routes/poke/sandbox_kill/request.ts
@@ -1,14 +1,10 @@
 import config from "@app/lib/api/config";
+import type { SandboxKillRequestResponseBody } from "@app/lib/api/poke/types";
 import { launchSandboxKillRequesterWorkflow } from "@app/temporal/sandbox_reaper/kill_requester/client";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface SandboxKillRequestResponseBody {
-  workflowId: string;
-  temporalLink: string;
-}
 
 const RequestBodySchema = z.object({
   baseImage: z.string().min(1),

--- a/front-api/routes/poke/search.ts
+++ b/front-api/routes/poke/search.ts
@@ -1,13 +1,9 @@
+import type { GetPokeSearchItemsResponseBody } from "@app/lib/api/poke/search";
 import { searchPokeResources } from "@app/lib/poke/search";
-import type { PokeItemBase } from "@app/types/poke";
 import { isString } from "@app/types/shared/utils/general";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type GetPokeSearchItemsResponseBody = {
-  results: PokeItemBase[];
-};
 
 // Mounted at /api/poke/search. pokeAuth is applied by the parent poke sub-app.
 const app = pokeApp();

--- a/front-api/routes/poke/stripe/customers/currency.ts
+++ b/front-api/routes/poke/stripe/customers/currency.ts
@@ -1,18 +1,12 @@
+import {
+  PostPokeStripeCustomerCurrencyBodySchema,
+  type PostPokeStripeCustomerCurrencyResponseBody,
+} from "@app/lib/api/poke/stripe_customers";
 import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
 import { getStripeCustomer } from "@app/lib/plans/stripe";
-import type { SupportedCurrency } from "@app/types/currency";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-const PostPokeStripeCustomerCurrencyBodySchema = z.object({
-  stripeCustomerId: z.string().min(1, "Required"),
-});
-
-export type PostPokeStripeCustomerCurrencyResponseBody = {
-  currency: SupportedCurrency;
-};
 
 // Mounted at /api/poke/stripe/customers/currency.
 const app = pokeApp();

--- a/front-api/routes/poke/templates/[tId].ts
+++ b/front-api/routes/poke/templates/[tId].ts
@@ -1,4 +1,5 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
+import type { PokeFetchAssistantTemplateResponse } from "@app/lib/api/poke/templates";
 import { buildSharedTemplateAttributes } from "@app/lib/api/poke/templates";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { TemplateResource } from "@app/lib/resources/template_resource";
@@ -14,10 +15,6 @@ import { validate } from "@front-api/middlewares/validator";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import { z } from "zod";
-
-export type PokeFetchAssistantTemplateResponse = ReturnType<
-  TemplateResource["toJSON"]
->;
 
 interface PokeCreateTemplateResponseBody {
   success: boolean;

--- a/front-api/routes/poke/templates/pull.ts
+++ b/front-api/routes/poke/templates/pull.ts
@@ -1,13 +1,9 @@
+import type { PullTemplatesResponseBody } from "@app/lib/api/poke/templates";
 import { pullTemplatesFromMainRegion } from "@app/lib/api/poke/templates";
 import { config } from "@app/lib/api/regions/config";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type PullTemplatesResponseBody = {
-  success: true;
-  count: number;
-};
 
 // Mounted at /api/poke/templates/pull. pokeAuth is applied by the parent poke
 // sub-app.

--- a/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,20 +1,14 @@
 import config from "@app/lib/api/config";
+import type { PokeGetAppDetails } from "@app/lib/api/poke/apps";
 import { getSpecification } from "@app/lib/api/run";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { cleanSpecificationFromCore } from "@app/lib/specification";
 import logger from "@app/logger/logger";
-import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type PokeGetAppDetails = {
-  app: AppType;
-  specification: SpecificationType;
-  specificationHashes: string[] | null;
-};
 
 const DetailsQuerySchema = z.object({
   hash: z.string().optional(),

--- a/front-api/routes/poke/workspaces/[wId]/apps/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/apps/index.ts
@@ -1,14 +1,10 @@
+import type { PokeListApps } from "@app/lib/api/poke/apps";
 import { AppResource } from "@app/lib/resources/app_resource";
-import type { AppType } from "@app/types/app";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import aId from "./[aId]";
 import importApp from "./import";
-
-export type PokeListApps = {
-  apps: AppType[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/apps. pokeAuth is applied by
 // the parent workspaces/[wId] sub-app.

--- a/front-api/routes/poke/workspaces/[wId]/auth-context.ts
+++ b/front-api/routes/poke/workspaces/[wId]/auth-context.ts
@@ -1,20 +1,10 @@
+import type { GetPokeWorkspaceAuthContextResponseType } from "@app/lib/api/poke/auth_context";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { Authenticator } from "@app/lib/auth";
-import type { SubscriptionType } from "@app/types/plan";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type GetPokeWorkspaceAuthContextResponseType = {
-  user: UserType;
-  workspace: LightWorkspaceType;
-  subscription: SubscriptionType;
-  isAdmin: true;
-  isBuilder: true;
-  isSuperUser: true;
-};
 
 const ParamsSchema = z.object({
   wId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/data_retention.ts
+++ b/front-api/routes/poke/workspaces/[wId]/data_retention.ts
@@ -1,5 +1,5 @@
+import type { PokeGetDataRetentionResponseBody } from "@app/lib/api/poke/data_retention";
 import {
-  type DataRetentionConfig,
   getAgentsDataRetention,
   getConversationsDataRetention,
   getWorkspaceDataRetention,
@@ -7,9 +7,7 @@ import {
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
-export type PokeGetDataRetentionResponseBody = {
-  data: DataRetentionConfig;
-};
+export type { PokeGetDataRetentionResponseBody };
 
 // Mounted at /api/poke/workspaces/:wId/data_retention.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/features.ts
+++ b/front-api/routes/poke/workspaces/[wId]/features.ts
@@ -1,14 +1,7 @@
+import type { GetPokeFeaturesResponseBody } from "@app/lib/api/poke/features";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetPokeFeaturesResponseBody = {
-  features: {
-    name: WhitelistableFeature;
-    createdAt: string;
-  }[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/features.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
+++ b/front-api/routes/poke/workspaces/[wId]/files/[sId].ts
@@ -1,25 +1,10 @@
 import { readInteractiveContentFile } from "@app/lib/api/files/read";
-import type {
-  FileShareScope,
-  FileTypeWithMetadata,
-  SharingGrantType,
-} from "@app/types/files";
+import type { GetPokeFileResponseBody } from "@app/lib/api/poke/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface GetPokeFileResponseBody {
-  content: string;
-  file: FileTypeWithMetadata;
-  shareInfo: {
-    scope: FileShareScope;
-    sharedAt: number;
-    shareUrl: string;
-  } | null;
-  sharingGrants: SharingGrantType[];
-}
 
 const ParamsSchema = z.object({
   sId: z.string(),

--- a/front-api/routes/poke/workspaces/[wId]/memberships.ts
+++ b/front-api/routes/poke/workspaces/[wId]/memberships.ts
@@ -1,15 +1,9 @@
+import type { PokeGetMemberships } from "@app/lib/api/poke/memberships";
 import { getMembers } from "@app/lib/api/workspace";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
-import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type PokeGetMemberships = {
-  members: UserTypeWithWorkspaces[];
-  pendingInvitations: MembershipInvitationTypeWithLink[];
-};
 
 // Mounted at /api/poke/workspaces/:wId/memberships.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/[wId]/observability/datasource-retrieval.ts
+++ b/front-api/routes/poke/workspaces/[wId]/observability/datasource-retrieval.ts
@@ -1,18 +1,13 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import {
   fetchWorkspaceDatasourceRetrievalMetrics,
-  type WorkspaceDatasourceRetrievalData,
+  type PokeGetWorkspaceDatasourceRetrievalResponse,
 } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PokeGetWorkspaceDatasourceRetrievalResponse = {
-  datasources: WorkspaceDatasourceRetrievalData[];
-  total: number;
-};
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),

--- a/front-api/routes/poke/workspaces/[wId]/workspace-info.ts
+++ b/front-api/routes/poke/workspaces/[wId]/workspace-info.ts
@@ -1,11 +1,9 @@
 import {
   getPokeWorkspaceInfo,
-  type PokeWorkspaceInfo,
+  type PokeGetWorkspaceInfo,
 } from "@app/lib/api/poke/workspace_info";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-
-export type PokeGetWorkspaceInfo = PokeWorkspaceInfo;
 
 // Mounted at /api/poke/workspaces/:wId/workspace-info.
 const app = pokeApp();

--- a/front-api/routes/poke/workspaces/index.ts
+++ b/front-api/routes/poke/workspaces/index.ts
@@ -1,3 +1,4 @@
+import type { GetPokeWorkspacesResponseBody } from "@app/lib/api/poke/workspaces";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
 import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
 import { getPlanCodeSortPriority } from "@app/lib/plans/plan_codes";
@@ -12,9 +13,7 @@ import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspa
 import { isDomain, isEmailValid } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
-import type { SubscriptionType } from "@app/types/plan";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { LightWorkspaceType } from "@app/types/user";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -23,15 +22,10 @@ import { Op } from "sequelize";
 
 import wId from "./[wId]";
 
-export type PokeWorkspaceType = LightWorkspaceType & {
-  createdAt: string;
-  subscription: SubscriptionType;
-  membersCount: number;
-};
-
-export type GetPokeWorkspacesResponseBody = {
-  workspaces: PokeWorkspaceType[];
-};
+export type {
+  GetPokeWorkspacesResponseBody,
+  PokeWorkspaceType,
+} from "@app/lib/api/poke/workspaces";
 
 // Note: the parent poke/index.ts already applies pokeAuth (super-user gate).
 // This sub-router handles the workspace LIST endpoint (GET /) and mounts the

--- a/front/components/poke/coupons/CreateCouponForm.tsx
+++ b/front/components/poke/coupons/CreateCouponForm.tsx
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { CreatePokeCouponResponseBody } from "@app/lib/api/poke/coupons";
 import { clientFetch } from "@app/lib/egress/client";
-import type { CreatePokeCouponResponseBody } from "@app/pages/api/poke/coupons/index";
 import type { CouponDiscountType } from "@app/types/coupon";
 import { CreateCouponBodySchema } from "@app/types/coupon";
 import { isString } from "@app/types/shared/utils/general";

--- a/front/components/poke/pages/CacheLookupPage.tsx
+++ b/front/components/poke/pages/CacheLookupPage.tsx
@@ -1,8 +1,5 @@
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import type {
-  RedisCacheResult,
-  RedisInstance,
-} from "@app/pages/api/poke/cache";
+import type { RedisCacheResult, RedisInstance } from "@app/lib/api/poke/cache";
 import {
   usePokeCacheInvalidate,
   usePokeCacheLookup,

--- a/front/components/poke/pages/PlansPage.tsx
+++ b/front/components/poke/pages/PlansPage.tsx
@@ -7,9 +7,9 @@ import {
   useEditingPlan,
 } from "@app/components/poke/plans/form";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PlanTypeSchema } from "@app/lib/api/poke/plans";
 import { clientFetch } from "@app/lib/egress/client";
 import { usePokePlans } from "@app/lib/swr/poke";
-import type { PlanTypeSchema } from "@app/pages/api/poke/plans";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import type { PlanType } from "@app/types/plan";
 import {

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -11,7 +11,7 @@ import {
   PokeFormTextArea,
   PokeFormUpload,
 } from "@app/components/poke/shadcn/ui/form";
-import type { PokeGetPluginDetailsResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/manifest";
+import type { PokeGetPluginDetailsResponseBody } from "@app/lib/api/poke/plugins/manifest";
 import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
 import { createZodSchemaFromArgs } from "@app/types/poke/plugins";
 import { Button, Checkbox, SliderToggle } from "@dust-tt/sparkle";

--- a/front/hooks/usePokeGlobalAgentFeedbacks.ts
+++ b/front/hooks/usePokeGlobalAgentFeedbacks.ts
@@ -1,5 +1,5 @@
+import type { GetGlobalAgentFeedbacksResponseBody } from "@app/lib/api/poke/global_agent_feedbacks";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { GetGlobalAgentFeedbacksResponseBody } from "@app/pages/api/poke/global-agent-feedbacks";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 

--- a/front/hooks/usePokeProductionChecks.ts
+++ b/front/hooks/usePokeProductionChecks.ts
@@ -1,8 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  GetCheckHistoryResponseBody,
+  GetProductionChecksResponseBody,
+} from "@app/lib/api/poke/production_checks";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { GetProductionChecksResponseBody } from "@app/pages/api/poke/production-checks";
-import type { GetCheckHistoryResponseBody } from "@app/pages/api/poke/production-checks/[checkName]/history";
 import { useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -442,3 +442,8 @@ export type GetDatasourceRetrievalResponse = {
   datasources: DatasourceRetrievalData[];
   total: number;
 };
+
+export type PokeGetWorkspaceDatasourceRetrievalResponse = {
+  datasources: WorkspaceDatasourceRetrievalData[];
+  total: number;
+};

--- a/front/lib/api/poke/apps.ts
+++ b/front/lib/api/poke/apps.ts
@@ -1,0 +1,45 @@
+import type { AppType, SpecificationType } from "@app/types/app";
+import { z } from "zod";
+
+export type PokeListApps = {
+  apps: AppType[];
+};
+
+export type PokeGetAppDetails = {
+  app: AppType;
+  specification: SpecificationType;
+  specificationHashes: string[] | null;
+};
+
+export const AppTypeSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  savedSpecification: z.string().nullable(),
+  savedConfig: z.string().nullable(),
+  savedRun: z.string().nullable(),
+  dustAPIProjectId: z.string(),
+  datasets: z
+    .array(
+      z.object({
+        name: z.string(),
+        description: z.string().nullable(),
+        schema: z
+          .array(
+            z.object({
+              type: z.enum(["string", "number", "boolean", "json"]),
+              description: z.string().nullable(),
+              key: z.string(),
+            })
+          )
+          .nullish(),
+        data: z.array(z.record(z.string(), z.any())).nullish(),
+      })
+    )
+    .optional(),
+  coreSpecifications: z.record(z.string(), z.string()).optional(),
+});
+
+export const ImportAppBody = z.object({
+  app: AppTypeSchema,
+});

--- a/front/lib/api/poke/auth_context.ts
+++ b/front/lib/api/poke/auth_context.ts
@@ -1,0 +1,19 @@
+// Contract types for the poke auth-context endpoints, shared between the Next
+// handlers (front/pages/api/poke/...) and their Hono counterparts
+// (front-api/routes/poke/...).
+import type { SubscriptionType } from "@app/types/plan";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+
+export type GetPokeNoWorkspaceAuthContextResponseType = {
+  user: UserType;
+  isSuperUser: true;
+};
+
+export type GetPokeWorkspaceAuthContextResponseType = {
+  user: UserType;
+  workspace: LightWorkspaceType;
+  subscription: SubscriptionType;
+  isAdmin: true; // Superusers have admin privileges
+  isBuilder: true; // Superusers have builder privileges
+  isSuperUser: true;
+};

--- a/front/lib/api/poke/cache.ts
+++ b/front/lib/api/poke/cache.ts
@@ -1,0 +1,21 @@
+// Contract types for the poke cache endpoint (GET/DELETE /api/poke/cache).
+// Shared between the Next handler and its Hono counterpart.
+
+export interface RedisCacheResult {
+  value: unknown | null;
+  ttlSeconds: number;
+}
+
+export type RedisInstance = "cache" | "stream";
+
+export type GetPokeCacheResponseBody = {
+  key: string;
+  cacheRedis: RedisCacheResult;
+  streamRedis: RedisCacheResult;
+};
+
+export type DeletePokeCacheResponseBody = {
+  key: string;
+  redisInstance: RedisInstance;
+  deleted: true;
+};

--- a/front/lib/api/poke/coupons.ts
+++ b/front/lib/api/poke/coupons.ts
@@ -1,0 +1,16 @@
+// Shared contract types for the poke coupons API endpoints, imported by both
+// the Next handlers under `front/pages/api/poke/coupons` and their Hono
+// counterparts under `front-api/routes/poke/coupons`.
+import type { CouponRedemptionType, CouponType } from "@app/types/coupon";
+
+export type GetPokeCouponsResponseBody = {
+  coupons: CouponType[];
+};
+
+export type CreatePokeCouponResponseBody = {
+  coupon: CouponType;
+};
+
+export type GetPokeCouponRedemptionsResponseBody = {
+  redemptions: CouponRedemptionType[];
+};

--- a/front/lib/api/poke/data_retention.ts
+++ b/front/lib/api/poke/data_retention.ts
@@ -1,0 +1,5 @@
+import type { DataRetentionConfig } from "@app/lib/data_retention";
+
+export type PokeGetDataRetentionResponseBody = {
+  data: DataRetentionConfig;
+};

--- a/front/lib/api/poke/features.ts
+++ b/front/lib/api/poke/features.ts
@@ -1,0 +1,13 @@
+// Contract types for the Poke workspace feature-flag endpoints.
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export type GetPokeFeaturesResponseBody = {
+  features: {
+    name: WhitelistableFeature;
+    createdAt: string;
+  }[];
+};
+
+export type CreateOrDeleteFeatureFlagResponseBody = {
+  success: true;
+};

--- a/front/lib/api/poke/files.ts
+++ b/front/lib/api/poke/files.ts
@@ -1,0 +1,16 @@
+import type {
+  FileShareScope,
+  FileTypeWithMetadata,
+  SharingGrantType,
+} from "@app/types/files";
+
+export interface GetPokeFileResponseBody {
+  content: string;
+  file: FileTypeWithMetadata;
+  shareInfo: {
+    scope: FileShareScope;
+    sharedAt: number;
+    shareUrl: string;
+  } | null;
+  sharingGrants: SharingGrantType[];
+}

--- a/front/lib/api/poke/global_agent_feedbacks.ts
+++ b/front/lib/api/poke/global_agent_feedbacks.ts
@@ -49,6 +49,11 @@ export interface ListGlobalAgentFeedbacksResult {
   hasMore: boolean;
 }
 
+export interface GetGlobalAgentFeedbacksResponseBody {
+  feedbacks: GlobalAgentFeedbackItem[];
+  hasMore: boolean;
+}
+
 /**
  * Aggregate global-agent feedback rows across all workspaces for the poke
  * super-admin review tool. Returns up to `PAGE_SIZE` rows, enriched with the

--- a/front/lib/api/poke/kill.ts
+++ b/front/lib/api/poke/kill.ts
@@ -1,0 +1,11 @@
+import type { KillSwitchType } from "@app/lib/poke/types";
+import { z } from "zod";
+
+export type GetKillSwitchesResponseBody = {
+  killSwitches: KillSwitchType[];
+};
+
+export const KillSwitchTypeSchema = z.object({
+  enabled: z.boolean(),
+  type: z.string(),
+});

--- a/front/lib/api/poke/memberships.ts
+++ b/front/lib/api/poke/memberships.ts
@@ -1,0 +1,7 @@
+import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
+import type { UserTypeWithWorkspaces } from "@app/types/user";
+
+export type PokeGetMemberships = {
+  members: UserTypeWithWorkspaces[];
+  pendingInvitations: MembershipInvitationTypeWithLink[];
+};

--- a/front/lib/api/poke/metronome.ts
+++ b/front/lib/api/poke/metronome.ts
@@ -1,0 +1,5 @@
+import type { MetronomePackageSummary } from "@app/lib/metronome/client";
+
+export type GetPokeMetronomePackagesResponseBody = {
+  packages: MetronomePackageSummary[];
+};

--- a/front/lib/api/poke/plans.ts
+++ b/front/lib/api/poke/plans.ts
@@ -1,0 +1,59 @@
+import type { PlanType } from "@app/types/plan";
+import { z } from "zod";
+
+export const PlanTypeSchema = z.object({
+  code: z.string(),
+  name: z.string(),
+  limits: z.object({
+    assistant: z.object({
+      isSlackBotAllowed: z.boolean(),
+      maxMessages: z.number(),
+      maxMessagesTimeframe: z.enum(["day", "lifetime"]),
+      isDeepDiveAllowed: z.boolean(),
+    }),
+    capabilities: z.object({
+      images: z.object({
+        maxImagesPerWeek: z.number(),
+      }),
+    }),
+    connections: z.object({
+      isConfluenceAllowed: z.boolean(),
+      isSlackAllowed: z.boolean(),
+      isNotionAllowed: z.boolean(),
+      isGoogleDriveAllowed: z.boolean(),
+      isGithubAllowed: z.boolean(),
+      isIntercomAllowed: z.boolean(),
+      isWebCrawlerAllowed: z.boolean(),
+      isSalesforceAllowed: z.boolean(),
+    }),
+    dataSources: z.object({
+      count: z.number(),
+      documents: z.object({
+        count: z.number(),
+        sizeMb: z.number(),
+      }),
+    }),
+    users: z.object({
+      maxUsers: z.number(),
+      maxFreeUsers: z.number(),
+      maxLifetimeFreeUsers: z.number(),
+      isSSOAllowed: z.boolean(),
+      isSCIMAllowed: z.boolean(),
+    }),
+    vaults: z.object({
+      maxVaults: z.number(),
+    }),
+    canUseProduct: z.boolean(),
+  }),
+  trialPeriodDays: z.number(),
+  isByok: z.boolean(),
+  isAuditLogsAllowed: z.boolean(),
+});
+
+export type UpsertPokePlanResponseBody = {
+  plan: PlanType;
+};
+
+export type GetPokePlansResponseBody = {
+  plans: PlanType[];
+};

--- a/front/lib/api/poke/plugin_manager.ts
+++ b/front/lib/api/poke/plugin_manager.ts
@@ -1,7 +1,14 @@
 import type { AllPlugins } from "@app/lib/api/poke/types";
-import type { SupportedResourceType } from "@app/types/poke/plugins";
+import type {
+  PluginRunType,
+  SupportedResourceType,
+} from "@app/types/poke/plugins";
 
 import * as allPlugins from "./plugins";
+
+export interface PokeListPluginRunsResponseBody {
+  pluginRuns: PluginRunType[];
+}
 
 class PluginManager {
   private plugins: Map<string, AllPlugins> = new Map();

--- a/front/lib/api/poke/plugins/async_args.ts
+++ b/front/lib/api/poke/plugins/async_args.ts
@@ -1,0 +1,8 @@
+import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
+
+export interface PokeGetPluginAsyncArgsResponseBody {
+  asyncArgs: Record<
+    string,
+    string | number | boolean | AsyncEnumValues | EnumValues
+  >;
+}

--- a/front/lib/api/poke/plugins/list.ts
+++ b/front/lib/api/poke/plugins/list.ts
@@ -1,0 +1,5 @@
+import type { PluginListItem } from "@app/lib/api/poke/types";
+
+export interface PokeListPluginsForScopeResponseBody {
+  plugins: PluginListItem[];
+}

--- a/front/lib/api/poke/plugins/manifest.ts
+++ b/front/lib/api/poke/plugins/manifest.ts
@@ -1,0 +1,9 @@
+import type {
+  PluginArgs,
+  PluginManifest,
+  SupportedResourceType,
+} from "@app/types/poke/plugins";
+
+export interface PokeGetPluginDetailsResponseBody {
+  manifest: PluginManifest<PluginArgs, SupportedResourceType>;
+}

--- a/front/lib/api/poke/plugins/run.ts
+++ b/front/lib/api/poke/plugins/run.ts
@@ -1,0 +1,5 @@
+import type { PluginResponse } from "@app/lib/api/poke/types";
+
+export interface PokeRunPluginResponseBody {
+  result: PluginResponse;
+}

--- a/front/lib/api/poke/plugins/spaces/import_app.ts
+++ b/front/lib/api/poke/plugins/spaces/import_app.ts
@@ -1,7 +1,7 @@
+import { ImportAppBody } from "@app/lib/api/poke/apps";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { importApp } from "@app/lib/utils/apps";
-import { ImportAppBody } from "@app/pages/api/poke/workspaces/[wId]/apps/import";
 import { Err, Ok } from "@app/types/shared/result";
 import { readFileSync } from "fs";
 import { fromError } from "zod-validation-error";

--- a/front/lib/api/poke/production_checks.ts
+++ b/front/lib/api/poke/production_checks.ts
@@ -12,6 +12,14 @@ import type {
   CheckSummaryStatus,
 } from "@app/types/production_checks";
 
+export type GetProductionChecksResponseBody = {
+  checks: CheckSummary[];
+};
+
+export type GetCheckHistoryResponseBody = {
+  runs: CheckHistoryRun[];
+};
+
 export function getRegisteredCheck(checkName: string): Check | null {
   return REGISTERED_CHECKS.find((c) => c.name === checkName) ?? null;
 }

--- a/front/lib/api/poke/search.ts
+++ b/front/lib/api/poke/search.ts
@@ -1,0 +1,5 @@
+import type { PokeItemBase } from "@app/types/poke";
+
+export type GetPokeSearchItemsResponseBody = {
+  results: PokeItemBase[];
+};

--- a/front/lib/api/poke/stripe_customers.ts
+++ b/front/lib/api/poke/stripe_customers.ts
@@ -1,0 +1,10 @@
+import type { SupportedCurrency } from "@app/types/currency";
+import { z } from "zod";
+
+export const PostPokeStripeCustomerCurrencyBodySchema = z.object({
+  stripeCustomerId: z.string().min(1, "Required"),
+});
+
+export type PostPokeStripeCustomerCurrencyResponseBody = {
+  currency: SupportedCurrency;
+};

--- a/front/lib/api/poke/templates.ts
+++ b/front/lib/api/poke/templates.ts
@@ -10,6 +10,19 @@ import type {
 } from "@app/types/assistant/templates";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 
+export type PokeFetchAssistantTemplateResponse = ReturnType<
+  TemplateResource["toJSON"]
+>;
+
+export interface PokeCreateTemplateResponseBody {
+  success: boolean;
+}
+
+export type PullTemplatesResponseBody = {
+  success: true;
+  count: number;
+};
+
 /**
  * Shared subset of `TemplateModel` attributes that the poke create and
  * update endpoints both write. Each endpoint adds its own extras

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -178,3 +178,8 @@ export type PluginListItem = Pick<
   PluginManifest<PluginArgs, SupportedResourceType>,
   "id" | "name" | "description" | "readonly"
 >;
+
+export interface SandboxKillRequestResponseBody {
+  workflowId: string;
+  temporalLink: string;
+}

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -86,6 +86,8 @@ export type PokeWorkspaceInfo = {
   workosEnvironmentId: string;
 };
 
+export type PokeGetWorkspaceInfo = PokeWorkspaceInfo;
+
 /**
  * Assembles the workspace-info payload shown in the poke admin UI: every
  * subscription, billing config (Stripe + Metronome with cross-lookup),

--- a/front/lib/api/poke/workspaces.ts
+++ b/front/lib/api/poke/workspaces.ts
@@ -1,0 +1,12 @@
+import type { SubscriptionType } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
+
+export type PokeWorkspaceType = LightWorkspaceType & {
+  createdAt: string;
+  subscription: SubscriptionType;
+  membersCount: number;
+};
+
+export type GetPokeWorkspacesResponseBody = {
+  workspaces: PokeWorkspaceType[];
+};

--- a/front/lib/api/regions/config.ts
+++ b/front/lib/api/regions/config.ts
@@ -7,6 +7,11 @@ export const REGION_TIMEZONES: Record<RegionType, string> = {
   "us-central1": "America/New_York",
 };
 
+export type GetRegionResponseType = {
+  region: RegionType;
+  regionUrls: Record<RegionType, string>;
+};
+
 export const config = {
   getCurrentRegion: (): RegionType => {
     return EnvironmentConfig.getEnvVariable("REGION") as RegionType;

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -114,3 +114,7 @@ export type {
 } from "@app/lib/api/sandbox/image/types";
 export { formatSandboxImageId } from "@app/lib/api/sandbox/image/types";
 export { getRegisteredImages, getSandboxImageFromRegistry };
+
+export interface SandboxKillImagesResponseBody {
+  images: Array<{ baseImage: string; version: string }>;
+}

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -1,18 +1,22 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { GetDataSourcePermissionsResponseBody } from "@app/lib/api/data_sources/managed_permissions";
+import type {
+  GetPokeNoWorkspaceAuthContextResponseType,
+  GetPokeWorkspaceAuthContextResponseType,
+} from "@app/lib/api/poke/auth_context";
+import type {
+  GetPokeCouponRedemptionsResponseBody,
+  GetPokeCouponsResponseBody,
+} from "@app/lib/api/poke/coupons";
+import type { GetPokeFeaturesResponseBody } from "@app/lib/api/poke/features";
+import type { GetPokeMetronomePackagesResponseBody } from "@app/lib/api/poke/metronome";
+import type { GetPokePlansResponseBody } from "@app/lib/api/poke/plans";
+import type { PostPokeStripeCustomerCurrencyResponseBody } from "@app/lib/api/poke/stripe_customers";
+import type { GetRegionResponseType } from "@app/lib/api/regions/config";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { isRegionRedirect } from "@app/lib/swr/workspaces";
-import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/pages/api/poke/auth-context";
-import type { GetPokeCouponRedemptionsResponseBody } from "@app/pages/api/poke/coupons/[couponId]/redemptions";
-import type { GetPokeCouponsResponseBody } from "@app/pages/api/poke/coupons/index";
-import type { GetPokeMetronomePackagesResponseBody } from "@app/pages/api/poke/metronome/packages";
-import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
-import type { GetRegionResponseType } from "@app/pages/api/poke/region";
-import type { PostPokeStripeCustomerCurrencyResponseBody } from "@app/pages/api/poke/stripe/customers/currency";
-import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
-import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { DataSourceType } from "@app/types/data_source";
 import {

--- a/front/pages/api/poke/auth-context.ts
+++ b/front/pages/api/poke/auth-context.ts
@@ -1,17 +1,12 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/lib/api/poke/auth_context";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPokeNoWorkspaceAuthContextResponseType = {
-  user: UserType;
-  isSuperUser: true;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/cache.ts
+++ b/front/pages/api/poke/cache.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  DeletePokeCacheResponseBody,
+  GetPokeCacheResponseBody,
+  RedisCacheResult,
+} from "@app/lib/api/poke/cache";
 import { runOnRedis, runOnRedisCache } from "@app/lib/api/redis";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -13,25 +18,6 @@ import {
 } from "@app/types/shared/cache_resource_registry";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface RedisCacheResult {
-  value: unknown | null;
-  ttlSeconds: number;
-}
-
-export type RedisInstance = "cache" | "stream";
-
-export type GetPokeCacheResponseBody = {
-  key: string;
-  cacheRedis: RedisCacheResult;
-  streamRedis: RedisCacheResult;
-};
-
-export type DeletePokeCacheResponseBody = {
-  key: string;
-  redisInstance: RedisInstance;
-  deleted: true;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/global-agent-feedbacks/index.ts
+++ b/front/pages/api/poke/global-agent-feedbacks/index.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import type { GlobalAgentFeedbackItem } from "@app/lib/api/poke/global_agent_feedbacks";
+import type { GetGlobalAgentFeedbacksResponseBody } from "@app/lib/api/poke/global_agent_feedbacks";
 import { listGlobalAgentFeedbacks } from "@app/lib/api/poke/global_agent_feedbacks";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -9,11 +9,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetGlobalAgentFeedbacksResponseBody {
-  feedbacks: GlobalAgentFeedbackItem[];
-  hasMore: boolean;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/kill.ts
+++ b/front/pages/api/poke/kill.ts
@@ -1,25 +1,18 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetKillSwitchesResponseBody } from "@app/lib/api/poke/kill";
+import { KillSwitchTypeSchema } from "@app/lib/api/poke/kill";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import type { KillSwitchType } from "@app/lib/poke/types";
 import { isKillSwitchType } from "@app/lib/poke/types";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type GetKillSwitchesResponseBody = {
-  killSwitches: KillSwitchType[];
-};
-
-const KillSwitchTypeSchema = z.object({
-  enabled: z.boolean(),
-  type: z.string(),
-});
+export type { GetKillSwitchesResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/metronome/packages.ts
+++ b/front/pages/api/poke/metronome/packages.ts
@@ -1,17 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetPokeMetronomePackagesResponseBody } from "@app/lib/api/poke/metronome";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import type { MetronomePackageSummary } from "@app/lib/metronome/client";
 import { listMetronomePackages } from "@app/lib/metronome/client";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPokeMetronomePackagesResponseBody = {
-  packages: MetronomePackageSummary[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  GetPokePlansResponseBody,
+  UpsertPokePlanResponseBody,
+} from "@app/lib/api/poke/plans";
+import { PlanTypeSchema } from "@app/lib/api/poke/plans";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel } from "@app/lib/models/plan";
@@ -11,65 +16,7 @@ import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/sp
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PlanType } from "@app/types/plan";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PlanTypeSchema = z.object({
-  code: z.string(),
-  name: z.string(),
-  limits: z.object({
-    assistant: z.object({
-      isSlackBotAllowed: z.boolean(),
-      maxMessages: z.number(),
-      maxMessagesTimeframe: z.enum(["day", "lifetime"]),
-      isDeepDiveAllowed: z.boolean(),
-    }),
-    capabilities: z.object({
-      images: z.object({
-        maxImagesPerWeek: z.number(),
-      }),
-    }),
-    connections: z.object({
-      isConfluenceAllowed: z.boolean(),
-      isSlackAllowed: z.boolean(),
-      isNotionAllowed: z.boolean(),
-      isGoogleDriveAllowed: z.boolean(),
-      isGithubAllowed: z.boolean(),
-      isIntercomAllowed: z.boolean(),
-      isWebCrawlerAllowed: z.boolean(),
-      isSalesforceAllowed: z.boolean(),
-    }),
-    dataSources: z.object({
-      count: z.number(),
-      documents: z.object({
-        count: z.number(),
-        sizeMb: z.number(),
-      }),
-    }),
-    users: z.object({
-      maxUsers: z.number(),
-      maxFreeUsers: z.number(),
-      maxLifetimeFreeUsers: z.number(),
-      isSSOAllowed: z.boolean(),
-      isSCIMAllowed: z.boolean(),
-    }),
-    vaults: z.object({
-      maxVaults: z.number(),
-    }),
-    canUseProduct: z.boolean(),
-  }),
-  trialPeriodDays: z.number(),
-  isByok: z.boolean(),
-  isAuditLogsAllowed: z.boolean(),
-});
-
-export type UpsertPokePlanResponseBody = {
-  plan: PlanType;
-};
-
-export type GetPokePlansResponseBody = {
-  plans: PlanType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/plugins/[pluginId]/async-args.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/async-args.ts
@@ -2,26 +2,16 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import type { PokeGetPluginAsyncArgsResponseBody } from "@app/lib/api/poke/plugins/async_args";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type {
-  AsyncEnumValues,
-  EnumValues,
-  SupportedResourceType,
-} from "@app/types/poke/plugins";
+import type { SupportedResourceType } from "@app/types/poke/plugins";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export interface PokeGetPluginAsyncArgsResponseBody {
-  asyncArgs: Record<
-    string,
-    string | number | boolean | AsyncEnumValues | EnumValues
-  >;
-}
 
 const asyncArgsSchema = z.object({
   pluginId: z.string(),

--- a/front/pages/api/poke/plugins/[pluginId]/manifest.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/manifest.ts
@@ -2,20 +2,12 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import type { PokeGetPluginDetailsResponseBody } from "@app/lib/api/poke/plugins/manifest";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type {
-  PluginArgs,
-  PluginManifest,
-  SupportedResourceType,
-} from "@app/types/poke/plugins";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface PokeGetPluginDetailsResponseBody {
-  manifest: PluginManifest<PluginArgs, SupportedResourceType>;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -2,7 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import type { PluginResponse } from "@app/lib/api/poke/types";
+import type { PokeRunPluginResponseBody } from "@app/lib/api/poke/plugins/run";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -34,10 +34,6 @@ const RunPluginParamsSchema = z.object({
   resourceId: z.string().optional(),
   workspaceId: z.string().optional(),
 });
-
-export interface PokeRunPluginResponseBody {
-  result: PluginResponse;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/plugins/index.ts
+++ b/front/pages/api/poke/plugins/index.ts
@@ -2,7 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
-import type { PluginListItem } from "@app/lib/api/poke/types";
+import type { PokeListPluginsForScopeResponseBody } from "@app/lib/api/poke/plugins/list";
 import { fetchPluginResource } from "@app/lib/api/poke/utils";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -10,10 +10,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isSupportedResourceType } from "@app/types/poke/plugins";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface PokeListPluginsForScopeResponseBody {
-  plugins: PluginListItem[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/plugins/runs.ts
+++ b/front/pages/api/poke/plugins/runs.ts
@@ -1,18 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListPluginRunsResponseBody } from "@app/lib/api/poke/plugin_manager";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PluginRunType } from "@app/types/poke/plugins";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface PokeListPluginRunsResponseBody {
-  pluginRuns: PluginRunType[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/production-checks/[checkName]/history.ts
+++ b/front/pages/api/poke/production-checks/[checkName]/history.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetCheckHistoryResponseBody } from "@app/lib/api/poke/production_checks";
 import {
   getCheckHistoryRuns,
   getRegisteredCheck,
@@ -9,13 +10,10 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { CheckHistoryRun } from "@app/types/production_checks";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetCheckHistoryResponseBody = {
-  runs: CheckHistoryRun[];
-};
+export type { GetCheckHistoryResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/production-checks/index.ts
+++ b/front/pages/api/poke/production-checks/index.ts
@@ -1,17 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetProductionChecksResponseBody } from "@app/lib/api/poke/production_checks";
 import { getCheckSummaries } from "@app/lib/api/poke/production_checks";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { CheckSummary } from "@app/types/production_checks";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetProductionChecksResponseBody = {
-  checks: CheckSummary[];
-};
+export type { GetProductionChecksResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/region.ts
+++ b/front/pages/api/poke/region.ts
@@ -1,19 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetRegionResponseType } from "@app/lib/api/regions/config";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { RegionType } from "@app/types/region";
 import { SUPPORTED_REGIONS } from "@app/types/region";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetRegionResponseType = {
-  region: RegionType;
-  regionUrls: Record<RegionType, string>;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/sandbox_kill/images.ts
+++ b/front/pages/api/poke/sandbox_kill/images.ts
@@ -1,16 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getRegisteredImages } from "@app/lib/api/sandbox/image";
+import {
+  getRegisteredImages,
+  type SandboxKillImagesResponseBody,
+} from "@app/lib/api/sandbox/image";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface SandboxKillImagesResponseBody {
-  images: Array<{ baseImage: string; version: string }>;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/sandbox_kill/request.ts
+++ b/front/pages/api/poke/sandbox_kill/request.ts
@@ -2,6 +2,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { SandboxKillRequestResponseBody } from "@app/lib/api/poke/types";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
@@ -10,11 +11,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export interface SandboxKillRequestResponseBody {
-  workflowId: string;
-  temporalLink: string;
-}
 
 const RequestBodySchema = z.object({
   baseImage: z.string().min(1),

--- a/front/pages/api/poke/search.ts
+++ b/front/pages/api/poke/search.ts
@@ -1,17 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetPokeSearchItemsResponseBody } from "@app/lib/api/poke/search";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { searchPokeResources } from "@app/lib/poke/search";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PokeItemBase } from "@app/types/poke";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetPokeSearchItemsResponseBody = {
-  results: PokeItemBase[];
-};
+export type { GetPokeSearchItemsResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/stripe/customers/currency.ts
+++ b/front/pages/api/poke/stripe/customers/currency.ts
@@ -1,24 +1,18 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import {
+  PostPokeStripeCustomerCurrencyBodySchema,
+  type PostPokeStripeCustomerCurrencyResponseBody,
+} from "@app/lib/api/poke/stripe_customers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { resolveCurrencyFromStripe } from "@app/lib/plans/billing_currency";
 import { getStripeCustomer } from "@app/lib/plans/stripe";
 import { apiError } from "@app/logger/withlogging";
-import type { SupportedCurrency } from "@app/types/currency";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PostPokeStripeCustomerCurrencyBodySchema = z.object({
-  stripeCustomerId: z.string().min(1, "Required"),
-});
-
-export type PostPokeStripeCustomerCurrencyResponseBody = {
-  currency: SupportedCurrency;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -2,6 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  PokeCreateTemplateResponseBody,
+  PokeFetchAssistantTemplateResponse,
+} from "@app/lib/api/poke/templates";
 import { buildSharedTemplateAttributes } from "@app/lib/api/poke/templates";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
@@ -17,14 +21,6 @@ import { isDevelopment } from "@app/types/shared/env";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeFetchAssistantTemplateResponse = ReturnType<
-  TemplateResource["toJSON"]
->;
-
-interface PokeCreateTemplateResponseBody {
-  success: boolean;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PullTemplatesResponseBody } from "@app/lib/api/poke/templates";
 import { pullTemplatesFromMainRegion } from "@app/lib/api/poke/templates";
 import { config } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
@@ -8,11 +9,6 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PullTemplatesResponseBody = {
-  success: true;
-  count: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -2,6 +2,7 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { PokeGetAppDetails } from "@app/lib/api/poke/apps";
 import { getSpecification } from "@app/lib/api/run";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -9,17 +10,12 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import { cleanSpecificationFromCore } from "@app/lib/specification";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PokeGetAppDetails = {
-  app: AppType;
-  specification: SpecificationType;
-  specificationHashes: string[] | null;
-};
+export type { PokeGetAppDetails };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/apps/import.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/import.ts
@@ -1,5 +1,6 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { AppTypeSchema, ImportAppBody } from "@app/lib/api/poke/apps";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -8,40 +9,8 @@ import { apiError } from "@app/logger/withlogging";
 import type { AppType } from "@app/types/app";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
-export const AppTypeSchema = z.object({
-  sId: z.string(),
-  name: z.string(),
-  description: z.string().nullable(),
-  savedSpecification: z.string().nullable(),
-  savedConfig: z.string().nullable(),
-  savedRun: z.string().nullable(),
-  dustAPIProjectId: z.string(),
-  datasets: z
-    .array(
-      z.object({
-        name: z.string(),
-        description: z.string().nullable(),
-        schema: z
-          .array(
-            z.object({
-              type: z.enum(["string", "number", "boolean", "json"]),
-              description: z.string().nullable(),
-              key: z.string(),
-            })
-          )
-          .nullish(),
-        data: z.array(z.record(z.string(), z.any())).nullish(),
-      })
-    )
-    .optional(),
-  coreSpecifications: z.record(z.string(), z.string()).optional(),
-});
-
-export const ImportAppBody = z.object({
-  app: AppTypeSchema,
-});
+export { AppTypeSchema, ImportAppBody };
 
 /**
  * @ignoreswagger

--- a/front/pages/api/poke/workspaces/[wId]/apps/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/index.ts
@@ -1,17 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeListApps } from "@app/lib/api/poke/apps";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { AppType } from "@app/types/app";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PokeListApps = {
-  apps: AppType[];
-};
+export type { PokeListApps };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/auth-context.ts
+++ b/front/pages/api/poke/workspaces/[wId]/auth-context.ts
@@ -1,24 +1,14 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetPokeWorkspaceAuthContextResponseType } from "@app/lib/api/poke/auth_context";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SubscriptionType } from "@app/types/plan";
 import { isString } from "@app/types/shared/utils/general";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPokeWorkspaceAuthContextResponseType = {
-  user: UserType;
-  workspace: LightWorkspaceType;
-  subscription: SubscriptionType;
-  isAdmin: true; // Superusers have admin privileges
-  isBuilder: true; // Superusers have builder privileges
-  isSuperUser: true;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/data_retention.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_retention.ts
@@ -1,8 +1,8 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetDataRetentionResponseBody } from "@app/lib/api/poke/data_retention";
 import { Authenticator } from "@app/lib/auth";
-import type { DataRetentionConfig } from "@app/lib/data_retention";
 import {
   getAgentsDataRetention,
   getConversationsDataRetention,
@@ -13,9 +13,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type PokeGetDataRetentionResponseBody = {
-  data: DataRetentionConfig;
-};
+export type { PokeGetDataRetentionResponseBody };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/features.ts
+++ b/front/pages/api/poke/workspaces/[wId]/features.ts
@@ -1,25 +1,17 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type {
+  CreateOrDeleteFeatureFlagResponseBody,
+  GetPokeFeaturesResponseBody,
+} from "@app/lib/api/poke/features";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { isWhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPokeFeaturesResponseBody = {
-  features: {
-    name: WhitelistableFeature;
-    createdAt: string;
-  }[];
-};
-
-export type CreateOrDeleteFeatureFlagResponseBody = {
-  success: true;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
@@ -2,29 +2,14 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { readInteractiveContentFile } from "@app/lib/api/files/read";
+import type { GetPokeFileResponseBody } from "@app/lib/api/poke/files";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type {
-  FileShareScope,
-  FileTypeWithMetadata,
-  SharingGrantType,
-} from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetPokeFileResponseBody {
-  content: string;
-  file: FileTypeWithMetadata;
-  shareInfo: {
-    scope: FileShareScope;
-    sharedAt: number;
-    shareUrl: string;
-  } | null;
-  sharingGrants: SharingGrantType[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/memberships.ts
+++ b/front/pages/api/poke/workspaces/[wId]/memberships.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { PokeGetMemberships } from "@app/lib/api/poke/memberships";
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -8,14 +9,7 @@ import { MembershipInvitationResource } from "@app/lib/resources/membership_invi
 import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetMemberships = {
-  members: UserTypeWithWorkspaces[];
-  pendingInvitations: MembershipInvitationTypeWithLink[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { WorkspaceDatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import type { PokeGetWorkspaceDatasourceRetrievalResponse } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { fetchWorkspaceDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
@@ -16,11 +16,6 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type PokeGetWorkspaceDatasourceRetrievalResponse = {
-  datasources: WorkspaceDatasourceRetrievalData[];
-  total: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -3,15 +3,13 @@
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import {
   getPokeWorkspaceInfo,
-  type PokeWorkspaceInfo,
+  type PokeGetWorkspaceInfo,
 } from "@app/lib/api/poke/workspace_info";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PokeGetWorkspaceInfo = PokeWorkspaceInfo;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import type { GetPokeWorkspacesResponseBody } from "@app/lib/api/poke/workspaces";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
@@ -18,21 +19,9 @@ import { isDomain, isEmailValid } from "@app/lib/utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SubscriptionType } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { FindOptions, Order, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
-
-export type PokeWorkspaceType = LightWorkspaceType & {
-  createdAt: string;
-  subscription: SubscriptionType;
-  membersCount: number;
-};
-
-export type GetPokeWorkspacesResponseBody = {
-  workspaces: PokeWorkspaceType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/poke/swr/app_details.ts
+++ b/front/poke/swr/app_details.ts
@@ -1,5 +1,5 @@
+import type { PokeGetAppDetails } from "@app/lib/api/poke/apps";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetAppDetails } from "@app/pages/api/poke/workspaces/[wId]/apps/[aId]/details";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/apps.ts
+++ b/front/poke/swr/apps.ts
@@ -1,5 +1,5 @@
+import type { PokeListApps } from "@app/lib/api/poke/apps";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeListApps } from "@app/pages/api/poke/workspaces/[wId]/apps";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/cache.ts
+++ b/front/poke/swr/cache.ts
@@ -1,9 +1,9 @@
-import { clientFetch } from "@app/lib/egress/client";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   GetPokeCacheResponseBody,
   RedisInstance,
-} from "@app/pages/api/poke/cache";
+} from "@app/lib/api/poke/cache";
+import { clientFetch } from "@app/lib/egress/client";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { useState } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/data_retention.ts
+++ b/front/poke/swr/data_retention.ts
@@ -1,5 +1,5 @@
+import type { PokeGetDataRetentionResponseBody } from "@app/lib/api/poke/data_retention";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetDataRetentionResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_retention";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/frame_details.ts
+++ b/front/poke/swr/frame_details.ts
@@ -1,5 +1,5 @@
+import type { GetPokeFileResponseBody } from "@app/lib/api/poke/files";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetPokeFileResponseBody } from "@app/pages/api/poke/workspaces/[wId]/files/[sId]";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -3,11 +3,13 @@ import type {
   GetDocumentsResponseBody,
   GetTablesResponseBody,
 } from "@app/lib/api/poke/data_sources";
+import type {
+  PokeFetchAssistantTemplateResponse,
+  PullTemplatesResponseBody,
+} from "@app/lib/api/poke/templates";
 import { clientFetch } from "@app/lib/egress/client";
 import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { PokeFetchAssistantTemplateResponse } from "@app/pages/api/poke/templates/[tId]";
-import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pull";
 import { useCallback, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 import useSWR from "swr";

--- a/front/poke/swr/kill.ts
+++ b/front/poke/swr/kill.ts
@@ -1,5 +1,5 @@
+import type { GetKillSwitchesResponseBody } from "@app/lib/api/poke/kill";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { GetKillSwitchesResponseBody } from "@app/pages/api/poke/kill";
 import type { Fetcher } from "swr";
 import useSWR from "swr";
 

--- a/front/poke/swr/memberships.ts
+++ b/front/poke/swr/memberships.ts
@@ -1,5 +1,5 @@
+import type { PokeGetMemberships } from "@app/lib/api/poke/memberships";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetMemberships } from "@app/pages/api/poke/workspaces/[wId]/memberships";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 

--- a/front/poke/swr/plugins.ts
+++ b/front/poke/swr/plugins.ts
@@ -1,3 +1,8 @@
+import type { PokeListPluginRunsResponseBody } from "@app/lib/api/poke/plugin_manager";
+import type { PokeGetPluginAsyncArgsResponseBody } from "@app/lib/api/poke/plugins/async_args";
+import type { PokeListPluginsForScopeResponseBody } from "@app/lib/api/poke/plugins/list";
+import type { PokeGetPluginDetailsResponseBody } from "@app/lib/api/poke/plugins/manifest";
+import type { PokeRunPluginResponseBody } from "@app/lib/api/poke/plugins/run";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -5,11 +10,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { PokeListPluginsForScopeResponseBody } from "@app/pages/api/poke/plugins/";
-import type { PokeGetPluginAsyncArgsResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/async-args";
-import type { PokeGetPluginDetailsResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/manifest";
-import type { PokeRunPluginResponseBody } from "@app/pages/api/poke/plugins/[pluginId]/run";
-import type { PokeListPluginRunsResponseBody } from "@app/pages/api/poke/plugins/runs";
 import type { PluginResourceTarget } from "@app/types/poke/plugins";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/poke/swr/sandbox_kill.ts
+++ b/front/poke/swr/sandbox_kill.ts
@@ -1,8 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { SandboxKillRequestResponseBody } from "@app/lib/api/poke/types";
+import type { SandboxKillImagesResponseBody } from "@app/lib/api/sandbox/image";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
-import type { SandboxKillImagesResponseBody } from "@app/pages/api/poke/sandbox_kill/images";
-import type { SandboxKillRequestResponseBody } from "@app/pages/api/poke/sandbox_kill/request";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,10 +1,10 @@
-import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
+import type { GetPokeSearchItemsResponseBody } from "@app/lib/api/poke/search";
 import type {
   GetPokeWorkspacesResponseBody,
   PokeWorkspaceType,
-} from "@app/pages/api/poke/workspaces";
+} from "@app/lib/api/poke/workspaces";
+import { clientFetch } from "@app/lib/egress/client";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeItemBase } from "@app/types/poke";
 import type { RegionType } from "@app/types/region";
 import { SUPPORTED_REGIONS } from "@app/types/region";

--- a/front/poke/swr/workspace_info.ts
+++ b/front/poke/swr/workspace_info.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { PokeGetWorkspaceDatasourceRetrievalResponse } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import type { PokeGetWorkspaceInfo } from "@app/lib/api/poke/workspace_info";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeGetWorkspaceDatasourceRetrievalResponse } from "@app/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval";
-import type { PokeGetWorkspaceInfo } from "@app/pages/api/poke/workspaces/[wId]/workspace-info";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { Fetcher } from "swr";
 


### PR DESCRIPTION
## Description

Relocates **poke** (admin) contract types and zod schemas out of the Next handlers into `lib/api/poke` homes. Next handlers and the Hono poke routes import from `lib`.

## Tests

Pure type/schema **relocation** with no behavior change, so existing functional tests cover these routes. `npx tsgo --noEmit` is green on both `front` and `front-api`, and `biome` passes. Where a relocated zod schema is consumed at module scope (`validate("json", …)`), the affected `vi.mock(...)` test helpers were switched to `importOriginal` so the real schema is preserved.

## Risk

Low. Types and zod schemas are moved into `lib/api` homes that both the Next handlers and the Hono routes import from — a single source of truth, no duplication, no runtime logic touched. Fully revertable by reverting the commit.

## Deploy Plan

No migration or special steps. ⚠️ This PR makes Next-only edits on modules whose Hono route had no duplicate, so it needs the **`skip-migration-check`** label (BACK17). Merge the stack bottom-up.
