### PR TITLE
Remove credit cost dropdown icon

### DIFF
--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -2,7 +2,6 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import { ActionCreditCoinsIcon } from "@dust-tt/sparkle";
 
 const CREDIT_COST_COPY = {
   label: "Message credit cost",
@@ -31,7 +30,6 @@ export function useCreditCostMenuItem({
 
   return {
     label,
-    icon: ActionCreditCoinsIcon,
     endComponent: formatCredits(credits),
     tooltip,
     className:


### PR DESCRIPTION
## Description

Removes the credit coin icon from the read-only `Message credit cost` item in the agent message dropdown menu, while keeping the label, formatted credit value, and tooltip unchanged.

## Tests

- Ran `git diff --check` in the Computer.
- No local UI validation was run in the Computer.

## Risk

Low risk. This is a small UI-only change that removes an optional dropdown item icon and leaves the existing cost display behavior intact. Safe to rollback by restoring the icon prop/import.

## Deploy Plan

Deploy with the normal web application release process after PR CI passes.
