### PR TITLE
Fix spend alerts allowance

### DIFF
--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -54,7 +54,7 @@ vi.mock("@app/lib/metronome/seat_types", async () => {
     ...actual,
     getProductSeatTypes: vi.fn(),
     getSeatSubscriptionsFromContract: vi.fn(),
-    getAwuAllocationForSeatType: vi.fn(),
+    getAwuAllocationForNormalizedSeatType: vi.fn(),
   };
 });
 
@@ -97,7 +97,9 @@ beforeEach(() => {
   vi.mocked(seatTypes.getSeatSubscriptionsFromContract).mockReturnValue(
     FAKE_SEAT_SUBSCRIPTIONS
   );
-  vi.mocked(seatTypes.getAwuAllocationForSeatType).mockReturnValue(8000);
+  vi.mocked(seatTypes.getAwuAllocationForNormalizedSeatType).mockReturnValue(
+    8000
+  );
 });
 
 describe("getDefaultUserSpendLimit", () => {

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/lib/metronome/alerts/spend_limits";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
-  getAwuAllocationForSeatType,
+  getAwuAllocationForNormalizedSeatType,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
@@ -109,7 +109,11 @@ export async function getDefaultUserSpendLimit(
       const totalThreshold = result.value.alert.threshold;
       const seatAllowance =
         contract && productSeatTypes
-          ? getAwuAllocationForSeatType(contract, seatType, productSeatTypes)
+          ? getAwuAllocationForNormalizedSeatType(
+              contract,
+              seatType,
+              productSeatTypes
+            )
           : 0;
       const poolAwuCredits = totalThreshold - seatAllowance;
       logger.info(
@@ -269,7 +273,7 @@ export async function setDefaultUserSpendLimit(
 
   // Create per-seat-type alerts.
   for (const seatType of normalizedSeatTypes) {
-    const seatAllowance = getAwuAllocationForSeatType(
+    const seatAllowance = getAwuAllocationForNormalizedSeatType(
       contract,
       seatType,
       productSeatTypes

--- a/front/lib/metronome/alerts.ts
+++ b/front/lib/metronome/alerts.ts
@@ -15,6 +15,68 @@ type UpsertMetronomeAlertParams = V1.AlertCreateParams & {
   uniqueness_key: string;
 };
 
+// A Metronome uniqueness key can only be released by archiving its alert with
+// `release_uniqueness_key: true`. An alert archived WITHOUT releasing its key
+// (e.g. manually in the console) orphans that key: re-archiving it returns
+// `400 Alert already archived` and there is no API to release the key
+// afterwards. To stay recoverable, an alert's effective key may carry a
+// generation suffix (`<baseKey>::g<N>`). The base key is used normally; only
+// when a lower generation is orphaned do we advance to the next. All lookups
+// match on the base key and ignore the suffix.
+const UNIQUENESS_KEY_GENERATION_SEPARATOR = "::g";
+
+// Backstop so a pathological customer (many orphaned generations) fails loudly
+// instead of looping forever.
+const MAX_UNIQUENESS_KEY_GENERATIONS = 20;
+
+function generationKey(baseKey: string, generation: number): string {
+  return generation === 0
+    ? baseKey
+    : `${baseKey}${UNIQUENESS_KEY_GENERATION_SEPARATOR}${generation}`;
+}
+
+// Strip the `::g<N>` generation suffix to recover the logical base key. Keys
+// without a numeric suffix are returned unchanged.
+export function baseUniquenessKey(key: string): string {
+  const idx = key.lastIndexOf(UNIQUENESS_KEY_GENERATION_SEPARATOR);
+  if (idx === -1) {
+    return key;
+  }
+  const suffix = key.slice(idx + UNIQUENESS_KEY_GENERATION_SEPARATOR.length);
+  return /^\d+$/.test(suffix) ? key.slice(0, idx) : key;
+}
+
+function uniquenessKeyGeneration(key: string): number {
+  const idx = key.lastIndexOf(UNIQUENESS_KEY_GENERATION_SEPARATOR);
+  if (idx === -1) {
+    return 0;
+  }
+  const suffix = key.slice(idx + UNIQUENESS_KEY_GENERATION_SEPARATOR.length);
+  return /^\d+$/.test(suffix) ? Number(suffix) : 0;
+}
+
+// Detect Metronome's `400 Alert already archived` response, returned when we
+// try to archive an alert that is already archived — meaning its uniqueness key
+// is orphaned and cannot be released via the API.
+function isAlertAlreadyArchivedError(err: unknown): boolean {
+  const messages: string[] = [];
+  if (typeof err === "object" && err !== null) {
+    if ("message" in err && typeof err.message === "string") {
+      messages.push(err.message);
+    }
+    if (
+      "error" in err &&
+      typeof err.error === "object" &&
+      err.error !== null &&
+      "message" in err.error &&
+      typeof err.error.message === "string"
+    ) {
+      messages.push(err.error.message);
+    }
+  }
+  return messages.some((m) => /already archived/i.test(m));
+}
+
 // Extract the id of the alert that already holds a uniqueness key from a
 // Metronome 409 conflict error. The SDK surfaces the response body on `.error`,
 // which carries `conflicting_id` for uniqueness-key conflicts. Narrowed with
@@ -34,6 +96,10 @@ function conflictingAlertIdFromError(err: unknown): string | null {
   return null;
 }
 
+// Find the live alert for a logical (base) uniqueness key. Matches on the base
+// key, ignoring any `::g<N>` generation suffix, and prefers an enabled alert
+// over a disabled one, then the highest generation. Returns null when no
+// enabled/disabled alert carries the key (archived alerts are excluded).
 export async function findMetronomeAlert({
   metronomeCustomerId,
   uniquenessKey,
@@ -42,15 +108,30 @@ export async function findMetronomeAlert({
   uniquenessKey: string;
 }): Promise<Result<CustomerAlert | null, Error>> {
   try {
+    let best: CustomerAlert | null = null;
+    let bestGeneration = -1;
+    let bestEnabled = false;
     for await (const entry of listMetronomeAlerts({
       customer_id: metronomeCustomerId,
       alert_statuses: ["ENABLED", "DISABLED"],
     })) {
-      if (entry.alert.uniqueness_key === uniquenessKey) {
-        return new Ok(entry);
+      const key = entry.alert.uniqueness_key;
+      if (!key || baseUniquenessKey(key) !== uniquenessKey) {
+        continue;
+      }
+      const enabled = entry.alert.status === "enabled";
+      const generation = uniquenessKeyGeneration(key);
+      if (
+        best === null ||
+        (enabled && !bestEnabled) ||
+        (enabled === bestEnabled && generation > bestGeneration)
+      ) {
+        best = entry;
+        bestEnabled = enabled;
+        bestGeneration = generation;
       }
     }
-    return new Ok(null);
+    return new Ok(best);
   } catch (err) {
     return new Err(normalizeError(err));
   }
@@ -108,46 +189,123 @@ export async function upsertMetronomeAlert(
       : "[Metronome Alert] upsert: creating new alert"
   );
 
-  try {
-    if (existing) {
+  if (existing) {
+    // Archive the stale alert to release its key before recreating. Tolerate a
+    // racing archive (another request beat us to it): the old alert is already
+    // inactive, which is the post-condition we want.
+    try {
       await archiveMetronomeAlert({ id: existing.alert.id });
-    }
-    const created = await createMetronomeAlert(params);
-    logger.info(
-      {
-        customerId: params.customer_id,
-        uniquenessKey: params.uniqueness_key,
-        alertId: created.data.id,
-        threshold: params.threshold,
-      },
-      "[Metronome Alert] upsert: created alert"
-    );
-    return new Ok({ alertId: created.data.id });
-  } catch (err) {
-    // A uniqueness-key 409 means another alert still holds this key — typically
-    // one archived previously without releasing the key, which
-    // `findMetronomeAlert` (ENABLED/DISABLED only) doesn't surface. Archive the
-    // conflicting alert (releasing the key) and retry the create once.
-    const conflictingId = conflictingAlertIdFromError(err);
-    if (conflictingId) {
-      logger.warn(
-        {
-          customerId: params.customer_id,
-          uniquenessKey: params.uniqueness_key,
-          conflictingAlertId: conflictingId,
-          threshold: params.threshold,
-        },
-        "[Metronome Alert] upsert: uniqueness_key conflict (409); archiving conflicting alert and retrying create"
-      );
-      try {
-        await archiveMetronomeAlert({ id: conflictingId });
-        const created = await createMetronomeAlert(params);
-        logger.info(
+    } catch (archiveErr) {
+      if (!isAlertAlreadyArchivedError(archiveErr)) {
+        logger.error(
           {
             customerId: params.customer_id,
             uniquenessKey: params.uniqueness_key,
-            alertId: created.data.id,
+            alertId: existing.alert.id,
+            err: normalizeError(archiveErr),
+          },
+          "[Metronome Alert] upsert: failed to archive stale alert before recreate"
+        );
+        return new Err(normalizeError(archiveErr));
+      }
+    }
+  }
+
+  return createAlertReleasingOrphanedKeys(params);
+}
+
+// Create the alert, recovering from uniqueness-key conflicts. On a 409 the key
+// is held by another alert: if it can be archived (releasing the key) we retry
+// the same key; if it is already archived — an orphaned key with no API path to
+// release it — we advance to the next generation key. Lookups match on the base
+// key, so the live alert stays discoverable at whatever generation wins.
+async function createAlertReleasingOrphanedKeys(
+  params: UpsertMetronomeAlertParams
+): Promise<Result<{ alertId: string }, Error>> {
+  const baseKey = params.uniqueness_key;
+
+  for (
+    let generation = 0;
+    generation <= MAX_UNIQUENESS_KEY_GENERATIONS;
+    generation++
+  ) {
+    const uniquenessKey = generationKey(baseKey, generation);
+    const createParams = { ...params, uniqueness_key: uniquenessKey };
+
+    try {
+      const created = await createMetronomeAlert(createParams);
+      logger.info(
+        {
+          customerId: params.customer_id,
+          baseUniquenessKey: baseKey,
+          uniquenessKey,
+          generation,
+          alertId: created.data.id,
+          threshold: params.threshold,
+        },
+        "[Metronome Alert] upsert: created alert"
+      );
+      return new Ok({ alertId: created.data.id });
+    } catch (err) {
+      const conflictingId = conflictingAlertIdFromError(err);
+      if (!conflictingId) {
+        logger.error(
+          {
+            customerId: params.customer_id,
+            baseUniquenessKey: baseKey,
+            uniquenessKey,
+            generation,
+            threshold: params.threshold,
+            err: normalizeError(err),
+            rawError:
+              typeof err === "object" && err !== null && "error" in err
+                ? err.error
+                : undefined,
+          },
+          "[Metronome Alert] upsert: create failed (no conflicting_id surfaced)"
+        );
+        return new Err(normalizeError(err));
+      }
+
+      try {
+        await archiveMetronomeAlert({ id: conflictingId });
+      } catch (archiveErr) {
+        if (isAlertAlreadyArchivedError(archiveErr)) {
+          logger.warn(
+            {
+              customerId: params.customer_id,
+              baseUniquenessKey: baseKey,
+              uniquenessKey,
+              conflictingAlertId: conflictingId,
+              generation,
+            },
+            "[Metronome Alert] upsert: uniqueness_key orphaned by an already-archived alert; advancing to next generation"
+          );
+          continue;
+        }
+        logger.error(
+          {
+            customerId: params.customer_id,
+            baseUniquenessKey: baseKey,
+            uniquenessKey,
             conflictingAlertId: conflictingId,
+            err: normalizeError(archiveErr),
+          },
+          "[Metronome Alert] upsert: failed to archive conflicting alert"
+        );
+        return new Err(normalizeError(archiveErr));
+      }
+
+      try {
+        const created = await createMetronomeAlert(createParams);
+        logger.info(
+          {
+            customerId: params.customer_id,
+            baseUniquenessKey: baseKey,
+            uniquenessKey,
+            generation,
+            conflictingAlertId: conflictingId,
+            alertId: created.data.id,
             threshold: params.threshold,
           },
           "[Metronome Alert] upsert: recreated alert after releasing conflicting uniqueness_key"
@@ -157,34 +315,33 @@ export async function upsertMetronomeAlert(
         logger.error(
           {
             customerId: params.customer_id,
-            uniquenessKey: params.uniqueness_key,
+            baseUniquenessKey: baseKey,
+            uniquenessKey,
+            generation,
             conflictingAlertId: conflictingId,
             threshold: params.threshold,
             err: normalizeError(retryErr),
           },
-          "[Metronome Alert] upsert: retry after archiving conflicting alert failed"
+          "[Metronome Alert] upsert: retry after releasing conflicting key failed"
         );
         return new Err(normalizeError(retryErr));
       }
     }
-    // No conflicting_id on the error: log the raw error so a uniqueness-key
-    // conflict whose shape we don't yet recognize is still visible in the logs
-    // (instead of being swallowed into a generic "metronome_error").
-    logger.error(
-      {
-        customerId: params.customer_id,
-        uniquenessKey: params.uniqueness_key,
-        threshold: params.threshold,
-        err: normalizeError(err),
-        rawError:
-          typeof err === "object" && err !== null && "error" in err
-            ? err.error
-            : undefined,
-      },
-      "[Metronome Alert] upsert: create failed (no conflicting_id surfaced)"
-    );
-    return new Err(normalizeError(err));
   }
+
+  logger.error(
+    {
+      customerId: params.customer_id,
+      baseUniquenessKey: baseKey,
+      maxGenerations: MAX_UNIQUENESS_KEY_GENERATIONS,
+    },
+    "[Metronome Alert] upsert: exhausted uniqueness-key generations; all orphaned by archived alerts"
+  );
+  return new Err(
+    new Error(
+      `Exhausted ${MAX_UNIQUENESS_KEY_GENERATIONS} uniqueness-key generations for "${baseKey}"; all held by already-archived alerts.`
+    )
+  );
 }
 
 /**
@@ -215,6 +372,10 @@ export async function clearMetronomeAlert({
     await archiveMetronomeAlert({ id: existing.alert.id });
     return new Ok({ alertId: existing.alert.id });
   } catch (err) {
+    // Already archived is the post-condition clear guarantees: treat as success.
+    if (isAlertAlreadyArchivedError(err)) {
+      return new Ok({ alertId: existing.alert.id });
+    }
     return new Err(normalizeError(err));
   }
 }

--- a/front/lib/metronome/alerts/spend_limits.ts
+++ b/front/lib/metronome/alerts/spend_limits.ts
@@ -1,4 +1,5 @@
 import {
+  baseUniquenessKey,
   clearMetronomeAlert,
   findMetronomeAlert,
   upsertMetronomeAlert,
@@ -181,10 +182,14 @@ export async function listMetronomePerUserCapsForWorkspace({
       alert_statuses: ["ENABLED"],
     })) {
       const key = entry.alert.uniqueness_key;
-      if (!key || !key.startsWith(prefix)) {
+      if (!key) {
         continue;
       }
-      const userId = key.slice(prefix.length);
+      const baseKey = baseUniquenessKey(key);
+      if (!baseKey.startsWith(prefix)) {
+        continue;
+      }
+      const userId = baseKey.slice(prefix.length);
       if (!userId) {
         continue;
       }
@@ -216,10 +221,14 @@ export async function listMetronomePerUserWarningAlertsForWorkspace({
       alert_statuses: ["ENABLED"],
     })) {
       const key = entry.alert.uniqueness_key;
-      if (!key || !key.startsWith(prefix)) {
+      if (!key) {
         continue;
       }
-      const userId = key.slice(prefix.length);
+      const baseKey = baseUniquenessKey(key);
+      if (!baseKey.startsWith(prefix)) {
+        continue;
+      }
+      const userId = baseKey.slice(prefix.length);
       if (!userId) {
         continue;
       }
@@ -279,10 +288,11 @@ async function fetchPerUserCapAlertIds(args: {
       customer_id: args.metronomeCustomerId,
       alert_statuses: ["ENABLED"],
     })) {
-      const key = entry.alert.uniqueness_key;
-      if (!key) {
+      const rawKey = entry.alert.uniqueness_key;
+      if (!rawKey) {
         continue;
       }
+      const key = baseUniquenessKey(rawKey);
       if (key.startsWith(capPrefix)) {
         const userId = key.slice(capPrefix.length);
         if (userId) {
@@ -348,7 +358,7 @@ async function fetchDefaultCapThresholdsBySeatType(args: {
 
   const capBySeat = new Map<
     NormalizedPoolLimitSeatType,
-    { threshold: number; alertId: string }
+    { threshold: number; alertId: string; enabled: boolean }
   >();
   const warningIdBySeat = new Map<NormalizedPoolLimitSeatType, string>();
 
@@ -359,16 +369,23 @@ async function fetchDefaultCapThresholdsBySeatType(args: {
       customer_id: args.metronomeCustomerId,
       alert_statuses: ["ENABLED", "DISABLED"],
     })) {
-      const key = entry.alert.uniqueness_key;
-      if (!key) {
+      const rawKey = entry.alert.uniqueness_key;
+      if (!rawKey) {
         continue;
       }
+      const key = baseUniquenessKey(rawKey);
+      const enabled = entry.alert.status === "enabled";
       const capSeat = capKeyToSeat.get(key);
       if (capSeat) {
-        capBySeat.set(capSeat, {
-          threshold: entry.alert.threshold,
-          alertId: entry.alert.id,
-        });
+        // Prefer an enabled generation over a disabled one for the same seat.
+        const current = capBySeat.get(capSeat);
+        if (!current || (enabled && !current.enabled)) {
+          capBySeat.set(capSeat, {
+            threshold: entry.alert.threshold,
+            alertId: entry.alert.id,
+            enabled,
+          });
+        }
         continue;
       }
       const warningSeat = warningKeyToSeat.get(key);
@@ -383,7 +400,8 @@ async function fetchDefaultCapThresholdsBySeatType(args: {
   const caps = {} as Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>;
   for (const [seatType, cap] of capBySeat) {
     caps[seatType] = {
-      ...cap,
+      threshold: cap.threshold,
+      alertId: cap.alertId,
       warningAlertId: warningIdBySeat.get(seatType) ?? null,
     };
   }

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -10,6 +10,7 @@ import type {
 import {
   isMembershipSeatType,
   NORMALIZED_POOL_LIMIT_SEAT_TYPES,
+  normalizeToPoolLimitSeatType,
 } from "@app/types/memberships";
 import type { Subscription } from "@metronome/sdk/resources";
 
@@ -403,6 +404,35 @@ export function getAwuAllocationForSeatType(
 }
 
 /**
+ * AWU allowance for a normalized pool-limit seat type (e.g. `"pro"`). Monthly
+ * and yearly variants of a tier share the same allowance, so this resolves the
+ * normalized type to whichever variant the contract actually sells and reads
+ * its allowance — a direct `getAwuAllocationForSeatType(contract, "pro", ...)`
+ * returns 0 on a contract that only sells `"pro_yearly"`. Returns 0 when no
+ * matching seat is sold.
+ */
+export function getAwuAllocationForNormalizedSeatType(
+  contract: CachedContract,
+  normalizedSeatType: NormalizedPoolLimitSeatType,
+  productSeatTypes: Map<string, MembershipSeatType>
+): number {
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+  for (const actualSeatType of seatSubscriptions.keys()) {
+    if (normalizeToPoolLimitSeatType(actualSeatType) === normalizedSeatType) {
+      return getAwuAllocationForSeatType(
+        contract,
+        actualSeatType,
+        productSeatTypes
+      );
+    }
+  }
+  return 0;
+}
+
+/**
  * Resolve the seat AWU allowance for each normalized pool-limit seat type of
  * the workspace's active contract. Returns an empty record when the workspace
  * has no active contract. Used to derive total per-user cap thresholds (pool
@@ -419,7 +449,7 @@ export async function getSeatAllowancesByNormalizedSeatType(
   const productSeatTypes = await getProductSeatTypes();
   const allowances: Partial<Record<NormalizedPoolLimitSeatType, number>> = {};
   for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
-    allowances[seatType] = getAwuAllocationForSeatType(
+    allowances[seatType] = getAwuAllocationForNormalizedSeatType(
       contract,
       seatType,
       productSeatTypes


### PR DESCRIPTION
## Description

Fixes two bugs that prevented updating per-user / default spend limits on Metronome-billed workspaces, plus adds diagnostic logging across the spend-limit flow.

**1. Orphaned uniqueness keys block alert creation.** A Metronome uniqueness key can only be released by archiving its alert with `release_uniqueness_key: true`. An alert archived *without* releasing its key (e.g. manually in the Metronome console) orphans the key forever: re-archiving it returns `400 Alert already archived`, and there is no API to release it afterwards. The existing 409-retry couldn't recover from this — it tried to archive the conflicting alert, which is already archived.

Fix: alerts now use a generation-suffixed uniqueness key (`<baseKey>::g<N>`). The base key is used normally; only when a generation is orphaned by an already-archived alert do we advance to the next. All lookups (`findMetronomeAlert` and the per-seat / per-user scans) match on the base key and ignore the suffix, so the live alert stays discoverable at whatever generation wins. `clearMetronomeAlert` and the pre-recreate archive now treat `already archived` as an idempotent success.

**2. Seat allowance resolved to 0 on yearly contracts.** The allowance lookup passed a *normalized* seat type (e.g. `"pro"`) to `getAwuAllocationForSeatType`, which matches against the contract's *actual* sold products (e.g. `"pro_yearly"`) — so it never matched and returned `0`, leaving the cap threshold short by the seat allowance.

Fix: new `getAwuAllocationForNormalizedSeatType` resolves the normalized tier to whichever variant the contract actually sells (monthly/yearly share the same allowance) and reads that variant's allowance. Used by `getSeatAllowancesByNormalizedSeatType` (per-user spend limit) and both the read/write paths of the default spend limit.

**3. Logging.** Added structured logging (with `workspaceId`) throughout `setDefaultUserSpendLimit` / `getDefaultUserSpendLimit` and the alert upsert/conflict paths, so failures surface the underlying Metronome error instead of a generic `metronome_error`.

## Tests

- Updated `default_user_spend_limit.test.ts` to mock the new resolver; 11/11 pass.
- `npx tsgo --noEmit` and `biome check` clean on changed files.
- Manual: reproduced on a real workspace (`pro_yearly`/`max_yearly` contract) — logs previously showed `seatAllowance: 0`; with the fix the threshold is `seatAllowance + poolAwuCredits`.

## Risk

Low. For keys that were never orphaned (the norm), behavior is unchanged — the generation suffix only engages once an archived alert blocks the base key. The allowance resolver returns the same value as before for contracts selling the non-suffixed seat type, and corrects the previously-wrong `0` for yearly-only contracts. Rollback is safe (no schema/state migration; alerts created under a generation key remain discoverable via base-key lookup).

## Deploy Plan

Standard deploy, no ordering constraints.
