### PR TITLE
[slim-api] move integrations API contracts out of pages/api

### DIFF
--- a/extension/shared/tools/takeScreenshotOrAttachFileTool.ts
+++ b/extension/shared/tools/takeScreenshotOrAttachFileTool.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { FileUploadRequestResponseBody } from "@app/lib/api/files/upload_metadata";
 import { clientFetch } from "@app/lib/egress/client";
-import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { normalizeError } from "@extension/shared/lib/utils";

--- a/front-api/routes/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front-api/routes/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -1,4 +1,4 @@
-import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
+import type { GetActionsResponseBody } from "@app/lib/agent_builder/server_side_props_helpers";
 import {
   buildInitialActions,
   getAccessibleSourcesAndAppsForActions,
@@ -13,10 +13,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   aId: z.string(),
 });
-
-export type GetActionsResponseBody = {
-  actions: AgentBuilderMCPConfiguration[];
-};
 
 // Mounted at /api/w/:wId/builder/assistants/:aId/actions.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/builder/skills/suggestions.test.ts
+++ b/front-api/routes/w/[wId]/builder/skills/suggestions.test.ts
@@ -2,9 +2,15 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@app/lib/api/skills/description_suggestion", () => ({
-  getSkillDescriptionSuggestion: vi.fn(),
-}));
+vi.mock(
+  "@app/lib/api/skills/description_suggestion",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/skills/description_suggestion")
+    >()),
+    getSkillDescriptionSuggestion: vi.fn(),
+  })
+);
 
 import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";
 

--- a/front-api/routes/w/[wId]/builder/skills/suggestions.ts
+++ b/front-api/routes/w/[wId]/builder/skills/suggestions.ts
@@ -1,18 +1,12 @@
-import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";
+import {
+  getSkillDescriptionSuggestion,
+  PostSkillSuggestionsRequestBodySchema,
+} from "@app/lib/api/skills/description_suggestion";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
 
-const PostSkillSuggestionsRequestBodySchema = z.object({
-  instructions: z.string(),
-  agentFacingDescription: z.string(),
-  tools: z.array(z.object({ name: z.string(), description: z.string() })),
-});
-
-export type PostSkillSuggestionsRequestBody = z.infer<
-  typeof PostSkillSuggestionsRequestBodySchema
->;
+export type { PostSkillSuggestionsRequestBody } from "@app/lib/api/skills/description_suggestion";
 
 // Mounted at /api/w/:wId/builder/skills/suggestions.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front-api/routes/w/[wId]/credentials/check_bigquery_locations.ts
@@ -1,19 +1,11 @@
-import { CheckBigQueryCredentialsSchema } from "@app/types/oauth/lib";
+import type { PostCheckBigQueryLocationsResponseBody } from "@app/lib/api/oauth";
+import { PostCheckBigQueryRegionsRequestBodySchema } from "@app/lib/api/oauth";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { BigQuery } from "@google-cloud/bigquery";
-import { z } from "zod";
-
-const PostCheckBigQueryRegionsRequestBodySchema = z.object({
-  credentials: CheckBigQueryCredentialsSchema,
-});
-
-export type PostCheckBigQueryLocationsResponseBody = {
-  locations: Record<string, string[]>;
-};
 
 const app = workspaceApp();
 

--- a/front-api/routes/w/[wId]/credentials/index.ts
+++ b/front-api/routes/w/[wId]/credentials/index.ts
@@ -4,56 +4,17 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import apiConfig from "@app/lib/api/config";
+import type { PostCredentialsResponseBody } from "@app/lib/api/oauth";
+import { PostCredentialsBodySchema } from "@app/lib/api/oauth";
 import logger from "@app/logger/logger";
-import {
-  BigQueryCredentialsWithLocationSchema,
-  NotionCredentialsSchema,
-  SalesforceCredentialsSchema,
-  SnowflakeCredentialsSchema,
-} from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
 
 import checkBigQueryLocations from "./check_bigquery_locations";
 import slackIsLegacy from "./slack_is_legacy";
-
-const PostSnowflakeCredentialsBodySchema = z.object({
-  provider: z.literal("snowflake"),
-  credentials: SnowflakeCredentialsSchema,
-});
-
-const PostBigQueryCredentialsBodySchema = z.object({
-  provider: z.literal("bigquery"),
-  credentials: BigQueryCredentialsWithLocationSchema,
-});
-
-const PostSalesforceCredentialsBodySchema = z.object({
-  provider: z.literal("salesforce"),
-  credentials: SalesforceCredentialsSchema,
-});
-
-const PostNotionCredentialsBodySchema = z.object({
-  provider: z.literal("notion"),
-  credentials: NotionCredentialsSchema,
-});
-
-const PostCredentialsBodySchema = z.union([
-  PostSnowflakeCredentialsBodySchema,
-  PostBigQueryCredentialsBodySchema,
-  PostSalesforceCredentialsBodySchema,
-  PostNotionCredentialsBodySchema,
-]);
-
-export type PostCredentialsBody = z.infer<typeof PostCredentialsBodySchema>;
-export type PostCredentialsResponseBody = {
-  credentials: {
-    id: string;
-  };
-};
 
 const app = workspaceApp();
 

--- a/front-api/routes/w/[wId]/credentials/slack_is_legacy.ts
+++ b/front-api/routes/w/[wId]/credentials/slack_is_legacy.ts
@@ -1,4 +1,5 @@
 import apiConfig from "@app/lib/api/config";
+import type { GetSlackClientIdResponseBody } from "@app/lib/api/credentials";
 import logger from "@app/logger/logger";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -6,10 +7,6 @@ import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type GetSlackClientIdResponseBody = {
-  isLegacySlackApp: boolean;
-};
 
 const SlackCredentialContentSchema = z.object({
   client_id: z.string(),

--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -1,9 +1,9 @@
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ShareFileResponseBody } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { APIErrorResponse } from "@app/types/error";
-import type { FileShareScope } from "@app/types/files";
 import {
   fileShareScopeSchema,
   isConversationFileUseCase,
@@ -16,12 +16,6 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context, TypedResponse } from "hono";
 import { z } from "zod";
-
-export type ShareFileResponseBody = {
-  scope: FileShareScope;
-  sharedAt: number;
-  shareUrl: string;
-};
 
 import grants from "./grants";
 

--- a/front-api/routes/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front-api/routes/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -1,23 +1,14 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getFeatureFlags } from "@app/lib/auth";
+import type { GetMCPActionsResult } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
-import type { AgentMCPActionType } from "@app/types/actions";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import assert from "assert";
 import { z } from "zod";
-
-export type GetMCPActionsResult = {
-  actions: (AgentMCPActionType & {
-    conversationId: string;
-    messageId: string;
-  })[];
-  nextCursor: string | null;
-  totalCount: number;
-};
 
 const GetMCPActionsParamSchema = z.object({
   agentId: z.string(),

--- a/front-api/routes/w/[wId]/labs/request_access.ts
+++ b/front-api/routes/w/[wId]/labs/request_access.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
+import { PostRequestFeatureAccessBodySchema } from "@app/lib/api/labs";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -8,16 +9,6 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { escape } from "html-escaper";
-import { z } from "zod";
-
-export const PostRequestFeatureAccessBodySchema = z.object({
-  emailMessage: z.string(),
-  featureName: z.string(),
-});
-
-export type PostRequestFeatureAccessBody = z.infer<
-  typeof PostRequestFeatureAccessBodySchema
->;
 
 const MAX_ACCESS_REQUESTS_PER_DAY = 30;
 

--- a/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
+++ b/front-api/routes/w/[wId]/labs/transcripts/[tId].ts
@@ -1,3 +1,7 @@
+import {
+  type GetLabsTranscriptsConfigurationResponseBody as GetResponseBody,
+  PatchLabsTranscriptsConfigurationBodySchema,
+} from "@app/lib/api/labs/transcripts";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
@@ -7,25 +11,12 @@ import {
   stopRetrieveTranscriptsWorkflow,
 } from "@app/temporal/labs/transcripts/client";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
-import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
 import { isProviderWithDefaultWorkspaceConfiguration } from "@app/types/oauth/lib";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import { z } from "zod";
-
-export const PatchLabsTranscriptsConfigurationBodySchema = z.object({
-  agentConfigurationId: z.string().optional(),
-  // `isActive` is deprecated in favor of `status`, kept for backward compatibility.
-  isActive: z.boolean().optional(),
-  status: z.enum(["active", "disabled"]).optional(),
-  dataSourceViewId: z.string().nullable().optional(),
-});
-
-type GetResponseBody = {
-  configuration: LabsTranscriptsConfigurationType | null;
-};
 
 const NOT_FOUND_ERROR: APIErrorWithContentfulStatusCode = {
   status_code: 404,

--- a/front-api/routes/w/[wId]/labs/transcripts/index.ts
+++ b/front-api/routes/w/[wId]/labs/transcripts/index.ts
@@ -1,7 +1,7 @@
 import config from "@app/lib/api/config";
+import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/lib/api/labs/transcripts";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import logger from "@app/logger/logger";
-import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
 import {
   isCredentialProvider,
   isProviderWithDefaultWorkspaceConfiguration,
@@ -19,10 +19,6 @@ import {
   isApiKeyConfig,
   PostLabsTranscriptsConfigurationBodySchema,
 } from "./schemas";
-
-export type GetLabsTranscriptsConfigurationResponseBody = {
-  configuration: LabsTranscriptsConfigurationType | null;
-};
 
 // Mounted at /api/w/:wId/labs/transcripts.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
@@ -3,8 +3,16 @@ import {
   getServerTypeAndIdFromSId,
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
-import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type {
+  DeleteMCPServerResponseBody,
+  GetMCPServerResponseBody,
+  MCPServerType,
+  MCPServerTypeWithViews,
+  PatchMCPServerBody,
+  PatchMCPServerResponseBody,
+} from "@app/lib/api/mcp";
 import { withWorkspaceConnectionRequirement } from "@app/lib/api/mcp_oauth_prerequisites";
+import { PatchMCPServerBodySchema } from "@app/lib/api/mcp_schemas";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -23,48 +31,6 @@ import { z } from "zod";
 
 import sync from "./sync";
 import tools from "./tools";
-
-const PatchMCPServerBodySchema = z
-  .object({
-    icon: z.string(),
-  })
-  .or(
-    z
-      .object({
-        sharedSecret: z.string().optional(),
-        customHeaders: z
-          .array(z.object({ key: z.string(), value: z.string() }))
-          .nullable()
-          .optional(),
-      })
-      .refine(
-        (data) =>
-          data.sharedSecret !== undefined || data.customHeaders !== undefined,
-        {
-          message: "Either sharedSecret or customHeaders must be provided",
-        }
-      )
-  )
-  .or(
-    z.object({
-      meta: z.record(z.string(), z.string()).nullable(),
-    })
-  );
-
-export type PatchMCPServerBody = z.infer<typeof PatchMCPServerBodySchema>;
-
-export type GetMCPServerResponseBody = {
-  server: MCPServerTypeWithViews;
-};
-
-export type PatchMCPServerResponseBody = {
-  success: true;
-  server: MCPServerType;
-};
-
-export type DeleteMCPServerResponseBody = {
-  deleted: boolean;
-};
 
 const ParamsSchema = z.object({
   serverId: z.string(),

--- a/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/sync.ts
@@ -1,5 +1,5 @@
 import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { SyncMCPServerResponseBody } from "@app/lib/api/mcp";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -11,11 +11,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   serverId: z.string(),
 });
-
-export type SyncMCPServerResponseBody = {
-  success: boolean;
-  server: MCPServerType;
-};
 
 // Mounted at /api/w/:wId/mcp/:serverId/sync. Admin-only — refreshes the cached
 // metadata for a remote MCP server.

--- a/front-api/routes/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -1,5 +1,9 @@
-import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import type {
+  PatchMCPServerToolsPermissionsResponseBody,
+  UpdateMCPToolSettingsBodyType,
+} from "@app/lib/api/mcp";
+import { UpdateMCPToolSettingsBodySchema } from "@app/lib/api/mcp_schemas";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsUser } from "@front-api/middlewares/ensure_role";
@@ -8,24 +12,9 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-const UpdateMCPToolSettingsBodySchema = z
-  .object({
-    permission: z.enum(MCP_TOOL_STAKE_LEVELS).optional(),
-    enabled: z.boolean().optional(),
-  })
-  .refine(
-    (data) => data.permission !== undefined || data.enabled !== undefined,
-    {
-      message: "At least one of 'permission' or 'enabled' must be provided.",
-    }
-  );
-
-export type UpdateMCPToolSettingsBodyType = z.infer<
-  typeof UpdateMCPToolSettingsBodySchema
->;
-
-export type PatchMCPServerToolsPermissionsResponseBody = {
-  success: boolean;
+export type {
+  PatchMCPServerToolsPermissionsResponseBody,
+  UpdateMCPToolSettingsBodyType,
 };
 
 const ParamsSchema = z.object({

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -7,10 +7,12 @@ import type { Authenticator } from "@app/lib/auth";
 import type {
   MCPServerConnectionConnectionType,
   MCPServerConnectionType,
+  PostConnectionBodyType,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import {
   isMCPServerConnectionConnectionType,
   MCPServerConnectionResource,
+  PostConnectionBodySchema,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -23,26 +25,9 @@ import { z } from "zod";
 
 import connection from "./[cId]";
 
-const PostConnectionOAuthBodySchema = z.object({
-  connectionId: z.string(),
-  mcpServerId: z.string(),
-});
-
-const PostConnectionCredentialsBodySchema = z.object({
-  credentialId: z.string(),
-  mcpServerId: z.string(),
-});
-
-const PostConnectionBodySchema = z.union([
-  PostConnectionOAuthBodySchema,
-  PostConnectionCredentialsBodySchema,
-]);
-
 const ParamsSchema = z.object({
   connectionType: z.string(),
 });
-
-export type PostConnectionBodyType = z.infer<typeof PostConnectionBodySchema>;
 
 // Wire shape: ctx.json serializes Date to ISO string, so the response type
 // must reflect that to satisfy HandlerResult<T>.

--- a/front-api/routes/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front-api/routes/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -1,7 +1,7 @@
 import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
-import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
+import type { DiscoverOAuthMetadataResponseBody } from "@app/lib/api/oauth/providers/mcp";
 import { validateExternalUrl } from "@app/lib/api/url_safety";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
@@ -10,15 +10,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type DiscoverOAuthMetadataResponseBody =
-  | {
-      oauthRequired: true;
-      connectionMetadata: MCPOAuthConnectionMetadataType;
-    }
-  | {
-      oauthRequired: false;
-    };
 
 const PostBodySchema = z.object({
   url: z.string(),

--- a/front-api/routes/w/[wId]/mcp/index.ts
+++ b/front-api/routes/w/[wId]/mcp/index.ts
@@ -1,5 +1,5 @@
 import { isRemoteMCPServerError } from "@app/lib/actions/mcp_errors";
-import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type { GetMCPServersResponseBody } from "@app/lib/api/mcp";
 import {
   createInternalMCPServer,
   createRemoteMCPServer,
@@ -23,16 +23,6 @@ import requests from "./requests";
 import results from "./results";
 import usage from "./usage";
 import views from "./views";
-
-export type GetMCPServersResponseBody = {
-  success: true;
-  servers: MCPServerTypeWithViews[];
-};
-
-export type CreateMCPServerResponseBody = {
-  success: true;
-  server: MCPServerType;
-};
 
 const CustomHeadersSchema = z
   .array(z.object({ key: z.string(), value: z.string() }))

--- a/front-api/routes/w/[wId]/mcp/request_access.ts
+++ b/front-api/routes/w/[wId]/mcp/request_access.ts
@@ -1,6 +1,7 @@
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
+import { PostRequestActionsAccessBodySchema } from "@app/lib/api/mcp_schemas";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
@@ -8,16 +9,8 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { escape } from "html-escaper";
-import { z } from "zod";
 
-export const PostRequestActionsAccessBodySchema = z.object({
-  emailMessage: z.string(),
-  mcpServerViewId: z.string(),
-});
-
-export type PostRequestActionsAccessBody = z.infer<
-  typeof PostRequestActionsAccessBodySchema
->;
+export type { PostRequestActionsAccessBody } from "@app/lib/api/mcp";
 
 const MAX_ACCESS_REQUESTS_PER_DAY = 30;
 

--- a/front-api/routes/w/[wId]/mcp/usage.ts
+++ b/front-api/routes/w/[wId]/mcp/usage.ts
@@ -1,11 +1,7 @@
-import type { MCPServersUsageByAgent } from "@app/lib/api/agent_actions";
 import { getToolsUsage } from "@app/lib/api/agent_actions";
+import type { GetMCPServersUsageResponseBody } from "@app/lib/api/mcp";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetMCPServersUsageResponseBody = {
-  usage: MCPServersUsageByAgent;
-};
 
 // Mounted at /api/w/:wId/mcp/usage.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
@@ -1,5 +1,6 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { PatchMCPServerViewResponseBody } from "@app/lib/api/mcp/views";
 import {
+  PatchMCPServerViewBodySchema,
   updateNameAndDescriptionForMCPServerViews,
   updateOAuthUseCaseForMCPServerViews,
 } from "@app/lib/api/mcp/views";
@@ -12,26 +13,6 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import { z } from "zod";
-
-const PatchMCPServerViewBodySchema = z
-  .object({
-    oAuthUseCase: z.enum(["platform_actions", "personal_actions"]),
-  })
-  .or(
-    z.object({
-      name: z.string().nullable(),
-      description: z.string().nullable(),
-    })
-  );
-
-export type PatchMCPServerViewBody = z.infer<
-  typeof PatchMCPServerViewBodySchema
->;
-
-export type PatchMCPServerViewResponseBody = {
-  success: true;
-  serverView: MCPServerViewType;
-};
 
 const ParamsSchema = z.object({
   viewId: z.string(),

--- a/front-api/routes/w/[wId]/mcp/views/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/index.ts
@@ -1,4 +1,4 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { GetMCPServerViewsListResponseBody } from "@app/lib/api/mcp";
 import {
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
@@ -22,11 +22,6 @@ const GetMCPViewsRequestSchema = z.object({
   spaceIds: z.array(z.string()),
   availabilities: z.array(MCPViewsRequestAvailabilitySchema),
 });
-
-export type GetMCPServerViewsListResponseBody = {
-  success: boolean;
-  serverViews: MCPServerViewType[];
-};
 
 // We don't allow fetching "auto_hidden_builder".
 function isAllowedAvailability(

--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -1,16 +1,12 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
+import type { GetEnabledModelsResponseType } from "@app/lib/api/assistant/models";
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { filterEnabledModels } from "@app/lib/assistant";
 import { getFeatureFlags } from "@app/lib/auth";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetEnabledModelsResponseType = {
-  models: ModelConfigurationType[];
-};
 
 // Mounted at /api/w/:wId/models.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/oauth/[provider]/setup.ts
+++ b/front-api/routes/w/[wId]/oauth/[provider]/setup.ts
@@ -1,4 +1,6 @@
 /** @ignoreswagger */
+
+import type { GetOAuthSetupResponseBody } from "@app/lib/api/oauth";
 import { createConnectionAndGetSetupUrl } from "@app/lib/api/oauth";
 import {
   ExtraConfigTypeSchema,
@@ -9,10 +11,6 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface GetOAuthSetupResponseBody {
-  redirectUrl: string;
-}
 
 const ProviderParamSchema = z.object({
   provider: z.enum(OAUTH_PROVIDERS),

--- a/front-api/routes/w/[wId]/provider_credentials/[providerId]/index.ts
+++ b/front-api/routes/w/[wId]/provider_credentials/[providerId]/index.ts
@@ -3,26 +3,21 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import type { ProviderCredentialResponseBody } from "@app/lib/resources/provider_credential_resource";
+import {
+  ProviderCredentialBodySchema,
+  ProviderCredentialResource,
+} from "@app/lib/resources/provider_credential_resource";
 import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import type { ProviderCredentialType } from "@app/types/provider_credential";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-const ProviderCredentialBodySchema = z.object({
-  apiKey: z.string(),
-});
-
 const ProviderCredentialParamsSchema = z.object({
   providerId: z.enum(BYOK_MODEL_PROVIDER_IDS),
 });
-
-export type ProviderCredentialResponseBody = {
-  providerCredential: ProviderCredentialType;
-};
 
 // Mounted at /api/w/:wId/provider_credentials/:providerId.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/provider_credentials/index.ts
+++ b/front-api/routes/w/[wId]/provider_credentials/index.ts
@@ -1,12 +1,10 @@
+import type { GetProviderCredentialsResponseBody } from "@app/lib/resources/provider_credential_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
-import type { ProviderCredentialType } from "@app/types/provider_credential";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 
-export type GetProviderCredentialsResponseBody = {
-  providerCredentials: ProviderCredentialType[];
-};
+export type { GetProviderCredentialsResponseBody };
 
 // Mounted at /api/w/:wId/provider_credentials.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/providers/[pId]/check.ts
+++ b/front-api/routes/w/[wId]/providers/[pId]/check.ts
@@ -1,12 +1,9 @@
+import type { GetProvidersCheckResponseBody } from "@app/lib/api/provider_credentials";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type GetProvidersCheckResponseBody =
-  | { ok: true }
-  | { ok: false; error: string };
 
 const PostCheckBodySchema = z.object({
   config: z.object({

--- a/front-api/routes/w/[wId]/providers/index.ts
+++ b/front-api/routes/w/[wId]/providers/index.ts
@@ -1,5 +1,5 @@
+import type { GetProvidersResponseBody } from "@app/lib/api/providers";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
-import type { ProviderType } from "@app/types/provider";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
@@ -7,10 +7,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import check from "./[pId]/check";
 import provider from "./[pId]/index";
 import models from "./[pId]/models";
-
-export type GetProvidersResponseBody = {
-  providers: ProviderType[];
-};
 
 function redactConfig(config: string) {
   const parsedConfig = JSON.parse(config);

--- a/front-api/routes/w/[wId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy.ts
@@ -3,22 +3,17 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type {
+  GetWorkspaceEgressPolicyResponseBody,
+  PutWorkspaceEgressPolicyResponseBody,
+} from "@app/lib/api/sandbox/egress_policy";
 import {
   readWorkspacePolicy,
   writeWorkspacePolicy,
 } from "@app/lib/api/sandbox/egress_policy";
-import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetWorkspaceEgressPolicyResponseBody = {
-  policy: EgressPolicy;
-};
-
-export type PutWorkspaceEgressPolicyResponseBody = {
-  policy: EgressPolicy;
-};
 
 // Mounted at /api/w/:wId/sandbox/egress-policy.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/[id].ts
@@ -1,18 +1,12 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import type { PatchWorkspaceSandboxEnvVarResponseBody } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
-import {
-  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
-  type WorkspaceSandboxEnvVarType,
-} from "@app/types/sandbox/env_var";
+import { WORKSPACE_SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { SuccessResponseBody } from "@front-api/routes/types";
 import { z } from "zod";
-
-export type PatchWorkspaceSandboxEnvVarResponseBody = {
-  envVar: WorkspaceSandboxEnvVarType;
-};
 
 const PatchWorkspaceSandboxEnvVarBodySchema = z.object({
   kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS).optional(),

--- a/front-api/routes/w/[wId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/index.ts
@@ -1,13 +1,14 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import type {
+  GetWorkspaceSandboxEnvVarsResponseBody,
+  PostWorkspaceSandboxEnvVarsResponseBody,
+} from "@app/lib/api/sandbox/env_vars";
 import {
   parseWorkspaceSandboxEnvVarNameForKind,
   validateEnvVarValueForKind,
 } from "@app/lib/api/sandbox/env_vars";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
-import {
-  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
-  type WorkspaceSandboxEnvVarType,
-} from "@app/types/sandbox/env_var";
+import { WORKSPACE_SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -21,15 +22,6 @@ const PostWorkspaceSandboxEnvVarBodySchema = z.object({
   kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS).optional(),
   allowedDomains: z.array(z.string()).nullable().optional(),
 });
-
-export type GetWorkspaceSandboxEnvVarsResponseBody = {
-  envVars: WorkspaceSandboxEnvVarType[];
-};
-
-export type PostWorkspaceSandboxEnvVarsResponseBody = {
-  envVar: WorkspaceSandboxEnvVarType;
-  created: boolean;
-};
 
 // Mounted at /api/w/:wId/sandbox/env-vars.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -1,8 +1,12 @@
+import type {
+  PatchSkillEditorsRequestBody,
+  SkillEditorsResponseBody,
+} from "@app/lib/api/skills/editors";
+import { PatchSkillEditorsRequestBodySchema } from "@app/lib/api/skills/editors";
 import type { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { UserType } from "@app/types/user";
 import { toLightUser } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -10,33 +14,11 @@ import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
 import { z } from "zod";
 
+export type { PatchSkillEditorsRequestBody, SkillEditorsResponseBody };
+
 const ParamsSchema = z.object({
   sId: z.string(),
 });
-
-const PatchSkillEditorsRequestBodySchema = z
-  .object({
-    addEditorIds: z.array(z.string()).optional(),
-    removeEditorIds: z.array(z.string()).optional(),
-  })
-  .refine(
-    (body) =>
-      (body.addEditorIds instanceof Array && body.addEditorIds.length > 0) ||
-      (body.removeEditorIds instanceof Array &&
-        body.removeEditorIds.length > 0),
-    {
-      message:
-        "Either addEditorIds or removeEditorIds must be provided and contain at least one ID.",
-    }
-  );
-
-export type PatchSkillEditorsRequestBody = z.infer<
-  typeof PatchSkillEditorsRequestBodySchema
->;
-
-export interface SkillEditorsResponseBody {
-  editors: UserType[];
-}
 
 // Resolve :sId into a skill + its editor group. Returns either the loaded
 // resources or a Response describing the failure — keeps the validation

--- a/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/history/index.ts
@@ -1,7 +1,7 @@
+import type { GetSkillHistoryResponseBody } from "@app/lib/api/assistant/skills/history";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GetSkillHistoryQuerySchema } from "@app/types/api/internal/skill";
-import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -12,10 +12,6 @@ import { fromError } from "zod-validation-error";
 const ParamsSchema = z.object({
   sId: z.string(),
 });
-
-export type GetSkillHistoryResponseBody = {
-  history: SkillWithVersionType[];
-};
 
 // Mounted at /api/w/:wId/skills/:sId/history.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -1,3 +1,9 @@
+import type {
+  DeleteSkillResponseBody,
+  GetSkillResponseBody,
+  GetSkillWithRelationsResponseBody,
+  PatchSkillResponseBody,
+} from "@app/lib/api/skills";
 import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -8,10 +14,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
-import type {
-  SkillType,
-  SkillWithRelationsType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { APIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -27,30 +30,6 @@ import filesRoute from "./files/[fileId]/content";
 import history from "./history";
 import reinforcement from "./reinforcement";
 import restore from "./restore";
-
-export type GetSkillResponseBody = {
-  skill: SkillType;
-};
-
-export type GetSkillWithRelationsResponseBody = {
-  skill: SkillWithRelationsType;
-};
-
-export type PatchSkillResponseBody = {
-  skill: Omit<
-    SkillType,
-    | "author"
-    | "requestedSpaceIds"
-    | "workspaceId"
-    | "createdAt"
-    | "updatedAt"
-    | "editedBy"
-  >;
-};
-
-export type DeleteSkillResponseBody = {
-  success: boolean;
-};
 
 const ParamsSchema = z.object({
   sId: z.string(),

--- a/front-api/routes/w/[wId]/skills/detect/index.ts
+++ b/front-api/routes/w/[wId]/skills/detect/index.ts
@@ -5,7 +5,10 @@ import {
 import { initGitHubRepoClient } from "@app/lib/api/skills/detection/github/github_api";
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { DetectedSkillSummary } from "@app/lib/skill_detection";
+import type {
+  DetectedSkillSummary,
+  DetectSkillsResponseBody,
+} from "@app/lib/skill_detection";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
@@ -15,10 +18,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
 import upload from "./upload";
-
-export type DetectSkillsResponseBody = {
-  skills: DetectedSkillSummary[];
-};
 
 // Mounted at /api/w/:wId/skills/detect.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/skills/import/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/index.ts
@@ -1,30 +1,22 @@
-import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
+import type {
+  ImportSkillsRequestBody,
+  ImportSkillsResponseBody,
+} from "@app/lib/api/skills/detection/github/import_skills";
+import {
+  ImportSkillsRequestBodySchema,
+  importSkillsFromGitHub,
+} from "@app/lib/api/skills/detection/github/import_skills";
 import logger from "@app/logger/logger";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
 
 import upload from "./upload";
 
-const ImportSkillsRequestBodySchema = z.object({
-  repoUrl: z.string(),
-  names: z.array(z.string()),
-});
-
-export type ImportSkillsRequestBody = z.infer<
-  typeof ImportSkillsRequestBodySchema
->;
-
-export type ImportSkillsResponseBody = {
-  imported: SkillType[];
-  updated: SkillType[];
-  skipped: { name: string; message: string }[];
-};
+export type { ImportSkillsRequestBody, ImportSkillsResponseBody };
 
 // Mounted at /api/w/:wId/skills/import.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -1,4 +1,10 @@
+import type {
+  GetSkillsResponseBody,
+  GetSkillsWithRelationsResponseBody,
+  PostSkillResponseBody,
+} from "@app/lib/api/skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -8,8 +14,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import {
   SKILL_REINFORCEMENT_MODES,
-  type SkillType,
-  type SkillWithoutInstructionsAndToolsType,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
   type UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
@@ -28,29 +32,9 @@ import reinforcementDailySpend from "./reinforcement_daily_spend";
 import reinforcementSpend from "./reinforcement_spend";
 import similar from "./similar";
 
-export type GetSkillsResponseBody = {
-  skills: SkillWithoutInstructionsAndToolsType[];
-};
-
-export type GetSkillsWithRelationsResponseBody = {
-  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
-};
-
-export type PostSkillResponseBody = {
-  skill: SkillType;
-};
-
 const SkillStatusSchema = z
   .enum(["active", "archived", "suggested"])
   .optional();
-
-// Schema for attached knowledge.
-export const AttachedKnowledgeSchema = z.object({
-  dataSourceViewId: z.string(),
-  nodeId: z.string(),
-  spaceId: z.string(),
-  title: z.string(),
-});
 
 // Request body schema for POST.
 const PostSkillRequestBodySchema = z.intersection(

--- a/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.ts
@@ -1,15 +1,9 @@
+import type { GetReinforcementDailySpendResponseBody } from "@app/lib/api/skills";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetReinforcementDailySpendResponseBody = {
-  // ISO date strings ("YYYY-MM-DD") → spend in microUSD for that day.
-  dailySpendMicroUsd: Record<string, number>;
-  periodStartDate: string;
-  periodEndDate: string;
-};
 
 // Mounted at /api/w/:wId/skills/reinforcement_daily_spend.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
@@ -1,15 +1,10 @@
+import type { GetSkillsSpendResponseBody } from "@app/lib/api/skills";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetSkillsSpendResponseBody = {
-  // Map from skill sId to total spent in the current billing period (microUSD).
-  // Skills with no usage in the period are omitted.
-  spentMicroUsdBySkillId: Record<string, number>;
-};
 
 // Mounted at /api/w/:wId/skills/reinforcement_spend.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/skills/similar.ts
+++ b/front-api/routes/w/[wId]/skills/similar.ts
@@ -4,10 +4,6 @@ import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 
-export type GetSimilarSkillsResponseBody = {
-  similar_skills: string[];
-};
-
 // Mounted at /api/w/:wId/skills/similar.
 const app = workspaceApp();
 

--- a/front-api/routes/w/[wId]/tags/index.ts
+++ b/front-api/routes/w/[wId]/tags/index.ts
@@ -1,7 +1,10 @@
+import type {
+  CreateTagResponseBody,
+  GetTagsResponseBody,
+} from "@app/lib/api/tags";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { TagResource } from "@app/lib/resources/tags_resource";
-import type { TagType } from "@app/types/tag";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -11,14 +14,6 @@ import { z } from "zod";
 import tagById from "./[tId]";
 import suggestFromAgents from "./suggest_from_agents";
 import usage from "./usage";
-
-export type GetTagsResponseBody = {
-  tags: TagType[];
-};
-
-export type CreateTagResponseBody = {
-  tag: TagType;
-};
 
 const PostBodySchema = z.object({
   name: z.string(),

--- a/front-api/routes/w/[wId]/tags/suggest_from_agents.ts
+++ b/front-api/routes/w/[wId]/tags/suggest_from_agents.ts
@@ -1,4 +1,5 @@
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import type { GetSuggestionsResponseBody } from "@app/lib/api/assistant/tag_manager";
 import { getWorkspaceTagSuggestions } from "@app/lib/api/assistant/tag_manager";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { isAdmin } from "@app/types/user";
@@ -27,16 +28,6 @@ const DEFAULT_SUGGESTIONS = [
   "Quality",
   "Product",
 ];
-
-export type GetSuggestionsResponseBody = {
-  suggestions:
-    | {
-        name: string;
-        agents: { sId: string; name: string }[];
-      }[]
-    | null
-    | undefined;
-};
 
 // Mounted at /api/w/:wId/tags/suggest_from_agents.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/tags/usage/index.ts
+++ b/front-api/routes/w/[wId]/tags/usage/index.ts
@@ -1,12 +1,8 @@
+import type { GetTagsUsageResponseBody } from "@app/lib/resources/tags_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
-import type { TagTypeWithUsage } from "@app/types/tag";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetTagsUsageResponseBody = {
-  tags: TagTypeWithUsage[];
-};
 
 // Mounted at /api/w/:wId/tags/usage.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
@@ -1,14 +1,10 @@
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger_usage_estimation";
 import { computeFilteredWebhookTriggerForecast } from "@app/lib/triggers/trigger_usage_estimation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type GetTriggerEstimationResponseBody = {
-  matchingCount: number;
-  totalCount: number;
-};
 
 const GetTriggerEstimationQuerySchema = z.object({
   filter: z.string().optional(),

--- a/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -1,6 +1,6 @@
+import type { GetWebhookSourceViewsForSourceResponseBody as GetWebhookSourceViewsResponseBody } from "@app/lib/api/webhook_source";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -9,11 +9,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   webhookSourceId: z.string(),
 });
-
-export type GetWebhookSourceViewsResponseBody = {
-  success: true;
-  views: WebhookSourceViewType[];
-};
 
 // Mounted at /api/w/:wId/webhook_sources/:webhookSourceId/views.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/webhook_sources/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/index.ts
@@ -1,7 +1,11 @@
 import { getWebhookSourcesUsage } from "@app/lib/api/agent_triggers";
 import config from "@app/lib/api/config";
 import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/services";
-import { deleteWebhookSource } from "@app/lib/api/webhook_source";
+import {
+  deleteWebhookSource,
+  type GetWebhookSourcesResponseBody,
+  type PostWebhookSourcesResponseBody,
+} from "@app/lib/api/webhook_source";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateSecureSecret } from "@app/lib/resources/string_ids_server";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -9,10 +13,6 @@ import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_v
 import { buildWebhookUrl } from "@app/lib/webhook_source";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
-import type {
-  WebhookSourceForAdminType,
-  WebhookSourceWithViewsAndUsageType,
-} from "@app/types/triggers/webhooks";
 import { WebhookSourcesSchema } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -22,16 +22,6 @@ import { validate } from "@front-api/middlewares/validator";
 import webhookSourceById from "./[webhookSourceId]";
 import serviceData from "./service-data";
 import views from "./views";
-
-export type GetWebhookSourcesResponseBody = {
-  success: true;
-  webhookSourcesWithViews: WebhookSourceWithViewsAndUsageType[];
-};
-
-export type PostWebhookSourcesResponseBody = {
-  success: true;
-  webhookSource: WebhookSourceForAdminType;
-};
 
 // Mounted at /api/w/:wId/webhook_sources.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/webhook_sources/service-data.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/service-data.ts
@@ -3,22 +3,13 @@ import { checkConnectionOwnership } from "@app/lib/api/oauth";
 import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/services";
 import logger from "@app/logger/logger";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
-import type {
-  WebhookProvider,
-  WebhookServiceDataForProvider,
-} from "@app/types/triggers/webhooks";
+import type { GetServiceDataResponseType } from "@app/types/triggers/webhooks";
 import { isWebhookProvider } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type GetServiceDataResponseType<
-  P extends WebhookProvider = WebhookProvider,
-> = {
-  serviceData: WebhookServiceDataForProvider<P>;
-};
 
 const GetServiceDataQuerySchema = z.object({
   connectionId: z.string().min(1, "connectionId is required"),

--- a/front-api/routes/w/[wId]/webhook_sources/views/index.ts
+++ b/front-api/routes/w/[wId]/webhook_sources/views/index.ts
@@ -1,17 +1,12 @@
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { GetWebhookSourceViewsListResponseBody } from "@app/lib/resources/webhook_sources_view_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import viewById from "./[viewId]";
-
-export type GetWebhookSourceViewsListResponseBody = {
-  success: boolean;
-  webhookSourceViews: WebhookSourceViewType[];
-};
 
 const GetWebhookSourceViewsQuerySchema = z.object({
   spaceIds: z.string(),

--- a/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
+++ b/front/components/actions/mcp/create/SnowflakeKeypairCredentialForm.tsx
@@ -1,8 +1,8 @@
 import type { StaticCredentialFormHandle } from "@app/components/actions/mcp/MCPServerAuthConnection";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PostCredentialsResponseBody } from "@app/lib/api/oauth";
 import { clientFetch } from "@app/lib/egress/client";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { PostCredentialsResponseBody } from "@app/pages/api/w/[wId]/credentials";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitCreateMCPServerDialogForm.ts
@@ -1,13 +1,15 @@
 import type { CreateMCPServerDialogFormValues } from "@app/components/actions/mcp/forms/types";
 import { requiresBearerTokenConfiguration } from "@app/lib/actions/mcp_helper";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type {
+  CreateMCPServerResponseBody,
+  MCPServerType,
+} from "@app/lib/api/mcp";
+import type { DiscoverOAuthMetadataResponseBody } from "@app/lib/api/oauth/providers/mcp";
 import {
   isMCPCreateServerError,
   type MCPConnectionType,
 } from "@app/lib/swr/mcp_servers";
-import type { CreateMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp";
-import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { RegionInfo } from "@app/types/region";

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -1,11 +1,11 @@
 // Okay to use public API types because it's front/connectors communication.
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { PostCredentialsBody } from "@app/lib/api/oauth";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { clientFetch } from "@app/lib/egress/client";
 import { useBigQueryLocations } from "@app/lib/swr/bigquery";
-import type { PostCredentialsBody } from "@app/pages/api/w/[wId]/credentials";
 import type {
   ConnectorProvider,
   ConnectorType,

--- a/front/components/labs/transcripts/ProcessingConfiguration.tsx
+++ b/front/components/labs/transcripts/ProcessingConfiguration.tsx
@@ -1,7 +1,7 @@
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/lib/api/labs/transcripts";
 import { useUpdateTranscriptsConfiguration } from "@app/lib/swr/labs";
-import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/components/labs/transcripts/ProviderSelection.tsx
+++ b/front/components/labs/transcripts/ProviderSelection.tsx
@@ -1,4 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/lib/api/labs/transcripts";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -6,7 +7,6 @@ import {
   useLabsTranscriptsIsConnectorConnected,
 } from "@app/lib/swr/labs";
 import datadogLogger from "@app/logger/datadogLogger";
-import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import type {
   LabsTranscriptsConfigurationType,
   LabsTranscriptsProviderType,

--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -1,6 +1,6 @@
 import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
+import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/lib/api/labs/transcripts";
 import { useUpdateTranscriptsConfiguration } from "@app/lib/swr/labs";
-import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
 import type {
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,7 +1,9 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
+import type {
+  PatchSkillResponseBody,
+  PostSkillResponseBody,
+} from "@app/lib/api/skills";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PostSkillResponseBody } from "@app/pages/api/w/[wId]/skills";
-import type { PatchSkillResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/components/skill_builder/utils.ts
+++ b/front/components/skill_builder/utils.ts
@@ -1,5 +1,5 @@
+import type { PostSkillSuggestionsRequestBody } from "@app/lib/api/skills/description_suggestion";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PostSkillSuggestionsRequestBody } from "@app/pages/api/w/[wId]/builder/skills/suggestions";
 import type { APIError } from "@app/types/error";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -1,9 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { FileUploadRequestResponseBody } from "@app/lib/api/files/upload_metadata";
 import { clientFetch } from "@app/lib/egress/client";
+import type { FileUploadedRequestResponseBody } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { FileUploadRequestResponseBody } from "@app/pages/api/w/[wId]/files";
-import type { FileUploadedRequestResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]";
 import { isAPIErrorResponse } from "@app/types/error";
 import type {
   FileUseCase,

--- a/front/lib/agent_builder/server_side_props_helpers.ts
+++ b/front/lib/agent_builder/server_side_props_helpers.ts
@@ -29,6 +29,10 @@ import type {
 } from "@app/types/data_source_view";
 import assert from "assert";
 
+export type GetActionsResponseBody = {
+  actions: AgentBuilderMCPConfiguration[];
+};
+
 // We are moving resource fetch to the client side. Until we finish,
 // we will keep this duplicated version for fetching actions.
 export const getAccessibleSourcesAndAppsForActions = async (

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -32,6 +32,10 @@ import {
   GROK_4_MODEL_CONFIG,
 } from "@app/types/assistant/models/xai";
 
+export type GetEnabledModelsResponseType = {
+  models: ModelConfigurationType[];
+};
+
 export function getWhitelistedProviders(
   auth: Authenticator
 ): Set<ModelProviderIdType> {

--- a/front/lib/api/assistant/skills/history.ts
+++ b/front/lib/api/assistant/skills/history.ts
@@ -1,0 +1,8 @@
+// Contract types for the skill history endpoint
+// (`/api/w/:wId/skills/:sId/history`). Shared by the Next.js handler and its
+// Hono counterpart so both rely on a single source of truth.
+import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
+
+export type GetSkillHistoryResponseBody = {
+  history: SkillWithVersionType[];
+};

--- a/front/lib/api/assistant/tag_manager.ts
+++ b/front/lib/api/assistant/tag_manager.ts
@@ -7,8 +7,25 @@ import { Err, Ok } from "@app/types/shared/result";
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import { formatValidationErrors } from "io-ts-reporters";
+import { z } from "zod";
 
 const SEND_TAGS_FUNCTION_NAME = "send_tags";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const GetSuggestionsResponseBodySchema = z.object({
+  suggestions: z
+    .array(
+      z.object({
+        name: z.string(),
+        agents: z.array(z.object({ sId: z.string(), name: z.string() })),
+      })
+    )
+    .nullish(),
+});
+
+export type GetSuggestionsResponseBody = z.infer<
+  typeof GetSuggestionsResponseBodySchema
+>;
 
 const WorkspaceTagSuggestionsResponseSchema = t.type({
   suggestions: t.union([

--- a/front/lib/api/credentials.ts
+++ b/front/lib/api/credentials.ts
@@ -1,0 +1,3 @@
+export type GetSlackClientIdResponseBody = {
+  isLegacySlackApp: boolean;
+};

--- a/front/lib/api/files/upload_metadata.ts
+++ b/front/lib/api/files/upload_metadata.ts
@@ -2,9 +2,14 @@ import { shouldStampSandboxRawDelimited } from "@app/lib/api/files/sandbox_raw";
 import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
 import type {
   AllSupportedFileContentType,
+  FileTypeWithUploadUrl,
   FileUseCase,
   FileUseCaseMetadata,
 } from "@app/types/files";
+
+export interface FileUploadRequestResponseBody {
+  file: FileTypeWithUploadUrl;
+}
 
 export function buildEffectiveUseCaseMetadata({
   contentType,

--- a/front/lib/api/labs.ts
+++ b/front/lib/api/labs.ts
@@ -8,6 +8,16 @@ import {
 } from "@app/temporal/labs/transcripts/client";
 import type { LabsTranscriptsConfigurationStatus } from "@app/types/labs";
 import { Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+export const PostRequestFeatureAccessBodySchema = z.object({
+  emailMessage: z.string(),
+  featureName: z.string(),
+});
+
+export type PostRequestFeatureAccessBody = z.infer<
+  typeof PostRequestFeatureAccessBodySchema
+>;
 
 /**
  * Pauses all Labs transcripts temporal workflows and their schedules for a workspace.

--- a/front/lib/api/labs/transcripts.ts
+++ b/front/lib/api/labs/transcripts.ts
@@ -1,0 +1,22 @@
+import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
+import { z } from "zod";
+
+export type GetLabsTranscriptsConfigurationResponseBody = {
+  configuration: LabsTranscriptsConfigurationType | null;
+};
+
+export type GetLabsTranscriptsConfigurationByIdResponseBody = {
+  configuration: LabsTranscriptsConfigurationResource | null;
+};
+
+export const PatchLabsTranscriptsConfigurationBodySchema = z.object({
+  agentConfigurationId: z.string().optional(),
+  // `isActive` is deprecated in favor of `status`, kept for backward compatibility.
+  isActive: z.boolean().optional(),
+  status: z.enum(["active", "disabled"]).optional(),
+  dataSourceViewId: z.string().nullable().optional(),
+});
+export type PatchTranscriptsConfiguration = z.infer<
+  typeof PatchLabsTranscriptsConfigurationBodySchema
+>;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -17,10 +17,17 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
+import type { MCPServersUsageByAgent } from "@app/lib/api/agent_actions";
+import type {
+  PatchMCPServerBodySchema,
+  PostRequestActionsAccessBodySchema,
+  UpdateMCPToolSettingsBodySchema,
+} from "@app/lib/api/mcp_schemas";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type { z } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const MCP_TOOL_RETRY_POLICY_TYPES = ["retry_on_interrupt", "no_retry"] as const;
@@ -167,3 +174,54 @@ export type GetMCPServerViewsNotActivatedResponseBody = {
   success: boolean;
   serverViews: MCPServerViewType[];
 };
+
+export type GetMCPServersResponseBody = {
+  success: true;
+  servers: MCPServerTypeWithViews[];
+};
+
+export type CreateMCPServerResponseBody = {
+  success: true;
+  server: MCPServerType;
+};
+
+export type PostRequestActionsAccessBody = z.infer<
+  typeof PostRequestActionsAccessBodySchema
+>;
+
+export type PatchMCPServerBody = z.infer<typeof PatchMCPServerBodySchema>;
+
+export type GetMCPServerResponseBody = {
+  server: MCPServerTypeWithViews;
+};
+
+export type PatchMCPServerResponseBody = {
+  success: true;
+  server: MCPServerType;
+};
+
+export type DeleteMCPServerResponseBody = {
+  deleted: boolean;
+};
+
+export type GetMCPServersUsageResponseBody = {
+  usage: MCPServersUsageByAgent;
+};
+
+export type SyncMCPServerResponseBody = {
+  success: boolean;
+  server: MCPServerType;
+};
+
+export type GetMCPServerViewsListResponseBody = {
+  success: boolean;
+  serverViews: MCPServerViewType[];
+};
+
+export type PatchMCPServerToolsPermissionsResponseBody = {
+  success: boolean;
+};
+
+export type UpdateMCPToolSettingsBodyType = z.infer<
+  typeof UpdateMCPToolSettingsBodySchema
+>;

--- a/front/lib/api/mcp/views.ts
+++ b/front/lib/api/mcp/views.ts
@@ -1,9 +1,31 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+export const PatchMCPServerViewBodySchema = z
+  .object({
+    oAuthUseCase: z.enum(["platform_actions", "personal_actions"]),
+  })
+  .or(
+    z.object({
+      name: z.string().nullable(),
+      description: z.string().nullable(),
+    })
+  );
+
+export type PatchMCPServerViewBody = z.infer<
+  typeof PatchMCPServerViewBodySchema
+>;
+
+export type PatchMCPServerViewResponseBody = {
+  success: true;
+  serverView: MCPServerViewType;
+};
 
 async function getAllMCPServerViewsInWorkspace(
   auth: Authenticator,

--- a/front/lib/api/mcp_schemas.ts
+++ b/front/lib/api/mcp_schemas.ts
@@ -79,3 +79,47 @@ export const MCPServerViewSchema = z.object({
   editedByUser: EditedByUserSchema.nullable(),
   toolsMetadata: z.array(ToolsMetadataSchema).optional(),
 });
+
+export const PostRequestActionsAccessBodySchema = z.object({
+  emailMessage: z.string(),
+  mcpServerViewId: z.string(),
+});
+
+export const PatchMCPServerBodySchema = z
+  .object({
+    icon: z.string(),
+  })
+  .or(
+    z
+      .object({
+        sharedSecret: z.string().optional(),
+        customHeaders: z
+          .array(z.object({ key: z.string(), value: z.string() }))
+          .nullable()
+          .optional(),
+      })
+      .refine(
+        (data) =>
+          data.sharedSecret !== undefined || data.customHeaders !== undefined,
+        {
+          message: "Either sharedSecret or customHeaders must be provided",
+        }
+      )
+  )
+  .or(
+    z.object({
+      meta: z.record(z.string(), z.string()).nullable(),
+    })
+  );
+
+export const UpdateMCPToolSettingsBodySchema = z
+  .object({
+    permission: z.enum(MCP_TOOL_STAKE_LEVELS).optional(),
+    enabled: z.boolean().optional(),
+  })
+  .refine(
+    (data) => data.permission !== undefined || data.enabled !== undefined,
+    {
+      message: "At least one of 'permission' or 'enabled' must be provided.",
+    }
+  );

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -45,12 +45,66 @@ import type {
   OAuthProvider,
   OAuthUseCase,
 } from "@app/types/oauth/lib";
+import {
+  BigQueryCredentialsWithLocationSchema,
+  CheckBigQueryCredentialsSchema,
+  NotionCredentialsSchema,
+  SalesforceCredentialsSchema,
+  SnowflakeCredentialsSchema,
+} from "@app/types/oauth/lib";
 import type { OAuthAPIError } from "@app/types/oauth/oauth_api";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { isString } from "@app/types/shared/utils/general";
 import type { ParsedUrlQuery } from "querystring";
+import { z } from "zod";
+
+const PostSnowflakeCredentialsBodySchema = z.object({
+  provider: z.literal("snowflake"),
+  credentials: SnowflakeCredentialsSchema,
+});
+
+const PostBigQueryCredentialsBodySchema = z.object({
+  provider: z.literal("bigquery"),
+  credentials: BigQueryCredentialsWithLocationSchema,
+});
+
+const PostSalesforceCredentialsBodySchema = z.object({
+  provider: z.literal("salesforce"),
+  credentials: SalesforceCredentialsSchema,
+});
+
+const PostNotionCredentialsBodySchema = z.object({
+  provider: z.literal("notion"),
+  credentials: NotionCredentialsSchema,
+});
+
+export const PostCredentialsBodySchema = z.union([
+  PostSnowflakeCredentialsBodySchema,
+  PostBigQueryCredentialsBodySchema,
+  PostSalesforceCredentialsBodySchema,
+  PostNotionCredentialsBodySchema,
+]);
+
+export type PostCredentialsBody = z.infer<typeof PostCredentialsBodySchema>;
+export type PostCredentialsResponseBody = {
+  credentials: {
+    id: string;
+  };
+};
+
+export const PostCheckBigQueryRegionsRequestBodySchema = z.object({
+  credentials: CheckBigQueryCredentialsSchema,
+});
+
+export type PostCheckBigQueryLocationsResponseBody = {
+  locations: Record<string, string[]>;
+};
+
+export interface GetOAuthSetupResponseBody {
+  redirectUrl: string;
+}
 
 export type OAuthError = {
   code:

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -58,6 +58,15 @@ export type MCPOAuthConnectionMetadataType = z.infer<
 
 type MCPMetadataType = z.infer<typeof MCPMetadataSchema>;
 
+export type DiscoverOAuthMetadataResponseBody =
+  | {
+      oauthRequired: true;
+      connectionMetadata: MCPOAuthConnectionMetadataType;
+    }
+  | {
+      oauthRequired: false;
+    };
+
 export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
   provider: OAuthProvider = "mcp";
   requiresWorkspaceConnectionForPersonalAuth = true;

--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -15,6 +15,10 @@ import { EnvironmentConfig } from "@app/types/shared/utils/config";
 import assert from "assert";
 import type { z } from "zod";
 
+export type GetProvidersCheckResponseBody =
+  | { ok: true }
+  | { ok: false; error: string };
+
 // Fraction of requests that use BYOK credentials during the transition period.
 const BYOK_TRANSITION_BYOK_KEYS_RATIO = 1; // 100%
 

--- a/front/lib/api/providers.ts
+++ b/front/lib/api/providers.ts
@@ -1,0 +1,5 @@
+import type { ProviderType } from "@app/types/provider";
+
+export type GetProvidersResponseBody = {
+  providers: ProviderType[];
+};

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -17,6 +17,14 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const INVALIDATION_TIMEOUT_MS = 5_000;
 const SANDBOX_POLICY_MAX_DOMAINS = 100;
 
+export type GetWorkspaceEgressPolicyResponseBody = {
+  policy: EgressPolicy;
+};
+
+export type PutWorkspaceEgressPolicyResponseBody = {
+  policy: EgressPolicy;
+};
+
 function getWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
 }

--- a/front/lib/api/sandbox/env_vars.ts
+++ b/front/lib/api/sandbox/env_vars.ts
@@ -1,6 +1,18 @@
-import type { WorkspaceSandboxEnvVarKind } from "@app/types/sandbox/env_var";
+import type {
+  WorkspaceSandboxEnvVarKind,
+  WorkspaceSandboxEnvVarType,
+} from "@app/types/sandbox/env_var";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type GetWorkspaceSandboxEnvVarsResponseBody = {
+  envVars: WorkspaceSandboxEnvVarType[];
+};
+
+export type PostWorkspaceSandboxEnvVarsResponseBody = {
+  envVar: WorkspaceSandboxEnvVarType;
+  created: boolean;
+};
 
 export const SANDBOX_ENV_VAR_PREFIX = "DST_";
 export const SANDBOX_HTTPS_SECRET_ENV_VAR_PREFIX = "DSEC_";

--- a/front/lib/api/skills/description_suggestion.ts
+++ b/front/lib/api/skills/description_suggestion.ts
@@ -5,6 +5,16 @@ import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+export const PostSkillSuggestionsRequestBodySchema = z.object({
+  instructions: z.string(),
+  agentFacingDescription: z.string(),
+  tools: z.array(z.object({ name: z.string(), description: z.string() })),
+});
+export type PostSkillSuggestionsRequestBody = z.infer<
+  typeof PostSkillSuggestionsRequestBodySchema
+>;
 
 const FUNCTION_NAME = "send_suggestion";
 

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -21,11 +21,28 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Octokit } from "@octokit/core";
 import path from "path";
+import { z } from "zod";
+
+export const ImportSkillsRequestBodySchema = z.object({
+  repoUrl: z.string(),
+  names: z.array(z.string()),
+});
+
+export type ImportSkillsRequestBody = z.infer<
+  typeof ImportSkillsRequestBodySchema
+>;
+
+export type ImportSkillsResponseBody = {
+  imported: SkillType[];
+  updated: SkillType[];
+  skipped: { name: string; message: string }[];
+};
 
 const FILE_IMPORT_CONCURRENCY = 4;
 

--- a/front/lib/api/skills/editors.ts
+++ b/front/lib/api/skills/editors.ts
@@ -1,0 +1,30 @@
+import type { LightUserType, UserType } from "@app/types/user";
+import { z } from "zod";
+
+export const PatchSkillEditorsRequestBodySchema = z
+  .object({
+    addEditorIds: z.array(z.string()).optional(),
+    removeEditorIds: z.array(z.string()).optional(),
+  })
+  .refine(
+    (body) =>
+      (body.addEditorIds instanceof Array && body.addEditorIds.length > 0) ||
+      (body.removeEditorIds instanceof Array &&
+        body.removeEditorIds.length > 0),
+    {
+      message:
+        "Either addEditorIds or removeEditorIds must be provided and contain at least one ID.",
+    }
+  );
+
+export type PatchSkillEditorsRequestBody = z.infer<
+  typeof PatchSkillEditorsRequestBodySchema
+>;
+
+export interface SkillEditorsResponseBody {
+  editors: UserType[];
+}
+
+export interface SkillEditorsLightResponseBody {
+  editors: LightUserType[];
+}

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -7,6 +7,10 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+export type GetSimilarSkillsResponseBody = {
+  similar_skills: string[];
+};
+
 // Safeguards to avoid sending a huge number of skills to the LLM
 const MAX_SKILLS_SENT_TO_LLM = 100;
 const MAX_DESCRIPTION_LENGTH = 500;

--- a/front/lib/api/skills/index.ts
+++ b/front/lib/api/skills/index.ts
@@ -1,0 +1,55 @@
+import type {
+  SkillType,
+  SkillWithoutInstructionsAndToolsType,
+  SkillWithoutInstructionsAndToolsWithRelationsType,
+  SkillWithRelationsType,
+} from "@app/types/assistant/skill_configuration";
+
+export type GetSkillsResponseBody = {
+  skills: SkillWithoutInstructionsAndToolsType[];
+};
+
+export type GetSkillsWithRelationsResponseBody = {
+  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
+};
+
+export type PostSkillResponseBody = {
+  skill: SkillType;
+};
+
+export type GetReinforcementDailySpendResponseBody = {
+  // ISO date strings ("YYYY-MM-DD") → spend in microUSD for that day.
+  dailySpendMicroUsd: Record<string, number>;
+  periodStartDate: string;
+  periodEndDate: string;
+};
+
+export type GetSkillResponseBody = {
+  skill: SkillType;
+};
+
+export type GetSkillWithRelationsResponseBody = {
+  skill: SkillWithRelationsType;
+};
+
+export type PatchSkillResponseBody = {
+  skill: Omit<
+    SkillType,
+    | "author"
+    | "requestedSpaceIds"
+    | "workspaceId"
+    | "createdAt"
+    | "updatedAt"
+    | "editedBy"
+  >;
+};
+
+export type DeleteSkillResponseBody = {
+  success: boolean;
+};
+
+export type GetSkillsSpendResponseBody = {
+  // Map from skill sId to total spent in the current billing period (microUSD).
+  // Skills with no usage in the period are omitted.
+  spentMicroUsdBySkillId: Record<string, number>;
+};

--- a/front/lib/api/tags.ts
+++ b/front/lib/api/tags.ts
@@ -1,0 +1,9 @@
+import type { TagType } from "@app/types/tag";
+
+export type GetTagsResponseBody = {
+  tags: TagType[];
+};
+
+export type CreateTagResponseBody = {
+  tag: TagType;
+};

--- a/front/lib/api/webhook_source.ts
+++ b/front/lib/api/webhook_source.ts
@@ -21,7 +21,9 @@ import type {
   WebhookSourceType,
   WebhookSourceViewForAdminType,
   WebhookSourceViewType,
+  WebhookSourceWithViewsAndUsageType,
 } from "@app/types/triggers/webhooks";
+import { WebhookSourcesSchema } from "@app/types/triggers/webhooks";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type { Transaction } from "sequelize";
@@ -40,6 +42,33 @@ export type PostWebhookSourceViewResponseBody = {
 export const PostWebhookSourceViewBodySchema = z.object({
   webhookSourceId: z.string(),
 });
+
+export const PostWebhookSourcesSchema = WebhookSourcesSchema;
+
+export type PostWebhookSourcesBody = z.infer<typeof PostWebhookSourcesSchema>;
+
+export type GetWebhookSourcesResponseBody = {
+  success: true;
+  webhookSourcesWithViews: WebhookSourceWithViewsAndUsageType[];
+};
+
+export type PostWebhookSourcesResponseBody = {
+  success: true;
+  webhookSource: WebhookSourceForAdminType;
+};
+
+export type DeleteWebhookSourceResponseBody = {
+  success: true;
+};
+
+export type PatchWebhookSourceResponseBody = {
+  success: true;
+};
+
+export type GetWebhookSourceViewsForSourceResponseBody = {
+  success: true;
+  views: WebhookSourceViewType[];
+};
 
 /**
  * Deletes a webhook source and all related entities (views, triggers, requests).

--- a/front/lib/email.ts
+++ b/front/lib/email.ts
@@ -1,7 +1,7 @@
 import type { PostRequestAccessBody } from "@app/lib/api/data_sources/request_access";
+import type { PostRequestFeatureAccessBody } from "@app/lib/api/labs";
+import type { PostRequestActionsAccessBody } from "@app/lib/api/mcp";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PostRequestFeatureAccessBody } from "@app/pages/api/w/[wId]/labs/request_access";
-import type { PostRequestActionsAccessBody } from "@app/pages/api/w/[wId]/mcp/request_access";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export async function sendRequestDataSourceEmail({

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -1,5 +1,5 @@
+import type { GetProvidersCheckResponseBody } from "@app/lib/api/provider_credentials";
 import { clientFetch } from "@app/lib/egress/client";
-import type { GetProvidersCheckResponseBody } from "@app/pages/api/w/[wId]/providers/[pId]/check";
 import type { WorkspaceType } from "@app/types/user";
 
 import type { useProviders } from "./swr/apps";

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -84,6 +84,15 @@ import type {
 import { Op } from "sequelize";
 import { AgentStepContentModel } from "../models/agent/agent_step_content";
 
+export type GetMCPActionsResult = {
+  actions: (AgentMCPActionType & {
+    conversationId: string;
+    messageId: string;
+  })[];
+  nextCursor: string | null;
+  totalCount: number;
+};
+
 // Batch size for fetching output items to avoid loading too many large rows at once.
 const OUTPUT_ITEMS_BATCH_SIZE = 32;
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -113,6 +113,19 @@ const FRAME_CONTENT_TYPES = new Set([
   frameSlideshowContentType,
 ]);
 
+export interface FileUploadedRequestResponseBody {
+  file: FileType & {
+    /** Scoped mount path when the file is on GCS (same shape as `GCSMountEntryBase.path`). */
+    path: string | null;
+  };
+}
+
+export type ShareFileResponseBody = {
+  scope: FileShareScope;
+  sharedAt: number;
+  shareUrl: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface FileResource extends ReadonlyAttributesType<FileModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -34,6 +34,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+import { z } from "zod";
 
 type MCPServerConnectionResourceFindOptions =
   ResourceFindOptions<MCPServerConnectionModel> & {
@@ -600,3 +601,29 @@ export interface MCPServerConnectionType {
   remoteMCPServerId: string | null;
   internalMCPServerId: string | null;
 }
+
+const PostConnectionOAuthBodySchema = z.object({
+  connectionId: z.string(),
+  mcpServerId: z.string(),
+});
+
+const PostConnectionCredentialsBodySchema = z.object({
+  credentialId: z.string(),
+  mcpServerId: z.string(),
+});
+
+export const PostConnectionBodySchema = z.union([
+  PostConnectionOAuthBodySchema,
+  PostConnectionCredentialsBodySchema,
+]);
+
+export type PostConnectionBodyType = z.infer<typeof PostConnectionBodySchema>;
+
+export type PostConnectionResponseBody = {
+  success: boolean;
+  connection: MCPServerConnectionType;
+};
+
+export type GetConnectionsResponseBody = {
+  connections: MCPServerConnectionType[];
+};

--- a/front/lib/resources/provider_credential_resource.ts
+++ b/front/lib/resources/provider_credential_resource.ts
@@ -32,9 +32,26 @@ import { GoogleGenAI } from "@google/genai";
 import assert from "assert";
 import OpenAI from "openai";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
+import { z } from "zod";
 
 const API_KEY_REVEAL_WINDOW_MINUTES = 2;
 const PROVIDER_CREDENTIALS_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export type GetProviderCredentialsResponseBody = {
+  providerCredentials: ProviderCredentialType[];
+};
+
+export const ProviderCredentialBodySchema = z.object({
+  apiKey: z.string(),
+});
+
+export type ProviderCredentialBody = z.infer<
+  typeof ProviderCredentialBodySchema
+>;
+
+export type ProviderCredentialResponseBody = {
+  providerCredential: ProviderCredentialType;
+};
 
 type ProviderCredential = {
   id: ModelId;

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -23,6 +23,10 @@ import type {
 } from "sequelize";
 import sequelize from "sequelize/lib/sequelize";
 
+export type GetTagsUsageResponseBody = {
+  tags: TagTypeWithUsage[];
+};
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -28,6 +28,11 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
+export type GetWebhookSourceViewsListResponseBody = {
+  success: boolean;
+  webhookSourceViews: WebhookSourceViewType[];
+};
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WebhookSourcesViewResource

--- a/front/lib/resources/workspace_sandbox_env_var_resource.ts
+++ b/front/lib/resources/workspace_sandbox_env_var_resource.ts
@@ -33,6 +33,14 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { randomBytes } from "crypto";
 import type { Attributes, Includeable, Transaction } from "sequelize";
 
+export type DeleteWorkspaceSandboxEnvVarResponseBody = {
+  success: true;
+};
+
+export type PatchWorkspaceSandboxEnvVarResponseBody = {
+  envVar: WorkspaceSandboxEnvVarType;
+};
+
 const USER_JOIN_INCLUDES: Includeable[] = [
   {
     association: "createdByUser",

--- a/front/lib/skill_detection.ts
+++ b/front/lib/skill_detection.ts
@@ -13,6 +13,10 @@ export type DetectedSkillSummary = {
   existingSkillId: string | null;
 };
 
+export type DetectSkillsResponseBody = {
+  skills: DetectedSkillSummary[];
+};
+
 export function isImportableSkillStatus(status: DetectedSkillStatus): boolean {
   return status === "ready" || status === "skill_already_exists";
 }

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -1,6 +1,6 @@
 import type { AgentBuilderMCPConfigurationWithId } from "@app/components/agent_builder/types";
+import type { GetActionsResponseBody } from "@app/lib/agent_builder/server_side_props_helpers";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetActionsResponseBody } from "@app/pages/api/w/[wId]/builder/assistants/[aId]/actions";
 import uniqueId from "lodash/uniqueId";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -18,8 +18,8 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger_usage_estimation";
 import type { GetUserTriggersResponseBody } from "@app/pages/api/w/[wId]/me/triggers";
-import type { GetTriggerEstimationResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation";
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -2,6 +2,7 @@ import type {
   GetAppsResponseBody,
   GetOrPostAppResponseBody,
 } from "@app/lib/api/apps";
+import type { GetProvidersResponseBody } from "@app/lib/api/providers";
 import type {
   GetRunBlockResponseBody,
   GetRunResponseBody,
@@ -14,7 +15,6 @@ import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
 import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
-import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
 import type { AppType } from "@app/types/app";
 import type { RunRunType } from "@app/types/run";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/swr/bigquery.ts
+++ b/front/lib/swr/bigquery.ts
@@ -1,5 +1,5 @@
+import type { PostCheckBigQueryLocationsResponseBody } from "@app/lib/api/oauth";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PostCheckBigQueryLocationsResponseBody } from "@app/pages/api/w/[wId]/credentials/check_bigquery_locations";
 import type { CheckBigQueryCredentials } from "@app/types/oauth/lib";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -6,6 +6,7 @@ import type {
   UpsertFileToDataSourceResponseBody,
 } from "@app/lib/api/files/upsert";
 import { clientFetch } from "@app/lib/egress/client";
+import type { ShareFileResponseBody } from "@app/lib/resources/file_resource";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   emptyArray,
@@ -13,7 +14,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { ShareFileResponseBody } from "@app/pages/api/w/[wId]/files/[fileId]/share";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type {
   FileShareScope,

--- a/front/lib/swr/labs.ts
+++ b/front/lib/swr/labs.ts
@@ -1,11 +1,13 @@
 // LABS - CAN BE REMOVED ANYTIME
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  GetLabsTranscriptsConfigurationResponseBody,
+  PatchTranscriptsConfiguration,
+} from "@app/lib/api/labs/transcripts";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/pages/api/w/[wId]/labs/transcripts";
-import type { PatchTranscriptsConfiguration } from "@app/pages/api/w/[wId]/labs/transcripts/[tId]";
 import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/swr/mcp_actions.ts
+++ b/front/lib/swr/mcp_actions.ts
@@ -1,5 +1,5 @@
+import type { GetMCPActionsResult } from "@app/lib/resources/agent_mcp_action_resource";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -8,46 +8,38 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
+  CreateMCPServerResponseBody,
+  DeleteMCPServerResponseBody,
+  GetMCPServerResponseBody,
+  GetMCPServersResponseBody,
+  GetMCPServersUsageResponseBody,
+  GetMCPServerViewsListResponseBody,
   GetMCPServerViewsNotActivatedResponseBody,
   MCPServerType,
   MCPServerTypeWithViews,
   MCPServerViewType,
+  PatchMCPServerBody,
+  PatchMCPServerResponseBody,
+  PatchMCPServerToolsPermissionsResponseBody,
+  SyncMCPServerResponseBody,
+  UpdateMCPToolSettingsBodyType,
 } from "@app/lib/api/mcp";
+import type {
+  PatchMCPServerViewBody,
+  PatchMCPServerViewResponseBody,
+} from "@app/lib/api/mcp/views";
+import type { DiscoverOAuthMetadataResponseBody } from "@app/lib/api/oauth/providers/mcp";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type {
+  GetConnectionsResponseBody,
   MCPServerConnectionConnectionType,
   MCPServerConnectionType,
+  PostConnectionResponseBody,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import type { GetMCPServerViewsResponseBody } from "@app/lib/resources/mcp_server_view_resource";
 import { useSpaceInfo, useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type {
-  CreateMCPServerResponseBody,
-  GetMCPServersResponseBody,
-} from "@app/pages/api/w/[wId]/mcp";
-import type {
-  DeleteMCPServerResponseBody,
-  GetMCPServerResponseBody,
-  PatchMCPServerBody,
-  PatchMCPServerResponseBody,
-} from "@app/pages/api/w/[wId]/mcp/[serverId]";
-import type { SyncMCPServerResponseBody } from "@app/pages/api/w/[wId]/mcp/[serverId]/sync";
-import type {
-  PatchMCPServerToolsPermissionsResponseBody,
-  UpdateMCPToolSettingsBodyType,
-} from "@app/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]";
-import type {
-  GetConnectionsResponseBody,
-  PostConnectionResponseBody,
-} from "@app/pages/api/w/[wId]/mcp/connections/[connectionType]";
-import type { DiscoverOAuthMetadataResponseBody } from "@app/pages/api/w/[wId]/mcp/discover_oauth_metadata";
-import type { GetMCPServersUsageResponseBody } from "@app/pages/api/w/[wId]/mcp/usage";
-import type { GetMCPServerViewsListResponseBody } from "@app/pages/api/w/[wId]/mcp/views";
-import type {
-  PatchMCPServerViewBody,
-  PatchMCPServerViewResponseBody,
-} from "@app/pages/api/w/[wId]/mcp/views/[viewId]";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isAPIErrorResponse } from "@app/types/error";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,5 +1,5 @@
+import type { GetEnabledModelsResponseType } from "@app/lib/api/assistant/models";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetEnabledModelsResponseType } from "@app/pages/api/w/[wId]/models";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,7 +1,7 @@
+import type { GetSlackClientIdResponseBody } from "@app/lib/api/credentials";
+import type { GetOAuthSetupResponseBody } from "@app/lib/api/oauth";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetSlackClientIdResponseBody } from "@app/pages/api/w/[wId]/credentials/slack_is_legacy";
-import type { GetOAuthSetupResponseBody } from "@app/pages/api/w/[wId]/oauth/[provider]/setup";
 import type { APIError, WithAPIErrorResponse } from "@app/types/error";
 import { isAPIErrorResponse } from "@app/types/error";
 import type {

--- a/front/lib/swr/provider_credentials.ts
+++ b/front/lib/swr/provider_credentials.ts
@@ -1,5 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import type {
+  GetProviderCredentialsResponseBody,
+  ProviderCredentialBody,
+  ProviderCredentialResponseBody,
+} from "@app/lib/resources/provider_credential_resource";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -7,11 +12,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { workspaceAuthContextUrl } from "@app/lib/swr/workspaces";
-import type { GetProviderCredentialsResponseBody } from "@app/pages/api/w/[wId]/provider_credentials";
-import type {
-  ProviderCredentialBody,
-  ProviderCredentialResponseBody,
-} from "@app/pages/api/w/[wId]/provider_credentials/[providerId]";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { ProviderCredentialType } from "@app/types/provider_credential";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -1,20 +1,20 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  GetWorkspaceEgressPolicyResponseBody,
+  PutWorkspaceEgressPolicyResponseBody,
+} from "@app/lib/api/sandbox/egress_policy";
+import type {
+  GetWorkspaceSandboxEnvVarsResponseBody,
+  PostWorkspaceSandboxEnvVarsResponseBody,
+} from "@app/lib/api/sandbox/env_vars";
 import { clientFetch } from "@app/lib/egress/client";
+import type { PatchWorkspaceSandboxEnvVarResponseBody } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import {
   emptyArray,
   getErrorFromResponse,
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type {
-  GetWorkspaceEgressPolicyResponseBody,
-  PutWorkspaceEgressPolicyResponseBody,
-} from "@app/pages/api/w/[wId]/sandbox/egress-policy";
-import type {
-  GetWorkspaceSandboxEnvVarsResponseBody,
-  PostWorkspaceSandboxEnvVarsResponseBody,
-} from "@app/pages/api/w/[wId]/sandbox/env-vars";
-import type { PatchWorkspaceSandboxEnvVarResponseBody } from "@app/pages/api/w/[wId]/sandbox/env-vars/[id]";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import { EMPTY_EGRESS_POLICY } from "@app/types/sandbox/egress_policy";
 import type {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -1,17 +1,19 @@
 import type { ImportFormValues } from "@app/components/skills/import/formSchema";
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { DetectedSkillSummary } from "@app/lib/skill_detection";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetSkillsWithRelationsResponseBody } from "@app/pages/api/w/[wId]/skills";
+import type { GetSkillHistoryResponseBody } from "@app/lib/api/assistant/skills/history";
 import type {
   GetSkillResponseBody,
+  GetSkillsWithRelationsResponseBody,
   GetSkillWithRelationsResponseBody,
-} from "@app/pages/api/w/[wId]/skills/[sId]";
-import type { GetSkillHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
-import type { DetectSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/detect";
-import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
-import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
+} from "@app/lib/api/skills";
+import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
+import type { GetSimilarSkillsResponseBody } from "@app/lib/api/skills/existing_skill_checker";
+import type {
+  DetectedSkillSummary,
+  DetectSkillsResponseBody,
+} from "@app/lib/skill_detection";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   SkillReinforcementMode,
   SkillStatus,

--- a/front/lib/swr/skill_editors.ts
+++ b/front/lib/swr/skill_editors.ts
@@ -1,11 +1,11 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type {
   PatchSkillEditorsRequestBody,
   SkillEditorsLightResponseBody,
   SkillEditorsResponseBody,
-} from "@app/pages/api/w/[wId]/skills/[sId]/editors";
+} from "@app/lib/api/skills/editors";
+import { clientFetch } from "@app/lib/egress/client";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";

--- a/front/lib/swr/tags.ts
+++ b/front/lib/swr/tags.ts
@@ -1,10 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { PatchAgentTagsRequestBody } from "@app/lib/api/assistant/configuration/agent_tags";
+import type { GetSuggestionsResponseBody } from "@app/lib/api/assistant/tag_manager";
+import type { GetTagsResponseBody } from "@app/lib/api/tags";
 import { clientFetch } from "@app/lib/egress/client";
+import type { GetTagsUsageResponseBody } from "@app/lib/resources/tags_resource";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetTagsResponseBody } from "@app/pages/api/w/[wId]/tags";
-import type { GetSuggestionsResponseBody } from "@app/pages/api/w/[wId]/tags/suggest_from_agents";
-import type { GetTagsUsageResponseBody } from "@app/pages/api/w/[wId]/tags/usage";
 import type { TagKind, TagType } from "@app/types/tag";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";

--- a/front/lib/swr/useSelfImprovingSkillsSettings.ts
+++ b/front/lib/swr/useSelfImprovingSkillsSettings.ts
@@ -1,12 +1,14 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  GetReinforcementDailySpendResponseBody,
+  GetSkillsSpendResponseBody,
+} from "@app/lib/api/skills";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   getReinforcementMonthlyCapMicroUsd,
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetReinforcementDailySpendResponseBody } from "@app/pages/api/w/[wId]/skills/reinforcement_daily_spend";
-import type { GetSkillsSpendResponseBody } from "@app/pages/api/w/[wId]/skills/reinforcement_spend";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useState } from "react";

--- a/front/lib/swr/useWebhookServiceData.ts
+++ b/front/lib/swr/useWebhookServiceData.ts
@@ -1,6 +1,8 @@
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetServiceDataResponseType } from "@app/pages/api/w/[wId]/webhook_sources/service-data";
-import type { WebhookProvider } from "@app/types/triggers/webhooks";
+import type {
+  GetServiceDataResponseType,
+  WebhookProvider,
+} from "@app/types/triggers/webhooks";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export function useWebhookServiceData<P extends WebhookProvider>({

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -1,6 +1,13 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { GetWebhookSourceViewsResponseBody } from "@app/lib/api/webhook_source";
+import type {
+  DeleteWebhookSourceResponseBody,
+  GetWebhookSourceViewsForSourceResponseBody as GetSpecificWebhookSourceViewsResponseBody,
+  GetWebhookSourcesResponseBody,
+  GetWebhookSourceViewsResponseBody,
+  PostWebhookSourcesBody,
+} from "@app/lib/api/webhook_source";
 import { clientFetch } from "@app/lib/egress/client";
+import type { GetWebhookSourceViewsListResponseBody } from "@app/lib/resources/webhook_sources_view_resource";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -8,13 +15,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetWebhookRequestsResponseBody } from "@app/lib/triggers/webhook";
-import type {
-  GetWebhookSourcesResponseBody,
-  PostWebhookSourcesBody,
-} from "@app/pages/api/w/[wId]/webhook_sources";
-import type { DeleteWebhookSourceResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]";
-import type { GetWebhookSourceViewsResponseBody as GetSpecificWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views";
-import type { GetWebhookSourceViewsListResponseBody } from "@app/pages/api/w/[wId]/webhook_sources/views";
 import type { SpaceType } from "@app/types/space";
 import type {
   WebhookSourceForAdminType,

--- a/front/lib/triggers/trigger_usage_estimation.ts
+++ b/front/lib/triggers/trigger_usage_estimation.ts
@@ -14,6 +14,11 @@ import { Op } from "sequelize";
 const NUMBER_HOURS_TO_FETCH = 24;
 const MAX_OUTPUT = 100;
 
+export type GetTriggerEstimationResponseBody = {
+  matchingCount: number;
+  totalCount: number;
+};
+
 export async function computeFilteredWebhookTriggerForecast(
   auth: Authenticator,
   {

--- a/front/pages/api/v1/w/[wId]/skills/index.ts
+++ b/front/pages/api/v1/w/[wId]/skills/index.ts
@@ -4,11 +4,11 @@ import {
   importSkillsFromFiles,
   isImportConflictStrategy,
 } from "@app/lib/api/skills/detection/files/import_skills";
+import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -1,6 +1,6 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
-import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
+import type { GetActionsResponseBody } from "@app/lib/agent_builder/server_side_props_helpers";
 import {
   buildInitialActions,
   getAccessibleSourcesAndAppsForActions,
@@ -11,10 +11,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetActionsResponseBody = {
-  actions: AgentBuilderMCPConfiguration[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.test.ts
@@ -5,9 +5,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import handler from "./suggestions";
 
-vi.mock("@app/lib/api/skills/description_suggestion", () => ({
-  getSkillDescriptionSuggestion: vi.fn(),
-}));
+vi.mock(
+  "@app/lib/api/skills/description_suggestion",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/skills/description_suggestion")
+    >()),
+    getSkillDescriptionSuggestion: vi.fn(),
+  })
+);
 
 import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";
 

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.ts
@@ -2,22 +2,15 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { SkillDescriptionSuggestionInputs } from "@app/lib/api/skills/description_suggestion";
-import { getSkillDescriptionSuggestion } from "@app/lib/api/skills/description_suggestion";
+import {
+  getSkillDescriptionSuggestion,
+  PostSkillSuggestionsRequestBodySchema,
+} from "@app/lib/api/skills/description_suggestion";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PostSkillSuggestionsRequestBodySchema = z.object({
-  instructions: z.string(),
-  agentFacingDescription: z.string(),
-  tools: z.array(z.object({ name: z.string(), description: z.string() })),
-});
-export type PostSkillSuggestionsRequestBody = z.infer<
-  typeof PostSkillSuggestionsRequestBodySchema
->;
 
 type SkillSuggestionsResponseType = {
   suggestion: string;

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -1,6 +1,8 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { PostCheckBigQueryLocationsResponseBody } from "@app/lib/api/oauth";
+import { PostCheckBigQueryRegionsRequestBodySchema } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { APIErrorType, WithAPIErrorResponse } from "@app/types/error";
@@ -8,15 +10,8 @@ import { CheckBigQueryCredentialsSchema } from "@app/types/oauth/lib";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { BigQuery } from "@google-cloud/bigquery";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
-const PostCheckBigQueryRegionsRequestBodySchema = z.object({
-  credentials: CheckBigQueryCredentialsSchema,
-});
-
-export type PostCheckBigQueryLocationsResponseBody = {
-  locations: Record<string, string[]>;
-};
+export type { PostCheckBigQueryLocationsResponseBody } from "@app/lib/api/oauth";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -7,54 +7,18 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
+import type { PostCredentialsResponseBody } from "@app/lib/api/oauth";
+import { PostCredentialsBodySchema } from "@app/lib/api/oauth";
+
+export type { PostCredentialsBody } from "@app/lib/api/oauth";
+
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import {
-  BigQueryCredentialsWithLocationSchema,
-  NotionCredentialsSchema,
-  SalesforceCredentialsSchema,
-  SnowflakeCredentialsSchema,
-} from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PostSnowflakeCredentialsBodySchema = z.object({
-  provider: z.literal("snowflake"),
-  credentials: SnowflakeCredentialsSchema,
-});
-
-const PostBigQueryCredentialsBodySchema = z.object({
-  provider: z.literal("bigquery"),
-  credentials: BigQueryCredentialsWithLocationSchema,
-});
-
-const PostSalesforceCredentialsBodySchema = z.object({
-  provider: z.literal("salesforce"),
-  credentials: SalesforceCredentialsSchema,
-});
-
-const PostNotionCredentialsBodySchema = z.object({
-  provider: z.literal("notion"),
-  credentials: NotionCredentialsSchema,
-});
-
-const PostCredentialsBodySchema = z.union([
-  PostSnowflakeCredentialsBodySchema,
-  PostBigQueryCredentialsBodySchema,
-  PostSalesforceCredentialsBodySchema,
-  PostNotionCredentialsBodySchema,
-]);
-
-export type PostCredentialsBody = z.infer<typeof PostCredentialsBodySchema>;
-export type PostCredentialsResponseBody = {
-  credentials: {
-    id: string;
-  };
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
+++ b/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
@@ -3,6 +3,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
+import type { GetSlackClientIdResponseBody } from "@app/lib/api/credentials";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -11,10 +12,6 @@ import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-export type GetSlackClientIdResponseBody = {
-  isLegacySlackApp: boolean;
-};
 
 const SlackCredentialContentSchema = z.object({
   client_id: z.string(),

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -131,22 +131,17 @@ import {
 import { addFileToProject } from "@app/lib/api/projects/context";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import type { FileVersion } from "@app/lib/resources/file_resource";
+import type {
+  FileUploadedRequestResponseBody,
+  FileVersion,
+} from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { FileType } from "@app/types/files";
 import { isConversationFileUseCase } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface FileUploadedRequestResponseBody {
-  file: FileType & {
-    /** Scoped mount path when the file is on GCS (same shape as `GCSMountEntryBase.path`). */
-    path: string | null;
-  };
-}
 
 export const config = {
   api: {

--- a/front/pages/api/w/[wId]/files/[fileId]/share/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/index.ts
@@ -4,10 +4,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ShareFileResponseBody } from "@app/lib/resources/file_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { FileShareScope } from "@app/types/files";
 import {
   fileShareScopeSchema,
   isConversationFileUseCase,
@@ -21,12 +21,6 @@ import { z } from "zod";
 const ShareFileRequestBodySchema = z.object({
   shareScope: fileShareScopeSchema,
 });
-
-export type ShareFileResponseBody = {
-  scope: FileShareScope;
-  sharedAt: number;
-  shareUrl: string;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -56,6 +56,7 @@
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { isUploadSupportedForContentType } from "@app/lib/api/files/processing";
+import type { FileUploadRequestResponseBody } from "@app/lib/api/files/upload_metadata";
 import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/upload_metadata";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -64,7 +65,6 @@ import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { FileTypeWithUploadUrl } from "@app/types/files";
 import { ensureFileSize, isSupportedFileContentType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -135,10 +135,6 @@ const FileUploadUrlRequestSchema = z.discriminatedUnion("useCase", [
     useCaseMetadata: z.object({ skillId: z.string() }).optional(),
   }),
 ]);
-
-export interface FileUploadRequestResponseBody {
-  file: FileTypeWithUploadUrl;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -4,24 +4,15 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import type { GetMCPActionsResult } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { AgentMCPActionType } from "@app/types/actions";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import assert from "assert";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetMCPActionsResult = {
-  actions: (AgentMCPActionType & {
-    conversationId: string;
-    messageId: string;
-  })[];
-  nextCursor: string | null;
-  totalCount: number;
-};
 
 const GetMCPActionsQuerySchema = z.object({
   agentId: z.string(),

--- a/front/pages/api/w/[wId]/labs/request_access.ts
+++ b/front/pages/api/w/[wId]/labs/request_access.ts
@@ -3,23 +3,14 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
+import { PostRequestFeatureAccessBodySchema } from "@app/lib/api/labs";
 import type { Authenticator } from "@app/lib/auth";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { escape } from "html-escaper";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostRequestFeatureAccessBodySchema = z.object({
-  emailMessage: z.string(),
-  featureName: z.string(),
-});
-
-export type PostRequestFeatureAccessBody = z.infer<
-  typeof PostRequestFeatureAccessBodySchema
->;
 
 const MAX_ACCESS_REQUESTS_PER_DAY = 30;
 

--- a/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/[tId].ts
@@ -2,6 +2,11 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  type GetLabsTranscriptsConfigurationByIdResponseBody,
+  PatchLabsTranscriptsConfigurationBodySchema,
+  type PatchTranscriptsConfiguration,
+} from "@app/lib/api/labs/transcripts";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -15,23 +20,13 @@ import {
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isProviderWithDefaultWorkspaceConfiguration } from "@app/types/oauth/lib";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type GetLabsTranscriptsConfigurationResponseBody = {
-  configuration: LabsTranscriptsConfigurationResource | null;
-};
+export type GetLabsTranscriptsConfigurationResponseBody =
+  GetLabsTranscriptsConfigurationByIdResponseBody;
 
-export const PatchLabsTranscriptsConfigurationBodySchema = z.object({
-  agentConfigurationId: z.string().optional(),
-  // `isActive` is deprecated in favor of `status`, kept for backward compatibility.
-  isActive: z.boolean().optional(),
-  status: z.enum(["active", "disabled"]).optional(),
-  dataSourceViewId: z.string().nullable().optional(),
-});
-export type PatchTranscriptsConfiguration = z.infer<
-  typeof PatchLabsTranscriptsConfigurationBodySchema
->;
+export type { PatchTranscriptsConfiguration };
+export { PatchLabsTranscriptsConfigurationBodySchema };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/labs/transcripts/index.ts
+++ b/front/pages/api/w/[wId]/labs/transcripts/index.ts
@@ -3,13 +3,13 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { GetLabsTranscriptsConfigurationResponseBody } from "@app/lib/api/labs/transcripts";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { LabsTranscriptsConfigurationType } from "@app/types/labs";
 import {
   isCredentialProvider,
   isProviderWithDefaultWorkspaceConfiguration,
@@ -19,9 +19,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type GetLabsTranscriptsConfigurationResponseBody = {
-  configuration: LabsTranscriptsConfigurationType | null;
-};
+export type { GetLabsTranscriptsConfigurationResponseBody };
 
 // Define provider type separately for better reuse
 export const acceptableTranscriptProvidersCodec = z.enum([

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -6,8 +6,14 @@ import {
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type {
+  DeleteMCPServerResponseBody,
+  GetMCPServerResponseBody,
+  PatchMCPServerBody,
+  PatchMCPServerResponseBody,
+} from "@app/lib/api/mcp";
 import { withWorkspaceConnectionRequirement } from "@app/lib/api/mcp_oauth_prerequisites";
+import { PatchMCPServerBodySchema } from "@app/lib/api/mcp_schemas";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -19,50 +25,7 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PatchMCPServerBodySchema = z
-  .object({
-    icon: z.string(),
-  })
-  .or(
-    z
-      .object({
-        sharedSecret: z.string().optional(),
-        customHeaders: z
-          .array(z.object({ key: z.string(), value: z.string() }))
-          .nullable()
-          .optional(),
-      })
-      .refine(
-        (data) =>
-          data.sharedSecret !== undefined || data.customHeaders !== undefined,
-        {
-          message: "Either sharedSecret or customHeaders must be provided",
-        }
-      )
-  )
-  .or(
-    z.object({
-      meta: z.record(z.string(), z.string()).nullable(),
-    })
-  );
-
-export type PatchMCPServerBody = z.infer<typeof PatchMCPServerBodySchema>;
-
-export type GetMCPServerResponseBody = {
-  server: MCPServerTypeWithViews;
-};
-
-export type PatchMCPServerResponseBody = {
-  success: true;
-  server: MCPServerType;
-};
-
-export type DeleteMCPServerResponseBody = {
-  deleted: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/sync.ts
@@ -2,17 +2,12 @@
 // @migration-status: MIGRATED_TO_HONO
 import { fetchRemoteServerMetaDataByServerId } from "@app/lib/actions/mcp_metadata";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { SyncMCPServerResponseBody } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type SyncMCPServerResponseBody = {
-  success: boolean;
-  server: MCPServerType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -1,35 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
-import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { PatchMCPServerToolsPermissionsResponseBody } from "@app/lib/api/mcp";
+import { UpdateMCPToolSettingsBodySchema } from "@app/lib/api/mcp_schemas";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PatchMCPServerToolsPermissionsResponseBody = {
-  success: boolean;
-};
-
-const UpdateMCPToolSettingsBodySchema = z
-  .object({
-    permission: z.enum(MCP_TOOL_STAKE_LEVELS).optional(),
-    enabled: z.boolean().optional(),
-  })
-  .refine(
-    (data) => data.permission !== undefined || data.enabled !== undefined,
-    {
-      message: "At least one of 'permission' or 'enabled' must be provided.",
-    }
-  );
-
-export type UpdateMCPToolSettingsBodyType = z.infer<
-  typeof UpdateMCPToolSettingsBodySchema
->;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -8,46 +8,22 @@ import apiConfig from "@app/lib/api/config";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import type {
+  GetConnectionsResponseBody,
   MCPServerConnectionConnectionType,
-  MCPServerConnectionType,
+  PostConnectionBodyType,
+  PostConnectionResponseBody,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import {
   isMCPServerConnectionConnectionType,
   MCPServerConnectionResource,
+  PostConnectionBodySchema,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PostConnectionOAuthBodySchema = z.object({
-  connectionId: z.string(),
-  mcpServerId: z.string(),
-});
-
-const PostConnectionCredentialsBodySchema = z.object({
-  credentialId: z.string(),
-  mcpServerId: z.string(),
-});
-
-const PostConnectionBodySchema = z.union([
-  PostConnectionOAuthBodySchema,
-  PostConnectionCredentialsBodySchema,
-]);
-
-export type PostConnectionBodyType = z.infer<typeof PostConnectionBodySchema>;
-
-export type PostConnectionResponseBody = {
-  success: boolean;
-  connection: MCPServerConnectionType;
-};
-
-export type GetConnectionsResponseBody = {
-  connections: MCPServerConnectionType[];
-};
 
 type PostConnectionAuthReference =
   | {

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -4,7 +4,7 @@ import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_ac
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/providers/mcp";
+import type { DiscoverOAuthMetadataResponseBody } from "@app/lib/api/oauth/providers/mcp";
 import { validateExternalUrl } from "@app/lib/api/url_safety";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
@@ -13,15 +13,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { headersArrayToRecord } from "@app/types/shared/utils/http_headers";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-export type DiscoverOAuthMetadataResponseBody =
-  | {
-      oauthRequired: true;
-      connectionMetadata: MCPOAuthConnectionMetadataType;
-    }
-  | {
-      oauthRequired: false;
-    };
 
 const PostBodySchema = z.object({
   url: z.string(),

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -2,7 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { isRemoteMCPServerError } from "@app/lib/actions/mcp_errors";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type {
+  CreateMCPServerResponseBody,
+  GetMCPServersResponseBody,
+} from "@app/lib/api/mcp";
 import {
   createInternalMCPServer,
   createRemoteMCPServer,
@@ -12,16 +15,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-export type GetMCPServersResponseBody = {
-  success: true;
-  servers: MCPServerTypeWithViews[];
-};
-
-export type CreateMCPServerResponseBody = {
-  success: true;
-  server: MCPServerType;
-};
 
 const CustomHeadersSchema = z
   .array(z.object({ key: z.string(), value: z.string() }))

--- a/front/pages/api/w/[wId]/mcp/request_access.ts
+++ b/front/pages/api/w/[wId]/mcp/request_access.ts
@@ -4,6 +4,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";
+import { PostRequestActionsAccessBodySchema } from "@app/lib/api/mcp_schemas";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
@@ -11,17 +12,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { escape } from "html-escaper";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostRequestActionsAccessBodySchema = z.object({
-  emailMessage: z.string(),
-  mcpServerViewId: z.string(),
-});
-
-export type PostRequestActionsAccessBody = z.infer<
-  typeof PostRequestActionsAccessBodySchema
->;
 
 const MAX_ACCESS_REQUESTS_PER_DAY = 30;
 

--- a/front/pages/api/w/[wId]/mcp/usage.ts
+++ b/front/pages/api/w/[wId]/mcp/usage.ts
@@ -1,16 +1,12 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
-import type { MCPServersUsageByAgent } from "@app/lib/api/agent_actions";
 import { getToolsUsage } from "@app/lib/api/agent_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetMCPServersUsageResponseBody } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetMCPServersUsageResponseBody = {
-  usage: MCPServersUsageByAgent;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
@@ -1,8 +1,9 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { PatchMCPServerViewResponseBody } from "@app/lib/api/mcp/views";
 import {
+  PatchMCPServerViewBodySchema,
   updateNameAndDescriptionForMCPServerViews,
   updateOAuthUseCaseForMCPServerViews,
 } from "@app/lib/api/mcp/views";
@@ -12,28 +13,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PatchMCPServerViewBodySchema = z
-  .object({
-    oAuthUseCase: z.enum(["platform_actions", "personal_actions"]),
-  })
-  .or(
-    z.object({
-      name: z.string().nullable(),
-      description: z.string().nullable(),
-    })
-  );
-
-export type PatchMCPServerViewBody = z.infer<
-  typeof PatchMCPServerViewBodySchema
->;
-
-export type PatchMCPServerViewResponseBody = {
-  success: true;
-  serverView: MCPServerViewType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -1,7 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { GetMCPServerViewsListResponseBody } from "@app/lib/api/mcp";
 import {
   oauthProviderRequiresWorkspaceConnectionForPersonalAuth,
   withWorkspaceConnectionRequirement,
@@ -25,11 +25,6 @@ const GetMCPViewsRequestSchema = z.object({
   spaceIds: z.array(z.string()),
   availabilities: z.array(MCPViewsRequestAvailabilitySchema),
 });
-
-export type GetMCPServerViewsListResponseBody = {
-  success: boolean;
-  serverViews: MCPServerViewType[];
-};
 
 // We don't allow to fetch "auto_hidden_builder".
 function isAllowedAvailability(

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
+import type { GetEnabledModelsResponseType } from "@app/lib/api/assistant/models";
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { config as regionConfig } from "@app/lib/api/regions/config";
@@ -10,13 +11,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetEnabledModelsResponseType = {
-  models: ModelConfigurationType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
+++ b/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
@@ -1,6 +1,7 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetOAuthSetupResponseBody } from "@app/lib/api/oauth";
 import { createConnectionAndGetSetupUrl } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -16,9 +17,7 @@ import { isString } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export interface GetOAuthSetupResponseBody {
-  redirectUrl: string;
-}
+export type { GetOAuthSetupResponseBody } from "@app/lib/api/oauth";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/provider_credentials/[providerId]/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/[providerId]/index.ts
@@ -7,29 +7,20 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
+import type { ProviderCredentialResponseBody } from "@app/lib/resources/provider_credential_resource";
+import {
+  ProviderCredentialBodySchema,
+  ProviderCredentialResource,
+} from "@app/lib/resources/provider_credential_resource";
 import { apiError } from "@app/logger/withlogging";
 import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { ProviderCredentialType } from "@app/types/provider_credential";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-const ProviderCredentialBodySchema = z.object({
-  apiKey: z.string(),
-});
-
-export type ProviderCredentialBody = z.infer<
-  typeof ProviderCredentialBodySchema
->;
 
 const ProviderCredentialParamsSchema = z.object({
   providerId: z.enum(BYOK_MODEL_PROVIDER_IDS),
 });
-
-export type ProviderCredentialResponseBody = {
-  providerCredential: ProviderCredentialType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/provider_credentials/index.ts
+++ b/front/pages/api/w/[wId]/provider_credentials/index.ts
@@ -2,15 +2,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { GetProviderCredentialsResponseBody } from "@app/lib/resources/provider_credential_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { ProviderCredentialType } from "@app/types/provider_credential";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetProviderCredentialsResponseBody = {
-  providerCredentials: ProviderCredentialType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/providers/[pId]/check.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/check.ts
@@ -1,14 +1,11 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetProvidersCheckResponseBody } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetProvidersCheckResponseBody =
-  | { ok: true }
-  | { ok: false; error: string };
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/providers/index.ts
+++ b/front/pages/api/w/[wId]/providers/index.ts
@@ -2,17 +2,13 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetProvidersResponseBody } from "@app/lib/api/providers";
 import type { Authenticator } from "@app/lib/auth";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { ProviderType } from "@app/types/provider";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetProvidersResponseBody = {
-  providers: ProviderType[];
-};
 
 function redactConfig(config: string) {
   const parsedConfig = JSON.parse(config);

--- a/front/pages/api/w/[wId]/sandbox/egress-policy.ts
+++ b/front/pages/api/w/[wId]/sandbox/egress-policy.ts
@@ -7,6 +7,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetWorkspaceEgressPolicyResponseBody,
+  PutWorkspaceEgressPolicyResponseBody,
+} from "@app/lib/api/sandbox/egress_policy";
 import {
   readWorkspacePolicy,
   writeWorkspacePolicy,
@@ -15,17 +19,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWorkspaceEgressPolicyResponseBody = {
-  policy: EgressPolicy;
-};
-
-export type PutWorkspaceEgressPolicyResponseBody = {
-  policy: EgressPolicy;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/[id].ts
@@ -5,24 +5,17 @@ import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
+import type {
+  DeleteWorkspaceSandboxEnvVarResponseBody,
+  PatchWorkspaceSandboxEnvVarResponseBody,
+} from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import {
-  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
-  type WorkspaceSandboxEnvVarType,
-} from "@app/types/sandbox/env_var";
+import { WORKSPACE_SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-export type DeleteWorkspaceSandboxEnvVarResponseBody = {
-  success: true;
-};
-
-export type PatchWorkspaceSandboxEnvVarResponseBody = {
-  envVar: WorkspaceSandboxEnvVarType;
-};
 
 const PatchWorkspaceSandboxEnvVarBodySchema = z.object({
   kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS).optional(),

--- a/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
+++ b/front/pages/api/w/[wId]/sandbox/env-vars/index.ts
@@ -3,6 +3,10 @@
 /** @ignoreswagger */
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetWorkspaceSandboxEnvVarsResponseBody,
+  PostWorkspaceSandboxEnvVarsResponseBody,
+} from "@app/lib/api/sandbox/env_vars";
 import {
   parseWorkspaceSandboxEnvVarNameForKind,
   validateEnvVarValueForKind,
@@ -12,10 +16,7 @@ import { hasFeatureFlag } from "@app/lib/auth";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import {
-  WORKSPACE_SANDBOX_ENV_VAR_KINDS,
-  type WorkspaceSandboxEnvVarType,
-} from "@app/types/sandbox/env_var";
+import { WORKSPACE_SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
@@ -25,15 +26,6 @@ const PostWorkspaceSandboxEnvVarBodySchema = z.object({
   kind: z.enum(WORKSPACE_SANDBOX_ENV_VAR_KINDS).optional(),
   allowedDomains: z.array(z.string()).nullable().optional(),
 });
-
-export type GetWorkspaceSandboxEnvVarsResponseBody = {
-  envVars: WorkspaceSandboxEnvVarType[];
-};
-
-export type PostWorkspaceSandboxEnvVarsResponseBody = {
-  envVar: WorkspaceSandboxEnvVarType;
-  created: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  SkillEditorsLightResponseBody,
+  SkillEditorsResponseBody,
+} from "@app/lib/api/skills/editors";
+import { PatchSkillEditorsRequestBodySchema } from "@app/lib/api/skills/editors";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -8,39 +13,9 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
-import type { LightUserType, UserType } from "@app/types/user";
 import { toLightUser } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const PatchSkillEditorsRequestBodySchema = z
-  .object({
-    addEditorIds: z.array(z.string()).optional(),
-    removeEditorIds: z.array(z.string()).optional(),
-  })
-  .refine(
-    (body) =>
-      (body.addEditorIds instanceof Array && body.addEditorIds.length > 0) ||
-      (body.removeEditorIds instanceof Array &&
-        body.removeEditorIds.length > 0),
-    {
-      message:
-        "Either addEditorIds or removeEditorIds must be provided and contain at least one ID.",
-    }
-  );
-
-export type PatchSkillEditorsRequestBody = z.infer<
-  typeof PatchSkillEditorsRequestBodySchema
->;
-
-export interface SkillEditorsResponseBody {
-  editors: UserType[];
-}
-
-export interface SkillEditorsLightResponseBody {
-  editors: LightUserType[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
@@ -1,20 +1,16 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+import type { GetSkillHistoryResponseBody } from "@app/lib/api/assistant/skills/history";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import { GetSkillHistoryQuerySchema } from "@app/types/api/internal/skill";
-import type { SkillWithVersionType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-export type GetSkillHistoryResponseBody = {
-  history: SkillWithVersionType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -1,6 +1,12 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  DeleteSkillResponseBody,
+  GetSkillResponseBody,
+  GetSkillWithRelationsResponseBody,
+  PatchSkillResponseBody,
+} from "@app/lib/api/skills";
 import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
@@ -12,10 +18,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { isResourceSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  SkillType,
-  SkillWithRelationsType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
 import { isString } from "@app/types/shared/utils/general";
@@ -23,30 +26,6 @@ import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetSkillResponseBody = {
-  skill: SkillType;
-};
-
-export type GetSkillWithRelationsResponseBody = {
-  skill: SkillWithRelationsType;
-};
-
-export type PatchSkillResponseBody = {
-  skill: Omit<
-    SkillType,
-    | "author"
-    | "requestedSpaceIds"
-    | "workspaceId"
-    | "createdAt"
-    | "updatedAt"
-    | "editedBy"
-  >;
-};
-
-export type DeleteSkillResponseBody = {
-  success: boolean;
-};
 
 // Request body schema for PATCH.
 const PatchSkillRequestBodySchema = z.object({

--- a/front/pages/api/w/[wId]/skills/detect/index.ts
+++ b/front/pages/api/w/[wId]/skills/detect/index.ts
@@ -9,17 +9,16 @@ import { initGitHubRepoClient } from "@app/lib/api/skills/detection/github/githu
 import { getWorkspaceLevelGitHubAccessToken } from "@app/lib/api/skills/detection/github/github_auth";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { DetectedSkillSummary } from "@app/lib/skill_detection";
+import type {
+  DetectedSkillSummary,
+  DetectSkillsResponseBody,
+} from "@app/lib/skill_detection";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type DetectSkillsResponseBody = {
-  skills: DetectedSkillSummary[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/detect/upload.ts
+++ b/front/pages/api/w/[wId]/skills/detect/upload.ts
@@ -5,9 +5,11 @@ import { detectSkillsFromUploadedFiles } from "@app/lib/api/skills/detection/fil
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { DetectedSkillSummary } from "@app/lib/skill_detection";
+import type {
+  DetectedSkillSummary,
+  DetectSkillsResponseBody,
+} from "@app/lib/skill_detection";
 import { apiError } from "@app/logger/withlogging";
-import type { DetectSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/detect";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import formidable from "formidable";

--- a/front/pages/api/w/[wId]/skills/import/index.ts
+++ b/front/pages/api/w/[wId]/skills/import/index.ts
@@ -1,31 +1,18 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
+import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
+import {
+  ImportSkillsRequestBodySchema,
+  importSkillsFromGitHub,
+} from "@app/lib/api/skills/detection/github/import_skills";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-const ImportSkillsRequestBodySchema = z.object({
-  repoUrl: z.string(),
-  names: z.array(z.string()),
-});
-
-export type ImportSkillsRequestBody = z.infer<
-  typeof ImportSkillsRequestBodySchema
->;
-
-export type ImportSkillsResponseBody = {
-  imported: SkillType[];
-  updated: SkillType[];
-  skipped: { name: string; message: string }[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/import/upload.ts
+++ b/front/pages/api/w/[wId]/skills/import/upload.ts
@@ -2,10 +2,10 @@
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { importSkillsFromFiles } from "@app/lib/api/skills/detection/files/import_skills";
+import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { ImportSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/import";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import formidable from "formidable";

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -1,6 +1,11 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetSkillsResponseBody,
+  GetSkillsWithRelationsResponseBody,
+  PostSkillResponseBody,
+} from "@app/lib/api/skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
@@ -13,8 +18,6 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import {
   SKILL_REINFORCEMENT_MODES,
-  type SkillType,
-  type SkillWithoutInstructionsAndToolsType,
   type SkillWithoutInstructionsAndToolsWithRelationsType,
   type UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
@@ -25,18 +28,6 @@ import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetSkillsResponseBody = {
-  skills: SkillWithoutInstructionsAndToolsType[];
-};
-
-export type GetSkillsWithRelationsResponseBody = {
-  skills: SkillWithoutInstructionsAndToolsWithRelationsType[];
-};
-
-export type PostSkillResponseBody = {
-  skill: SkillType;
-};
 
 const SkillStatusSchema = z
   .enum(["active", "archived", "suggested"])

--- a/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_daily_spend.ts
@@ -1,19 +1,13 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetReinforcementDailySpendResponseBody } from "@app/lib/api/skills";
 import type { Authenticator } from "@app/lib/auth";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetReinforcementDailySpendResponseBody = {
-  // ISO date strings ("YYYY-MM-DD") → spend in microUSD for that day.
-  dailySpendMicroUsd: Record<string, number>;
-  periodStartDate: string;
-  periodEndDate: string;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
+++ b/front/pages/api/w/[wId]/skills/reinforcement_spend.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetSkillsSpendResponseBody } from "@app/lib/api/skills";
 import type { Authenticator } from "@app/lib/auth";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
@@ -8,12 +9,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSkillsSpendResponseBody = {
-  // Map from skill sId to total spent in the current billing period (microUSD).
-  // Skills with no usage in the period are omitted.
-  spentMicroUsdBySkillId: Record<string, number>;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/skills/similar.ts
+++ b/front/pages/api/w/[wId]/skills/similar.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetSimilarSkillsResponseBody } from "@app/lib/api/skills/existing_skill_checker";
 import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -8,10 +9,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSimilarSkillsResponseBody = {
-  similar_skills: string[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/tags/index.ts
+++ b/front/pages/api/w/[wId]/tags/index.ts
@@ -1,24 +1,19 @@
 // @migration-status: MIGRATED_TO_HONO
 
-/** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+/** @ignoreswagger */
+import type {
+  CreateTagResponseBody,
+  GetTagsResponseBody,
+} from "@app/lib/api/tags";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { TagType } from "@app/types/tag";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
-
-export type GetTagsResponseBody = {
-  tags: TagType[];
-};
-
-export type CreateTagResponseBody = {
-  tag: TagType;
-};
 
 const PostBodySchema = z.object({
   name: z.string(),

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import type { GetSuggestionsResponseBody } from "@app/lib/api/assistant/tag_manager";
 import { getWorkspaceTagSuggestions } from "@app/lib/api/assistant/tag_manager";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,7 +11,6 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { isAdmin } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 
 const DEFAULT_SUGGESTIONS = [
   "Writing",
@@ -34,22 +34,6 @@ const DEFAULT_SUGGESTIONS = [
   "Quality",
   "Product",
 ];
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const GetSuggestionsResponseBodySchema = z.object({
-  suggestions: z
-    .array(
-      z.object({
-        name: z.string(),
-        agents: z.array(z.object({ sId: z.string(), name: z.string() })),
-      })
-    )
-    .nullish(),
-});
-
-export type GetSuggestionsResponseBody = z.infer<
-  typeof GetSuggestionsResponseBodySchema
->;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/tags/usage/index.ts
+++ b/front/pages/api/w/[wId]/tags/usage/index.ts
@@ -3,15 +3,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { GetTagsUsageResponseBody } from "@app/lib/resources/tags_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { TagTypeWithUsage } from "@app/types/tag";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetTagsUsageResponseBody = {
-  tags: TagTypeWithUsage[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/index.ts
@@ -1,7 +1,11 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { deleteWebhookSource } from "@app/lib/api/webhook_source";
+import {
+  type DeleteWebhookSourceResponseBody,
+  deleteWebhookSource,
+  type PatchWebhookSourceResponseBody,
+} from "@app/lib/api/webhook_source";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
@@ -9,14 +13,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type DeleteWebhookSourceResponseBody = {
-  success: true;
-};
-
-export type PatchWebhookSourceResponseBody = {
-  success: true;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/trigger-estimation.ts
@@ -3,16 +3,12 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger_usage_estimation";
 import { computeFilteredWebhookTriggerForecast } from "@app/lib/triggers/trigger_usage_estimation";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetTriggerEstimationResponseBody = {
-  matchingCount: number;
-  totalCount: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/[webhookSourceId]/views/index.ts
@@ -1,18 +1,16 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetWebhookSourceViewsForSourceResponseBody } from "@app/lib/api/webhook_source";
 import type { Authenticator } from "@app/lib/auth";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export type GetWebhookSourceViewsResponseBody = {
-  success: true;
-  views: WebhookSourceViewType[];
-};
+export type GetWebhookSourceViewsResponseBody =
+  GetWebhookSourceViewsForSourceResponseBody;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -4,7 +4,12 @@ import { getWebhookSourcesUsage } from "@app/lib/api/agent_triggers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import { WEBHOOK_SERVICES } from "@app/lib/api/triggers/built-in-webhooks/services";
-import { deleteWebhookSource } from "@app/lib/api/webhook_source";
+import {
+  deleteWebhookSource,
+  type GetWebhookSourcesResponseBody,
+  type PostWebhookSourcesResponseBody,
+  PostWebhookSourcesSchema,
+} from "@app/lib/api/webhook_source";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateSecureSecret } from "@app/lib/resources/string_ids_server";
@@ -15,28 +20,8 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
-import type {
-  WebhookSourceForAdminType,
-  WebhookSourceWithViewsAndUsageType,
-} from "@app/types/triggers/webhooks";
-import { WebhookSourcesSchema } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
-import type { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostWebhookSourcesSchema = WebhookSourcesSchema;
-
-export type PostWebhookSourcesBody = z.infer<typeof PostWebhookSourcesSchema>;
-
-export type GetWebhookSourcesResponseBody = {
-  success: true;
-  webhookSourcesWithViews: WebhookSourceWithViewsAndUsageType[];
-};
-
-export type PostWebhookSourcesResponseBody = {
-  success: true;
-  webhookSource: WebhookSourceForAdminType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/webhook_sources/service-data.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/service-data.ts
@@ -10,18 +10,9 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import { isString } from "@app/types/shared/utils/general";
-import type {
-  WebhookProvider,
-  WebhookServiceDataForProvider,
-} from "@app/types/triggers/webhooks";
+import type { GetServiceDataResponseType } from "@app/types/triggers/webhooks";
 import { isWebhookProvider } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetServiceDataResponseType<
-  P extends WebhookProvider = WebhookProvider,
-> = {
-  serviceData: WebhookServiceDataForProvider<P>;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -3,11 +3,11 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { GetWebhookSourceViewsListResponseBody } from "@app/lib/resources/webhook_sources_view_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
@@ -15,11 +15,6 @@ import { fromError } from "zod-validation-error";
 const GetWebhookSourceViewsRequestSchema = z.object({
   spaceIds: z.array(z.string()),
 });
-
-export type GetWebhookSourceViewsListResponseBody = {
-  success: boolean;
-  webhookSourceViews: WebhookSourceViewType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -55,6 +55,12 @@ type WebhookProviderServiceDataMap = {
 export type WebhookServiceDataForProvider<P extends WebhookProvider> =
   WebhookProviderServiceDataMap[P];
 
+export type GetServiceDataResponseType<
+  P extends WebhookProvider = WebhookProvider,
+> = {
+  serviceData: WebhookServiceDataForProvider<P>;
+};
+
 // Data-only presets (no React components). Safe to import from temporal workers
 // and server-side code without pulling in sparkle/React.
 export const WEBHOOK_PRESETS = {


### PR DESCRIPTION
## Description

Relocates **mcp / skills / labs / webhook_sources / sandbox / providers / credentials / files / tags / oauth / models / builder** contract types and zod schemas out of the Next handlers into `lib/api` (and resource) homes. Next handlers, Hono routes, and the browser `extension` import from `lib`. A few types were renamed on relocation to avoid collisions (shapes unchanged).

## Tests

Pure type/schema **relocation** with no behavior change, so existing functional tests cover these routes. `npx tsgo --noEmit` is green on both `front` and `front-api`, and `biome` passes. Where a relocated zod schema is consumed at module scope (`validate("json", …)`), the affected `vi.mock(...)` test helpers were switched to `importOriginal` so the real schema is preserved.

## Risk

Low. Types and zod schemas are moved into `lib/api` homes that both the Next handlers and the Hono routes import from — a single source of truth, no duplication, no runtime logic touched. Fully revertable by reverting the commit.

## Deploy Plan

No migration or special steps. ⚠️ This PR makes Next-only edits on modules whose Hono route had no duplicate, so it needs the **`skip-migration-check`** label (BACK17). Merge the stack bottom-up.
