### PR TITLE
Strip control characters from file name

### DIFF
--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -1,4 +1,7 @@
-import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import {
+  DustFileSystem,
+  sanitizeFileSystemName,
+} from "@app/lib/api/file_system/dust_file_system";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
@@ -1505,5 +1508,58 @@ describe("DustFileSystem.rename", () => {
     }
     // Delete must not be called when the copy failed.
     expect(deleteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sanitizeFileSystemName", () => {
+  it("leaves a plain ASCII name unchanged", () => {
+    expect(sanitizeFileSystemName("quarterly-report.pdf")).toBe(
+      "quarterly-report.pdf"
+    );
+  });
+
+  it("strips leading control characters", () => {
+    expect(sanitizeFileSystemName("\n\tsummary.txt")).toBe("summary.txt");
+  });
+
+  it("strips embedded control characters", () => {
+    expect(sanitizeFileSystemName("my\x00file\x1Fname.txt")).toBe(
+      "myfilename.txt"
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeFileSystemName("  notes.md  ")).toBe("notes.md");
+  });
+
+  it("preserves accented and non-ASCII printable characters", () => {
+    const name = "données — résumé.csv";
+    expect(sanitizeFileSystemName(name)).toBe(name);
+  });
+
+  it("NFC-normalizes the result", () => {
+    const nfd = "café".normalize("NFD");
+    const nfc = "café".normalize("NFC");
+    expect(sanitizeFileSystemName(nfd)).toBe(nfc);
+  });
+});
+
+describe("DustFileSystem.normalizeScopedPath strips control characters", () => {
+  it("strips leading control characters from the filename segment", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc/\n\tsummary.txt")
+    ).toBe("conversation-abc/summary.txt");
+  });
+
+  it("strips control characters embedded in the mount prefix", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc\x00/notes.txt")
+    ).toBe("conversation-abc/notes.txt");
+  });
+
+  it("still rejects path traversal after stripping controls", () => {
+    expect(
+      DustFileSystem.normalizeScopedPath("conversation-abc/\n../../etc/passwd")
+    ).toBeNull();
   });
 });

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -50,9 +50,14 @@ export type {
 } from "@app/lib/api/file_system/types";
 export { DustFileSystemError } from "@app/lib/api/file_system/types";
 
-// ---------------------------------------------------------------------------
-// Scoped-path prefix parsing
-// ---------------------------------------------------------------------------
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE = /[\x00-\x1F\x7F-\x9F]/g;
+
+// Strip control characters, trim whitespace, and NFC-normalize. macOS uploads commonly arrive
+// in NFD; NFC normalization keeps paths stable when consumers echo them back.
+export function sanitizeFileSystemName(name: string): string {
+  return name.replace(CONTROL_CHAR_RE, "").trim().normalize("NFC");
+}
 
 type ParsedScopedPrefix =
   | { kind: "conversation"; id: string }
@@ -466,7 +471,8 @@ export class DustFileSystem {
    * This is the primary defense against path-traversal attacks.
    */
   static normalizeScopedPath(scopedPath: string): string | null {
-    const normalized = path.posix.normalize(scopedPath);
+    const sanitized = scopedPath.replace(CONTROL_CHAR_RE, "");
+    const normalized = path.posix.normalize(sanitized);
     if (
       normalized === ".." ||
       normalized.startsWith("../") ||
@@ -804,7 +810,10 @@ export class DustFileSystem {
     }
     if (destExists.value) {
       return new Err(
-        new DustFileSystemError("already_exists", `File name already exists`)
+        new DustFileSystemError(
+          "already_exists",
+          "File name already exists in the destination directory."
+        )
       );
     }
 

--- a/front/lib/api/file_system/index.ts
+++ b/front/lib/api/file_system/index.ts
@@ -1,6 +1,7 @@
 export {
   DustFileSystem,
   DustFileSystemError,
+  sanitizeFileSystemName,
 } from "@app/lib/api/file_system/dust_file_system";
 export type {
   DustFileSystemErrorCode,

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -340,6 +340,7 @@ export async function moveCanonicalFile(
  * the path corresponds to one. If no FileResource exists (for example a file
  * created directly in the sandbox), falls back to deleting the raw GCS object.
  */
+// TODO(FILE_SYSTEM): Remove once no more dependencies on FileResource.
 export async function deleteCanonicalFile(
   auth: Authenticator,
   dustFs: DustFileSystem,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -3,6 +3,7 @@
 
 import config from "@app/lib/api/config";
 import {
+  sanitizeFileSystemName,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system";
@@ -148,12 +149,9 @@ export class FileResource extends BaseResource<FileModel> {
   static async makeNew(
     blob: Omit<CreationAttributes<FileModel>, "status" | "sId" | "version">
   ) {
-    // Normalize the user-visible file name to NFC. GCS object names are byte-exact and macOS
-    // uploads commonly arrive in NFD, which breaks lookups when consumers (e.g. LLMs) echo paths
-    // back in NFC. Normalizing on the way in keeps mount paths stable.
     const key = await FileResource.model.create({
       ...blob,
-      fileName: blob.fileName.normalize("NFC"),
+      fileName: sanitizeFileSystemName(blob.fileName),
       status: "created",
       version: 0,
     });
@@ -1365,12 +1363,12 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   rename(newFileName: string) {
-    return this.update({ fileName: newFileName.normalize("NFC") });
+    return this.update({ fileName: sanitizeFileSystemName(newFileName) });
   }
 
   renameMountFile(newFileName: string, newMountFilePath: string) {
     return this.update({
-      fileName: newFileName.normalize("NFC"),
+      fileName: sanitizeFileSystemName(newFileName),
       mountFilePath: newMountFilePath,
     });
   }
@@ -1387,7 +1385,7 @@ export class FileResource extends BaseResource<FileModel> {
     destUseCaseMetadata?: FileUseCaseMetadata;
   }) {
     return this.update({
-      fileName: destFileName.normalize("NFC"),
+      fileName: sanitizeFileSystemName(destFileName),
       mountFilePath: destMountFilePath,
       useCase: destUseCase,
       useCaseMetadata: destUseCaseMetadata ?? null,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -3,9 +3,9 @@
 
 import config from "@app/lib/api/config";
 import {
-  sanitizeFileSystemName,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
+  sanitizeFileSystemName,
 } from "@app/lib/api/file_system";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/8710.

Web page titles scraped during agent runs can contain leading newlines and tabs (e.g. `\n\tPage Title`). When those titles were used as file names, they propagated into storage object names verbatim, which storage rejects. Causing the agent loop worker to retry indefinitely and the run to stall.

This PR introduces `sanitizeFileSystemName` in `DustFileSystem` as the single place that strips control characters, trims whitespace, and NFC-normalizes. `FileResource` now calls it on every path where a file name enters the system. `normalizeScopedPath` also applies it as a second layer so any path that passes through `DustFileSystem` operations is clean before reaching storage.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
