### PR TITLE
[connectors] Bound concurrency in Microsoft getRootNodesToSync fan-out

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -221,82 +221,82 @@ export async function getRootNodesToSyncFromResources(
   // get root folders and drives and drill down site-root and sites to their
   // child drives (converted to MicrosoftNode types)
   const rootFolderAndDriveNodes = removeNulls(
-    await Promise.all(
-      rootResources
-        .filter(
-          (resource) =>
-            resource.nodeType === "folder" || resource.nodeType === "drive"
-        )
-        .map(async (resource) => {
-          try {
-            const item = await getItem(
-              logger,
-              client,
-              typeAndPathFromInternalId(resource.internalId).itemAPIPath
-            );
+    await concurrentExecutor(
+      rootResources.filter(
+        (resource) =>
+          resource.nodeType === "folder" || resource.nodeType === "drive"
+      ),
+      async (resource) => {
+        try {
+          const item = await getItem(
+            logger,
+            client,
+            typeAndPathFromInternalId(resource.internalId).itemAPIPath
+          );
 
-            const node = itemToMicrosoftNode(
-              resource.nodeType as "folder" | "drive",
-              item
-            );
-            return {
-              ...node,
-              name: node.name,
-            };
-          } catch (error) {
-            if (error instanceof GraphError && error.statusCode === 404) {
-              return null;
-            }
-            if (isAccessBlockedError(error)) {
-              logger.warn(
-                {
-                  connectorId,
-                  id: resource.internalId,
-                  error: error.message,
-                },
-                "Root resource access blocked by administrator, skipping"
-              );
-              return null;
-            }
-            if (isGeneralExceptionError(error)) {
-              logger.warn(
-                {
-                  connectorId,
-                  internalId: resource.internalId,
-                  errorCode: error.code,
-                  errorMessage: error.message,
-                },
-                "Skipping root resource due to 401 generalException - possible site permission change. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when"
-              );
-              return null;
-            }
-            if (isBillingPolicyError(error)) {
-              logger.warn(
-                {
-                  connectorId,
-                  internalId: resource.internalId,
-                  error: error.message,
-                },
-                "Billing policy error from Microsoft, skipping root resource"
-              );
-              return null;
-            }
-            if (error instanceof ExternalOAuthTokenError) {
-              // Do not throw immediately, the token may still be valid for other roots.
-              oauthTokenErrors.push(error);
-              return null;
-            }
-            logger.error(
+          const node = itemToMicrosoftNode(
+            resource.nodeType as "folder" | "drive",
+            item
+          );
+          return {
+            ...node,
+            name: node.name,
+          };
+        } catch (error) {
+          if (error instanceof GraphError && error.statusCode === 404) {
+            return null;
+          }
+          if (isAccessBlockedError(error)) {
+            logger.warn(
               {
                 connectorId,
-                error,
                 id: resource.internalId,
+                error: error.message,
               },
-              "Failed to get item"
+              "Root resource access blocked by administrator, skipping"
             );
-            throw error;
+            return null;
           }
-        })
+          if (isGeneralExceptionError(error)) {
+            logger.warn(
+              {
+                connectorId,
+                internalId: resource.internalId,
+                errorCode: error.code,
+                errorMessage: error.message,
+              },
+              "Skipping root resource due to 401 generalException - possible site permission change. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when"
+            );
+            return null;
+          }
+          if (isBillingPolicyError(error)) {
+            logger.warn(
+              {
+                connectorId,
+                internalId: resource.internalId,
+                error: error.message,
+              },
+              "Billing policy error from Microsoft, skipping root resource"
+            );
+            return null;
+          }
+          if (error instanceof ExternalOAuthTokenError) {
+            // Do not throw immediately, the token may still be valid for other roots.
+            oauthTokenErrors.push(error);
+            return null;
+          }
+          logger.error(
+            {
+              connectorId,
+              error,
+              id: resource.internalId,
+            },
+            "Failed to get item"
+          );
+          throw error;
+        }
+      },
+      { concurrency: 5 }
     )
   );
 


### PR DESCRIPTION
## Problem

A Microsoft connector had a stuck `incrementalSyncWorkflowV2` retrying forever. The failing activity was `getRootNodesToSync` → `getRootNodesToSyncFromResources`, with errors alternating between `MicrosoftThrottlingError` (429) and `GraphError: Access denied` (403), originating from a `Promise.all (index 499)`.

The root cause is **self-inflicted throttling**: `getRootNodesToSyncFromResources` fired one Graph API call (`getItem`) per root resource through an **unbounded `Promise.all`**. On this connector that's 500+ concurrent calls in a single burst — large enough to trigger Microsoft Graph's 429 throttling (and surface a stray 403 on a drive the token can't see).

Because any single rejection rejects the whole `Promise.all`, the activity failed and (with the default unlimited retry policy) retried after ~5s — re-firing the **same 500-call burst**, throttling again, looping forever. The `Retry-After` backoff could never win because each retry recreated the cause.

## Fix

Convert the fan-out to `concurrentExecutor(..., { concurrency: 5 })`, capping in-flight calls at 5. This matches:
- the sibling `siteDriveNodes` block ~40 lines below in the same function, which already uses `concurrentExecutor({ concurrency: 5 })`, and
- the 8 other `concurrentExecutor` call sites in this file.

It also resolves the [BACK7] violation (no `Promise.all` on dynamic arrays).

## Impact on the stuck connector

No manual intervention required: once a worker carrying this change is deployed, the next retry of `getRootNodesToSync` runs the bounded version and should get past it on its own.

## Out of scope (flagged, not changed here)

- The Microsoft activities use Temporal's default unlimited retry policy, which is why "stuck" meant "silently forever" rather than "fails and surfaces." This matches all other connectors and is a broader decision left for a separate discussion.
- The raw 403 `Access denied` path: `clientApiGet` already maps 403 → `ExternalOAuthTokenError` (handled per-root). If a non-403 status was slipping through to the generic `throw`, it'd want its own branch — but it's no longer what keeps the workflow stuck once concurrency is bounded.

## Testing

- `npx biome check` formatted
- `npx tsgo --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)