### PR TITLE
fix(skills): Fix requestedSpaceIds of agent when archiving/unarchiving skills

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,3 +1,4 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillDataSourceConfigurationModel } from "@app/lib/models/skill";
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
@@ -1013,6 +1014,97 @@ describe("SkillResource", () => {
       expect(membershipsAfterRestore.every((m) => m.status === "active")).toBe(
         true
       );
+    });
+
+    it("removes the skill's space requirements from agents when archiving and adds them back when restoring", async () => {
+      const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(
+        restrictedSpace,
+        testContext.globalGroup
+      );
+
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With Space To Archive",
+        requestedSpaceIds: [restrictedSpace.id],
+      });
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        {
+          name: "Agent With Skill Space",
+          requestedSpaceIds: [restrictedSpace.id],
+        }
+      );
+
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skill.id,
+        agentConfigurationId: agent.id,
+      });
+
+      // Archiving the skill should drop its space from the agent's requirements.
+      await skill.archive(testContext.authenticator);
+
+      const agentAfterArchive = await getAgentConfiguration(
+        testContext.authenticator,
+        { agentId: agent.sId, variant: "light" }
+      );
+      expect(agentAfterArchive?.requestedSpaceIds).not.toContain(
+        restrictedSpace.sId
+      );
+
+      // Restoring the skill should add its space back to the agent's requirements.
+      await skill.restore(testContext.authenticator);
+
+      const agentAfterRestore = await getAgentConfiguration(
+        testContext.authenticator,
+        { agentId: agent.sId, variant: "light" }
+      );
+      expect(agentAfterRestore?.requestedSpaceIds).toContain(
+        restrictedSpace.sId
+      );
+    });
+
+    it("keeps a space on the agent when archiving a skill if another active skill still requires it", async () => {
+      const sharedSpace = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(sharedSpace, testContext.globalGroup);
+
+      const skill1 = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill 1 Sharing Space",
+        requestedSpaceIds: [sharedSpace.id],
+      });
+      const skill2 = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill 2 Sharing Space",
+        requestedSpaceIds: [sharedSpace.id],
+      });
+
+      const agent = await AgentConfigurationFactory.createTestAgent(
+        testContext.authenticator,
+        {
+          name: "Agent With Two Skills",
+          requestedSpaceIds: [sharedSpace.id],
+        }
+      );
+
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skill1.id,
+        agentConfigurationId: agent.id,
+      });
+      await SkillFactory.linkToAgent(testContext.authenticator, {
+        skillId: skill2.id,
+        agentConfigurationId: agent.id,
+      });
+
+      // Archiving skill1 must not remove sharedSpace because skill2 still requires it.
+      await skill1.archive(testContext.authenticator);
+
+      const agentAfter = await getAgentConfiguration(
+        testContext.authenticator,
+        {
+          agentId: agent.sId,
+          variant: "light",
+        }
+      );
+      expect(agentAfter?.requestedSpaceIds).toContain(sharedSpace.sId);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1754,12 +1754,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   private async updateActiveAgentsRequirements(
     auth: Authenticator,
-    { previousRequestedSpaceIds }: { previousRequestedSpaceIds: ModelId[] },
+    {
+      previousRequestedSpaceIds,
+      newRequestedSpaceIds = this.requestedSpaceIds,
+    }: {
+      // The spaces the skill previously contributed before the change
+      previousRequestedSpaceIds: ModelId[];
+      // The spaces the skill contributes after the change. Defaults to the
+      // skill's current `requestedSpaceIds`, but callers can override it (e.g.
+      // archiving treats the skill as contributing no spaces).
+      newRequestedSpaceIds?: ModelId[];
+    },
     { transaction }: { transaction?: Transaction }
   ): Promise<void> {
     if (
-      previousRequestedSpaceIds.length === this.requestedSpaceIds.length &&
-      hasAll(previousRequestedSpaceIds, this.requestedSpaceIds)
+      previousRequestedSpaceIds.length === newRequestedSpaceIds.length &&
+      hasAll(previousRequestedSpaceIds, newRequestedSpaceIds)
     ) {
       // Requested spaces didn't change, skip.
       return;
@@ -1773,7 +1783,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     const spaceIdsRemovedFromThisSkill = previousRequestedSpaceIds.filter(
-      (spaceId) => !this.requestedSpaceIds.includes(spaceId)
+      (spaceId) => !newRequestedSpaceIds.includes(spaceId)
     );
 
     const workspace = auth.getNonNullableWorkspace();
@@ -1856,7 +1866,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       const newSpaceIds = uniq(
         agent.requestedSpaceIds
           .filter((id) => !spaceIdsToRemoveFromAgent.has(id))
-          .concat(this.requestedSpaceIds)
+          .concat(newRequestedSpaceIds)
       );
 
       await updateAgentRequirements(
@@ -2314,9 +2324,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // so they can be restored when the skill is unarchived.
       const [count] = await this.update({ status: "archived" }, transaction);
 
-      // Suspend all editor group memberships for this skill.
-      if (count > 0 && this.editorGroup) {
-        await this.editorGroup.suspendMembers(auth, { transaction });
+      if (count > 0) {
+        // The skill no longer contributes any space requirement: drop its
+        // spaces from the agents using it (unless another active capability
+        // still requires them).
+        await this.updateActiveAgentsRequirements(
+          auth,
+          {
+            previousRequestedSpaceIds: this.requestedSpaceIds,
+            newRequestedSpaceIds: [],
+          },
+          { transaction }
+        );
+
+        // Suspend all editor group memberships for this skill.
+        if (this.editorGroup) {
+          await this.editorGroup.suspendMembers(auth, { transaction });
+        }
       }
 
       return count;
@@ -2328,12 +2352,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   async restore(auth: Authenticator): Promise<{ affectedCount: number }> {
     assert(this.canWrite(auth), "User is not authorized to restore this skill");
 
-    const [affectedCount] = await this.update({ status: "active" });
+    const affectedCount = await withTransaction(async (transaction) => {
+      const [count] = await this.update({ status: "active" }, transaction);
 
-    // Restore all editor group memberships (set suspended → active).
-    if (affectedCount > 0 && this.editorGroup) {
-      await this.editorGroup.restoreMembers(auth);
-    }
+      if (count > 0) {
+        // The skill contributes its space requirements again: add them back to
+        // the agents using it.
+        await this.updateActiveAgentsRequirements(
+          auth,
+          {
+            previousRequestedSpaceIds: [],
+            newRequestedSpaceIds: this.requestedSpaceIds,
+          },
+          { transaction }
+        );
+
+        // Restore all editor group memberships (set suspended → active).
+        if (this.editorGroup) {
+          await this.editorGroup.restoreMembers(auth, { transaction });
+        }
+      }
+
+      return count;
+    });
 
     return { affectedCount };
   }


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8668

Archiving/unarchiving a skill was not correctly updating the requestSpaceIds of the agents using this skill.

## Tests

Unit tests added

## Risk

low, easy to revert 

## Deploy Plan

deploy front
