### PR TITLE
feat(credits): show loading spinner in members usage table during updates

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -91,6 +91,18 @@ export function UsagePage() {
   const { doUpdateSeatType } = useUpdateMemberSeatType({
     workspaceId: owner.sId,
   });
+  const [seatChangePendingMemberIds, setSeatChangePendingMemberIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const handleSeatChangePendingChange = useCallback(
+    (memberId: string, isPending: boolean) =>
+      setSeatChangePendingMemberIds((prev) => {
+        const next = new Set(prev);
+        next[isPending ? "add" : "delete"](memberId);
+        return next;
+      }),
+    []
+  );
   const onRemoveSeat = useCallback(
     async (member: MemberUsageType) => {
       const confirmed = await confirm({
@@ -102,18 +114,36 @@ export function UsagePage() {
       if (!confirmed) {
         return;
       }
-      void doUpdateSeatType({
-        memberId: member.sId,
-        memberName: member.name,
-        seatType: "none",
-        isCancellingScheduledChange: false,
-        hasSeatPool: false,
-      });
+      handleSeatChangePendingChange(member.sId, true);
+      try {
+        await doUpdateSeatType({
+          memberId: member.sId,
+          memberName: member.name,
+          seatType: "none",
+          isCancellingScheduledChange: false,
+          hasSeatPool: false,
+        });
+      } finally {
+        handleSeatChangePendingChange(member.sId, false);
+      }
     },
-    [confirm, doUpdateSeatType]
+    [confirm, doUpdateSeatType, handleSeatChangePendingChange]
   );
   const [editSpendLimitMember, setEditSpendLimitMember] =
     useState<MemberUsageType | null>(null);
+  const [
+    totalAllowedUsagePendingMemberIds,
+    setTotalAllowedUsagePendingMemberIds,
+  ] = useState<ReadonlySet<string>>(() => new Set());
+  const handleUsagePendingChange = useCallback(
+    (memberId: string, isPending: boolean) =>
+      setTotalAllowedUsagePendingMemberIds((prev) => {
+        const next = new Set(prev);
+        next[isPending ? "add" : "delete"](memberId);
+        return next;
+      }),
+    []
+  );
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
   useEffect(() => {
@@ -357,6 +387,10 @@ export function UsagePage() {
           <MembersUsageTable
             members={membersUsage}
             isLoading={isMembersUsageLoading}
+            totalAllowedUsagePendingMemberIds={
+              totalAllowedUsagePendingMemberIds
+            }
+            seatChangePendingMemberIds={seatChangePendingMemberIds}
             seatTypeFilter={seatTypeFilter}
             isSeatBased={isSeatBased}
             onChangeSeat={setChangeSeatMember}
@@ -387,6 +421,7 @@ export function UsagePage() {
           member={changeSeatMember}
           owner={owner}
           seatPlans={seatPlans}
+          onSavingChange={handleSeatChangePendingChange}
         />
 
         <EditSpendLimitModal
@@ -394,6 +429,7 @@ export function UsagePage() {
           onClose={() => setEditSpendLimitMember(null)}
           member={editSpendLimitMember}
           owner={owner}
+          onSavingChange={handleUsagePendingChange}
         />
       </div>
     </>

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -169,6 +169,7 @@ interface ChangeSeatModalProps {
   member: MemberUsageType | null;
   owner: WorkspaceType;
   seatPlans: SeatPlanResponseBody;
+  onSavingChange?: (memberId: string, isSaving: boolean) => void;
 }
 
 export function ChangeSeatModal({
@@ -177,6 +178,7 @@ export function ChangeSeatModal({
   member,
   owner,
   seatPlans,
+  onSavingChange,
 }: ChangeSeatModalProps) {
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
@@ -340,6 +342,7 @@ export function ChangeSeatModal({
     }
 
     setIsSaving(true);
+    onSavingChange?.(displayedMember.sId, true);
     try {
       const ok = await doUpdateSeatType({
         memberId: displayedMember.sId,
@@ -355,6 +358,7 @@ export function ChangeSeatModal({
       }
     } finally {
       setIsSaving(false);
+      onSavingChange?.(displayedMember.sId, false);
     }
   }
 

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -36,6 +36,7 @@ interface EditSpendLimitModalProps {
   onClose: () => void;
   member: MemberUsageType | null;
   owner: WorkspaceType;
+  onSavingChange?: (memberId: string, isSaving: boolean) => void;
 }
 
 export function EditSpendLimitModal({
@@ -43,6 +44,7 @@ export function EditSpendLimitModal({
   onClose,
   member,
   owner,
+  onSavingChange,
 }: EditSpendLimitModalProps) {
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
@@ -146,6 +148,7 @@ export function EditSpendLimitModal({
     }
 
     setIsSaving(true);
+    onSavingChange?.(displayedMember.sId, true);
     try {
       let limit:
         | { kind: "unlimited" }
@@ -171,6 +174,7 @@ export function EditSpendLimitModal({
       }
     } finally {
       setIsSaving(false);
+      onSavingChange?.(displayedMember.sId, false);
     }
   }
 

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -15,6 +15,7 @@ import {
   LoadingBlock,
   type MenuItem,
   SeatMax,
+  Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type {
@@ -40,6 +41,8 @@ type RowData = {
   billingFrequency: BillingFrequency | null;
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
+  isTotalAllowedUsagePending: boolean;
+  isSeatChangePending: boolean;
   menuItems: MenuItem[];
 };
 
@@ -90,6 +93,7 @@ interface AwuUsageBarProps {
   memberUsageLimit: number | null;
   limit: number | null;
   seatType: MembershipSeatType | null;
+  isTotalAllowedUsagePending: boolean;
 }
 
 const MUTED_BAR_CLASSES = {
@@ -120,6 +124,7 @@ function AwuUsageBar({
   memberUsageLimit,
   limit,
   seatType,
+  isTotalAllowedUsagePending: isPending,
 }: AwuUsageBarProps) {
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
@@ -260,7 +265,11 @@ function AwuUsageBar({
     <div className="flex w-full flex-col gap-1">
       <div className="flex justify-between text-xs tabular-nums text-foreground dark:text-foreground-night">
         <span>{formatCredits(consumed)}</span>
-        <span>{limit === null ? "∞" : formatCredits(limit)}</span>
+        {isPending ? (
+          <Spinner size="xs" />
+        ) : (
+          <span>{limit === null ? "∞" : formatCredits(limit)}</span>
+        )}
       </div>
       {tooltipContent ? (
         <Tooltip tooltipTriggerAsChild label={tooltipContent} trigger={bar} />
@@ -300,6 +309,13 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
   enableSorting: false,
   accessorFn: (row) => row.seatType ?? "",
   cell: (info: Info) => {
+    if (info.row.original.isSeatChangePending) {
+      return (
+        <DataTable.CellContent>
+          <Spinner size="xs" />
+        </DataTable.CellContent>
+      );
+    }
     const seatType = info.row.original.seatType;
     const scheduledSeatType = info.row.original.scheduledSeatType;
     const scheduledSeatChangeAt = info.row.original.scheduledSeatChangeAt;
@@ -381,6 +397,9 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
         memberUsageLimit={info.row.original.memberUsageLimit}
         limit={info.row.original.spendLimitAwuCredits}
         seatType={info.row.original.seatType}
+        isTotalAllowedUsagePending={
+          info.row.original.isTotalAllowedUsagePending
+        }
       />
     </div>
   ),
@@ -430,6 +449,8 @@ function buildColumns({
 interface MembersUsageTableProps {
   members: MemberUsageType[];
   isLoading: boolean;
+  totalAllowedUsagePendingMemberIds: ReadonlySet<string>;
+  seatChangePendingMemberIds: ReadonlySet<string>;
   seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
@@ -445,6 +466,8 @@ interface MembersUsageTableProps {
 export function MembersUsageTable({
   members,
   isLoading,
+  totalAllowedUsagePendingMemberIds,
+  seatChangePendingMemberIds,
   seatTypeFilter,
   isSeatBased,
   onChangeSeat,
@@ -492,6 +515,10 @@ export function MembersUsageTable({
         billingFrequency: m.billingFrequency,
         scheduledSeatType: m.scheduledSeatType,
         scheduledSeatChangeAt: m.scheduledSeatChangeAt,
+        isTotalAllowedUsagePending: totalAllowedUsagePendingMemberIds.has(
+          m.sId
+        ),
+        isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
         menuItems: [
           ...(isSeatBased
             ? [
@@ -520,7 +547,15 @@ export function MembersUsageTable({
           },
         ],
       })),
-    [filtered, isSeatBased, onChangeSeat, onRemoveSeat, onEditSpendLimit]
+    [
+      filtered,
+      totalAllowedUsagePendingMemberIds,
+      seatChangePendingMemberIds,
+      isSeatBased,
+      onChangeSeat,
+      onRemoveSeat,
+      onEditSpendLimit,
+    ]
   );
 
   const displayPeriodColumn = useMemo(

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -6,7 +6,7 @@ import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/types/credits";
-import { Input, Page, SettingsList } from "@dust-tt/sparkle";
+import { Input, Page, SettingsList, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 interface UsageSettingsCardProps {
@@ -82,9 +82,15 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
                 disabled={isDefaultLimitInputDisabled}
                 className="pr-16 text-right"
               />
-              <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                credits
-              </span>
+              {isSavingLimit ? (
+                <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
+                  <Spinner size="xs" />
+                </div>
+              ) : (
+                <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
+                  credits
+                </span>
+              )}
             </div>
           }
         />


### PR DESCRIPTION
## Description

Before:
https://github.com/user-attachments/assets/ff22ec56-1e15-4ad1-a505-0ea18f4ce896
(1min to load the total)

After:
https://github.com/user-attachments/assets/b582c736-095c-4b76-88ca-6d4ea4a78eec
(at least we have a loader :) )

When an admin updates a member's spend limit, changes/removes their seat, or edits the workspace default pool credit limit from the Usage page, the UI could keep showing the stale value with no indication the change was in flight.

This adds loading states to the Usage page:

- **Spend limit**: while a member spend-limit edit is saving, the limit figure in the "Credits usage" column (the right-hand `∞` / total) is replaced by a spinner.
- **Seat change**: while a seat change or removal is applying, the "Seat" column shows a spinner in place of the seat type.
- **Default pool credit limit**: while the default spend limit update is saving, the input adornment is replaced by a spinner.

The spinner appears the moment the update starts and clears exactly when the refreshed data lands for member updates. Pending member state is tracked as a set of member sIds, independently for usage and seat changes, so updating several members in quick succession keeps each row's spinner until its own data refreshes.

## Tests

Verify on the Usage page (credit-priced workspace):
- Edit a member's spend limit, the usage column's limit figure shows a spinner until it updates to the new value.
- Change a member's seat type / remove a seat, the Seat column shows a spinner until the new seat is reflected.
- Edit the default pool credit limit, the input's `credits` adornment is replaced by a spinner while the update is saving.

Local validation run in the Computer:
- `git diff --check`

## Risk

Low. This is a UI-only loading indicator change and does not change API behavior or persisted data. If needed, it can be safely reverted.

## Deploy Plan

Standard deployment through the normal PR CI and deploy flow.