### PR TITLE
[front] Skip already backfilled skill tool sections

### DIFF
--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -72,6 +72,10 @@ async function processWorkspace(
       continue;
     }
 
+    if (skill.instructions.startsWith(ASSOCIATED_TOOLS_LABEL)) {
+      continue;
+    }
+
     const tools = skill.mcpServerViews.map((view): ToolReference => {
       const viewType = view.toJSON();
 


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/26668.

Avoids duplicating the generated tool-reference section when the skill tool references backfill is rerun on a skill whose instructions already start with `Tools associated with this skill:`.

## Risks
Blast radius: skill tool-reference backfill for custom skills.
Risk: low

## Deploy Plan
- pmrr

## Tests
- [x] `NODE_ENV=test npm test -- lib/skills/tool_references_backfill.test.ts`