### PR TITLE
[front] feat: add workspace_analytics MCP server with get_top_agents

### DIFF
--- a/front-api/routes/w/[wId]/analytics/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/top-agents.ts
@@ -1,34 +1,16 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
 import type { GetWorkspaceTopAgentsResponse } from "@app/lib/api/workspace/analytics";
-import type { estypes } from "@elastic/elasticsearch";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   limit: z.coerce.number().positive().max(100).optional().default(25),
 });
-
-type TopAgentsAggs = {
-  by_agent?: estypes.AggregationsMultiBucketAggregateBase<{
-    key: string;
-    doc_count: number;
-    unique_users?: estypes.AggregationsCardinalityAggregate;
-  }>;
-};
-
-type TopAgentBucket = {
-  key: string;
-  doc_count: number;
-  unique_users?: estypes.AggregationsCardinalityAggregate;
-};
 
 // Mounted at /api/w/:wId/analytics/top-agents.
 const app = workspaceApp();
@@ -38,76 +20,20 @@ app.get("/", ensureIsAdmin(), validate("query", QuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
 
   const { days, limit } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    days,
-  });
-
-  const result = await searchAnalytics<never, TopAgentsAggs>(
-    {
-      bool: {
-        filter: [baseQuery, { exists: { field: "agent_id" } }],
-      },
-    },
-    {
-      aggregations: {
-        by_agent: {
-          terms: {
-            field: "agent_id",
-            size: limit,
-          },
-          aggs: {
-            unique_users: {
-              cardinality: {
-                field: "user_id",
-              },
-            },
-          },
-        },
-      },
-      size: 0,
-    }
-  );
+  const result = await fetchTopAgents(auth, { days, limit });
 
   if (result.isErr()) {
     return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
-        message: `Failed to retrieve top agents: ${fromError(result.error).toString()}`,
+        message: `Failed to retrieve top agents: ${result.error.message}`,
       },
     });
   }
 
-  const buckets = bucketsToArray<TopAgentBucket>(
-    result.value.aggregations?.by_agent?.buckets
-  );
-
-  const agentIds = buckets.map((bucket) => String(bucket.key));
-  const agents =
-    agentIds.length > 0
-      ? await getAgentConfigurations(auth, {
-          agentIds,
-          variant: "extra_light",
-        })
-      : [];
-  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
-
-  const rows = buckets.map((bucket) => {
-    const agentId = String(bucket.key);
-    const agent = agentsById.get(agentId);
-    return {
-      agentId,
-      name: agent?.name ?? "Unknown agent",
-      pictureUrl: agent?.pictureUrl ?? null,
-      messageCount: bucket.doc_count ?? 0,
-      userCount: Math.round(bucket.unique_users?.value ?? 0),
-    };
-  });
-
-  const body: GetWorkspaceTopAgentsResponse = { agents: rows };
+  const body: GetWorkspaceTopAgentsResponse = { agents: result.value };
   return ctx.json(body);
 });
 

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -700,6 +700,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "webbrowser": "never_ask",
     "websearch": "never_ask",
   },
+  "workspace_analytics": {
+    "get_top_agents": "never_ask",
+  },
   "zendesk": {
     "draft_reply": "low",
     "get_ticket": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1139,11 +1139,13 @@ export const INTERNAL_MCP_SERVERS = {
   },
   workspace_analytics: {
     id: 1035,
-    // Available so the Workspace Analytics skill can wire it, but hidden from
-    // the builder tool-picker. Access is enforced per-tool via auth.isAdmin().
+    // Gated by the workspace_analytics feature flag (off by default) and hidden
+    // from the builder tool-picker; the skill wires it by name. Data access is
+    // enforced per-tool via auth.isAdmin().
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
-    isRestricted: undefined,
+    isRestricted: ({ featureFlags }) =>
+      !featureFlags.includes("workspace_analytics"),
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -87,6 +87,7 @@ import {
   WEB_SEARCH_BROWSE_SERVER,
   WEB_SEARCH_BROWSE_SERVER_NAME,
 } from "@app/lib/api/actions/servers/web_search_browse/metadata";
+import { WORKSPACE_ANALYTICS_SERVER } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { ZENDESK_SERVER } from "@app/lib/api/actions/servers/zendesk/metadata";
 import type {
   InternalMCPServerDefinitionType,
@@ -216,6 +217,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "ask_user_question",
   "wakeups",
   "plan_mode",
+  "workspace_analytics",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1134,6 +1136,19 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: FILES_SERVER,
+  },
+  workspace_analytics: {
+    id: 1035,
+    // Available so the Workspace Analytics skill can wire it, but hidden from
+    // the builder tool-picker. Access is enforced per-tool via auth.isAdmin().
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: WORKSPACE_ANALYTICS_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -32,7 +32,8 @@
     { "name": "wakeups", "id": 1031 },
     { "name": "plan_mode", "id": 1032 },
     { "name": "files", "id": 1033 },
-    { "name": "skill_authoring", "id": 1034 }
+    { "name": "skill_authoring", "id": 1034 },
+    { "name": "workspace_analytics", "id": 1035 }
   ],
   "manual": [
     { "name": "github", "id": 1 },

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -78,6 +78,7 @@ import { default as valtownServer } from "@app/lib/api/actions/servers/val_town"
 import { default as vantaServer } from "@app/lib/api/actions/servers/vanta";
 import { default as wakeupsServer } from "@app/lib/api/actions/servers/wakeups";
 import { default as webSearchBrowseServer } from "@app/lib/api/actions/servers/web_search_browse";
+import { default as workspaceAnalyticsServer } from "@app/lib/api/actions/servers/workspace_analytics";
 import { default as zendeskServer } from "@app/lib/api/actions/servers/zendesk";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -242,6 +243,8 @@ export async function getInternalMCPServer(
       return frontServer(auth, agentLoopContext);
     case "zendesk":
       return zendeskServer(auth, agentLoopContext);
+    case "workspace_analytics":
+      return workspaceAnalyticsServer(auth, agentLoopContext);
     case "skill_management":
       return skillManagementServer(auth, agentLoopContext);
     case "skill_authoring":

--- a/front/lib/api/actions/servers/workspace_analytics/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/index.ts
@@ -1,0 +1,23 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { TOOLS } from "@app/lib/api/actions/servers/workspace_analytics/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("workspace_analytics");
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: "workspace_analytics",
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -1,0 +1,64 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  timeWindowSchemaShape,
+  usageFilterSchema,
+} from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+const getTopAgentsSchema = {
+  ...timeWindowSchemaShape,
+  ...usageFilterSchema,
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .optional()
+    .describe("Maximum number of agents to return (default 25, max 100)."),
+};
+
+export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
+  get_top_agents: {
+    description:
+      "Return the workspace's agents over a time window (defaults to the " +
+      "current calendar month), ranked by number of messages, with the number " +
+      "of unique users for each. Each row includes the agent's id. Optionally " +
+      "filter by source (context_origin), agent, or user. Use this to answer " +
+      "which agents are used most. Admin-only.",
+    schema: getTopAgentsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top agents",
+      done: "Retrieved top agents",
+    },
+  },
+});
+
+export const WORKSPACE_ANALYTICS_SERVER = {
+  serverInfo: {
+    name: "workspace_analytics",
+    version: "1.0.0",
+    description:
+      "Answer workspace usage questions for admins (top agents, and more to " +
+      "come).",
+    icon: "ActionPieChartIcon",
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(WORKSPACE_ANALYTICS_TOOLS_METADATA).map((t) => [
+      t.name,
+      t.stake,
+    ])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -1,0 +1,48 @@
+import { TOOLS } from "@app/lib/api/actions/servers/workspace_analytics/tools";
+import { Authenticator } from "@app/lib/auth";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+function getToolByName(name: string) {
+  const tool = TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`Tool ${name} not found`);
+  }
+  return tool;
+}
+
+function createTestExtra(auth: Authenticator) {
+  return {
+    signal: new AbortController().signal,
+    auth,
+    agentLoopContext: undefined,
+  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+}
+
+describe("workspace_analytics tools", () => {
+  it.each([
+    "get_top_agents",
+  ])("%s refuses non-admin callers", async (toolName) => {
+    const workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    expect(auth.isAdmin()).toBe(false);
+
+    const tool = getToolByName(toolName);
+    const result = await tool.handler({}, createTestExtra(auth));
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("admins");
+    }
+  });
+});

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -1,0 +1,70 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
+import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
+import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
+import { Err, Ok } from "@app/types/shared/result";
+
+const DEFAULT_LIMIT = 25;
+
+const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
+  get_top_agents: async (
+    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const result = await fetchTopAgents(auth, {
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      limit: limit ?? DEFAULT_LIMIT,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to retrieve top agents: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+
+    if (result.value.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No agent activity recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = result.value.map(
+      (agent, index) =>
+        `${index + 1}. ${agent.name} [${agent.agentId}] — ` +
+        `${agent.messageCount} messages, ${agent.userCount} users`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Top agents for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(WORKSPACE_ANALYTICS_TOOLS_METADATA, handlers);

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -1,0 +1,111 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { WorkspaceTopAgentRow } from "@app/lib/api/workspace/analytics";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+type TopAgentsAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<{
+    key: string;
+    doc_count: number;
+    unique_users?: estypes.AggregationsCardinalityAggregate;
+  }>;
+};
+
+type TopAgentBucket = {
+  key: string;
+  doc_count: number;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+// Ranks agents by message count over a time window, with unique-user counts and
+// name/picture resolution. Backs both the top-agents analytics endpoint and the
+// workspace_analytics get_top_agents tool. Either `days` or `startDate`/`endDate`
+// bounds the window; the source/agent/user filters are optional.
+export async function fetchTopAgents(
+  auth: Authenticator,
+  {
+    days,
+    startDate,
+    endDate,
+    limit,
+    contextOrigin,
+    agentIds,
+    userIds,
+  }: {
+    days?: number;
+    startDate?: string;
+    endDate?: string;
+    limit: number;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+  }
+): Promise<Result<WorkspaceTopAgentRow[], ElasticsearchError>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+
+  const result = await searchAnalytics<never, TopAgentsAggs>(
+    {
+      bool: {
+        filter: [baseQuery, { exists: { field: "agent_id" } }],
+      },
+    },
+    {
+      aggregations: {
+        by_agent: {
+          terms: { field: "agent_id", size: limit },
+          aggs: {
+            unique_users: { cardinality: { field: "user_id" } },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<TopAgentBucket>(
+    result.value.aggregations?.by_agent?.buckets
+  );
+
+  const bucketAgentIds = buckets.map((bucket) => String(bucket.key));
+  const agents =
+    bucketAgentIds.length > 0
+      ? await getAgentConfigurations(auth, {
+          agentIds: bucketAgentIds,
+          variant: "extra_light",
+        })
+      : [];
+  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
+
+  const rows = buckets.map((bucket) => {
+    const agentId = String(bucket.key);
+    const agent = agentsById.get(agentId);
+    return {
+      agentId,
+      name: agent?.name ?? "Unknown agent",
+      pictureUrl: agent?.pictureUrl ?? null,
+      messageCount: bucket.doc_count ?? 0,
+      userCount: Math.round(bucket.unique_users?.value ?? 0),
+    };
+  });
+
+  return new Ok(rows);
+}

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -129,6 +129,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   monday: "advanced",
   notion: "advanced",
   openai_usage: "advanced",
+  workspace_analytics: "advanced",
   outlook_calendar: "advanced",
   outlook: "advanced",
   productboard: "advanced",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -132,6 +132,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "API for accessing usage data (Means that any builder with an API key can access usage data of the workspace from API)",
     stage: "on_demand",
   },
+  workspace_analytics: {
+    description:
+      "Admin-only workspace usage analytics: the workspace_analytics MCP server, its skill, and the Workspace Analyst agent.",
+    stage: "on_demand",
+  },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -751,6 +751,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "skills_as_user_messages"
   | "run_tools_from_prompt"
   | "usage_data_api"
+  | "workspace_analytics"
   | "xai_feature"
   | "conversations_slack_notifications"
   | "anthropic_reasoning_token_count"


### PR DESCRIPTION
## Description

Add an admin-only workspace_analytics internal MCP server (auto_hidden_builder) exposing a get_top_agents tool: it resolves a time window + optional source/agent/user filters, enforces admin access via workspaceAdminGuard, and returns a ranked text list of the workspace's most-used agents.

Extract the top-agents Elasticsearch query out of the Hono route into fetchTopAgents (lib/api/assistant/observability/top_agents), so both the analytics endpoint and the tool share one implementation; the row/response types come from the shared lib/api/workspace/analytics module. Register the server (id 1035, advanced tier) and refresh the MCP metadata/availability snapshots.

Add a workspace_analytics whitelistable feature flag (on_demand, mirrored in the SDK schema) and gate the workspace_analytics MCP server on it via isRestricted, so its workspace view is only created where the flag is enabled. The server is now off by default: feature-flag gated + hidden from the builder, with data access still enforced per-tool by workspaceAdminGuard. The same flag will gate the skill and Workspace Analyst agent for one consistent capability switch.

## Tests

Unit

## Risk

None, not wired yet.

## Deploy Plan

front + enable ff via Poke on workspaces where the feature should be enabled