### PR TITLE
[front] feat: add shared workspaceAdminGuard for internal MCP tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -1,0 +1,104 @@
+import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  buildTools,
+  createToolsRecord,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { Authenticator } from "@app/lib/auth";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Err, Ok } from "@app/types/shared/result";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, expect, it } from "vitest";
+
+// Two artificial tools to exercise the guard's behaviour through the real MCP
+// stack, decoupled from any feature tool: one wraps workspaceAdminGuard, the
+// other (control) does not.
+const TEST_TOOLS_METADATA = createToolsRecord({
+  guarded_tool: {
+    description: "Admin-guarded test tool.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: { running: "Running", done: "Ran" },
+  },
+  open_tool: {
+    description: "Unguarded test tool.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: { running: "Running", done: "Ran" },
+  },
+});
+
+const handlers: ToolHandlers<typeof TEST_TOOLS_METADATA> = {
+  guarded_tool: async (_params, { auth }) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+    return new Ok([{ type: "text" as const, text: "guarded ok" }]);
+  },
+  open_tool: async () => new Ok([{ type: "text" as const, text: "open ok" }]),
+};
+
+const TEST_TOOLS = buildTools(TEST_TOOLS_METADATA, handlers);
+
+async function authForRole(role: MembershipRoleType): Promise<Authenticator> {
+  const workspace = await WorkspaceFactory.basic();
+  await GroupFactory.defaults(workspace);
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role });
+  return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+}
+
+// Stands up an in-memory MCP server with the test tools registered for `auth`,
+// connects a client over the in-memory transport, and calls one tool.
+async function callTestTool(auth: Authenticator, toolName: string) {
+  const server = new McpServer({ name: "admin_guard_test", version: "1.0.0" });
+  for (const tool of TEST_TOOLS) {
+    registerTool(auth, undefined, server, tool, {
+      monitoringName: "admin_guard_test",
+    });
+  }
+
+  const [clientTransport, serverTransport] =
+    InMemoryWithAuthTransport.createLinkedPair();
+  const client = new Client({ name: "admin_guard_test", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  const result = await client.callTool({ name: toolName, arguments: {} });
+  await client.close();
+  return result;
+}
+
+describe("workspaceAdminGuard (via an in-memory MCP tool)", () => {
+  it("lets an admin call a guarded tool", async () => {
+    const auth = await authForRole("admin");
+    const result = await callTestTool(auth, "guarded_tool");
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result.content)).toContain("guarded ok");
+  });
+
+  it("blocks a builder from a guarded tool", async () => {
+    const auth = await authForRole("builder");
+    const result = await callTestTool(auth, "guarded_tool");
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain("admins");
+  });
+
+  it("lets a builder call an unguarded tool", async () => {
+    const auth = await authForRole("builder");
+    const result = await callTestTool(auth, "open_tool");
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result.content)).toContain("open ok");
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -1,3 +1,4 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   getInternalMCPServerInfo,
@@ -10,6 +11,7 @@ import type {
   SingleResourceToolOutput,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
 import { hasNoRequiredProperties } from "@app/lib/utils/json_schemas";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -23,6 +25,18 @@ export function makeInternalMCPServer(
   return new McpServer(serverInfo, {
     instructions: serverInfo.instructions ?? undefined,
   });
+}
+
+// Returns an MCPError when the caller is not a workspace admin, null otherwise.
+// For internal tools that expose workspace-wide data and must enforce admin
+// access independently of skill/agent/server visibility.
+export function workspaceAdminGuard(auth: Authenticator): MCPError | null {
+  if (!auth.isAdmin()) {
+    return new MCPError("This tool is restricted to workspace admins.", {
+      tracked: false,
+    });
+  }
+  return null;
 }
 
 export function makePersonalAuthenticationError(


### PR DESCRIPTION
## Description

Add a reusable workspaceAdminGuard(auth) to mcp_internal_actions/utils.ts, alongside the other shared MCP helpers. It returns an untracked MCPError when the caller is not a workspace admin and null otherwise, so any internal tool exposing workspace-wide data can enforce admin access independently of skill/agent/server visibility.

Tested end-to-end through the real MCP stack (in-memory transport): an artificial server exposes a guarded and an unguarded (control) tool, and we assert an admin can call the guarded tool, a builder is rejected, and a builder can still call the unguarded tool.

This is not used anywhere yet. It will be used to build a `workspace_analytics` skill only available to admins.

## Tests

Behaviour test

## Risk

Low

## Deploy Plan

Front