### PR TITLE
Remove cost icon from message dropdown

### DIFF
--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -26,12 +26,10 @@ export function useCreditCostMenuItem({
     return null;
   }
 
-  const { label, tooltip } = CREDIT_COST_COPY;
-
   return {
-    label,
+    label: CREDIT_COST_COPY.label,
     endComponent: formatCredits(credits),
-    tooltip,
+    tooltip: CREDIT_COST_COPY.tooltip,
     className:
       "cursor-default font-normal text-muted-foreground hover:bg-transparent focus:bg-transparent dark:text-muted-foreground-night dark:hover:bg-transparent dark:focus:bg-transparent",
     onSelect: (e) => e.preventDefault(),

--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -2,7 +2,6 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import { ActionCreditCoinsIcon } from "@dust-tt/sparkle";
 
 const CREDIT_COST_COPY = {
   label: "Message credit cost",
@@ -31,7 +30,6 @@ export function useCreditCostMenuItem({
 
   return {
     label,
-    icon: ActionCreditCoinsIcon,
     endComponent: formatCredits(credits),
     tooltip,
     className:

--- a/front/lib/metronome/mau_contract.test.ts
+++ b/front/lib/metronome/mau_contract.test.ts
@@ -7,10 +7,17 @@ vi.mock("@app/lib/metronome/client", () => ({
   updateSubscriptionQuantity: vi.fn(),
 }));
 
-vi.mock("@app/lib/metronome/constants", () => ({
-  getProductMauId: () => "mau-product",
-  getProductMauTierIds: () => ["mau-tier-1", "mau-tier-2", "mau-tier-3"],
-}));
+vi.mock("@app/lib/metronome/constants", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/constants")
+  >("@app/lib/metronome/constants");
+
+  return {
+    ...actual,
+    getProductMauId: () => "mau-product",
+    getProductMauTierIds: () => ["mau-tier-1", "mau-tier-2", "mau-tier-3"],
+  };
+});
 
 // CachedContract has many required fields the function doesn't read; cast
 // partial fixtures through `unknown` so the test stays focused on the


### PR DESCRIPTION
## Description

Remove the credit cost icon from the assistant message dropdown menu while keeping the credit cost label, value, and tooltip visible.

Also fix an unrelated MAU contract test mock that was failing in the front test shard because it fully mocked `@app/lib/metronome/constants` without preserving newly required exports.

## Tests

- Ran `git diff --check` in the Computer.
- GitHub PR CI is being re-run after fixing the failing test mock.

## Risk

Low. The UI change only removes an icon prop from the existing credit cost dropdown item. The test change keeps the mock focused on MAU product IDs while preserving the rest of the constants module exports.

## Deploy Plan

Deploy with the regular web app release process. Final validation is expected through PR CI checks.
