### PR TITLE
[slim-api] move billing/members/workspace/misc API contracts out of pages/api

### DIFF
--- a/front-api/routes/debug/profiler.ts
+++ b/front-api/routes/debug/profiler.ts
@@ -1,14 +1,10 @@
 import config from "@app/lib/api/config";
+import type { GetProfilerResponse } from "@app/lib/api/debug/profiler";
 import { profileCPU, profileHeap } from "@app/lib/api/debug/profiler";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
-
-export interface GetProfilerResponse {
-  cpu: string;
-  heap: string;
-}
 
 // Mounted at /api/debug/profiler.
 const app = createHono();

--- a/front-api/routes/geo/location.ts
+++ b/front-api/routes/geo/location.ts
@@ -1,3 +1,4 @@
+import type { GeoLocationResponse } from "@app/lib/geo/country-detection";
 import { resolveCountryCode } from "@app/lib/geo/country-detection";
 import { isGDPRCountry } from "@app/lib/geo/eu-detection";
 import { getClientIp } from "@app/lib/utils/request";
@@ -5,12 +6,6 @@ import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import { getConnInfo } from "@hono/node-server/conninfo";
-
-export type GeoLocationResponse = {
-  isGDPR: boolean;
-  countryCode?: string;
-  dev?: boolean;
-};
 
 // Mounted at /api/geo/location. No workspace auth — top-level route.
 const app = unauthedApp();

--- a/front-api/routes/invitations.ts
+++ b/front-api/routes/invitations.ts
@@ -1,3 +1,4 @@
+import type { GetPendingInvitationsLookupResponseBody } from "@app/lib/api/invitation";
 import { fetchInvitationsFromOtherRegion } from "@app/lib/api/regions/lookup";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
@@ -9,10 +10,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 
 import { sessionAuth } from "../middlewares/session_auth";
-
-export type GetPendingInvitationsLookupResponseBody = {
-  pendingInvitations: PendingInvitationOption[];
-};
 
 export const invitationsApp = sessionApp();
 

--- a/front-api/routes/lookup/[resource]/index.ts
+++ b/front-api/routes/lookup/[resource]/index.ts
@@ -1,12 +1,25 @@
 import config from "@app/lib/api/config";
+import type {
+  InvitationsLookupRequestBodyType,
+  InvitationsLookupResponse,
+  ShareTokenLookupRequestBodyType,
+  ShareTokenLookupResponse,
+  UserLookupRequestBodyType,
+  UserLookupResponse,
+  WorkspaceLookupRequestBodyType,
+  WorkspaceLookupResponse,
+} from "@app/lib/api/regions/lookup";
 import {
   handleLookupInvitations,
   handleLookupWorkspace,
   hasEmailLocalRegionAffinity,
+  InvitationsLookupSchema,
+  ShareTokenLookupSchema,
+  UserLookupSchema,
+  WorkspaceLookupSchema,
 } from "@app/lib/api/regions/lookup";
 import { getBearerToken } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
-import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { createHono } from "@front-api/lib/hono";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -14,22 +27,15 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-export type WorkspaceLookupResponse = {
-  workspace: {
-    sId: string;
-  } | null;
-};
-
-export type UserLookupResponse = {
-  exists: boolean;
-};
-
-export type InvitationsLookupResponse = {
-  pendingInvitations: PendingInvitationOption[];
-};
-
-export type ShareTokenLookupResponse = {
-  exists: boolean;
+export type {
+  InvitationsLookupRequestBodyType,
+  InvitationsLookupResponse,
+  ShareTokenLookupRequestBodyType,
+  ShareTokenLookupResponse,
+  UserLookupRequestBodyType,
+  UserLookupResponse,
+  WorkspaceLookupRequestBodyType,
+  WorkspaceLookupResponse,
 };
 
 type LookupResponseBody =
@@ -37,38 +43,6 @@ type LookupResponseBody =
   | WorkspaceLookupResponse
   | InvitationsLookupResponse
   | ShareTokenLookupResponse;
-
-const ExternalUserCodec = z.object({
-  email: z.string(),
-  email_verified: z.boolean(),
-});
-
-const UserLookupSchema = z.object({
-  user: ExternalUserCodec,
-});
-
-const WorkspaceLookupSchema = z.object({
-  workspace: z.string(),
-});
-
-const InvitationsLookupSchema = z.object({
-  email: z.string(),
-});
-
-const ShareTokenLookupSchema = z.object({
-  token: z.string(),
-});
-
-export type UserLookupRequestBodyType = z.infer<typeof UserLookupSchema>;
-export type WorkspaceLookupRequestBodyType = z.infer<
-  typeof WorkspaceLookupSchema
->;
-export type InvitationsLookupRequestBodyType = z.infer<
-  typeof InvitationsLookupSchema
->;
-export type ShareTokenLookupRequestBodyType = z.infer<
-  typeof ShareTokenLookupSchema
->;
 
 const ResourceParamSchema = z.object({
   resource: z.enum(["user", "workspace", "invitations", "share-token"]),

--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import type { GetShareFrameMetadataResponseBody } from "@app/lib/api/files/share";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { lookupShareToken } from "@app/lib/api/regions/lookup";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -10,15 +11,6 @@ import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface GetShareFrameMetadataResponseBody {
-  requiresEmailVerification: boolean;
-  shareUrl: string;
-  title: string;
-  vizUrl: string;
-  workspaceId: string;
-  workspaceName: string;
-}
 
 const ParamsSchema = z.object({
   token: z.string(),

--- a/front-api/routes/templates/[tId]/index.ts
+++ b/front-api/routes/templates/[tId]/index.ts
@@ -1,10 +1,9 @@
+import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export type FetchAgentTemplateResponse = ReturnType<TemplateResource["toJSON"]>;
 
 const ParamsSchema = z.object({
   tId: z.string(),

--- a/front-api/routes/user/index.ts
+++ b/front-api/routes/user/index.ts
@@ -1,3 +1,7 @@
+import type {
+  GetUserResponseBody,
+  PostUserMetadataResponseBody,
+} from "@app/lib/api/user";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { getSubscriberHash } from "@app/lib/notifications";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -7,7 +11,6 @@ import logger from "@app/logger/logger";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import { isJobType } from "@app/types/job_type";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import { sessionAuth } from "@front-api/middlewares/session_auth";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -16,14 +19,6 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import metadata from "./metadata";
-
-export type GetUserResponseBody = {
-  user: UserTypeWithWorkspaces & { subscriberHash: string | null };
-};
-
-export type PostUserMetadataResponseBody = {
-  success: boolean;
-};
 
 const PatchUserBodySchema = z.object({
   firstName: z.string(),

--- a/front-api/routes/user/metadata/[key]/index.ts
+++ b/front-api/routes/user/metadata/[key]/index.ts
@@ -1,7 +1,10 @@
+import type {
+  GetUserMetadataResponseBody,
+  PostUserMetadataKeyResponseBody as PostUserMetadataResponseBody,
+} from "@app/lib/api/user";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { APIErrorResponse } from "@app/types/error";
-import type { UserMetadataType } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -9,14 +12,6 @@ import { validate } from "@front-api/middlewares/validator";
 import type { Context, TypedResponse } from "hono";
 import { Op } from "sequelize";
 import { z } from "zod";
-
-export type GetUserMetadataResponseBody = {
-  metadata: UserMetadataType | null;
-};
-
-export type PostUserMetadataResponseBody = {
-  metadata: UserMetadataType;
-};
 
 const PostUserMetadataBodySchema = z.object({
   value: z.string(),

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/index.ts
@@ -5,6 +5,7 @@ import {
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import { MAX_CONVERSATION_DEPTH } from "@app/lib/api/assistant/conversation/constants";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isUserMessageContextOverflowing } from "@app/lib/api/assistant/conversation/helper";
@@ -54,8 +55,6 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 import conversation from "./[cId]";
-
-export const MAX_CONVERSATION_DEPTH = 4;
 
 // Mounted at /api/v1/w/:wId/assistant/conversations.
 const app = publicApiApp();

--- a/front-api/routes/w/[wId]/analytics/active-users.ts
+++ b/front-api/routes/w/[wId]/analytics/active-users.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
+import type { GetWorkspaceActiveUsersResponse } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
@@ -13,10 +13,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceActiveUsersResponse = {
-  points: ActiveUsersMetricsPoint[];
-};
 
 // Mounted at /api/w/:wId/analytics/active-users.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/analytics/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/overview.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/lib/api/workspace/analytics";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { estypes } from "@elastic/elasticsearch";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -13,11 +14,6 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceAnalyticsOverviewResponse = {
-  totalMembers: number;
-  activeUsers: number;
-};
 
 type OverviewAggs = {
   unique_users?: estypes.AggregationsCardinalityAggregate;

--- a/front-api/routes/w/[wId]/analytics/skill-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/skill-usage.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
+import type { GetWorkspaceSkillUsageResponse } from "@app/lib/api/analytics/workspace_analytics";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
@@ -14,10 +14,6 @@ const QuerySchema = z.object({
   skillName: z.string().optional(),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceSkillUsageResponse = {
-  points: SkillUsagePoint[];
-};
 
 // Mounted at /api/w/:wId/analytics/skill-usage.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/analytics/skills.ts
+++ b/front-api/routes/w/[wId]/analytics/skills.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";
+import type { GetWorkspaceSkillsResponse } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -11,10 +11,6 @@ import { z } from "zod";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceSkillsResponse = {
-  skills: AvailableSkill[];
-};
 
 // Mounted at /api/w/:wId/analytics/skills.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/analytics/source.ts
+++ b/front-api/routes/w/[wId]/analytics/source.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceContextOriginResponse } from "@app/lib/api/assistant/observability/context_origin";
 import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -11,14 +12,6 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceContextOriginResponse = {
-  total: number;
-  buckets: {
-    origin: string;
-    count: number;
-  }[];
-};
 
 // Mounted at /api/w/:wId/analytics/source.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/analytics/tool-usage.ts
+++ b/front-api/routes/w/[wId]/analytics/tool-usage.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
+import type { GetWorkspaceToolUsageResponse } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
@@ -14,10 +14,6 @@ const QuerySchema = z.object({
   serverName: z.string().optional(),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceToolUsageResponse = {
-  points: ToolUsagePoint[];
-};
 
 // Mounted at /api/w/:wId/analytics/tool-usage.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/analytics/tools.ts
+++ b/front-api/routes/w/[wId]/analytics/tools.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
+import type { GetWorkspaceToolsResponse } from "@app/lib/api/assistant/observability/tool_usage";
 import {
   fetchAvailableTools,
   resolveToolDisplayNames,
@@ -14,10 +14,6 @@ import { z } from "zod";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceToolsResponse = {
-  tools: AvailableTool[];
-};
 
 // Mounted at /api/w/:wId/analytics/tools.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/analytics/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/top-agents.ts
@@ -2,6 +2,7 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { GetWorkspaceTopAgentsResponse } from "@app/lib/api/workspace/analytics";
 import type { estypes } from "@elastic/elasticsearch";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -14,18 +15,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   limit: z.coerce.number().positive().max(100).optional().default(25),
 });
-
-export type WorkspaceTopAgentRow = {
-  agentId: string;
-  name: string;
-  pictureUrl: string | null;
-  messageCount: number;
-  userCount: number;
-};
-
-export type GetWorkspaceTopAgentsResponse = {
-  agents: WorkspaceTopAgentRow[];
-};
 
 type TopAgentsAggs = {
   by_agent?: estypes.AggregationsMultiBucketAggregateBase<{

--- a/front-api/routes/w/[wId]/analytics/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/top-users.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceTopUsersResponse } from "@app/lib/api/analytics/workspace_analytics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -14,18 +15,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   limit: z.coerce.number().positive().max(100).optional().default(25),
 });
-
-export type WorkspaceTopUserRow = {
-  userId: string;
-  name: string;
-  imageUrl: string | null;
-  messageCount: number;
-  agentCount: number;
-};
-
-export type GetWorkspaceTopUsersResponse = {
-  users: WorkspaceTopUserRow[];
-};
 
 type TopUsersAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<{

--- a/front-api/routes/w/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics.ts
@@ -1,8 +1,5 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type {
-  MessageMetricsPoint,
-  UsageMetricsInterval,
-} from "@app/lib/api/assistant/observability/messages_metrics";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
@@ -18,14 +15,6 @@ const QuerySchema = z.object({
   interval: z.enum(["day", "week"]).optional().default("day"),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceUsageMetricsResponse = {
-  interval: UsageMetricsInterval;
-  points: Pick<
-    MessageMetricsPoint,
-    "timestamp" | "count" | "conversations" | "activeUsers"
-  >[];
-};
 
 // Mounted at /api/w/:wId/analytics/usage-metrics.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/audit-logs.ts
+++ b/front-api/routes/w/[wId]/audit-logs.ts
@@ -1,3 +1,4 @@
+import type { AuditLogsPortalResponse } from "@app/lib/api/audit/workos_audit";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -17,10 +18,6 @@ import { z } from "zod";
 const PostAuditLogsRequestBodySchema = z.object({
   portal: z.enum(["view_logs", "configure_export"]),
 });
-
-export type AuditLogsPortalResponse = {
-  portalUrl: string;
-};
 
 // Mounted at /api/w/:wId/audit-logs.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/auth-context.ts
+++ b/front-api/routes/w/[wId]/auth-context.ts
@@ -1,3 +1,4 @@
+import type { GetWorkspaceAuthContextResponseType } from "@app/lib/api/auth_context";
 import config from "@app/lib/api/config";
 import {
   getForcedApiUrlRedirect,
@@ -5,10 +6,6 @@ import {
 } from "@app/lib/api/regions/lookup";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
-import type { SubscriptionType } from "@app/types/plan";
-import type { ProvidersHealth } from "@app/types/provider_credential";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -17,18 +14,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   wId: z.string(),
 });
-
-export type GetWorkspaceAuthContextResponseType = {
-  user: UserType;
-  workspace: LightWorkspaceType;
-  subscription: SubscriptionType;
-  isAdmin: boolean;
-  isBuilder: boolean;
-  featureFlags: WhitelistableFeature[];
-  isEligibleForTrial?: boolean;
-  vizUrl: string;
-  providersHealth: ProvidersHealth | null;
-};
 
 // Mounted at /api/w/:wId/auth-context.
 //

--- a/front-api/routes/w/[wId]/coupon/validate.ts
+++ b/front-api/routes/w/[wId]/coupon/validate.ts
@@ -1,15 +1,12 @@
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
-import type { CouponType } from "@app/types/coupon";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-export type GetCouponValidateResponseBody = {
-  coupon: CouponType;
-};
+export type { GetCouponValidateResponseBody } from "@app/lib/resources/coupon_resource";
 
 const GetCouponValidateQuerySchema = z.object({
   code: z.string(),

--- a/front-api/routes/w/[wId]/credits/purchase.ts
+++ b/front-api/routes/w/[wId]/credits/purchase.ts
@@ -1,12 +1,13 @@
 import type {
   CreateCreditPurchaseError,
   CreatedCreditPurchase,
-  CreditPurchaseInfo,
   CreditPurchaseInfoError,
+  GetCreditPurchaseInfoResponseBody,
 } from "@app/lib/api/credits/purchase";
 import {
   createCreditPurchase,
   getCreditPurchaseInfo,
+  PostCreditPurchaseRequestBody,
 } from "@app/lib/api/credits/purchase";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -15,17 +16,10 @@ import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-export const PostCreditPurchaseRequestBody = z.object({
-  amountDollars: z.number().positive(),
-});
 
 type PostCreditPurchaseResponseBody = CreatedCreditPurchase & {
   success: true;
 };
-
-export type GetCreditPurchaseInfoResponseBody = CreditPurchaseInfo;
 
 function infoErrorToApi(
   err: CreditPurchaseInfoError

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -1,32 +1,16 @@
+import type {
+  GetCreditUsageConfigurationResponseBody,
+  PatchCreditUsageConfigurationResponseBody,
+} from "@app/lib/api/credits/balance_threshold_alert";
 import {
   getWorkspaceBalanceThreshold,
+  PatchCreditUsageConfigurationRequestBody,
   syncMetronomeBalanceThresholdAlert,
 } from "@app/lib/api/credits/balance_threshold_alert";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-export type CreditUsageConfigurationBody = {
-  // Credit balance (in AWU credits) below which workspace admins are emailed.
-  // `null` means no threshold is configured (the warning is off). Derived from
-  // the workspace's Metronome balance-threshold alert.
-  balanceThresholdCredits: number | null;
-};
-
-export type GetCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export type PatchCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export const PatchCreditUsageConfigurationRequestBody = z.object({
-  // 0 (or null) clears the threshold; a positive value enables the alert.
-  balanceThresholdCredits: z.number().int().min(0).nullable(),
-});
 
 // Mounted at /api/w/:wId/credits/usage-configuration.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/domains.ts
+++ b/front-api/routes/w/[wId]/domains.ts
@@ -3,6 +3,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type { GetWorkspaceDomainsResponseBody } from "@app/lib/api/workos/organization";
 import {
   generateWorkOSAdminPortalUrl,
   getOrCreateWorkOSOrganization,
@@ -14,17 +15,11 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import type { Organization } from "@workos-inc/node";
 import { z } from "zod";
 
 const DeleteWorkspaceDomainRequestBodySchema = z.object({
   domain: z.string(),
 });
-
-export interface GetWorkspaceDomainsResponseBody {
-  addDomainLink?: string;
-  domains: Organization["domains"];
-}
 
 // Mounted at /api/w/:wId/domains.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/dust_app_secrets/index.ts
+++ b/front-api/routes/w/[wId]/dust_app_secrets/index.ts
@@ -1,3 +1,7 @@
+import type {
+  GetDustAppSecretsResponseBody,
+  PostDustAppSecretsResponseBody,
+} from "@app/lib/api/dust_app_secrets";
 import {
   getDustAppSecret,
   getDustAppSecrets,
@@ -5,7 +9,6 @@ import {
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
-import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import {
@@ -17,14 +20,6 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import nameRoute from "./[name]";
-
-export type GetDustAppSecretsResponseBody = {
-  secrets: DustAppSecretType[];
-};
-
-export type PostDustAppSecretsResponseBody = {
-  secret: DustAppSecretType;
-};
 
 const PostDustAppSecretBodySchema = z.object({
   name: z.string(),

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -1,10 +1,7 @@
+import type { GetExtensionConfigResponseBody } from "@app/lib/resources/extension";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetExtensionConfigResponseBody = {
-  blacklistedDomains: string[];
-};
 
 // Mounted at /api/w/:wId/extension/config.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/google_drive/picker_token.ts
+++ b/front-api/routes/w/[wId]/google_drive/picker_token.ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import config from "@app/lib/api/config";
+import type { PickerTokenResponseType } from "@app/lib/api/google_drive";
 import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -13,13 +14,6 @@ const RequestBodySchema = z.object({
   // The MCP server ID (e.g., "google_drive") - used to look up the OAuth connection
   mcpServerId: z.string().min(1, "mcpServerId is required"),
 });
-
-export interface PickerTokenResponseType {
-  accessToken: string;
-  clientId: string;
-  developerKey: string;
-  appId: string; // Project number extracted from clientId
-}
 
 // Mounted at /api/w/:wId/google_drive/picker_token.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -4,6 +4,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type { GetWorkspaceResponseBody } from "@app/lib/api/workspace";
 import { renameWorkspace } from "@app/lib/api/workspace";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -11,7 +12,6 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { EmbeddingProviderSchema } from "@app/types/assistant/models/embedding";
 import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
-import type { WorkspaceType } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -274,10 +274,6 @@ app.use(
 
 // === Default auth for everything else.
 app.use("*", workspaceAuth());
-
-interface GetWorkspaceResponseBody {
-  workspace: WorkspaceType;
-}
 
 app.get(
   "/",

--- a/front-api/routes/w/[wId]/join.test.ts
+++ b/front-api/routes/w/[wId]/join.test.ts
@@ -5,7 +5,8 @@ import { honoApp } from "@front-api/app";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 // Mock region redirect to always return null (same region).
-vi.mock("@app/lib/api/regions/lookup", () => ({
+vi.mock("@app/lib/api/regions/lookup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/regions/lookup")>()),
   getWorkspaceRegionRedirect: vi.fn().mockResolvedValue(null),
 }));
 

--- a/front-api/routes/w/[wId]/join.ts
+++ b/front-api/routes/w/[wId]/join.ts
@@ -3,10 +3,10 @@ import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { fetchUsersFromWorkOSWithEmails } from "@app/lib/api/workos/user";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { GetJoinResponseBody, OnboardingType } from "@app/lib/signup";
 import { getSignInUrl } from "@app/lib/signup";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { isString } from "@app/types/shared/utils/general";
-import type { LightWorkspaceType } from "@app/types/user";
 import { createHono } from "@front-api/lib/hono";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -15,18 +15,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   wId: z.string(),
 });
-
-type OnboardingType =
-  | "email_invite"
-  | "domain_conversation_link"
-  | "domain_invite_link";
-
-interface GetJoinResponseBody {
-  onboardingType: OnboardingType;
-  workspace: LightWorkspaceType;
-  signInUrl: string;
-  userExists: boolean;
-}
 
 interface GetJoinErrorBody {
   redirectUrl: string;

--- a/front-api/routes/w/[wId]/keys/index.ts
+++ b/front-api/routes/w/[wId]/keys/index.ts
@@ -3,11 +3,14 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import type {
+  GetKeysResponseBody,
+  PostKeysResponseBody,
+} from "@app/lib/api/keys";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
-import type { KeyType } from "@app/types/key";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -17,14 +20,6 @@ import { z } from "zod";
 import keyId from "./[id]";
 
 const MAX_API_KEY_CREATION_PER_DAY = 30;
-
-export type GetKeysResponseBody = {
-  keys: KeyType[];
-};
-
-export type PostKeysResponseBody = {
-  key: KeyType;
-};
 
 const CreateKeyPostBodySchema = z.object({
   name: z.string(),

--- a/front-api/routes/w/[wId]/me/approvals.ts
+++ b/front-api/routes/w/[wId]/me/approvals.ts
@@ -2,23 +2,15 @@ import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type {
+  DeleteUserApprovalsResponseBody,
+  GetUserApprovalsResponseBody,
+} from "@app/lib/resources/user_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-export interface GetUserApprovalsResponseBody {
-  approvals: {
-    mcpServerId: string;
-    toolNames: string[];
-    serverName: string;
-  }[];
-}
-
-export interface DeleteUserApprovalsResponseBody {
-  success: boolean;
-}
 
 const DeleteQuerySchema = z.object({
   mcpServerId: z.string(),

--- a/front-api/routes/w/[wId]/me/pending-invitations.ts
+++ b/front-api/routes/w/[wId]/me/pending-invitations.ts
@@ -1,12 +1,9 @@
+import type { GetPendingInvitationsResponseBody } from "@app/lib/api/invitation";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetPendingInvitationsResponseBody = {
-  pendingInvitations: PendingInvitationOption[];
-};
 
 // Mounted at /api/w/:wId/me/pending-invitations.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/me/slack-notifications.ts
+++ b/front-api/routes/w/[wId]/me/slack-notifications.ts
@@ -1,11 +1,8 @@
+import type { GetSlackNotificationResponseBody } from "@app/lib/api/me/slack_notifications";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetSlackNotificationResponseBody = {
-  canConfigure: boolean;
-};
 
 // Mounted at /api/w/:wId/me/slack-notifications.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/me/triggers.ts
+++ b/front-api/routes/w/[wId]/me/triggers.ts
@@ -1,17 +1,9 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import type { GetUserTriggersResponseBody } from "@app/lib/api/assistant/configuration/triggers";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import type { TriggerType } from "@app/types/assistant/triggers";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetUserTriggersResponseBody = {
-  triggers: (TriggerType & {
-    isEditor: boolean;
-    agentName: string;
-    agentPictureUrl: string;
-  })[];
-};
 
 // Mounted at /api/w/:wId/me/triggers.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,10 +1,10 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
-  type GetUserSpendLimitResponse,
+  type GetUserSpendLimitResponseBody,
   getUserSpendLimit,
   MAX_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_USER_SPEND_LIMIT_AWU_CREDITS,
-  type SetUserSpendLimitResponse,
+  type PutUserSpendLimitResponseBody,
   setUserSpendLimit,
   type UserSpendLimitError,
 } from "@app/lib/api/users/spend_limit";
@@ -31,10 +31,6 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
 const ParamsSchema = z.object({
   uId: z.string(),
 });
-
-export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
-
-export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
 
 function spendLimitErrorToApiError(
   error: UserSpendLimitError

--- a/front-api/routes/w/[wId]/members/index.ts
+++ b/front-api/routes/w/[wId]/members/index.ts
@@ -1,6 +1,6 @@
+import type { GetMembersResponseBody } from "@app/lib/api/workspace";
 import { getMembers } from "@app/lib/api/workspace";
 import type { MembershipsPaginationParams } from "@app/lib/resources/membership_resource";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -15,12 +15,6 @@ import search from "./search";
 
 export const DEFAULT_PAGE_LIMIT = 50;
 export const MAX_PAGE_LIMIT = 150;
-
-export type GetMembersResponseBody = {
-  members: UserTypeWithWorkspaces[];
-  total: number;
-  nextPageUrl?: string;
-};
 
 const MembersPaginationSchema = z.object({
   limit: z.coerce

--- a/front-api/routes/w/[wId]/members/lookup.ts
+++ b/front-api/routes/w/[wId]/members/lookup.ts
@@ -1,6 +1,9 @@
+import type {
+  MembersLookupAdminResponseBody,
+  MembersLookupResponseBody,
+} from "@app/lib/api/members";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import type { LightUserType, UserType } from "@app/types/user";
 import { toLightUser } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -17,18 +20,6 @@ const MEMBERS_LOOKUP_MAX_IDS = 50;
 const MembersLookupQuerySchema = z.object({
   ids: z.union([z.coerce.number(), z.array(z.coerce.number())]),
 });
-
-// The lookup endpoint is queried by numeric ModelId, so the response must
-// include `id` so callers can correlate results back to the requested ids.
-type LightLookupUserType = LightUserType & { id: number };
-
-export type MembersLookupResponseBody = {
-  users: LightLookupUserType[];
-};
-
-type MembersLookupAdminResponseBody = {
-  users: UserType[];
-};
 
 // Mounted at /api/w/:wId/members/lookup.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/members/search.ts
+++ b/front-api/routes/w/[wId]/members/search.ts
@@ -1,10 +1,10 @@
+import type {
+  SearchMembersAdminResponseBody,
+  SearchMembersResponseBody,
+} from "@app/lib/api/workspace";
 import { searchMembers } from "@app/lib/api/workspace";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { GROUP_KINDS } from "@app/types/groups";
-import type {
-  LightUserTypeWithWorkspace,
-  UserTypeWithWorkspace,
-} from "@app/types/user";
 import { toLightUserWithWorkspace } from "@app/types/user";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -25,16 +25,6 @@ const SearchMembersQuerySchema = z.object({
     .transform((v) => v === "true")
     .optional(),
 });
-
-export type SearchMembersResponseBody = {
-  members: LightUserTypeWithWorkspace[];
-  total: number;
-};
-
-type SearchMembersAdminResponseBody = {
-  members: UserTypeWithWorkspace[];
-  total: number;
-};
 
 // Mounted at /api/w/:wId/members/search.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/metronome/contract.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.ts
@@ -1,7 +1,8 @@
-import type { MetronomeContractSummary } from "@app/lib/api/credits/metronome_contract";
+import type { GetMetronomeContractResponseBody } from "@app/lib/api/credits/metronome_contract";
 import {
   applyContractLifecycleAction,
   getMetronomeContractSummary,
+  PatchMetronomeContractRequestBody,
 } from "@app/lib/api/credits/metronome_contract";
 import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecycle";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -9,19 +10,10 @@ import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
-import { z } from "zod";
-
-export type GetMetronomeContractResponseBody = {
-  contract: MetronomeContractSummary | null;
-};
 
 type PatchMetronomeContractResponseBody = {
   success: boolean;
 };
-
-export const PatchMetronomeContractRequestBody = z.object({
-  action: z.enum(["cancel", "reactivate"]),
-});
 
 function lifecycleErrorToApi(ctx: Context, err: ContractLifecycleError) {
   return apiError(ctx, {

--- a/front-api/routes/w/[wId]/metronome/invoice.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.ts
@@ -7,35 +7,16 @@ import {
   getProductMauTierIds,
   getProductWorkspaceSeatId,
 } from "@app/lib/metronome/constants";
+import type {
+  GetMetronomeInvoiceResponseBody,
+  MetronomeInvoiceSummary,
+} from "@app/lib/metronome/invoice";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { BillingPeriod } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type MetronomeInvoiceSummary = {
-  currency: SupportedCurrency;
-  billingPeriod: BillingPeriod;
-  currentPeriodStartMs: number;
-  currentPeriodEndMs: number;
-  estimatedAmountCents: number;
-  mau: number | null;
-  /** Pro: effective per-seat unit price from the seat line item. */
-  seatUnitPriceCents: number | null;
-  /** Enterprise simple MAU: effective unit price from the MAU line item. */
-  mauUnitPriceCents: number | null;
-  /**
-   * Enterprise tiered MAU: effective per-tier unit prices, indexed by tier
-   * position (same order as getProductMauTierIds()). `null` at a position
-   * means that tier is not present on this contract / not charged this period.
-   */
-  mauTierUnitPricesCents: Array<number | null> | null;
-};
-
-export type GetMetronomeInvoiceResponseBody = {
-  invoice: MetronomeInvoiceSummary | null;
-};
 
 function creditTypeIdToCurrency(
   creditTypeId: string

--- a/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.ts
@@ -1,13 +1,11 @@
+import type { PostSeedInitialPodTasksResponseBody } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { seedInitialPodTasks } from "@app/lib/project_task/seed_initial_pod_tasks";
-import type { PodTaskType } from "@app/types/project_task";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
 
-export type PostSeedInitialPodTasksResponseBody = {
-  tasks: PodTaskType[];
-};
+export type { PostSeedInitialPodTasksResponseBody };
 
 // Mounted under /api/w/:wId/pods/:podId/tasks/seed.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/provisioning-status.ts
+++ b/front-api/routes/w/[wId]/provisioning-status.ts
@@ -1,3 +1,4 @@
+import type { GetProvisioningStatusResponseBody } from "@app/lib/api/workspace";
 import {
   ADMIN_GROUP_NAME,
   BUILDER_GROUP_NAME,
@@ -5,11 +6,6 @@ import {
 } from "@app/lib/resources/group_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetProvisioningStatusResponseBody = {
-  hasAdminGroup: boolean;
-  hasBuilderGroup: boolean;
-};
 
 // Mounted at /api/w/:wId/provisioning-status.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/search.ts
+++ b/front-api/routes/w/[wId]/search.ts
@@ -1,3 +1,4 @@
+import type { DataSourceContentNode } from "@app/lib/api/search";
 import {
   handleSearch,
   SearchRequestBody,
@@ -6,10 +7,7 @@ import {
 import { streamToolFiles } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
 import logger from "@app/logger/logger";
-import type { ContentNodeWithParent } from "@app/types/connectors/connectors_api";
 import type { SearchWarningCode } from "@app/types/core/core_api";
-import type { DataSourceType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { setSSEHeaders } from "@front-api/middlewares/streaming";
@@ -17,11 +15,6 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { stream } from "hono/streaming";
 import { fromError } from "zod-validation-error";
-
-type DataSourceContentNode = ContentNodeWithParent & {
-  dataSource: DataSourceType;
-  dataSourceViews: DataSourceViewType[];
-};
 
 interface UnifiedSearchStreamChunk {
   knowledgeResults?: {

--- a/front-api/routes/w/[wId]/search/tools/upload.ts
+++ b/front-api/routes/w/[wId]/search/tools/upload.ts
@@ -2,25 +2,12 @@
 import {
   downloadAndUploadToolFile,
   getToolAccessToken,
+  ToolUploadRequestBodySchema,
 } from "@app/lib/search/tools/search";
 import type { FileType } from "@app/types/files";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
-
-const ToolUploadRequestBodySchema = z.object({
-  serverViewId: z.string().min(1, "serverViewId is required"),
-  externalId: z.string().min(1, "externalId is required"),
-  conversationId: z.string().optional(), // TODO(seb): remove after the next extension release + a few days.
-  useCase: z.enum(["conversation", "project_context"]).default("conversation"),
-  useCaseMetadata: z.object({
-    conversationId: z.string().optional(),
-    spaceId: z.string().optional(),
-  }),
-  serverName: z.string().optional(),
-  serverIcon: z.string().optional(),
-});
 
 interface ToolUploadResponseBody {
   file: FileType;

--- a/front-api/routes/w/[wId]/seats/availability.ts
+++ b/front-api/routes/w/[wId]/seats/availability.ts
@@ -1,11 +1,8 @@
+import type { GetSeatAvailabilityResponseBody } from "@app/lib/api/workspace";
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetSeatAvailabilityResponseBody = {
-  hasAvailableSeats: boolean;
-};
 
 // Mounted at /api/w/:wId/seats/availability.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/seats/count.ts
+++ b/front-api/routes/w/[wId]/seats/count.ts
@@ -1,11 +1,8 @@
+import type { GetWorkspaceSeatsCountResponseBody } from "@app/lib/api/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetWorkspaceSeatsCountResponseBody = {
-  seatsCount: number;
-};
 
 // Mounted at /api/w/:wId/seats/count.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/subscriptions/awu-purchase-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/awu-purchase-status.ts
@@ -1,12 +1,8 @@
-import type { AwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
+import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { getAwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetAwuPurchaseStatusResponseBody = {
-  attempt: AwuPurchaseAttempt | null;
-};
 
 // Mounted at /api/w/:wId/subscriptions/awu-purchase-status.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
@@ -1,4 +1,7 @@
-import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
+import type {
+  GetAwuPurchaseInfoResponseBody,
+  PostAwuPurchaseResponseBody,
+} from "@app/lib/credits/awu_purchase";
 import {
   getAwuPurchaseInfo,
   purchaseAwuCredits,
@@ -12,15 +15,9 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
-export type GetAwuPurchaseInfoResponseBody = AwuPurchaseInfo;
-
 const PostAwuPurchaseBody = z.object({
   amountCredits: z.number().int().positive(),
 });
-
-export type PostAwuPurchaseResponseBody = {
-  amountCredits: number;
-};
 
 // Mounted at /api/w/:wId/subscriptions/awu-purchase.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
@@ -1,15 +1,9 @@
+import type { GetCheckoutStatusResponseBody } from "@app/lib/api/subscription";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-type CheckoutStatus =
-  | { status: "success" }
-  | { status: "error"; message: string }
-  | { status: "pending" };
-
-export type GetCheckoutStatusResponseBody = CheckoutStatus;
 
 const GetCheckoutStatusQuerySchema = z.object({
   session_id: z.string(),

--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -1,4 +1,11 @@
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import type {
+  GetSubscriptionsResponseBody,
+  PostSubscriptionResponseBody,
+} from "@app/lib/api/subscription";
+import {
+  isMetronomeBillingEnabled,
+  PatchSubscriptionRequestBody,
+} from "@app/lib/api/subscription";
 import {
   createCheckoutUrl,
   PostSubscriptionRequestBody,
@@ -10,14 +17,12 @@ import {
 } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import logger from "@app/logger/logger";
-import type { CheckoutUrlResult, SubscriptionType } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { z } from "zod";
 
 import awuPurchase from "./awu-purchase";
 import awuPurchaseStatus from "./awu-purchase-status";
@@ -27,19 +32,9 @@ import pricing from "./pricing";
 import status from "./status";
 import trialInfo from "./trial-info";
 
-export type GetSubscriptionsResponseBody = {
-  subscriptions: SubscriptionType[];
-};
-
-export type PostSubscriptionResponseBody = CheckoutUrlResult;
-
 export type PatchSubscriptionResponseBody = {
   success: boolean;
 };
-
-const PatchSubscriptionRequestBody = z.object({
-  action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
-});
 
 // Mounted under /api/w/:wId/subscriptions. The bare `/` handles GET, POST,
 // and PATCH on the workspace's subscription itself; admin-only.

--- a/front-api/routes/w/[wId]/subscriptions/pricing.ts
+++ b/front-api/routes/w/[wId]/subscriptions/pricing.ts
@@ -1,11 +1,7 @@
-import type { SubscriptionPerSeatPricing } from "@app/types/plan";
+import type { GetSubscriptionPricingResponseBody } from "@app/lib/resources/subscription_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetSubscriptionPricingResponseBody = {
-  perSeatPricing: SubscriptionPerSeatPricing | null;
-};
 
 // Mounted at /api/w/:wId/subscriptions/pricing.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/subscriptions/status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/status.ts
@@ -1,13 +1,9 @@
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
+import type { GetSubscriptionStatusResponseBody } from "@app/lib/resources/subscription_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetSubscriptionStatusResponseBody = {
-  shouldRedirect: boolean;
-  redirectUrl: string | null;
-};
 
 // Mounted at /api/w/:wId/subscriptions/status.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.ts
@@ -1,11 +1,8 @@
+import type { GetSubscriptionTrialInfoResponseBody } from "@app/lib/api/subscription";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetSubscriptionTrialInfoResponseBody = {
-  trialDaysRemaining: number | null;
-};
 
 // Mounted at /api/w/:wId/subscriptions/trial-info.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/trial-message-usage.ts
+++ b/front-api/routes/w/[wId]/trial-message-usage.ts
@@ -1,10 +1,6 @@
+import type { GetTrialMessageUsageResponseType } from "@app/lib/api/assistant/rate_limits";
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-
-export type GetTrialMessageUsageResponseType = {
-  count: number;
-  limit: number;
-};
 
 // Mounted at /api/w/:wId/trial-message-usage.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -1,3 +1,7 @@
+import type {
+  GetWorkspaceUsageStatusResponseBody,
+  ProgrammaticCreditStatus,
+} from "@app/lib/metronome/user_block";
 import {
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
@@ -5,18 +9,9 @@ import {
   isUserBlocked,
   isWorkspaceProgrammaticWarned,
 } from "@app/lib/metronome/user_block";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
-
-export type GetWorkspaceUsageStatusResponseBody = {
-  awuStatus: "normal" | "warned" | "blocked";
-  poolCreditState: WorkspacePoolCreditState;
-  programmaticCreditStatus: ProgrammaticCreditStatus;
-};
 
 // Mounted at /api/w/:wId/usage-status.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -2,9 +2,10 @@
 
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
-  type DefaultUserSpendLimit,
   type DefaultUserSpendLimitError,
+  type GetDefaultUserSpendLimitResponseBody,
   getDefaultUserSpendLimit,
+  type PutDefaultUserSpendLimitResponseBody,
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
 import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
@@ -27,12 +28,6 @@ const UpdateDefaultUserSpendLimitBodySchema = z.object({
     .min(MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS)
     .max(MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS),
 });
-
-export type GetDefaultUserSpendLimitResponseBody = {
-  awuCredits: number | null;
-};
-
-export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;
 
 function mapErrorToApiError(
   error: DefaultUserSpendLimitError

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -1,6 +1,10 @@
 /** @ignoreswagger */
 
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import type {
+  GetProgrammaticUsageLimitResponseBody,
+  PutProgrammaticUsageLimitResponseBody,
+} from "@app/lib/api/credits/programmatic_usage_limit";
 import {
   getProgrammaticUsageLimit,
   syncProgrammaticUsageLimit,
@@ -14,14 +18,6 @@ import { z } from "zod";
 const UpdateProgrammaticUsageLimitBodySchema = z.object({
   monthlyCapCredits: z.number().int().nonnegative().nullable(),
 });
-
-export type GetProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
-};
-
-export type PutProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
-};
 
 // Mounted at /api/w/:wId/usage_settings/programmatic_usage_limit.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/verified-domains.ts
+++ b/front-api/routes/w/[wId]/verified-domains.ts
@@ -1,13 +1,9 @@
+import type { GetWorkspaceVerifiedDomainsResponseBody } from "@app/lib/api/workspace";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import type { WorkspaceDomain } from "@app/types/workspace";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
-
-export type GetWorkspaceVerifiedDomainsResponseBody = {
-  verifiedDomains: WorkspaceDomain[];
-};
 
 // Mounted at /api/w/:wId/verified-domains.
 const app = workspaceApp();

--- a/front-api/routes/w/[wId]/verify.ts
+++ b/front-api/routes/w/[wId]/verify.ts
@@ -1,4 +1,5 @@
 import { resolveCountryCode } from "@app/lib/geo/country-detection";
+import type { GetVerifyResponseBody } from "@app/lib/plans/trial/index";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial/index";
 import { getClientIp } from "@app/lib/utils/request";
 import logger from "@app/logger/logger";
@@ -10,11 +11,6 @@ import type { Country } from "react-phone-number-input";
 import { isSupportedCountry } from "react-phone-number-input";
 
 const DEFAULT_COUNTRY: Country = "US";
-
-export type GetVerifyResponseBody = {
-  isEligibleForTrial: boolean;
-  initialCountryCode: Country;
-};
 
 async function detectCountryFromIP(ctx: Context): Promise<Country> {
   try {

--- a/front-api/routes/w/[wId]/welcome.ts
+++ b/front-api/routes/w/[wId]/welcome.ts
@@ -1,13 +1,8 @@
+import type { GetWelcomeResponseBody } from "@app/lib/api/workspace";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { detectEmailProvider } from "@app/lib/utils/email_provider_detection";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
-
-export type GetWelcomeResponseBody = {
-  isFirstAdmin: boolean;
-  emailProvider: EmailProviderType;
-};
 
 // Mounted at /api/w/:wId/welcome.
 const app = workspaceApp();

--- a/front-api/routes/workspace-lookup.ts
+++ b/front-api/routes/workspace-lookup.ts
@@ -1,8 +1,8 @@
 import { fetchRevokedWorkspace } from "@app/lib/api/user";
+import type { GetWorkspaceLookupResponseBody } from "@app/lib/api/workspace";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import type { LightWorkspaceType } from "@app/types/user";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -10,12 +10,6 @@ import { z } from "zod";
 
 import { sessionAuth } from "../middlewares/session_auth";
 import { validate } from "../middlewares/validator";
-
-export type GetWorkspaceLookupResponseBody = {
-  workspace: LightWorkspaceType;
-  status: "auto-join-disabled" | "revoked";
-  workspaceVerifiedDomain: string | null;
-};
 
 const GetWorkspaceLookupQuerySchema = z.object({
   flow: z.enum(["no-auto-join", "revoked"]),

--- a/front/components/agent_builder/AgentBuilderContext.tsx
+++ b/front/components/agent_builder/AgentBuilderContext.tsx
@@ -3,7 +3,7 @@ import { PreviewPanelProvider } from "@app/components/agent_builder/PreviewPanel
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
 import { SkillsProvider } from "@app/components/shared/skills/SkillsContext";
 import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
+import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_resource";
 import type { TemplateActionPreset } from "@app/types/assistant/templates";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";

--- a/front/components/agent_builder/AgentBuilderTemplate.tsx
+++ b/front/components/agent_builder/AgentBuilderTemplate.tsx
@@ -1,6 +1,6 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ConfirmContext } from "@app/components/Confirm";
-import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
+import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_resource";
 import type {
   MultiActionPreset,
   TemplateActionPreset,

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -1,6 +1,6 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AgentBuilderMCPConfiguration } from "@app/components/agent_builder/types";
-import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
+import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_resource";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/types/assistant/creativity";
 import {

--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -7,11 +7,11 @@ import type {
   FileAuthorizationInfo,
 } from "@app/lib/actions/mcp";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import type { PickerTokenResponseType } from "@app/lib/api/google_drive";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PickerTokenResponseType } from "@app/pages/api/w/[wId]/google_drive/picker_token";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
   Button,

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -1,5 +1,6 @@
 import { ConversationSidebarStatusDot } from "@app/components/assistant/conversation/ConversationSidebarStatusDot";
 import { PodTaskStartWorkingDropdown } from "@app/components/pod/tasks/PodTaskStartWorkingDropdown";
+import type { GetWorkspacePodTaskResponseBody } from "@app/lib/api/projects/tasks";
 import { useAppRouter } from "@app/lib/platform";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
@@ -9,7 +10,6 @@ import {
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConversationDotStatus } from "@app/lib/utils/conversation_dot_status";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
-import type { GetWorkspacePodTaskResponseBody } from "@app/pages/api/w/[wId]/project_tasks/[taskSId]/index";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { PodTaskStatus, PodTaskType } from "@app/types/project_task";

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -3,8 +3,8 @@ import {
   type SearchMemberWithWorkspaceType,
 } from "@app/components/members/MemberSelectionTable";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
+import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
 import assert from "@app/lib/utils/assert";
-import type { SearchMembersAdminResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type { MembershipOriginType } from "@app/types/memberships";
 import type { RoleType, UserType } from "@app/types/user";
 import {

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -5,6 +5,7 @@ import {
 } from "@app/hooks/useMetronomeContractLifecycleAction";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
+import type { PatchSubscriptionRequestBody } from "@app/lib/api/subscription";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -21,7 +22,6 @@ import {
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -1,6 +1,7 @@
 import { MetronomeSubscriptionPanel } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PatchSubscriptionRequestBody } from "@app/lib/api/subscription";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -18,7 +19,6 @@ import {
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type {
   BillingPeriod,
   SubscriptionPerSeatPricing,

--- a/front/components/workspace/AuditLogsSection.tsx
+++ b/front/components/workspace/AuditLogsSection.tsx
@@ -1,5 +1,5 @@
+import type { AuditLogsPortal } from "@app/lib/api/audit/workos_audit";
 import { useOpenAuditLogsPortal } from "@app/lib/swr/workos";
-import type { AuditLogsPortal } from "@app/pages/api/w/[wId]/audit-logs";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, File04, Page } from "@dust-tt/sparkle";
 import { useState } from "react";

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -1,9 +1,9 @@
 import { ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import { useProvisioningStatus } from "@app/lib/swr/workos";
-import type { SearchMembersAdminResponseBody } from "@app/pages/api/w/[wId]/members/search";
 import type {
   ActiveRoleType,
   LightWorkspaceType,

--- a/front/hooks/useMetronomeContractLifecycleAction.ts
+++ b/front/hooks/useMetronomeContractLifecycleAction.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { PatchMetronomeContractRequestBody } from "@app/lib/api/credits/metronome_contract";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PatchMetronomeContractRequestBody } from "@app/pages/api/w/[wId]/metronome/contract";
 import { useCallback, useState } from "react";
 import type { z } from "zod";
 

--- a/front/hooks/useToolFileUpload.ts
+++ b/front/hooks/useToolFileUpload.ts
@@ -1,8 +1,8 @@
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
+import type { ToolUploadRequestBody } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
-import type { ToolUploadRequestBody } from "@app/pages/api/w/[wId]/search/tools/upload";
 import type { FileUseCaseMetadata } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";

--- a/front/lib/api/academy_api.ts
+++ b/front/lib/api/academy_api.ts
@@ -2,6 +2,12 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { fetchUserFromSession } from "@app/lib/iam/users";
 import type { AcademyIdentifier } from "@app/types/academy";
 
+export interface CourseProgressData {
+  completedChapterSlugs: string[];
+  attemptedChapterSlugs: string[];
+  lastAttemptAt: string;
+}
+
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 

--- a/front/lib/api/analytics/workspace_analytics.ts
+++ b/front/lib/api/analytics/workspace_analytics.ts
@@ -1,0 +1,17 @@
+import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
+
+export type GetWorkspaceSkillUsageResponse = {
+  points: SkillUsagePoint[];
+};
+
+export type WorkspaceTopUserRow = {
+  userId: string;
+  name: string;
+  imageUrl: string | null;
+  messageCount: number;
+  agentCount: number;
+};
+
+export type GetWorkspaceTopUsersResponse = {
+  users: WorkspaceTopUserRow[];
+};

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -1,6 +1,9 @@
 import { getCronTimezoneGeneration } from "@app/lib/api/assistant/configuration/triggers/cron_timezone";
 import type { Authenticator } from "@app/lib/auth";
-import type { ScheduleConfig } from "@app/types/assistant/triggers";
+import type {
+  ScheduleConfig,
+  TriggerType,
+} from "@app/types/assistant/triggers";
 import {
   FullTriggerSchema,
   TriggerSchema,
@@ -8,6 +11,14 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
+
+export interface GetUserTriggersResponseBody {
+  triggers: (TriggerType & {
+    isEditor: boolean;
+    agentName: string;
+    agentPictureUrl: string;
+  })[];
+}
 
 export const GetTriggersResponseBodySchema = z.object({
   triggers: z.array(

--- a/front/lib/api/assistant/conversation/constants.ts
+++ b/front/lib/api/assistant/conversation/constants.ts
@@ -1,1 +1,3 @@
+// Maximum depth of recursive run_agent calls (a conversation triggering another
+// conversation). Guards against unbounded recursion.
 export const MAX_CONVERSATION_DEPTH = 4;

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -19,6 +19,10 @@ export interface ActiveUsersMetricsPoint {
   memberCount: number;
 }
 
+export type GetWorkspaceActiveUsersResponse = {
+  points: ActiveUsersMetricsPoint[];
+};
+
 interface UserBucket {
   key: string;
   doc_count: number;

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -182,3 +182,11 @@ export type GetContextOriginResponse = {
     count: number;
   }[];
 };
+
+export type GetWorkspaceContextOriginResponse = {
+  total: number;
+  buckets: {
+    origin: string;
+    count: number;
+  }[];
+};

--- a/front/lib/api/assistant/observability/messages_metrics.ts
+++ b/front/lib/api/assistant/observability/messages_metrics.ts
@@ -236,3 +236,11 @@ export type GetUsageMetricsResponse = {
     "timestamp" | "count" | "conversations" | "activeUsers"
   >[];
 };
+
+export type GetWorkspaceUsageMetricsResponse = {
+  interval: UsageMetricsInterval;
+  points: Pick<
+    MessageMetricsPoint,
+    "timestamp" | "count" | "conversations" | "activeUsers"
+  >[];
+};

--- a/front/lib/api/assistant/observability/skill_usage.ts
+++ b/front/lib/api/assistant/observability/skill_usage.ts
@@ -19,6 +19,10 @@ export type AvailableSkill = {
   totalExecutions: number;
 };
 
+export type GetWorkspaceSkillsResponse = {
+  skills: AvailableSkill[];
+};
+
 type DateBucket = {
   key: number;
   key_as_string: string;

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -23,6 +23,14 @@ export type AvailableTool = {
   totalExecutions: number;
 };
 
+export type GetWorkspaceToolsResponse = {
+  tools: AvailableTool[];
+};
+
+export type GetWorkspaceToolUsageResponse = {
+  points: ToolUsagePoint[];
+};
+
 type DateBucket = {
   key: number;
   key_as_string: string;

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -9,6 +9,11 @@ import {
 import type { MaxMessagesTimeframeType } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 
+export type GetTrialMessageUsageResponseType = {
+  count: number;
+  limit: number;
+};
+
 export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE = 100;
 export const MESSAGE_RATE_LIMIT_WINDOW_SECONDS = 60;
 export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR = 3_000;

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -13,6 +13,12 @@ import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 
+export type AuditLogsPortal = "view_logs" | "configure_export";
+
+export type AuditLogsPortalResponse = {
+  portalUrl: string;
+};
+
 export const AUDIT_ACTIONS = [
   // Existing Tier 1 events.
   "user.login",

--- a/front/lib/api/auth_context.ts
+++ b/front/lib/api/auth_context.ts
@@ -1,0 +1,21 @@
+import type { SubscriptionType } from "@app/types/plan";
+import type { ProvidersHealth } from "@app/types/provider_credential";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+
+export type GetNoWorkspaceAuthContextResponseType = {
+  user: UserType;
+  defaultWorkspaceId: string | null;
+};
+
+export type GetWorkspaceAuthContextResponseType = {
+  user: UserType;
+  workspace: LightWorkspaceType;
+  subscription: SubscriptionType;
+  isAdmin: boolean;
+  isBuilder: boolean;
+  featureFlags: WhitelistableFeature[];
+  isEligibleForTrial?: boolean;
+  vizUrl: string;
+  providersHealth: ProvidersHealth | null;
+};

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -11,6 +11,27 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+export type CreditUsageConfigurationBody = {
+  // Credit balance (in AWU credits) below which workspace admins are emailed.
+  // `null` means no threshold is configured (the warning is off). Derived from
+  // the workspace's Metronome balance-threshold alert.
+  balanceThresholdCredits: number | null;
+};
+
+export type GetCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export type PatchCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export const PatchCreditUsageConfigurationRequestBody = z.object({
+  // 0 (or null) clears the threshold; a positive value enables the alert.
+  balanceThresholdCredits: z.number().int().min(0).nullable(),
+});
 
 /**
  * Read the workspace's credit-balance-threshold notification setting.

--- a/front/lib/api/credits/metronome_contract.ts
+++ b/front/lib/api/credits/metronome_contract.ts
@@ -16,6 +16,15 @@ import { isSeatBased } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
+
+export type GetMetronomeContractResponseBody = {
+  contract: MetronomeContractSummary | null;
+};
+
+export const PatchMetronomeContractRequestBody = z.object({
+  action: z.enum(["cancel", "reactivate"]),
+});
 
 export type MetronomeContractSummary = {
   planFamily: "pro" | "enterprise";

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -12,6 +12,14 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
+export type GetProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
+export type PutProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
 /**
  * Read the workspace's programmatic usage monthly cap.
  *

--- a/front/lib/api/credits/purchase.ts
+++ b/front/lib/api/credits/purchase.ts
@@ -24,6 +24,11 @@ import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { StripePricingData } from "@app/types/stripe/pricing";
+import { z } from "zod";
+
+export const PostCreditPurchaseRequestBody = z.object({
+  amountDollars: z.number().positive(),
+});
 
 export type CreditPurchaseInfo = {
   isEnterprise: boolean;
@@ -33,6 +38,8 @@ export type CreditPurchaseInfo = {
   creditPurchaseLimits: CreditPurchaseLimits | null;
   billingCycleStartDay: number | null;
 };
+
+export type GetCreditPurchaseInfoResponseBody = CreditPurchaseInfo;
 
 export class CreditPurchaseInfoError extends Error {
   constructor(readonly type: "subscription_not_found" | "internal") {

--- a/front/lib/api/debug/profiler.ts
+++ b/front/lib/api/debug/profiler.ts
@@ -8,6 +8,11 @@ import logger from "@app/logger/logger";
 const CPU_PROFILE_DURATION_MS = 30_000;
 const HEAP_PROFILE_DURATION_MS = 30_000;
 
+export interface GetProfilerResponse {
+  cpu: string;
+  heap: string;
+}
+
 export async function saveProfile({
   extension,
   filename,

--- a/front/lib/api/dust_app_secrets.ts
+++ b/front/lib/api/dust_app_secrets.ts
@@ -4,6 +4,14 @@ import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import { decrypt } from "@app/types/shared/utils/encryption";
 import { redactString } from "@app/types/shared/utils/string_utils";
 
+export type GetDustAppSecretsResponseBody = {
+  secrets: DustAppSecretType[];
+};
+
+export type PostDustAppSecretsResponseBody = {
+  secret: DustAppSecretType;
+};
+
 export async function getDustAppSecrets(
   auth: Authenticator,
   clear = false

--- a/front/lib/api/files/share.ts
+++ b/front/lib/api/files/share.ts
@@ -1,0 +1,8 @@
+export interface GetShareFrameMetadataResponseBody {
+  requiresEmailVerification: boolean;
+  shareUrl: string;
+  title: string;
+  vizUrl: string;
+  workspaceId: string;
+  workspaceName: string;
+}

--- a/front/lib/api/google_drive.ts
+++ b/front/lib/api/google_drive.ts
@@ -1,0 +1,6 @@
+export interface PickerTokenResponseType {
+  accessToken: string;
+  clientId: string;
+  developerKey: string;
+  appId: string; // Project number extracted from clientId
+}

--- a/front/lib/api/groups.ts
+++ b/front/lib/api/groups.ts
@@ -1,0 +1,5 @@
+import type { GroupType } from "@app/types/groups";
+
+export type GetGroupsResponseBody = {
+  groups: GroupType[];
+};

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -18,7 +18,10 @@ import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
-import type { MembershipInvitationType } from "@app/types/membership_invitation";
+import type {
+  MembershipInvitationType,
+  PendingInvitationOption,
+} from "@app/types/membership_invitation";
 import type { SubscriptionType } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -44,6 +47,14 @@ const EMAIL_CONCURRENCY = 8;
 
 export type GetWorkspaceInvitationsResponseBody = {
   invitations: MembershipInvitationType[];
+};
+
+export type GetPendingInvitationsLookupResponseBody = {
+  pendingInvitations: PendingInvitationOption[];
+};
+
+export type GetPendingInvitationsResponseBody = {
+  pendingInvitations: PendingInvitationOption[];
 };
 
 export const PostInvitationRequestBodySchema = z.array(

--- a/front/lib/api/keys.ts
+++ b/front/lib/api/keys.ts
@@ -1,0 +1,9 @@
+import type { KeyType } from "@app/types/key";
+
+export type GetKeysResponseBody = {
+  keys: KeyType[];
+};
+
+export type PostKeysResponseBody = {
+  key: KeyType;
+};

--- a/front/lib/api/me/slack_notifications.ts
+++ b/front/lib/api/me/slack_notifications.ts
@@ -1,0 +1,3 @@
+export type GetSlackNotificationResponseBody = {
+  canConfigure: boolean;
+};

--- a/front/lib/api/members.ts
+++ b/front/lib/api/members.ts
@@ -1,0 +1,13 @@
+import type { LightUserType, UserType } from "@app/types/user";
+
+// The lookup endpoint is queried by numeric ModelId, so the response must
+// include `id` so callers can correlate results back to the requested ids.
+export type LightLookupUserType = LightUserType & { id: number };
+
+export type MembersLookupResponseBody = {
+  users: LightLookupUserType[];
+};
+
+export type MembersLookupAdminResponseBody = {
+  users: UserType[];
+};

--- a/front/lib/api/poke/templates.ts
+++ b/front/lib/api/poke/templates.ts
@@ -1,8 +1,10 @@
 import { config } from "@app/lib/api/regions/config";
-import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
+import type {
+  FetchAgentTemplateResponse,
+  FetchAssistantTemplatesResponse,
+} from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import logger from "@app/logger/logger";
-import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { ModelConfig } from "@app/types/assistant/models/types";
 import type {
   CreateTemplateFormType,

--- a/front/lib/api/projects/tasks.ts
+++ b/front/lib/api/projects/tasks.ts
@@ -3,6 +3,7 @@
 // counterparts (front-api/routes/...) so there is a single source of truth.
 import type { PodTaskType } from "@app/types/project_task";
 import { POD_TASK_STATUSES } from "@app/types/project_task";
+import type { PodType } from "@app/types/space";
 import { z } from "zod";
 
 export const PatchProjectTaskBodySchema = z
@@ -81,4 +82,10 @@ export interface GetPodTasksResponseBody {
 
 export interface PostPodTaskResponseBody {
   task: PodTaskType;
+}
+
+export interface GetWorkspacePodTaskResponseBody {
+  task: PodTaskType;
+  /** Pod space (same shape as entries in `GET /api/w/{wId}/spaces` for pods). */
+  space: PodType;
 }

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -6,16 +6,6 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import type {
-  InvitationsLookupRequestBodyType,
-  InvitationsLookupResponse,
-  ShareTokenLookupRequestBodyType,
-  ShareTokenLookupResponse,
-  UserLookupRequestBodyType,
-  UserLookupResponse,
-  WorkspaceLookupRequestBodyType,
-  WorkspaceLookupResponse,
-} from "@app/pages/api/lookup/[resource]";
 import type { RegionRedirectError } from "@app/types/error";
 import { isAPIErrorResponse } from "@app/types/error";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
@@ -23,6 +13,60 @@ import type { RegionType } from "@app/types/region";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+export type WorkspaceLookupResponse = {
+  workspace: {
+    sId: string;
+  } | null;
+};
+
+export type UserLookupResponse = {
+  exists: boolean;
+};
+
+export type InvitationsLookupResponse = {
+  pendingInvitations: PendingInvitationOption[];
+};
+
+export type ShareTokenLookupResponse = {
+  exists: boolean;
+};
+
+const ExternalUserCodec = z.object({
+  email: z.string(),
+  email_verified: z.boolean(),
+});
+
+export const UserLookupSchema = z.object({
+  user: ExternalUserCodec,
+});
+
+export const WorkspaceLookupSchema = z.object({
+  workspace: z.string(),
+});
+
+export const InvitationsLookupSchema = z.object({
+  email: z.string(),
+});
+
+export const ShareTokenLookupSchema = z.object({
+  token: z.string(),
+});
+
+export type UserLookupRequestBodyType = z.infer<typeof UserLookupSchema>;
+
+export type WorkspaceLookupRequestBodyType = z.infer<
+  typeof WorkspaceLookupSchema
+>;
+
+export type InvitationsLookupRequestBodyType = z.infer<
+  typeof InvitationsLookupSchema
+>;
+
+export type ShareTokenLookupRequestBodyType = z.infer<
+  typeof ShareTokenLookupSchema
+>;
 
 interface UserLookup {
   email: string;

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -30,6 +30,13 @@ export type DataSourceContentNode = ContentNodeWithParent & {
   dataSourceViews: DataSourceViewType[];
 };
 
+export type PostWorkspaceSearchResponseBody = {
+  nodes: DataSourceContentNode[];
+  warningCode: SearchWarningCode | null;
+  nextPageCursor: string | null;
+  resultsCount: number | null;
+};
+
 export type SearchResult = {
   nodes: DataSourceContentNode[];
   warningCode: SearchWarningCode | null;

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -17,7 +17,30 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import type { CheckoutUrlResult, SubscriptionType } from "@app/types/plan";
 import { removeNulls } from "@app/types/shared/utils/general";
+import { z } from "zod";
+
+export const PatchSubscriptionRequestBody = z.object({
+  action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
+});
+
+type CheckoutStatus =
+  | { status: "success" }
+  | { status: "error"; message: string }
+  | { status: "pending" };
+
+export type GetCheckoutStatusResponseBody = CheckoutStatus;
+
+export type PostSubscriptionResponseBody = CheckoutUrlResult;
+
+export type GetSubscriptionsResponseBody = {
+  subscriptions: SubscriptionType[];
+};
+
+export type GetSubscriptionTrialInfoResponseBody = {
+  trialDaysRemaining: number | null;
+};
 
 // Metronome billing is enabled by default for all workspaces. The
 // `global_disable_metronome_billing` kill switch turns it off globally; the

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -15,6 +15,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type {
   LightWorkspaceType,
   RoleType,
+  UserMetadataType,
   UserType,
   UserTypeWithExtensionWorkspaces,
   UserTypeWithWorkspaces,
@@ -41,6 +42,22 @@ export type GetMemberResponseBody = {
 
 export type PostMemberResponseBody = {
   member: UserTypeWithWorkspaces;
+};
+
+export type GetUserResponseBody = {
+  user: UserTypeWithWorkspaces & { subscriberHash: string | null };
+};
+
+export type PostUserMetadataResponseBody = {
+  success: boolean;
+};
+
+export type GetUserMetadataResponseBody = {
+  metadata: UserMetadataType | null;
+};
+
+export type PostUserMetadataKeyResponseBody = {
+  metadata: UserMetadataType;
 };
 
 /**

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -36,6 +36,10 @@ export type UserSpendLimit =
 
 export type GetUserSpendLimitResponse = UserSpendLimit;
 
+export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
+
+export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
+
 export type SetUserSpendLimitResponse = {
   limit: UserSpendLimit;
   // The credit-state we transitioned the user to, computed locally from

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -21,6 +21,11 @@ import {
 import assert from "assert";
 import uniqueId from "lodash/uniqueId";
 
+export interface GetWorkspaceDomainsResponseBody {
+  addDomainLink?: string;
+  domains: Organization["domains"];
+}
+
 export async function getOrCreateWorkOSOrganization(
   workspace: LightWorkspaceType,
   { domain }: { domain?: string } = {}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -19,6 +19,7 @@ import {
   WorkspaceResource,
 } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
@@ -34,6 +35,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { md5 } from "@app/types/shared/utils/encryption";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type {
+  LightUserTypeWithWorkspace,
   LightWorkspaceType,
   RoleType,
   UserTypeWithWorkspace,
@@ -42,6 +44,7 @@ import type {
   WorkspaceType,
 } from "@app/types/user";
 import { ACTIVE_ROLES, isBuilder } from "@app/types/user";
+import type { WorkspaceDomain } from "@app/types/workspace";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
@@ -730,3 +733,55 @@ export async function findWorkspaceByWorkOSOrganizationId(
 
   return renderLightWorkspaceType({ workspace });
 }
+
+export type GetWorkspaceLookupResponseBody = {
+  workspace: LightWorkspaceType;
+  status: "auto-join-disabled" | "revoked";
+  workspaceVerifiedDomain: string | null;
+};
+
+export type GetSeatAvailabilityResponseBody = {
+  hasAvailableSeats: boolean;
+};
+
+export type GetMembersResponseBody = {
+  members: UserTypeWithWorkspaces[];
+  total: number;
+  nextPageUrl?: string;
+};
+
+export type GetWorkspaceSeatsCountResponseBody = {
+  seatsCount: number;
+};
+
+export type GetWorkspaceVerifiedDomainsResponseBody = {
+  verifiedDomains: WorkspaceDomain[];
+};
+
+export type GetProvisioningStatusResponseBody = {
+  hasAdminGroup: boolean;
+  hasBuilderGroup: boolean;
+};
+
+export type GetWelcomeResponseBody = {
+  isFirstAdmin: boolean;
+  emailProvider: EmailProviderType;
+};
+
+export type PostWorkspaceResponseBody = {
+  workspace: WorkspaceType;
+};
+
+export type GetWorkspaceResponseBody = {
+  workspace: WorkspaceType;
+};
+
+export type SearchMembersResponseBody = {
+  members: LightUserTypeWithWorkspace[];
+  total: number;
+};
+
+export type SearchMembersAdminResponseBody = {
+  members: UserTypeWithWorkspace[];
+  total: number;
+};

--- a/front/lib/api/workspace/analytics.ts
+++ b/front/lib/api/workspace/analytics.ts
@@ -1,0 +1,16 @@
+export type GetWorkspaceAnalyticsOverviewResponse = {
+  totalMembers: number;
+  activeUsers: number;
+};
+
+export type WorkspaceTopAgentRow = {
+  agentId: string;
+  name: string;
+  pictureUrl: string | null;
+  messageCount: number;
+  userCount: number;
+};
+
+export type GetWorkspaceTopAgentsResponse = {
+  agents: WorkspaceTopAgentRow[];
+};

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -32,6 +32,12 @@ export type DefaultUserSpendLimit = {
   awuCredits: number;
 };
 
+export type GetDefaultUserSpendLimitResponseBody = {
+  awuCredits: number | null;
+};
+
+export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;
+
 export type DefaultUserSpendLimitErrorType =
   | "workspace_not_metronome_billed"
   | "metronome_error"

--- a/front/lib/api/workspace_analytics.ts
+++ b/front/lib/api/workspace_analytics.ts
@@ -18,6 +18,8 @@ export type WorkspaceAnalytics = {
   };
 };
 
+export type GetWorkspaceAnalyticsResponse = WorkspaceAnalytics;
+
 export async function getWorkspaceAnalytics(
   auth: Authenticator
 ): Promise<WorkspaceAnalytics> {

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -60,6 +60,12 @@ export type AwuPurchaseResult = {
   amountCredits: number;
 };
 
+export type GetAwuPurchaseInfoResponseBody = AwuPurchaseInfo;
+
+export type PostAwuPurchaseResponseBody = {
+  amountCredits: number;
+};
+
 export type AwuPurchaseError =
   | { code: "not_metronome_billed" }
   | { code: "legacy_plan" }

--- a/front/lib/credits/awu_purchase_status.ts
+++ b/front/lib/credits/awu_purchase_status.ts
@@ -19,6 +19,10 @@ export type AwuPurchaseAttempt = {
   errorMessage?: string;
 };
 
+export type GetAwuPurchaseStatusResponseBody = {
+  attempt: AwuPurchaseAttempt | null;
+};
+
 // 1 hour: matches a generous bound on the webhook delivery / UI polling
 // window. The UI polls for ~minutes; this TTL gives us margin for retries
 // and Stripe-side delays without leaving stale entries lying around.

--- a/front/lib/geo/country-detection.ts
+++ b/front/lib/geo/country-detection.ts
@@ -3,6 +3,12 @@ import logger from "@app/logger/logger";
 
 import { untrustedFetch } from "../egress/server";
 
+export type GeoLocationResponse = {
+  isGDPR: boolean;
+  countryCode?: string;
+  dev?: boolean;
+};
+
 export async function resolveCountryCode(ip: string): Promise<string> {
   // Handle localhost IPs in development (including IPv4-mapped IPv6 format)
   if (

--- a/front/lib/metronome/invoice.ts
+++ b/front/lib/metronome/invoice.ts
@@ -1,0 +1,25 @@
+import type { SupportedCurrency } from "@app/types/currency";
+import type { BillingPeriod } from "@app/types/plan";
+
+export type MetronomeInvoiceSummary = {
+  currency: SupportedCurrency;
+  billingPeriod: BillingPeriod;
+  currentPeriodStartMs: number;
+  currentPeriodEndMs: number;
+  estimatedAmountCents: number;
+  mau: number | null;
+  /** Pro: effective per-seat unit price from the seat line item. */
+  seatUnitPriceCents: number | null;
+  /** Enterprise simple MAU: effective unit price from the MAU line item. */
+  mauUnitPriceCents: number | null;
+  /**
+   * Enterprise tiered MAU: effective per-tier unit prices, indexed by tier
+   * position (same order as getProductMauTierIds()). `null` at a position
+   * means that tier is not present on this contract / not charged this period.
+   */
+  mauTierUnitPricesCents: Array<number | null> | null;
+};
+
+export type GetMetronomeInvoiceResponseBody = {
+  invoice: MetronomeInvoiceSummary | null;
+};

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -44,6 +44,14 @@ import {
 
 export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
+export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
+
+export type GetWorkspaceUsageStatusResponseBody = {
+  awuStatus: "normal" | "warned" | "blocked";
+  poolCreditState: WorkspacePoolCreditState;
+  programmaticCreditStatus: ProgrammaticCreditStatus;
+};
+
 const REDIS_ORIGIN = "metronome_limit" as const;
 const BLOCKED_FLAG = "1";
 const NOT_BLOCKED_FLAG = "0";

--- a/front/lib/plans/trial/index.ts
+++ b/front/lib/plans/trial/index.ts
@@ -8,6 +8,12 @@ import {
   TRIAL_DURATION_DAYS,
 } from "@app/lib/plans/trial/constants";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { Country } from "react-phone-number-input";
+
+export type GetVerifyResponseBody = {
+  isEligibleForTrial: boolean;
+  initialCountryCode: Country;
+};
 
 /**
  * Checks if a workspace is eligible for the trial page.

--- a/front/lib/project_task/seed_initial_pod_tasks.ts
+++ b/front/lib/project_task/seed_initial_pod_tasks.ts
@@ -10,6 +10,10 @@ import {
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+export type PostSeedInitialPodTasksResponseBody = {
+  tasks: PodTaskType[];
+};
+
 export type SeedInitialPodTasksErrorCode =
   | "not_a_project"
   | "already_seeded"

--- a/front/lib/resources/coupon_resource.ts
+++ b/front/lib/resources/coupon_resource.ts
@@ -15,6 +15,10 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
+export type GetCouponValidateResponseBody = {
+  coupon: CouponType;
+};
+
 export type CouponValidationError =
   | { code: "expired"; expirationDate: Date }
   | { code: "exhausted"; maxRedemptions: number }

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -16,6 +16,10 @@ import type {
   Transaction,
 } from "sequelize";
 
+export type GetExtensionConfigResponseBody = {
+  blacklistedDomains: string[];
+};
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -77,6 +77,15 @@ import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 import type Stripe from "stripe";
 
+export type GetSubscriptionPricingResponseBody = {
+  perSeatPricing: SubscriptionPerSeatPricing | null;
+};
+
+export type GetSubscriptionStatusResponseBody = {
+  shouldRedirect: boolean;
+  redirectUrl: string | null;
+};
+
 const DEFAULT_PLAN_WHEN_NO_SUBSCRIPTION: PlanAttributes = FREE_NO_PLAN_DATA;
 const FREE_NO_PLAN_SUBSCRIPTION_ID = -1;
 

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -197,6 +197,8 @@ export class TemplateResource extends BaseResource<TemplateModel> {
   }
 }
 
+export type FetchAgentTemplateResponse = ReturnType<TemplateResource["toJSON"]>;
+
 export type AssistantTemplateListType = ReturnType<
   TemplateResource["toListJSON"]
 >;

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -46,6 +46,18 @@ export interface SearchMembersPaginationParams {
   limit: number;
 }
 
+export interface GetUserApprovalsResponseBody {
+  approvals: {
+    mcpServerId: string;
+    toolNames: string[];
+    serverName: string;
+  }[];
+}
+
+export interface DeleteUserApprovalsResponseBody {
+  success: boolean;
+}
+
 const USER_METADATA_COMMA_SEPARATOR = ",";
 const USER_METADATA_COMMA_REPLACEMENT = "DUST_COMMA";
 const TOOLS_VALIDATION_WILDCARD = "*";

--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -48,6 +48,22 @@ import type {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { Readable } from "stream";
+import { z } from "zod";
+
+export const ToolUploadRequestBodySchema = z.object({
+  serverViewId: z.string().min(1, "serverViewId is required"),
+  externalId: z.string().min(1, "externalId is required"),
+  conversationId: z.string().optional(), // TODO(seb): remove after the next extension release + a few days.
+  useCase: z.enum(["conversation", "project_context"]).default("conversation"),
+  useCaseMetadata: z.object({
+    conversationId: z.string().optional(),
+    spaceId: z.string().optional(),
+  }),
+  serverName: z.string().optional(),
+  serverIcon: z.string().optional(),
+});
+
+export type ToolUploadRequestBody = z.infer<typeof ToolUploadRequestBodySchema>;
 
 const SEARCHABLE_TOOLS = {
   github: { search: githubSearch, download: githubDownload },

--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -1,4 +1,17 @@
 import config from "@app/lib/api/config";
+import type { LightWorkspaceType } from "@app/types/user";
+
+export type OnboardingType =
+  | "email_invite"
+  | "domain_conversation_link"
+  | "domain_invite_link";
+
+export type GetJoinResponseBody = {
+  onboardingType: OnboardingType;
+  workspace: LightWorkspaceType;
+  signInUrl: string;
+  userExists: boolean;
+};
 
 export function getSignInUrl({
   signupCallbackUrl,

--- a/front/lib/swr/academy.ts
+++ b/front/lib/swr/academy.ts
@@ -1,7 +1,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { CourseProgressData } from "@app/lib/api/academy_api";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { CourseProgressData } from "@app/pages/api/marketing/academy/progress/courses";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Fetcher } from "swr";
 import { useSWRConfig } from "swr";

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -1,6 +1,7 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type {
   GetTriggersResponseBody,
+  GetUserTriggersResponseBody,
   PatchTriggersRequestBody,
   PostTextAsCronRuleRequestBody,
   PostTextAsCronRuleResponseBody,
@@ -19,7 +20,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger_usage_estimation";
-import type { GetUserTriggersResponseBody } from "@app/pages/api/w/[wId]/me/triggers";
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -2,6 +2,8 @@ import type {
   GetAppsResponseBody,
   GetOrPostAppResponseBody,
 } from "@app/lib/api/apps";
+import type { GetDustAppSecretsResponseBody } from "@app/lib/api/dust_app_secrets";
+import type { GetKeysResponseBody } from "@app/lib/api/keys";
 import type { GetProvidersResponseBody } from "@app/lib/api/providers";
 import type {
   GetRunBlockResponseBody,
@@ -13,8 +15,6 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
-import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_app_secrets";
-import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { AppType } from "@app/types/app";
 import type { RunRunType } from "@app/types/run";
 import { normalizeError } from "@app/types/shared/utils/error_utils";

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -31,7 +31,10 @@ import type { GetVersionMarkersResponse } from "@app/lib/api/assistant/observabi
 import type { PostAgentUserFavoriteRequestBody } from "@app/lib/api/assistant/user_relation";
 import type { GetMemberResponseBody } from "@app/lib/api/user";
 import { clientFetch } from "@app/lib/egress/client";
-import type { FetchAssistantTemplatesResponse } from "@app/lib/resources/template_resource";
+import type {
+  FetchAgentTemplateResponse,
+  FetchAssistantTemplatesResponse,
+} from "@app/lib/resources/template_resource";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -40,7 +43,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
-import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type {
   AgentConfigurationType,
   AgentsGetViewType,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -1,11 +1,11 @@
 import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
 import type { GetMembersSeatsResponseBody } from "@app/lib/api/credits/members_seats";
+import type { GetCreditPurchaseInfoResponseBody } from "@app/lib/api/credits/purchase";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
+import type { GetAwuPurchaseInfoResponseBody } from "@app/lib/credits/awu_purchase";
+import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetCreditPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/credits/purchase";
-import type { GetAwuPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/subscriptions/awu-purchase";
-import type { GetAwuPurchaseStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/awu-purchase-status";
 import type {
   GetCreditsResponseBody,
   PendingCreditData,

--- a/front/lib/swr/extension.ts
+++ b/front/lib/swr/extension.ts
@@ -1,5 +1,5 @@
+import type { GetExtensionConfigResponseBody } from "@app/lib/resources/extension";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetExtensionConfigResponseBody } from "@app/pages/api/w/[wId]/extension/config";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/lib/swr/geo.ts
+++ b/front/lib/swr/geo.ts
@@ -1,4 +1,4 @@
-import type { GeoLocationResponse } from "@app/pages/api/geo/location";
+import type { GeoLocationResponse } from "@app/lib/geo/country-detection";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Fetcher } from "swr";
 

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -1,5 +1,5 @@
+import type { GetGroupsResponseBody } from "@app/lib/api/groups";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetGroupsResponseBody } from "@app/pages/api/w/[wId]/groups";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,15 +1,15 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/lib/api/invitation";
-import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import { debounce } from "@app/lib/utils/debounce";
-import type { GetMembersResponseBody } from "@app/pages/api/w/[wId]/members";
+import type { MembersLookupResponseBody } from "@app/lib/api/members";
 import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
-} from "@app/pages/api/w/[wId]/members/[uId]/spend_limit";
-import type { MembersLookupResponseBody } from "@app/pages/api/w/[wId]/members/lookup";
+} from "@app/lib/api/users/spend_limit";
+import type { GetMembersResponseBody } from "@app/lib/api/workspace";
+import { clientFetch } from "@app/lib/egress/client";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { debounce } from "@app/lib/utils/debounce";
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -25,6 +25,7 @@ import type {
 } from "@app/lib/api/projects/preferences";
 import type {
   GetPodTasksResponseBody,
+  GetWorkspacePodTaskResponseBody,
   PatchPodTaskResponseBody,
   PostPodTaskResponseBody,
   PostStartPodTaskResponseBody,
@@ -32,6 +33,7 @@ import type {
 import type { CheckNameResponseBody } from "@app/lib/api/spaces";
 import { clientFetch } from "@app/lib/egress/client";
 import { flattenPodTasksWithStableAssigneeOrder } from "@app/lib/project_task/display_order";
+import type { PostSeedInitialPodTasksResponseBody } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import {
   emptyArray,
@@ -39,8 +41,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { PostSeedInitialPodTasksResponseBody } from "@app/pages/api/w/[wId]/pods/[podId]/tasks/seed";
-import type { GetWorkspacePodTaskResponseBody } from "@app/pages/api/w/[wId]/project_tasks/[taskSId]/index";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/internal/assistant";
 import type { PatchPodMetadataBodyType } from "@app/types/api/internal/spaces";
 import type {

--- a/front/lib/swr/share.ts
+++ b/front/lib/swr/share.ts
@@ -1,3 +1,4 @@
+import type { GetShareFrameMetadataResponseBody } from "@app/lib/api/files/share";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -6,7 +7,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { isRegionRedirect } from "@app/lib/swr/workspaces";
-import type { GetShareFrameMetadataResponseBody } from "@app/pages/api/share/frame/[token]";
 import { useCallback, useEffect } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -10,6 +10,10 @@ import type {
 } from "@app/lib/api/pagination";
 import type { SpacesLookupResponseBody } from "@app/lib/api/projects/lookup";
 import type {
+  DataSourceContentNode,
+  PostWorkspaceSearchResponseBody,
+} from "@app/lib/api/search";
+import type {
   GetSpaceResponseBody,
   GetSpacesResponseBody,
   PatchSpaceResponseBody,
@@ -27,10 +31,6 @@ import {
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type {
-  DataSourceContentNode,
-  PostWorkspaceSearchResponseBody,
-} from "@app/pages/api/w/[wId]/search";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import type { SearchWarningCode } from "@app/types/core/core_api";

--- a/front/lib/swr/trial_message_usage.ts
+++ b/front/lib/swr/trial_message_usage.ts
@@ -1,5 +1,5 @@
+import type { GetTrialMessageUsageResponseType } from "@app/lib/api/assistant/rate_limits";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetTrialMessageUsageResponseType } from "@app/pages/api/w/[wId]/trial-message-usage";
 import type { Fetcher } from "swr";
 
 export function useTrialMessageUsage({

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -1,4 +1,13 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetCreditUsageConfigurationResponseBody } from "@app/lib/api/credits/balance_threshold_alert";
+import type {
+  GetProgrammaticUsageLimitResponseBody,
+  PutProgrammaticUsageLimitResponseBody,
+} from "@app/lib/api/credits/programmatic_usage_limit";
+import type {
+  GetDefaultUserSpendLimitResponseBody,
+  PutDefaultUserSpendLimitResponseBody,
+} from "@app/lib/api/workspace/default_user_spend_limit";
 import { clientFetch } from "@app/lib/egress/client";
 import { invalidateMembersUsage } from "@app/lib/swr/memberships";
 import {
@@ -6,15 +15,6 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { GetCreditUsageConfigurationResponseBody } from "@app/pages/api/w/[wId]/credits/usage-configuration";
-import type {
-  GetDefaultUserSpendLimitResponseBody,
-  PutDefaultUserSpendLimitResponseBody,
-} from "@app/pages/api/w/[wId]/usage_settings/default_user_spend_limit";
-import type {
-  GetProgrammaticUsageLimitResponseBody,
-  PutProgrammaticUsageLimitResponseBody,
-} from "@app/pages/api/w/[wId]/usage_settings/programmatic_usage_limit";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback, useSyncExternalStore } from "react";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,5 +1,13 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetPendingInvitationsResponseBody } from "@app/lib/api/invitation";
+import type { GetSlackNotificationResponseBody } from "@app/lib/api/me/slack_notifications";
+import type {
+  GetUserMetadataResponseBody,
+  GetUserResponseBody,
+} from "@app/lib/api/user";
 import { clientFetch } from "@app/lib/egress/client";
+import type { GetWorkspaceUsageStatusResponseBody } from "@app/lib/metronome/user_block";
+import type { GetUserApprovalsResponseBody } from "@app/lib/resources/user_resource";
 import { nonRedirectingFetcher } from "@app/lib/swr/fetcher";
 import {
   emptyArray,
@@ -8,12 +16,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
-import type { GetUserResponseBody } from "@app/pages/api/user";
-import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
-import type { GetUserApprovalsResponseBody } from "@app/pages/api/w/[wId]/me/approvals";
-import type { GetPendingInvitationsResponseBody } from "@app/pages/api/w/[wId]/me/pending-invitations";
-import type { GetSlackNotificationResponseBody } from "@app/pages/api/w/[wId]/me/slack-notifications";
-import type { GetWorkspaceUsageStatusResponseBody } from "@app/pages/api/w/[wId]/usage-status";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/lib/swr/website.ts
+++ b/front/lib/swr/website.ts
@@ -1,5 +1,5 @@
+import type { GetNoWorkspaceAuthContextResponseType } from "@app/lib/api/auth_context";
 import { useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
 
 // A fetcher that does NOT redirect to login on auth errors.
 // The global fetcher in fetcher.ts redirects to /api/workos/login on

--- a/front/lib/swr/workos.ts
+++ b/front/lib/swr/workos.ts
@@ -1,4 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
+import type {
+  AuditLogsPortal,
+  AuditLogsPortalResponse,
+} from "@app/lib/api/audit/workos_audit";
+import type { GetWorkspaceDomainsResponseBody } from "@app/lib/api/workos/organization";
+import type { GetProvisioningStatusResponseBody } from "@app/lib/api/workspace";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -7,12 +13,6 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
-import type {
-  AuditLogsPortal,
-  AuditLogsPortalResponse,
-} from "@app/pages/api/w/[wId]/audit-logs";
-import type { GetWorkspaceDomainsResponseBody } from "@app/pages/api/w/[wId]/domains";
-import type { GetProvisioningStatusResponseBody } from "@app/pages/api/w/[wId]/provisioning-status";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -12,46 +12,58 @@ import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
+import type {
+  GetWorkspaceSkillUsageResponse,
+  GetWorkspaceTopUsersResponse,
+} from "@app/lib/api/analytics/workspace_analytics";
+import type { GetWorkspaceActiveUsersResponse } from "@app/lib/api/assistant/observability/active_users_metrics";
+import type { GetWorkspaceContextOriginResponse } from "@app/lib/api/assistant/observability/context_origin";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
+import type { GetWorkspaceSkillsResponse } from "@app/lib/api/assistant/observability/skill_usage";
+import type {
+  GetWorkspaceToolsResponse,
+  GetWorkspaceToolUsageResponse,
+} from "@app/lib/api/assistant/observability/tool_usage";
+import type {
+  GetNoWorkspaceAuthContextResponseType,
+  GetWorkspaceAuthContextResponseType,
+} from "@app/lib/api/auth_context";
 import type { GetBillingInfoResponseBody } from "@app/lib/api/billing/info";
 import type { GetBillingInvoicesResponseBody } from "@app/lib/api/billing/invoices";
 import type { PostCheckoutPaymentResponseBody } from "@app/lib/api/checkout/payment";
 import type { GetPreparePaymentResponseBody } from "@app/lib/api/checkout/prepare_payment";
+import type { GetMetronomeContractResponseBody } from "@app/lib/api/credits/metronome_contract";
+import type { GetPendingInvitationsLookupResponseBody } from "@app/lib/api/invitation";
+import type {
+  GetCheckoutStatusResponseBody,
+  GetSubscriptionsResponseBody,
+  GetSubscriptionTrialInfoResponseBody,
+  PostSubscriptionResponseBody,
+} from "@app/lib/api/subscription";
+import type {
+  GetSeatAvailabilityResponseBody,
+  GetWelcomeResponseBody,
+  GetWorkspaceLookupResponseBody,
+  GetWorkspaceResponseBody,
+  GetWorkspaceSeatsCountResponseBody,
+  GetWorkspaceVerifiedDomainsResponseBody,
+} from "@app/lib/api/workspace";
+import type {
+  GetWorkspaceAnalyticsOverviewResponse,
+  GetWorkspaceTopAgentsResponse,
+} from "@app/lib/api/workspace/analytics";
+import type { GetWorkspaceAnalyticsResponse } from "@app/lib/api/workspace_analytics";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
-import type { GetPendingInvitationsLookupResponseBody } from "@app/pages/api/invitations";
-import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
-import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
-import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/pages/api/w/[wId]/analytics/overview";
-import type { GetWorkspaceSkillUsageResponse } from "@app/pages/api/w/[wId]/analytics/skill-usage";
-import type { GetWorkspaceSkillsResponse } from "@app/pages/api/w/[wId]/analytics/skills";
-import type { GetWorkspaceContextOriginResponse } from "@app/pages/api/w/[wId]/analytics/source";
-import type { GetWorkspaceToolUsageResponse } from "@app/pages/api/w/[wId]/analytics/tool-usage";
-import type { GetWorkspaceToolsResponse } from "@app/pages/api/w/[wId]/analytics/tools";
-import type { GetWorkspaceTopAgentsResponse } from "@app/pages/api/w/[wId]/analytics/top-agents";
-import type { GetWorkspaceTopUsersResponse } from "@app/pages/api/w/[wId]/analytics/top-users";
-import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
-import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";
-import type { GetCouponValidateResponseBody } from "@app/pages/api/w/[wId]/coupon/validate";
-import type { GetJoinResponseBody } from "@app/pages/api/w/[wId]/join";
-import type { GetMetronomeContractResponseBody } from "@app/pages/api/w/[wId]/metronome/contract";
-import type { GetMetronomeInvoiceResponseBody } from "@app/pages/api/w/[wId]/metronome/invoice";
-import type { GetSeatAvailabilityResponseBody } from "@app/pages/api/w/[wId]/seats/availability";
-import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
+import type { GetMetronomeInvoiceResponseBody } from "@app/lib/metronome/invoice";
+import type { GetVerifyResponseBody } from "@app/lib/plans/trial/index";
+import type { GetCouponValidateResponseBody } from "@app/lib/resources/coupon_resource";
 import type {
-  GetSubscriptionsResponseBody,
-  PostSubscriptionResponseBody,
-} from "@app/pages/api/w/[wId]/subscriptions";
-import type { GetCheckoutStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/checkout-status";
-import type { GetSubscriptionPricingResponseBody } from "@app/pages/api/w/[wId]/subscriptions/pricing";
-import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";
-import type { GetSubscriptionTrialInfoResponseBody } from "@app/pages/api/w/[wId]/subscriptions/trial-info";
-import type { GetWorkspaceVerifiedDomainsResponseBody } from "@app/pages/api/w/[wId]/verified-domains";
-import type { GetVerifyResponseBody } from "@app/pages/api/w/[wId]/verify";
-import type { GetWelcomeResponseBody } from "@app/pages/api/w/[wId]/welcome";
-import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
-import type { GetWorkspaceLookupResponseBody } from "@app/pages/api/workspace-lookup";
+  GetSubscriptionPricingResponseBody,
+  GetSubscriptionStatusResponseBody,
+} from "@app/lib/resources/subscription_resource";
+import type { GetJoinResponseBody } from "@app/lib/signup";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { APIErrorResponse, RegionRedirectError } from "@app/types/error";
 import type { BillingPeriod } from "@app/types/plan";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";

--- a/front/pages/api/auth-context.ts
+++ b/front/pages/api/auth-context.ts
@@ -1,5 +1,6 @@
 // @migration-status: MIGRATED_TO_HONO
 
+import type { GetNoWorkspaceAuthContextResponseType } from "@app/lib/api/auth_context";
 /** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
@@ -7,13 +8,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { fetchUserFromSession } from "@app/lib/iam/users";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetNoWorkspaceAuthContextResponseType = {
-  user: UserType;
-  defaultWorkspaceId: string | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/debug/profiler.ts
+++ b/front/pages/api/debug/profiler.ts
@@ -1,17 +1,13 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import config from "@app/lib/api/config";
+import type { GetProfilerResponse } from "@app/lib/api/debug/profiler";
 import { profileCPU, profileHeap } from "@app/lib/api/debug/profiler";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetProfilerResponse {
-  cpu: string;
-  heap: string;
-}
 
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default async function handler(

--- a/front/pages/api/geo/location.ts
+++ b/front/pages/api/geo/location.ts
@@ -1,17 +1,12 @@
 // @migration-status: MIGRATED_TO_HONO
 
 /** @ignoreswagger */
+import type { GeoLocationResponse } from "@app/lib/geo/country-detection";
 import { resolveCountryCode } from "@app/lib/geo/country-detection";
 import { isGDPRCountry } from "@app/lib/geo/eu-detection";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GeoLocationResponse = {
-  isGDPR: boolean;
-  countryCode?: string;
-  dev?: boolean;
-};
 
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default async function handler(

--- a/front/pages/api/invitations.ts
+++ b/front/pages/api/invitations.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import type { GetPendingInvitationsLookupResponseBody } from "@app/lib/api/invitation";
 import { fetchInvitationsFromOtherRegion } from "@app/lib/api/regions/lookup";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
@@ -12,10 +13,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPendingInvitationsLookupResponseBody = {
-  pendingInvitations: PendingInvitationOption[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -2,79 +2,35 @@
 
 /** @ignoreswagger */
 import config from "@app/lib/api/config";
+import type {
+  InvitationsLookupResponse,
+  ShareTokenLookupResponse,
+  UserLookupResponse,
+  WorkspaceLookupResponse,
+} from "@app/lib/api/regions/lookup";
 import {
   handleLookupInvitations,
   handleLookupWorkspace,
   hasEmailLocalRegionAffinity,
+  InvitationsLookupSchema,
+  ShareTokenLookupSchema,
+  UserLookupSchema,
+  WorkspaceLookupSchema,
 } from "@app/lib/api/regions/lookup";
 import { getBearerToken } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type WorkspaceLookupResponse = {
-  workspace: {
-    sId: string;
-  } | null;
-};
-
-export type UserLookupResponse = {
-  exists: boolean;
-};
-
-export type InvitationsLookupResponse = {
-  pendingInvitations: PendingInvitationOption[];
-};
-
-export type ShareTokenLookupResponse = {
-  exists: boolean;
-};
-
-const ExternalUserCodec = z.object({
-  email: z.string(),
-  email_verified: z.boolean(),
-});
 
 type LookupResponseBody =
   | UserLookupResponse
   | WorkspaceLookupResponse
   | InvitationsLookupResponse
   | ShareTokenLookupResponse;
-
-const UserLookupSchema = z.object({
-  user: ExternalUserCodec,
-});
-
-const WorkspaceLookupSchema = z.object({
-  workspace: z.string(),
-});
-
-const InvitationsLookupSchema = z.object({
-  email: z.string(),
-});
-
-const ShareTokenLookupSchema = z.object({
-  token: z.string(),
-});
-
-export type UserLookupRequestBodyType = z.infer<typeof UserLookupSchema>;
-
-export type WorkspaceLookupRequestBodyType = z.infer<
-  typeof WorkspaceLookupSchema
->;
-
-export type InvitationsLookupRequestBodyType = z.infer<
-  typeof InvitationsLookupSchema
->;
-
-export type ShareTokenLookupRequestBodyType = z.infer<
-  typeof ShareTokenLookupSchema
->;
 
 const ResourceType = z.enum([
   "user",

--- a/front/pages/api/marketing/academy/progress/courses.ts
+++ b/front/pages/api/marketing/academy/progress/courses.ts
@@ -1,4 +1,5 @@
 /** @ignoreswagger */
+import type { CourseProgressData } from "@app/lib/api/academy_api";
 import { getAcademyIdentifier } from "@app/lib/api/academy_api";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AcademyQuizAttemptResource } from "@app/lib/resources/academy_quiz_attempt_resource";
@@ -6,12 +7,6 @@ import type { NextApiRequestWithContext } from "@app/logger/withlogging";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiResponse } from "next";
-
-export interface CourseProgressData {
-  completedChapterSlugs: string[];
-  attemptedChapterSlugs: string[];
-  lastAttemptAt: string;
-}
 
 interface GetCourseProgressResponse {
   courseProgress: Record<string, CourseProgressData>;

--- a/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/active-users.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceActiveUsersResponse } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
@@ -8,7 +9,6 @@ import { timezoneSchema } from "@app/lib/api/timezone";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
-import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
@@ -8,7 +9,6 @@ import { timezoneSchema } from "@app/lib/api/timezone";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
-import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/share/frame/[token].ts
+++ b/front/pages/api/share/frame/[token].ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import config from "@app/lib/api/config";
+import type { GetShareFrameMetadataResponseBody } from "@app/lib/api/files/share";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { lookupShareToken } from "@app/lib/api/regions/lookup";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -11,15 +12,6 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isInteractiveContentType } from "@app/types/files";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetShareFrameMetadataResponseBody {
-  requiresEmailVerification: boolean;
-  shareUrl: string;
-  title: string;
-  vizUrl: string;
-  workspaceId: string;
-  workspaceName: string;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/templates/[tId]/index.ts
+++ b/front/pages/api/templates/[tId]/index.ts
@@ -1,11 +1,10 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+import type { FetchAgentTemplateResponse } from "@app/lib/resources/template_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type FetchAgentTemplateResponse = ReturnType<TemplateResource["toJSON"]>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/user/index.ts
+++ b/front/pages/api/user/index.ts
@@ -71,6 +71,10 @@
  *         description: User not found
  */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import type {
+  GetUserResponseBody,
+  PostUserMetadataResponseBody,
+} from "@app/lib/api/user";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { getSubscriberHash } from "@app/lib/notifications";
@@ -83,14 +87,9 @@ import type { WithAPIErrorResponse } from "@app/types/error";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import { isJobType } from "@app/types/job_type";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PostUserMetadataResponseBody = {
-  success: boolean;
-};
 
 const PatchUserBodySchema = z.object({
   firstName: z.string(),
@@ -101,10 +100,6 @@ const PatchUserBodySchema = z.object({
   emailProvider: z.string().optional(),
   workspaceId: z.string().optional(),
 });
-
-export type GetUserResponseBody = {
-  user: UserTypeWithWorkspaces & { subscriberHash: string | null };
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/user/metadata/[key]/index.ts
+++ b/front/pages/api/user/metadata/[key]/index.ts
@@ -1,21 +1,17 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
+import type {
+  GetUserMetadataResponseBody,
+  PostUserMetadataKeyResponseBody as PostUserMetadataResponseBody,
+} from "@app/lib/api/user";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserMetadataType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Op } from "sequelize";
-
-export type PostUserMetadataResponseBody = {
-  metadata: UserMetadataType;
-};
-export type GetUserMetadataResponseBody = {
-  metadata: UserMetadataType | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/active-users.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users.ts
@@ -2,7 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
+import type { GetWorkspaceActiveUsersResponse } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
 import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -17,10 +17,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceActiveUsersResponse = {
-  points: ActiveUsersMetricsPoint[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/overview.ts
+++ b/front/pages/api/w/[wId]/analytics/overview.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/lib/api/workspace/analytics";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -17,11 +18,6 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceAnalyticsOverviewResponse = {
-  totalMembers: number;
-  activeUsers: number;
-};
 
 type OverviewAggs = {
   unique_users?: estypes.AggregationsCardinalityAggregate;

--- a/front/pages/api/w/[wId]/analytics/skill-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/skill-usage.ts
@@ -2,7 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { SkillUsagePoint } from "@app/lib/api/assistant/observability/skill_usage";
+import type { GetWorkspaceSkillUsageResponse } from "@app/lib/api/analytics/workspace_analytics";
 import { fetchSkillUsageMetrics } from "@app/lib/api/assistant/observability/skill_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -19,10 +19,6 @@ const QuerySchema = z.object({
   skillName: z.string().optional(),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceSkillUsageResponse = {
-  points: SkillUsagePoint[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/skills.ts
+++ b/front/pages/api/w/[wId]/analytics/skills.ts
@@ -2,7 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { AvailableSkill } from "@app/lib/api/assistant/observability/skill_usage";
+import type { GetWorkspaceSkillsResponse } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -15,10 +15,6 @@ import { z } from "zod";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceSkillsResponse = {
-  skills: AvailableSkill[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/source.ts
+++ b/front/pages/api/w/[wId]/analytics/source.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceContextOriginResponse } from "@app/lib/api/assistant/observability/context_origin";
 import { fetchContextOriginBreakdown } from "@app/lib/api/assistant/observability/context_origin";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -15,14 +16,6 @@ import { fromError } from "zod-validation-error";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceContextOriginResponse = {
-  total: number;
-  buckets: {
-    origin: string;
-    count: number;
-  }[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/tool-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage.ts
@@ -2,7 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
+import type { GetWorkspaceToolUsageResponse } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -19,10 +19,6 @@ const QuerySchema = z.object({
   serverName: z.string().optional(),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceToolUsageResponse = {
-  points: ToolUsagePoint[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/tools.ts
+++ b/front/pages/api/w/[wId]/analytics/tools.ts
@@ -2,7 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
+import type { GetWorkspaceToolsResponse } from "@app/lib/api/assistant/observability/tool_usage";
 import {
   fetchAvailableTools,
   resolveToolDisplayNames,
@@ -18,10 +18,6 @@ import { z } from "zod";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
-
-export type GetWorkspaceToolsResponse = {
-  tools: AvailableTool[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/analytics/top-agents.ts
+++ b/front/pages/api/w/[wId]/analytics/top-agents.ts
@@ -6,6 +6,7 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { GetWorkspaceTopAgentsResponse } from "@app/lib/api/workspace/analytics";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -18,18 +19,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   limit: z.coerce.number().positive().max(100).optional().default(25),
 });
-
-export type WorkspaceTopAgentRow = {
-  agentId: string;
-  name: string;
-  pictureUrl: string | null;
-  messageCount: number;
-  userCount: number;
-};
-
-export type GetWorkspaceTopAgentsResponse = {
-  agents: WorkspaceTopAgentRow[];
-};
 
 type TopAgentsAggs = {
   by_agent?: estypes.AggregationsMultiBucketAggregateBase<{

--- a/front/pages/api/w/[wId]/analytics/top-users.ts
+++ b/front/pages/api/w/[wId]/analytics/top-users.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceTopUsersResponse } from "@app/lib/api/analytics/workspace_analytics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
@@ -18,18 +19,6 @@ const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   limit: z.coerce.number().positive().max(100).optional().default(25),
 });
-
-export type WorkspaceTopUserRow = {
-  userId: string;
-  name: string;
-  imageUrl: string | null;
-  messageCount: number;
-  agentCount: number;
-};
-
-export type GetWorkspaceTopUsersResponse = {
-  users: WorkspaceTopUserRow[];
-};
 
 type TopUsersAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<{

--- a/front/pages/api/w/[wId]/analytics/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/analytics/usage-metrics.ts
@@ -2,10 +2,7 @@
 
 /** @ignoreswagger */
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import type {
-  MessageMetricsPoint,
-  UsageMetricsInterval,
-} from "@app/lib/api/assistant/observability/messages_metrics";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -22,14 +19,6 @@ const QuerySchema = z.object({
   interval: z.enum(["day", "week"]).optional().default("day"),
   timezone: timezoneSchema,
 });
-
-export type GetWorkspaceUsageMetricsResponse = {
-  interval: UsageMetricsInterval;
-  points: Pick<
-    MessageMetricsPoint,
-    "timestamp" | "count" | "conversations" | "activeUsers"
-  >[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/audit-logs.ts
+++ b/front/pages/api/w/[wId]/audit-logs.ts
@@ -1,5 +1,6 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+import type { AuditLogsPortalResponse } from "@app/lib/api/audit/workos_audit";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -14,12 +15,6 @@ import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type AuditLogsPortal = "view_logs" | "configure_export";
-
-export type AuditLogsPortalResponse = {
-  portalUrl: string;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,5 +1,6 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
+import type { GetWorkspaceAuthContextResponseType } from "@app/lib/api/auth_context";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import {
@@ -11,24 +12,8 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SubscriptionType } from "@app/types/plan";
-import type { ProvidersHealth } from "@app/types/provider_credential";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { isString } from "@app/types/shared/utils/general";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWorkspaceAuthContextResponseType = {
-  user: UserType;
-  workspace: LightWorkspaceType;
-  subscription: SubscriptionType;
-  isAdmin: boolean;
-  isBuilder: boolean;
-  featureFlags: WhitelistableFeature[];
-  isEligibleForTrial?: boolean;
-  vizUrl: string;
-  providersHealth: ProvidersHealth | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/coupon/validate.ts
+++ b/front/pages/api/w/[wId]/coupon/validate.ts
@@ -4,16 +4,12 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { CouponRedemptionResource } from "@app/lib/resources/coupon_redemption_resource";
+import type { GetCouponValidateResponseBody } from "@app/lib/resources/coupon_resource";
 import { CouponResource } from "@app/lib/resources/coupon_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { CouponType } from "@app/types/coupon";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetCouponValidateResponseBody = {
-  coupon: CouponType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -4,30 +4,24 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type {
   CreateCreditPurchaseError,
   CreatedCreditPurchase,
-  CreditPurchaseInfo,
   CreditPurchaseInfoError,
+  GetCreditPurchaseInfoResponseBody,
 } from "@app/lib/api/credits/purchase";
 import {
   createCreditPurchase,
   getCreditPurchaseInfo,
+  PostCreditPurchaseRequestBody,
 } from "@app/lib/api/credits/purchase";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export const PostCreditPurchaseRequestBody = z.object({
-  amountDollars: z.number().positive(),
-});
 
 type PostCreditPurchaseResponseBody = CreatedCreditPurchase & {
   success: true;
 };
-
-export type GetCreditPurchaseInfoResponseBody = CreditPurchaseInfo;
 
 function infoErrorToApi(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/credits/usage-configuration.ts
+++ b/front/pages/api/w/[wId]/credits/usage-configuration.ts
@@ -1,36 +1,20 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetCreditUsageConfigurationResponseBody,
+  PatchCreditUsageConfigurationResponseBody,
+} from "@app/lib/api/credits/balance_threshold_alert";
 import {
   getWorkspaceBalanceThreshold,
+  PatchCreditUsageConfigurationRequestBody,
   syncMetronomeBalanceThresholdAlert,
 } from "@app/lib/api/credits/balance_threshold_alert";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type CreditUsageConfigurationBody = {
-  // Credit balance (in AWU credits) below which workspace admins are emailed.
-  // `null` means no threshold is configured (the warning is off). Derived from
-  // the workspace's Metronome balance-threshold alert.
-  balanceThresholdCredits: number | null;
-};
-
-export type GetCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export type PatchCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export const PatchCreditUsageConfigurationRequestBody = z.object({
-  // 0 (or null) clears the threshold; a positive value enables the alert.
-  balanceThresholdCredits: z.number().int().min(0).nullable(),
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/domains.ts
+++ b/front/pages/api/w/[wId]/domains.ts
@@ -6,6 +6,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetWorkspaceDomainsResponseBody } from "@app/lib/api/workos/organization";
 import {
   generateWorkOSAdminPortalUrl,
   getOrCreateWorkOSOrganization,
@@ -16,15 +17,9 @@ import { WorkOSPortalIntent } from "@app/lib/types/workos";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { Organization } from "@workos-inc/node";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export interface GetWorkspaceDomainsResponseBody {
-  addDomainLink?: string;
-  domains: Organization["domains"];
-}
 
 const DeleteWorkspaceDomainRequestBodySchema = z.object({
   domain: z.string(),

--- a/front/pages/api/w/[wId]/dust_app_secrets/index.ts
+++ b/front/pages/api/w/[wId]/dust_app_secrets/index.ts
@@ -1,6 +1,10 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetDustAppSecretsResponseBody,
+  PostDustAppSecretsResponseBody,
+} from "@app/lib/api/dust_app_secrets";
 import {
   getDustAppSecret,
   getDustAppSecrets,
@@ -10,18 +14,9 @@ import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetDustAppSecretsResponseBody = {
-  secrets: DustAppSecretType[];
-};
-
-export type PostDustAppSecretsResponseBody = {
-  secret: DustAppSecretType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/extension/config.ts
+++ b/front/pages/api/w/[wId]/extension/config.ts
@@ -29,14 +29,11 @@
  */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { GetExtensionConfigResponseBody } from "@app/lib/resources/extension";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetExtensionConfigResponseBody = {
-  blacklistedDomains: string[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -2,6 +2,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import type { PickerTokenResponseType } from "@app/lib/api/google_drive";
 import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -16,13 +17,6 @@ const RequestBodySchema = z.object({
   // The MCP server ID (e.g., "google_drive") - used to look up the OAuth connection
   mcpServerId: z.string().min(1, "mcpServerId is required"),
 });
-
-export interface PickerTokenResponseType {
-  accessToken: string;
-  clientId: string;
-  developerKey: string;
-  appId: string; // Project number extracted from clientId
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -2,19 +2,16 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetGroupsResponseBody } from "@app/lib/api/groups";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { GroupKind, GroupType } from "@app/types/groups";
+import type { GroupKind } from "@app/types/groups";
 import { GroupKindCodec } from "@app/types/groups";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type GetGroupsResponseBody = {
-  groups: GroupType[];
-};
 
 const GetGroupsQuerySchema = z.object({
   kind: z.union([GroupKindCodec, z.array(GroupKindCodec)]).optional(),

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -7,6 +7,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetWorkspaceResponseBody,
+  PostWorkspaceResponseBody,
+} from "@app/lib/api/workspace";
 import { renameWorkspace } from "@app/lib/api/workspace";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -16,19 +20,10 @@ import { apiError } from "@app/logger/withlogging";
 import { EmbeddingProviderSchema } from "@app/types/assistant/models/embedding";
 import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { WorkspaceType } from "@app/types/user";
 import { escape } from "html-escaper";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PostWorkspaceResponseBody = {
-  workspace: WorkspaceType;
-};
-
-export type GetWorkspaceResponseBody = {
-  workspace: WorkspaceType;
-};
 
 const WorkspaceNameUpdateBodySchema = z.object({
   name: z.string(),

--- a/front/pages/api/w/[wId]/join.test.ts
+++ b/front/pages/api/w/[wId]/join.test.ts
@@ -8,7 +8,8 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import handler from "./join";
 
 // Mock region redirect to always return null (same region).
-vi.mock("@app/lib/api/regions/lookup", () => ({
+vi.mock("@app/lib/api/regions/lookup", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/regions/lookup")>()),
   getWorkspaceRegionRedirect: vi.fn().mockResolvedValue(null),
 }));
 

--- a/front/pages/api/w/[wId]/join.ts
+++ b/front/pages/api/w/[wId]/join.ts
@@ -5,12 +5,12 @@ import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import { fetchUsersFromWorkOSWithEmails } from "@app/lib/api/workos/user";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { GetJoinResponseBody, OnboardingType } from "@app/lib/signup";
 import { getSignInUrl } from "@app/lib/signup";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { LightWorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 /**
@@ -31,18 +31,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
  *      -> you're redirected to this page from trying to join a workspace and the workspace has a verified domain.
  *      -> the workspace needs to have a verified domain with auto-join enabled.
  */
-
-export type OnboardingType =
-  | "email_invite"
-  | "domain_conversation_link"
-  | "domain_invite_link";
-
-export type GetJoinResponseBody = {
-  onboardingType: OnboardingType;
-  workspace: LightWorkspaceType;
-  signInUrl: string;
-  userExists: boolean;
-};
 
 type GetJoinErrorBody = {
   redirectUrl: string;

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -6,6 +6,10 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetKeysResponseBody,
+  PostKeysResponseBody,
+} from "@app/lib/api/keys";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
@@ -13,19 +17,10 @@ import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { KeyType } from "@app/types/key";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
 const MAX_API_KEY_CREATION_PER_DAY = 30;
-
-export type GetKeysResponseBody = {
-  keys: KeyType[];
-};
-
-export type PostKeysResponseBody = {
-  key: KeyType;
-};
 
 const CreateKeyPostBodySchema = z.object({
   name: z.string(),

--- a/front/pages/api/w/[wId]/me/approvals.ts
+++ b/front/pages/api/w/[wId]/me/approvals.ts
@@ -7,23 +7,15 @@ import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type {
+  DeleteUserApprovalsResponseBody,
+  GetUserApprovalsResponseBody,
+} from "@app/lib/resources/user_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetUserApprovalsResponseBody {
-  approvals: {
-    mcpServerId: string;
-    toolNames: string[];
-    serverName: string;
-  }[];
-}
-
-export interface DeleteUserApprovalsResponseBody {
-  success: boolean;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/me/pending-invitations.ts
+++ b/front/pages/api/w/[wId]/me/pending-invitations.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetPendingInvitationsResponseBody } from "@app/lib/api/invitation";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { getMembershipInvitationToken } from "@app/lib/utils/invitation_token";
@@ -9,10 +10,6 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetPendingInvitationsResponseBody = {
-  pendingInvitations: PendingInvitationOption[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -2,15 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetSlackNotificationResponseBody } from "@app/lib/api/me/slack_notifications";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSlackNotificationResponseBody = {
-  canConfigure: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/me/triggers.ts
+++ b/front/pages/api/w/[wId]/me/triggers.ts
@@ -2,22 +2,14 @@
 
 /** @ignoreswagger */
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import type { GetUserTriggersResponseBody } from "@app/lib/api/assistant/configuration/triggers";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
-import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetUserTriggersResponseBody {
-  triggers: (TriggerType & {
-    isEditor: boolean;
-    agentName: string;
-    agentPictureUrl: string;
-  })[];
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/spend_limit.ts
@@ -4,11 +4,11 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
-  type GetUserSpendLimitResponse,
+  type GetUserSpendLimitResponseBody,
   getUserSpendLimit,
   MAX_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_USER_SPEND_LIMIT_AWU_CREDITS,
-  type SetUserSpendLimitResponse,
+  type PutUserSpendLimitResponseBody,
   setUserSpendLimit,
   type UserSpendLimitError,
 } from "@app/lib/api/users/spend_limit";
@@ -32,10 +32,6 @@ const UpdateUserSpendLimitBodySchema = z.discriminatedUnion("kind", [
       .max(MAX_USER_SPEND_LIMIT_AWU_CREDITS),
   }),
 ]);
-
-export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
-
-export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
 
 function mapErrorToHttp(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/members/index.ts
+++ b/front/pages/api/w/[wId]/members/index.ts
@@ -1,24 +1,18 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetMembersResponseBody } from "@app/lib/api/workspace";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import type { MembershipsPaginationParams } from "@app/lib/resources/membership_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 export const DEFAULT_PAGE_LIMIT = 50;
 export const MAX_PAGE_LIMIT = 150;
-
-export type GetMembersResponseBody = {
-  members: UserTypeWithWorkspaces[];
-  total: number;
-  nextPageUrl?: string;
-};
 
 const MembersPaginationSchema = z.object({
   limit: z.coerce

--- a/front/pages/api/w/[wId]/members/lookup.ts
+++ b/front/pages/api/w/[wId]/members/lookup.ts
@@ -2,12 +2,15 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  MembersLookupAdminResponseBody,
+  MembersLookupResponseBody,
+} from "@app/lib/api/members";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { LightUserType, UserType } from "@app/types/user";
 import { toLightUser } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -17,18 +20,6 @@ const MEMBERS_LOOKUP_MAX_IDS = 50;
 const MembersLookupQuerySchema = z.object({
   ids: z.union([z.coerce.number(), z.array(z.coerce.number())]),
 });
-
-// The lookup endpoint is queried by numeric ModelId, so the response must
-// include `id` so callers can correlate results back to the requested ids.
-export type LightLookupUserType = LightUserType & { id: number };
-
-export type MembersLookupResponseBody = {
-  users: LightLookupUserType[];
-};
-
-export type MembersLookupAdminResponseBody = {
-  users: UserType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -2,16 +2,16 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  SearchMembersAdminResponseBody,
+  SearchMembersResponseBody,
+} from "@app/lib/api/workspace";
 import { searchMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { GROUP_KINDS } from "@app/types/groups";
-import type {
-  LightUserTypeWithWorkspace,
-  UserTypeWithWorkspace,
-} from "@app/types/user";
 import { toLightUserWithWorkspace } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
@@ -30,16 +30,6 @@ const SearchMembersQuerySchema = z.object({
     .transform((v) => v === "true")
     .optional(),
 });
-
-export type SearchMembersResponseBody = {
-  members: LightUserTypeWithWorkspace[];
-  total: number;
-};
-
-export type SearchMembersAdminResponseBody = {
-  members: UserTypeWithWorkspace[];
-  total: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/metronome/contract.ts
+++ b/front/pages/api/w/[wId]/metronome/contract.ts
@@ -1,32 +1,29 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MetronomeContractSummary } from "@app/lib/api/credits/metronome_contract";
+import type {
+  GetMetronomeContractResponseBody,
+  MetronomeContractSummary,
+} from "@app/lib/api/credits/metronome_contract";
 import {
   applyContractLifecycleAction,
   getMetronomeContractSummary,
+  PatchMetronomeContractRequestBody,
 } from "@app/lib/api/credits/metronome_contract";
 import type { Authenticator } from "@app/lib/auth";
 import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecycle";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type { MetronomeContractSummary };
-
-export type GetMetronomeContractResponseBody = {
-  contract: MetronomeContractSummary | null;
-};
+export type { GetMetronomeContractResponseBody, MetronomeContractSummary };
 
 type PatchMetronomeContractResponseBody = {
   success: boolean;
 };
 
-export const PatchMetronomeContractRequestBody = z.object({
-  action: z.enum(["cancel", "reactivate"]),
-});
+export { PatchMetronomeContractRequestBody };
 
 function lifecycleErrorToApi(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/metronome/invoice.ts
+++ b/front/pages/api/w/[wId]/metronome/invoice.ts
@@ -11,34 +11,15 @@ import {
   getProductMauTierIds,
   getProductWorkspaceSeatId,
 } from "@app/lib/metronome/constants";
+import type {
+  GetMetronomeInvoiceResponseBody,
+  MetronomeInvoiceSummary,
+} from "@app/lib/metronome/invoice";
 import { apiError } from "@app/logger/withlogging";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { BillingPeriod } from "@app/types/plan";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type MetronomeInvoiceSummary = {
-  currency: SupportedCurrency;
-  billingPeriod: BillingPeriod;
-  currentPeriodStartMs: number;
-  currentPeriodEndMs: number;
-  estimatedAmountCents: number;
-  mau: number | null;
-  /** Pro: effective per-seat unit price from the seat line item. */
-  seatUnitPriceCents: number | null;
-  /** Enterprise simple MAU: effective unit price from the MAU line item. */
-  mauUnitPriceCents: number | null;
-  /**
-   * Enterprise tiered MAU: effective per-tier unit prices, indexed by tier
-   * position (same order as getProductMauTierIds()). `null` at a position
-   * means that tier is not present on this contract / not charged this period.
-   */
-  mauTierUnitPricesCents: Array<number | null> | null;
-};
-
-export type GetMetronomeInvoiceResponseBody = {
-  invoice: MetronomeInvoiceSummary | null;
-};
 
 function creditTypeIdToCurrency(
   creditTypeId: string

--- a/front/pages/api/w/[wId]/pods/[podId]/tasks/seed.ts
+++ b/front/pages/api/w/[wId]/pods/[podId]/tasks/seed.ts
@@ -3,17 +3,13 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { PostSeedInitialPodTasksResponseBody } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { seedInitialPodTasks } from "@app/lib/project_task/seed_initial_pod_tasks";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { PodTaskType } from "@app/types/project_task";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type PostSeedInitialPodTasksResponseBody = {
-  tasks: PodTaskType[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/project_tasks/[taskSId]/index.ts
+++ b/front/pages/api/w/[wId]/project_tasks/[taskSId]/index.ts
@@ -2,6 +2,7 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { enrichProjectsWithMetadata } from "@app/lib/api/projects/list";
+import type { GetWorkspacePodTaskResponseBody } from "@app/lib/api/projects/tasks";
 import type { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -15,14 +16,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { PodTaskType } from "@app/types/project_task";
 import { isString } from "@app/types/shared/utils/general";
-import type { PodType } from "@app/types/space";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export interface GetWorkspacePodTaskResponseBody {
-  task: PodTaskType;
-  /** Pod space (same shape as entries in `GET /api/w/{wId}/spaces` for pods). */
-  space: PodType;
-}
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/provisioning-status.ts
+++ b/front/pages/api/w/[wId]/provisioning-status.ts
@@ -2,6 +2,7 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetProvisioningStatusResponseBody } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import {
   ADMIN_GROUP_NAME,
@@ -11,11 +12,6 @@ import {
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetProvisioningStatusResponseBody = {
-  hasAdminGroup: boolean;
-  hasBuilderGroup: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -1,6 +1,10 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  DataSourceContentNode,
+  PostWorkspaceSearchResponseBody,
+} from "@app/lib/api/search";
 import { handleSearch, SearchRequestBody } from "@app/lib/api/search";
 import { initSSEResponse } from "@app/lib/api/sse";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,25 +12,11 @@ import { streamToolFiles } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { ContentNodeWithParent } from "@app/types/connectors/connectors_api";
 import type { SearchWarningCode } from "@app/types/core/core_api";
-import type { DataSourceType } from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
-
-export type DataSourceContentNode = ContentNodeWithParent & {
-  dataSource: DataSourceType;
-  dataSourceViews: DataSourceViewType[];
-};
-export type PostWorkspaceSearchResponseBody = {
-  nodes: DataSourceContentNode[];
-  warningCode: SearchWarningCode | null;
-  nextPageCursor: string | null;
-  resultsCount: number | null;
-};
 
 interface UnifiedSearchStreamChunk {
   knowledgeResults?: {

--- a/front/pages/api/w/[wId]/search/tools/upload.ts
+++ b/front/pages/api/w/[wId]/search/tools/upload.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   downloadAndUploadToolFile,
   getToolAccessToken,
+  ToolUploadRequestBodySchema,
 } from "@app/lib/search/tools/search";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -14,23 +15,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 interface ToolUploadResponseBody {
   file: FileType;
 }
-
-import { z } from "zod";
-
-const ToolUploadRequestBodySchema = z.object({
-  serverViewId: z.string().min(1, "serverViewId is required"),
-  externalId: z.string().min(1, "externalId is required"),
-  conversationId: z.string().optional(), // TODO(seb): remove after the next extension release + a few days.
-  useCase: z.enum(["conversation", "project_context"]).default("conversation"),
-  useCaseMetadata: z.object({
-    conversationId: z.string().optional(),
-    spaceId: z.string().optional(),
-  }),
-  serverName: z.string().optional(),
-  serverIcon: z.string().optional(),
-});
-
-export type ToolUploadRequestBody = z.infer<typeof ToolUploadRequestBodySchema>;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/seats/availability.ts
+++ b/front/pages/api/w/[wId]/seats/availability.ts
@@ -2,15 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetSeatAvailabilityResponseBody } from "@app/lib/api/workspace";
 import { checkWorkspaceSeatAvailabilityUsingAuth } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSeatAvailabilityResponseBody = {
-  hasAvailableSeats: boolean;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/seats/count.ts
+++ b/front/pages/api/w/[wId]/seats/count.ts
@@ -2,15 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetWorkspaceSeatsCountResponseBody } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWorkspaceSeatsCountResponseBody = {
-  seatsCount: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase-status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase-status.ts
@@ -2,15 +2,11 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import type { AwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
+import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { getAwuPurchaseAttempt } from "@app/lib/credits/awu_purchase_status";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetAwuPurchaseStatusResponseBody = {
-  attempt: AwuPurchaseAttempt | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front/pages/api/w/[wId]/subscriptions/awu-purchase.ts
@@ -2,7 +2,10 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
+import type {
+  GetAwuPurchaseInfoResponseBody,
+  PostAwuPurchaseResponseBody,
+} from "@app/lib/credits/awu_purchase";
 import {
   getAwuPurchaseInfo,
   purchaseAwuCredits,
@@ -16,15 +19,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-export type GetAwuPurchaseInfoResponseBody = AwuPurchaseInfo;
-
 const PostAwuPurchaseBody = z.object({
   amountCredits: z.number().int().positive(),
 });
-
-export type PostAwuPurchaseResponseBody = {
-  amountCredits: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/checkout-status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/checkout-status.ts
@@ -2,18 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetCheckoutStatusResponseBody } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-type CheckoutStatus =
-  | { status: "success" }
-  | { status: "error"; message: string }
-  | { status: "pending" };
-
-export type GetCheckoutStatusResponseBody = CheckoutStatus;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -1,7 +1,15 @@
 /** @ignoreswagger */
 // @migration-status: MIGRATED_TO_HONO
+
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
+import type {
+  GetSubscriptionsResponseBody,
+  PostSubscriptionResponseBody,
+} from "@app/lib/api/subscription";
+import {
+  isMetronomeBillingEnabled,
+  PatchSubscriptionRequestBody,
+} from "@app/lib/api/subscription";
 import {
   createCheckoutUrl,
   PostSubscriptionRequestBody,
@@ -16,25 +24,13 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { CheckoutUrlResult, SubscriptionType } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { z } from "zod";
 import { fromError } from "zod-validation-error";
-
-export type PostSubscriptionResponseBody = CheckoutUrlResult;
 
 type PatchSubscriptionResponseBody = {
   success: boolean;
 };
-
-export type GetSubscriptionsResponseBody = {
-  subscriptions: SubscriptionType[];
-};
-
-export const PatchSubscriptionRequestBody = z.object({
-  action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
-});
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/pricing.ts
+++ b/front/pages/api/w/[wId]/subscriptions/pricing.ts
@@ -3,14 +3,10 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { GetSubscriptionPricingResponseBody } from "@app/lib/resources/subscription_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { SubscriptionPerSeatPricing } from "@app/types/plan";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSubscriptionPricingResponseBody = {
-  perSeatPricing: SubscriptionPerSeatPricing | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/status.ts
@@ -5,15 +5,11 @@ import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
+import type { GetSubscriptionStatusResponseBody } from "@app/lib/resources/subscription_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSubscriptionStatusResponseBody = {
-  shouldRedirect: boolean;
-  redirectUrl: string | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/subscriptions/trial-info.ts
+++ b/front/pages/api/w/[wId]/subscriptions/trial-info.ts
@@ -2,15 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetSubscriptionTrialInfoResponseBody } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetSubscriptionTrialInfoResponseBody = {
-  trialDaysRemaining: number | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/trial-message-usage.ts
+++ b/front/pages/api/w/[wId]/trial-message-usage.ts
@@ -1,17 +1,13 @@
 // @migration-status: MIGRATED_TO_HONO
 
 /** @ignoreswagger */
+import type { GetTrialMessageUsageResponseType } from "@app/lib/api/assistant/rate_limits";
 import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetTrialMessageUsageResponseType = {
-  count: number;
-  limit: number;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/usage-status.ts
+++ b/front/pages/api/w/[wId]/usage-status.ts
@@ -3,6 +3,10 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type {
+  GetWorkspaceUsageStatusResponseBody,
+  ProgrammaticCreditStatus,
+} from "@app/lib/metronome/user_block";
 import {
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
@@ -11,18 +15,9 @@ import {
   isWorkspaceProgrammaticWarned,
 } from "@app/lib/metronome/user_block";
 import { apiError } from "@app/logger/withlogging";
-import type { WorkspacePoolCreditState } from "@app/types/credits";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
-
-export type GetWorkspaceUsageStatusResponseBody = {
-  awuStatus: "normal" | "warned" | "blocked";
-  poolCreditState: WorkspacePoolCreditState;
-  programmaticCreditStatus: ProgrammaticCreditStatus;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -4,9 +4,10 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
-  type DefaultUserSpendLimit,
   type DefaultUserSpendLimitError,
+  type GetDefaultUserSpendLimitResponseBody,
   getDefaultUserSpendLimit,
+  type PutDefaultUserSpendLimitResponseBody,
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
 import type { Authenticator } from "@app/lib/auth";
@@ -29,12 +30,6 @@ const UpdateDefaultUserSpendLimitBodySchema = z.object({
     .min(MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS)
     .max(MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS),
 });
-
-export type GetDefaultUserSpendLimitResponseBody = {
-  awuCredits: number | null;
-};
-
-export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;
 
 function mapErrorToHttp(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front/pages/api/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -3,6 +3,10 @@
 
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type {
+  GetProgrammaticUsageLimitResponseBody,
+  PutProgrammaticUsageLimitResponseBody,
+} from "@app/lib/api/credits/programmatic_usage_limit";
 import {
   getProgrammaticUsageLimit,
   syncProgrammaticUsageLimit,
@@ -17,14 +21,6 @@ import { fromError } from "zod-validation-error";
 const UpdateProgrammaticUsageLimitBodySchema = z.object({
   monthlyCapCredits: z.number().int().nonnegative().nullable(),
 });
-
-export type GetProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
-};
-
-export type PutProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/verified-domains.ts
+++ b/front/pages/api/w/[wId]/verified-domains.ts
@@ -2,16 +2,12 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetWorkspaceVerifiedDomainsResponseBody } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
-import type { WorkspaceDomain } from "@app/types/workspace";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWorkspaceVerifiedDomainsResponseBody = {
-  verifiedDomains: WorkspaceDomain[];
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/verify.ts
+++ b/front/pages/api/w/[wId]/verify.ts
@@ -4,6 +4,7 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { resolveCountryCode } from "@app/lib/geo/country-detection";
+import type { GetVerifyResponseBody } from "@app/lib/plans/trial/index";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial/index";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -15,11 +16,6 @@ import type { Country } from "react-phone-number-input";
 import { isSupportedCountry } from "react-phone-number-input";
 
 const DEFAULT_COUNTRY: Country = "US";
-
-export type GetVerifyResponseBody = {
-  isEligibleForTrial: boolean;
-  initialCountryCode: Country;
-};
 
 async function detectCountryFromIP(req: IncomingMessage): Promise<Country> {
   try {

--- a/front/pages/api/w/[wId]/welcome.ts
+++ b/front/pages/api/w/[wId]/welcome.ts
@@ -2,18 +2,13 @@
 
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { GetWelcomeResponseBody } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { detectEmailProvider } from "@app/lib/utils/email_provider_detection";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWelcomeResponseBody = {
-  isFirstAdmin: boolean;
-  emailProvider: EmailProviderType;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/workspace-analytics.ts
+++ b/front/pages/api/w/[wId]/workspace-analytics.ts
@@ -2,15 +2,13 @@
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
+  type GetWorkspaceAnalyticsResponse,
   getWorkspaceAnalytics,
-  type WorkspaceAnalytics,
 } from "@app/lib/api/workspace_analytics";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { APIErrorResponse } from "@app/types/error";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWorkspaceAnalyticsResponse = WorkspaceAnalytics;
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/workspace-lookup.ts
+++ b/front/pages/api/workspace-lookup.ts
@@ -3,6 +3,7 @@
 /** @ignoreswagger */
 import { withSessionAuthentication } from "@app/lib/api/auth_wrappers";
 import { fetchRevokedWorkspace } from "@app/lib/api/user";
+import type { GetWorkspaceLookupResponseBody } from "@app/lib/api/workspace";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -10,14 +11,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { LightWorkspaceType } from "@app/types/user";
 import type { NextApiRequest, NextApiResponse } from "next";
-
-export type GetWorkspaceLookupResponseBody = {
-  workspace: LightWorkspaceType;
-  status: "auto-join-disabled" | "revoked";
-  workspaceVerifiedDomain: string | null;
-};
 
 async function handler(
   req: NextApiRequest,

--- a/front/poke/swr/analytics.ts
+++ b/front/poke/swr/analytics.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetWorkspaceActiveUsersResponse } from "@app/lib/api/assistant/observability/active_users_metrics";
+import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
-import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
 import type { Fetcher } from "swr";
 
 export function usePokeWorkspaceUsageMetrics({

--- a/front/scripts/debug/run_profiler.ts
+++ b/front/scripts/debug/run_profiler.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
+import type { GetProfilerResponse } from "@app/lib/api/debug/profiler";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import type { GetProfilerResponse } from "@app/pages/api/debug/profiler";
 import { makeScript } from "@app/scripts/helpers";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 


### PR DESCRIPTION
## Description

Final batch. Relocates **analytics / subscriptions / metronome / seats / credits / members / me / user / templates / audit-logs / search / usage / workspace / geo / invitations / keys / groups / domains** contract types (and zod schemas) into `lib/api` homes; also relocates the `MAX_CONVERSATION_DEPTH` constant into `lib/api/assistant/conversation/constants`.

With this batch, **nothing outside `front/pages/api` imports from it** (`front-api` and the `extension` included) — the Next API folder can now be removed.

## Tests

Pure type/schema **relocation** with no behavior change, so existing functional tests cover these routes. `npx tsgo --noEmit` is green on both `front` and `front-api`, and `biome` passes. Where a relocated zod schema is consumed at module scope (`validate("json", …)`), the affected `vi.mock(...)` test helpers were switched to `importOriginal` so the real schema is preserved.

## Risk

Low. Types and zod schemas are moved into `lib/api` homes that both the Next handlers and the Hono routes import from — a single source of truth, no duplication, no runtime logic touched. Fully revertable by reverting the commit.

## Deploy Plan

No migration or special steps. ⚠️ This PR makes Next-only edits on modules whose Hono route had no duplicate, so it needs the **`skip-migration-check`** label (BACK17). Merge the stack bottom-up.
