### PR TITLE
Register MCP server views Temporal worker

### DIFF
--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -48,6 +48,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/credit_alerts");
     case "data_retention":
       return path.join(baseDir, "temporal/data_retention");
+    case "ensure_mcp_server_views":
+      return path.join(baseDir, "temporal/ensure_mcp_server_views");
     case "hard_delete":
       return path.join(baseDir, "temporal/hard_delete");
     case "invitations":

--- a/front/temporal/ensure_mcp_server_views/activities.ts
+++ b/front/temporal/ensure_mcp_server_views/activities.ts
@@ -7,7 +7,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import {
   errorToString,
@@ -19,12 +18,6 @@ import {
   DEFAULT_WORKSPACE_CONCURRENCY,
   MAX_FAILURE_SAMPLES,
 } from "./activity_config";
-
-export type EnsureMCPServerViewsWorkflowTrigger = {
-  triggeringFeature?: WhitelistableFeature;
-  previousRolloutPercentage?: number;
-  rolloutPercentage?: number;
-};
 
 export type EnsureMCPServerViewsForWorkspaceBatchActivityArgs = {
   lastProcessedWorkspaceModelId?: ModelId;

--- a/front/temporal/ensure_mcp_server_views/client.ts
+++ b/front/temporal/ensure_mcp_server_views/client.ts
@@ -1,0 +1,57 @@
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+import { ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID, QUEUE_NAME } from "./config";
+import type { EnsureMCPServerViewsWorkflowArgs } from "./workflows";
+import { ensureMCPServerViewsWorkflow } from "./workflows";
+
+export type LaunchEnsureMCPServerViewsWorkflowOutcome =
+  | "started"
+  | "already_running";
+
+export type LaunchEnsureMCPServerViewsWorkflowResult = {
+  workflowId: string;
+  outcome: LaunchEnsureMCPServerViewsWorkflowOutcome;
+};
+
+export async function launchEnsureMCPServerViewsWorkflow(
+  args: Omit<
+    EnsureMCPServerViewsWorkflowArgs,
+    "lastProcessedWorkspaceModelId" | "summary"
+  > = {}
+): Promise<Result<LaunchEnsureMCPServerViewsWorkflowResult, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID;
+
+  try {
+    await client.workflow.start(ensureMCPServerViewsWorkflow, {
+      args: [args],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+    });
+
+    logger.info(
+      { workflowId, ...args },
+      "[Ensure MCP Server Views] Started workflow."
+    );
+    return new Ok({ workflowId, outcome: "started" });
+  } catch (error) {
+    if (error instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId, ...args },
+        "[Ensure MCP Server Views] Workflow already running."
+      );
+      return new Ok({ workflowId, outcome: "already_running" });
+    }
+
+    logger.error(
+      { workflowId, err: normalizeError(error) },
+      "[Ensure MCP Server Views] Failed starting workflow."
+    );
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/temporal/ensure_mcp_server_views/config.ts
+++ b/front/temporal/ensure_mcp_server_views/config.ts
@@ -1,0 +1,5 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `ensure-mcp-server-views-queue-v${QUEUE_VERSION}`;
+
+export const ENSURE_MCP_SERVER_VIEWS_WORKFLOW_ID = "ensure-mcp-server-views";

--- a/front/temporal/ensure_mcp_server_views/worker.ts
+++ b/front/temporal/ensure_mcp_server_views/worker.ts
@@ -1,0 +1,38 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/ensure_mcp_server_views/activities";
+import { QUEUE_NAME } from "@app/temporal/ensure_mcp_server_views/config";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+export async function runEnsureMCPServerViewsWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "ensure_mcp_server_views",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 2,
+    connection,
+    namespace,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/ensure_mcp_server_views/workflows.ts
+++ b/front/temporal/ensure_mcp_server_views/workflows.ts
@@ -15,13 +15,12 @@ const {
   heartbeatTimeout: "5 minutes",
 });
 
-export type EnsureMCPServerViewsWorkflowArgs =
-  activities.EnsureMCPServerViewsWorkflowTrigger & {
-    lastProcessedWorkspaceModelId?: number;
-    batchSize?: number;
-    concurrency?: number;
-    summary?: activities.EnsureMCPServerViewsWorkflowSummary;
-  };
+export type EnsureMCPServerViewsWorkflowArgs = {
+  lastProcessedWorkspaceModelId?: number;
+  batchSize?: number;
+  concurrency?: number;
+  summary?: activities.EnsureMCPServerViewsWorkflowSummary;
+};
 
 const INITIAL_SUMMARY: activities.EnsureMCPServerViewsWorkflowSummary = {
   scannedWorkspacesCount: 0,
@@ -35,9 +34,6 @@ export async function ensureMCPServerViewsWorkflow({
   lastProcessedWorkspaceModelId = 0,
   batchSize = DEFAULT_WORKSPACE_BATCH_SIZE,
   concurrency = DEFAULT_WORKSPACE_CONCURRENCY,
-  triggeringFeature,
-  previousRolloutPercentage,
-  rolloutPercentage,
   summary = INITIAL_SUMMARY,
 }: EnsureMCPServerViewsWorkflowArgs = {}): Promise<activities.EnsureMCPServerViewsWorkflowSummary> {
   const processBatchResult =
@@ -69,9 +65,6 @@ export async function ensureMCPServerViewsWorkflow({
         processBatchResult.lastScannedWorkspaceModelId,
       batchSize,
       concurrency,
-      triggeringFeature,
-      previousRolloutPercentage,
-      rolloutPercentage,
       summary: nextSummary,
     });
   }

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -4,6 +4,7 @@ import { runAnalyticsWorker } from "@app/temporal/analytics_queue/worker";
 import { runConversationForkQueueWorker } from "@app/temporal/conversation_fork_queue/worker";
 import { runCreditAlertsWorker } from "@app/temporal/credit_alerts/worker";
 import { runDataRetentionWorker } from "@app/temporal/data_retention/worker";
+import { runEnsureMCPServerViewsWorker } from "@app/temporal/ensure_mcp_server_views/worker";
 import { runESIndexationQueueWorker } from "@app/temporal/es_indexation/worker";
 import { runHardDeleteWorker } from "@app/temporal/hard_delete/worker";
 import { runInvitationsWorker } from "@app/temporal/invitations/worker";
@@ -35,6 +36,7 @@ export type WorkerName =
   | "project_task"
   | "credit_alerts"
   | "data_retention"
+  | "ensure_mcp_server_views"
   | "es_indexation_queue"
   | "hard_delete"
   | "labs"
@@ -63,6 +65,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   conversation_fork_queue: runConversationForkQueueWorker,
   credit_alerts: runCreditAlertsWorker,
   data_retention: runDataRetentionWorker,
+  ensure_mcp_server_views: runEnsureMCPServerViewsWorker,
   hard_delete: runHardDeleteWorker,
   labs: runLabsTranscriptsWorker,
   invitations: runInvitationsWorker,


### PR DESCRIPTION
## Summary

Registers the MCP server view backfill Temporal runtime:

- dedicated task queue and worker
- direct-launch client using that queue
- Temporal bundle registration
- worker registry entry

The worker introduced here is the consumer for `ensure-mcp-server-views-queue-v1`. The workflow is checkpointed between workspace batches so worker restarts resume from the last model-id checkpoint.

There is intentionally **no automatic triggering**: no schedule, and no hook into application logic. The workflow only runs when explicitly launched (Poke plugin in #26988). As part of this, the trigger metadata (`triggeringFeature`, rollout percentages) that the workflow carried for the previously planned feature-flag hook is removed from the workflow and activity types.

## Concurrency semantics

All launches go through `launchEnsureMCPServerViewsWorkflow`, which uses the fixed workflow id `ensure-mcp-server-views`, so concurrent starts dedupe through Temporal (`already_running` outcome).

## Stack

1. #26986 (merged)
2. This PR
3. #26988

## Validation

- `npm run format:changed`
- `npx tsc --noEmit`
- `FRONT_DATABASE_URI=postgres://dust:dust@localhost:5432/dust_test npm run build:temporal-bundles`

## Risk

Low. The worker starts and consumes an empty queue; nothing launches the workflow until #26988 lands and someone runs the Poke plugin.

## Deploy Plan

- Deploy front workers with the new `ensure_mcp_server_views` worker enabled.
- Verify the Temporal bundle includes `ensure_mcp_server_views`.
