### PR TITLE
feat: use edited input in tool activity

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -164,12 +164,16 @@ function MCPActionDetailsInner({
   messageStatus,
 }: MCPActionDetailsProps) {
   const {
-    params,
+    params: originalParams,
     status,
     output: baseOutput,
     internalMCPServerName,
     toolName,
   } = action;
+  const params = {
+    ...originalParams,
+    ...(action.userEditedInputs ?? {}),
+  };
 
   const [output, setOutput] = useState(baseOutput);
 
@@ -419,7 +423,7 @@ function MCPActionDetailsInner({
       lastNotification={lastNotification}
       messageStatus={messageStatus}
       displayContext={displayContext}
-      action={{ ...action, output }}
+      action={{ ...action, params, output }}
     />
   );
 }

--- a/front/lib/api/assistant/conversation/edit_and_validate_action.test.ts
+++ b/front/lib/api/assistant/conversation/edit_and_validate_action.test.ts
@@ -175,6 +175,14 @@ describe("editAndValidateAction", () => {
     expect(action.userEditedInputs).toEqual({
       subject: "New subject",
     });
+    expect(action.toJSON().params).toEqual({
+      subject: "Old subject",
+      to: "user@example.com",
+      body: "Hello",
+    });
+    expect(action.toJSON().userEditedInputs).toEqual({
+      subject: "New subject",
+    });
     expect(action.status).toBe("ready_allowed_explicitly");
 
     const stepContentValue = await reloadStepContentValue(stepContentModelId);

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1494,12 +1494,16 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     internalMCPServerName: InternalMCPServerNameType | null,
     toolName: string
   ): ToolDisplayLabels | null {
+    const inputs = {
+      ...this.augmentedInputs,
+      ...(this.userEditedInputs ?? {}),
+    };
     return (
       getToolDisplayLabels({
         internalMCPServerName,
         mcpServerName: this.toolConfiguration.mcpServerName,
         toolName,
-        inputs: this.augmentedInputs,
+        inputs,
       }) ??
       this.toolConfiguration.displayLabels ??
       null


### PR DESCRIPTION
## Description

This PR updates the tool activity display to show user-edited inputs instead of the original AI-generated parameters when a user has modified tool inputs before execution.

- Merges `userEditedInputs` on top of `params` in `MCPActionDetails` before passing them to the activity display components
- Exposes `userEditedInputs` in `AgentMCPActionResource.toJSON()` and uses merged inputs for `getToolDisplayLabels`

## Tests

Manually. Unit tests updated to assert that `params` retains the original values while `userEditedInputs` holds only the overrides.

## Risks
Low.

## Deploy Plan
Standard deployment.

