### PR TITLE
Fix: allow longer string for paths

### DIFF
--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -335,7 +335,7 @@ AuthorizedFileAccessModel.init(
       allowNull: false,
     },
     ref: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(4096),
       allowNull: false,
     },
     fileName: {
@@ -344,7 +344,7 @@ AuthorizedFileAccessModel.init(
       defaultValue: null,
     },
     legacyPath: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(4096),
       allowNull: true,
       defaultValue: null,
     },

--- a/front/migrations/db/migration_669.sql
+++ b/front/migrations/db/migration_669.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jun 6, 2026
+-- Canonical paths (ref) and legacy paths can exceed VARCHAR(255).
+ALTER TABLE "authorized_file_accesses"
+ALTER COLUMN "ref" TYPE VARCHAR(4096);
+
+ALTER TABLE "authorized_file_accesses"
+ALTER COLUMN "legacyPath" TYPE VARCHAR(4096);


### PR DESCRIPTION
## Description

Canonical paths and legacy paths stored in `authorized_file_accesses` can exceed the default `VARCHAR(255)` limit. Widens `ref` and `legacyPath` columns in `AuthorizedFileAccessModel` to `VARCHAR(4096)` and adds `migration_669.sql` to apply the same change in Postgres.

## Tests

Tested locally — existing authorized file access flows continue to work. No new test coverage needed for a column width increase.

## Risk

Low. `ALTER COLUMN … TYPE VARCHAR(4096)` is a metadata-only change on Postgres (no table rewrite); safe to rollback by reverting the migration. Rows with paths longer than 255 chars would have been failing inserts; widening can only fix errors, not introduce them.

## Deploy Plan

1. Run `migration_669.sql` against the front DB.
2. Deploy front.
