### PR TITLE
Improve indexes on AuthorizedFileAccessModel.

### DIFF
--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -374,9 +374,13 @@ AuthorizedFileAccessModel.init(
     modelName: "authorized_file_access",
     sequelize: frontSequelize,
     indexes: [
+      { fields: ["workspaceId"], concurrently: true },
+      { fields: ["shareableFileId"], concurrently: true },
       {
-        fields: ["workspaceId", "shareableFileId"],
+        fields: ["shareableFileId"],
         where: { revokedAt: null },
+        name: "authorized_file_accesses_shareable_file_id_non_revoked",
+        concurrently: true,
       },
     ],
   }

--- a/front/migrations/db/migration_670.sql
+++ b/front/migrations/db/migration_670.sql
@@ -1,0 +1,11 @@
+-- Migration created on Jun 7, 2026
+-- Split authorized_file_access indexes: standalone workspaceId + active shareableFileId rows.
+CREATE INDEX CONCURRENTLY "authorized_file_accesses_workspace_id" ON "authorized_file_accesses" ("workspaceId");
+
+CREATE INDEX CONCURRENTLY "authorized_file_accesses_shareable_file_id" ON "authorized_file_accesses" ("shareableFileId");
+
+CREATE INDEX CONCURRENTLY "authorized_file_accesses_shareable_file_id_non_revoked" ON "authorized_file_accesses" ("shareableFileId")
+WHERE
+    "revokedAt" IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS "authorized_file_accesses_workspace_id_shareable_file_id";


### PR DESCRIPTION
## Description

Splits the composite index `(workspaceId, shareableFileId)` on `authorized_file_accesses` into three more targeted indexes:
- `authorized_file_accesses_workspace_id` — standalone `workspaceId` for workspace-scoped lookups
- `authorized_file_accesses_shareable_file_id` — standalone `shareableFileId` for file-scoped lookups
- `authorized_file_accesses_shareable_file_id_non_revoked` — partial index on `shareableFileId WHERE revokedAt IS NULL` for active-access queries

The old composite index `authorized_file_accesses_workspace_id_shareable_file_id` is dropped. All operations use `CONCURRENTLY` to avoid table locks.

## Tests

Tested via the SQL migration locally. Sequelize model updated to reflect the new index definitions.

## Risk

Low. All `CREATE INDEX` and `DROP INDEX` use `CONCURRENTLY`, so no table lock or downtime. The new indexes are strictly additive before the drop — there is no window where lookups go unindexed. Rollback would require re-creating the composite index manually.

## Deploy Plan

1. Run `migration_670.sql` against the front DB (`CREATE INDEX CONCURRENTLY` steps can take time on large tables — monitor progress).
2. Deploy front.
