### PR TITLE
Add MCP server views Temporal workflow

### DIFF
--- a/front/temporal/ensure_mcp_server_views/workflows.ts
+++ b/front/temporal/ensure_mcp_server_views/workflows.ts
@@ -1,0 +1,81 @@
+import { continueAsNew, proxyActivities } from "@temporalio/workflow";
+
+import type * as activities from "./activities";
+import {
+  DEFAULT_WORKSPACE_BATCH_SIZE,
+  DEFAULT_WORKSPACE_CONCURRENCY,
+  MAX_FAILURE_SAMPLES,
+} from "./activity_config";
+
+const {
+  ensureMCPServerViewsForWorkspaceBatchActivity,
+  logEnsureMCPServerViewsWorkflowSummaryActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "60 minutes",
+  heartbeatTimeout: "5 minutes",
+});
+
+export type EnsureMCPServerViewsWorkflowArgs =
+  activities.EnsureMCPServerViewsWorkflowTrigger & {
+    lastProcessedWorkspaceModelId?: number;
+    batchSize?: number;
+    concurrency?: number;
+    summary?: activities.EnsureMCPServerViewsWorkflowSummary;
+  };
+
+const INITIAL_SUMMARY: activities.EnsureMCPServerViewsWorkflowSummary = {
+  scannedWorkspacesCount: 0,
+  processedWorkspacesCount: 0,
+  createdViewsCount: 0,
+  failuresCount: 0,
+  failureSamples: [],
+};
+
+export async function ensureMCPServerViewsWorkflow({
+  lastProcessedWorkspaceModelId = 0,
+  batchSize = DEFAULT_WORKSPACE_BATCH_SIZE,
+  concurrency = DEFAULT_WORKSPACE_CONCURRENCY,
+  triggeringFeature,
+  previousRolloutPercentage,
+  rolloutPercentage,
+  summary = INITIAL_SUMMARY,
+}: EnsureMCPServerViewsWorkflowArgs = {}): Promise<activities.EnsureMCPServerViewsWorkflowSummary> {
+  const processBatchResult =
+    await ensureMCPServerViewsForWorkspaceBatchActivity({
+      lastProcessedWorkspaceModelId,
+      batchSize,
+      concurrency,
+    });
+
+  const nextSummary: activities.EnsureMCPServerViewsWorkflowSummary = {
+    scannedWorkspacesCount:
+      summary.scannedWorkspacesCount +
+      processBatchResult.scannedWorkspacesCount,
+    processedWorkspacesCount:
+      summary.processedWorkspacesCount +
+      processBatchResult.processedWorkspacesCount,
+    createdViewsCount:
+      summary.createdViewsCount + processBatchResult.createdViewsCount,
+    failuresCount: summary.failuresCount + processBatchResult.failuresCount,
+    failureSamples: [
+      ...summary.failureSamples,
+      ...processBatchResult.failureSamples,
+    ].slice(0, MAX_FAILURE_SAMPLES),
+  };
+
+  if (processBatchResult.hasMore) {
+    await continueAsNew<typeof ensureMCPServerViewsWorkflow>({
+      lastProcessedWorkspaceModelId:
+        processBatchResult.lastScannedWorkspaceModelId,
+      batchSize,
+      concurrency,
+      triggeringFeature,
+      previousRolloutPercentage,
+      rolloutPercentage,
+      summary: nextSummary,
+    });
+  }
+
+  await logEnsureMCPServerViewsWorkflowSummaryActivity(nextSummary);
+  return nextSummary;
+}


### PR DESCRIPTION
## Summary

Adds the Temporal workflow for the MCP server view backfill:

- loops over workspace model-id batches
- processes each batch through the activity merged in #26984
- checkpoints with `continueAsNew`
- logs a final summary with scanned, processed, created, and failure counts

This PR does not define the task queue or launch client. The queue, client, and worker are introduced together in #26987.

## Stack

1. This PR
2. #26987
3. #26988

## Validation

- `npm run format:changed`
- `npx tsgo --noEmit --pretty false`
- `FRONT_DATABASE_URI=postgres://dust:dust@localhost:5432/dust_test npm run build:temporal-bundles`

## Risk

Low until the worker is registered in the next PR.
