### PR TITLE
feat: add business admin to roles

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -180,7 +180,21 @@ app.post(
           api_error: {
             type: "invalid_request_error",
             message:
-              "The request body is invalid, expects { role: 'admin' | 'builder' | 'user' }.",
+              "The request body is invalid, expects { role: 'admin' | 'business_admin' | 'builder' | 'user' }.",
+          },
+        });
+      }
+
+      if (
+        role === "business_admin" &&
+        !featureFlags.includes("admin_governance")
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You cannot assign the business_admin role as the feature is not enabled for your workspace.",
           },
         });
       }
@@ -274,6 +288,7 @@ app.post(
 
     switch (body.role) {
       case "admin":
+      case "business_admin":
       case "builder":
       case "user":
         w.role = body.role;

--- a/front/components/members/Roles.ts
+++ b/front/components/members/Roles.ts
@@ -1,7 +1,13 @@
 import type { ActiveRoleType, RoleType } from "@app/types/user";
 
 export function displayRole(role: RoleType): string {
-  return role === "user" ? "member" : role;
+  if (role === "user") {
+    return "member";
+  }
+  if (role === "business_admin") {
+    return "business admin";
+  }
+  return role;
 }
 
 export const ROLES_DATA: Record<
@@ -12,6 +18,10 @@ export const ROLES_DATA: Record<
     description:
       "Can use and create agents, manage settings, members, spaces, connections, and tools.",
     color: "rose",
+  },
+  business_admin: {
+    description: "Business administrator.",
+    color: "primary",
   },
   builder: {
     description:

--- a/front/components/members/RolesDropDown.tsx
+++ b/front/components/members/RolesDropDown.tsx
@@ -1,4 +1,5 @@
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { ActiveRoleType } from "@app/types/user";
 import { ACTIVE_ROLES } from "@app/types/user";
 import {
@@ -22,6 +23,14 @@ export function RoleDropDown({
   selectedRole,
   disabled = false,
 }: RoleDropDownProps) {
+  const { hasFeature } = useFeatureFlags();
+
+  // `business_admin` can only be assigned when the
+  // workspace has the `admin_governance` feature flag.
+  const availableRoles = hasFeature("admin_governance")
+    ? ACTIVE_ROLES
+    : ACTIVE_ROLES.filter((role) => role !== "business_admin");
+
   if (disabled) {
     return (
       <Chip
@@ -49,7 +58,7 @@ export function RoleDropDown({
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        {ACTIVE_ROLES.map((role) => (
+        {availableRoles.map((role) => (
           <DropdownMenuItem
             key={role}
             onClick={() => onChange(role)}

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -35,6 +35,7 @@ const formatKeyScope = (role: RoleType): string => {
   switch (role) {
     case "user":
       return "Read-only";
+    case "business_admin":
     case "builder":
       return "Read & write";
     case "admin":

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -204,6 +204,7 @@ export async function getMembers(
     if (!m.isRevoked()) {
       switch (m.role) {
         case "admin":
+        case "business_admin":
         case "builder":
         case "user":
           role = m.role;

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -88,6 +88,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   get isBuilder(): boolean {
     switch (this.role) {
       case "admin":
+      case "business_admin":
       case "builder":
         return true;
       case "user":

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -1,6 +1,11 @@
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-export const MEMBERSHIP_ROLE_TYPES = ["admin", "builder", "user"] as const;
+export const MEMBERSHIP_ROLE_TYPES = [
+  "admin",
+  "business_admin",
+  "builder",
+  "user",
+] as const;
 
 export type MembershipRoleType = (typeof MEMBERSHIP_ROLE_TYPES)[number];
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -326,6 +326,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Auto-attach the Dust Desktop client-side MCP server to agent runs when registered for the user.",
     stage: "dust_only",
   },
+  admin_governance: {
+    description:
+      "Access to admin governance features, including assigning the business_admin role from the UI",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -13,8 +13,19 @@ import { assertNever } from "./shared/utils/assert_never";
 
 export type WorkspaceSegmentationType = "interesting" | null;
 
-export const ROLES = ["admin", "builder", "user", "none"] as const;
-export const ACTIVE_ROLES = ["admin", "builder", "user"] as const;
+export const ROLES = [
+  "admin",
+  "business_admin",
+  "builder",
+  "user",
+  "none",
+] as const;
+export const ACTIVE_ROLES = [
+  "admin",
+  "business_admin",
+  "builder",
+  "user",
+] as const;
 export const ANONYMOUS_USER_IMAGE_URL = "/static/humanavatar/anonymous.png";
 
 function keyObject<T extends readonly string[]>(
@@ -192,6 +203,7 @@ export function isAdmin(
   switch (owner.role) {
     case "admin":
       return true;
+    case "business_admin":
     case "builder":
     case "user":
     case "none":
@@ -209,6 +221,7 @@ export function isBuilder(
   }
   switch (owner.role) {
     case "admin":
+    case "business_admin":
     case "builder":
       return true;
     case "user":
@@ -227,6 +240,7 @@ export function isUser(
   }
   switch (owner.role) {
     case "admin":
+    case "business_admin":
     case "builder":
     case "user":
       return true;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -763,6 +763,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "metronome_billing_usage_page"
   | "user_settings_v2"
   | "metronome_cp_checkout"
+  | "admin_governance"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;
@@ -770,7 +771,13 @@ export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;
 const WorkspaceSegmentationSchema =
   FlexibleEnumSchema<"interesting">().nullable();
 
-const RoleSchema = z.enum(["admin", "builder", "user", "none"]);
+const RoleSchema = z.enum([
+  "admin",
+  "business_admin",
+  "builder",
+  "user",
+  "none",
+]);
 
 const LightWorkspaceSchema = z.object({
   id: ModelIdSchema,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8636

This PR introduces a new `business_admin` role to the workspace role system, gated behind an `admin_governance` feature flag.

- Adds `business_admin` to `ROLES`, `ACTIVE_ROLES`, and `MEMBERSHIP_ROLE_TYPES` across types and SDK
- The role has builder-level permissions (`isBuilder` returns true, but `isAdmin` returns false)
- In the roles dropdown UI, `business_admin` is only shown when the workspace has the `admin_governance` feature flag enabled; it can be assigned via API if the flag is enabled
- Adds the `admin_governance` feature flag
- Updates the member API endpoint to accept and handle `business_admin` as a valid role value, returning a 403 if assigned without the feature flag

## Tests

Manually.

## Risks
Low.
<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps. -->

