### PR TITLE
Refresh authorized file allowlist when share scope changes.

### DIFF
--- a/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/share/index.ts
@@ -1,3 +1,4 @@
+import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -7,6 +8,7 @@ import {
   fileShareScopeSchema,
   isConversationFileUseCase,
   isInteractiveContentType,
+  isUnverifiableFrameFileRefsShareError,
 } from "@app/types/files";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -79,6 +81,28 @@ app.post(
     const { shareScope } = ctx.req.valid("json");
 
     await file.setShareScope(auth, shareScope);
+
+    const allowlistResult = await ensureAuthorizedFileAccessForShare(
+      auth,
+      file
+    );
+    if (allowlistResult.isErr()) {
+      const allowlistError = allowlistResult.error;
+      return apiError(ctx, {
+        status_code:
+          allowlistError.code === "invalid_request_error" ? 400 : 500,
+        api_error: {
+          type:
+            allowlistError.code === "invalid_request_error"
+              ? "invalid_request_error"
+              : "internal_server_error",
+          message: allowlistError.message,
+          ...(isUnverifiableFrameFileRefsShareError(allowlistError)
+            ? { unverifiableRefs: allowlistError.unverifiableRefs }
+            : {}),
+        },
+      });
+    }
 
     const shareInfo = await file.getShareInfo();
     if (!shareInfo) {

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/viz/authorized_file_access";
 import {
   computeFrameContentHash,
+  isAllowlistShareScopeStale,
   isAllowlistStale,
   isAuthorizedFileRef,
 } from "@app/lib/api/viz/authorized_file_access_policy";
@@ -62,6 +63,14 @@ describe("isAllowlistStale", () => {
 
     expect(isAllowlistStale(allowlist, content)).toBe(false);
     expect(isAllowlistStale(allowlist, `${content}// edited`)).toBe(true);
+  });
+});
+
+describe("isAllowlistShareScopeStale", () => {
+  it("detects when share scope changed", () => {
+    expect(isAllowlistShareScopeStale("workspace", "workspace")).toBe(false);
+    expect(isAllowlistShareScopeStale("workspace", "public")).toBe(true);
+    expect(isAllowlistShareScopeStale("emails_only", "public")).toBe(true);
   });
 });
 
@@ -389,6 +398,80 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       },
     });
     expect(rows).toHaveLength(0);
+  });
+
+  it("recomputes when share scope changed but frame content is unchanged", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const dataFile = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "data.txt",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const frameContent = `useFile("${dataFile.sId}");`;
+    const frameFile = await FileFactory.create(auth, null, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const shareableFile = await FileResource.shareableFileModel.findOne({
+      where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+    });
+    expect(shareableFile).not.toBeNull();
+    const initialShareScope = shareableFile!.shareScope;
+
+    await AuthorizedFileAccessModel.create({
+      workspaceId: frameFile.workspaceId,
+      shareableFileId: shareableFile!.id,
+      kind: "file_id",
+      ref: dataFile.sId,
+      fileName: "data.txt",
+      legacyPath: null,
+      shareScope: initialShareScope,
+      computedByUserId: auth.user()!.sId,
+      frameContentHash: computeFrameContentHash(frameContent),
+      allowedAt: new Date(),
+      revokedAt: null,
+    });
+
+    await frameFile.setShareScope(auth, "public");
+
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from(frameContent, "utf-8")])
+    );
+
+    const result = await ensureAuthorizedFileAccessForShare(auth, frameFile);
+
+    expect(result.isOk()).toBe(true);
+
+    const rows = await AuthorizedFileAccessModel.findAll({
+      where: {
+        shareableFileId: shareableFile!.id,
+        workspaceId: frameFile.workspaceId,
+        revokedAt: null,
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.shareScope).toBe("public");
+    expect(rows[0]?.ref).toBe(dataFile.sId);
+    expect(rows[0]?.frameContentHash).toBe(
+      computeFrameContentHash(frameContent)
+    );
   });
 
   it("skips recompute when the active allowlist matches current content", async () => {

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -1,6 +1,7 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { legacyScopedPathsMatch } from "@app/lib/api/files/mount_path";
 import {
+  isAllowlistShareScopeStale,
   isAllowlistStale,
   isAuthorizedFileRef,
 } from "@app/lib/api/viz/authorized_file_access_policy";
@@ -64,7 +65,14 @@ export async function ensureAuthorizedFileAccessForShare(
   }
 
   const active = await frameFile.getActiveAuthorizedFileAccessAllowlist();
-  const needsRecompute = !active || isAllowlistStale(active, frameContent);
+  const activeShareScope =
+    await frameFile.getActiveAuthorizedFileAccessShareScope();
+  const currentShareScope = await frameFile.getShareScope();
+  const needsRecompute =
+    !active ||
+    isAllowlistStale(active, frameContent) ||
+    (activeShareScope !== null &&
+      isAllowlistShareScopeStale(activeShareScope, currentShareScope));
 
   if (!needsRecompute) {
     return new Ok(active);

--- a/front/lib/api/viz/authorized_file_access_policy.ts
+++ b/front/lib/api/viz/authorized_file_access_policy.ts
@@ -1,5 +1,8 @@
 import { legacyScopedPathsMatch } from "@app/lib/api/files/mount_path";
-import type { AuthorizedFileAccessAllowlist } from "@app/types/files";
+import type {
+  AuthorizedFileAccessAllowlist,
+  FileShareScope,
+} from "@app/types/files";
 
 const FNV_OFFSET_BASIS_64 = BigInt("0xcbf29ce484222325");
 const FNV_PRIME_64 = BigInt("0x100000001b3");
@@ -24,6 +27,13 @@ export function isAllowlistStale(
     authorizedFileAccess.frameContentHash !==
     computeFrameContentHash(currentContent)
   );
+}
+
+export function isAllowlistShareScopeStale(
+  persistedShareScope: FileShareScope,
+  currentShareScope: FileShareScope
+): boolean {
+  return persistedShareScope !== currentShareScope;
 }
 
 export function isAuthorizedFileRef(

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1854,6 +1854,25 @@ export class FileResource extends BaseResource<FileModel> {
     return FileResource.allowlistFromActiveRows(rows);
   }
 
+  async getActiveAuthorizedFileAccessShareScope(): Promise<FileShareScope | null> {
+    const shareableFile = await this.getShareableFile();
+    const row = await FileResource.authorizedFileAccessModel.findOne({
+      where: {
+        shareableFileId: shareableFile.id,
+        workspaceId: this.workspaceId,
+        revokedAt: null,
+      },
+      attributes: ["shareScope"],
+    });
+
+    return row?.shareScope ?? null;
+  }
+
+  async getShareScope(): Promise<FileShareScope> {
+    const shareableFile = await this.getShareableFile();
+    return shareableFile.shareScope;
+  }
+
   async persistAuthorizedFileAccess(
     computed: ComputedAuthorizedFileAccess,
     allowedAt: Date = new Date()

--- a/front/pages/api/w/[wId]/files/[fileId]/share/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share/index.ts
@@ -1,6 +1,7 @@
 // @migration-status: MIGRATED_TO_HONO
 /** @ignoreswagger */
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -11,6 +12,7 @@ import {
   fileShareScopeSchema,
   isConversationFileUseCase,
   isInteractiveContentType,
+  isUnverifiableFrameFileRefsShareError,
 } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -103,6 +105,28 @@ async function handler(
       const { shareScope } = parseResult.data;
 
       await file.setShareScope(auth, shareScope);
+
+      const allowlistResult = await ensureAuthorizedFileAccessForShare(
+        auth,
+        file
+      );
+      if (allowlistResult.isErr()) {
+        const allowlistError = allowlistResult.error;
+        return apiError(req, res, {
+          status_code:
+            allowlistError.code === "invalid_request_error" ? 400 : 500,
+          api_error: {
+            type:
+              allowlistError.code === "invalid_request_error"
+                ? "invalid_request_error"
+                : "internal_server_error",
+            message: allowlistError.message,
+            ...(isUnverifiableFrameFileRefsShareError(allowlistError)
+              ? { unverifiableRefs: allowlistError.unverifiableRefs }
+              : {}),
+          },
+        });
+      }
 
       const shareInfo = await file.getShareInfo();
       if (!shareInfo) {


### PR DESCRIPTION
## Description

When a frame file's `shareScope` changes (e.g. from `workspace` to `public`), the persisted `AuthorizedFileAccess` rows were stale — still stamped with the old scope — so downstream enforcement could read incorrect permissions. Two fixes:

- Added `isAllowlistShareScopeStale` in `authorized_file_access_policy.ts` and wired it into `ensureAuthorizedFileAccessForShare` so a scope change triggers a recompute even when frame content is unchanged. Uses two new `FileResource` helpers: `getActiveAuthorizedFileAccessShareScope` (reads the scope from the active allowlist row) and `getShareScope` (reads the current scope from `ShareableFileModel`).
- Added `ensureAuthorizedFileAccessForShare` call after `setShareScope` in both the Hono and Next.js share POST handlers so the allowlist is refreshed and verified before the share info is returned. Returns 400 for `invalid_request_error` (with `unverifiableRefs`) and 500 for internal errors.

## Tests

Added a unit test in `authorized_file_access.test.ts` covering the case where scope changes but frame content is unchanged — verifies the allowlist row is rewritten with the new `shareScope`. Tested locally.

## Risk

Low. `ensureAuthorizedFileAccessForShare` was already called in the share flow for new shares; this extends it to cover scope updates. Worst case on failure: share POST returns a 400/500 instead of silently succeeding with a stale allowlist — a stricter, safer behavior. Safe to rollback.

## Deploy Plan

Deploy front.
