### PR TITLE
Add MCP server views backfill workflow

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -235,6 +235,9 @@ export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 export const INTERNAL_MCP_SERVERS = {
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
+  // If an auto/auto_hidden_builder server is gated with isRestricted, update the SQL pre-filter hints in
+  // temporal/ensure_mcp_server_views/activities.ts so the recurring MCP server view backfill can find
+  // affected workspaces without scanning every workspace unnecessarily.
 
   github: {
     id: 1,

--- a/front/lib/api/poke/plugins/global/toggle_global_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/global/toggle_global_feature_flag.test.ts
@@ -14,7 +14,7 @@ describe("toggleGlobalFeatureFlagPlugin.execute", () => {
   beforeEach(async () => {
     vi.mocked(launchEnsureMCPServerViewsWorkflow).mockReset();
     vi.mocked(launchEnsureMCPServerViewsWorkflow).mockResolvedValue(
-      new Ok("ensure-mcp-server-views")
+      new Ok({ workflowId: "ensure-mcp-server-views", outcome: "started" })
     );
     await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 0);
   });
@@ -46,6 +46,33 @@ describe("toggleGlobalFeatureFlagPlugin.execute", () => {
     });
     expect(result.value.value).toContain(
       "MCP server view backfill workflow started"
+    );
+  });
+
+  it("reports when the backfill workflow is already running on rollout increase", async () => {
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockResolvedValueOnce(
+      new Ok({
+        workflowId: "ensure-mcp-server-views",
+        outcome: "already_running",
+      })
+    );
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 10);
+
+    const result = await toggleGlobalFeatureFlagPlugin.execute(auth, null, {
+      feature: ["sandbox_tools"],
+      rolloutPercentage: 20,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw result.error;
+    }
+
+    expect(launchEnsureMCPServerViewsWorkflow).toHaveBeenCalledTimes(1);
+    expect(result.value.value).toContain(
+      "MCP server view backfill workflow is already running"
     );
   });
 

--- a/front/lib/api/poke/plugins/global/toggle_global_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/global/toggle_global_feature_flag.test.ts
@@ -1,0 +1,79 @@
+import { toggleGlobalFeatureFlagPlugin } from "@app/lib/api/poke/plugins/global/toggle_global_feature_flag";
+import { Authenticator } from "@app/lib/auth";
+import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
+import { launchEnsureMCPServerViewsWorkflow } from "@app/temporal/ensure_mcp_server_views/client";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/ensure_mcp_server_views/client", () => ({
+  launchEnsureMCPServerViewsWorkflow: vi.fn(),
+}));
+
+describe("toggleGlobalFeatureFlagPlugin.execute", () => {
+  beforeEach(async () => {
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockReset();
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockResolvedValue(
+      new Ok("ensure-mcp-server-views")
+    );
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 0);
+  });
+
+  afterEach(async () => {
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 0);
+  });
+
+  it("starts the MCP server view backfill workflow on rollout increase", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 10);
+
+    const result = await toggleGlobalFeatureFlagPlugin.execute(auth, null, {
+      feature: ["sandbox_tools"],
+      rolloutPercentage: 20,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw result.error;
+    }
+
+    expect(launchEnsureMCPServerViewsWorkflow).toHaveBeenCalledTimes(1);
+    expect(launchEnsureMCPServerViewsWorkflow).toHaveBeenCalledWith({
+      triggeringFeature: "sandbox_tools",
+      previousRolloutPercentage: 10,
+      rolloutPercentage: 20,
+    });
+    expect(result.value.value).toContain(
+      "MCP server view backfill workflow started"
+    );
+  });
+
+  it("does not start the backfill workflow when removing a global rollout", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 20);
+
+    const result = await toggleGlobalFeatureFlagPlugin.execute(auth, null, {
+      feature: ["sandbox_tools"],
+      rolloutPercentage: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(launchEnsureMCPServerViewsWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("does not start the backfill workflow on rollout decrease", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 20);
+
+    const result = await toggleGlobalFeatureFlagPlugin.execute(auth, null, {
+      feature: ["sandbox_tools"],
+      rolloutPercentage: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(launchEnsureMCPServerViewsWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
+++ b/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
@@ -1,5 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import { invalidateGlobalFeatureFlagsCache } from "@app/lib/auth";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
+import { launchEnsureMCPServerViewsWorkflow } from "@app/temporal/ensure_mcp_server_views/client";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
   FEATURE_FLAG_STAGE_LABELS,
@@ -70,6 +72,10 @@ export const toggleGlobalFeatureFlagPlugin = createPlugin({
     }
     const feature: WhitelistableFeature = featureName;
 
+    const globalFlags = await GlobalFeatureFlagResource.listAll();
+    const previousRolloutPercentage =
+      globalFlags.find((flag) => flag.name === feature)?.rolloutPercentage ?? 0;
+
     const rolloutPercentage = args.rolloutPercentage;
     if (
       !Number.isInteger(rolloutPercentage) ||
@@ -85,6 +91,7 @@ export const toggleGlobalFeatureFlagPlugin = createPlugin({
       feature,
       rolloutPercentage
     );
+    invalidateGlobalFeatureFlagsCache();
 
     if (rolloutPercentage === 0) {
       return new Ok({
@@ -93,9 +100,23 @@ export const toggleGlobalFeatureFlagPlugin = createPlugin({
       });
     }
 
+    const didIncrease = rolloutPercentage > previousRolloutPercentage;
+    let workflowMessage = "";
+    if (didIncrease) {
+      const launchResult = await launchEnsureMCPServerViewsWorkflow({
+        triggeringFeature: feature,
+        previousRolloutPercentage,
+        rolloutPercentage,
+      });
+      if (launchResult.isErr()) {
+        return new Err(launchResult.error);
+      }
+      workflowMessage = ` MCP server view backfill workflow started (${launchResult.value}).`;
+    }
+
     return new Ok({
       display: "text",
-      value: `Global feature flag "${feature}" set to ${rolloutPercentage}% rollout.`,
+      value: `Global feature flag "${feature}" set to ${rolloutPercentage}% rollout.${workflowMessage}`,
     });
   },
 });

--- a/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
+++ b/front/lib/api/poke/plugins/global/toggle_global_feature_flag.ts
@@ -111,7 +111,10 @@ export const toggleGlobalFeatureFlagPlugin = createPlugin({
       if (launchResult.isErr()) {
         return new Err(launchResult.error);
       }
-      workflowMessage = ` MCP server view backfill workflow started (${launchResult.value}).`;
+      workflowMessage =
+        launchResult.value.outcome === "started"
+          ? ` MCP server view backfill workflow started (${launchResult.value.workflowId}).`
+          : ` MCP server view backfill workflow is already running; newly eligible workspaces will be covered by the daily schedule (${launchResult.value.workflowId}).`;
     }
 
     return new Ok({

--- a/front/scripts/ensure_all_mcp_server_views_created.ts
+++ b/front/scripts/ensure_all_mcp_server_views_created.ts
@@ -1,8 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
+import { launchEnsureMCPServerViewsWorkflow } from "@app/temporal/ensure_mcp_server_views/client";
 
 makeScript(
   {
@@ -19,65 +19,53 @@ makeScript(
     },
   },
   async ({ execute, workspaceId, concurrency }, parentLogger) => {
-    let workspaces: WorkspaceResource[] = [];
     if (workspaceId) {
       const workspace = await WorkspaceResource.fetchById(workspaceId);
       if (!workspace) {
         throw new Error(`Workspace with SID ${workspaceId} not found.`);
       }
-      workspaces = [workspace];
-    } else {
-      // Process all workspaces
-      workspaces = await WorkspaceResource.listAll("ASC");
+
+      const logger = parentLogger.child({
+        workspaceId: workspace.sId,
+      });
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      if (execute) {
+        const { createdViewsCount } =
+          await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+        logger.info(
+          { createdViewsCount },
+          "Successfully ensured MCP server views are created."
+        );
+      } else {
+        logger.info("Would ensure MCP server views are created.");
+      }
+      return;
+    }
+
+    parentLogger.warn(
+      "All-workspace direct mode is deprecated. Launching the resumable Temporal workflow instead."
+    );
+
+    if (!execute) {
+      parentLogger.info(
+        { concurrency },
+        "Would launch ensure MCP server views Temporal workflow."
+      );
+      return;
+    }
+
+    const launchResult = await launchEnsureMCPServerViewsWorkflow({
+      concurrency,
+    });
+    if (launchResult.isErr()) {
+      throw launchResult.error;
     }
 
     parentLogger.info(
-      `Processing ${workspaces.length} workspaces to ensure MCP server views are created.`
+      { workflowId: launchResult.value, concurrency },
+      "Launched ensure MCP server views Temporal workflow."
     );
-
-    const errors: { workspaceId: string; error: unknown }[] = [];
-
-    await concurrentExecutor(
-      workspaces,
-      async (workspace) => {
-        const logger = parentLogger.child({
-          workspaceId: workspace.sId,
-        });
-
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
-
-        if (execute) {
-          try {
-            const { createdViewsCount } =
-              await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-            logger.info(
-              { createdViewsCount },
-              "Successfully ensured MCP server views are created."
-            );
-          } catch (e) {
-            logger.error(
-              { error: e },
-              "Error creating MCP server views for workspace."
-            );
-            errors.push({ workspaceId: workspace.sId, error: e });
-          }
-        } else {
-          logger.info("Would ensure MCP server views are created.");
-        }
-      },
-      { concurrency }
-    );
-
-    if (errors.length > 0) {
-      parentLogger.error(
-        `Migration completed with ${errors.length} errors for the following workspaces: ${errors
-          .map((e) => e.workspaceId)
-          .join(", ")}`
-      );
-    } else {
-      parentLogger.info("Migration completed successfully.");
-    }
   }
 );

--- a/front/scripts/ensure_all_mcp_server_views_created.ts
+++ b/front/scripts/ensure_all_mcp_server_views_created.ts
@@ -2,7 +2,9 @@ import { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { getAffectedMCPServerViewsWorkspaceBatchActivity } from "@app/temporal/ensure_mcp_server_views/activities";
 import { launchEnsureMCPServerViewsWorkflow } from "@app/temporal/ensure_mcp_server_views/client";
+import { DEFAULT_SCAN_BATCH_SIZE } from "@app/temporal/ensure_mcp_server_views/config";
 
 makeScript(
   {
@@ -49,9 +51,22 @@ makeScript(
     );
 
     if (!execute) {
+      const scanResult = await getAffectedMCPServerViewsWorkspaceBatchActivity({
+        batchSize: DEFAULT_SCAN_BATCH_SIZE,
+      });
+
       parentLogger.info(
-        { concurrency },
-        "Would launch ensure MCP server views Temporal workflow."
+        {
+          concurrency,
+          scannedWorkspacesCount: scanResult.scannedWorkspacesCount,
+          affectedWorkspacesCount: scanResult.affectedWorkspaces.length,
+          affectedWorkspaceIds: scanResult.affectedWorkspaces.map(
+            (workspace) => workspace.workspaceId
+          ),
+          lastScannedWorkspaceModelId: scanResult.lastScannedWorkspaceModelId,
+          hasMore: scanResult.hasMore,
+        },
+        "Would launch ensure MCP server views Temporal workflow. First scan batch completed."
       );
       return;
     }
@@ -64,7 +79,11 @@ makeScript(
     }
 
     parentLogger.info(
-      { workflowId: launchResult.value, concurrency },
+      {
+        workflowId: launchResult.value.workflowId,
+        outcome: launchResult.value.outcome,
+        concurrency,
+      },
       "Launched ensure MCP server views Temporal workflow."
     );
   }

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -48,6 +48,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/credit_alerts");
     case "data_retention":
       return path.join(baseDir, "temporal/data_retention");
+    case "ensure_mcp_server_views":
+      return path.join(baseDir, "temporal/ensure_mcp_server_views");
     case "hard_delete":
       return path.join(baseDir, "temporal/hard_delete");
     case "invitations":

--- a/front/temporal/ensure_mcp_server_views/activities.test.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.test.ts
@@ -1,0 +1,98 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import {
+  ensureMCPServerViewsForWorkspaceBatchActivity,
+  getAffectedMCPServerViewsWorkspaceBatchActivity,
+} from "@app/temporal/ensure_mcp_server_views/activities";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: vi.fn(() => ({
+      heartbeat: vi.fn(),
+    })),
+  },
+}));
+
+describe("ensure MCP server views activities", () => {
+  it("finds a workspace missing views and skips one that has them", async () => {
+    const missingWorkspace = await WorkspaceFactory.basic();
+    const missingAuth = await Authenticator.internalAdminForWorkspace(
+      missingWorkspace.sId
+    );
+    await SpaceFactory.defaults(missingAuth);
+
+    const healthyWorkspace = await WorkspaceFactory.basic();
+    const healthyAuth = await Authenticator.internalAdminForWorkspace(
+      healthyWorkspace.sId
+    );
+    await SpaceFactory.defaults(healthyAuth);
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(healthyAuth);
+
+    const result = await getAffectedMCPServerViewsWorkspaceBatchActivity({
+      lastProcessedWorkspaceModelId:
+        Math.min(missingWorkspace.id, healthyWorkspace.id) - 1,
+      batchSize: 10,
+    });
+
+    const affectedWorkspaceIds = new Set(
+      result.affectedWorkspaces.map((workspace) => workspace.workspaceId)
+    );
+    expect(affectedWorkspaceIds.has(missingWorkspace.sId)).toBe(true);
+    expect(affectedWorkspaceIds.has(healthyWorkspace.sId)).toBe(false);
+  });
+
+  it("creates views idempotently in a batch", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const firstRun = await ensureMCPServerViewsForWorkspaceBatchActivity({
+      workspaces: [
+        {
+          workspaceId: workspace.sId,
+          workspaceModelId: workspace.id,
+        },
+      ],
+      concurrency: 1,
+    });
+
+    expect(firstRun.processedWorkspacesCount).toBe(1);
+    expect(firstRun.failures).toEqual([]);
+    expect(firstRun.createdViewsCount).toBeGreaterThan(0);
+
+    const commonUtilitiesServerId = autoInternalMCPServerNameToSId({
+      name: "common_utilities",
+      workspaceId: workspace.id,
+    });
+    await expect(
+      MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        commonUtilitiesServerId
+      )
+    ).resolves.not.toBeNull();
+    await expect(
+      MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        commonUtilitiesServerId
+      )
+    ).resolves.not.toBeNull();
+
+    const secondRun = await ensureMCPServerViewsForWorkspaceBatchActivity({
+      workspaces: [
+        {
+          workspaceId: workspace.sId,
+          workspaceModelId: workspace.id,
+        },
+      ],
+      concurrency: 1,
+    });
+
+    expect(secondRun.processedWorkspacesCount).toBe(1);
+    expect(secondRun.failures).toEqual([]);
+    expect(secondRun.createdViewsCount).toBe(0);
+  });
+});

--- a/front/temporal/ensure_mcp_server_views/activities.test.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.test.ts
@@ -45,6 +45,27 @@ describe("ensure MCP server views activities", () => {
     expect(affectedWorkspaceIds.has(healthyWorkspace.sId)).toBe(false);
   });
 
+  it("falls back to a broad scan for an unhinted triggering feature", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const result = await getAffectedMCPServerViewsWorkspaceBatchActivity({
+      lastProcessedWorkspaceModelId: workspace.id - 1,
+      batchSize: 1,
+      triggeringFeature: "advanced_notion_management",
+      previousRolloutPercentage: 0,
+      rolloutPercentage: 100,
+    });
+
+    expect(result.affectedWorkspaces).toEqual([
+      {
+        workspaceId: workspace.sId,
+        workspaceModelId: workspace.id,
+      },
+    ]);
+  });
+
   it("creates views idempotently in a batch", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);

--- a/front/temporal/ensure_mcp_server_views/activities.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.ts
@@ -1,0 +1,682 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import {
+  type AutoInternalMCPServerNameType,
+  AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
+  INTERNAL_MCP_SERVERS,
+  isAutoInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  Authenticator,
+  invalidateFeatureFlagsCache,
+  invalidateGlobalFeatureFlagsCache,
+} from "@app/lib/auth";
+import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
+import { FeatureFlagModel } from "@app/lib/models/feature_flag";
+import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { ModelId } from "@app/types/shared/model_id";
+import { errorToString } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import { Context } from "@temporalio/activity";
+import { Op } from "sequelize";
+
+import { DEFAULT_WORKSPACE_CONCURRENCY } from "./config";
+
+type SpaceKindForDefaultMCPViews = "system" | "global";
+
+export type EnsureMCPServerViewsWorkflowTrigger = {
+  triggeringFeature?: WhitelistableFeature;
+  previousRolloutPercentage?: number;
+  rolloutPercentage?: number;
+};
+
+export type AffectedMCPServerViewsWorkspace = {
+  workspaceModelId: ModelId;
+  workspaceId: string;
+};
+
+export type GetAffectedMCPServerViewsWorkspaceBatchActivityArgs =
+  EnsureMCPServerViewsWorkflowTrigger & {
+    lastProcessedWorkspaceModelId?: ModelId;
+    batchSize: number;
+  };
+
+export type GetAffectedMCPServerViewsWorkspaceBatchActivityResult = {
+  scannedWorkspacesCount: number;
+  affectedWorkspaces: AffectedMCPServerViewsWorkspace[];
+  lastScannedWorkspaceModelId: ModelId | null;
+  hasMore: boolean;
+};
+
+export type EnsureMCPServerViewsForWorkspaceBatchActivityArgs = {
+  workspaces: AffectedMCPServerViewsWorkspace[];
+  concurrency?: number;
+};
+
+export type EnsureMCPServerViewsWorkspaceFailure = {
+  workspaceId: string;
+  error: string;
+};
+
+export type EnsureMCPServerViewsForWorkspaceBatchActivityResult = {
+  processedWorkspacesCount: number;
+  createdViewsCount: number;
+  failures: EnsureMCPServerViewsWorkspaceFailure[];
+};
+
+export type EnsureMCPServerViewsWorkflowSummary = {
+  scannedWorkspacesCount: number;
+  affectedWorkspacesCount: number;
+  processedWorkspacesCount: number;
+  createdViewsCount: number;
+  failuresCount: number;
+  failureSamples: EnsureMCPServerViewsWorkspaceFailure[];
+};
+
+type AutoMCPServerFeatureFlagHint = {
+  feature: WhitelistableFeature;
+  serverNames: AutoInternalMCPServerNameType[];
+};
+
+const AUTO_MCP_SERVER_FEATURE_FLAG_HINTS = [
+  { feature: "legacy_dust_apps", serverNames: ["run_dust_app"] },
+  { feature: "slideshow", serverNames: ["slideshow"] },
+  { feature: "sandbox_tools", serverNames: ["sandbox"] },
+  { feature: "plan_mode", serverNames: ["plan_mode"] },
+] satisfies AutoMCPServerFeatureFlagHint[];
+
+// SQL pre-filter hints only. The resource method remains the source of truth.
+const FEATURE_FLAG_BY_AUTO_MCP_SERVER_NAME = new Map<
+  AutoInternalMCPServerNameType,
+  WhitelistableFeature
+>();
+for (const hint of AUTO_MCP_SERVER_FEATURE_FLAG_HINTS) {
+  for (const serverName of hint.serverNames) {
+    FEATURE_FLAG_BY_AUTO_MCP_SERVER_NAME.set(serverName, hint.feature);
+  }
+}
+
+// This server is plan-gated rather than feature-gated. The SQL pre-filter
+// intentionally over-selects slightly here; ensureAllAutoToolsAreCreated does
+// the authoritative plan check.
+const PLAN_GATED_AUTO_MCP_SERVER_NAMES = new Set<AutoInternalMCPServerNameType>(
+  ["speech_generator"]
+);
+
+const SpaceModelWithBypass: ModelStaticWorkspaceAware<SpaceModel> = SpaceModel;
+const FeatureFlagModelWithBypass: ModelStaticWorkspaceAware<FeatureFlagModel> =
+  FeatureFlagModel;
+const MCPServerViewModelWithBypass: ModelStaticWorkspaceAware<MCPServerViewModel> =
+  MCPServerViewModel;
+
+type CandidateAutoMCPServer = {
+  name: AutoInternalMCPServerNameType;
+  feature?: WhitelistableFeature;
+};
+
+type DefaultSpacesByWorkspace = {
+  systemSpaceModelId?: ModelId;
+  globalSpaceModelId?: ModelId;
+};
+
+type WorkspaceProcessingResult =
+  | { status: "success"; workspaceId: string; createdViewsCount: number }
+  | { status: "failure"; workspaceId: string; error: string };
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}
+
+function getFeatureHintedAutoMCPServerNames(
+  feature: WhitelistableFeature
+): AutoInternalMCPServerNameType[] {
+  const hint = AUTO_MCP_SERVER_FEATURE_FLAG_HINTS.find(
+    (h) => h.feature === feature
+  );
+  return hint?.serverNames ?? [];
+}
+
+function getCandidateAutoMCPServers({
+  triggeringFeature,
+}: {
+  triggeringFeature?: WhitelistableFeature;
+}): CandidateAutoMCPServer[] {
+  if (triggeringFeature) {
+    return getFeatureHintedAutoMCPServerNames(triggeringFeature).map(
+      (name) => ({
+        name,
+        feature: triggeringFeature,
+      })
+    );
+  }
+
+  const candidates: CandidateAutoMCPServer[] = [];
+  for (const name of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
+    if (!isAutoInternalMCPServerName(name)) {
+      continue;
+    }
+
+    if (INTERNAL_MCP_SERVERS[name].isRestricted === undefined) {
+      candidates.push({ name });
+      continue;
+    }
+
+    const feature = FEATURE_FLAG_BY_AUTO_MCP_SERVER_NAME.get(name);
+    if (feature) {
+      candidates.push({ name, feature });
+      continue;
+    }
+
+    if (PLAN_GATED_AUTO_MCP_SERVER_NAMES.has(name)) {
+      candidates.push({ name });
+    }
+  }
+
+  return candidates;
+}
+
+function getFeatureKey({
+  workspaceModelId,
+  feature,
+}: {
+  workspaceModelId: ModelId;
+  feature: WhitelistableFeature;
+}): string {
+  return `${workspaceModelId}:${feature}`;
+}
+
+function getViewKey({
+  workspaceModelId,
+  internalMCPServerId,
+  spaceModelId,
+}: {
+  workspaceModelId: ModelId;
+  internalMCPServerId: string;
+  spaceModelId: ModelId;
+}): string {
+  return `${workspaceModelId}:${internalMCPServerId}:${spaceModelId}`;
+}
+
+function isRolloutIncreaseTarget({
+  workspaceModelId,
+  previousRolloutPercentage,
+  rolloutPercentage,
+}: {
+  workspaceModelId: ModelId;
+  previousRolloutPercentage: number;
+  rolloutPercentage: number;
+}): boolean {
+  return (
+    GlobalFeatureFlagResource.isInRollout(
+      workspaceModelId,
+      rolloutPercentage
+    ) &&
+    !GlobalFeatureFlagResource.isInRollout(
+      workspaceModelId,
+      previousRolloutPercentage
+    )
+  );
+}
+
+function isFeatureEnabledForWorkspace({
+  feature,
+  workspaceModelId,
+  workspaceFeatureKeys,
+  globalRolloutByFeature,
+  trigger,
+}: {
+  feature: WhitelistableFeature;
+  workspaceModelId: ModelId;
+  workspaceFeatureKeys: Set<string>;
+  globalRolloutByFeature: Map<WhitelistableFeature, number>;
+  trigger: EnsureMCPServerViewsWorkflowTrigger;
+}): boolean {
+  if (
+    workspaceFeatureKeys.has(
+      getFeatureKey({
+        workspaceModelId,
+        feature,
+      })
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    trigger.triggeringFeature === feature &&
+    trigger.rolloutPercentage !== undefined
+  ) {
+    return isRolloutIncreaseTarget({
+      workspaceModelId,
+      previousRolloutPercentage: trigger.previousRolloutPercentage ?? 0,
+      rolloutPercentage: trigger.rolloutPercentage,
+    });
+  }
+
+  const rolloutPercentage = globalRolloutByFeature.get(feature);
+  if (rolloutPercentage === undefined) {
+    return false;
+  }
+
+  return GlobalFeatureFlagResource.isInRollout(
+    workspaceModelId,
+    rolloutPercentage
+  );
+}
+
+function isCandidateExpectedForWorkspace({
+  candidate,
+  workspaceModelId,
+  workspaceFeatureKeys,
+  globalRolloutByFeature,
+  trigger,
+}: {
+  candidate: CandidateAutoMCPServer;
+  workspaceModelId: ModelId;
+  workspaceFeatureKeys: Set<string>;
+  globalRolloutByFeature: Map<WhitelistableFeature, number>;
+  trigger: EnsureMCPServerViewsWorkflowTrigger;
+}): boolean {
+  if (!candidate.feature) {
+    return true;
+  }
+
+  return isFeatureEnabledForWorkspace({
+    feature: candidate.feature,
+    workspaceModelId,
+    workspaceFeatureKeys,
+    globalRolloutByFeature,
+    trigger,
+  });
+}
+
+function isSuccessResult(
+  result: WorkspaceProcessingResult
+): result is Extract<WorkspaceProcessingResult, { status: "success" }> {
+  return result.status === "success";
+}
+
+function isFailureResult(
+  result: WorkspaceProcessingResult
+): result is Extract<WorkspaceProcessingResult, { status: "failure" }> {
+  return result.status === "failure";
+}
+
+export async function getAffectedMCPServerViewsWorkspaceBatchActivity({
+  lastProcessedWorkspaceModelId = 0,
+  batchSize,
+  triggeringFeature,
+  previousRolloutPercentage,
+  rolloutPercentage,
+}: GetAffectedMCPServerViewsWorkspaceBatchActivityArgs): Promise<GetAffectedMCPServerViewsWorkspaceBatchActivityResult> {
+  const trigger = {
+    triggeringFeature,
+    previousRolloutPercentage,
+    rolloutPercentage,
+  };
+  const candidates = getCandidateAutoMCPServers({ triggeringFeature });
+
+  if (candidates.length === 0) {
+    logger.info(
+      { triggeringFeature },
+      "[Ensure MCP Server Views] No auto MCP server candidates for scan."
+    );
+    return {
+      scannedWorkspacesCount: 0,
+      affectedWorkspaces: [],
+      lastScannedWorkspaceModelId: lastProcessedWorkspaceModelId,
+      hasMore: false,
+    };
+  }
+
+  const workspaceModels = await WorkspaceModel.findAll({
+    attributes: ["id", "sId"],
+    where: {
+      id: {
+        [Op.gt]: lastProcessedWorkspaceModelId,
+      },
+    },
+    order: [["id", "ASC"]],
+    limit: batchSize,
+  });
+
+  if (workspaceModels.length === 0) {
+    return {
+      scannedWorkspacesCount: 0,
+      affectedWorkspaces: [],
+      lastScannedWorkspaceModelId: lastProcessedWorkspaceModelId,
+      hasMore: false,
+    };
+  }
+
+  const workspaceModelIds = workspaceModels.map((workspace) => workspace.id);
+  const lastScannedWorkspaceModelId =
+    workspaceModels[workspaceModels.length - 1].id;
+
+  const featureNames = Array.from(
+    new Set(candidates.map((c) => c.feature).filter(isDefined))
+  );
+
+  const [spaceModels, featureFlagModels, globalFeatureFlags] =
+    await Promise.all([
+      SpaceModelWithBypass.findAll({
+        attributes: ["id", "workspaceId", "kind"],
+        where: {
+          workspaceId: {
+            [Op.in]: workspaceModelIds,
+          },
+          kind: {
+            [Op.in]: [
+              "system",
+              "global",
+            ] satisfies SpaceKindForDefaultMCPViews[],
+          },
+        },
+        // WORKSPACE_ISOLATION_BYPASS: Cross-workspace scan to find default spaces missing MCP server views.
+        // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+        dangerouslyBypassWorkspaceIsolationSecurity: true,
+      }),
+      featureNames.length > 0
+        ? FeatureFlagModelWithBypass.findAll({
+            attributes: ["workspaceId", "name"],
+            where: {
+              workspaceId: {
+                [Op.in]: workspaceModelIds,
+              },
+              name: {
+                [Op.in]: featureNames,
+              },
+            },
+            // WORKSPACE_ISOLATION_BYPASS: Cross-workspace scan to evaluate feature-gated MCP server candidates.
+            // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+            dangerouslyBypassWorkspaceIsolationSecurity: true,
+          })
+        : Promise.resolve([]),
+      GlobalFeatureFlagResource.listAll(),
+    ]);
+
+  const defaultSpacesByWorkspace = new Map<ModelId, DefaultSpacesByWorkspace>();
+  for (const space of spaceModels) {
+    const current = defaultSpacesByWorkspace.get(space.workspaceId) ?? {};
+    switch (space.kind) {
+      case "system":
+        defaultSpacesByWorkspace.set(space.workspaceId, {
+          ...current,
+          systemSpaceModelId: space.id,
+        });
+        break;
+      case "global":
+        defaultSpacesByWorkspace.set(space.workspaceId, {
+          ...current,
+          globalSpaceModelId: space.id,
+        });
+        break;
+      default:
+        if (isString(space.kind)) {
+          logger.warn(
+            { workspaceModelId: space.workspaceId, spaceKind: space.kind },
+            "[Ensure MCP Server Views] Unexpected default-space scan kind."
+          );
+        }
+    }
+  }
+
+  const workspaceFeatureKeys = new Set(
+    featureFlagModels.map((flag) =>
+      getFeatureKey({
+        workspaceModelId: flag.workspaceId,
+        feature: flag.name,
+      })
+    )
+  );
+
+  const globalRolloutByFeature = new Map<WhitelistableFeature, number>();
+  for (const flag of globalFeatureFlags) {
+    if (featureNames.includes(flag.name)) {
+      globalRolloutByFeature.set(flag.name, flag.rolloutPercentage);
+    }
+  }
+
+  const expectedRows = workspaceModels.flatMap((workspace) => {
+    const spaces = defaultSpacesByWorkspace.get(workspace.id);
+    const systemSpaceModelId = spaces?.systemSpaceModelId;
+    const globalSpaceModelId = spaces?.globalSpaceModelId;
+    if (!systemSpaceModelId || !globalSpaceModelId) {
+      logger.warn(
+        { workspaceId: workspace.sId, workspaceModelId: workspace.id },
+        "[Ensure MCP Server Views] Workspace missing system or global space during pre-filter."
+      );
+      return [];
+    }
+
+    return candidates
+      .filter((candidate) =>
+        isCandidateExpectedForWorkspace({
+          candidate,
+          workspaceModelId: workspace.id,
+          workspaceFeatureKeys,
+          globalRolloutByFeature,
+          trigger,
+        })
+      )
+      .map((candidate) => ({
+        workspaceModelId: workspace.id,
+        workspaceId: workspace.sId,
+        internalMCPServerId: autoInternalMCPServerNameToSId({
+          name: candidate.name,
+          workspaceId: workspace.id,
+        }),
+        systemSpaceModelId,
+        globalSpaceModelId,
+      }));
+  });
+
+  if (expectedRows.length === 0) {
+    logger.info(
+      {
+        lastProcessedWorkspaceModelId,
+        lastScannedWorkspaceModelId,
+        scannedWorkspacesCount: workspaceModels.length,
+        candidatesCount: candidates.length,
+      },
+      "[Ensure MCP Server Views] No expected MCP server views in scanned workspace batch."
+    );
+    return {
+      scannedWorkspacesCount: workspaceModels.length,
+      affectedWorkspaces: [],
+      lastScannedWorkspaceModelId,
+      hasMore: workspaceModels.length === batchSize,
+    };
+  }
+
+  const expectedInternalMCPServerIds = Array.from(
+    new Set(expectedRows.map((row) => row.internalMCPServerId))
+  );
+  const defaultSpaceModelIds = Array.from(
+    new Set(
+      expectedRows.flatMap((row) => [
+        row.systemSpaceModelId,
+        row.globalSpaceModelId,
+      ])
+    )
+  );
+
+  const existingViews = await MCPServerViewModelWithBypass.findAll({
+    attributes: ["workspaceId", "internalMCPServerId", "vaultId"],
+    where: {
+      workspaceId: {
+        [Op.in]: workspaceModelIds,
+      },
+      serverType: "internal",
+      internalMCPServerId: {
+        [Op.in]: expectedInternalMCPServerIds,
+      },
+      vaultId: {
+        [Op.in]: defaultSpaceModelIds,
+      },
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Cross-workspace scan for missing default MCP server views.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  const existingViewKeys = new Set(
+    existingViews
+      .map((view) => {
+        if (!view.internalMCPServerId) {
+          return undefined;
+        }
+        return getViewKey({
+          workspaceModelId: view.workspaceId,
+          internalMCPServerId: view.internalMCPServerId,
+          spaceModelId: view.vaultId,
+        });
+      })
+      .filter(isDefined)
+  );
+
+  const affectedWorkspacesByModelId = new Map<
+    ModelId,
+    AffectedMCPServerViewsWorkspace
+  >();
+  for (const expected of expectedRows) {
+    const hasSystemView = existingViewKeys.has(
+      getViewKey({
+        workspaceModelId: expected.workspaceModelId,
+        internalMCPServerId: expected.internalMCPServerId,
+        spaceModelId: expected.systemSpaceModelId,
+      })
+    );
+    const hasGlobalView = existingViewKeys.has(
+      getViewKey({
+        workspaceModelId: expected.workspaceModelId,
+        internalMCPServerId: expected.internalMCPServerId,
+        spaceModelId: expected.globalSpaceModelId,
+      })
+    );
+
+    if (!hasSystemView || !hasGlobalView) {
+      affectedWorkspacesByModelId.set(expected.workspaceModelId, {
+        workspaceModelId: expected.workspaceModelId,
+        workspaceId: expected.workspaceId,
+      });
+    }
+  }
+
+  const affectedWorkspaces = Array.from(
+    affectedWorkspacesByModelId.values()
+  ).sort((a, b) => a.workspaceModelId - b.workspaceModelId);
+
+  logger.info(
+    {
+      lastProcessedWorkspaceModelId,
+      lastScannedWorkspaceModelId,
+      scannedWorkspacesCount: workspaceModels.length,
+      expectedViewsPairsCount: expectedRows.length * 2,
+      affectedWorkspacesCount: affectedWorkspaces.length,
+      candidates: candidates.map((candidate) => candidate.name),
+      triggeringFeature,
+    },
+    "[Ensure MCP Server Views] Scanned workspace batch."
+  );
+
+  return {
+    scannedWorkspacesCount: workspaceModels.length,
+    affectedWorkspaces,
+    lastScannedWorkspaceModelId,
+    hasMore: workspaceModels.length === batchSize,
+  };
+}
+
+export async function ensureMCPServerViewsForWorkspaceBatchActivity({
+  workspaces,
+  concurrency = DEFAULT_WORKSPACE_CONCURRENCY,
+}: EnsureMCPServerViewsForWorkspaceBatchActivityArgs): Promise<EnsureMCPServerViewsForWorkspaceBatchActivityResult> {
+  invalidateGlobalFeatureFlagsCache();
+
+  const results = await concurrentExecutor(
+    workspaces,
+    async (workspace): Promise<WorkspaceProcessingResult> => {
+      const workspaceLogger = logger.child({
+        workspaceId: workspace.workspaceId,
+        workspaceModelId: workspace.workspaceModelId,
+      });
+
+      try {
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.workspaceId
+        );
+        invalidateFeatureFlagsCache(auth);
+        const { createdViewsCount } =
+          await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+        workspaceLogger.info(
+          { createdViewsCount },
+          "[Ensure MCP Server Views] Ensured auto MCP server views."
+        );
+        Context.current().heartbeat();
+
+        return {
+          status: "success",
+          workspaceId: workspace.workspaceId,
+          createdViewsCount,
+        };
+      } catch (error) {
+        const errorMessage = errorToString(error);
+        workspaceLogger.error(
+          { error },
+          "[Ensure MCP Server Views] Failed ensuring auto MCP server views."
+        );
+        Context.current().heartbeat();
+
+        return {
+          status: "failure",
+          workspaceId: workspace.workspaceId,
+          error: errorMessage,
+        };
+      }
+    },
+    { concurrency }
+  );
+
+  const successes = results.filter(isSuccessResult);
+  const failures = results
+    .filter(isFailureResult)
+    .map(({ workspaceId, error }) => ({ workspaceId, error }));
+  const createdViewsCount = successes.reduce(
+    (sum, result) => sum + result.createdViewsCount,
+    0
+  );
+
+  logger.info(
+    {
+      processedWorkspacesCount: workspaces.length,
+      createdViewsCount,
+      failures,
+    },
+    "[Ensure MCP Server Views] Processed affected workspace batch."
+  );
+
+  return {
+    processedWorkspacesCount: workspaces.length,
+    createdViewsCount,
+    failures,
+  };
+}
+
+export async function logEnsureMCPServerViewsWorkflowSummaryActivity(
+  summary: EnsureMCPServerViewsWorkflowSummary
+): Promise<void> {
+  logger.info(
+    {
+      ...summary,
+    },
+    "[Ensure MCP Server Views] Workflow completed."
+  );
+}

--- a/front/temporal/ensure_mcp_server_views/activities.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.ts
@@ -120,6 +120,12 @@ type CandidateAutoMCPServer = {
   feature?: WhitelistableFeature;
 };
 
+type CandidateAutoMCPServerSelection = {
+  candidates: CandidateAutoMCPServer[];
+  skippedRestrictedAutoServerNames: AutoInternalMCPServerNameType[];
+  usedFullScanFallback: boolean;
+};
+
 type DefaultSpacesByWorkspace = {
   systemSpaceModelId?: ModelId;
   globalSpaceModelId?: ModelId;
@@ -142,26 +148,47 @@ function getFeatureHintedAutoMCPServerNames(
   return hint?.serverNames ?? [];
 }
 
+function getAutoMCPServerNames(): AutoInternalMCPServerNameType[] {
+  return AVAILABLE_INTERNAL_MCP_SERVER_NAMES.filter(
+    isAutoInternalMCPServerName
+  );
+}
+
+function getBroadCandidateAutoMCPServers(): CandidateAutoMCPServer[] {
+  return getAutoMCPServerNames().map((name) => ({
+    name,
+    feature: FEATURE_FLAG_BY_AUTO_MCP_SERVER_NAME.get(name),
+  }));
+}
+
 function getCandidateAutoMCPServers({
   triggeringFeature,
 }: {
   triggeringFeature?: WhitelistableFeature;
-}): CandidateAutoMCPServer[] {
+}): CandidateAutoMCPServerSelection {
   if (triggeringFeature) {
-    return getFeatureHintedAutoMCPServerNames(triggeringFeature).map(
-      (name) => ({
+    const hintedNames = getFeatureHintedAutoMCPServerNames(triggeringFeature);
+    if (hintedNames.length === 0) {
+      return {
+        candidates: getBroadCandidateAutoMCPServers(),
+        skippedRestrictedAutoServerNames: [],
+        usedFullScanFallback: true,
+      };
+    }
+
+    return {
+      candidates: hintedNames.map((name) => ({
         name,
         feature: triggeringFeature,
-      })
-    );
+      })),
+      skippedRestrictedAutoServerNames: [],
+      usedFullScanFallback: false,
+    };
   }
 
   const candidates: CandidateAutoMCPServer[] = [];
-  for (const name of AVAILABLE_INTERNAL_MCP_SERVER_NAMES) {
-    if (!isAutoInternalMCPServerName(name)) {
-      continue;
-    }
-
+  const skippedRestrictedAutoServerNames: AutoInternalMCPServerNameType[] = [];
+  for (const name of getAutoMCPServerNames()) {
     if (INTERNAL_MCP_SERVERS[name].isRestricted === undefined) {
       candidates.push({ name });
       continue;
@@ -175,10 +202,17 @@ function getCandidateAutoMCPServers({
 
     if (PLAN_GATED_AUTO_MCP_SERVER_NAMES.has(name)) {
       candidates.push({ name });
+      continue;
     }
+
+    skippedRestrictedAutoServerNames.push(name);
   }
 
-  return candidates;
+  return {
+    candidates,
+    skippedRestrictedAutoServerNames,
+    usedFullScanFallback: false,
+  };
 }
 
 function getFeatureKey({
@@ -201,27 +235,6 @@ function getViewKey({
   spaceModelId: ModelId;
 }): string {
   return `${workspaceModelId}:${internalMCPServerId}:${spaceModelId}`;
-}
-
-function isRolloutIncreaseTarget({
-  workspaceModelId,
-  previousRolloutPercentage,
-  rolloutPercentage,
-}: {
-  workspaceModelId: ModelId;
-  previousRolloutPercentage: number;
-  rolloutPercentage: number;
-}): boolean {
-  return (
-    GlobalFeatureFlagResource.isInRollout(
-      workspaceModelId,
-      rolloutPercentage
-    ) &&
-    !GlobalFeatureFlagResource.isInRollout(
-      workspaceModelId,
-      previousRolloutPercentage
-    )
-  );
 }
 
 function isFeatureEnabledForWorkspace({
@@ -252,11 +265,10 @@ function isFeatureEnabledForWorkspace({
     trigger.triggeringFeature === feature &&
     trigger.rolloutPercentage !== undefined
   ) {
-    return isRolloutIncreaseTarget({
+    return GlobalFeatureFlagResource.isInRollout(
       workspaceModelId,
-      previousRolloutPercentage: trigger.previousRolloutPercentage ?? 0,
-      rolloutPercentage: trigger.rolloutPercentage,
-    });
+      trigger.rolloutPercentage
+    );
   }
 
   const rolloutPercentage = globalRolloutByFeature.get(feature);
@@ -320,7 +332,29 @@ export async function getAffectedMCPServerViewsWorkspaceBatchActivity({
     previousRolloutPercentage,
     rolloutPercentage,
   };
-  const candidates = getCandidateAutoMCPServers({ triggeringFeature });
+  const { candidates, skippedRestrictedAutoServerNames, usedFullScanFallback } =
+    getCandidateAutoMCPServers({ triggeringFeature });
+
+  if (usedFullScanFallback && lastProcessedWorkspaceModelId === 0) {
+    logger.warn(
+      {
+        triggeringFeature,
+        candidates: candidates.map((candidate) => candidate.name),
+      },
+      "[Ensure MCP Server Views] Triggering feature has no MCP server hint, falling back to broad candidate scan."
+    );
+  }
+
+  if (
+    !triggeringFeature &&
+    skippedRestrictedAutoServerNames.length > 0 &&
+    lastProcessedWorkspaceModelId === 0
+  ) {
+    logger.warn(
+      { skippedRestrictedAutoServerNames },
+      "[Ensure MCP Server Views] Restricted auto MCP servers are not covered by SQL pre-filter hints and will be skipped by the daily scan."
+    );
+  }
 
   if (candidates.length === 0) {
     logger.info(
@@ -603,10 +637,13 @@ export async function ensureMCPServerViewsForWorkspaceBatchActivity({
   const results = await concurrentExecutor(
     workspaces,
     async (workspace): Promise<WorkspaceProcessingResult> => {
+      const activityContext = Context.current();
       const workspaceLogger = logger.child({
         workspaceId: workspace.workspaceId,
         workspaceModelId: workspace.workspaceModelId,
       });
+
+      activityContext.heartbeat();
 
       try {
         const auth = await Authenticator.internalAdminForWorkspace(
@@ -620,7 +657,7 @@ export async function ensureMCPServerViewsForWorkspaceBatchActivity({
           { createdViewsCount },
           "[Ensure MCP Server Views] Ensured auto MCP server views."
         );
-        Context.current().heartbeat();
+        activityContext.heartbeat();
 
         return {
           status: "success",
@@ -633,7 +670,7 @@ export async function ensureMCPServerViewsForWorkspaceBatchActivity({
           { error },
           "[Ensure MCP Server Views] Failed ensuring auto MCP server views."
         );
-        Context.current().heartbeat();
+        activityContext.heartbeat();
 
         return {
           status: "failure",
@@ -654,14 +691,22 @@ export async function ensureMCPServerViewsForWorkspaceBatchActivity({
     0
   );
 
-  logger.info(
-    {
-      processedWorkspacesCount: workspaces.length,
-      createdViewsCount,
-      failures,
-    },
-    "[Ensure MCP Server Views] Processed affected workspace batch."
-  );
+  const batchLogPayload = {
+    processedWorkspacesCount: workspaces.length,
+    createdViewsCount,
+    failures,
+  };
+  if (failures.length > 0) {
+    logger.error(
+      batchLogPayload,
+      "[Ensure MCP Server Views] Processed affected workspace batch with failures."
+    );
+  } else {
+    logger.info(
+      batchLogPayload,
+      "[Ensure MCP Server Views] Processed affected workspace batch."
+    );
+  }
 
   return {
     processedWorkspacesCount: workspaces.length,
@@ -673,10 +718,13 @@ export async function ensureMCPServerViewsForWorkspaceBatchActivity({
 export async function logEnsureMCPServerViewsWorkflowSummaryActivity(
   summary: EnsureMCPServerViewsWorkflowSummary
 ): Promise<void> {
-  logger.info(
-    {
-      ...summary,
-    },
-    "[Ensure MCP Server Views] Workflow completed."
-  );
+  if (summary.failuresCount > 0) {
+    logger.error(
+      { ...summary },
+      "[Ensure MCP Server Views] Workflow completed with failures."
+    );
+    return;
+  }
+
+  logger.info({ ...summary }, "[Ensure MCP Server Views] Workflow completed.");
 }

--- a/front/temporal/ensure_mcp_server_views/client.ts
+++ b/front/temporal/ensure_mcp_server_views/client.ts
@@ -18,12 +18,21 @@ import {
 import type { EnsureMCPServerViewsWorkflowArgs } from "./workflows";
 import { ensureMCPServerViewsWorkflow } from "./workflows";
 
+export type LaunchEnsureMCPServerViewsWorkflowOutcome =
+  | "started"
+  | "already_running";
+
+export type LaunchEnsureMCPServerViewsWorkflowResult = {
+  workflowId: string;
+  outcome: LaunchEnsureMCPServerViewsWorkflowOutcome;
+};
+
 export async function launchEnsureMCPServerViewsWorkflow(
   args: Omit<
     EnsureMCPServerViewsWorkflowArgs,
     "lastProcessedWorkspaceModelId" | "summary"
   > = {}
-): Promise<Result<string, Error>> {
+): Promise<Result<LaunchEnsureMCPServerViewsWorkflowResult, Error>> {
   invalidateGlobalFeatureFlagsCache();
 
   const client = await getTemporalClientForFrontNamespace();
@@ -43,14 +52,14 @@ export async function launchEnsureMCPServerViewsWorkflow(
       { workflowId, ...args },
       "[Ensure MCP Server Views] Started workflow."
     );
-    return new Ok(workflowId);
+    return new Ok({ workflowId, outcome: "started" });
   } catch (error) {
     if (error instanceof WorkflowExecutionAlreadyStartedError) {
       logger.info(
         { workflowId, ...args },
-        "[Ensure MCP Server Views] Workflow already running, treating as success."
+        "[Ensure MCP Server Views] Workflow already running."
       );
-      return new Ok(workflowId);
+      return new Ok({ workflowId, outcome: "already_running" });
     }
 
     logger.error(
@@ -77,6 +86,9 @@ export async function launchEnsureMCPServerViewsSchedule(): Promise<
     },
     scheduleId,
     policies: {
+      // The schedule overlap policy prevents schedule-vs-schedule overlap. Direct Poke/script launches
+      // use the fixed workflow id; if a schedule action is already running under a generated id, overlap
+      // is tolerated because the activity is idempotent and worker activity concurrency is bounded.
       overlap: ScheduleOverlapPolicy.SKIP,
     },
     spec: {

--- a/front/temporal/ensure_mcp_server_views/client.ts
+++ b/front/temporal/ensure_mcp_server_views/client.ts
@@ -1,0 +1,118 @@
+import { invalidateGlobalFeatureFlagsCache } from "@app/lib/auth";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  ScheduleNotFoundError,
+  ScheduleOverlapPolicy,
+  WorkflowExecutionAlreadyStartedError,
+} from "@temporalio/client";
+
+import {
+  ENSURE_MCP_SERVER_VIEWS_SCHEDULE_ID,
+  ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID,
+  QUEUE_NAME,
+} from "./config";
+import type { EnsureMCPServerViewsWorkflowArgs } from "./workflows";
+import { ensureMCPServerViewsWorkflow } from "./workflows";
+
+export async function launchEnsureMCPServerViewsWorkflow(
+  args: Omit<
+    EnsureMCPServerViewsWorkflowArgs,
+    "lastProcessedWorkspaceModelId" | "summary"
+  > = {}
+): Promise<Result<string, Error>> {
+  invalidateGlobalFeatureFlagsCache();
+
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID;
+
+  try {
+    await client.workflow.start(ensureMCPServerViewsWorkflow, {
+      args: [args],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        triggeringFeature: args.triggeringFeature,
+      },
+    });
+
+    logger.info(
+      { workflowId, ...args },
+      "[Ensure MCP Server Views] Started workflow."
+    );
+    return new Ok(workflowId);
+  } catch (error) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId, ...args },
+        "[Ensure MCP Server Views] Workflow already running, treating as success."
+      );
+      return new Ok(workflowId);
+    }
+
+    logger.error(
+      { workflowId, error },
+      "[Ensure MCP Server Views] Failed starting workflow."
+    );
+    return new Err(normalizeError(error));
+  }
+}
+
+export async function launchEnsureMCPServerViewsSchedule(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const scheduleId = ENSURE_MCP_SERVER_VIEWS_SCHEDULE_ID;
+  const scheduleWorkflowArgs: [] = [];
+  const scheduleOptions = {
+    action: {
+      type: "startWorkflow" as const,
+      workflowType: ensureMCPServerViewsWorkflow,
+      args: scheduleWorkflowArgs,
+      taskQueue: QUEUE_NAME,
+      workflowId: ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID,
+    },
+    scheduleId,
+    policies: {
+      overlap: ScheduleOverlapPolicy.SKIP,
+    },
+    spec: {
+      // Daily bounds code-removal drift to <24h while the SQL pre-filter keeps healthy runs cheap.
+      cronExpressions: ["0 3 * * *"],
+      timezone: "UTC",
+    },
+  };
+
+  try {
+    const existingSchedule = client.schedule.getHandle(scheduleId);
+    await existingSchedule.update((previous) => ({
+      ...scheduleOptions,
+      state: previous.state,
+    }));
+    logger.info({ scheduleId }, "[Ensure MCP Server Views] Updated schedule.");
+    return new Ok(undefined);
+  } catch (error) {
+    if (!(error instanceof ScheduleNotFoundError)) {
+      logger.error(
+        { scheduleId, error },
+        "[Ensure MCP Server Views] Failed updating schedule."
+      );
+      return new Err(normalizeError(error));
+    }
+  }
+
+  try {
+    await client.schedule.create(scheduleOptions);
+    logger.info({ scheduleId }, "[Ensure MCP Server Views] Created schedule.");
+    return new Ok(undefined);
+  } catch (error) {
+    logger.error(
+      { scheduleId, error },
+      "[Ensure MCP Server Views] Failed creating schedule."
+    );
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/temporal/ensure_mcp_server_views/config.ts
+++ b/front/temporal/ensure_mcp_server_views/config.ts
@@ -1,0 +1,12 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `ensure-mcp-server-views-queue-v${QUEUE_VERSION}`;
+
+export const ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID = "ensure-mcp-server-views";
+
+export const ENSURE_MCP_SERVER_VIEWS_SCHEDULE_ID =
+  "ensure-mcp-server-views-daily";
+
+export const DEFAULT_SCAN_BATCH_SIZE = 1_000;
+export const DEFAULT_WORKSPACE_CONCURRENCY = 50;
+export const MAX_FAILURE_SAMPLES = 100;

--- a/front/temporal/ensure_mcp_server_views/worker.ts
+++ b/front/temporal/ensure_mcp_server_views/worker.ts
@@ -21,7 +21,7 @@ export async function runEnsureMCPServerViewsWorker() {
     activities,
     taskQueue: QUEUE_NAME,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
-    maxConcurrentActivityTaskExecutions: 4,
+    maxConcurrentActivityTaskExecutions: 2,
     connection,
     namespace,
     interceptors: {

--- a/front/temporal/ensure_mcp_server_views/worker.ts
+++ b/front/temporal/ensure_mcp_server_views/worker.ts
@@ -1,0 +1,41 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/ensure_mcp_server_views/activities";
+import { launchEnsureMCPServerViewsSchedule } from "@app/temporal/ensure_mcp_server_views/client";
+import { QUEUE_NAME } from "@app/temporal/ensure_mcp_server_views/config";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+export async function runEnsureMCPServerViewsWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "ensure_mcp_server_views",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 4,
+    connection,
+    namespace,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  await launchEnsureMCPServerViewsSchedule();
+
+  await worker.run();
+}

--- a/front/temporal/ensure_mcp_server_views/workflows.ts
+++ b/front/temporal/ensure_mcp_server_views/workflows.ts
@@ -1,0 +1,127 @@
+import { continueAsNew, proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "./activities";
+import {
+  DEFAULT_SCAN_BATCH_SIZE,
+  DEFAULT_WORKSPACE_CONCURRENCY,
+  MAX_FAILURE_SAMPLES,
+} from "./config";
+
+const { getAffectedMCPServerViewsWorkspaceBatchActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+  heartbeatTimeout: "1 minute",
+});
+
+const {
+  ensureMCPServerViewsForWorkspaceBatchActivity,
+  logEnsureMCPServerViewsWorkflowSummaryActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "60 minutes",
+  heartbeatTimeout: "5 minutes",
+});
+
+export type EnsureMCPServerViewsWorkflowArgs =
+  activities.EnsureMCPServerViewsWorkflowTrigger & {
+    lastProcessedWorkspaceModelId?: number;
+    batchSize?: number;
+    concurrency?: number;
+    summary?: activities.EnsureMCPServerViewsWorkflowSummary;
+  };
+
+const INITIAL_SUMMARY: activities.EnsureMCPServerViewsWorkflowSummary = {
+  scannedWorkspacesCount: 0,
+  affectedWorkspacesCount: 0,
+  processedWorkspacesCount: 0,
+  createdViewsCount: 0,
+  failuresCount: 0,
+  failureSamples: [],
+};
+
+function mergeSummary({
+  summary,
+  scannedWorkspacesCount,
+  affectedWorkspacesCount,
+  processedWorkspacesCount,
+  createdViewsCount,
+  failures,
+}: {
+  summary: activities.EnsureMCPServerViewsWorkflowSummary;
+  scannedWorkspacesCount: number;
+  affectedWorkspacesCount: number;
+  processedWorkspacesCount: number;
+  createdViewsCount: number;
+  failures: activities.EnsureMCPServerViewsWorkspaceFailure[];
+}): activities.EnsureMCPServerViewsWorkflowSummary {
+  return {
+    scannedWorkspacesCount:
+      summary.scannedWorkspacesCount + scannedWorkspacesCount,
+    affectedWorkspacesCount:
+      summary.affectedWorkspacesCount + affectedWorkspacesCount,
+    processedWorkspacesCount:
+      summary.processedWorkspacesCount + processedWorkspacesCount,
+    createdViewsCount: summary.createdViewsCount + createdViewsCount,
+    failuresCount: summary.failuresCount + failures.length,
+    failureSamples: [...summary.failureSamples, ...failures].slice(
+      0,
+      MAX_FAILURE_SAMPLES
+    ),
+  };
+}
+
+export async function ensureMCPServerViewsWorkflow({
+  lastProcessedWorkspaceModelId = 0,
+  batchSize = DEFAULT_SCAN_BATCH_SIZE,
+  concurrency = DEFAULT_WORKSPACE_CONCURRENCY,
+  triggeringFeature,
+  previousRolloutPercentage,
+  rolloutPercentage,
+  summary = INITIAL_SUMMARY,
+}: EnsureMCPServerViewsWorkflowArgs = {}): Promise<activities.EnsureMCPServerViewsWorkflowSummary> {
+  const affectedBatch = await getAffectedMCPServerViewsWorkspaceBatchActivity({
+    lastProcessedWorkspaceModelId,
+    batchSize,
+    triggeringFeature,
+    previousRolloutPercentage,
+    rolloutPercentage,
+  });
+
+  const processBatchResult =
+    affectedBatch.affectedWorkspaces.length > 0
+      ? await ensureMCPServerViewsForWorkspaceBatchActivity({
+          workspaces: affectedBatch.affectedWorkspaces,
+          concurrency,
+        })
+      : {
+          processedWorkspacesCount: 0,
+          createdViewsCount: 0,
+          failures: [],
+        };
+
+  const nextSummary = mergeSummary({
+    summary,
+    scannedWorkspacesCount: affectedBatch.scannedWorkspacesCount,
+    affectedWorkspacesCount: affectedBatch.affectedWorkspaces.length,
+    processedWorkspacesCount: processBatchResult.processedWorkspacesCount,
+    createdViewsCount: processBatchResult.createdViewsCount,
+    failures: processBatchResult.failures,
+  });
+
+  if (affectedBatch.hasMore) {
+    await continueAsNew<typeof ensureMCPServerViewsWorkflow>({
+      lastProcessedWorkspaceModelId:
+        affectedBatch.lastScannedWorkspaceModelId ??
+        lastProcessedWorkspaceModelId,
+      batchSize,
+      concurrency,
+      triggeringFeature,
+      previousRolloutPercentage,
+      rolloutPercentage,
+      summary: nextSummary,
+    });
+  }
+
+  await logEnsureMCPServerViewsWorkflowSummaryActivity(nextSummary);
+  return nextSummary;
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -4,6 +4,7 @@ import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
 import { runConversationForkQueueWorker } from "@app/temporal/conversation_fork_queue/worker";
 import { runCreditAlertsWorker } from "@app/temporal/credit_alerts/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
+import { runEnsureMCPServerViewsWorker } from "@app/temporal/ensure_mcp_server_views/worker";
 import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runInvitationsWorker } from "@app/temporal/invitations/worker";
@@ -35,6 +36,7 @@ export type WorkerName =
   | "project_task"
   | "credit_alerts"
   | "data_retention"
+  | "ensure_mcp_server_views"
   | "es_indexation_queue"
   | "hard_delete"
   | "labs"
@@ -63,6 +65,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   conversation_fork_queue: runConversationForkQueueWorker,
   credit_alerts: runCreditAlertsWorker,
   data_retention: runDataRetentionWorker,
+  ensure_mcp_server_views: runEnsureMCPServerViewsWorker,
   hard_delete: runHardDeleteWorker,
   labs: runLabsTranscriptsWorker,
   invitations: runInvitationsWorker,


### PR DESCRIPTION
## Summary

- Adds a new `ensure_mcp_server_views` Temporal worker/domain with a fixed direct-launch workflow id, daily schedule, SQL pre-filter, batch processing, continue-as-new checkpointing, and per-workspace failure capture.
- Starts the workflow from the global feature flag Poke plugin when rollout percentage increases. Triggered scans use current rollout membership, report when a run is already in progress, and fall back to a broad candidate scan when the triggering feature has no MCP-server hint.
- Updates `scripts/ensure_all_mcp_server_views_created.ts` so all-workspace mode launches Temporal while preserving direct single-workspace fixes and making dry-run report the first scan batch.

## Risk assessment

- DB load is bounded by scan batches (default 1,000 workspaces), workspace processing concurrency (default 50), and worker activity concurrency (2).
- `ensureAllAutoToolsAreCreated` remains the only creation/eligibility source of truth; the SQL/Sequelize pre-filter only selects candidates and may over-select slightly.
- Direct Poke/script launches use a fixed workflow id and dedupe with an `already_running` outcome. The daily schedule uses `SKIP` for schedule-vs-schedule overlap; if a scheduled run overlaps a direct launch, that is accepted because the operation is idempotent and concurrency is bounded.
- Main operational risk is a new Temporal task queue not being deployed; until the worker runs, Poke launches will dedupe/start but no activity can execute.

## Deploy plan

1. Deploy front workers with the new `ensure_mcp_server_views` worker registered and bundled.
2. Confirm the `ensure-mcp-server-views-daily` schedule is created/updated by the worker.
3. After rollout, raise a small MCP-related global feature flag percentage in staging/Poke and confirm workflow logs show scan, created counts, and failures.
4. Monitor DB query latency and Temporal activity failures during the first production run.

## Validation

- `npm run format:changed`
- `npx biome check --write --error-on-warnings lib/actions/mcp_internal_actions/constants.ts lib/api/poke/plugins/global/toggle_global_feature_flag.ts lib/api/poke/plugins/global/toggle_global_feature_flag.test.ts scripts/ensure_all_mcp_server_views_created.ts temporal/ensure_mcp_server_views temporal/ensure_mcp_server_views/worker.ts`
- Filtered typecheck for touched paths: `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit --pretty false 2>&1 | rg "temporal/ensure_mcp_server_views|toggle_global_feature_flag|ensure_all_mcp_server_views_created|mcp_internal_actions/constants|worker_registry|build-temporal-bundles" || true` produced no touched-file errors.
- `FRONT_DATABASE_URI=postgres://dust:dust@localhost:5432/dust_test npm run build:temporal-bundles` passed and built all 28 bundles, including `ensure_mcp_server_views`.
- Targeted Vitest command could not run in this shell because `TEST_FRONT_DATABASE_URI` is unset; Vitest global setup requires a test DB.
- Full pre-commit/typecheck still fails on unrelated repo drift around Sparkle/client exports plus existing `temporal/project_task/activities.ts` / SDK drift errors.
