### PR TITLE
Fix Compaction activity is not registered on this Worker

### DIFF
--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -7,7 +7,10 @@ import { markShuttingDownWithDelayedAbort } from "@app/lib/shutdown_signal";
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { compactionActivity } from "@app/temporal/agent_loop/activities/compaction";
+import {
+  compactionActivity,
+  compactionCleanupActivity,
+} from "@app/temporal/agent_loop/activities/compaction";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   finalizeCancelledAgentLoopActivity,
@@ -54,6 +57,7 @@ export async function runAgentLoopWorker() {
     }),
     activities: {
       compactionActivity,
+      compactionCleanupActivity,
       ensureConversationTitleActivity,
       finalizeSuccessfulAgentLoopActivity,
       finalizeGracefullyStoppedAgentLoopActivity,


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8680

Registers `compactionCleanupActivity` in the agent-loop Temporal worker (front/temporal/agent_loop/worker.ts):

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front