### PR TITLE
poke: List skill usage (agents and skills) in poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -39,10 +39,18 @@ app.get(
       serializedSkill.requestedSpaceIds
     );
 
+    const agentsUsage = await skill.fetchUsage(auth);
+    const usedBySkillsMap = await SkillResource.batchFetchUsedBySkills(auth, [
+      skill,
+    ]);
+    const usedBySkills = usedBySkillsMap.get(skill.sId) ?? [];
+
     return ctx.json({
       skill: serializedSkill,
       editedByUser: editedByUser ? editedByUser.toJSON() : null,
       spaces: spaces.map((s) => s.toJSON()),
+      agentsUsage,
+      usedBySkills,
     });
   }
 );

--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -65,7 +65,8 @@ export function SkillDetailsPage() {
     );
   }
 
-  const { skill, editedByUser, spaces } = skillDetails;
+  const { skill, editedByUser, spaces, agentsUsage, usedBySkills } =
+    skillDetails;
 
   return (
     <div>
@@ -156,6 +157,69 @@ export function SkillDetailsPage() {
               />
             </div>
           ))}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="border-material-200 rounded-lg border p-4">
+          <Collapsible defaultOpen={false}>
+            <CollapsibleTrigger>
+              <h2 className="text-md font-bold">
+                Used by ({agentsUsage.count} agents, {usedBySkills.length}{" "}
+                skills)
+              </h2>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-4 flex flex-row gap-4">
+                <div className="flex-1">
+                  <h3 className="pb-2 text-sm font-bold">
+                    Agents ({agentsUsage.count})
+                  </h3>
+                  {agentsUsage.agents.length === 0 ? (
+                    <p className="text-muted-foreground dark:text-muted-foreground-night text-sm">
+                      No agents use this skill.
+                    </p>
+                  ) : (
+                    <div className="space-y-1">
+                      {agentsUsage.agents.map((agent) => (
+                        <div key={agent.sId}>
+                          <LinkWrapper
+                            href={`/poke/${owner.sId}/assistants/${agent.sId}`}
+                            className="text-highlight-500"
+                          >
+                            {agent.name}
+                          </LinkWrapper>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="flex-1">
+                  <h3 className="pb-2 text-sm font-bold">
+                    Skills ({usedBySkills.length})
+                  </h3>
+                  {usedBySkills.length === 0 ? (
+                    <p className="text-muted-foreground dark:text-muted-foreground-night text-sm">
+                      No skills use this skill.
+                    </p>
+                  ) : (
+                    <div className="space-y-1">
+                      {usedBySkills.map((usedBySkill) => (
+                        <div key={usedBySkill.sId}>
+                          <LinkWrapper
+                            href={`/poke/${owner.sId}/skills/${usedBySkill.sId}`}
+                            className="text-highlight-500"
+                          >
+                            {usedBySkill.name}
+                          </LinkWrapper>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       </div>
 

--- a/front/lib/api/poke/skills.ts
+++ b/front/lib/api/poke/skills.ts
@@ -1,7 +1,9 @@
 import type {
   SkillType,
   SkillWithVersionType,
+  UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
+import type { AgentsUsageType } from "@app/types/data_source";
 import type { SpaceType } from "@app/types/space";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import type { UserType } from "@app/types/user";
@@ -26,6 +28,10 @@ export type PokeGetSkillDetails = {
   skill: SkillType;
   editedByUser: UserType | null;
   spaces: SpaceType[];
+  // Agents that use this skill.
+  agentsUsage: AgentsUsageType;
+  // Parent skills that reference this skill.
+  usedBySkills: UsedBySkillType[];
 };
 
 export type PokeGetSkillVersions = {


### PR DESCRIPTION
## Description

Add an easy way to find agents/skills using a skill in poke

Collapsed by default to avoid taking a huge space.

<img width="1688" height="253" alt="Screenshot 2026-06-08 at 14 12 24" src="https://github.com/user-attachments/assets/76681a17-7b9d-44e6-8d3d-aa6ff073bdb3" />


## Tests

tested locally

## Risk

low, easy to revert, only a poke change

## Deploy Plan

deploy front 
