### PR TITLE
feat: add become business admin to dev tools

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -24,7 +24,12 @@ import { isAgentMention } from "@app/types/assistant/mentions";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
-import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@app/types/user";
+import {
+  isOnlyAdmin,
+  isOnlyBuilder,
+  isOnlyBusinessAdmin,
+  isOnlyUser,
+} from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
   Avatar,
@@ -161,7 +166,7 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
 
   const forceRoleUpdate = useMemo(
-    () => async (role: "user" | "builder" | "admin") => {
+    () => async (role: "user" | "builder" | "admin" | "business_admin") => {
       const result = await forceUserRole(user, owner, role, featureFlags);
       if (result.isOk()) {
         sendNotification({
@@ -446,6 +451,13 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
                       <DropdownMenuItem
                         label="Become Admin"
                         onClick={() => forceRoleUpdate("admin")}
+                        icon={Star01}
+                      />
+                    )}
+                    {!isOnlyBusinessAdmin(owner) && (
+                      <DropdownMenuItem
+                        label="Become Business Admin"
+                        onClick={() => forceRoleUpdate("business_admin")}
                         icon={Star01}
                       />
                     )}

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -11,7 +11,7 @@ export function showDebugTools(flags: WhitelistableFeature[]) {
 export async function forceUserRole(
   user: UserType,
   owner: LightWorkspaceType,
-  role: "user" | "builder" | "admin",
+  role: "user" | "builder" | "admin" | "business_admin",
   featureFlags: WhitelistableFeature[]
 ) {
   // Ideally we should check if the user is dust super user but we don't have this information in the front-end

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -278,6 +278,15 @@ export function isOnlyAdmin(
   return owner.role === "admin";
 }
 
+export function isOnlyBusinessAdmin(
+  owner: WorkspaceType | null
+): owner is WorkspaceType & { role: "business_admin" } {
+  if (!owner) {
+    return false;
+  }
+  return owner.role === "business_admin";
+}
+
 const DustUserEmailHeader = "x-api-user-email";
 
 export function getUserEmailFromHeaders(headers: {


### PR DESCRIPTION
## Description

This PR adds a "Become Business Admin" option to the dev tools user menu, alongside the existing role-switching options.

<img width="282" height="234" alt="Capture d’écran 2026-06-08 à 16 11 41" src="https://github.com/user-attachments/assets/13a67700-5186-4b9b-8bb6-06c216a8784c" />


## Tests

Manually.

## Risks

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
