### PR TITLE
[dust-hive] use front-api, remove next service

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -24,10 +24,10 @@
 #   dhcd  - cd into environment worktree (changes dir in current shell)
 
 _dust_hive_services=(
-  sdk sparkle front core oauth connectors front-workers front-spa-poke front-spa-app viz
+  sdk sparkle front-api core oauth connectors front-workers front-spa-poke front-spa-app viz
 )
 _dust_hive_warm_state_services=(
-  front front-api core oauth connectors front-workers front-spa-poke front-spa-app viz
+  front-api core oauth connectors front-workers front-spa-poke front-spa-app viz
 )
 # Avoid invoking the Bun CLI from completion; derive state from PID files plus one Docker scan.
 
@@ -248,6 +248,7 @@ _dust-hive() {
         'sync:Pull latest main, rebuild binaries, refresh deps'
         'temporal:Manage Temporal server'
         'seed-config:Extract user data from existing DB'
+        'env:Manage config.env vars (list|get|set|unset)'
         'feed:Run seed script for a scenario'
         'flag:Toggle a feature flag on the workspace'
         'help:Show help'
@@ -389,6 +390,12 @@ _dust-hive() {
           ;;
         seed-config)
           _arguments '1:postgres-uri:'
+          ;;
+        env)
+          _arguments \
+            '1::subcommand:(list get set unset)' \
+            '2::key:' \
+            '3::value:'
           ;;
         feed)
           _arguments \

--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -136,7 +136,7 @@ async function destroySingleEnvironment(
   logger.info(`Destroying environment '${env.name}'...`);
   console.log();
 
-  const portServices: ServiceName[] = ["front", "core", "connectors", "oauth"];
+  const portServices: ServiceName[] = ["front-api", "core", "connectors", "oauth"];
   const servicePids = await Promise.all(portServices.map((service) => readPid(env.name, service)));
   const allowedPids = new Set(servicePids.filter((pid): pid is number => pid !== null));
 

--- a/x/henry/dust-hive/src/commands/forward.ts
+++ b/x/henry/dust-hive/src/commands/forward.ts
@@ -79,12 +79,12 @@ async function forwardToEnv(name: string): Promise<Result<void>> {
     return Err(new CommandError(`Environment '${name}' not found`));
   }
 
-  // Check if front is running (at minimum)
-  const frontRunning = await isServiceRunning(name, "front");
+  // Check if front-api is running (at minimum)
+  const frontRunning = await isServiceRunning(name, "front-api");
   if (!frontRunning) {
     return Err(
       new CommandError(
-        `Environment '${name}' does not have front running. Run 'dust-hive warm ${name}' first.`
+        `Environment '${name}' does not have front-api running. Run 'dust-hive warm ${name}' first.`
       )
     );
   }

--- a/x/henry/dust-hive/src/commands/logs.ts
+++ b/x/henry/dust-hive/src/commands/logs.ts
@@ -5,7 +5,7 @@ import { withEnvironment } from "../lib/commands";
 import { getLogPath } from "../lib/paths";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { ensureServiceLogsTui } from "../lib/scripts";
-import { ALL_SERVICES, type ServiceName, getFrontService, isServiceName } from "../lib/services";
+import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
 
 interface LogsOptions {
   follow?: boolean;
@@ -54,8 +54,8 @@ export const logsCommand = withEnvironment(
       return runInteractiveMode(env.name, serviceArg);
     }
 
-    // Determine target service (default to the active front variant)
-    let targetService: ServiceName = getFrontService();
+    // Determine target service (default to front-api).
+    let targetService: ServiceName = "front-api";
     if (serviceArg) {
       const result = validateServiceArg(serviceArg);
       if (!result.ok) return result;

--- a/x/henry/dust-hive/src/commands/refresh.ts
+++ b/x/henry/dust-hive/src/commands/refresh.ts
@@ -11,6 +11,7 @@ import { installAllDependencies } from "../lib/setup";
 const WORKSPACE_DIRS = [
   "sdks/js",
   "front",
+  "front-api",
   "connectors",
   "sparkle",
   "front-spa",

--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -5,12 +5,12 @@ import { stopService } from "../lib/process";
 import { restoreTerminal } from "../lib/prompt";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { ALL_SERVICES, type ServiceName, getActiveServices, isServiceName } from "../lib/services";
+import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
 
 async function selectService(): Promise<ServiceName | null> {
   const result = await p.select({
     message: "Select service to restart",
-    options: getActiveServices().map((name) => ({ value: name, label: name })),
+    options: ALL_SERVICES.map((name) => ({ value: name, label: name })),
   });
 
   if (p.isCancel(result)) {

--- a/x/henry/dust-hive/src/commands/status.ts
+++ b/x/henry/dust-hive/src/commands/status.ts
@@ -2,18 +2,20 @@ import { withEnvironment } from "../lib/commands";
 import { getLogPath } from "../lib/paths";
 import type { PortAllocation } from "../lib/ports";
 import { isServiceRunning } from "../lib/process";
-import { checkServiceHealth, getHealthChecks } from "../lib/registry";
+import { SERVICE_REGISTRY, checkServiceHealth, getHealthChecks } from "../lib/registry";
 import { Ok } from "../lib/result";
-import { getActiveServices } from "../lib/services";
+import { ALL_SERVICES } from "../lib/services";
 import { getStateInfo, isDockerRunning } from "../lib/state";
 
-async function printServiceStatus(name: string): Promise<void> {
+async function printServiceStatus(name: string, ports: PortAllocation): Promise<void> {
   console.log("Services:");
 
-  for (const service of getActiveServices()) {
+  for (const service of ALL_SERVICES) {
     const running = await isServiceRunning(name, service);
     const status = running ? "\x1b[32m●\x1b[0m" : "\x1b[90m○\x1b[0m";
-    console.log(`  ${status} ${service}`);
+    const { portKey } = SERVICE_REGISTRY[service];
+    const portLabel = portKey ? `\x1b[90m:${ports[portKey]}\x1b[0m` : "";
+    console.log(`  ${status} ${service.padEnd(14)} ${portLabel}`);
     if (running) {
       console.log(`    Log: ${getLogPath(name, service)}`);
     }
@@ -50,7 +52,7 @@ export const statusCommand = withEnvironment("status", async (env) => {
     console.log();
   }
 
-  await printServiceStatus(env.name);
+  await printServiceStatus(env.name, env.ports);
 
   console.log();
 

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -12,7 +12,7 @@ import { cleanupServicePorts, formatBlockedPorts } from "../lib/ports";
 import { isServiceRunning, readPid } from "../lib/process";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok } from "../lib/result";
-import { type ServiceName, getFrontService } from "../lib/services";
+import type { ServiceName } from "../lib/services";
 import { buildShell } from "../lib/shell";
 import { isDockerRunning } from "../lib/state";
 
@@ -152,10 +152,9 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
 
   // Check if already warm
   const dockerRunning = await isDockerRunning(env.name);
-  const frontService = getFrontService();
 
   if (dockerRunning) {
-    const frontRunning = await isServiceRunning(env.name, frontService);
+    const frontRunning = await isServiceRunning(env.name, "front-api");
     if (frontRunning) {
       logger.info(`Environment '${env.name}' is already warm`);
       return Ok(undefined);
@@ -166,7 +165,7 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   console.log();
 
   // Clean up orphaned processes on service ports
-  const portServices: ServiceName[] = [frontService, "core", "connectors", "oauth"];
+  const portServices: ServiceName[] = ["front-api", "core", "connectors", "oauth"];
   const servicePids = await Promise.all(portServices.map((service) => readPid(env.name, service)));
   const allowedPids = new Set(servicePids.filter((pid): pid is number => pid !== null));
   const { killedPorts, blockedPorts } = await cleanupServicePorts(env.ports, {
@@ -199,12 +198,11 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   // Start Docker (don't await - let it run in background)
   const dockerPromise = startDocker(env);
 
-  // Start front immediately to begin page compilation
+  // Start front-api immediately so it can begin building.
   // It will retry connections to DB/Redis until they're ready
-  await startService(env, frontService);
+  await startService(env, "front-api");
 
-  // Start pre-warming immediately - curls will retry until Next.js is ready
-  // Pages compile while Docker containers start and init runs
+  // Start pre-warming immediately - curls will retry until front-api is ready.
   startPreWarmingImmediately(env.ports.front);
 
   // Now wait for Docker and start other services
@@ -279,10 +277,10 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
 
   // Wait for services with health checks
   // Pre-warming is already running in parallel (started above)
-  // Start forwarder as soon as front is healthy (don't wait for core/oauth)
+  // Start forwarder as soon as front-api is healthy (don't wait for core/oauth)
   logger.step("Waiting for services to be healthy...");
   await Promise.all([
-    waitForServiceReady(env, frontService).then(async () => {
+    waitForServiceReady(env, "front-api").then(async () => {
       if (!noForward) {
         await startForwarder(env.ports.base, env.name);
       }
@@ -301,7 +299,7 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   console.log();
   logger.success(`Environment '${env.name}' is now warm! (${elapsed}s)`);
   console.log();
-  console.log(`  ${`${frontService}:`.padEnd(13)}http://localhost:${env.ports.front}`);
+  console.log(`  front-api:   http://localhost:${env.ports.front}`);
   console.log(`  Core:        http://localhost:${env.ports.core}`);
   console.log(`  Connectors:  http://localhost:${env.ports.connectors}`);
   console.log(`  Front app:   http://localhost:${env.ports.frontSpaApp}`);

--- a/x/henry/dust-hive/src/lib/forwarderConfig.ts
+++ b/x/henry/dust-hive/src/lib/forwarderConfig.ts
@@ -1,7 +1,7 @@
 import { PORT_OFFSETS } from "./ports";
 
 export const FORWARDER_MAPPINGS = [
-  { listenPort: 3000, targetOffset: PORT_OFFSETS.front, name: "front" },
+  { listenPort: 3000, targetOffset: PORT_OFFSETS.front, name: "front-api" },
   { listenPort: 3001, targetOffset: PORT_OFFSETS.core, name: "core" },
   { listenPort: 3002, targetOffset: PORT_OFFSETS.connectors, name: "connectors" },
   { listenPort: 3006, targetOffset: PORT_OFFSETS.oauth, name: "oauth" },

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { logger } from "../logger";
 import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
-import { getActiveServices } from "../services";
+import { ALL_SERVICES } from "../services";
 import { shellQuote } from "../shell";
 import type {
   InstallCheckResult,
@@ -219,7 +219,7 @@ export class TmuxAdapter implements MultiplexerAdapter {
       );
     } else {
       // Individual service windows
-      for (const service of getActiveServices()) {
+      for (const service of ALL_SERVICES) {
         const tabName = getTabName(service);
         lines.push(
           `# Create ${service} logs window`,

--- a/x/henry/dust-hive/src/lib/multiplexer/types.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/types.ts
@@ -222,7 +222,6 @@ export const MAIN_SESSION_NAME = "dust-hive-main";
 const TAB_NAMES: Record<ServiceName, string> = {
   sparkle: "sparkle",
   sdk: "sdk",
-  front: "front",
   "front-api": "front-api",
   core: "core",
   oauth: "oauth",

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { logger } from "../logger";
 import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
 import { restoreTerminal } from "../prompt";
-import { type ServiceName, getActiveServices } from "../services";
+import { ALL_SERVICES, type ServiceName } from "../services";
 import { shellQuote } from "../shell";
 import type {
   InstallCheckResult,
@@ -245,9 +245,9 @@ export class ZellijAdapter implements MultiplexerAdapter {
     }`;
     } else {
       // Individual service tabs (default)
-      logsTabs = getActiveServices()
-        .map((service) => this.generateServiceTab(envName, service, worktreePath))
-        .join("\n\n");
+      logsTabs = ALL_SERVICES.map((service) =>
+        this.generateServiceTab(envName, service, worktreePath)
+      ).join("\n\n");
     }
 
     // When compact mode is enabled, use bottom bar; otherwise use top bar

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -6,7 +6,7 @@ import { logger } from "./logger";
 import { getEnvFilePath, getLogPath, getWorktreeDir } from "./paths";
 import type { PortAllocation } from "./ports";
 import { isServiceRunning, readFileTail, spawnShellDaemon } from "./process";
-import { ALL_SERVICES, type ServiceName, getActiveServices } from "./services";
+import { ALL_SERVICES, type ServiceName } from "./services";
 import { buildShell } from "./shell";
 
 // Readiness check types - how to determine if a service is ready
@@ -53,22 +53,18 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
         `${getWorktreeDir(env.name, env.metadata.repoRoot)}/sdks/js/dist/client.esm.js`,
     },
   },
-  front: {
-    cwd: "front",
-    needsNvm: true,
-    needsEnvSh: true,
-    buildCommand: () => "npm run dev",
-    readinessCheck: {
-      type: "http",
-      url: (ports) => `http://localhost:${ports.front}/api/healthz`,
-    },
-    portKey: "front",
-  },
   "front-api": {
     cwd: "front-api",
     needsNvm: true,
     needsEnvSh: true,
-    buildCommand: () => "npm run dev",
+    // forbid-next.cjs throws if anything loads `next` at runtime, guaranteeing
+    // the Hono server (not Next) serves every request. Mirrors the front-hono
+    // proc in tools/mprocs.yaml.
+    // HOSTNAME=127.0.0.1 forces an IPv4 bind: "localhost" resolves to ::1 on
+    // macOS, but the port forwarder connects upstream over IPv4, so without
+    // this the forwarded port (3000) cannot reach front-api.
+    buildCommand: () =>
+      "HOSTNAME=127.0.0.1 NODE_ENV=development NODE_OPTIONS=--require=./forbid-next.cjs npm run dev",
     readinessCheck: {
       type: "http",
       url: (ports) => `http://localhost:${ports.front}/api/healthz`,
@@ -157,9 +153,8 @@ if (missingKeys.length > 0 || extraKeys.length > 0) {
   );
 }
 
-// Services to start during warm (all active services except sparkle, SDK, and viz which start at spawn/manually).
-// Uses getActiveServices() so only the active front variant (front or front-api) is included.
-export const WARM_SERVICES: ServiceName[] = getActiveServices().filter(
+// Services to start during warm (all services except sparkle, SDK, and viz which start at spawn/manually).
+export const WARM_SERVICES: ServiceName[] = ALL_SERVICES.filter(
   (service) => service !== "sparkle" && service !== "sdk" && service !== "viz"
 );
 
@@ -330,7 +325,7 @@ export function getHealthChecks(
 ): Array<{ service: ServiceName; url: string }> {
   const checks: Array<{ service: ServiceName; url: string }> = [];
 
-  for (const service of getActiveServices()) {
+  for (const service of ALL_SERVICES) {
     const config = SERVICE_REGISTRY[service];
     if (config.readinessCheck?.type === "http") {
       checks.push({

--- a/x/henry/dust-hive/src/lib/scripts.ts
+++ b/x/henry/dust-hive/src/lib/scripts.ts
@@ -1,6 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import { DUST_HIVE_SCRIPTS, getServiceLogsTuiPath } from "./paths";
-import { getActiveServices } from "./services";
+import { ALL_SERVICES } from "./services";
 
 /**
  * Generates the service logs TUI bash script content.
@@ -20,7 +20,7 @@ import { getActiveServices } from "./services";
  *   x   - exit
  */
 export function getServiceLogsTuiContent(): string {
-  const services = getActiveServices().join(" ");
+  const services = ALL_SERVICES.join(" ");
 
   // Script header and argument parsing
   const header = `#!/usr/bin/env bash

--- a/x/henry/dust-hive/src/lib/services.ts
+++ b/x/henry/dust-hive/src/lib/services.ts
@@ -1,10 +1,9 @@
 // Service names - array order defines start order, reverse for stop order.
-// "front" and "front-api" are mutually exclusive: exactly one of them is in
-// the active service set for a given hive run (see getActiveServices).
+// The API is served exclusively by front-api (Hono); the old Next server
+// (`front`) no longer serves any endpoint and is not run by the hive.
 export const ALL_SERVICES = [
   "sdk",
   "sparkle",
-  "front",
   "front-api",
   "core",
   "oauth",
@@ -19,26 +18,6 @@ export const ALL_SERVICES = [
 export const COLD_STATE_SERVICES = ["sdk", "sparkle"] as const satisfies readonly ServiceName[];
 
 export type ServiceName = (typeof ALL_SERVICES)[number];
-
-// When set, the hive runs front-api (Hono+Next hybrid server out of front-api/)
-// instead of the plain Next server out of front/. The two services share the
-// "front" port slot; opt-in via env var for now until front-api is the default.
-export function useFrontApi(): boolean {
-  const v = process.env["DUST_HIVE_USE_FRONT_API"];
-  return v === "1" || v === "true";
-}
-
-// Returns whichever front variant is active for this hive run.
-export function getFrontService(): ServiceName {
-  return useFrontApi() ? "front-api" : "front";
-}
-
-// Returns the services that apply to the current hive run. front-api and front
-// are mutually exclusive — useFrontApi() picks which one is active.
-export function getActiveServices(): readonly ServiceName[] {
-  const excluded: ServiceName = useFrontApi() ? "front" : "front-api";
-  return ALL_SERVICES.filter((s) => s !== excluded);
-}
 
 /**
  * Type guard to check if a string is a valid service name.

--- a/x/henry/dust-hive/tests/lib/registry.test.ts
+++ b/x/henry/dust-hive/tests/lib/registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { calculatePorts } from "../../src/lib/ports";
 import { SERVICE_REGISTRY, WARM_SERVICES, getHealthChecks } from "../../src/lib/registry";
-import { ALL_SERVICES, getFrontService, useFrontApi } from "../../src/lib/services";
+import { ALL_SERVICES } from "../../src/lib/services";
 
 describe("registry", () => {
   describe("SERVICE_REGISTRY", () => {
@@ -16,16 +16,6 @@ describe("registry", () => {
       expect(config.cwd).toBe("sdks/js");
       expect(config.needsNvm).toBe(true);
       expect(config.needsEnvSh).toBe(false);
-    });
-
-    it("front config has correct settings", () => {
-      const config = SERVICE_REGISTRY.front;
-      expect(config.cwd).toBe("front");
-      expect(config.needsNvm).toBe(true);
-      expect(config.needsEnvSh).toBe(true);
-      expect(config.portKey).toBe("front");
-      expect(config.readinessCheck).toBeDefined();
-      expect(config.readinessCheck?.type).toBe("http");
     });
 
     it("front-api config has correct settings", () => {
@@ -84,7 +74,7 @@ describe("registry", () => {
     });
 
     it("includes all other services", () => {
-      expect(WARM_SERVICES).toContain(getFrontService());
+      expect(WARM_SERVICES).toContain("front-api");
       expect(WARM_SERVICES).toContain("core");
       expect(WARM_SERVICES).toContain("oauth");
       expect(WARM_SERVICES).toContain("connectors");
@@ -93,14 +83,8 @@ describe("registry", () => {
       expect(WARM_SERVICES).toContain("front-spa-app");
     });
 
-    it("has 7 services (all except sparkle, sdk, viz, and the inactive front variant)", () => {
+    it("has 7 services (all except sparkle, sdk, and viz)", () => {
       expect(WARM_SERVICES).toHaveLength(7);
-    });
-
-    it("includes only the active front variant", () => {
-      const inactive = useFrontApi() ? "front" : "front-api";
-      expect(WARM_SERVICES).toContain(getFrontService());
-      expect(WARM_SERVICES).not.toContain(inactive);
     });
   });
 
@@ -112,9 +96,9 @@ describe("registry", () => {
       expect(Array.isArray(checks)).toBe(true);
     });
 
-    it("includes the active front health check", () => {
+    it("includes the front-api health check", () => {
       const checks = getHealthChecks(ports);
-      const frontCheck = checks.find((c) => c.service === getFrontService());
+      const frontCheck = checks.find((c) => c.service === "front-api");
       expect(frontCheck).toBeDefined();
       expect(frontCheck?.url).toBe("http://localhost:10000/api/healthz");
     });
@@ -140,7 +124,7 @@ describe("registry", () => {
       const secondPorts = calculatePorts(11000);
       const checks = getHealthChecks(secondPorts);
 
-      const frontCheck = checks.find((c) => c.service === getFrontService());
+      const frontCheck = checks.find((c) => c.service === "front-api");
       expect(frontCheck?.url).toBe("http://localhost:11000/api/healthz");
 
       const coreCheck = checks.find((c) => c.service === "core");
@@ -167,9 +151,11 @@ describe("registry", () => {
       expect(command).toBe("npm run watch");
     });
 
-    it("front returns npm run dev", () => {
-      const command = SERVICE_REGISTRY.front.buildCommand(mockEnv);
-      expect(command).toBe("npm run dev");
+    it("front-api binds IPv4, forbids next, and runs npm run dev", () => {
+      const command = SERVICE_REGISTRY["front-api"].buildCommand(mockEnv);
+      expect(command).toBe(
+        "HOSTNAME=127.0.0.1 NODE_ENV=development NODE_OPTIONS=--require=./forbid-next.cjs npm run dev"
+      );
     });
 
     it("core returns cargo run --bin core-api", () => {

--- a/x/henry/dust-hive/tests/lib/services.test.ts
+++ b/x/henry/dust-hive/tests/lib/services.test.ts
@@ -6,7 +6,6 @@ describe("services", () => {
     it("contains all expected services", () => {
       expect(ALL_SERVICES).toContain("sparkle");
       expect(ALL_SERVICES).toContain("sdk");
-      expect(ALL_SERVICES).toContain("front");
       expect(ALL_SERVICES).toContain("front-api");
       expect(ALL_SERVICES).toContain("core");
       expect(ALL_SERVICES).toContain("oauth");
@@ -17,8 +16,8 @@ describe("services", () => {
       expect(ALL_SERVICES).toContain("viz");
     });
 
-    it("has 11 services total", () => {
-      expect(ALL_SERVICES).toHaveLength(11);
+    it("has 10 services total", () => {
+      expect(ALL_SERVICES).toHaveLength(10);
     });
 
     it("has sdk as first service (start order)", () => {
@@ -38,15 +37,15 @@ describe("services", () => {
     it("defines start order with SDK first, then sparkle", () => {
       const sdkIndex = ALL_SERVICES.indexOf("sdk");
       const sparkleIndex = ALL_SERVICES.indexOf("sparkle");
-      const frontIndex = ALL_SERVICES.indexOf("front");
+      const frontApiIndex = ALL_SERVICES.indexOf("front-api");
       const coreIndex = ALL_SERVICES.indexOf("core");
 
       // SDK should be first
       expect(sdkIndex).toBe(0);
       // Sparkle should be second
       expect(sparkleIndex).toBe(1);
-      // Front and core come after sparkle
-      expect(frontIndex).toBeGreaterThan(sparkleIndex);
+      // front-api and core come after sparkle
+      expect(frontApiIndex).toBeGreaterThan(sparkleIndex);
       expect(coreIndex).toBeGreaterThan(sparkleIndex);
     });
   });
@@ -56,7 +55,6 @@ describe("services", () => {
       const services: ServiceName[] = [
         "sdk",
         "sparkle",
-        "front",
         "front-api",
         "core",
         "oauth",

--- a/x/henry/dust-hive/tests/lib/state.test.ts
+++ b/x/henry/dust-hive/tests/lib/state.test.ts
@@ -69,7 +69,13 @@ describe("state", () => {
     });
 
     it("returns empty array for warm state (all running)", () => {
-      const allServices: ServiceName[] = ["front", "core", "oauth", "connectors", "front-workers"];
+      const allServices: ServiceName[] = [
+        "front-api",
+        "core",
+        "oauth",
+        "connectors",
+        "front-workers",
+      ];
       const warnings = detectWarnings(true, true, true, allServices);
       expect(warnings).toEqual([]);
     });
@@ -80,7 +86,7 @@ describe("state", () => {
     });
 
     it("warns when Build watchers not running but app services are", () => {
-      const warnings = detectWarnings(false, false, true, ["front"]);
+      const warnings = detectWarnings(false, false, true, ["front-api"]);
       expect(warnings).toContain("Build watchers not running");
     });
 
@@ -90,20 +96,20 @@ describe("state", () => {
     });
 
     it("warns when app services running but docker is not", () => {
-      const warnings = detectWarnings(true, false, true, ["front"]);
+      const warnings = detectWarnings(true, false, true, ["front-api"]);
       expect(warnings).toContain("App services running but Docker is not");
     });
 
     it("warns about missing services when some are running in inconsistent state", () => {
       // Build watchers not running creates an inconsistent state where missing services warning triggers
-      const partial: ServiceName[] = ["front", "core"];
+      const partial: ServiceName[] = ["front-api", "core"];
       const warnings = detectWarnings(false, true, true, partial);
       expect(warnings.some((w) => w.includes("Missing services"))).toBe(true);
     });
 
     it("lists specific missing services in inconsistent state", () => {
       // Build watchers not running creates an inconsistent state where missing services warning triggers
-      const partial: ServiceName[] = ["front"];
+      const partial: ServiceName[] = ["front-api"];
       const warnings = detectWarnings(false, true, true, partial);
       const missingWarning = warnings.find((w) => w.includes("Missing services"));
       expect(missingWarning).toBeDefined();
@@ -114,7 +120,7 @@ describe("state", () => {
     it("does not warn about missing services in consistent warm state", () => {
       // When all consistent (buildWatchers + docker + appServices all true), even with partial
       // services, the early return prevents missing services warning
-      const partial: ServiceName[] = ["front", "core"];
+      const partial: ServiceName[] = ["front-api", "core"];
       const warnings = detectWarnings(true, true, true, partial);
       expect(warnings.some((w) => w.includes("Missing services"))).toBe(false);
     });
@@ -127,7 +133,7 @@ describe("state", () => {
 
     it("can have multiple warnings", () => {
       // Build watchers not running, no docker, but app services running
-      const warnings = detectWarnings(false, false, true, ["front"]);
+      const warnings = detectWarnings(false, false, true, ["front-api"]);
       expect(warnings.length).toBeGreaterThanOrEqual(1);
       // Should have both "Build watchers not running" and "App services running but Docker is not"
       expect(warnings).toContain("Build watchers not running");


### PR DESCRIPTION
Make `front-api` (Hono) the only API server in dust-hive and drop the Next `front` service, which no longer serves any endpoint.

Removes the `DUST_HIVE_USE_FRONT_API` flag and the front/front-api duality, forces Hono via `forbid-next.cjs`, and shows each service's port in `status`/`warm` output.