### PR TITLE
feat: run tool with edited inputs

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -256,7 +256,7 @@ The following skills were set as favorites by the user and are also available fo
     });
   });
 
-  it("renders user-edited tool inputs as user messages", async () => {
+  it("folds user-edited tool inputs into the tool result content", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agentConfig = await AgentConfigurationFactory.createTestAgent(
       authenticator,
@@ -276,23 +276,17 @@ The following skills were set as favorites by the user and are also available fo
           functionCallId: "toolu_send_mail",
           internalMCPServerName: "gmail",
           toolName: "send_mail",
-          params: { subject: "Old subject" },
-          userEditedInputs: { subject: "New subject" },
+          params: {
+            to: "recipient@example.com",
+            subject: "Old subject",
+            body: "Old body",
+          },
+          userEditedInputs: {
+            subject: "New subject",
+            body: "New body",
+          },
           status: "succeeded",
           output: "Email sent.",
-        },
-      ],
-      contents: [
-        {
-          step: 0,
-          content: {
-            type: "function_call",
-            value: {
-              id: "toolu_send_mail",
-              name: "gmail__send_mail",
-              arguments: '{"subject":"Old subject"}',
-            },
-          },
         },
       ],
     });
@@ -308,18 +302,9 @@ The following skills were set as favorites by the user and are also available fo
 
     expect(steps).toHaveLength(1);
     expect(steps[0].actions).toHaveLength(1);
-    expect(steps[0].actions[0].toolInputEditMessages).toEqual([
-      {
-        role: "user",
-        name: "system",
-        content: [
-          {
-            type: "text",
-            text: `<dust_system>\nThe user edited the inputs of this pending tool call before approving it.\n\nThe tool was executed with these user-edited input values:\n- subject: "New subject"\n\nThe tool result above corresponds to the edited inputs.\n</dust_system>`,
-          },
-        ],
-      },
-    ]);
+    expect(steps[0].actions[0].result.content).toBe(
+      `The tool was executed with these user-edited input values:\n- body: "New body"\n- subject: "New subject".\nEmail sent.`
+    );
   });
 
   it("renders enabled skills as user messages", async () => {

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -276,14 +276,12 @@ The following skills were set as favorites by the user and are also available fo
           functionCallId: "toolu_send_mail",
           internalMCPServerName: "gmail",
           toolName: "send_mail",
-          params: { subject: "New subject" },
+          params: { subject: "Old subject" },
           userEditedInputs: { subject: "New subject" },
           status: "succeeded",
           output: "Email sent.",
         },
       ],
-      // The function call the model emitted still carries the original inputs; only the action
-      // params reflect the user's edit.
       contents: [
         {
           step: 0,

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -256,6 +256,74 @@ The following skills were set as favorites by the user and are also available fo
     });
   });
 
+  it("renders user-edited tool inputs as user messages", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Test Agent",
+        description: "A test agent for editable tool input rendering",
+      }
+    );
+    const model = getSupportedModelConfig(agentConfig.model);
+    assert(model, "Expected a supported model configuration.");
+
+    const message = mockFullAgentMessage({
+      configuration: agentConfig,
+      actions: [
+        {
+          functionCallName: "gmail__send_mail",
+          functionCallId: "toolu_send_mail",
+          internalMCPServerName: "gmail",
+          toolName: "send_mail",
+          params: { subject: "New subject" },
+          userEditedInputs: { subject: "New subject" },
+          status: "succeeded",
+          output: "Email sent.",
+        },
+      ],
+      // The function call the model emitted still carries the original inputs; only the action
+      // params reflect the user's edit.
+      contents: [
+        {
+          step: 0,
+          content: {
+            type: "function_call",
+            value: {
+              id: "toolu_send_mail",
+              name: "gmail__send_mail",
+              arguments: '{"subject":"Old subject"}',
+            },
+          },
+        },
+      ],
+    });
+
+    const steps = await getSteps(authenticator, {
+      enabledSkillById: new Map(),
+      model,
+      message,
+      workspaceId: "workspace_123",
+      conversationId: "conv_1",
+      onMissingAction: "skip",
+    });
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].actions).toHaveLength(1);
+    expect(steps[0].actions[0].toolInputEditMessages).toEqual([
+      {
+        role: "user",
+        name: "system",
+        content: [
+          {
+            type: "text",
+            text: `<dust_system>\nThe user edited the inputs of this pending tool call before approving it.\n\nThe tool was executed with these user-edited input values:\n- subject: "New subject"\n\nThe tool result above corresponds to the edited inputs.\n</dust_system>`,
+          },
+        ],
+      },
+    ]);
+  });
+
   it("renders enabled skills as user messages", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agentConfig = await AgentConfigurationFactory.createTestAgent(

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -140,9 +140,42 @@ export type Step = {
   actions: {
     call: FunctionCallType;
     result: FunctionMessageTypeModel;
+    toolInputEditMessages: UserMessageTypeModel[];
     enabledSkillMessages: UserMessageTypeModel[];
   }[];
 };
+
+function formatToolInputValueForModel(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function renderToolInputEditMessagesForAction(
+  action: AgentMCPActionWithOutputType
+): UserMessageTypeModel[] {
+  if (!action.userEditedInputs) {
+    return [];
+  }
+
+  const editedInputLines = Object.entries(action.userEditedInputs).map(
+    ([key, value]) => `- ${key}: ${formatToolInputValueForModel(value)}`
+  );
+  if (editedInputLines.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      role: "user",
+      name: "system",
+      content: [
+        {
+          type: "text",
+          text: `<dust_system>\nThe user edited the inputs of this pending tool call before approving it.\n\nThe tool was executed with these user-edited input values:\n${editedInputLines.join("\n")}\n\nThe tool result above corresponds to the edited inputs.\n</dust_system>`,
+        },
+      ],
+    },
+  ];
+}
 
 function renderEnabledSkillMessagesForAction(
   action: AgentMCPActionWithOutputType,
@@ -298,6 +331,7 @@ export async function getSteps(
       result: await renderActionForMultiActionsModel(auth, action, model, {
         conversationId,
       }),
+      toolInputEditMessages: renderToolInputEditMessagesForAction(action),
       enabledSkillMessages: renderEnabledSkillMessagesForAction(action, {
         enabledSkillById,
       }),
@@ -305,7 +339,12 @@ export async function getSteps(
     { concurrency: RENDER_ACTIONS_CONCURRENCY }
   );
 
-  for (const { action, result, enabledSkillMessages } of renderedActions) {
+  for (const {
+    action,
+    result,
+    toolInputEditMessages,
+    enabledSkillMessages,
+  } of renderedActions) {
     const stepIndex = action.step;
     stepByStepIndex[stepIndex] = stepByStepIndex[stepIndex] || emptyStep();
     stepByStepIndex[stepIndex].actions.push({
@@ -315,6 +354,7 @@ export async function getSteps(
         arguments: JSON.stringify(action.params),
       },
       result,
+      toolInputEditMessages,
       enabledSkillMessages,
     });
   }
@@ -386,6 +426,7 @@ export async function getSteps(
                   function_call_id: functionCall.id,
                   content: "Error: tool execution failed",
                 },
+                toolInputEditMessages: [],
                 enabledSkillMessages: [],
               });
             }

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -140,7 +140,6 @@ export type Step = {
   actions: {
     call: FunctionCallType;
     result: FunctionMessageTypeModel;
-    toolInputEditMessages: UserMessageTypeModel[];
     enabledSkillMessages: UserMessageTypeModel[];
   }[];
 };
@@ -149,32 +148,21 @@ function formatToolInputValueForModel(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function renderToolInputEditMessagesForAction(
+function renderUserEditedInputsNote(
   action: AgentMCPActionWithOutputType
-): UserMessageTypeModel[] {
+): string | null {
   if (!action.userEditedInputs) {
-    return [];
+    return null;
   }
 
-  const editedInputLines = Object.entries(action.userEditedInputs).map(
-    ([key, value]) => `- ${key}: ${formatToolInputValueForModel(value)}`
-  );
+  const editedInputLines = Object.entries(action.userEditedInputs)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, value]) => `- ${key}: ${formatToolInputValueForModel(value)}`);
   if (editedInputLines.length === 0) {
-    return [];
+    return null;
   }
 
-  return [
-    {
-      role: "user",
-      name: "system",
-      content: [
-        {
-          type: "text",
-          text: `<dust_system>\nThe user edited the inputs of this pending tool call before approving it.\n\nThe tool was executed with these user-edited input values:\n${editedInputLines.join("\n")}\n\nThe tool result above corresponds to the edited inputs.\n</dust_system>`,
-        },
-      ],
-    },
-  ];
+  return `The tool was executed with these user-edited input values:\n${editedInputLines.join("\n")}.`;
 }
 
 function renderEnabledSkillMessagesForAction(
@@ -231,6 +219,10 @@ async function renderActionForMultiActionsModel(
     action.output?.map(rewriteContentForModel) ?? []
   );
 
+  // When the user edited the tool inputs before approving, the result is prepended with a note so
+  // the model knows which input values the tool actually ran with.
+  const editedInputsNote = renderUserEditedInputsNote(action);
+
   // Vision-capable models receive images as a structured payload with the text interleaved. This is
   // the one case that needs async signed URLs, so it stays here rather than in the shared text view.
   // Every other case delegates to renderToolResultForModelAsText below.
@@ -238,7 +230,9 @@ async function renderActionForMultiActionsModel(
     model.supportsVision &&
     outputItems.some((item) => isModelVisionImage(item))
   ) {
-    const contentArray: Content[] = [];
+    const contentArray: Content[] = editedInputsNote
+      ? [{ type: "text", text: editedInputsNote }]
+      : [];
     for (const item of outputItems) {
       if (isTextContent(item)) {
         contentArray.push({ type: "text", text: item.text });
@@ -279,11 +273,15 @@ async function renderActionForMultiActionsModel(
     };
   }
 
+  const resultText = renderToolResultForModelAsText(action);
+
   return {
     role: "function" as const,
     name: action.functionCallName,
     function_call_id: action.functionCallId,
-    content: renderToolResultForModelAsText(action),
+    content: editedInputsNote
+      ? `${editedInputsNote}\n${resultText}`
+      : resultText,
   };
 }
 
@@ -331,7 +329,6 @@ export async function getSteps(
       result: await renderActionForMultiActionsModel(auth, action, model, {
         conversationId,
       }),
-      toolInputEditMessages: renderToolInputEditMessagesForAction(action),
       enabledSkillMessages: renderEnabledSkillMessagesForAction(action, {
         enabledSkillById,
       }),
@@ -339,12 +336,7 @@ export async function getSteps(
     { concurrency: RENDER_ACTIONS_CONCURRENCY }
   );
 
-  for (const {
-    action,
-    result,
-    toolInputEditMessages,
-    enabledSkillMessages,
-  } of renderedActions) {
+  for (const { action, result, enabledSkillMessages } of renderedActions) {
     const stepIndex = action.step;
     stepByStepIndex[stepIndex] = stepByStepIndex[stepIndex] || emptyStep();
     stepByStepIndex[stepIndex].actions.push({
@@ -354,7 +346,6 @@ export async function getSteps(
         arguments: JSON.stringify(action.params),
       },
       result,
-      toolInputEditMessages,
       enabledSkillMessages,
     });
   }
@@ -426,7 +417,6 @@ export async function getSteps(
                   function_call_id: functionCall.id,
                   content: "Error: tool execution failed",
                 },
-                toolInputEditMessages: [],
                 enabledSkillMessages: [],
               });
             }

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -387,7 +387,6 @@ describe("renderAllMessages", () => {
                 function_call_id: "toolu_123",
                 content: "result",
               },
-              toolInputEditMessages: [],
               enabledSkillMessages: [],
             },
           ],
@@ -442,7 +441,6 @@ describe("renderAllMessages", () => {
                 function_call_id: "toolu_123",
                 content: "result",
               },
-              toolInputEditMessages: [],
               enabledSkillMessages: [],
             },
           ],
@@ -466,7 +464,7 @@ describe("renderAllMessages", () => {
     });
   });
 
-  it("renders tool input edit messages and enabled skill messages after tool results", async () => {
+  it("renders enabled skill messages after tool results", async () => {
     const conversation = createConversation([
       { type: "agent", visibility: "visible" },
     ]);
@@ -490,18 +488,6 @@ describe("renderAllMessages", () => {
               name: "skill_management__enable_skill",
               arguments: '{"skillName":"commit"}',
             },
-            toolInputEditMessages: [
-              {
-                role: "user",
-                name: "system",
-                content: [
-                  {
-                    type: "text",
-                    text: "<dust_system>Tool input edit</dust_system>",
-                  },
-                ],
-              },
-            ],
             enabledSkillMessages: [
               {
                 role: "user",
@@ -536,19 +522,8 @@ describe("renderAllMessages", () => {
       "assistant",
       "function",
       "user",
-      "user",
     ]);
-    const toolInputEditMessage = result[2];
-    expect(toolInputEditMessage?.role).toBe("user");
-    if (!toolInputEditMessage || toolInputEditMessage.role !== "user") {
-      throw new Error("Expected a tool input edit message.");
-    }
-    expect(toolInputEditMessage.content[0]).toEqual({
-      type: "text",
-      text: "<dust_system>Tool input edit</dust_system>",
-    });
-
-    const enabledSkillMessage = result[3];
+    const enabledSkillMessage = result[2];
     expect(enabledSkillMessage?.role).toBe("user");
     if (!enabledSkillMessage || enabledSkillMessage.role !== "user") {
       throw new Error("Expected a follow-up user message.");

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -387,6 +387,7 @@ describe("renderAllMessages", () => {
                 function_call_id: "toolu_123",
                 content: "result",
               },
+              toolInputEditMessages: [],
               enabledSkillMessages: [],
             },
           ],
@@ -441,6 +442,7 @@ describe("renderAllMessages", () => {
                 function_call_id: "toolu_123",
                 content: "result",
               },
+              toolInputEditMessages: [],
               enabledSkillMessages: [],
             },
           ],
@@ -464,7 +466,7 @@ describe("renderAllMessages", () => {
     });
   });
 
-  it("renders enabled skill messages after tool results", async () => {
+  it("renders tool input edit messages and enabled skill messages after tool results", async () => {
     const conversation = createConversation([
       { type: "agent", visibility: "visible" },
     ]);
@@ -488,6 +490,18 @@ describe("renderAllMessages", () => {
               name: "skill_management__enable_skill",
               arguments: '{"skillName":"commit"}',
             },
+            toolInputEditMessages: [
+              {
+                role: "user",
+                name: "system",
+                content: [
+                  {
+                    type: "text",
+                    text: "<dust_system>Tool input edit</dust_system>",
+                  },
+                ],
+              },
+            ],
             enabledSkillMessages: [
               {
                 role: "user",
@@ -522,8 +536,19 @@ describe("renderAllMessages", () => {
       "assistant",
       "function",
       "user",
+      "user",
     ]);
-    const enabledSkillMessage = result[2];
+    const toolInputEditMessage = result[2];
+    expect(toolInputEditMessage?.role).toBe("user");
+    if (!toolInputEditMessage || toolInputEditMessage.role !== "user") {
+      throw new Error("Expected a tool input edit message.");
+    }
+    expect(toolInputEditMessage.content[0]).toEqual({
+      type: "text",
+      text: "<dust_system>Tool input edit</dust_system>",
+    });
+
+    const enabledSkillMessage = result[3];
     expect(enabledSkillMessage?.role).toBe("user");
     if (!enabledSkillMessage || enabledSkillMessage.role !== "user") {
       throw new Error("Expected a follow-up user message.");

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -118,15 +118,11 @@ function renderAgentSteps(
         } satisfies AssistantContentMessageTypeModel);
       }
 
-      // Tool calls must be immediately followed by their results; synthetic user messages come after.
+      // Tool calls must be immediately followed by their results; skill messages come after.
       for (const { result } of step.actions) {
         messages.push(result);
       }
-      for (const {
-        toolInputEditMessages,
-        enabledSkillMessages,
-      } of step.actions) {
-        messages.push(...toolInputEditMessages);
+      for (const { enabledSkillMessages } of step.actions) {
         messages.push(...enabledSkillMessages);
       }
     }

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -118,11 +118,15 @@ function renderAgentSteps(
         } satisfies AssistantContentMessageTypeModel);
       }
 
-      // Tool calls must be immediately followed by their results, skill messages come after.
+      // Tool calls must be immediately followed by their results; synthetic user messages come after.
       for (const { result } of step.actions) {
         messages.push(result);
       }
-      for (const { enabledSkillMessages } of step.actions) {
+      for (const {
+        toolInputEditMessages,
+        enabledSkillMessages,
+      } of step.actions) {
+        messages.push(...toolInputEditMessages);
         messages.push(...enabledSkillMessages);
       }
     }

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -63,9 +63,13 @@ export async function* runToolWithStreaming(
 
   const signal = options?.signal;
 
-  // Inputs as issued in the run context.
+  // Inputs as issued in the run context. For agent-loop runs, user-edited inputs (if any)
+  // override the augmented inputs.
   const inputs = isAgentLoopRunContext(runContext)
-    ? runContext.action.augmentedInputs
+    ? {
+        ...runContext.action.augmentedInputs,
+        ...(runContext.action.userEditedInputs ?? {}),
+      }
     : runContext.action.inputs;
 
   const localLogger = logger.child({

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1477,6 +1477,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       toolName,
       mcpServerId,
       params: this.augmentedInputs,
+      userEditedInputs: this.userEditedInputs,
       status: this.status,
       step: this.stepContent.step,
       executionDurationMs: this.executionDurationMs,

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -133,6 +133,7 @@ export function mockAction(params: {
   functionCallName: string;
   status: "succeeded" | "failed";
   params?: Record<string, unknown>;
+  userEditedInputs?: Record<string, unknown> | null;
   output?: string | CallToolResult["content"] | null;
   internalMCPServerName?: AgentMCPActionWithOutputType["internalMCPServerName"];
   toolName?: string;
@@ -158,6 +159,7 @@ export function mockAction(params: {
     functionCallName: params.functionCallName,
     functionCallId: params.functionCallId ?? "",
     params: params.params ?? {},
+    userEditedInputs: params.userEditedInputs ?? null,
     citationsAllocated: params.citationsAllocated ?? 0,
     status,
     step: params.step ?? 0,

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -19,6 +19,7 @@ export type AgentMCPActionType = {
   functionCallId: string;
 
   params: Record<string, unknown>;
+  userEditedInputs?: Record<string, unknown> | null;
   citationsAllocated: number;
   status: ToolExecutionStatus;
   step: number;


### PR DESCRIPTION
## Description

This PR enables MCP tool execution to use user-edited inputs when present, and informs the model about those edits.

- In `run_tool.ts`, merges `userEditedInputs` on top of `augmentedInputs` so the tool is executed with the user's overrides.
- ~~In conversation rendering, adds `toolInputEditMessages` — a synthetic user/system message injected after tool results to tell the model which inputs were edited by the user before approval.~~ Adds a note to the rendered tool output to explain that the inputs were changed. This is better than the previous implementation because it allows the message to be pruned.

## Tests

Manually + unit tests added.

## Risks
Low.

## Deploy Plan
Standard deployment.

