### PR TITLE
Add: Dust Desktop FF + auto discovery (temporary)

### DIFF
--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -36,6 +36,23 @@ export function getMCPServerRegistryKey({
 }
 
 /**
+ * Redis SCAN pattern for all registry keys sharing a server name's base id.
+ * Used only by {@link getLatestMCPServerRegistrationByName} (temporary).
+ */
+export function getMCPServerRegistryKeyPatternForServerName({
+  workspaceId,
+  userId,
+  serverName,
+}: {
+  workspaceId: string;
+  userId: string;
+  serverName: string;
+}): string {
+  const baseServerId = getMCPServerIdFromServerName({ serverName });
+  return `w:${workspaceId}:mcp:reg:u:${userId}:s:${baseServerId}*`;
+}
+
+/**
  * Get the base serverId by removing any numeric suffix.
  * For example: "mcp-client-side:my-server.1" -> "mcp-client-side:my-server"
  * This is safe because:
@@ -56,10 +73,20 @@ export function getMCPServerIdFromServerName({
   return `mcp-client-side:${slugify(serverName)}`;
 }
 
+/** Registration name used by Dust Desktop (slug → mcp-client-side:dust_desktop). */
+export const DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME = "dust-desktop";
+
+function clientSideMCPServerNamesMatch(
+  requestedName: string,
+  storedName: string
+): boolean {
+  return slugify(requestedName) === slugify(storedName);
+}
+
 /**
  * Interface for MCP server registration metadata.
  */
-interface MCPServerRegistration {
+export interface MCPServerRegistration {
   lastHeartbeat: number;
   registeredAt: number;
   serverId: string;
@@ -181,6 +208,90 @@ export async function getMCPServersMetadata(
         return [serverId, result ? JSON.parse(result) : null];
       })
     );
+  });
+}
+
+/**
+ * Return the registered instance with the most recent heartbeat for a server name.
+ *
+ * TODO: Temporary helper to make Dust Desktop testing easier (reconnect without a
+ * persisted serverId). Do not keep long term — it relies on a Redis SCAN over the
+ * full keyspace. Replace with client-side serverId persistence or a bounded lookup.
+ */
+export async function getLatestMCPServerRegistrationByName(
+  auth: Authenticator,
+  {
+    serverName,
+    workspaceId,
+  }: {
+    serverName: string;
+    workspaceId?: string;
+  }
+): Promise<MCPServerRegistration | null> {
+  const user = auth.getNonNullableUser();
+  const userId = user.id.toString();
+  const resolvedWorkspaceId = workspaceId ?? auth.getNonNullableWorkspace().sId;
+
+  const pattern = getMCPServerRegistryKeyPatternForServerName({
+    workspaceId: resolvedWorkspaceId,
+    userId,
+    serverName,
+  });
+
+  return runOnRedis({ origin: "mcp_client_side_request" }, async (redis) => {
+    const keys: string[] = [];
+    for await (const key of redis.scanIterator({ MATCH: pattern })) {
+      keys.push(key);
+    }
+
+    if (keys.length === 0) {
+      return null;
+    }
+
+    const results = await redis.mGet(keys);
+    let latest: MCPServerRegistration | null = null;
+    const scannedRegistrations: Array<{
+      key: string;
+      serverId: string;
+      storedServerName: string;
+      lastHeartbeat: number;
+      matchesRequestedName: boolean;
+    }> = [];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const key = keys[i];
+      if (!result) {
+        scannedRegistrations.push({
+          key,
+          serverId: "missing",
+          storedServerName: "missing",
+          lastHeartbeat: 0,
+          matchesRequestedName: false,
+        });
+        continue;
+      }
+      const metadata = JSON.parse(result) as MCPServerRegistration;
+      const matchesRequestedName = clientSideMCPServerNamesMatch(
+        serverName,
+        metadata.serverName
+      );
+      scannedRegistrations.push({
+        key,
+        serverId: metadata.serverId,
+        storedServerName: metadata.serverName,
+        lastHeartbeat: metadata.lastHeartbeat,
+        matchesRequestedName,
+      });
+      if (!matchesRequestedName) {
+        continue;
+      }
+      if (!latest || metadata.lastHeartbeat > latest.lastHeartbeat) {
+        latest = metadata;
+      }
+    }
+
+    return latest;
   });
 }
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -7,6 +7,10 @@ import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
+import {
+  DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME,
+  getLatestMCPServerRegistrationByName,
+} from "@app/lib/api/actions/mcp/client_side_registry";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
@@ -244,10 +248,27 @@ export async function runModel(
       }
     );
 
+    const clientSideMCPServerIds = [
+      ...(userMessage.context.clientSideMCPServerIds ?? []),
+    ];
+    const featureFlags = await getFeatureFlags(auth);
+    if (featureFlags.includes("dust_desktop")) {
+      const dustDesktopRegistration =
+        await getLatestMCPServerRegistrationByName(auth, {
+          serverName: DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME,
+        });
+      if (
+        dustDesktopRegistration &&
+        !clientSideMCPServerIds.includes(dustDesktopRegistration.serverId)
+      ) {
+        clientSideMCPServerIds.push(dustDesktopRegistration.serverId);
+      }
+    }
+
     const clientSideMCPActionConfigurations =
       await createClientSideMCPServerConfigurations(
         auth,
-        userMessage.context.clientSideMCPServerIds
+        clientSideMCPServerIds
       );
 
     const { enabledSkills, systemSkills, equippedSkills } =

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,6 +320,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the Metronome-owned payment-gated checkout flow for Business plan activation (replaces direct Stripe charge).",
     stage: "dust_only",
   },
+  dust_desktop: {
+    description:
+      "Auto-attach the Dust Desktop client-side MCP server to agent runs when registered for the user.",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -700,6 +700,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dummy_feature_for_flag_testing"
   | "dust_academy"
   | "dust_agent_gpt_5_5_default"
+  | "dust_desktop"
   | "dust_internal_global_agents"
   | "dust_no_spa"
   | "dust_spa"


### PR DESCRIPTION
## Description

Adds a `dust_desktop` feature flag (`dust_only`) and temporary auto-discovery for the Dust Desktop client-side MCP server. When the flag is enabled, `runModel` calls `getLatestMCPServerRegistrationByName` — a Redis SCAN over the current user's registry keys — to find the most recently heartbeated `dust-desktop` registration and auto-injects its `serverId` into `clientSideMCPServerIds`. This lets Dust Desktop reconnect without requiring the client to persist or re-send its `serverId` on each session.

The helper is intentionally marked `TODO: temporary` and should be replaced with client-side `serverId` persistence or a bounded lookup once Dust Desktop stabilises.

## Tests

Tested manually with Dust Desktop registered and the `dust_desktop` FF enabled.

## Risk

Low for users without the flag — no code path change. For flagged users, `getLatestMCPServerRegistrationByName` performs a Redis SCAN scoped to the user's keyspace; acceptable at current volume but not production-grade at scale. Auto-discovery is additive — if no registration is found, behaviour is identical to today.

## Deploy Plan

Deploy front. Enable `dust_desktop` FF selectively via Poke.
