### PR TITLE
[front] feat: add admin-only analyst global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -1,0 +1,37 @@
+import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { describe, expect, it } from "vitest";
+
+async function fetchAnalyst(role: MembershipRoleType, flagOn: boolean) {
+  const { authenticator } = await createResourceTest({ role });
+  if (flagOn) {
+    await FeatureFlagFactory.basic(authenticator, "workspace_analytics");
+  }
+  return getGlobalAgents(authenticator, [GLOBAL_AGENTS_SID.ANALYST], "light");
+}
+
+describe("analyst global agent visibility", () => {
+  it("is available to admins when the flag is on", async () => {
+    const agents = await fetchAnalyst("admin", true);
+    expect(agents).toHaveLength(1);
+    expect(agents[0].sId).toBe(GLOBAL_AGENTS_SID.ANALYST);
+    expect(agents[0].name).toBe("analyst");
+    expect(agents[0].skills).toContain("workspace-analytics");
+    expect(agents[0].skills).toContain("frames");
+  });
+
+  it("is hidden from admins when the flag is off", async () => {
+    expect(await fetchAnalyst("admin", false)).toEqual([]);
+  });
+
+  it("is hidden from builders even when the flag is on", async () => {
+    expect(await fetchAnalyst("builder", true)).toEqual([]);
+  });
+
+  it("is hidden from regular users even when the flag is on", async () => {
+    expect(await fetchAnalyst("user", true)).toEqual([]);
+  });
+});

--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -1,0 +1,75 @@
+import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
+import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
+import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+} from "@app/lib/api/assistant/models";
+import type { Authenticator } from "@app/lib/auth";
+import type {
+  AgentConfigurationType,
+  AgentModelConfigurationType,
+} from "@app/types/assistant/agent";
+import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+
+export function _getAnalystGlobalAgent({
+  auth,
+}: {
+  auth: Authenticator;
+}): AgentConfigurationType {
+  const prompt = `<primary_goal>
+You are @analyst, an analytics assistant for workspace admins. You help admins understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
+</primary_goal>
+
+<guidelines>
+1. Only report figures returned by your tools — never estimate or fabricate numbers.
+2. Use the workspace analytics tools to answer the question (e.g. which agents are used most). Present results as clear ranked lists or summaries.
+3. When a chart communicates the result better than text (trends over time, distributions, comparisons), use the Frames skill to render it. Default to a concise text answer for single figures.
+4. If a tool reports an authorization error, explain that workspace analytics is restricted to workspace admins.
+5. Be concise and lead with the answer; add brief context only when it helps interpretation.
+</guidelines>`;
+
+  const modelConfiguration = auth.isUpgraded()
+    ? getLargeWhitelistedModel(auth)
+    : getSmallWhitelistedModel(auth);
+
+  const model: AgentModelConfigurationType = modelConfiguration
+    ? {
+        providerId: modelConfiguration.providerId,
+        modelId: modelConfiguration.modelId,
+        temperature: 0.2,
+        reasoningEffort: modelConfiguration.defaultReasoningEffort,
+      }
+    : dummyModelConfiguration;
+  const status = modelConfiguration ? "active" : "disabled_by_admin";
+
+  const sId = GLOBAL_AGENTS_SID.ANALYST;
+  const metadata = getGlobalAgentMetadata(sId);
+
+  return {
+    id: -1,
+    sId,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: metadata.name,
+    description: metadata.description,
+    instructions: prompt + globalAgentGuidelines,
+    instructionsHtml: null,
+    pictureUrl: metadata.pictureUrl,
+    status,
+    userFavorite: false,
+    scope: "global",
+    model,
+    actions: [],
+    skills: ["workspace-analytics", "frames"],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    templateId: null,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -734,6 +734,16 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         pictureUrl:
           "https://dust.tt/static/systemavatar/dust-task_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.ANALYST:
+      return {
+        sId: GLOBAL_AGENTS_SID.ANALYST,
+        name: "analyst",
+        description:
+          "Admin-only agent that answers questions about how your workspace " +
+          "is being used.",
+        pictureUrl: DUST_AVATAR_URL,
+        audience: "admins",
+      };
     default:
       assertNever(sId);
   }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1,4 +1,5 @@
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
+import { _getAnalystGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/analyst";
 import {
   _getClaude3_7GlobalAgent,
   _getClaude3GlobalAgent,
@@ -491,6 +492,12 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsWorkspaceContext: true,
   },
   [GLOBAL_AGENTS_SID.REINFORCEMENT]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.ANALYST]: {
     injectsMemory: false,
     injectsToolsets: false,
     injectsUserContext: false,
@@ -1271,6 +1278,9 @@ function getGlobalAgent({
     case GLOBAL_AGENTS_SID.REINFORCEMENT:
       agentConfiguration = _getReinforcementGlobalAgent();
       break;
+    case GLOBAL_AGENTS_SID.ANALYST:
+      agentConfiguration = _getAnalystGlobalAgent({ auth });
+      break;
     case GLOBAL_AGENTS_SID.NOOP:
       // we want only to have it in development
       if (isDevelopment()) {
@@ -1399,6 +1409,11 @@ export async function getGlobalAgents(
   if (!flags.includes("openai_o1_high_reasoning_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.O1_HIGH_REASONING
+    );
+  }
+  if (!flags.includes("workspace_analytics")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.ANALYST
     );
   }
   const DUST_INTERNAL_AGENTS: readonly GLOBAL_AGENTS_SID[] = [

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -143,6 +143,8 @@ export enum GLOBAL_AGENTS_SID {
   MISTRAL_SMALL = "mistral",
   GEMINI_PRO = "gemini-pro",
 
+  ANALYST = "analyst",
+
   NOOP = "noop",
 }
 


### PR DESCRIPTION
## Description

Add the analyst global agent (GLOBAL_AGENTS_SID.ANALYST) that equips the workspace-analytics and frames skills to answer workspace usage questions for admins. It is gated by audience: "admins" (PR's role-aware visibility) and the workspace_analytics feature flag, so it only appears for admins in enabled workspaces.

Tested end-to-end via getGlobalAgents across the flag x role matrix.
## Tests

Unit

## Risk

None, feature flagged.

## Deploy Plan

Front
