### PR TITLE
[front] feat: add admin-only workspace-analytics skill

### DIFF
--- a/front/lib/resources/skill/code_defined/global_registry.ts
+++ b/front/lib/resources/skill/code_defined/global_registry.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/resources/skill/code_defined/shared";
 import { skillAuthoringSkill } from "@app/lib/resources/skill/code_defined/skill_authoring";
 import { supportSkill } from "@app/lib/resources/skill/code_defined/support";
+import { workspaceAnalyticsSkill } from "@app/lib/resources/skill/code_defined/workspace_analytics";
 import { xlsxSkill } from "@app/lib/resources/skill/code_defined/xlsx";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { serializeSkillTag } from "@app/lib/skills/format";
@@ -24,6 +25,7 @@ const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   projectsSkill,
   skillAuthoringSkill,
   supportSkill,
+  workspaceAnalyticsSkill,
   xlsxSkill,
 ] as const);
 

--- a/front/lib/resources/skill/code_defined/workspace_analytics.test.ts
+++ b/front/lib/resources/skill/code_defined/workspace_analytics.test.ts
@@ -1,0 +1,42 @@
+import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("workspace-analytics code-defined skill", () => {
+  it("is hidden from non-admins even when the flag is on", async () => {
+    const { authenticator } = await createResourceTest({ role: "builder" });
+    await FeatureFlagFactory.basic(authenticator, "workspace_analytics");
+
+    const skill = await GlobalSkillsRegistry.getById(
+      authenticator,
+      "workspace-analytics"
+    );
+    expect(skill).toBeNull();
+  });
+
+  it("is hidden from admins when the flag is off", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const skill = await GlobalSkillsRegistry.getById(
+      authenticator,
+      "workspace-analytics"
+    );
+    expect(skill).toBeNull();
+  });
+
+  it("is visible to admins with the flag on and wires the workspace_analytics server", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    await FeatureFlagFactory.basic(authenticator, "workspace_analytics");
+
+    const skill = await GlobalSkillsRegistry.getById(
+      authenticator,
+      "workspace-analytics"
+    );
+    expect(skill).toMatchObject({
+      sId: "workspace-analytics",
+      name: "Workspace Analytics",
+      mcpServers: [{ name: "workspace_analytics" }],
+    });
+  });
+});

--- a/front/lib/resources/skill/code_defined/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/workspace_analytics.ts
@@ -1,0 +1,31 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+
+export const workspaceAnalyticsSkill = {
+  sId: "workspace-analytics",
+  name: "Workspace Analytics",
+  userFacingDescription:
+    "Analyze how your workspace is being used — for example, which agents " +
+    "are used most. Available to workspace admins only.",
+  agentFacingDescription:
+    "Enable when a workspace admin asks about workspace usage analytics, " +
+    "such as which agents are used most. Restricted to admins.",
+  instructions:
+    "You help workspace admins analyze how their Dust workspace is being " +
+    "used. Use the available workspace analytics tools to answer the admin's " +
+    "question and present the results clearly. Only report figures returned " +
+    "by the tools — never fabricate numbers. If a tool reports an " +
+    "authorization error, explain that workspace analytics is restricted to " +
+    "workspace admins.",
+  mcpServers: [{ name: "workspace_analytics" }],
+  version: 1,
+  icon: "ActionPieChartIcon",
+  isRestricted: async (auth: Authenticator) => {
+    if (!auth.isAdmin()) {
+      return true;
+    }
+    const flags = await getFeatureFlags(auth);
+    return !flags.includes("workspace_analytics");
+  },
+} as const satisfies GlobalSkillDefinition;


### PR DESCRIPTION
## Description

Add a code-defined workspace-analytics global skill that wires the workspace_analytics MCP server and instructs the agent to answer workspace usage questions from tool results only. Its isRestricted gate hides it unless the caller is a workspace admin AND the workspace_analytics feature flag is on, matching the server gate so the whole capability appears together. Registered in the global skills registry. Tested across the admin/flag visibility matrix.

The skill will be updated as we add tools to the underlying workspace_analytics MCP server.

## Tests

Unit

## Risk

None

## Deploy Plan

Front