### PR TITLE
prevent ERR_STREAM_UNABLE_TO_PIPE crash when client disconnects from GCS stream

### DIFF
--- a/front-api/routes/v1/viz/files/[fileId].ts
+++ b/front-api/routes/v1/viz/files/[fileId].ts
@@ -5,6 +5,7 @@ import { assertVizFileAuthorized } from "@app/lib/api/viz/authorized_file_access
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
 import { isInteractiveContentType } from "@app/types/files";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { unauthedApp } from "@front-api/middlewares/ctx";
@@ -148,6 +149,9 @@ app.get("/:fileId", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const readStream = targetFile.getSharedReadStream(owner, "original");
+  readStream.on("error", (err) =>
+    logger.error({ err, fileId }, "Error streaming viz file")
+  );
   return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: { "Content-Type": targetFile.contentType },

--- a/front-api/routes/v1/viz/files/[fileId].ts
+++ b/front-api/routes/v1/viz/files/[fileId].ts
@@ -5,8 +5,8 @@ import { assertVizFileAuthorized } from "@app/lib/api/viz/authorized_file_access
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
-import logger from "@app/logger/logger";
 import { isInteractiveContentType } from "@app/types/files";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -148,21 +148,7 @@ app.get("/:fileId", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const readStream = targetFile.getSharedReadStream(owner, "original");
-  const webStream = new ReadableStream({
-    start(controller) {
-      readStream.on("data", (chunk) => controller.enqueue(chunk));
-      readStream.on("end", () => controller.close());
-      readStream.on("error", (err) => {
-        logger.error({ err, fileId }, "Error streaming viz file");
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readStream.destroy();
-    },
-  });
-
-  return new Response(webStream, {
+  return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: { "Content-Type": targetFile.contentType },
   });

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -132,6 +133,9 @@ app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
   }
   const contentType = contentTypeResult.value ?? "application/octet-stream";
   const readStream = bucket.file(mountFilePath).createReadStream();
+  readStream.on("error", (err) =>
+    logger.error({ err, mountFilePath }, "Error streaming conversation file (GCS)")
+  );
   return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: { "Content-Type": contentType },

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -134,7 +134,10 @@ app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
   const contentType = contentTypeResult.value ?? "application/octet-stream";
   const readStream = bucket.file(mountFilePath).createReadStream();
   readStream.on("error", (err) =>
-    logger.error({ err, mountFilePath }, "Error streaming conversation file (GCS)")
+    logger.error(
+      { err, mountFilePath },
+      "Error streaming conversation file (GCS)"
+    )
   );
   return new Response(readableToReadableStream(readStream), {
     status: 200,

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -4,7 +4,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import logger from "@app/logger/logger";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -132,25 +132,7 @@ app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
   }
   const contentType = contentTypeResult.value ?? "application/octet-stream";
   const readStream = bucket.file(mountFilePath).createReadStream();
-
-  const webStream = new ReadableStream({
-    start(controller) {
-      readStream.on("data", (chunk) => controller.enqueue(chunk));
-      readStream.on("end", () => controller.close());
-      readStream.on("error", (err) => {
-        logger.error(
-          { err, mountFilePath },
-          "Error streaming conversation file (GCS)"
-        );
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readStream.destroy();
-    },
-  });
-
-  return new Response(webStream, {
+  return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: { "Content-Type": contentType },
   });

--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -15,6 +15,7 @@ import {
   isConversationFileUseCase,
   isPubliclySupportedUseCase,
 } from "@app/types/files";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { createHono } from "@front-api/lib/hono";
 import type { PublicApiCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -118,17 +119,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
       auth,
       version,
     });
-    const webStream = new ReadableStream({
-      start(controller) {
-        readStream.on("data", (chunk) => controller.enqueue(chunk));
-        readStream.on("end", () => controller.close());
-        readStream.on("error", (err) => controller.error(err));
-      },
-      cancel() {
-        readStream.destroy();
-      },
-    });
-    return new Response(webStream, {
+    return new Response(readableToReadableStream(readStream), {
       status: 200,
       headers: { "Content-Type": file.contentType },
     });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -7,9 +7,9 @@ import {
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -94,25 +94,7 @@ app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
 
   const contentType = contentTypeResult.value ?? "application/octet-stream";
   const readStream = bucket.file(normalizedGcsPath).createReadStream();
-
-  const webStream = new ReadableStream({
-    start(controller) {
-      readStream.on("data", (chunk) => controller.enqueue(chunk));
-      readStream.on("end", () => controller.close());
-      readStream.on("error", (err) => {
-        logger.error(
-          { err, gcsPath: normalizedGcsPath },
-          "Error streaming conversation file (GCS)"
-        );
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readStream.destroy();
-    },
-  });
-
-  return new Response(webStream, {
+  return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: { "Content-Type": contentType },
   });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -96,7 +96,10 @@ app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
   const contentType = contentTypeResult.value ?? "application/octet-stream";
   const readStream = bucket.file(normalizedGcsPath).createReadStream();
   readStream.on("error", (err) =>
-    logger.error({ err, gcsPath: normalizedGcsPath }, "Error streaming conversation file (GCS)")
+    logger.error(
+      { err, gcsPath: normalizedGcsPath },
+      "Error streaming conversation file (GCS)"
+    )
   );
   return new Response(readableToReadableStream(readStream), {
     status: 200,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/[...rel].ts
@@ -7,6 +7,7 @@ import {
 import { MoveMountFileRequestBodySchema } from "@app/lib/api/files/mount_schemas";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
@@ -94,6 +95,9 @@ app.get("/:rel{.+}", validate("param", ParamsSchema), async (ctx) => {
 
   const contentType = contentTypeResult.value ?? "application/octet-stream";
   const readStream = bucket.file(normalizedGcsPath).createReadStream();
+  readStream.on("error", (err) =>
+    logger.error({ err, gcsPath: normalizedGcsPath }, "Error streaming conversation file (GCS)")
+  );
   return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: { "Content-Type": contentType },

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -4,7 +4,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import logger from "@app/logger/logger";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -97,25 +97,10 @@ app.post(
       `attachment; filename="${encodeURIComponent(fileName)}"`;
 
     const readStream = bucket.file(normalizedPath).createReadStream();
-
-    const webStream = new ReadableStream({
-      start(controller) {
-        readStream.on("data", (chunk) => controller.enqueue(chunk));
-        readStream.on("end", () => controller.close());
-        readStream.on("error", (err) => {
-          logger.error(
-            { err, filePath: normalizedPath },
-            "Error streaming conversation file"
-          );
-          controller.error(err);
-        });
-      },
-      cancel() {
-        readStream.destroy();
-      },
+    return new Response(readableToReadableStream(readStream), {
+      status: 200,
+      headers,
     });
-
-    return new Response(webStream, { status: 200, headers });
   }
 );
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -97,6 +98,9 @@ app.post(
       `attachment; filename="${encodeURIComponent(fileName)}"`;
 
     const readStream = bucket.file(normalizedPath).createReadStream();
+    readStream.on("error", (err) =>
+      logger.error({ err, filePath: normalizedPath }, "Error streaming conversation file")
+    );
     return new Response(readableToReadableStream(readStream), {
       status: 200,
       headers,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/download.ts
@@ -99,7 +99,10 @@ app.post(
 
     const readStream = bucket.file(normalizedPath).createReadStream();
     readStream.on("error", (err) =>
-      logger.error({ err, filePath: normalizedPath }, "Error streaming conversation file")
+      logger.error(
+        { err, filePath: normalizedPath },
+        "Error streaming conversation file"
+      )
     );
     return new Response(readableToReadableStream(readStream), {
       status: 200,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -5,6 +5,7 @@ import {
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
 import { isSupportedImageContentType } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
@@ -130,6 +131,9 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const readStream = bucket.file(normalizedPath).createReadStream();
+  readStream.on("error", (err) =>
+    logger.error({ err, filePath: normalizedPath }, "Error streaming thumbnail (GCS)")
+  );
   return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -5,7 +5,6 @@ import {
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import logger from "@app/logger/logger";
 import { isSupportedImageContentType } from "@app/types/files";
 import { isString } from "@app/types/shared/utils/general";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
@@ -131,25 +130,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const readStream = bucket.file(normalizedPath).createReadStream();
-
-  const webStream = new ReadableStream({
-    start(controller) {
-      readStream.on("data", (chunk) => controller.enqueue(chunk));
-      readStream.on("end", () => controller.close());
-      readStream.on("error", (err) => {
-        logger.error(
-          { err, filePath: normalizedPath },
-          "Error streaming thumbnail (GCS)"
-        );
-        controller.error(err);
-      });
-    },
-    cancel() {
-      readStream.destroy();
-    },
-  });
-
-  return new Response(webStream, {
+  return new Response(readableToReadableStream(readStream), {
     status: 200,
     headers: {
       "Content-Type": contentType,

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/thumbnail.ts
@@ -132,7 +132,10 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
 
   const readStream = bucket.file(normalizedPath).createReadStream();
   readStream.on("error", (err) =>
-    logger.error({ err, filePath: normalizedPath }, "Error streaming thumbnail (GCS)")
+    logger.error(
+      { err, filePath: normalizedPath },
+      "Error streaming thumbnail (GCS)"
+    )
   );
   return new Response(readableToReadableStream(readStream), {
     status: 200,

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -13,6 +13,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { isConversationFileUseCase } from "@app/types/files";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { createHono } from "@front-api/lib/hono";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -217,17 +218,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
       : "original";
 
     const readStream = file.getReadStream({ auth, version });
-    const webStream = new ReadableStream({
-      start(controller) {
-        readStream.on("data", (chunk) => controller.enqueue(chunk));
-        readStream.on("end", () => controller.close());
-        readStream.on("error", (err) => controller.error(err));
-      },
-      cancel() {
-        readStream.destroy();
-      },
-    });
-    return new Response(webStream, {
+    return new Response(readableToReadableStream(readStream), {
       status: 200,
       headers: { "Content-Type": file.contentType },
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -15,8 +15,8 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { APIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { isString } from "@app/types/shared/utils/general";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -130,7 +130,10 @@ app.get(
     const contentType = contentTypeResult.value ?? "application/octet-stream";
     const readStream = bucket.file(normalizedGcsPath).createReadStream();
     readStream.on("error", (err) =>
-      logger.error({ err, gcsPath: normalizedGcsPath }, "Error streaming project file (GCS)")
+      logger.error(
+        { err, gcsPath: normalizedGcsPath },
+        "Error streaming project file (GCS)"
+      )
     );
     return new Response(readableToReadableStream(readStream), {
       status: 200,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -12,9 +12,9 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import type { APIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -128,26 +128,7 @@ app.get(
 
     const contentType = contentTypeResult.value ?? "application/octet-stream";
     const readStream = bucket.file(normalizedGcsPath).createReadStream();
-
-    // Stream the file as the Hono response body.
-    const webStream = new ReadableStream({
-      start(controller) {
-        readStream.on("data", (chunk) => controller.enqueue(chunk));
-        readStream.on("end", () => controller.close());
-        readStream.on("error", (err) => {
-          logger.error(
-            { err, gcsPath: normalizedGcsPath },
-            "Error streaming project file (GCS)"
-          );
-          controller.error(err);
-        });
-      },
-      cancel() {
-        readStream.destroy();
-      },
-    });
-
-    return new Response(webStream, {
+    return new Response(readableToReadableStream(readStream), {
       status: 200,
       headers: { "Content-Type": contentType },
     });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/[...rel].ts
@@ -12,6 +12,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import type { APIErrorResponse } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
@@ -128,6 +129,9 @@ app.get(
 
     const contentType = contentTypeResult.value ?? "application/octet-stream";
     const readStream = bucket.file(normalizedGcsPath).createReadStream();
+    readStream.on("error", (err) =>
+      logger.error({ err, gcsPath: normalizedGcsPath }, "Error streaming project file (GCS)")
+    );
     return new Response(readableToReadableStream(readStream), {
       status: 200,
       headers: { "Content-Type": contentType },

--- a/front/types/shared/utils/streams.test.ts
+++ b/front/types/shared/utils/streams.test.ts
@@ -1,0 +1,82 @@
+import { PassThrough } from "stream";
+import { describe, expect, it } from "vitest";
+
+import { readableToReadableStream } from "./streams";
+
+describe("readableToReadableStream", () => {
+  it("streams data chunks to the web ReadableStream", async () => {
+    const readable = new PassThrough();
+    const webStream = readableToReadableStream<Buffer>(readable);
+    const reader = webStream.getReader();
+
+    readable.push(Buffer.from("hello"));
+    readable.push(Buffer.from(" world"));
+    readable.push(null);
+
+    const chunks: Buffer[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+    }
+
+    expect(Buffer.concat(chunks).toString()).toBe("hello world");
+  });
+
+  it("propagates stream errors to the controller", async () => {
+    const readable = new PassThrough();
+    const webStream = readableToReadableStream(readable);
+    const reader = webStream.getReader();
+
+    const boom = new Error("GCS read error");
+    readable.destroy(boom);
+
+    await expect(reader.read()).rejects.toThrow("GCS read error");
+  });
+
+  it("destroys the readable immediately when cancelled after pipe event", async () => {
+    const readable = new PassThrough();
+    const webStream = readableToReadableStream(readable);
+
+    // Simulate GCS having already called pipeline() — 'pipe' fires after our
+    // listener is registered.
+    readable.emit("pipe");
+
+    const reader = webStream.getReader();
+    await reader.cancel();
+
+    expect(readable.destroyed).toBe(true);
+  });
+
+  it("drains instead of destroying when cancelled before pipe event", async () => {
+    const readable = new PassThrough();
+    // No 'pipe' event yet — simulates client disconnecting before GCS HTTP
+    // response arrives and pipeline() is called.
+
+    const webStream = readableToReadableStream(readable);
+    const reader = webStream.getReader();
+    await reader.cancel();
+
+    // Must NOT be destroyed: calling destroy() before GCS's pipeline() fires
+    // causes an uncaught ERR_STREAM_UNABLE_TO_PIPE that crashes the pod.
+    expect(readable.destroyed).toBe(false);
+    // Must be flowing (resuming to drain) so GCS can complete its setup.
+    expect(readable.readableFlowing).toBe(true);
+  });
+
+  it("destroys after pipe event fires when cancelled pre-pipe", async () => {
+    const readable = new PassThrough();
+
+    const webStream = readableToReadableStream(readable);
+    const reader = webStream.getReader();
+    await reader.cancel();
+
+    // Simulate GCS pipeline() setting up — 'pipe' fires synchronously during it.
+    const src = new PassThrough();
+    src.pipe(readable); // triggers 'pipe' on readable → our once-listener destroys
+
+    expect(readable.destroyed).toBe(true);
+  });
+});

--- a/front/types/shared/utils/streams.ts
+++ b/front/types/shared/utils/streams.ts
@@ -29,7 +29,7 @@ export function readableToReadableStream<T = unknown>(
 
   return new ReadableStream<T>({
     start(controller) {
-      readable.on("data", (chunk) => controller.enqueue(chunk as T));
+      readable.on("data", (chunk: T) => controller.enqueue(chunk));
       readable.on("end", () => controller.close());
       readable.on("error", (err) => controller.error(err));
     },

--- a/front/types/shared/utils/streams.ts
+++ b/front/types/shared/utils/streams.ts
@@ -16,5 +16,38 @@ export function readableStreamToReadable<T = unknown>(
 export function readableToReadableStream<T = unknown>(
   readable: Readable
 ): ReadableStream<T> {
-  return Readable.toWeb(readable) as ReadableStream<T>;
+  // Track whether node:pipeline() has already piped into this readable (GCS calls pipeline()
+  // inside its HTTP onResponse callback). The 'pipe' event fires on the destination synchronously
+  // during pipeline() setup, after the isWritable() check passes. So destroying here is safe and
+  // causes pipeline() to call onComplete(ERR_STREAM_PREMATURE_CLOSE) instead
+  // of throwing ERR_STREAM_UNABLE_TO_PIPE as an uncaught exception.
+  let pipeReceived = false;
+  // Additive: does not replace any existing listeners on the stream.
+  readable.on("pipe", () => {
+    pipeReceived = true;
+  });
+
+  return new ReadableStream<T>({
+    start(controller) {
+      readable.on("data", (chunk) => controller.enqueue(chunk as T));
+      readable.on("end", () => controller.close());
+      readable.on("error", (err) => controller.error(err));
+    },
+    cancel() {
+      readable.removeAllListeners("data");
+      readable.removeAllListeners("end");
+      readable.removeAllListeners("error");
+      readable.removeAllListeners("pipe");
+      readable.on("error", () => {});
+
+      if (pipeReceived) {
+        readable.destroy();
+      } else {
+        // pipeline() hasn't piped into this stream yet. Wait for 'pipe', then destroy immediately.
+        // Stops the GCS transfer with zero bytes read past what was already in-flight.
+        readable.once("pipe", () => readable.destroy());
+        readable.resume();
+      }
+    },
+  });
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a client disconnects mid-download from any file-streaming endpoint, the `front-api` pod used to crash with an uncaught `ERR_STREAM_UNABLE_TO_PIPE` exception. This was partially solved by adding a global event handler for uncaught exceptions. This PR focuses around solving the underlying issue. This is a known unresolved bug in the `@google-cloud/storage` read-stream path (the repo was archived in March 2026 with no fix planned for this case).

The crash path is: `@google-cloud/storage` makes its HTTP request lazily (when reading starts) and sets up an internal `node:pipeline()` call inside its `onResponse` callback. That callback fires asynchronously when Google's servers respond. If the client has already disconnected, our `cancel()` handler calls `readStream.destroy()` first. When `onResponse` then fires and calls `pipeline(rawResponseStream, ..., destroyedThroughStream, onComplete)`, Node.js's `pipelineImpl` detects `throughStream.destroyed === true`, throws `ERR_STREAM_UNABLE_TO_PIPE` synchronously inside an event listener, and the error escapes all try/catch. It becomes an uncaughtException that crashes the pod.

The fix uses the 'pipe' event emitted by Node.js on a stream when `src.pipe(dest)` is called. `pipelineImpl` calls `src.pipe(throughStream)` after its `isWritable(throughStream)` check passes. So `'pipe'` fires synchronously during `pipeline()` setup, at the exact point where it becomes safe to destroy. We track whether 'pipe' has been received: if yes, `destroy()` is safe and stops the GCS transfer immediately; if not, we register a `once('pipe', ...)` listener and call `resume()` to drain, then destroy the moment `pipeline()` fires `'pipe'`. Which happens with essentially zero extra bytes read from GCS since it's the same synchronous pipeline setup tick.

The fix lives in `readableToReadableStream`, which replaces the inline `new ReadableStream({...})` blocks that were spread across various Hono route files, all sharing the same broken `cancel() { readStream.destroy() }` pattern. The existing `Readable.toWeb()` wrapper also had the same bug since Node.js's own implementation calls `destroy()` in its cancel path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
