### PR TITLE
Add Poke plugin to launch MCP server view workflow

### DIFF
--- a/front/lib/api/poke/plugins/global/ensure_mcp_server_views.test.ts
+++ b/front/lib/api/poke/plugins/global/ensure_mcp_server_views.test.ts
@@ -1,0 +1,75 @@
+import { ensureMCPServerViewsPlugin } from "@app/lib/api/poke/plugins/global/ensure_mcp_server_views";
+import { Authenticator } from "@app/lib/auth";
+import { launchEnsureMCPServerViewsWorkflow } from "@app/temporal/ensure_mcp_server_views/client";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/temporal/ensure_mcp_server_views/client", () => ({
+  launchEnsureMCPServerViewsWorkflow: vi.fn(),
+}));
+
+describe("ensureMCPServerViewsPlugin.execute", () => {
+  beforeEach(() => {
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockReset();
+  });
+
+  it("starts the workflow and reports the workflow id", async () => {
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockResolvedValueOnce(
+      new Ok({ workflowId: "ensure-mcp-server-views", outcome: "started" })
+    );
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await ensureMCPServerViewsPlugin.execute(auth, null, {});
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw result.error;
+    }
+
+    expect(launchEnsureMCPServerViewsWorkflow).toHaveBeenCalledTimes(1);
+    expect(result.value.value).toContain(
+      "MCP server view backfill workflow started (ensure-mcp-server-views)."
+    );
+  });
+
+  it("reports when the workflow is already running", async () => {
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockResolvedValueOnce(
+      new Ok({
+        workflowId: "ensure-mcp-server-views",
+        outcome: "already_running",
+      })
+    );
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await ensureMCPServerViewsPlugin.execute(auth, null, {});
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      throw result.error;
+    }
+
+    expect(result.value.value).toContain(
+      "MCP server view backfill workflow is already running (ensure-mcp-server-views)."
+    );
+  });
+
+  it("returns an error when the launch fails", async () => {
+    vi.mocked(launchEnsureMCPServerViewsWorkflow).mockResolvedValueOnce(
+      new Err(new Error("temporal unavailable"))
+    );
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await ensureMCPServerViewsPlugin.execute(auth, null, {});
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error("Expected an error result.");
+    }
+
+    expect(result.error.message).toBe("temporal unavailable");
+  });
+});

--- a/front/lib/api/poke/plugins/global/ensure_mcp_server_views.ts
+++ b/front/lib/api/poke/plugins/global/ensure_mcp_server_views.ts
@@ -1,0 +1,32 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { launchEnsureMCPServerViewsWorkflow } from "@app/temporal/ensure_mcp_server_views/client";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const ensureMCPServerViewsPlugin = createPlugin({
+  manifest: {
+    id: "ensure-mcp-server-views",
+    name: "Ensure MCP Server Views",
+    description:
+      "Launch the Temporal workflow that ensures auto MCP server views exist in every workspace. " +
+      "Run it after changing global feature flags or rolling out new auto MCP servers. " +
+      "The workflow is resumable and dedupes on a fixed workflow id.",
+    resourceTypes: ["global"],
+    args: {},
+  },
+  execute: async () => {
+    const launchResult = await launchEnsureMCPServerViewsWorkflow();
+    if (launchResult.isErr()) {
+      return new Err(launchResult.error);
+    }
+
+    const { workflowId, outcome } = launchResult.value;
+
+    return new Ok({
+      display: "text",
+      value:
+        outcome === "started"
+          ? `MCP server view backfill workflow started (${workflowId}).`
+          : `MCP server view backfill workflow is already running (${workflowId}).`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/global/index.ts
+++ b/front/lib/api/poke/plugins/global/index.ts
@@ -1,6 +1,7 @@
 export * from "./batch_downgrade";
 export * from "./create_workspace";
 export * from "./emit_metronome_gauges";
+export * from "./ensure_mcp_server_views";
 export * from "./force_client_reload";
 export * from "./get_admins_for_workspaces";
 export * from "./relocate_user";


### PR DESCRIPTION
## Summary

Adds a global Poke plugin (`Ensure MCP Server Views`) to proactively launch the MCP server view backfill workflow.

- the plugin takes no arguments and launches the workflow on the fixed workflow id
- the Poke message reports whether the workflow started or was already running
- launch failures surface as a plugin error (nothing is persisted before the launch)

This is the **only** entry point for the workflow: there is no schedule and no hook into feature-flag changes or any other application logic. Operators run the plugin after changing global feature flags or rolling out new auto MCP servers.

## Stack

1. #26986 (merged)
2. #26987
3. This PR

## Validation

- `npm run format:changed`
- `npx tsc --noEmit`
- Vitest covers: started message, already-running message, launch failure surfaced as error. DB-backed tests run in CI (local test Postgres role `dust` missing).

## Risk

Low. The plugin only does something when an operator explicitly runs it, and concurrent runs dedupe on the fixed workflow id.
