### PR TITLE
Update viz/frame instructions to accurately describe network restrictions

### DIFF
--- a/front/lib/api/actions/servers/common/viz/instructions.ts
+++ b/front/lib/api/actions/servers/common/viz/instructions.ts
@@ -5,7 +5,7 @@ export const VIZ_REACT_COMPONENT_GUIDELINES = `
 - The generated component should always be exported as default.
 - All code must be wrapped in a proper React function component - never generate standalone JSX outside a component.
 - When displaying text with < or > symbols in JSX, use HTML entities: &lt; for < and &gt; for >, or wrap in curly braces like {"< 100"}.
-- There is no internet access in the visualization environment.
+- Outbound network requests (fetch, XHR, WebSocket) are blocked. connect-src is restricted to the Dust service only. External images can be rendered via <img src="https://..."> tags.
 - External links: All anchor tags (<a>) with external URLs must include target="_blank" attribute since content is rendered inside an iframe.
 - Supported React features:
   - React elements, e.g. \`<strong>Hello World!</strong>\`.
@@ -80,7 +80,7 @@ export const VIZ_FILE_HANDLING_GUIDELINES = `
 - Using image files from the conversation:
   - Always load images via \`useFile()\` to obtain a \`File\` object — never reference images directly by URL/path or by copying the \`<attachment/>\` tag contents.
   - Create a local object URL from the \`File\` when rendering (e.g. \`const src = URL.createObjectURL(file)\`).
-  - Use the resulting object URL for \`<img src={src} alt="..." />\` or as a background image; do not attempt to fetch remote images (no internet access).
+  - Use the resulting object URL for \`<img src={src} alt="..." />\` or as a background image.
   - When creating custom components that render files, always use \`fileId\` as the prop name for file identifiers (e.g., \`<EventPhoto fileId="fil_abc123" caption="..." />\` or \`<EventPhoto fileId="conversation/photo.jpg" caption="..." />\`). This naming convention ensures proper file prefetching during server-side rendering. The prop accepts either a file ID or a scoped file path.
 - Importing other frames as React components:
   - Another frame can be imported directly as a React component using a standard ES import, with either its file ID (\`import MyComponent from "fil_abc123"\`) or its scoped file path (\`import MyComponent from "conversation/MyFrame.tsx"\`).
@@ -127,7 +127,7 @@ export const VIZ_LIBRARY_USAGE = `
 
 export const VIZ_MISCELLANEOUS_GUIDELINES = `
 - Miscellaneous:
-  - Images from the web cannot be rendered or used in the visualization (no internet access).
+  - Outbound network requests (fetch, XHR, WebSocket) are blocked. External images can be rendered via <img> tags with a direct URL.
   - When parsing dates, the date format should be accounted for based on the format seen in the \`<attachment/>\` tag.
   - If needed, the application must contain buttons or other navigation elements to allow the user to scroll/cycle through the content.
 `;

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -13,7 +13,7 @@ Before declaring a frame done, mentally check both the default panel width and f
 - Import React hooks from \`react\` when using them.
 - Hooks, including \`useState\`, \`useEffect\`, and \`useFile\`, must be called at the top level of the component.
 - \`React.createElement\` is not supported.
-- There is no internet access in the frame environment.
+- Outbound network requests (fetch, XHR, WebSocket) are blocked. connect-src is restricted to the Dust service only. External images can be rendered via <img src="https://..."> tags.
 - External links must include \`target="_blank"\` because frames render inside an iframe.
 - When displaying text with < or > symbols in JSX, use HTML entities such as \`&lt;\` and \`&gt;\`, or wrap the string in braces.
 
@@ -100,7 +100,7 @@ The same decision rule applies regardless of where the data came from:
 - Never use bare \`conversation/filename\` or \`pod/filename\` paths. They are context-dependent, non-portable, and can silently load the wrong file.
 - Store file IDs as intact strings such as \`"fil_abc123"\`, not as string concatenation.
 - \`file.text()\` is async. Await it inside \`useEffect\`; never call it directly in render logic.
-- For images, always load with \`useFile\`, create a local object URL with \`URL.createObjectURL(file)\`, and render that URL in \`<img>\` or background styles. Do not fetch remote images.
+- For images from the conversation, load with \`useFile\`, create a local object URL with \`URL.createObjectURL(file)\`, and render that URL in \`<img>\` or background styles. External images can be rendered directly via \`<img src="https://...">\`.
 - Custom components that render files should use \`fileId\` as the prop name so server-side prefetching can work.
 - Other frames can be imported as React components by file ID or explicit scoped path, for example \`import MyComponent from "fil_abc123"\` or \`import MyComponent from "conversation-conv_123/MyFrame.tsx"\`. Transitive imports are supported.
 - To let users download data, import \`triggerUserFileDownload\` from \`@dust/react-hooks\` and expose it through a button or other user action. Never auto-trigger downloads.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR replaces "no internet access" with the accurate constraints: outbound network requests (fetch, XHR, WebSocket) are blocked via `connect-src: self`, but external images can be rendered directly via `<img src="https://...">` tags since `img-src` is unrestricted. Updated image guidance to distinguish between conversation images (use `useFile`) and external images (direct URL in `<img>` is supported).

### Context

The viz iframe CSP (`connect-src 'self'`) blocks outbound fetch/XHR calls but does not restrict `img-src`. The previous instructions incorrectly stated "no internet access" which prevented the LLM from referencing external image URLs even though they render fine.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
