### PR TITLE
[Front CI] Fix MAU contract constants mock

### DIFF
--- a/front/lib/metronome/mau_contract.test.ts
+++ b/front/lib/metronome/mau_contract.test.ts
@@ -7,10 +7,15 @@ vi.mock("@app/lib/metronome/client", () => ({
   updateSubscriptionQuantity: vi.fn(),
 }));
 
-vi.mock("@app/lib/metronome/constants", () => ({
-  getProductMauId: () => "mau-product",
-  getProductMauTierIds: () => ["mau-tier-1", "mau-tier-2", "mau-tier-3"],
-}));
+vi.mock("@app/lib/metronome/constants", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/metronome/constants")>();
+  return {
+    ...actual,
+    getProductMauId: () => "mau-product",
+    getProductMauTierIds: () => ["mau-tier-1", "mau-tier-2", "mau-tier-3"],
+  };
+});
 
 // CachedContract has many required fields the function doesn't read; cast
 // partial fixtures through `unknown` so the test stays focused on the

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -10,9 +10,6 @@ export default defineConfig({
     setupFiles: "./vite.setup.ts",
     globalSetup: "./vite.globalSetup.ts",
     passWithNoTests: true,
-    include: [
-      "{components,hooks,lib,logger,scripts,temporal,tests,types}/**/*.{test,spec}.{ts,tsx,js,jsx}",
-    ],
     exclude: ["**/node_modules/**", "**/dist/**"],
     maxConcurrency: 20,
 

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -10,6 +10,9 @@ export default defineConfig({
     setupFiles: "./vite.setup.ts",
     globalSetup: "./vite.globalSetup.ts",
     passWithNoTests: true,
+    include: [
+      "{components,hooks,lib,logger,scripts,temporal,tests,types}/**/*.{test,spec}.{ts,tsx,js,jsx}",
+    ],
     exclude: ["**/node_modules/**", "**/dist/**"],
     maxConcurrency: 20,
 


### PR DESCRIPTION
## Description
Fixes the front CI failure observed on https://github.com/dust-tt/dust/pull/26816.

The test failure was:

```text
node_modules/thread-stream/test/ts.test.ts:4 | [vitest] No "USAGE_TYPE_GROUP_KEY" export is defined on the "@app/lib/metronome/constants" mock. Did you forget to return it from "vi.mock"?
```

Root cause:`front/lib/metronome/mau_contract.test.ts` replaced the whole `@app/lib/metronome/constants` module with a small mock that only exported the MAU helpers used by the test. In the broader shard, imported Metronome/Stripe setup code also needs `USAGE_TYPE_GROUP_KEY`. Since the mock replaced the whole module, that export disappeared and Vitest failed while loading the suite.

The fix changes the test to partially mock `@app/lib/metronome/constants`: it keeps the real exports, and only overrides `getProductMauId` and `getProductMauTierIds` for the test. So future constants that unrelated imported code needs remain available.

## Risks
Blast radius: MAU contract unit test mock only.
Risk: low

## Deploy Plan
- pmrr
- merge only

## Test
- [x] `npx vitest run lib/metronome/contracts.test.ts lib/metronome/mau_contract.test.ts lib/metronome/payg_excess_credits.test.ts --reporter=verbose`