### PR TITLE
State machines: clean old Redis keys

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -7,7 +7,6 @@ import {
   getWorkspaceProgrammaticCreditStatus,
   isUserAwuWarned,
   isUserBlocked,
-  isWorkspaceProgrammaticWarned,
 } from "@app/lib/metronome/user_block";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -52,7 +51,10 @@ app.get(
     let programmaticCreditStatus: ProgrammaticCreditStatus = "active";
     if (programmaticState === "depleted") {
       programmaticCreditStatus = "depleted";
-    } else if (await isWorkspaceProgrammaticWarned(workspace.sId)) {
+    } else if (
+      programmaticState === "active_low_balance" ||
+      programmaticState === "active_critical_balance"
+    ) {
       programmaticCreditStatus = "warned";
     }
 

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -19,9 +19,8 @@ import {
   getProductSeatTypes,
 } from "@app/lib/metronome/seat_types";
 import {
-  clearUserCapBlocked,
-  clearWorkspaceProgrammaticWarned,
-  setWorkspaceProgrammaticWarned,
+  setUserCreditState,
+  setWorkspaceProgrammaticCreditStatus,
 } from "@app/lib/metronome/user_block";
 import type { LiveUserSeatBalance } from "@app/lib/metronome/user_credit_state_machine";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
@@ -398,6 +397,53 @@ export async function dispatchPerUserCapWarning({
   }
 }
 
+export async function dispatchPerUserCapWarningResolved({
+  workspace,
+  userId,
+}: {
+  workspace: WorkspaceResource;
+  userId: string;
+}): Promise<void> {
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId },
+      "[CreditStateDispatcher] per_user_cap_warning_resolved: user not found, skipping"
+    );
+    return;
+  }
+
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace: lightWorkspace,
+    });
+  if (!membership) {
+    logger.warn(
+      { workspaceId: workspace.sId, userId },
+      "[CreditStateDispatcher] per_user_cap_warning_resolved: no active membership, skipping"
+    );
+    return;
+  }
+
+  const result = await transitionUserCreditState(
+    membership,
+    { type: "per_user_cap_warning_resolved" },
+    { workspaceId: workspace.sId, userId }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        userId,
+        creditState: membership.creditState,
+      },
+      "[CreditStateDispatcher] per_user_cap_warning_resolved: transition skipped"
+    );
+  }
+}
+
 export async function dispatchPerUserCapResolved({
   workspace,
   userId,
@@ -409,9 +455,9 @@ export async function dispatchPerUserCapResolved({
   if (!user) {
     logger.warn(
       { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] per_user_cap_resolved: user not found, clearing legacy block"
+      "[CreditStateDispatcher] per_user_cap_resolved: user not found, resetting credit state"
     );
-    await clearUserCapBlocked(workspace.sId, userId);
+    await setUserCreditState(workspace.sId, userId, "on_pool");
     return new Ok(undefined);
   }
 
@@ -425,9 +471,9 @@ export async function dispatchPerUserCapResolved({
   if (!membership) {
     logger.warn(
       { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] per_user_cap_resolved: no active membership, clearing legacy block"
+      "[CreditStateDispatcher] per_user_cap_resolved: no active membership, resetting credit state"
     );
-    await clearUserCapBlocked(workspace.sId, userId);
+    await setUserCreditState(workspace.sId, userId, "on_pool");
     return new Ok(undefined);
   }
 
@@ -621,7 +667,6 @@ export async function dispatchProgrammaticCapReset({
   await transitionProgrammaticCreditState(workspace, {
     type: "programmatic_cap_reset",
   });
-  void clearWorkspaceProgrammaticWarned(workspace.sId);
 }
 
 /**
@@ -638,7 +683,10 @@ export async function dispatchProgrammaticWarning({
   workspace: WorkspaceResource;
   eventId: string;
 }): Promise<void> {
-  void setWorkspaceProgrammaticWarned(workspace.sId);
+  void setWorkspaceProgrammaticCreditStatus(
+    workspace.sId,
+    "active_low_balance"
+  );
   void notifyAdminsProgrammaticCapAboutStatus({
     workspace,
     isBlocked: false,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -65,10 +65,6 @@ import {
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
-import {
-  clearUserAwuWarned,
-  setUserAwuWarned,
-} from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
@@ -734,11 +730,9 @@ async function handlePerUserSpendThresholdEvent({
           )
         );
       }
-      void clearUserAwuWarned(workspace.sId, userId);
     }
   } else if (eventAlertId === warningAlertId && isReached) {
     // Warning alert (80%) fired — notify but don't block.
-    void setUserAwuWarned(workspace.sId, userId);
     void dispatchPerUserCapWarning({ workspace, userId });
     const user = await UserResource.fetchById(userId);
     if (user) {

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -5,6 +5,7 @@ import {
 import {
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
+  dispatchPerUserCapWarningResolved,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
@@ -18,7 +19,6 @@ import {
 } from "@app/lib/metronome/alerts/spend_limits";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
-import { clearUserAwuWarned } from "@app/lib/metronome/user_block";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -291,7 +291,7 @@ export async function setUserSpendLimit(
     limit.kind === "limited" ? limit.awuCredits : null
   );
 
-  let transitionedTo: "reached" | "resolved" | null;
+  let transitionedTo: "reached" | "resolved" | null = null;
 
   switch (limit.kind) {
     case "unlimited": {
@@ -331,7 +331,14 @@ export async function setUserSpendLimit(
           "[Metronome PerUserCap] Failed to clear warning alert; continuing"
         );
       }
-      void clearUserAwuWarned(workspace.sId, user.sId);
+      void dispatchPerUserCapResolved({
+        workspace: workspaceResource,
+        userId,
+      });
+      void dispatchPerUserCapWarningResolved({
+        workspace: workspaceResource,
+        userId,
+      });
 
       // Look up the user's seat type to find the matching default cap.
       const normalizedSeatType = normalizeToPoolLimitSeatType(

--- a/front/lib/metronome/programmatic_credit_state_machine.test.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.test.ts
@@ -12,13 +12,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 const {
-  mockSetWorkspaceProgrammaticDepleted,
-  mockClearWorkspaceProgrammaticDepleted,
   mockSetWorkspaceProgrammaticCreditStatus,
   mockInvalidateCacheAfterCommit,
 } = vi.hoisted(() => ({
-  mockSetWorkspaceProgrammaticDepleted: vi.fn(),
-  mockClearWorkspaceProgrammaticDepleted: vi.fn(),
   mockSetWorkspaceProgrammaticCreditStatus: vi.fn(),
   mockInvalidateCacheAfterCommit: vi.fn(
     (_tx: Transaction | undefined, fn: () => Promise<void>) => {
@@ -28,8 +24,6 @@ const {
 }));
 
 vi.mock("@app/lib/metronome/user_block", () => ({
-  setWorkspaceProgrammaticDepleted: mockSetWorkspaceProgrammaticDepleted,
-  clearWorkspaceProgrammaticDepleted: mockClearWorkspaceProgrammaticDepleted,
   setWorkspaceProgrammaticCreditStatus:
     mockSetWorkspaceProgrammaticCreditStatus,
 }));
@@ -82,9 +76,6 @@ describe("ProgrammaticCreditStateMachine — low balance", () => {
     expect(workspace.updateProgrammaticCreditState).toHaveBeenCalledWith(
       "active_low_balance",
       undefined
-    );
-    expect(mockClearWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
-      "ws_test"
     );
   });
 
@@ -165,9 +156,6 @@ describe("ProgrammaticCreditStateMachine — cap reached", () => {
     if (result.isOk()) {
       expect(result.value).toBe("depleted");
     }
-    expect(mockSetWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
-      "ws_test"
-    );
   });
 
   it("depleted + cap_reached is idempotent", async () => {
@@ -180,9 +168,6 @@ describe("ProgrammaticCreditStateMachine — cap reached", () => {
       expect(result.value).toBe("depleted");
     }
     expect(workspace.updateProgrammaticCreditState).not.toHaveBeenCalled();
-    expect(mockSetWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
-      "ws_test"
-    );
   });
 });
 
@@ -211,9 +196,6 @@ describe("ProgrammaticCreditStateMachine — cap reset", () => {
         undefined
       );
     }
-    expect(mockClearWorkspaceProgrammaticDepleted).toHaveBeenCalledWith(
-      "ws_test"
-    );
   });
 });
 

--- a/front/lib/metronome/programmatic_credit_state_machine.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.ts
@@ -1,16 +1,11 @@
 import { CRITICAL_BALANCE_OFFSET } from "@app/lib/metronome/alerts/programmatic_cap";
-import {
-  clearWorkspaceProgrammaticDepleted,
-  setWorkspaceProgrammaticCreditStatus,
-  setWorkspaceProgrammaticDepleted,
-} from "@app/lib/metronome/user_block";
+import { setWorkspaceProgrammaticCreditStatus } from "@app/lib/metronome/user_block";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { WorkspaceProgrammaticCreditState } from "@app/types/credits";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 
 export type ProgrammaticCreditEvent =
@@ -71,37 +66,6 @@ function remainingAtMost(threshold: number): ProgrammaticCreditGuard {
   return (event) =>
     event.type === "programmatic_low_balance" &&
     event.remainingCredits <= threshold;
-}
-
-function syncProgrammaticCacheForState(
-  state: WorkspaceProgrammaticCreditState,
-  workspaceId: string,
-  transaction: Transaction | undefined
-): void {
-  switch (state) {
-    case "active":
-    case "active_low_balance":
-    case "active_critical_balance":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearWorkspaceProgrammaticDepleted(workspaceId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspaceProgrammaticCreditStatus(workspaceId, state)
-      );
-      return;
-
-    case "depleted":
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspaceProgrammaticDepleted(workspaceId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspaceProgrammaticCreditStatus(workspaceId, state)
-      );
-      return;
-
-    default:
-      assertNever(state);
-  }
 }
 
 const TRANSITIONS: ProgrammaticCreditTransition[] = [
@@ -199,7 +163,9 @@ export async function transitionProgrammaticCreditState(
   if (currentState !== match.to) {
     await workspace.updateProgrammaticCreditState(match.to, transaction);
   }
-  syncProgrammaticCacheForState(match.to, workspaceId, transaction);
+  invalidateCacheAfterCommit(transaction, () =>
+    setWorkspaceProgrammaticCreditStatus(workspaceId, match.to)
+  );
   logger.info(
     {
       workspaceId,
@@ -232,7 +198,9 @@ export async function setProgrammaticCreditStateReconciled(
   if (currentState !== targetState) {
     await workspace.updateProgrammaticCreditState(targetState, transaction);
   }
-  syncProgrammaticCacheForState(targetState, workspaceId, transaction);
+  invalidateCacheAfterCommit(transaction, () =>
+    setWorkspaceProgrammaticCreditStatus(workspaceId, targetState)
+  );
   logger.info(
     {
       workspaceId,

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -1,26 +1,22 @@
 // Redis fast-path cache for credit-state-driven access control.
 //
-// Three keys back the credit state machines:
-//   - `metronome:user_cap:<ws>:<user>`: caches the user's per-user cap state.
-//   - `metronome:user_awu_warning:<ws>:<user>`: caches the 80% AWU warning state.
-//   - `metronome:pool_depleted:<ws>`: caches the workspace pool state.
+// Four keys back the credit state machines:
+//   - `metronome:user_credit_state:<ws>:<user>`: fine-grained user credit state
+//     (mirrors `memberships.creditState`). Replaces the legacy boolean cap and
+//     warning flags — "capped" means blocked, "*_low_balance" means warned.
+//   - `metronome:pool_credit_status:<ws>`: fine-grained workspace pool state
+//     (mirrors `workspaces.poolCreditState`).
+//   - `metronome:pool_depleted:<ws>`: boolean shortcut for isUserBlocked /
+//     isApiBlocked hot paths (still maintained alongside pool_credit_status).
+//   - `metronome:programmatic_credit_status:<ws>` / `metronome:programmatic_depleted:<ws>`:
+//     programmatic (API) cap state.
 //
-// Each key stores an explicit boolean flag:
-//   - `"1"`: blocked / warned / depleted
-//   - `"0"`: not blocked / not warned / not depleted
-//
-// `isUserBlocked` is the unified read: a user is blocked iff either cached flag
-// is `"1"`, and it returns the reason ("credits_exhausted" for a depleted
-// workspace pool, or "user_cap_reached" for a per-user cap) so callers can
-// surface a tailored message. When both flags are set, `credits_exhausted`
-// wins since the pool shadows the per-user state. The DB columns
-// (`memberships.creditState`, `workspaces.poolCreditState`) remain the source
-// of truth. Cache writes are gated on DB transaction commit via
-// `invalidateCacheAfterCommit`, and cache misses fall back to DB and
-// repopulate both flags.
-//
-// The warning flag (`metronome:user_awu_warning`) has no DB column backing it:
-// a cold-cache miss returns `false` (safe default until the next webhook re-sets the flag).
+// `isUserBlocked` is the unified read: a user is blocked iff the pool is
+// depleted or the user's credit state is "capped". It returns the reason
+// ("credits_exhausted" / "user_cap_reached") so callers can surface a tailored
+// message. The DB columns remain the source of truth; cache writes are gated on
+// DB transaction commit via `invalidateCacheAfterCommit`, and cache misses fall
+// back to DB and repopulate the relevant keys.
 //
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -53,20 +49,6 @@ export type GetWorkspaceUsageStatusResponseBody = {
 };
 
 const REDIS_ORIGIN = "metronome_limit" as const;
-const BLOCKED_FLAG = "1";
-const NOT_BLOCKED_FLAG = "0";
-
-function buildUserCapKey(workspaceId: string, userId: string): string {
-  return `metronome:user_cap:${workspaceId}:${userId}`;
-}
-
-function buildUserAwuWarningKey(workspaceId: string, userId: string): string {
-  return `metronome:user_awu_warning:${workspaceId}:${userId}`;
-}
-
-function buildWorkspacePoolDepletedKey(workspaceId: string): string {
-  return `metronome:pool_depleted:${workspaceId}`;
-}
 
 function buildWorkspaceCreditPoolStatusKey(workspaceId: string): string {
   return `metronome:pool_credit_status:${workspaceId}`;
@@ -76,22 +58,10 @@ function buildUserCreditStateKey(workspaceId: string, userId: string): string {
   return `metronome:user_credit_state:${workspaceId}:${userId}`;
 }
 
-function buildWorkspaceProgrammaticWarningKey(workspaceId: string): string {
-  return `metronome:programmatic_warning:${workspaceId}`;
-}
-
-function buildWorkspaceProgrammaticDepletedKey(workspaceId: string): string {
-  return `metronome:programmatic_depleted:${workspaceId}`;
-}
-
 function buildWorkspaceProgrammaticCreditStatusKey(
   workspaceId: string
 ): string {
   return `metronome:programmatic_credit_status:${workspaceId}`;
-}
-
-function isBlockFlag(value: string | null): value is "0" | "1" {
-  return value === BLOCKED_FLAG || value === NOT_BLOCKED_FLAG;
 }
 
 async function setFlag(key: string, value: string): Promise<void> {
@@ -100,152 +70,15 @@ async function setFlag(key: string, value: string): Promise<void> {
   });
 }
 
-async function getUserBlockedStateFromDb({
-  workspaceId,
-  userId,
-}: {
-  workspaceId: string;
-  userId: string;
-}): Promise<{ userCapBlocked: boolean; workspacePoolDepleted: boolean }> {
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    logger.warn(
-      { workspaceId, userId },
-      "[MetronomeUserBlock] Workspace not found during cache read-through fallback"
-    );
-    return {
-      userCapBlocked: false,
-      workspacePoolDepleted: false,
-    };
-  }
-
-  const user = await UserResource.fetchById(userId);
-  if (!user) {
-    logger.warn(
-      { workspaceId, userId },
-      "[MetronomeUserBlock] User not found during cache read-through fallback"
-    );
-    return {
-      userCapBlocked: false,
-      workspacePoolDepleted: workspace.poolCreditState === "depleted",
-    };
-  }
-
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace: renderLightWorkspaceType({ workspace }),
-    });
-
-  return {
-    userCapBlocked: membership?.creditState === "capped",
-    workspacePoolDepleted: workspace.poolCreditState === "depleted",
-  };
-}
-
-async function syncCachedBlockedState({
-  workspaceId,
-  userId,
-  userCapBlocked,
-  workspacePoolDepleted,
-}: {
-  workspaceId: string;
-  userId: string;
-  userCapBlocked: boolean;
-  workspacePoolDepleted: boolean;
-}): Promise<void> {
-  await Promise.all([
-    setFlag(buildUserCapKey(workspaceId, userId), userCapBlocked ? "1" : "0"),
-    setFlag(
-      buildWorkspacePoolDepletedKey(workspaceId),
-      workspacePoolDepleted ? "1" : "0"
-    ),
-  ]);
-}
-
-// Per-user cap (user credit state machine)
-
-export async function setUserCapBlocked(
-  workspaceId: string,
-  userId: string
-): Promise<void> {
-  await setFlag(buildUserCapKey(workspaceId, userId), BLOCKED_FLAG);
-}
-
-export async function clearUserCapBlocked(
-  workspaceId: string,
-  userId: string
-): Promise<void> {
-  await setFlag(buildUserCapKey(workspaceId, userId), NOT_BLOCKED_FLAG);
-}
-
-// Per-user AWU 80% warning (set by webhook; no DB fallback)
-
-export async function setUserAwuWarned(
-  workspaceId: string,
-  userId: string
-): Promise<void> {
-  await setFlag(buildUserAwuWarningKey(workspaceId, userId), BLOCKED_FLAG);
-}
-
-export async function clearUserAwuWarned(
-  workspaceId: string,
-  userId: string
-): Promise<void> {
-  await setFlag(buildUserAwuWarningKey(workspaceId, userId), NOT_BLOCKED_FLAG);
-}
+// Per-user AWU 80% warning — derived from the fine-grained credit state.
+// "*_low_balance" states mean the user is warned but not yet blocked.
 
 export async function isUserAwuWarned(
   workspaceId: string,
   userId: string
 ): Promise<boolean> {
-  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
-    client.get(buildUserAwuWarningKey(workspaceId, userId))
-  );
-  return val === BLOCKED_FLAG;
-}
-
-// Workspace programmatic cap 80% warning (set by webhook; no DB fallback)
-
-export async function setWorkspaceProgrammaticWarned(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(
-    buildWorkspaceProgrammaticWarningKey(workspaceId),
-    BLOCKED_FLAG
-  );
-}
-
-export async function clearWorkspaceProgrammaticWarned(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(
-    buildWorkspaceProgrammaticWarningKey(workspaceId),
-    NOT_BLOCKED_FLAG
-  );
-}
-
-export async function isWorkspaceProgrammaticWarned(
-  workspaceId: string
-): Promise<boolean> {
-  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
-    client.get(buildWorkspaceProgrammaticWarningKey(workspaceId))
-  );
-  return val === BLOCKED_FLAG;
-}
-
-// Workspace pool depleted (workspace credit state machine)
-
-export async function setWorkspacePoolDepleted(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(buildWorkspacePoolDepletedKey(workspaceId), BLOCKED_FLAG);
-}
-
-export async function clearWorkspacePoolDepleted(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(buildWorkspacePoolDepletedKey(workspaceId), NOT_BLOCKED_FLAG);
+  const state = await getUserCreditState(workspaceId, userId);
+  return state === "on_pool_low_balance" || state === "user_seat_low_balance";
 }
 
 // Unified read
@@ -270,57 +103,39 @@ export async function isUserBlocked(
   workspaceId: string,
   userId: string
 ): Promise<UserBlockedReason | null> {
-  const [userCap, poolDepleted] = await runOnRedis(
+  const [creditStateRaw, poolStatusRaw] = await runOnRedis(
     { origin: REDIS_ORIGIN },
     async (client) =>
       Promise.all([
-        client.get(buildUserCapKey(workspaceId, userId)),
-        client.get(buildWorkspacePoolDepletedKey(workspaceId)),
+        client.get(buildUserCreditStateKey(workspaceId, userId)),
+        client.get(buildWorkspaceCreditPoolStatusKey(workspaceId)),
       ])
   );
 
-  let userCapBlocked: boolean;
-  let workspacePoolDepleted: boolean;
+  // Both getters have their own DB fallback and cache repopulation.
+  const userCreditState =
+    creditStateRaw && isUserCreditState(creditStateRaw)
+      ? creditStateRaw
+      : await getUserCreditState(workspaceId, userId);
 
-  if (isBlockFlag(userCap) && isBlockFlag(poolDepleted)) {
-    userCapBlocked = userCap === BLOCKED_FLAG;
-    workspacePoolDepleted = poolDepleted === BLOCKED_FLAG;
-  } else {
-    logger.info(
-      {
-        workspaceId,
-        userId,
-        userCapCacheHit: isBlockFlag(userCap),
-        workspacePoolCacheHit: isBlockFlag(poolDepleted),
-      },
-      "[MetronomeUserBlock] Cache miss during user blocked check, falling back to DB"
-    );
+  const poolStatus =
+    poolStatusRaw && isWorkspacePoolCreditState(poolStatusRaw)
+      ? poolStatusRaw
+      : await getWorkspaceCreditPoolStatus(workspaceId);
 
-    const state = await getUserBlockedStateFromDb({ workspaceId, userId });
-    await syncCachedBlockedState({
-      workspaceId,
-      userId,
-      userCapBlocked: state.userCapBlocked,
-      workspacePoolDepleted: state.workspacePoolDepleted,
-    });
-
-    userCapBlocked = state.userCapBlocked;
-    workspacePoolDepleted = state.workspacePoolDepleted;
-  }
+  let workspacePoolDepleted = poolStatus === "depleted";
 
   // A user spending from their personal seat balance (`user_seat` /
   // `user_seat_low_balance`) still has their own credits, so workspace pool
-  // depletion must not block them — only their per-user cap can. We only need
-  // the per-user credit state when the pool is depleted, since otherwise it
-  // cannot change the outcome.
-  if (workspacePoolDepleted) {
-    const userCreditState = await getUserCreditState(workspaceId, userId);
-    if (isSpendingFromPersonalSeat(userCreditState)) {
-      workspacePoolDepleted = false;
-    }
+  // depletion must not block them — only their per-user cap can.
+  if (workspacePoolDepleted && isSpendingFromPersonalSeat(userCreditState)) {
+    workspacePoolDepleted = false;
   }
 
-  return deriveBlockedReason({ userCapBlocked, workspacePoolDepleted });
+  return deriveBlockedReason({
+    userCapBlocked: userCreditState === "capped",
+    workspacePoolDepleted,
+  });
 }
 
 // Per-user credit state (fine-grained state mirroring memberships.creditState).
@@ -427,24 +242,6 @@ export async function getWorkspaceCreditPoolStatus(
 
 // Workspace programmatic credit state (monthly cap).
 
-export async function setWorkspaceProgrammaticDepleted(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(
-    buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    BLOCKED_FLAG
-  );
-}
-
-export async function clearWorkspaceProgrammaticDepleted(
-  workspaceId: string
-): Promise<void> {
-  await setFlag(
-    buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    NOT_BLOCKED_FLAG
-  );
-}
-
 export async function setWorkspaceProgrammaticCreditStatus(
   workspaceId: string,
   status: WorkspaceProgrammaticCreditState
@@ -488,72 +285,14 @@ export async function getWorkspaceProgrammaticCreditStatus(
 export async function isProgrammaticApiBlocked(
   workspaceId: string
 ): Promise<boolean> {
-  const depleted = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
-    client.get(buildWorkspaceProgrammaticDepletedKey(workspaceId))
-  );
-
-  if (isBlockFlag(depleted)) {
-    return depleted === BLOCKED_FLAG;
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      workspaceProgrammaticCacheHit: false,
-    },
-    "[MetronomeUserBlock] Cache miss during programmatic API blocked check, falling back to DB"
-  );
-
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    logger.warn(
-      { workspaceId },
-      "[MetronomeUserBlock] Workspace not found during programmatic API blocked cache read-through fallback"
-    );
-    return false;
-  }
-
-  const programmaticDepleted = workspace.programmaticCreditState === "depleted";
-  await setFlag(
-    buildWorkspaceProgrammaticDepletedKey(workspaceId),
-    programmaticDepleted ? BLOCKED_FLAG : NOT_BLOCKED_FLAG
-  );
-  return programmaticDepleted;
+  // getWorkspaceProgrammaticCreditStatus has its own DB fallback and cache repopulation.
+  const status = await getWorkspaceProgrammaticCreditStatus(workspaceId);
+  return status === "depleted";
 }
 
 // Workspace-pool-only read for API calls (no per-user cap).
 export async function isApiBlocked(workspaceId: string): Promise<boolean> {
-  const poolDepleted = await runOnRedis(
-    { origin: REDIS_ORIGIN },
-    async (client) => client.get(buildWorkspacePoolDepletedKey(workspaceId))
-  );
-
-  if (isBlockFlag(poolDepleted)) {
-    return poolDepleted === BLOCKED_FLAG;
-  }
-
-  logger.info(
-    {
-      workspaceId,
-      workspacePoolCacheHit: false,
-    },
-    "[MetronomeUserBlock] Cache miss during API blocked check, falling back to DB"
-  );
-
-  const workspace = await WorkspaceResource.fetchById(workspaceId);
-  if (!workspace) {
-    logger.warn(
-      { workspaceId },
-      "[MetronomeUserBlock] Workspace not found during API blocked cache read-through fallback"
-    );
-    return false;
-  }
-
-  const workspacePoolDepleted = workspace.poolCreditState === "depleted";
-  await setFlag(
-    buildWorkspacePoolDepletedKey(workspaceId),
-    workspacePoolDepleted ? "1" : "0"
-  );
-
-  return workspacePoolDepleted;
+  // getWorkspaceCreditPoolStatus has its own DB fallback and cache repopulation.
+  const poolStatus = await getWorkspaceCreditPoolStatus(workspaceId);
+  return poolStatus === "depleted";
 }

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -19,33 +19,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const {
-  mockSetUserCapBlocked,
-  mockClearUserCapBlocked,
-  mockInvalidateCacheAfterCommit,
-  mockClearUserAwuWarned,
-  mockSetUserAwuWarned,
-  mockSetUserCreditState,
-} = vi.hoisted(() => ({
-  mockSetUserCapBlocked: vi.fn(),
-  mockClearUserCapBlocked: vi.fn(),
-  // Mimics the no-transaction branch of the real helper: fire the callback
-  // synchronously so tests can assert against the underlying Redis calls.
-  mockInvalidateCacheAfterCommit: vi.fn(
-    (_tx: Transaction | undefined, fn: () => Promise<void>) => {
-      void fn();
-    }
-  ),
-  mockClearUserAwuWarned: vi.fn(),
-  mockSetUserAwuWarned: vi.fn(),
-  mockSetUserCreditState: vi.fn(),
-}));
+const { mockInvalidateCacheAfterCommit, mockSetUserCreditState } = vi.hoisted(
+  () => ({
+    // Mimics the no-transaction branch of the real helper: fire the callback
+    // synchronously so tests can assert against the underlying Redis calls.
+    mockInvalidateCacheAfterCommit: vi.fn(
+      (_tx: Transaction | undefined, fn: () => Promise<void>) => {
+        void fn();
+      }
+    ),
+    mockSetUserCreditState: vi.fn(),
+  })
+);
 
 vi.mock("@app/lib/metronome/user_block", () => ({
-  setUserCapBlocked: mockSetUserCapBlocked,
-  clearUserCapBlocked: mockClearUserCapBlocked,
-  clearUserAwuWarned: mockClearUserAwuWarned,
-  setUserAwuWarned: mockSetUserAwuWarned,
   setUserCreditState: mockSetUserCreditState,
 }));
 
@@ -105,8 +92,6 @@ describe("UserCreditStateMachine — transitions", () => {
       "capped",
       undefined
     );
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockClearUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -129,8 +114,6 @@ describe("UserCreditStateMachine — transitions", () => {
       "on_pool",
       undefined
     );
-    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -153,8 +136,6 @@ describe("UserCreditStateMachine — transitions", () => {
       "on_pool",
       undefined
     );
-    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -174,8 +155,6 @@ describe("UserCreditStateMachine — transitions", () => {
       expect(result.value).toBe("capped");
     }
     expect(membership.updateCreditState).not.toHaveBeenCalled();
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockClearUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -195,8 +174,6 @@ describe("UserCreditStateMachine — transitions", () => {
       expect(result.value).toBe("on_pool");
     }
     expect(membership.updateCreditState).not.toHaveBeenCalled();
-    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -228,7 +205,6 @@ describe("UserCreditStateMachine — transitions", () => {
       "user_seat",
       undefined
     );
-    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -326,8 +302,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
       "capped",
       undefined
     );
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockClearUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -350,7 +324,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
       "capped",
       undefined
     );
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -373,8 +346,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
       "on_pool",
       undefined
     );
-    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -419,7 +390,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
       "capped",
       undefined
     );
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -471,7 +441,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
       "capped",
       undefined
     );
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
   });
 
   // Guard 2: same as above from user_seat_low_balance.
@@ -490,7 +459,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
       "capped",
       undefined
     );
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
   });
 
   // Guard 3: < 20 % cap remaining → on_pool_low_balance.
@@ -509,8 +477,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
       "on_pool_low_balance",
       undefined
     );
-    expect(mockSetUserAwuWarned).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
   });
 
   // Guard 3: boundary — exactly 19 % (just below 0.2) → on_pool_low_balance.
@@ -547,7 +513,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
       "on_pool",
       undefined
     );
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
   });
 
   // Guard 4: ample cap remaining → on_pool.
@@ -566,7 +531,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
       "on_pool",
       undefined
     );
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
   });
 
   // Guard 4: null percentage (no cap configured) → on_pool (guard 3 skipped).
@@ -599,7 +563,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     if (result.isOk()) {
       expect(result.value).toBe("capped");
     }
-    expect(mockSetUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
   });
 });
 
@@ -622,8 +585,6 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
       "user_seat_low_balance",
       undefined
     );
-    expect(mockSetUserAwuWarned).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockSetUserCapBlocked).not.toHaveBeenCalled();
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -649,7 +610,6 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
       "user_seat_low_balance",
       undefined
     );
-    expect(mockSetUserAwuWarned).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",
@@ -711,9 +671,6 @@ describe("UserCreditStateMachine — setUserCreditStateReconciled", () => {
       "user_seat",
       undefined
     );
-    // user_seat clears both the cap block and the AWU warning.
-    expect(mockClearUserCapBlocked).toHaveBeenCalledWith("ws_test", "u_test");
-    expect(mockClearUserAwuWarned).toHaveBeenCalledWith("ws_test", "u_test");
     expect(mockSetUserCreditState).toHaveBeenCalledWith(
       "ws_test",
       "u_test",

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -1,10 +1,4 @@
-import {
-  clearUserAwuWarned,
-  clearUserCapBlocked,
-  setUserAwuWarned,
-  setUserCapBlocked,
-  setUserCreditState,
-} from "@app/lib/metronome/user_block";
+import { setUserCreditState } from "@app/lib/metronome/user_block";
 import type { MembershipResource } from "@app/lib/resources/membership_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
@@ -19,7 +13,6 @@ import {
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 import {
   MAX_SEAT_MONTHLY_AWU_CREDITS,
@@ -97,7 +90,12 @@ export type UserCreditEvent =
    * spend cap. Moves `on_pool` → `on_pool_low_balance` to surface the
    * low-balance warning without blocking the user.
    */
-  | { type: "per_user_cap_warning" };
+  | { type: "per_user_cap_warning" }
+  /**
+   * The 80% warning was cleared (e.g. admin raised or removed the per-user cap).
+   * Moves `on_pool_low_balance` → `on_pool`; idempotent from `on_pool`.
+   */
+  | { type: "per_user_cap_warning_resolved" };
 
 type UserCreditGuard = (
   ctx: UserCreditContext,
@@ -124,58 +122,6 @@ function targetAfterCapResolved(ctx: UserCreditContext): UserCreditState {
     seatType: ctx.seatType ?? null,
     ...ctx.liveBalance,
   });
-}
-
-function syncUserCapCacheForState(
-  state: UserCreditState,
-  ctx: UserCreditContext,
-  transaction: Transaction | undefined
-): void {
-  switch (state) {
-    // Spending normally (personal credits or workspace pool): not capped, no
-    // low-balance warning. "normal" is the legacy alias of "on_pool" kept
-    // during the migration window (see USER_CREDIT_STATES).
-    case "normal":
-    case "user_seat":
-    case "on_pool":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearUserCapBlocked(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        clearUserAwuWarned(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserCreditState(ctx.workspaceId, ctx.userId, state)
-      );
-      return;
-
-    // Still spending, but ≥80% of the personal balance / per-user cap used:
-    // not capped, but the low-balance warning is active.
-    case "user_seat_low_balance":
-    case "on_pool_low_balance":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearUserCapBlocked(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserAwuWarned(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserCreditState(ctx.workspaceId, ctx.userId, state)
-      );
-      return;
-
-    case "capped":
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserCapBlocked(ctx.workspaceId, ctx.userId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setUserCreditState(ctx.workspaceId, ctx.userId, state)
-      );
-      return;
-
-    default:
-      assertNever(state);
-  }
 }
 
 const TRANSITIONS: UserCreditTransition[] = [
@@ -318,6 +264,13 @@ const TRANSITIONS: UserCreditTransition[] = [
     to: "on_pool_low_balance",
   },
 
+  // Per-user cap warning cleared (admin raised/removed cap): move on_pool_low_balance → on_pool.
+  {
+    from: ["on_pool", "on_pool_low_balance"],
+    event: "per_user_cap_warning_resolved",
+    to: "on_pool",
+  },
+
   // Billing-period renewal for pro/max seats: reset to user_seat regardless
   // of current state. Workspace seats are reset by per_user_cap_resolved;
   // free seats are not reset.
@@ -389,7 +342,9 @@ export async function transitionUserCreditState(
   if (rawState !== match.to) {
     await membership.updateCreditState(match.to, transaction);
   }
-  syncUserCapCacheForState(match.to, ctx, transaction);
+  invalidateCacheAfterCommit(transaction, () =>
+    setUserCreditState(ctx.workspaceId, ctx.userId, match.to)
+  );
   logger.info(
     {
       workspaceId: ctx.workspaceId,
@@ -426,7 +381,9 @@ export async function setUserCreditStateReconciled(
   if (rawState !== targetState) {
     await membership.updateCreditState(targetState, transaction);
   }
-  syncUserCapCacheForState(targetState, ctx, transaction);
+  invalidateCacheAfterCommit(transaction, () =>
+    setUserCreditState(ctx.workspaceId, ctx.userId, targetState)
+  );
   logger.info(
     {
       workspaceId: ctx.workspaceId,

--- a/front/lib/metronome/workspace_credit_state_machine.test.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.test.ts
@@ -12,25 +12,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const {
-  mockSetWorkspacePoolDepleted,
-  mockClearWorkspacePoolDepleted,
-  mockSetWorkspaceCreditPoolStatus,
-  mockInvalidateCacheAfterCommit,
-} = vi.hoisted(() => ({
-  mockSetWorkspacePoolDepleted: vi.fn(),
-  mockClearWorkspacePoolDepleted: vi.fn(),
-  mockSetWorkspaceCreditPoolStatus: vi.fn(),
-  mockInvalidateCacheAfterCommit: vi.fn(
-    (_tx: Transaction | undefined, fn: () => Promise<void>) => {
-      void fn();
-    }
-  ),
-}));
+const { mockSetWorkspaceCreditPoolStatus, mockInvalidateCacheAfterCommit } =
+  vi.hoisted(() => ({
+    mockSetWorkspaceCreditPoolStatus: vi.fn(),
+    mockInvalidateCacheAfterCommit: vi.fn(
+      (_tx: Transaction | undefined, fn: () => Promise<void>) => {
+        void fn();
+      }
+    ),
+  }));
 
 vi.mock("@app/lib/metronome/user_block", () => ({
-  setWorkspacePoolDepleted: mockSetWorkspacePoolDepleted,
-  clearWorkspacePoolDepleted: mockClearWorkspacePoolDepleted,
   setWorkspaceCreditPoolStatus: mockSetWorkspaceCreditPoolStatus,
 }));
 
@@ -94,8 +86,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       "overage",
       undefined
     );
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
-    expect(mockSetWorkspacePoolDepleted).not.toHaveBeenCalled();
   });
 
   it("depleted + pool_exhausted (paygEnabled) → overage (clears depleted cache)", async () => {
@@ -113,8 +103,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       "overage",
       undefined
     );
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
-    expect(mockSetWorkspacePoolDepleted).not.toHaveBeenCalled();
   });
 
   it("active + pool_exhausted (no PAYG) → depleted (marks pool depleted)", async () => {
@@ -132,7 +120,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       "depleted",
       undefined
     );
-    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("overage + payg_cap_reached → depleted (marks pool depleted)", async () => {
@@ -146,7 +133,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("depleted");
     }
-    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("overage + credits_added (high balance) → active (clears depleted cache)", async () => {
@@ -160,7 +146,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("active");
     }
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("depleted + credits_added (high balance) → active (clears depleted flag)", async () => {
@@ -174,7 +159,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("active");
     }
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("overage + pool_exhausted is idempotent and keeps the depleted cache cleared", async () => {
@@ -189,8 +173,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       expect(result.value).toBe("overage");
     }
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
-    expect(mockSetWorkspacePoolDepleted).not.toHaveBeenCalled();
   });
 
   it("depleted + payg_cap_reached is idempotent and re-applies the depleted cache", async () => {
@@ -205,7 +187,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       expect(result.value).toBe("depleted");
     }
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
-    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("overage + payg_disabled → depleted (marks pool depleted)", async () => {
@@ -223,7 +204,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       "depleted",
       undefined
     );
-    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("depleted + payg_enabled → overage (clears depleted cache)", async () => {
@@ -241,8 +221,6 @@ describe("WorkspaceCreditStateMachine — transitions", () => {
       "overage",
       undefined
     );
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
-    expect(mockSetWorkspacePoolDepleted).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -301,7 +279,6 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
       "active_low_balance",
       undefined
     );
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
     expect(mockSetWorkspaceCreditPoolStatus).toHaveBeenCalledWith(
       "ws_test",
       "active_low_balance"
@@ -413,7 +390,6 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("depleted");
     }
-    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("active_low_balance + pool_exhausted (PAYG) → overage", async () => {
@@ -427,7 +403,6 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("overage");
     }
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("active_critical_balance + pool_exhausted (no PAYG) → depleted", async () => {
@@ -441,7 +416,6 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("depleted");
     }
-    expect(mockSetWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("active_critical_balance + pool_exhausted (PAYG) → overage", async () => {
@@ -455,7 +429,6 @@ describe("WorkspaceCreditStateMachine — low balance transitions", () => {
     if (result.isOk()) {
       expect(result.value).toBe("overage");
     }
-    expect(mockClearWorkspacePoolDepleted).toHaveBeenCalledWith("ws_test");
   });
 
   it("active_low_balance + credits_added (high balance) → active", async () => {
@@ -633,8 +606,6 @@ describe("WorkspaceCreditStateMachine — illegal transitions", () => {
     expect(result.isErr()).toBe(true);
     expect(workspace.updatePoolCreditState).not.toHaveBeenCalled();
     expect(mockInvalidateCacheAfterCommit).not.toHaveBeenCalled();
-    expect(mockSetWorkspacePoolDepleted).not.toHaveBeenCalled();
-    expect(mockClearWorkspacePoolDepleted).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/metronome/workspace_credit_state_machine.ts
+++ b/front/lib/metronome/workspace_credit_state_machine.ts
@@ -1,15 +1,10 @@
-import {
-  clearWorkspacePoolDepleted,
-  setWorkspaceCreditPoolStatus,
-  setWorkspacePoolDepleted,
-} from "@app/lib/metronome/user_block";
+import { setWorkspaceCreditPoolStatus } from "@app/lib/metronome/user_block";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { WorkspacePoolCreditState } from "@app/types/credits";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Transaction } from "sequelize";
 
 export type WorkspaceCreditContext = {
@@ -97,46 +92,6 @@ type WorkspaceCreditTransition = {
 function balanceAtMost(threshold: number): WorkspaceCreditGuard {
   return (_ctx, event) =>
     "balanceAwu" in event && event.balanceAwu <= threshold;
-}
-
-function syncWorkspacePoolCacheForState(
-  state: WorkspacePoolCreditState,
-  ctx: WorkspaceCreditContext,
-  transaction: Transaction | undefined
-): void {
-  switch (state) {
-    case "active":
-    case "overage":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearWorkspacePoolDepleted(ctx.workspaceId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspaceCreditPoolStatus(ctx.workspaceId, state)
-      );
-      return;
-
-    case "active_low_balance":
-    case "active_critical_balance":
-      invalidateCacheAfterCommit(transaction, () =>
-        clearWorkspacePoolDepleted(ctx.workspaceId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspaceCreditPoolStatus(ctx.workspaceId, state)
-      );
-      return;
-
-    case "depleted":
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspacePoolDepleted(ctx.workspaceId)
-      );
-      invalidateCacheAfterCommit(transaction, () =>
-        setWorkspaceCreditPoolStatus(ctx.workspaceId, state)
-      );
-      return;
-
-    default:
-      assertNever(state);
-  }
 }
 
 const TRANSITIONS: WorkspaceCreditTransition[] = [
@@ -357,7 +312,9 @@ export async function transitionWorkspaceCreditState(
   if (currentState !== match.to) {
     await workspace.updatePoolCreditState(match.to, transaction);
   }
-  syncWorkspacePoolCacheForState(match.to, ctx, transaction);
+  invalidateCacheAfterCommit(transaction, () =>
+    setWorkspaceCreditPoolStatus(ctx.workspaceId, match.to)
+  );
   logger.info(
     {
       workspaceId: ctx.workspaceId,
@@ -389,7 +346,9 @@ export async function setWorkspacePoolCreditStateReconciled(
   if (currentState !== targetState) {
     await workspace.updatePoolCreditState(targetState, transaction);
   }
-  syncWorkspacePoolCacheForState(targetState, ctx, transaction);
+  invalidateCacheAfterCommit(transaction, () =>
+    setWorkspaceCreditPoolStatus(ctx.workspaceId, targetState)
+  );
   logger.info(
     {
       workspaceId: ctx.workspaceId,


### PR DESCRIPTION
## Description

Now that all three credit state machines write fine-grained state values to Redis (`metronome:user_credit_state`, `metronome:pool_credit_status`, `metronome:programmatic_credit_status`), the legacy boolean shortcut keys (`metronome:user_cap`, `metronome:user_awu_warning`, `metronome:pool_depleted`, `metronome:programmatic_warning`, `metronome:programmatic_depleted`) are redundant. 

This PR removes them along with the intermediate `syncXxxCacheForState` helpers that were writing multiple keys per transition. `isUserBlocked`, `isApiBlocked` and `isProgrammaticApiBlocked` now read directly from the fine-grained state keys, and `isUserAwuWarned` is derived from `user_credit_state` instead of a standalone flag. A new `per_user_cap_warning_resolved` event and `dispatchPerUserCapWarningResolved` dispatcher are also added to properly transition `on_pool_low_balance → on_pool` when an admin raises or removes a per-user cap.

## Tests

Unit tests updated throughout (`user_credit_state_machine.test.ts`, `workspace_credit_state_machine.test.ts`, `programmatic_credit_state_machine.test.ts`) — mocks for the removed boolean-flag functions are dropped.

## Risk

The legacy boolean keys are no longer written after deploy; any in-flight Redis cache entries for the old keys will be ignored (reads now go to the fine-grained keys, which have their own DB fallback). Low risk as the fine-grained keys have been live for a while.

## Deploy Plan

Deploy front.