### PR TITLE
Add motion/react to frame runtime

### DIFF
--- a/front/lib/api/actions/servers/common/viz/instructions.ts
+++ b/front/lib/api/actions/servers/common/viz/instructions.ts
@@ -53,6 +53,7 @@ export const VIZ_STYLING_GUIDELINES = `
   - Always use padding around plots to ensure elements are fully visible and labels/legends do not overlap with the plot or with each other.
   - Use shadcn's background classes (bg-background, bg-card) instead of hardcoded bg-white for automatic theme compatibility.
   - If you need to generate a legend for a chart, ensure it uses relative positioning or follows the natural flow of the layout, avoiding \`position: absolute\`, to maintain responsiveness and adaptability.
+  - **Animation**: \`motion/react\` is available for animations. Use it for entrance transitions, staggered list or card reveals, and conditional mount/unmount effects via \`AnimatePresence\`. Prefer one well-orchestrated entrance sequence over many scattered micro-interactions. Keep entrance durations between 0.3 s and 0.5 s; interactive feedback between 0.15 s and 0.25 s.
 `;
 
 export const VIZ_FILE_HANDLING_GUIDELINES = `

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -59,6 +59,10 @@ The heading uses an explicit chroma accent (\`text-indigo-700\`). The structural
 - Use shadcn/ui components for a polished baseline. Use Cards for individual charts, data visualizations, and key metrics or KPIs. Do not wrap controls, inputs, navigation, or simple text content in Cards. Avoid nested Cards.
 - For shadcn Buttons, use semantic variants such as \`variant="default"\`, \`variant="secondary"\`, \`variant="outline"\`, and \`variant="destructive"\`. Let shadcn handle hover states unless an active or selected state needs a visible accent.
 
+### Animation
+
+\`motion/react\` is available for animations. Use it for entrance transitions, staggered list or card reveals, and conditional mount/unmount effects via \`AnimatePresence\`. Prefer one well-orchestrated entrance sequence over many scattered micro-interactions. Keep entrance durations between 0.3 s and 0.5 s; interactive feedback between 0.15 s and 0.25 s.
+
 ### Chart Rules
 
 - Use shadcn chart components for charts: \`ChartContainer\`, \`ChartConfig\`, \`ChartTooltip\`, and \`ChartTooltipContent\`.
@@ -128,7 +132,7 @@ These apply to data from any source: the user's prompt, attached files, tool out
 
 - Default output is a single Frame React component with a default export.
 - Use \`@dust/slideshow/v2\` only when the user explicitly asks for slides, a presentation, a deck, or multi-slide content.
-- Imports are limited to \`react\`, \`recharts\`, \`lucide-react\`, \`papaparse\`, \`shadcn\`, \`@viz/lib/utils\`, \`@dust/react-hooks\`, \`@dust/slideshow/v2\`, legacy \`@dust/slideshow/v1\` imports only when editing an existing v1 slideshow, and frame file references.
+- Imports are limited to \`react\`, \`recharts\`, \`lucide-react\`, \`papaparse\`, \`shadcn\`, \`@viz/lib/utils\`, \`@dust/react-hooks\`, \`@dust/slideshow/v2\`, \`motion/react\`, legacy \`@dust/slideshow/v1\` imports only when editing an existing v1 slideshow, and frame file references.
 - No other third-party libraries are installed or available.
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28942,13 +28942,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.5.tgz",
-      "integrity": "sha512-Z2dQ+o7BsfpJI3+u0SQUNCrN+ajCKJen1blC4rCHx1Ta2EOHs+xKJegLT2aaD9iSMbU3OoX+WabQXkloUbZmJQ==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.34.5",
-        "motion-utils": "^12.29.2",
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -37794,12 +37794,12 @@
       }
     },
     "node_modules/motion": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.5.tgz",
-      "integrity": "sha512-N06NLJ9IeBHeielRqIvYvjPfXuRdyTxa+9++BgpGa+hY2D7TcMkI6QzV3jaRuv0aZRXgMa7cPy9YcBUBisPzAQ==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.34.5",
+        "framer-motion": "^12.40.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -37820,18 +37820,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.5.tgz",
-      "integrity": "sha512-k33CsnxO2K3gBRMUZT+vPmc4Utlb5menKdG0RyVNLtlqRaaJPRWlE9fXl8NTtfZ5z3G8TDvqSu0MENLqSTaHZA==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.29.2"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.29.2",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
-      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/mri": {
@@ -55536,6 +55536,7 @@
         "html-to-image": "^1.11.11",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.483.0",
+        "motion": "^12.40.0",
         "next": "^14.2.35",
         "next-themes": "^0.4.6",
         "papaparse": "^5.4.1",

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -28,6 +28,7 @@ import * as shadcnAll from "@viz/components/ui";
 import * as utilsAll from "@viz/lib/utils";
 import { toBlob, toSvg } from "html-to-image";
 import * as lucideAll from "lucide-react";
+import * as motionAll from "motion/react";
 import * as papaparseAll from "papaparse";
 import * as reactAll from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -431,6 +432,7 @@ export function VisualizationWrapper({
           // New location for utils.
           "@viz/lib/utils": utilsAll,
           "lucide-react": lucideAll,
+          "motion/react": motionAll,
           "@dust/slideshow/v1": dustSlideshowV1,
           "@dust/slideshow/v2": dustSlideshowV2,
           "@dust/react-hooks": {

--- a/viz/package.json
+++ b/viz/package.json
@@ -51,6 +51,7 @@
     "html-to-image": "^1.11.11",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.483.0",
+    "motion": "^12.40.0",
     "next": "^14.2.35",
     "next-themes": "^0.4.6",
     "papaparse": "^5.4.1",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Both Anthropic and OpenAI front-end guidelines explicitly recommend the Motion library for React. Anthropic's cookbook says "Use Motion library for React when available", and it appears in OpenAI's Canvas system prompt too.

This PR installs motion in the viz package and adds it to the `baseImports` scope. The frame instructions are updated in both the legacy and v2 paths to surface animation as a named section alongside color and styling, with guidance on when to use it and appropriate timing ranges.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
