### PR TITLE
[sparkle] fix warning icon color in dropdown

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -134,11 +134,13 @@ interface ItemWithLabelIconAndDescriptionProps {
   children?: React.ReactNode;
   truncate?: boolean;
   endComponent?: React.ReactNode;
+  variant?: ItemVariantType;
 }
 
 const renderIcon = (
   icon: React.ComponentType | React.ReactNode,
-  size: "xs" | "sm" = "xs"
+  size: "xs" | "sm" = "xs",
+  variant?: ItemVariantType
 ) => {
   // If it's a React element (already rendered), return it as is
   if (React.isValidElement(icon)) {
@@ -151,7 +153,11 @@ const renderIcon = (
       <Icon
         size={size}
         visual={icon as React.ComponentType}
-        className="s-text-muted-foreground dark:s-text-muted-foreground-night"
+        className={
+          variant === "warning"
+            ? undefined
+            : "s-text-muted-foreground dark:s-text-muted-foreground-night"
+        }
       />
     );
   }
@@ -169,6 +175,7 @@ const ItemWithLabelIconAndDescription = <
   truncate,
   children,
   endComponent,
+  variant,
 }: T) => {
   return (
     <>
@@ -185,7 +192,7 @@ const ItemWithLabelIconAndDescription = <
                   : "s-grid-cols-[1fr]"
           )}
         >
-          {renderIcon(icon, "sm")}
+          {renderIcon(icon, "sm", variant)}
           <div className={cn("s-flex s-flex-col", truncate && "s-truncate")}>
             <span className={cn(truncate ? "s-truncate" : "s-line-clamp-3")}>
               {label}
@@ -610,6 +617,7 @@ const DropdownMenuItem = React.forwardRef<
               description={description}
               truncate={truncateText}
               endComponent={endComponent}
+              variant={variant}
             >
               {children}
             </ItemWithLabelIconAndDescription>


### PR DESCRIPTION
## Description
This PR is to avoid overriding icon color in dropdown for variant warning

before:
<img width="562" height="596" alt="CleanShot 2026-06-06 at 09 30 53@2x" src="https://github.com/user-attachments/assets/6a9841fd-7c81-43cf-86de-7032ef557e1e" />

after:
<img width="418" height="558" alt="CleanShot 2026-06-06 at 09 31 20@2x" src="https://github.com/user-attachments/assets/880b9cd1-a914-4170-b3c2-0532d57f5308" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
