### PR TITLE
Fix Confluence page body rendering by switching to view format

### DIFF
--- a/front/lib/api/actions/servers/confluence/helpers.ts
+++ b/front/lib/api/actions/servers/confluence/helpers.ts
@@ -62,6 +62,7 @@ async function confluenceApiCall<T extends z.ZodTypeAny>(
     }
 
     const responseText = await response.text();
+
     if (!responseText) {
       return new Ok(undefined);
     }
@@ -412,7 +413,7 @@ export async function getPage(
 ): Promise<Result<ConfluencePage | null, string>> {
   const searchParams = new URLSearchParams();
   if (includeBody) {
-    searchParams.append("body-format", "storage");
+    searchParams.append("body-format", "view");
   }
 
   const endpoint = `/wiki/api/v2/pages/${pageId}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
@@ -432,6 +433,7 @@ export async function getPage(
     if (result.error.includes("404")) {
       return new Ok(null);
     }
+
     return new Err(result.error);
   }
 

--- a/front/lib/api/actions/servers/confluence/rendering.ts
+++ b/front/lib/api/actions/servers/confluence/rendering.ts
@@ -231,14 +231,17 @@ function extractBodyMarkdown(page: RenderablePage): {
     return { markdown: null };
   }
 
+  // Prefer rendered HTML (view format) over raw storage XML since TurndownService
+  // expects HTML. Storage format contains Confluence-specific XML (CDATA, ac:* elements)
+  // that TurndownService cannot parse correctly.
+  const viewHtml = body.view?.value?.trim();
+  if (viewHtml) {
+    return { markdown: convertHtmlToMarkdown(viewHtml) };
+  }
+
   const storageHtml = body.storage?.value?.trim();
   if (storageHtml) {
     return { markdown: convertHtmlToMarkdown(storageHtml) };
-  }
-
-  const storageRepresentation = body.storage?.representation;
-  if (storageRepresentation === "storage") {
-    return { markdown: convertHtmlToMarkdown(body.storage?.value ?? "") };
   }
 
   return { markdown: null };

--- a/front/lib/api/actions/servers/confluence/tools/index.ts
+++ b/front/lib/api/actions/servers/confluence/tools/index.ts
@@ -125,6 +125,7 @@ export function createConfluenceTools(): ToolDefinition[] {
           if (result.isErr()) {
             throw new MCPError(`Error getting page: ${result.error}`);
           }
+
           return result.value;
         }
       );

--- a/front/lib/api/actions/servers/confluence/types.ts
+++ b/front/lib/api/actions/servers/confluence/types.ts
@@ -108,16 +108,7 @@ export const ConfluenceV1SearchPageSchema = z
         })
       )
       .optional(),
-    body: z
-      .object({
-        storage: z
-          .object({
-            value: z.string(),
-            representation: z.literal("storage"),
-          })
-          .optional(),
-      })
-      .optional(),
+    body: ConfluencePageBodySchema.optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/8031.

The `get_page` tool was requesting page bodies using `body-format=storage`, which returns Confluence's XML-based representation. `TurndownService` expects HTML, so it could not parse the storage format correctly, resulting in garbled output including raw `CDATA` markers (]]>), missing content from code blocks, and dropped text around angle brackets.

Switching to `body-format=view` returns pre-rendered HTML that `TurndownService` converts to Markdown correctly. The `extractBodyMarkdown` function in the renderer has been updated to prefer `body.view` over `body.storage` when available.

Will update connectors implementation in a follow up PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
