### PR TITLE
[marketing] feat: Add marketing deployments

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -152,8 +152,10 @@ runs:
           fi
         fi
 
-        # Only set Contentful credentials for front and front-edge builds (needed for ISR)
-        if [[ "$COMPONENT" == "front" || "$COMPONENT" == "front-edge" ]]; then
+        # Only set Contentful credentials for front and front-edge builds (needed for ISR),
+        # and for marketing / marketing-edge (which currently builds from front/ and renders
+        # the same Contentful-backed pages).
+        if [[ "$COMPONENT" == "front" || "$COMPONENT" == "front-edge" || "$COMPONENT" == "marketing" || "$COMPONENT" == "marketing-edge" ]]; then
           if [[ -n "${{ inputs.contentful_space_id }}" ]]; then
             build_args+=("--build-arg CONTENTFUL_SPACE_ID=${{ inputs.contentful_space_id }}")
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ on:
         options:
           - front
           - front-edge
+          - marketing
+          - marketing-edge
           - connectors
           - core
           - front-sse
@@ -62,7 +64,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: "deploy_${{ inputs.component }}${{ inputs.component == 'front-edge' && format('_{0}', github.run_id) || '' }}"
+  group: "deploy_${{ inputs.component }}${{ (inputs.component == 'front-edge' || inputs.component == 'marketing-edge') && format('_{0}', github.run_id) || '' }}"
   cancel-in-progress: false
 
 jobs:
@@ -78,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if deployment is from main branch
-        if: ${{ github.ref != 'refs/heads/main' && inputs.component != 'front-edge' }}
+        if: ${{ github.ref != 'refs/heads/main' && inputs.component != 'front-edge' && inputs.component != 'marketing-edge' }}
         run: |
           echo "Error: Deployments for ${{ inputs.component }} are only allowed from the main branch"
           exit 1

--- a/.github/workflows/list-tags.yaml
+++ b/.github/workflows/list-tags.yaml
@@ -19,6 +19,8 @@ on:
           - core
           - front
           - front-edge
+          - marketing
+          - marketing-edge
           - metabase
           - oauth
           - prodbox

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -25,6 +25,8 @@ on:
           - core
           - front
           - front-edge
+          - marketing
+          - marketing-edge
           - metabase
           - oauth
           - prodbox

--- a/dockerfiles/marketing.Dockerfile
+++ b/dockerfiles/marketing.Dockerfile
@@ -1,0 +1,136 @@
+# Marketing image — Next.js backend (no SPA, no workers, no front-api).
+#
+# Currently builds from the existing `front/` workspace so we can deploy the
+# marketing component without waiting for the dedicated `marketing/` workspace
+# to exist. When that workspace lands, swap the `COPY /front .` line(s) below
+# to `COPY /marketing .` (and adjust WORKDIRs / artifact paths accordingly).
+FROM node:24.14.0-slim AS base-deps
+
+RUN apt-get update && \
+  apt-get install -y libjemalloc2 libjemalloc-dev
+
+RUN npm install -g npm@11.11.0
+
+WORKDIR /app
+
+# Copy all package.json files and lockfile (front has cross-workspace imports
+# into sdks/js, sparkle, front-spa, front-api — keep the install graph identical
+# to front.Dockerfile so the same source compiles).
+COPY package.json package-lock.json ./
+COPY sdks/js/package.json ./sdks/js/
+COPY sparkle/package.json ./sparkle/
+COPY front/package.json ./front/
+COPY front-spa/package.json ./front-spa/
+COPY front-api/package.json ./front-api/
+
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci -w sdks/js -w sparkle -w front -w front-spa -w front-api
+
+# Build SDK
+WORKDIR /app/sdks/js
+COPY /sdks/js/ .
+RUN npm run build
+
+# Build Sparkle
+WORKDIR /app/sparkle
+COPY /sparkle/ .
+RUN npm run build
+
+# Copy front-spa source (imported by front)
+WORKDIR /app/front-spa
+COPY /front-spa .
+
+# Copy front source — swap to /marketing once the workspace exists
+WORKDIR /app/front
+COPY /front .
+
+# Remove test files (shared optimization)
+RUN find . -name "*.test.ts" -delete
+RUN find . -name "*.test.tsx" -delete
+
+WORKDIR /app/front
+
+# Next.js build stage
+FROM base-deps AS marketing-build
+
+ARG COMMIT_HASH
+ARG COMMIT_HASH_LONG
+ARG NEXT_PUBLIC_VIZ_URL
+ARG NEXT_PUBLIC_DUST_API_URL
+ARG NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL
+ARG NEXT_PUBLIC_DUST_APP_URL
+ARG NEXT_PUBLIC_GTM_TRACKING_ID
+ARG NEXT_PUBLIC_ENABLE_BOT_CRAWLING
+ARG NEXT_PUBLIC_POSTHOG_KEY
+ARG NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_VIRTUOSO_LICENSE_KEY
+ARG NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER
+ARG NEXT_PUBLIC_NOVU_API_URL
+ARG NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL
+ARG NEXT_PUBLIC_BUILD_DATE
+ARG CONTENTFUL_SPACE_ID
+ARG CONTENTFUL_ACCESS_TOKEN
+
+ENV NEXT_PUBLIC_COMMIT_HASH=$COMMIT_HASH
+ENV NEXT_PUBLIC_BUILD_DATE=$NEXT_PUBLIC_BUILD_DATE
+ENV NEXT_PUBLIC_VIZ_URL=$NEXT_PUBLIC_VIZ_URL
+ENV NEXT_PUBLIC_DUST_API_URL=$NEXT_PUBLIC_DUST_API_URL
+ENV NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=$NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL
+ENV NEXT_PUBLIC_DUST_APP_URL=$NEXT_PUBLIC_DUST_APP_URL
+ENV NEXT_PUBLIC_GTM_TRACKING_ID=$NEXT_PUBLIC_GTM_TRACKING_ID
+ENV NEXT_PUBLIC_ENABLE_BOT_CRAWLING=$NEXT_PUBLIC_ENABLE_BOT_CRAWLING
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
+ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_VIRTUOSO_LICENSE_KEY=$NEXT_PUBLIC_VIRTUOSO_LICENSE_KEY
+ENV NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER=$NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER
+ENV NEXT_PUBLIC_NOVU_API_URL=$NEXT_PUBLIC_NOVU_API_URL
+ENV NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL=$NEXT_PUBLIC_NOVU_WEBSOCKET_API_URL
+ENV CONTENTFUL_SPACE_ID=$CONTENTFUL_SPACE_ID
+ENV CONTENTFUL_ACCESS_TOKEN=$CONTENTFUL_ACCESS_TOKEN
+
+# Fake PostgreSQL URI is needed because Sequelize validates the connection string
+# during module initialization (imported by `next build`), but doesn't actually
+# connect.
+RUN --mount=type=cache,id=marketing-next-cache,target=/app/front/.next/cache \
+  FRONT_DATABASE_URI="postgres://fake:fake@localhost:5432/fake" \
+  NODE_OPTIONS="--max-old-space-size=8192" \
+  npm run build -- --no-lint && \
+  if [ ! -d .next/standalone ]; then \
+  echo "ERROR: next build did not emit .next/standalone (output:standalone). Likely a corrupt next-cache mount; bump the --mount id to reset it."; \
+  exit 1; \
+  fi
+
+# Runtime image
+FROM node:24.14.0-slim AS marketing
+
+RUN apt-get update && \
+  apt-get install -y libjemalloc2 curl && \
+  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy entire standalone output (self-contained with traced node_modules)
+COPY --from=marketing-build /app/front/.next/standalone ./
+
+WORKDIR /app/front
+
+# Copy static assets and public (not included in standalone)
+COPY --from=marketing-build /app/front/.next/static ./.next/static
+COPY --from=marketing-build /app/front/public ./public
+
+ARG NEXT_PUBLIC_DUST_API_URL
+ARG NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL
+ARG NEXT_PUBLIC_DUST_APP_URL
+
+ENV NEXT_PUBLIC_DUST_API_URL=$NEXT_PUBLIC_DUST_API_URL
+ENV NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL=$NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL
+ENV NEXT_PUBLIC_DUST_APP_URL=$NEXT_PUBLIC_DUST_APP_URL
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
+ARG COMMIT_HASH
+ARG COMMIT_HASH_LONG
+ENV DD_VERSION=${COMMIT_HASH}
+ENV DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/
+ENV DD_GIT_COMMIT_SHA=${COMMIT_HASH_LONG}
+
+CMD ["node", "--require", "dd-trace/init", "server.js"]


### PR DESCRIPTION
## Description


- Add marketing CI / CD deployment, its sister PR is here: https://github.com/dust-tt/dust-infra/pull/847
- For now we simply build from front folder, with all the bells and whistles. Obviously this is temporary and we will trim most of the docker image once we have a separate clean folder for marketing


## Tests

N/A

## Risk

None

## Deploy Plan

- Merge