### PR TITLE
[front] feat: add role-aware visibility for global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
@@ -1,0 +1,45 @@
+import { canRoleSeeAudience } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
+import { Authenticator } from "@app/lib/auth";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { describe, expect, it } from "vitest";
+
+async function authForRole(role: MembershipRoleType): Promise<Authenticator> {
+  const workspace = await WorkspaceFactory.basic();
+  await GroupFactory.defaults(workspace);
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role });
+  return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
+}
+
+describe("canRoleSeeAudience", () => {
+  it("makes 'everyone' visible to every role", async () => {
+    for (const role of ["admin", "builder", "user"] as const) {
+      const auth = await authForRole(role);
+      expect(canRoleSeeAudience("everyone", auth)).toBe(true);
+    }
+  });
+
+  it("makes 'builders' visible to builders and admins, not users", async () => {
+    expect(canRoleSeeAudience("builders", await authForRole("admin"))).toBe(
+      true
+    );
+    expect(canRoleSeeAudience("builders", await authForRole("builder"))).toBe(
+      true
+    );
+    expect(canRoleSeeAudience("builders", await authForRole("user"))).toBe(
+      false
+    );
+  });
+
+  it("makes 'admins' visible to admins only", async () => {
+    expect(canRoleSeeAudience("admins", await authForRole("admin"))).toBe(true);
+    expect(canRoleSeeAudience("admins", await authForRole("builder"))).toBe(
+      false
+    );
+    expect(canRoleSeeAudience("admins", await authForRole("user"))).toBe(false);
+  });
+});

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -2,6 +2,7 @@ import {
   DEEP_DIVE_DESC,
   DEEP_DIVE_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import type { Authenticator } from "@app/lib/auth";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import {
@@ -31,12 +32,44 @@ import {
 } from "@app/types/assistant/models/openai";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
+export const GLOBAL_AGENT_AUDIENCES = [
+  "everyone",
+  "builders",
+  "admins",
+] as const;
+export type GlobalAgentAudience = (typeof GLOBAL_AGENT_AUDIENCES)[number];
+
 type AgentMetadata = {
   sId: string;
   name: string;
   description: string;
   pictureUrl: string;
+  audience?: GlobalAgentAudience;
 };
+
+export function canRoleSeeAudience(
+  audience: GlobalAgentAudience,
+  auth: Authenticator
+): boolean {
+  switch (audience) {
+    case "everyone":
+      return true;
+    case "builders":
+      return auth.isBuilder();
+    case "admins":
+      return auth.isAdmin();
+    default:
+      return assertNever(audience);
+  }
+}
+
+export function canRoleSeeGlobalAgent(
+  sId: GLOBAL_AGENTS_SID,
+  auth: Authenticator
+): boolean {
+  const { audience = "everyone" } = getGlobalAgentMetadata(sId);
+  return canRoleSeeAudience(audience, auth);
+}
 
 export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
   switch (sId) {

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -85,6 +85,7 @@ import {
   _getNotionGlobalAgent,
   _getSlackGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/retired_managed";
+import { canRoleSeeGlobalAgent } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import {
   buildSidekickContext,
   type SidekickContext,
@@ -1482,6 +1483,10 @@ export async function getGlobalAgents(
 
     return !customModelFlag || flags.includes(customModelFlag);
   });
+
+  agentsIdsToFetch = agentsIdsToFetch.filter(
+    (sId) => !isGlobalAgentId(sId) || canRoleSeeGlobalAgent(sId, auth)
+  );
 
   const sidekickContext =
     variant === "full"


### PR DESCRIPTION
## Description

Add an audience ladder (everyone | builders | admins) to global agent metadata and a canRoleSeeGlobalAgent gate, wired into getGlobalAgents so agents whose declared audience the caller's workspace role cannot see are dropped. Audience defaults to "everyone", so this is a no-op for existing agents. It is the mechanism the admin-only Analyst agent will use. Orthogonal to feature-flag rollout. Unit-tested via the role x audience matrix.

A scoped agent will look like:
```typescript
  case GLOBAL_AGENTS_SID.WORKSPACE_ANALYST:
    return {
      sId: GLOBAL_AGENTS_SID.WORKSPACE_ANALYST,
      name: "workspaceAnalyst",
      description:
        "Admin-only agent that answers questions about how your workspace is being used.",
      pictureUrl: DUST_AVATAR_URL,
      audience: "admins",
    };
```

## Tests

Units

## Risk

None, not wired yet.

## Deploy Plan

Front