### PR TITLE
Add MCP server view processing activity

### DIFF
--- a/front/temporal/ensure_mcp_server_views/activities.test.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.test.ts
@@ -1,0 +1,87 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { ensureMCPServerViewsForWorkspaceBatchActivity } from "@app/temporal/ensure_mcp_server_views/activities";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: vi.fn(() => ({
+      heartbeat: vi.fn(),
+    })),
+  },
+}));
+
+describe("ensureMCPServerViewsForWorkspaceBatchActivity", () => {
+  it("fetches and processes workspaces after the checkpoint without returning workspace data", async () => {
+    const checkpointWorkspace = await WorkspaceFactory.basic();
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const result = await ensureMCPServerViewsForWorkspaceBatchActivity({
+      lastProcessedWorkspaceModelId: checkpointWorkspace.id,
+      batchSize: 1,
+      concurrency: 1,
+    });
+
+    expect(result).toMatchObject({
+      scannedWorkspacesCount: 1,
+      processedWorkspacesCount: 1,
+      failuresCount: 0,
+      failureSamples: [],
+      lastScannedWorkspaceModelId: workspace.id,
+      hasMore: true,
+    });
+    expect(result.createdViewsCount).toBeGreaterThan(0);
+    expect(result).not.toHaveProperty("workspaces");
+  });
+
+  it("creates views idempotently in a batch", async () => {
+    const checkpointWorkspace = await WorkspaceFactory.basic();
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    const firstRun = await ensureMCPServerViewsForWorkspaceBatchActivity({
+      lastProcessedWorkspaceModelId: checkpointWorkspace.id,
+      batchSize: 1,
+      concurrency: 1,
+    });
+
+    expect(firstRun.processedWorkspacesCount).toBe(1);
+    expect(firstRun.failuresCount).toBe(0);
+    expect(firstRun.failureSamples).toEqual([]);
+    expect(firstRun.createdViewsCount).toBeGreaterThan(0);
+
+    const commonUtilitiesServerId = autoInternalMCPServerNameToSId({
+      name: "common_utilities",
+      workspaceId: workspace.id,
+    });
+    await expect(
+      MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        commonUtilitiesServerId
+      )
+    ).resolves.not.toBeNull();
+    await expect(
+      MCPServerViewResource.getMCPServerViewForGlobalSpace(
+        auth,
+        commonUtilitiesServerId
+      )
+    ).resolves.not.toBeNull();
+
+    const secondRun = await ensureMCPServerViewsForWorkspaceBatchActivity({
+      lastProcessedWorkspaceModelId: checkpointWorkspace.id,
+      batchSize: 1,
+      concurrency: 1,
+    });
+
+    expect(secondRun.processedWorkspacesCount).toBe(1);
+    expect(secondRun.failuresCount).toBe(0);
+    expect(secondRun.failureSamples).toEqual([]);
+    expect(secondRun.createdViewsCount).toBe(0);
+  });
+});

--- a/front/temporal/ensure_mcp_server_views/activities.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.ts
@@ -1,0 +1,192 @@
+import {
+  Authenticator,
+  invalidateFeatureFlagsCache,
+  invalidateGlobalFeatureFlagsCache,
+} from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { ModelId } from "@app/types/shared/model_id";
+import {
+  errorToString,
+  normalizeError,
+} from "@app/types/shared/utils/error_utils";
+import { Context } from "@temporalio/activity";
+
+import { DEFAULT_WORKSPACE_CONCURRENCY, MAX_FAILURE_SAMPLES } from "./config";
+
+export type EnsureMCPServerViewsWorkflowTrigger = {
+  triggeringFeature?: WhitelistableFeature;
+  previousRolloutPercentage?: number;
+  rolloutPercentage?: number;
+};
+
+export type EnsureMCPServerViewsForWorkspaceBatchActivityArgs = {
+  lastProcessedWorkspaceModelId?: ModelId;
+  batchSize: number;
+  concurrency?: number;
+};
+
+export type EnsureMCPServerViewsWorkspaceFailure = {
+  workspaceId: string;
+  error: string;
+};
+
+export type EnsureMCPServerViewsForWorkspaceBatchActivityResult = {
+  scannedWorkspacesCount: number;
+  processedWorkspacesCount: number;
+  createdViewsCount: number;
+  failuresCount: number;
+  failureSamples: EnsureMCPServerViewsWorkspaceFailure[];
+  lastScannedWorkspaceModelId: ModelId;
+  hasMore: boolean;
+};
+
+export type EnsureMCPServerViewsWorkflowSummary = {
+  scannedWorkspacesCount: number;
+  processedWorkspacesCount: number;
+  createdViewsCount: number;
+  failuresCount: number;
+  failureSamples: EnsureMCPServerViewsWorkspaceFailure[];
+};
+
+export type WorkspaceProcessingResult =
+  | { status: "success"; workspaceId: string; createdViewsCount: number }
+  | { status: "failure"; workspaceId: string; error: string };
+
+export function isSuccessResult(
+  result: WorkspaceProcessingResult
+): result is Extract<WorkspaceProcessingResult, { status: "success" }> {
+  return result.status === "success";
+}
+
+export function isFailureResult(
+  result: WorkspaceProcessingResult
+): result is Extract<WorkspaceProcessingResult, { status: "failure" }> {
+  return result.status === "failure";
+}
+
+export async function ensureMCPServerViewsForWorkspaceBatchActivity({
+  lastProcessedWorkspaceModelId = 0,
+  batchSize,
+  concurrency = DEFAULT_WORKSPACE_CONCURRENCY,
+}: EnsureMCPServerViewsForWorkspaceBatchActivityArgs): Promise<EnsureMCPServerViewsForWorkspaceBatchActivityResult> {
+  const workspaces =
+    await WorkspaceResource.unsafeListWorkspaceIdBatchAfterModelId({
+      lastWorkspaceModelId: lastProcessedWorkspaceModelId,
+      limit: batchSize,
+    });
+  const lastScannedWorkspaceModelId =
+    workspaces.at(-1)?.workspaceModelId ?? lastProcessedWorkspaceModelId;
+
+  logger.info(
+    {
+      lastProcessedWorkspaceModelId,
+      lastScannedWorkspaceModelId,
+      scannedWorkspacesCount: workspaces.length,
+    },
+    "[Ensure MCP Server Views] Listed workspace batch."
+  );
+
+  invalidateGlobalFeatureFlagsCache();
+
+  const results = await concurrentExecutor(
+    workspaces,
+    async (workspace): Promise<WorkspaceProcessingResult> => {
+      const activityContext = Context.current();
+      const workspaceLogger = logger.child({
+        workspaceId: workspace.workspaceId,
+        workspaceModelId: workspace.workspaceModelId,
+      });
+
+      activityContext.heartbeat();
+
+      try {
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.workspaceId
+        );
+        invalidateFeatureFlagsCache(auth);
+        const { createdViewsCount } =
+          await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+        workspaceLogger.info(
+          { createdViewsCount },
+          "[Ensure MCP Server Views] Ensured auto MCP server views."
+        );
+        activityContext.heartbeat();
+
+        return {
+          status: "success",
+          workspaceId: workspace.workspaceId,
+          createdViewsCount,
+        };
+      } catch (error) {
+        const errorMessage = errorToString(error);
+        workspaceLogger.error(
+          { err: normalizeError(error) },
+          "[Ensure MCP Server Views] Failed ensuring auto MCP server views."
+        );
+        activityContext.heartbeat();
+
+        return {
+          status: "failure",
+          workspaceId: workspace.workspaceId,
+          error: errorMessage,
+        };
+      }
+    },
+    { concurrency }
+  );
+
+  const successes = results.filter(isSuccessResult);
+  const failures = results
+    .filter(isFailureResult)
+    .map(({ workspaceId, error }) => ({ workspaceId, error }));
+  const createdViewsCount = successes.reduce(
+    (sum, result) => sum + result.createdViewsCount,
+    0
+  );
+
+  const batchLogPayload = {
+    processedWorkspacesCount: workspaces.length,
+    createdViewsCount,
+    failures,
+  };
+  if (failures.length > 0) {
+    logger.error(
+      batchLogPayload,
+      "[Ensure MCP Server Views] Processed workspace batch with failures."
+    );
+  } else {
+    logger.info(
+      batchLogPayload,
+      "[Ensure MCP Server Views] Processed workspace batch."
+    );
+  }
+
+  return {
+    scannedWorkspacesCount: workspaces.length,
+    processedWorkspacesCount: workspaces.length,
+    createdViewsCount,
+    failuresCount: failures.length,
+    failureSamples: failures.slice(0, MAX_FAILURE_SAMPLES),
+    lastScannedWorkspaceModelId,
+    hasMore: workspaces.length === batchSize,
+  };
+}
+
+export async function logEnsureMCPServerViewsWorkflowSummaryActivity(
+  summary: EnsureMCPServerViewsWorkflowSummary
+): Promise<void> {
+  if (summary.failuresCount > 0) {
+    logger.error(
+      { ...summary },
+      "[Ensure MCP Server Views] Workflow completed with failures."
+    );
+    return;
+  }
+
+  logger.info({ ...summary }, "[Ensure MCP Server Views] Workflow completed.");
+}

--- a/front/temporal/ensure_mcp_server_views/config.ts
+++ b/front/temporal/ensure_mcp_server_views/config.ts
@@ -1,0 +1,12 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `ensure-mcp-server-views-queue-v${QUEUE_VERSION}`;
+
+export const ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID = "ensure-mcp-server-views";
+
+export const ENSURE_MCP_SERVER_VIEWS_SCHEDULE_ID =
+  "ensure-mcp-server-views-daily";
+
+export const DEFAULT_WORKSPACE_BATCH_SIZE = 1_000;
+export const DEFAULT_WORKSPACE_CONCURRENCY = 50;
+export const MAX_FAILURE_SAMPLES = 100;


### PR DESCRIPTION
## Summary

Adds the processing activity for the MCP server view backfill:

- fetches a workspace batch inside the activity, keeping workspace ids out of workflow history
- processes the batch with bounded concurrency
- calls `Authenticator.internalAdminForWorkspace` and `MCPServerViewResource.ensureAllAutoToolsAreCreated`
- captures and logs per-workspace failures so one workspace does not abort the batch
- returns only aggregate counts, bounded failure samples, `hasMore`, and the model-id checkpoint

No SQL pre-filtering is performed; every workspace in the listed batch is processed.

## Stack

1. #26984
2. This PR
3. #26986
4. #26987
5. #26988

## Validation

- `npm run format:changed`
- `npx tsgo --noEmit --pretty false`
- `FRONT_DATABASE_URI=postgres://dust:dust@localhost:5432/dust_test npm run build:temporal-bundles`
- Focused Vitest was blocked locally by the test Postgres role `dust` missing; CI runs the DB-backed tests.

## Risk

Low. Adds an activity but no workflow runtime or trigger yet. Temporal history payload is intentionally small: the activity does not return the workspace batch.
