### PR TITLE
[front] Filter skill tool backfill workspaces

### DIFF
--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -2,7 +2,14 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { Authenticator } from "@app/lib/auth";
 import { generateShortBlockId } from "@app/lib/generate_short_block_id";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
+import {
+  CREDIT_PRICED_FREE_PLAN_CODE,
+  FREE_TRIAL_PHONE_PLAN_CODE,
+  FREE_UPGRADED_PLAN_CODE,
+  isFreePlan,
+} from "@app/lib/plans/plan_codes";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -21,6 +28,11 @@ import type { Logger } from "pino";
 const ASSOCIATED_TOOLS_LABEL = "Tools associated with this skill:";
 const TOOLS_SECTION_SEPARATOR = "----";
 const TOOL_ELEMENT_REGEX = /<tool\b([^>]*)>[\s\S]*?<\/tool>/g;
+const TRIAL_PLAN_CODES = new Set([
+  CREDIT_PRICED_FREE_PLAN_CODE,
+  FREE_TRIAL_PHONE_PLAN_CODE,
+  FREE_UPGRADED_PLAN_CODE,
+]);
 
 type WorkspaceStats = {
   changed: number;
@@ -28,6 +40,24 @@ type WorkspaceStats = {
   processed: number;
   skippedWithoutTools: number;
 };
+
+async function isPayingOrTrialWorkspace(
+  workspace: LightWorkspaceType
+): Promise<boolean> {
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription) {
+    return false;
+  }
+
+  if (subscription.trialing === true) {
+    return true;
+  }
+
+  const planCode = subscription.getPlan().code;
+  return !isFreePlan(planCode) || TRIAL_PLAN_CODES.has(planCode);
+}
 
 async function processWorkspace(
   workspace: LightWorkspaceType,
@@ -190,18 +220,29 @@ makeScript(
       describe: "Resume from this numeric workspace id.",
       type: "number",
     },
+    payingOrTrialWorkspaces: {
+      choices: ["include", "exclude"],
+      default: "include",
+      describe:
+        "Whether to process only paying/trial workspaces or only the others.",
+      type: "string",
+    },
     wId: {
       describe:
         "Process skills for a single workspace (sId). Omit to run on all workspaces.",
       type: "string",
     },
   },
-  async ({ concurrency, execute, fromWorkspaceId, wId }, logger) => {
+  async (
+    { concurrency, execute, fromWorkspaceId, payingOrTrialWorkspaces, wId },
+    logger
+  ) => {
     logger.info(
       {
         concurrency,
         execute,
         fromWorkspaceId,
+        payingOrTrialWorkspaces,
         workspaceId: wId ?? "all",
       },
       execute
@@ -226,6 +267,12 @@ makeScript(
       },
       {
         concurrency,
+        filter: async (workspace) => {
+          const isPayingOrTrial = await isPayingOrTrialWorkspace(workspace);
+          return payingOrTrialWorkspaces === "include"
+            ? isPayingOrTrial
+            : !isPayingOrTrial;
+        },
         fromWorkspaceId,
         wId,
       }

--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -10,7 +10,6 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -23,7 +22,6 @@ import {
   type ToolReference,
 } from "@app/lib/tools/format";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
-import type { ModelId } from "@app/types/shared/model_id";
 import * as cheerio from "cheerio";
 import type { Logger } from "pino";
 
@@ -252,35 +250,6 @@ makeScript(
       skippedWithoutTools: 0,
     };
 
-    let workspaceModelIds: ModelId[];
-    if (wId) {
-      const workspace = await WorkspaceResource.fetchById(wId);
-      if (!workspace) {
-        throw new Error(`Workspace not found: ${wId}`);
-      }
-      workspaceModelIds = [workspace.id];
-    } else {
-      const allWorkspaceModelIds =
-        await WorkspaceResource.listAllModelIds("ASC");
-      workspaceModelIds = fromWorkspaceId
-        ? allWorkspaceModelIds.filter(
-            (workspaceModelId) => workspaceModelId >= fromWorkspaceId
-          )
-        : allWorkspaceModelIds;
-    }
-
-    const subscriptionsByWorkspaceModelId =
-      await SubscriptionResource.fetchActiveByWorkspacesModelId(
-        workspaceModelIds
-      );
-    const payingOrTrialWorkspaceModelIds = new Set(
-      workspaceModelIds.filter((workspaceModelId) =>
-        isPayingOrTrialSubscription(
-          subscriptionsByWorkspaceModelId[workspaceModelId]
-        )
-      )
-    );
-
     await runOnAllWorkspaces(
       async (workspace) => {
         const stats = await processWorkspace(workspace, { execute }, logger);
@@ -291,10 +260,15 @@ makeScript(
       },
       {
         concurrency,
-        filter: (workspace) => {
-          const isPayingOrTrial = payingOrTrialWorkspaceModelIds.has(
-            workspace.id
-          );
+        filter: async (workspace) => {
+          const subscription =
+            await SubscriptionResource.fetchActiveByWorkspaceModelId(
+              workspace.id
+            );
+          const isPayingOrTrial = subscription
+            ? isPayingOrTrialSubscription(subscription)
+            : false;
+
           return payingOrTrialWorkspaces === "include"
             ? isPayingOrTrial
             : !isPayingOrTrial;

--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/plans/plan_codes";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -22,6 +23,7 @@ import {
   type ToolReference,
 } from "@app/lib/tools/format";
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+import type { ModelId } from "@app/types/shared/model_id";
 import * as cheerio from "cheerio";
 import type { Logger } from "pino";
 
@@ -250,6 +252,35 @@ makeScript(
       skippedWithoutTools: 0,
     };
 
+    let workspaceModelIds: ModelId[];
+    if (wId) {
+      const workspace = await WorkspaceResource.fetchById(wId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      workspaceModelIds = [workspace.id];
+    } else {
+      const allWorkspaceModelIds =
+        await WorkspaceResource.listAllModelIds("ASC");
+      workspaceModelIds = fromWorkspaceId
+        ? allWorkspaceModelIds.filter(
+            (workspaceModelId) => workspaceModelId >= fromWorkspaceId
+          )
+        : allWorkspaceModelIds;
+    }
+
+    const subscriptionsByWorkspaceModelId =
+      await SubscriptionResource.fetchActiveByWorkspacesModelId(
+        workspaceModelIds
+      );
+    const payingOrTrialWorkspaceModelIds = new Set(
+      workspaceModelIds.filter((workspaceModelId) =>
+        isPayingOrTrialSubscription(
+          subscriptionsByWorkspaceModelId[workspaceModelId]
+        )
+      )
+    );
+
     await runOnAllWorkspaces(
       async (workspace) => {
         const stats = await processWorkspace(workspace, { execute }, logger);
@@ -260,22 +291,13 @@ makeScript(
       },
       {
         concurrency,
-        filter: async (workspaces) => {
-          const subscriptionsByWorkspaceModelId =
-            await SubscriptionResource.fetchActiveByWorkspacesModelId(
-              workspaces.map((workspace) => workspace.id)
-            );
-
-          return workspaces.filter((workspace) => {
-            const subscription = subscriptionsByWorkspaceModelId[workspace.id];
-            const isPayingOrTrial = subscription
-              ? isPayingOrTrialSubscription(subscription)
-              : false;
-
-            return payingOrTrialWorkspaces === "include"
-              ? isPayingOrTrial
-              : !isPayingOrTrial;
-          });
+        filter: (workspace) => {
+          const isPayingOrTrial = payingOrTrialWorkspaceModelIds.has(
+            workspace.id
+          );
+          return payingOrTrialWorkspaces === "include"
+            ? isPayingOrTrial
+            : !isPayingOrTrial;
         },
         fromWorkspaceId,
         wId,

--- a/front/migrations/20260602_backfill_skill_tool_references.ts
+++ b/front/migrations/20260602_backfill_skill_tool_references.ts
@@ -41,16 +41,9 @@ type WorkspaceStats = {
   skippedWithoutTools: number;
 };
 
-async function isPayingOrTrialWorkspace(
-  workspace: LightWorkspaceType
-): Promise<boolean> {
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
-  );
-  if (!subscription) {
-    return false;
-  }
-
+function isPayingOrTrialSubscription(
+  subscription: SubscriptionResource
+): boolean {
   if (subscription.trialing === true) {
     return true;
   }
@@ -267,11 +260,22 @@ makeScript(
       },
       {
         concurrency,
-        filter: async (workspace) => {
-          const isPayingOrTrial = await isPayingOrTrialWorkspace(workspace);
-          return payingOrTrialWorkspaces === "include"
-            ? isPayingOrTrial
-            : !isPayingOrTrial;
+        filter: async (workspaces) => {
+          const subscriptionsByWorkspaceModelId =
+            await SubscriptionResource.fetchActiveByWorkspacesModelId(
+              workspaces.map((workspace) => workspace.id)
+            );
+
+          return workspaces.filter((workspace) => {
+            const subscription = subscriptionsByWorkspaceModelId[workspace.id];
+            const isPayingOrTrial = subscription
+              ? isPayingOrTrialSubscription(subscription)
+              : false;
+
+            return payingOrTrialWorkspaces === "include"
+              ? isPayingOrTrial
+              : !isPayingOrTrial;
+          });
         },
         fromWorkspaceId,
         wId,

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -1,6 +1,7 @@
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 
 /**
@@ -44,17 +45,13 @@ export async function runOnAllWorkspaces(
   }
 
   if (filter) {
-    const filterResults = await concurrentExecutor(
-      workspaces,
-      async (workspace) => ({
-        keep: await filter(workspace),
-        workspace,
-      }),
-      { concurrency }
+    workspaces = removeNulls(
+      await concurrentExecutor(
+        workspaces,
+        async (workspace) => ((await filter(workspace)) ? workspace : null),
+        { concurrency }
+      )
     );
-    workspaces = filterResults
-      .filter(({ keep }) => keep)
-      .map(({ workspace }) => workspace);
   }
 
   await concurrentExecutor(workspaces, (workspace) => worker(workspace), {

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -20,7 +20,9 @@ export async function runOnAllWorkspaces(
     fromWorkspaceId,
   }: {
     concurrency?: number;
-    filter?: (workspace: LightWorkspaceType) => boolean | Promise<boolean>;
+    filter?: (
+      workspaces: LightWorkspaceType[]
+    ) => LightWorkspaceType[] | Promise<LightWorkspaceType[]>;
     wId?: string;
     fromWorkspaceId?: number;
   } = {}
@@ -44,17 +46,7 @@ export async function runOnAllWorkspaces(
   }
 
   if (filter) {
-    const filterResults = await concurrentExecutor(
-      workspaces,
-      async (workspace) => ({
-        keep: await filter(workspace),
-        workspace,
-      }),
-      { concurrency }
-    );
-    workspaces = filterResults
-      .filter(({ keep }) => keep)
-      .map(({ workspace }) => workspace);
+    workspaces = await filter(workspaces);
   }
 
   await concurrentExecutor(workspaces, (workspace) => worker(workspace), {

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -20,9 +20,7 @@ export async function runOnAllWorkspaces(
     fromWorkspaceId,
   }: {
     concurrency?: number;
-    filter?: (
-      workspaces: LightWorkspaceType[]
-    ) => LightWorkspaceType[] | Promise<LightWorkspaceType[]>;
+    filter?: (workspace: LightWorkspaceType) => boolean;
     wId?: string;
     fromWorkspaceId?: number;
   } = {}
@@ -46,7 +44,7 @@ export async function runOnAllWorkspaces(
   }
 
   if (filter) {
-    workspaces = await filter(workspaces);
+    workspaces = workspaces.filter(filter);
   }
 
   await concurrentExecutor(workspaces, (workspace) => worker(workspace), {

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -9,15 +9,18 @@ import type { LightWorkspaceType } from "@app/types/user";
  * - If `wId` is provided, runs on that single workspace.
  * - Otherwise runs on all workspaces, ordered by numeric model id.
  * - `fromWorkspaceId` skips workspaces with model id < this value (for resuming).
+ * - `filter` can skip workspaces before running the worker.
  */
 export async function runOnAllWorkspaces(
   worker: (workspace: LightWorkspaceType) => Promise<void>,
   {
     concurrency = 1,
+    filter,
     wId,
     fromWorkspaceId,
   }: {
     concurrency?: number;
+    filter?: (workspace: LightWorkspaceType) => boolean | Promise<boolean>;
     wId?: string;
     fromWorkspaceId?: number;
   } = {}
@@ -38,6 +41,20 @@ export async function runOnAllWorkspaces(
     workspaces = filtered.map((w) =>
       renderLightWorkspaceType({ workspace: w })
     );
+  }
+
+  if (filter) {
+    const filterResults = await concurrentExecutor(
+      workspaces,
+      async (workspace) => ({
+        keep: await filter(workspace),
+        workspace,
+      }),
+      { concurrency }
+    );
+    workspaces = filterResults
+      .filter(({ keep }) => keep)
+      .map(({ workspace }) => workspace);
   }
 
   await concurrentExecutor(workspaces, (workspace) => worker(workspace), {

--- a/front/scripts/workspace_helpers.ts
+++ b/front/scripts/workspace_helpers.ts
@@ -20,7 +20,7 @@ export async function runOnAllWorkspaces(
     fromWorkspaceId,
   }: {
     concurrency?: number;
-    filter?: (workspace: LightWorkspaceType) => boolean;
+    filter?: (workspace: LightWorkspaceType) => boolean | Promise<boolean>;
     wId?: string;
     fromWorkspaceId?: number;
   } = {}
@@ -44,7 +44,17 @@ export async function runOnAllWorkspaces(
   }
 
   if (filter) {
-    workspaces = workspaces.filter(filter);
+    const filterResults = await concurrentExecutor(
+      workspaces,
+      async (workspace) => ({
+        keep: await filter(workspace),
+        workspace,
+      }),
+      { concurrency }
+    );
+    workspaces = filterResults
+      .filter(({ keep }) => keep)
+      .map(({ workspace }) => workspace);
   }
 
   await concurrentExecutor(workspaces, (workspace) => worker(workspace), {


### PR DESCRIPTION
## Description
Adds a generic async `filter` predicate to `runOnAllWorkspaces` so scripts can skip individual workspaces before running the worker.

Uses it in the skill tool references backfill with `--payingOrTrialWorkspaces include|exclude`:
- default `include`: only paying or trial workspaces
- `exclude`: only non-paying, non-trial workspaces

Paying uses the existing non-free plan-code classification. Trial includes `trialing` subscriptions and the explicit free-trial plan codes. The filter checks each workspace subscription with bounded concurrency, avoiding a giant all-workspace subscription `IN` query.

## Risks
Blast radius: workspace iteration helper and the skill tool references backfill script.
Risk: low

## Deploy Plan
- deploy front
- run the skill tool references backfill with the desired `--payingOrTrialWorkspaces` mode