### PR TITLE
chore(credits): remove icon from credit cost menu item

### DIFF
--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -2,7 +2,6 @@ import { useAuth } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
-import { ActionCreditCoinsIcon } from "@dust-tt/sparkle";
 
 const CREDIT_COST_COPY = {
   label: "Message credit cost",
@@ -31,7 +30,6 @@ export function useCreditCostMenuItem({
 
   return {
     label,
-    icon: ActionCreditCoinsIcon,
     endComponent: formatCredits(credits),
     tooltip,
     className:


### PR DESCRIPTION
## Description

Removes the `ActionCreditCoinsIcon` from the "Message credit cost" dropdown menu item, so the entry now shows only its label and the formatted credit cost without a leading icon.
