### PR TITLE
[instrumentation] chore: Instrument data_source_document deletes

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -319,7 +319,8 @@ export async function getDataSourceDocumentBlob({
 export async function deleteDataSourceDocument(
   dataSourceConfig: DataSourceConfig,
   documentId: string,
-  loggerArgs: Record<string, string | number> = {}
+  loggerArgs: Record<string, string | number> = {},
+  caller?: string
 ) {
   const localLogger = logger.child({ ...loggerArgs, documentId });
 
@@ -329,6 +330,7 @@ export async function deleteDataSourceDocument(
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
       Authorization: `Bearer ${dataSourceConfig.workspaceAPIKey}`,
+      ...(caller ? { "X-Dust-Caller": caller } : {}),
     },
   };
 

--- a/core/src/api/data_sources.rs
+++ b/core/src/api/data_sources.rs
@@ -1516,6 +1516,12 @@ pub async fn data_sources_documents_delete(
     Path((project_id, data_source_id, document_id)): Path<(i64, String, String)>,
     State(state): State<Arc<APIState>>,
 ) -> (StatusCode, Json<APIResponse>) {
+    info!(
+        project_id,
+        data_source_id = data_source_id.as_str(),
+        document_id = document_id.as_str(),
+        "data_sources_documents_delete"
+    );
     let project = project::Project::new_from_id(project_id);
     match state
         .store

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2228,14 +2228,16 @@ impl Store for PostgresStore {
             _ => unreachable!(),
         };
 
+        let started_ms = utils::now();
+
         let stmt = tx
             .prepare(
                 "DELETE FROM data_sources_nodes \
                    WHERE data_source = $1 AND node_id = $2 AND document IS NOT NULL",
             )
             .await?;
-        let _ = tx
-            .query(&stmt, &[&data_source_row_id, &document_id])
+        let nodes_deleted = tx
+            .execute(&stmt, &[&data_source_row_id, &document_id])
             .await?;
         let stmt = tx
             .prepare(
@@ -2243,11 +2245,22 @@ impl Store for PostgresStore {
                    WHERE data_source = $1 AND document_id = $2",
             )
             .await?;
-        let _ = tx
-            .query(&stmt, &[&data_source_row_id, &document_id])
+        let documents_soft_deleted = tx
+            .execute(&stmt, &[&data_source_row_id, &document_id])
             .await?;
 
         tx.commit().await?;
+
+        info!(
+            project_id,
+            data_source_id = data_source_id.as_str(),
+            data_source_row_id,
+            document_id = document_id.as_str(),
+            nodes_deleted,
+            documents_soft_deleted,
+            duration_ms = (utils::now() - started_ms) as i64,
+            "delete_data_source_document"
+        );
 
         Ok(())
     }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -180,7 +180,11 @@ impl<B> MakeSpan<B> for CoreRequestMakeSpan {
             dust_client_name = request.extensions()
             .get::<Extension<Arc<String>>>()
             .map(|ext| ext.as_ref().as_str())
-            .unwrap_or("unknown")
+            .unwrap_or("unknown"),
+            dust_caller = request.headers()
+                .get("x-dust-caller")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("unknown")
         )
     }
 }

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -786,6 +786,7 @@ app.delete(
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
       documentId,
+      caller: ctx.req.header("X-Dust-Caller") ?? "public-api",
     });
 
     if (delRes.isErr()) {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -261,6 +261,7 @@ app.delete(
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
       folderId: fId,
+      caller: "public-api",
     });
 
     if (delRes.isErr()) {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -256,6 +256,7 @@ app.delete(
       dataSourceId: dataSource.dustAPIDataSourceId,
       tableId: tId,
       rowId: rId,
+      caller: "public-api",
     });
 
     if (deleteRes.isErr()) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -151,6 +151,7 @@ app.delete(
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
       documentId,
+      caller: "private-api",
     });
     if (deleteRes.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId]/index.ts
@@ -41,6 +41,7 @@ app.delete(
       projectId: dataSource.dustAPIProjectId,
       dataSourceId: dataSource.dustAPIDataSourceId,
       folderId: fId,
+      caller: "private-api",
     });
     if (delRes.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -396,6 +396,7 @@ async function handleDataSourceWithProvider({
     const deleteRes = await coreAPI.deleteDataSource({
       projectId: dustProjectId,
       dataSourceId: dustDataSourceId,
+      caller: "private-api-create-rollback",
     });
     if (deleteRes.isErr()) {
       logger.error(
@@ -542,6 +543,7 @@ async function handleDataSourceWithProvider({
       const deleteRes = await coreAPI.deleteDataSource({
         projectId: dustProjectId,
         dataSourceId: dustDataSourceId,
+        caller: "private-api-connector-rollback",
       });
       if (deleteRes.isErr()) {
         logger.error(

--- a/front/lib/api/apps.ts
+++ b/front/lib/api/apps.ts
@@ -4,6 +4,7 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { RunType } from "@app/types/run";
@@ -86,9 +87,18 @@ export async function hardDeleteApp(
 ): Promise<Result<void, Error>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
-  const deleteProjectRes = await coreAPI.deleteProject({
-    projectId: app.dustAPIProjectId,
-  });
+  const deleteProjectRes = await tracer.trace(
+    "apps.hard_delete_app",
+    async (span) => {
+      span?.setTag("workspace.id", auth.workspace()?.sId ?? "unknown");
+      span?.setTag("app.s_id", app.sId);
+      span?.setTag("core.project_id", app.dustAPIProjectId);
+      return coreAPI.deleteProject({
+        projectId: app.dustAPIProjectId,
+        caller: "apps-api-hard-delete",
+      });
+    }
+  );
   if (deleteProjectRes.isErr()) {
     return new Err(new Error(deleteProjectRes.error.message));
   }

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -32,6 +32,7 @@ import { cacheWithRedis } from "@app/lib/utils/cache";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
 import type { FrontDataSourceDocumentSectionType } from "@app/types/api/public/data_sources";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -433,10 +434,25 @@ export async function hardDeleteDataSource(
 
   // Delete the data source from core.
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const coreDeleteRes = await coreAPI.deleteDataSource({
-    projectId: dustAPIProjectId,
-    dataSourceId: dataSource.dustAPIDataSourceId,
-  });
+  const coreDeleteRes = await tracer.trace(
+    "data_sources.hard_delete_data_source",
+    { resource: dataSource.connectorProvider ?? "managed-none" },
+    async (span) => {
+      span?.setTag("workspace.id", auth.workspace()?.sId ?? "unknown");
+      span?.setTag("data_source.s_id", dataSource.sId);
+      span?.setTag(
+        "data_source.connector_provider",
+        dataSource.connectorProvider ?? "none"
+      );
+      span?.setTag("core.project_id", dustAPIProjectId);
+      span?.setTag("core.data_source_id", dataSource.dustAPIDataSourceId);
+      return coreAPI.deleteDataSource({
+        projectId: dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        caller: "data-sources-api-hard-delete",
+      });
+    }
+  );
   if (coreDeleteRes.isErr()) {
     // Same as above we proceed with the deletion if the data source is not found in core. Otherwise
     // we throw as this is unexpected.

--- a/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
+++ b/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
@@ -2,6 +2,7 @@ import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -10,30 +11,37 @@ export async function garbageCollectGoogleDriveDocument(
   dataSource: DataSourceResource,
   args: { documentId: string }
 ): Promise<Result<void, Error>> {
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const getRes = await coreAPI.getDataSourceDocument({
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceId: dataSource.dustAPIDataSourceId,
-    documentId: args.documentId,
-  });
-  if (getRes.isErr()) {
-    return new Err(
-      new Error(`Error while getting the document: ` + getRes.error.message)
-    );
-  }
+  return tracer.trace("poke.gc_gdrive_document", async (span) => {
+    span?.setTag("data_source.s_id", dataSource.sId);
+    span?.setTag("document.id", args.documentId);
+    span?.setTag("core.project_id", dataSource.dustAPIProjectId);
+    span?.setTag("core.data_source_id", dataSource.dustAPIDataSourceId);
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    const getRes = await coreAPI.getDataSourceDocument({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      documentId: args.documentId,
+    });
+    if (getRes.isErr()) {
+      return new Err(
+        new Error(`Error while getting the document: ` + getRes.error.message)
+      );
+    }
 
-  const delRes = await coreAPI.deleteDataSourceDocument({
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceId: dataSource.dustAPIDataSourceId,
-    documentId: args.documentId,
-  });
-  if (delRes.isErr()) {
-    return new Err(
-      new Error(`Error deleting document: ${delRes.error.message}`)
-    );
-  }
+    const delRes = await coreAPI.deleteDataSourceDocument({
+      projectId: dataSource.dustAPIProjectId,
+      dataSourceId: dataSource.dustAPIDataSourceId,
+      documentId: args.documentId,
+      caller: "poke-gc-gdrive",
+    });
+    if (delRes.isErr()) {
+      return new Err(
+        new Error(`Error deleting document: ${delRes.error.message}`)
+      );
+    }
 
-  return new Ok(undefined);
+    return new Ok(undefined);
+  });
 }
 
 export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({

--- a/front/lib/api/poke/plugins/data_sources/remove_old_documents.ts
+++ b/front/lib/api/poke/plugins/data_sources/remove_old_documents.ts
@@ -2,6 +2,7 @@ import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -140,29 +141,39 @@ export const removeOldDocumentsPlugin = createPlugin({
     }
 
     // Actually delete the documents
-    const deleteResults = await concurrentExecutor(
-      documentsToDelete,
-      async ({ documentId }) => {
-        const delRes = await coreAPI.deleteDataSourceDocument({
-          projectId: dataSource.dustAPIProjectId,
-          dataSourceId: dataSource.dustAPIDataSourceId,
-          documentId,
-        });
+    const deleteResults = await tracer.trace(
+      "poke.remove_old_documents.bulk_delete",
+      async (span) => {
+        span?.setTag("workspace.id", auth.workspace()?.sId ?? "unknown");
+        span?.setTag("data_source.s_id", dataSource.sId);
+        span?.setTag("documents.count", documentsToDelete.length);
+        span?.setTag("cutoff_date", cutoffDate);
+        return concurrentExecutor(
+          documentsToDelete,
+          async ({ documentId }) => {
+            const delRes = await coreAPI.deleteDataSourceDocument({
+              projectId: dataSource.dustAPIProjectId,
+              dataSourceId: dataSource.dustAPIDataSourceId,
+              documentId,
+              caller: "poke-remove-old-documents",
+            });
 
-        if (delRes.isErr()) {
-          return {
-            documentId,
-            success: false,
-            error: delRes.error.message,
-          };
-        }
+            if (delRes.isErr()) {
+              return {
+                documentId,
+                success: false,
+                error: delRes.error.message,
+              };
+            }
 
-        return {
-          documentId,
-          success: true,
-        };
-      },
-      { concurrency: 10 }
+            return {
+              documentId,
+              success: true,
+            };
+          },
+          { concurrency: 10 }
+        );
+      }
     );
 
     const successCount = deleteResults.filter((r) => r.success).length;

--- a/front/lib/api/projects/connector.test.ts
+++ b/front/lib/api/projects/connector.test.ts
@@ -579,6 +579,7 @@ describe("createDataSourceAndConnectorForProject", () => {
       expect(deleteProjectSpy).toHaveBeenCalledTimes(1);
       expect(deleteProjectSpy).toHaveBeenCalledWith({
         projectId: mockProjectId.toString(),
+        caller: "projects-connector-rollback-create-data-source",
       });
 
       createProjectSpy.mockRestore();
@@ -664,6 +665,7 @@ describe("createDataSourceAndConnectorForProject", () => {
       expect(deleteProjectSpy).toHaveBeenCalledTimes(1);
       expect(deleteProjectSpy).toHaveBeenCalledWith({
         projectId: mockProjectId.toString(),
+        caller: "projects-connector-rollback-folder-failed",
       });
 
       upsertFolderSpy.mockRestore();
@@ -799,10 +801,12 @@ describe("createDataSourceAndConnectorForProject", () => {
       expect(deleteCoreDataSourceSpy).toHaveBeenCalledWith({
         projectId: mockProjectId.toString(),
         dataSourceId: mockDataSourceId,
+        caller: "projects-connector-rollback-connector-failed",
       });
       expect(deleteProjectSpy).toHaveBeenCalledTimes(1);
       expect(deleteProjectSpy).toHaveBeenCalledWith({
         projectId: mockProjectId.toString(),
+        caller: "projects-connector-rollback-connector-failed",
       });
 
       createConnectorSpy.mockRestore();

--- a/front/lib/api/projects/connector.ts
+++ b/front/lib/api/projects/connector.ts
@@ -171,6 +171,7 @@ export async function createDataSourceAndConnectorForProject(
           // Clean up Core API project if data source creation fails
           await coreAPI.deleteProject({
             projectId: coreProjectId,
+            caller: "projects-connector-rollback-create-data-source",
           });
           return new Err(
             new Error(
@@ -205,9 +206,11 @@ export async function createDataSourceAndConnectorForProject(
           await coreAPI.deleteDataSource({
             projectId: coreProjectId,
             dataSourceId: coreDataSourceId,
+            caller: "projects-connector-rollback-folder-failed",
           });
           await coreAPI.deleteProject({
             projectId: coreProjectId,
+            caller: "projects-connector-rollback-folder-failed",
           });
         }
         return new Err(
@@ -279,9 +282,11 @@ export async function createDataSourceAndConnectorForProject(
             await coreAPI.deleteDataSource({
               projectId: coreProjectId,
               dataSourceId: coreDataSourceId,
+              caller: "projects-connector-rollback-connector-failed",
             });
             await coreAPI.deleteProject({
               projectId: coreProjectId,
+              caller: "projects-connector-rollback-connector-failed",
             });
           }
 

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -4,6 +4,7 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import { FileResource } from "@app/lib/resources/file_resource";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import type { CoreAPIError, CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { Result } from "@app/types/shared/result";
@@ -47,12 +48,36 @@ export async function deleteTable({
   dataSource: DataSourceResource;
   tableId: string;
 }): Promise<Result<null, TableOperationError>> {
+  return tracer.trace(
+    "tables.delete_table",
+    { resource: dataSource.connectorProvider ?? "managed-none" },
+    async (span) => {
+      span?.setTag("workspace.id", owner.sId);
+      span?.setTag("data_source.s_id", dataSource.sId);
+      span?.setTag("table.id", tableId);
+      span?.setTag("core.project_id", dataSource.dustAPIProjectId);
+      span?.setTag("core.data_source_id", dataSource.dustAPIDataSourceId);
+      return _deleteTable({ owner, dataSource, tableId });
+    }
+  );
+}
+
+async function _deleteTable({
+  owner,
+  dataSource,
+  tableId,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceResource;
+  tableId: string;
+}): Promise<Result<null, TableOperationError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   const deleteRes = await coreAPI.deleteTable({
     projectId: dataSource.dustAPIProjectId,
     dataSourceId: dataSource.dustAPIDataSourceId,
     tableId,
+    caller: "tables-api-delete-table",
   });
   if (deleteRes.isErr()) {
     logger.error(
@@ -240,6 +265,7 @@ export async function upsertTableFromCsv({
           projectId: dataSource.dustAPIProjectId,
           dataSourceId: dataSource.dustAPIDataSourceId,
           tableId,
+          caller: "tables-api-truncate-on-upsert-fail",
         });
 
         if (delRes.isErr()) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -63,6 +63,7 @@ import { copyContent } from "@app/lib/utils/files";
 import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import tracer from "@app/logger/tracer";
 import { CoreAPI } from "@app/types/core/core_api";
 import type {
   AuthorizedFileAccessAllowlist,
@@ -2336,51 +2337,66 @@ async function deleteCoreFileArtifactsFromDataSource(
   dataSource: DataSourceResource,
   file: FileResource
 ): Promise<void> {
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const projectId = dataSource.dustAPIProjectId;
-  const dataSourceId = dataSource.dustAPIDataSourceId;
-  const logCtx = {
-    workspaceId: auth.workspace()?.sId,
-    fileId: file.sId,
-    dataSourceSId: dataSource.sId,
-  };
+  return tracer.trace(
+    "file_resource.delete_core_artifacts",
+    { resource: file.useCase },
+    async (span) => {
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const projectId = dataSource.dustAPIProjectId;
+      const dataSourceId = dataSource.dustAPIDataSourceId;
+      const logCtx = {
+        workspaceId: auth.workspace()?.sId,
+        fileId: file.sId,
+        dataSourceSId: dataSource.sId,
+      };
 
-  const tableIds = new Set<string>([
-    ...(file.useCaseMetadata?.generatedTables ?? []),
-    file.sId,
-  ]);
+      const tableIds = new Set<string>([
+        ...(file.useCaseMetadata?.generatedTables ?? []),
+        file.sId,
+      ]);
 
-  for (const tableId of tableIds) {
-    const delTableRes = await coreAPI.deleteTable({
-      projectId,
-      dataSourceId,
-      tableId,
-    });
-    if (
-      delTableRes.isErr() &&
-      !isBenignCoreIndexedFileDeleteError(delTableRes.error.code)
-    ) {
-      logger.warn(
-        { ...logCtx, tableId, error: delTableRes.error },
-        "File delete: failed to remove table from Core data source."
-      );
+      span?.setTag("workspace.id", auth.workspace()?.sId ?? "unknown");
+      span?.setTag("file.id", file.sId);
+      span?.setTag("file.use_case", file.useCase);
+      span?.setTag("data_source.s_id", dataSource.sId);
+      span?.setTag("core.project_id", projectId);
+      span?.setTag("core.data_source_id", dataSourceId);
+      span?.setTag("tables.count", tableIds.size);
+
+      for (const tableId of tableIds) {
+        const delTableRes = await coreAPI.deleteTable({
+          projectId,
+          dataSourceId,
+          tableId,
+        });
+        if (
+          delTableRes.isErr() &&
+          !isBenignCoreIndexedFileDeleteError(delTableRes.error.code)
+        ) {
+          logger.warn(
+            { ...logCtx, tableId, error: delTableRes.error },
+            "File delete: failed to remove table from Core data source."
+          );
+        }
+      }
+
+      const delDocRes = await coreAPI.deleteDataSourceDocument({
+        projectId,
+        dataSourceId,
+        documentId: file.sId,
+        caller: "file-resource",
+      });
+      if (
+        delDocRes.isErr() &&
+        !isBenignCoreIndexedFileDeleteError(delDocRes.error.code)
+      ) {
+        logger.warn(
+          { ...logCtx, error: delDocRes.error },
+          "File delete: failed to remove document from Core data source."
+        );
+      }
     }
-  }
-
-  const delDocRes = await coreAPI.deleteDataSourceDocument({
-    projectId,
-    dataSourceId,
-    documentId: file.sId,
-  });
-  if (
-    delDocRes.isErr() &&
-    !isBenignCoreIndexedFileDeleteError(delDocRes.error.code)
-  ) {
-    logger.warn(
-      { ...logCtx, error: delDocRes.error },
-      "File delete: failed to remove document from Core data source."
-    );
-  }
+  );
 }
 
 async function maybeDeleteCoreArtifactsForIndexedFile(

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -388,13 +388,16 @@ export class CoreAPI {
 
   async deleteProject({
     projectId,
+    caller,
   }: {
     projectId: string;
+    caller?: string;
   }): Promise<CoreAPIResponse<{ success: true }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(projectId)}`,
       {
         method: "DELETE",
+        headers: caller ? { "X-Dust-Caller": caller } : undefined,
       }
     );
 
@@ -916,9 +919,11 @@ export class CoreAPI {
   async deleteDataSource({
     projectId,
     dataSourceId,
+    caller,
   }: {
     projectId: string;
     dataSourceId: string;
+    caller?: string;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
@@ -926,6 +931,7 @@ export class CoreAPI {
       )}/data_sources/${encodeURIComponent(dataSourceId)}`,
       {
         method: "DELETE",
+        headers: caller ? { "X-Dust-Caller": caller } : undefined,
       }
     );
 
@@ -1451,10 +1457,12 @@ export class CoreAPI {
     projectId,
     dataSourceId,
     documentId,
+    caller,
   }: {
     projectId: string;
     dataSourceId: string;
     documentId: string;
+    caller?: string;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
@@ -1464,6 +1472,7 @@ export class CoreAPI {
       )}/documents/${encodeURIComponent(documentId)}`,
       {
         method: "DELETE",
+        headers: caller ? { "X-Dust-Caller": caller } : undefined,
       }
     );
 
@@ -1797,10 +1806,12 @@ export class CoreAPI {
     projectId,
     dataSourceId,
     tableId,
+    caller,
   }: {
     projectId: string;
     dataSourceId: string;
     tableId: string;
+    caller?: string;
   }): Promise<CoreAPIResponse<{ success: true }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
@@ -1810,6 +1821,7 @@ export class CoreAPI {
       )}/tables/${encodeURIComponent(tableId)}`,
       {
         method: "DELETE",
+        headers: caller ? { "X-Dust-Caller": caller } : undefined,
       }
     );
 
@@ -2027,11 +2039,13 @@ export class CoreAPI {
     dataSourceId,
     tableId,
     rowId,
+    caller,
   }: {
     projectId: string;
     dataSourceId: string;
     tableId: string;
     rowId: string;
+    caller?: string;
   }): Promise<CoreAPIResponse<{ success: true }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
@@ -2043,6 +2057,7 @@ export class CoreAPI {
       )}`,
       {
         method: "DELETE",
+        headers: caller ? { "X-Dust-Caller": caller } : undefined,
       }
     );
 
@@ -2314,10 +2329,12 @@ export class CoreAPI {
     projectId,
     dataSourceId,
     folderId,
+    caller,
   }: {
     projectId: string;
     dataSourceId: string;
     folderId: string;
+    caller?: string;
   }): Promise<CoreAPIResponse<{ data_source: CoreAPIDataSource }>> {
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
@@ -2327,6 +2344,7 @@ export class CoreAPI {
       )}/folders/${encodeURIComponent(folderId)}`,
       {
         method: "DELETE",
+        headers: caller ? { "X-Dust-Caller": caller } : undefined,
       }
     );
 


### PR DESCRIPTION
## Description

This PR is meant to be reverted once I'm done taking some measurements, which is why I bundled core/front updates.

Currently we see a lot of disk writes in core db caused by soft deletes update statements.
The numbers are completely ridiculous (10000 times more updates than inserts)
I don't have a single solid thread leading to it, and I prefer to instrument every codepath and have an agent generate me a DD notebook rather than spend half a day digging in database itself, data_source_document being very abstract, it's not that easy to find the guiltly path.


## Tests

Unit tests

## Risk

Low

## Deploy Plan


- Deploy core
- Deploy front