### PR TITLE
Scrub workspaces without subscriptions

### DIFF
--- a/front/scripts/scrub_workspaces_without_subscription.ts
+++ b/front/scripts/scrub_workspaces_without_subscription.ts
@@ -1,0 +1,114 @@
+import { SubscriptionModel } from "@app/lib/models/plan";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { launchImmediateWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
+import { Op } from "sequelize";
+
+const AGE_THRESHOLD_DAYS = 7;
+const BATCH_SIZE = 1000;
+const SCRUB_CONCURRENCY = 4;
+
+async function scrubWorkspaceBatch(
+  workspaces: WorkspaceModel[],
+  execute: boolean,
+  logger: Logger
+): Promise<number> {
+  if (workspaces.length === 0) {
+    return 0;
+  }
+
+  // Scoped lookup: which of these workspaces have ever had a subscription
+  // (any status, free trial, active, or past/expired). Indexed on workspaceId.
+  const subscribedRows = await SubscriptionModel.findAll({
+    where: { workspaceId: { [Op.in]: workspaces.map((w) => w.id) } },
+    attributes: ["workspaceId"],
+    group: ["workspaceId"],
+  });
+  const subscribedWorkspaceModelIds = new Set(
+    subscribedRows.map((s) => s.workspaceId)
+  );
+
+  const toScrub = workspaces.filter(
+    (w) => !subscribedWorkspaceModelIds.has(w.id)
+  );
+
+  if (!execute) {
+    for (const workspace of toScrub) {
+      logger.info(
+        { workspaceId: workspace.sId, createdAt: workspace.createdAt },
+        "[DRY RUN] Would scrub workspace."
+      );
+    }
+    return toScrub.length;
+  }
+
+  await concurrentExecutor(
+    toScrub,
+    async (workspace) => {
+      const res = await launchImmediateWorkspaceScrubWorkflow({
+        workspaceId: workspace.sId,
+      });
+      if (res.isErr()) {
+        logger.error(
+          { workspaceId: workspace.sId, error: res.error },
+          "Failed to launch scrub workflow."
+        );
+        return;
+      }
+      logger.info(
+        { workspaceId: workspace.sId, workflowId: res.value },
+        "Launched immediate scrub workflow."
+      );
+    },
+    { concurrency: SCRUB_CONCURRENCY }
+  );
+
+  return toScrub.length;
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const cutoffDate = new Date(
+    Date.now() - AGE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000
+  );
+
+  logger.info({ cutoffDate, batchSize: BATCH_SIZE }, "Starting scrub scan.");
+
+  // Keyset pagination on the primary key to keep memory bounded: we never hold
+  // more than BATCH_SIZE workspaces in memory, and the subscription lookup is
+  // scoped to each batch instead of scanning the whole table.
+  let lastSeenModelId = 0;
+  let scannedCount = 0;
+  let scrubbedCount = 0;
+
+  for (;;) {
+    const workspaces = await WorkspaceModel.findAll({
+      where: {
+        createdAt: { [Op.lt]: cutoffDate },
+        id: { [Op.gt]: lastSeenModelId },
+      },
+      attributes: ["id", "sId", "createdAt"],
+      order: [["id", "ASC"]],
+      limit: BATCH_SIZE,
+    });
+
+    if (workspaces.length === 0) {
+      break;
+    }
+
+    scannedCount += workspaces.length;
+    lastSeenModelId = workspaces[workspaces.length - 1].id;
+
+    scrubbedCount += await scrubWorkspaceBatch(workspaces, execute, logger);
+
+    logger.info({ scannedCount, scrubbedCount, lastSeenModelId }, "Progress.");
+  }
+
+  logger.info(
+    { scannedCount, scrubbedCount, execute },
+    execute
+      ? "Done launching scrub workflows."
+      : "Dry run complete (use --execute to run)."
+  );
+});


### PR DESCRIPTION
## Description

Adds an admin script `front/scripts/scrub_workspaces_without_subscription.ts` that immediately scrubs every workspace older than **7 days** that has **never had any subscription created** (no row in the `subscriptions` table, any status — so free trials, active, and past/expired subscriptions are all kept).

A workspace with zero subscription rows is already effectively `FREE_NO_PLAN` (per the `SubscriptionType.sId` comment in `types/plan.ts`), so — unlike the Poke `batch_downgrade` path — no downgrade-to-NO_PLAN step is needed before scrubbing. Each target is scrubbed via the existing `launchImmediateWorkspaceScrubWorkflow`, which runs the full data-scrub pipeline (conversations, spaces, keys, connectors, agents, WorkOS SSO/SCIM, etc.). As with the rest of the codebase, "scrub" wipes the workspace's data/resources; it does not delete the `workspaces` row itself.

The scan is built for scale (300k+ workspaces):

- **Keyset pagination** on the primary key (`id > lastSeenModelId`, batches of 1000) — no `OFFSET`, so per-page cost does not degrade as we page deeper, and we never hold more than `BATCH_SIZE` rows in memory.
- The "has any subscription ever" check is **scoped per batch** (`workspaceId IN (...)` against the indexed `workspaceId` column) instead of a full-table `GROUP BY`.
- Scrub workflows launch per batch via `concurrentExecutor` at concurrency 4, so we never enqueue hundreds of thousands of Temporal starts at once.
- Running `scannedCount` / `scrubbedCount` / `lastSeenModelId` are logged per batch for visibility.

## Tests

Dry-run by default — without `--execute` the script only logs the workspaces it *would* scrub and launches nothing. Validated by `npx tsgo --noEmit` (type-checks clean). No automated tests added; this is a one-shot operational admin script run manually against the DB.

Run:

```bash
# dry run — lists targets, scrubs nothing
npx tsx scripts/scrub_workspaces_without_subscription.ts

# actually launch scrub workflows
npx tsx scripts/scrub_workspaces_without_subscription.ts --execute
```

## Risk

Medium — scrubbing is destructive and irreversible for the affected workspaces' data. Mitigations:

- Dry-run is the default; `--execute` is required to launch any workflow.
- Filtering is conservative: a workspace is kept if it has **any** subscription row, of **any** status, ever — only workspaces that never had a subscription are eligible.
- Per-batch logging makes the run auditable.

**Rollback complexity:**

- [ ] Simple revert
- [x] Manual steps required — scrubbed workspace data cannot be recovered. Reverting the script prevents future runs but does not restore already-scrubbed workspaces.

**Service downtime:**

- [x] None expected
- [ ] Brief downtime expected
- [ ] Extended downtime possible

## Deploy Plan

Operational script, not part of the request path — nothing to deploy to serve traffic. To run: execute against the target environment first **without** `--execute` to review the candidate list, confirm the count is expected, then re-run with `--execute`.
