### PR TITLE
Fixed per-user spend window

### DIFF
--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -282,6 +282,15 @@ export function BaseAwuUsageChart({
   );
   const canGoNext = billingCycle.cycleEnd.getTime() <= nowMs;
 
+  // Block navigating before the contract's first period: the displayed period is
+  // the first one when the contract start falls within it.
+  const contractStartTs = awuUsageData?.contractStartTimestamp ?? null;
+  const isFirstPeriod =
+    contractStartTs !== null &&
+    billingCycle.cycleStart.getTime() <= contractStartTs &&
+    contractStartTs < billingCycle.cycleEnd.getTime();
+  const canGoPrevious = !isFirstPeriod;
+
   const availableGroupsArray = useMemo(
     () => awuUsageData?.availableGroups ?? [],
     [awuUsageData]
@@ -464,13 +473,17 @@ export function BaseAwuUsageChart({
       title={
         <div className="flex items-center gap-2">
           <span>Usage</span>
-          <Button
-            icon={ChevronLeft}
-            size="xs"
-            variant="ghost"
-            onClick={() => setSelectedPeriod(formatPeriod(previousPeriodDate))}
-            tooltip="Previous period"
-          />
+          {canGoPrevious && (
+            <Button
+              icon={ChevronLeft}
+              size="xs"
+              variant="ghost"
+              onClick={() =>
+                setSelectedPeriod(formatPeriod(previousPeriodDate))
+              }
+              tooltip="Previous period"
+            />
+          )}
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             {periodLabel}
           </span>

--- a/front/lib/api/analytics/awu_usage.ts
+++ b/front/lib/api/analytics/awu_usage.ts
@@ -1,10 +1,12 @@
 import {
-  aggregateToFourHourBuckets,
+  aggregateToWindowBuckets,
   getMetronomeWindowSize,
 } from "@app/lib/api/analytics/metronome_usage";
 import {
   DAY_MS,
   getTimestampsForWindow,
+  getWindowSizeMs,
+  HOUR_MS,
 } from "@app/lib/api/analytics/time_utils";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,6 +30,7 @@ import {
   isToolCategory,
   TOOL_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -128,6 +131,9 @@ export interface AwuUsageAvailableGroup {
 export interface GetAwuUsageResponse {
   points: AwuUsagePoint[];
   availableGroups: AwuUsageAvailableGroup[];
+  // Contract start instant (ms epoch), or null when there's no contract. The
+  // chart uses it to block navigating before the contract's first period.
+  contractStartTimestamp: number | null;
 }
 
 export type AwuUsageError =
@@ -163,10 +169,12 @@ function getLlmQueryConfig(groupBy: AwuUsageGroupByType): {
       };
     case "user":
       // Group by user, excluding programmatic traffic (not user-attributable).
+      // Drop entries with no user_id (the "unknown" bucket).
       return {
         groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
         bucketProp: "user_id",
         groupFilters: { [USAGE_TYPE_GROUP_KEY]: NON_PROGRAMMATIC_USAGE_TYPES },
+        dropKeys: [UNKNOWN_KEY],
       };
     case "api_key":
       // API-key traffic is programmatic; user traffic carries no api_key (it is
@@ -248,11 +256,15 @@ interface GroupedUsageEntry {
 // Accumulate grouped Metronome entries into bucketKey → (timestamp → value).
 // `weight` returns the value to add, or null to skip the entry. When
 // `bucketKeyOverride` is set, every entry is collapsed into that single bucket.
+// Entries starting before `minTsMs` are dropped (used to trim the pre-start
+// portion of a mid-day-started period). When `aggregateToMs` is set, the
+// per-bucket hourly map is re-bucketed up to that window (DAY/FOUR_HOURS).
 function bucketGroupedEntries(
   entries: GroupedUsageEntry[],
   bucketProp: string,
   weight: (entry: GroupedUsageEntry) => number | null,
-  needsFourHourAggregation: boolean,
+  minTsMs: number,
+  aggregateToMs: number | null,
   bucketKeyOverride?: string
 ): Map<string, Map<number, number>> {
   const map = new Map<string, Map<number, number>>();
@@ -261,8 +273,11 @@ function bucketGroupedEntries(
     if (w === null) {
       continue;
     }
-    const key = bucketKeyOverride ?? entry.group?.[bucketProp] ?? UNKNOWN_KEY;
     const ts = new Date(entry.startingOn).getTime();
+    if (ts < minTsMs) {
+      continue;
+    }
+    const key = bucketKeyOverride ?? entry.group?.[bucketProp] ?? UNKNOWN_KEY;
     let tsMap = map.get(key);
     if (!tsMap) {
       tsMap = new Map();
@@ -270,9 +285,9 @@ function bucketGroupedEntries(
     }
     tsMap.set(ts, (tsMap.get(ts) ?? 0) + w);
   }
-  if (needsFourHourAggregation) {
+  if (aggregateToMs !== null) {
     for (const key of [...map.keys()]) {
-      map.set(key, aggregateToFourHourBuckets(map.get(key)!));
+      map.set(key, aggregateToWindowBuckets(map.get(key)!, aggregateToMs));
     }
   }
   return map;
@@ -382,26 +397,56 @@ export async function getAwuUsage(
   if (selectedPeriod) {
     referenceDate.setUTCDate(billingCycleStartDay);
   }
-  const { cycleStart: periodStart, cycleEnd: periodEnd } =
+  const { cycleStart: clientPeriodStart, cycleEnd: periodEnd } =
     getBillingCycleFromDay(billingCycleStartDay, referenceDate, true);
+
+  // Never show usage from before the contract began. The client-side cycle is
+  // anchored to a day-of-month, so for the contract's first (mid-month) period
+  // it can start before the contract; clamp it up to the real contract start.
+  const contract = await getActiveContract(workspace.sId);
+  const contractStart = contract ? new Date(contract.starting_at) : null;
+  const periodStart =
+    contractStart && contractStart.getTime() > clientPeriodStart.getTime()
+      ? contractStart
+      : clientPeriodStart;
+  const periodStartMs = periodStart.getTime();
 
   const TEN_DAYS_MS = 10 * DAY_MS;
   const cappedEnd = new Date(
     Math.min(periodEnd.getTime(), Date.now() + TEN_DAYS_MS)
   );
 
+  // The usage endpoint requires midnight-aligned bounds. When the period start
+  // is not itself midnight (a mid-day contract start), query hourly so we can
+  // drop the pre-start buckets and aggregate the rest up to the display window.
+  const hourSplit = periodStartMs !== floorToMidnightUTC(periodStart).getTime();
+  const displayWindowMs = getWindowSizeMs(windowSize);
+  const metronomeApiWindowSize = hourSplit
+    ? "HOUR"
+    : getMetronomeWindowSize(windowSize);
+  // Re-bucket hourly fetches up to the display window (covers both the hour-split
+  // case and the pre-existing FOUR_HOURS display, which also fetches hourly).
+  const aggregateToMs =
+    metronomeApiWindowSize === "HOUR" && displayWindowMs > HOUR_MS
+      ? displayWindowMs
+      : null;
+
   const rangeStart = floorToMidnightUTC(periodStart);
   const rangeEnd = ceilToMidnightUTC(cappedEnd);
   const startingOn = rangeStart.toISOString();
   const endingBefore = rangeEnd.toISOString();
 
-  const timestamps = getTimestampsForWindow(rangeStart, rangeEnd, windowSize);
+  // Build the axis from the display-window floor of the period start (never
+  // before it), so we don't emit zero points for the trimmed pre-start span.
+  const displayFloorMs = periodStartMs - (periodStartMs % displayWindowMs);
+  const timestamps = getTimestampsForWindow(
+    new Date(displayFloorMs),
+    rangeEnd,
+    windowSize
+  );
 
   const groupValues: Record<string, Map<number, number>> = {};
   const availableGroups: AwuUsageAvailableGroup[] = [];
-
-  const metronomeApiWindowSize = getMetronomeWindowSize(windowSize);
-  const needsFourHourAggregation = windowSize === "FOUR_HOURS";
 
   if (!groupBy) {
     const result = await listMetronomeUsage({
@@ -422,10 +467,13 @@ export async function getAwuUsage(
     let totalMap = new Map<number, number>();
     for (const entry of result.value) {
       const ts = new Date(entry.startTimestamp).getTime();
+      if (ts < periodStartMs) {
+        continue;
+      }
       totalMap.set(ts, (totalMap.get(ts) ?? 0) + (entry.value ?? 0));
     }
-    if (needsFourHourAggregation) {
-      totalMap = aggregateToFourHourBuckets(totalMap);
+    if (aggregateToMs !== null) {
+      totalMap = aggregateToWindowBuckets(totalMap, aggregateToMs);
     }
     groupValues["total"] = totalMap;
 
@@ -486,7 +534,8 @@ export async function getAwuUsage(
       llmResult.value,
       llmCfg.bucketProp,
       (entry) => entry.value ?? 0,
-      needsFourHourAggregation,
+      periodStartMs,
+      aggregateToMs,
       llmCfg.bucketKeyOverride
     );
 
@@ -503,7 +552,8 @@ export async function getAwuUsage(
           }
           return entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
         },
-        needsFourHourAggregation
+        periodStartMs,
+        aggregateToMs
       );
       mergeBuckets(mergedGroupMap, toolMap);
     }
@@ -591,5 +641,9 @@ export async function getAwuUsage(
     availableGroups.push({ groupKey: "others", groupLabel: "Others" });
   }
 
-  return new Ok({ points, availableGroups });
+  return new Ok({
+    points,
+    availableGroups,
+    contractStartTimestamp: contractStart?.getTime() ?? null,
+  });
 }

--- a/front/lib/api/analytics/metronome_usage.ts
+++ b/front/lib/api/analytics/metronome_usage.ts
@@ -99,15 +99,25 @@ export function getMetronomeWindowSize(
   }
 }
 
-export function aggregateToFourHourBuckets(
-  hourlyMap: Map<number, number>
+// Re-bucket a timestamp→value map by flooring each timestamp to a `windowMs`
+// boundary. Works for HOUR/FOUR_HOURS/DAY because the unix epoch is itself
+// midnight-aligned and those windows divide the day evenly.
+export function aggregateToWindowBuckets(
+  map: Map<number, number>,
+  windowMs: number
 ): Map<number, number> {
   const aggregated = new Map<number, number>();
-  for (const [ts, value] of hourlyMap) {
-    const bucket = ts - (ts % FOUR_HOURS_MS);
+  for (const [ts, value] of map) {
+    const bucket = ts - (ts % windowMs);
     aggregated.set(bucket, (aggregated.get(bucket) ?? 0) + value);
   }
   return aggregated;
+}
+
+export function aggregateToFourHourBuckets(
+  hourlyMap: Map<number, number>
+): Map<number, number> {
+  return aggregateToWindowBuckets(hourlyMap, FOUR_HOURS_MS);
 }
 
 interface ParsedBalance {

--- a/front/lib/api/analytics/time_utils.ts
+++ b/front/lib/api/analytics/time_utils.ts
@@ -6,7 +6,7 @@ export const DAY_MS = 24 * HOUR_MS;
 
 export type WindowSize = "HOUR" | "FOUR_HOURS" | "DAY";
 
-function getWindowSizeMs(windowSize: WindowSize): number {
+export function getWindowSizeMs(windowSize: WindowSize): number {
   switch (windowSize) {
     case "HOUR":
       return HOUR_MS;

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -69,10 +69,20 @@ export async function fetchPerUserAwuUsage({
   }
   const { cycleStart, cycleEnd } = periodResult.value;
   const cycleEndMs = cycleEnd.getTime();
+  const cycleStartMs = cycleStart.getTime();
 
+  // The usage endpoint requires midnight-aligned bounds, so we always query from
+  // the floored start. When the period start is not itself midnight (e.g. a
+  // contract that started mid-day), the floored start pulls in usage from before
+  // the period began. Query at HOUR granularity in that case and drop the
+  // pre-start buckets below, so we count exactly the period — matching the
+  // Metronome spend alert and the seat grant. Steady-state periods start at
+  // midnight, so this stays on DAY.
   const startingOn = floorToMidnightUTC(cycleStart).toISOString();
   const requestEnd = new Date(Math.min(cycleEndMs, Date.now()));
   const endingBefore = ceilToMidnightUTC(requestEnd).toISOString();
+  const windowSize =
+    cycleStartMs === floorToMidnightUTC(cycleStart).getTime() ? "DAY" : "HOUR";
 
   const [aiResult, toolResult] = await Promise.all([
     listMetronomeUsageWithGroups({
@@ -80,7 +90,7 @@ export async function fetchPerUserAwuUsage({
       billableMetricId: getMetricLlmProviderCostAwuId(),
       startingOn,
       endingBefore,
-      windowSize: "DAY",
+      windowSize,
       groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
       groupFilters: { [USAGE_TYPE_GROUP_KEY]: PAID_USAGE_TYPES },
     }),
@@ -89,7 +99,7 @@ export async function fetchPerUserAwuUsage({
       billableMetricId: getMetricToolInvocationsId(),
       startingOn,
       endingBefore,
-      windowSize: "DAY",
+      windowSize,
       groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
       groupFilters: { [USAGE_TYPE_GROUP_KEY]: PAID_USAGE_TYPES },
     }),
@@ -106,7 +116,11 @@ export async function fetchPerUserAwuUsage({
   // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
   for (const entry of aiResult.value) {
     const userId = entry.group?.["user_id"];
-    if (!userId || entry.value === null) {
+    if (
+      !userId ||
+      entry.value === null ||
+      new Date(entry.startingOn).getTime() < cycleStartMs
+    ) {
       continue;
     }
     perUser.set(userId, (perUser.get(userId) ?? 0) + entry.value);
@@ -120,6 +134,7 @@ export async function fetchPerUserAwuUsage({
     if (
       !userId ||
       entry.value === null ||
+      new Date(entry.startingOn).getTime() < cycleStartMs ||
       !category ||
       !isToolCategory(category)
     ) {


### PR DESCRIPTION
## What & why

The per-user **"Consumed"** figure (members table) and the **AWU usage graph** both started their billing window at `floorToMidnightUTC(periodStart)`. For a contract that starts mid-day (e.g. Jun 2 **15:00 UTC**), this swept in the 00:00–15:00 usage that happened *before* the contract existed — over-counting versus what actually drives billing: Metronome's `spend_threshold_reached` alert and the seat grant both accrue from the exact period start (15:00).

Symptoms seen in prod: a user's "Consumed" read higher than `seatStartingBalance − seatBalance` (the seat ledger), which left users misclassified in the seat↔pool credit state and decoupled the displayed state from the alert that actually fires.

This only affects a contract's **first** billing period — every later period starts on a midnight boundary, so the new path is a no-op there.

## Changes

**"Consumed" — `lib/metronome/per_user_usage.ts`**
- When the period start isn't UTC midnight, query at `HOUR` granularity and drop buckets before the exact period start, so it counts exactly the period (matching the spend alert / seat grant). Steady-state periods stay on `DAY`.
- Keeps the `PAID_USAGE_TYPES` (user + programmatic, no free) filter: "Consumed" recomputes AWU from usage counts, so counting free would invent spend the credit-based alert never sees.

**Usage graph — `lib/api/analytics/awu_usage.ts`**
- Clamps the (client-side, day-of-month) period start up to the real **contract start** (`getActiveContract().starting_at`) — never shows usage from before the contract began.
- Same hour-split + trim when the clamped start isn't midnight: fetch hourly, drop pre-start buckets, then aggregate back up to the display window. The timestamp axis starts at the display-window floor of the period start, so no empty points precede the contract.
- Per-user line now drops the `unknown` (no `user_id`) bucket.
- Returns `contractStartTimestamp` so the UI can gate navigation.

**Shared helpers**
- `aggregateToFourHourBuckets` → generalized to `aggregateToWindowBuckets(map, windowMs)`; `getWindowSizeMs` exported (`metronome_usage.ts`, `time_utils.ts`).

**Chart UI — `components/workspace/AwuUsageChart.tsx`**
- Hides the "Previous period" button when the displayed period is the contract's first one (`cycleStart ≤ contractStart < cycleEnd`), mirroring the existing next-period gating. Shared automatically with the Poke chart via `BaseAwuUsageChart`.

## Notes
- No usage_type filter changes: "Consumed" keeps `PAID_USAGE_TYPES`; the graph keeps `NON_PROGRAMMATIC_USAGE_TYPES` on the non-free metric (free contributes 0 unless the Poke include-free toggle is on).
- The hourly fetch is heavier than daily but only fires for a contract's first (mid-day-started) period.
- Both awu-usage endpoints are Hono-migrated, but only the shared `getAwuUsage` lib + types/UI changed (neither handler), so the fix flows to both frameworks — no migration-sync needed.

## Verification
- `npx tsgo --noEmit` clean (pre-existing OpenAI SDK errors aside); biome clean.
- Manual (Poke, affected workspace whose contract started mid-day): "Consumed" drops to line up with `seatStarting − seatBalance`; the graph starts drawing at the contract-start hour with no pre-start data; the "Previous period" chevron is hidden on the first period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)