### PR TITLE
Fix renderConversationAsText truncation (last message)

### DIFF
--- a/front/lib/api/assistant/conversation/render_as_text.ts
+++ b/front/lib/api/assistant/conversation/render_as_text.ts
@@ -134,13 +134,23 @@ export function renderConversationAsText(
     }
   }
 
-  if (truncatedByTotalChars) {
-    parts.unshift(
-      `(conversation content truncated at ${options.truncateTotalChars} chars)\n`
-    );
+  let join = parts.join("\n");
+
+  if (
+    options.truncateTotalChars !== undefined &&
+    (truncatedByTotalChars || join.length > options.truncateTotalChars)
+  ) {
+    // If we exceeded, reduce the string by removing the first characters.
+    join =
+      options.truncateTotalChars === 0
+        ? ""
+        : join.slice(-options.truncateTotalChars);
+    join =
+      `(conversation content truncated at ${options.truncateTotalChars} chars)\n` +
+      join;
   }
 
-  return parts.join("\n");
+  return join;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/8679

Ensure we truncate even if the BULK of the data comes from the latest message.

Evidence log that this is possible: [logs](https://app.datadoghq.eu/logs?query=service%3Afront-agent-loop-worker%20%22Compaction%20generation%20failed%22%20%22prompt%20is%20too%20long%22&agg_m=count&agg_m_source=base&agg_q=%40workspaceId&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ6JKoOJr-a_ZwAAABhBWjZKS3BhSkFBQzV1bFNIQi16cUd3QUUAAAAkMDE5ZTg5MmItYTczZi00MmE3LWFlYTgtZDlmMzljM2ViMWQwAAkbog&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1780302310078&to_ts=1780907110078&live=true)

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`