### PR TITLE
Trim custom-model dust agents to dust-chawi and dust-lionel

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -939,6 +939,91 @@ export function _getDustNextHighGlobalAgent(
   });
 }
 
+// Formerly custom-model dust-* global agents (soupinou, sundae, pistache,
+// chalom). Their eval models were removed from the infra custom-models config
+// (GCS), so they no longer resolve to a custom model. They remain callable for
+// past conversations via a concrete fallback model and are listed in
+// RETIRED_GLOBAL_AGENTS_SID (see global_agents.ts). We may revive them as
+// custom-model agents in the future by moving them back into
+// CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS.
+type RetiredDustGlobalAgentConfig = {
+  name: string;
+  preferredReasoningEffort: ReasoningEffort;
+};
+
+const RETIRED_DUST_GLOBAL_AGENT_CONFIGS = new Map<
+  GLOBAL_AGENTS_SID,
+  RetiredDustGlobalAgentConfig
+>([
+  [
+    GLOBAL_AGENTS_SID.DUST_SOUPINOU,
+    { name: "dust-soupinou", preferredReasoningEffort: "light" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM,
+    { name: "dust-soupinou-medium", preferredReasoningEffort: "medium" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH,
+    { name: "dust-soupinou-high", preferredReasoningEffort: "high" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_SUNDAE,
+    { name: "dust-sundae", preferredReasoningEffort: "light" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM,
+    { name: "dust-sundae-medium", preferredReasoningEffort: "medium" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH,
+    { name: "dust-sundae-high", preferredReasoningEffort: "high" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_PISTACHE,
+    { name: "dust-pistache", preferredReasoningEffort: "light" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
+    { name: "dust-pistache-medium", preferredReasoningEffort: "medium" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
+    { name: "dust-pistache-high", preferredReasoningEffort: "high" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHALOM,
+    { name: "dust-chalom", preferredReasoningEffort: "light" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
+    { name: "dust-chalom-medium", preferredReasoningEffort: "medium" },
+  ],
+  [
+    GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
+    { name: "dust-chalom-high", preferredReasoningEffort: "high" },
+  ],
+]);
+
+export function _getRetiredDustLikeGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs,
+  agentId: GLOBAL_AGENTS_SID
+): AgentConfigurationType | null {
+  const config = RETIRED_DUST_GLOBAL_AGENT_CONFIGS.get(agentId);
+
+  if (!config) {
+    return null;
+  }
+
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId,
+    name: config.name,
+    preferredModelConfiguration: GPT_5_5_MODEL_CONFIG,
+    preferredReasoningEffort: config.preferredReasoningEffort,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Active custom-model dust-* global agents.
 // ---------------------------------------------------------------------------
@@ -1005,106 +1090,10 @@ export const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
     },
   ],
   [
-    GLOBAL_AGENTS_SID.DUST_SOUPINOU,
-    {
-      name: "dust-soupinou",
-      customModelIndex: 1,
-      preferredReasoningEffort: "light",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM,
-    {
-      name: "dust-soupinou-medium",
-      customModelIndex: 1,
-      preferredReasoningEffort: "medium",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH,
-    {
-      name: "dust-soupinou-high",
-      customModelIndex: 1,
-      preferredReasoningEffort: "high",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_SUNDAE,
-    {
-      name: "dust-sundae",
-      customModelIndex: 2,
-      preferredReasoningEffort: "light",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM,
-    {
-      name: "dust-sundae-medium",
-      customModelIndex: 2,
-      preferredReasoningEffort: "medium",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH,
-    {
-      name: "dust-sundae-high",
-      customModelIndex: 2,
-      preferredReasoningEffort: "high",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_PISTACHE,
-    {
-      name: "dust-pistache",
-      customModelIndex: 3,
-      preferredReasoningEffort: "light",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
-    {
-      name: "dust-pistache-medium",
-      customModelIndex: 3,
-      preferredReasoningEffort: "medium",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
-    {
-      name: "dust-pistache-high",
-      customModelIndex: 3,
-      preferredReasoningEffort: "high",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_CHALOM,
-    {
-      name: "dust-chalom",
-      customModelIndex: 4,
-      preferredReasoningEffort: "light",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
-    {
-      name: "dust-chalom-medium",
-      customModelIndex: 4,
-      preferredReasoningEffort: "medium",
-    },
-  ],
-  [
-    GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
-    {
-      name: "dust-chalom-high",
-      customModelIndex: 4,
-      preferredReasoningEffort: "high",
-    },
-  ],
-  [
     GLOBAL_AGENTS_SID.DUST_LIONEL,
     {
       name: "dust-lionel",
-      customModelIndex: 5,
+      customModelIndex: 1,
       preferredReasoningEffort: "light",
     },
   ],
@@ -1112,7 +1101,7 @@ export const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
     GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM,
     {
       name: "dust-lionel-medium",
-      customModelIndex: 5,
+      customModelIndex: 1,
       preferredReasoningEffort: "medium",
     },
   ],
@@ -1120,7 +1109,7 @@ export const CUSTOM_MODEL_DUST_GLOBAL_AGENT_CONFIGS = new Map<
     GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH,
     {
       name: "dust-lionel-high",
-      customModelIndex: 5,
+      customModelIndex: 1,
       preferredReasoningEffort: "high",
     },
   ],

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -52,6 +52,7 @@ import {
   _getDustOmittedGlobalAgent,
   _getDustQuickGlobalAgent,
   _getDustQuickMediumGlobalAgent,
+  _getRetiredDustLikeGlobalAgent,
   getCustomModelDustGlobalAgentIndex,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
@@ -1205,9 +1206,27 @@ function getGlobalAgent({
         hasDeepDive,
       });
       break;
+    // Active custom-model dust-* agents.
     case GLOBAL_AGENTS_SID.DUST_CHAWI:
     case GLOBAL_AGENTS_SID.DUST_CHAWI_MEDIUM:
     case GLOBAL_AGENTS_SID.DUST_CHAWI_HIGH:
+    case GLOBAL_AGENTS_SID.DUST_LIONEL:
+    case GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM:
+    case GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH:
+      agentConfiguration = _getCustomModelDustLikeGlobalAgent(
+        auth,
+        {
+          settings,
+          preFetchedDataSources,
+          mcpServerViews,
+          hasDeepDive,
+        },
+        sId
+      );
+      break;
+    // Retired custom-model dust-* agents: their eval models were removed from
+    // the infra config, so they resolve to a fallback model for past
+    // conversations only (see RETIRED_GLOBAL_AGENTS_SID).
     case GLOBAL_AGENTS_SID.DUST_SOUPINOU:
     case GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM:
     case GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH:
@@ -1220,10 +1239,7 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.DUST_CHALOM:
     case GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM:
     case GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH:
-    case GLOBAL_AGENTS_SID.DUST_LIONEL:
-    case GLOBAL_AGENTS_SID.DUST_LIONEL_MEDIUM:
-    case GLOBAL_AGENTS_SID.DUST_LIONEL_HIGH:
-      agentConfiguration = _getCustomModelDustLikeGlobalAgent(
+      agentConfiguration = _getRetiredDustLikeGlobalAgent(
         auth,
         {
           settings,
@@ -1319,6 +1335,20 @@ const RETIRED_GLOBAL_AGENTS_SID = [
   GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM,
   GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM_OMITTED,
   GLOBAL_AGENTS_SID.DUST_ANT_HIGH_OMITTED,
+  // Custom-model dust-* agents whose eval models were removed from the infra
+  // config. Kept callable for past conversations; may be revived in the future.
+  GLOBAL_AGENTS_SID.DUST_SOUPINOU,
+  GLOBAL_AGENTS_SID.DUST_SOUPINOU_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_SOUPINOU_HIGH,
+  GLOBAL_AGENTS_SID.DUST_SUNDAE,
+  GLOBAL_AGENTS_SID.DUST_SUNDAE_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_SUNDAE_HIGH,
+  GLOBAL_AGENTS_SID.DUST_PISTACHE,
+  GLOBAL_AGENTS_SID.DUST_PISTACHE_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_PISTACHE_HIGH,
+  GLOBAL_AGENTS_SID.DUST_CHALOM,
+  GLOBAL_AGENTS_SID.DUST_CHALOM_MEDIUM,
+  GLOBAL_AGENTS_SID.DUST_CHALOM_HIGH,
 ];
 
 function getCustomModelIndexForGlobalAgent(sId: string): number | null {


### PR DESCRIPTION
## Description

Cut the custom-model dust-* agents down to two. The infra custom-models config now holds two models (index 0 and index 1); the four other eval models are removed.

- dust-chawi now uses the index 0 model.
- dust-lionel moves from index 5 to index 1.
- dust-soupinou, dust-sundae, dust-pistache and dust-chalom are retired: still callable for past conversations via a GPT-5.5 fallback, removed from the default agent list.

SID enum, metadata, sort order and the internal-agents list are left intact so any of these can be brought back cleanly. Reviving a retired agent means moving it back into the active map and restoring its infra-config entry at a matching index.

## Tests

Ran global_agents.test.ts and generation.test.ts locally (pass). Verified the uploaded config resolves to the model at index 0 and the model at index 1.

## Risk

Low blast radius: these agents are gated behind custom_model_feature + dust_internal_global_agents (Dust-internal workspaces only).

Code and the infra config are coupled by array index and cannot change atomically across the two systems. The config is already updated, so any build off main before this merges will see the new config plus old code and resolve internal custom agents (including dust-lionel) inconsistently. A backup of the previous config is kept for a fast rollback.

## Deploy Plan

Ship this branch promptly and avoid deploying main in the interim, or roll the config back to the backup and re-upload at deploy time. Standard deploy otherwise; the generated model file is rebuilt from the config at build time.