### PR TITLE
Fix free credits allocation

### DIFF
--- a/front/components/poke/credits/AlertChip.tsx
+++ b/front/components/poke/credits/AlertChip.tsx
@@ -1,0 +1,54 @@
+import type {
+  MetronomeAlertRef,
+  MetronomeAlertStatus,
+} from "@app/lib/metronome/alerts/types";
+import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Chip, LinkExternal01 } from "@dust-tt/sparkle";
+
+// Maps a Metronome alert's evaluation status to a Chip color and readable
+// label. `in_alarm` (breached) reads red; `ok` (resolved) green; `evaluating`
+// (pending) amber; `null` (unknown) neutral.
+function alertStatusChip(status: MetronomeAlertStatus): {
+  color: "rose" | "success" | "warning" | "info";
+  label: string;
+} {
+  switch (status) {
+    case "in_alarm":
+      return { color: "rose", label: "in alarm" };
+    case "ok":
+      return { color: "success", label: "ok" };
+    case "evaluating":
+      return { color: "warning", label: "evaluating" };
+    case null:
+      return { color: "info", label: "unknown" };
+    default:
+      assertNeverAndIgnore(status);
+      return { color: "info", label: "unknown" };
+  }
+}
+
+interface AlertChipProps {
+  alert: MetronomeAlertRef | null;
+  label: string;
+}
+
+// A clickable badge deep-linking to a Metronome alert, labelled with the alert
+// name and its current evaluation status and colored by that status. Renders
+// nothing when the alert is unknown (not configured).
+export function AlertChip({ alert, label }: AlertChipProps) {
+  if (!alert) {
+    return null;
+  }
+  const { color, label: statusLabel } = alertStatusChip(alert.status);
+  return (
+    <Chip
+      size="xs"
+      color={color}
+      label={`${label}: ${statusLabel}`}
+      icon={LinkExternal01}
+      href={getMetronomeAlertUrl(alert.id)}
+      target="_blank"
+    />
+  );
+}

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -1,11 +1,16 @@
+import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
 import { usePokeMembersUsage } from "@app/poke/swr/credits";
-import type { UserCreditState } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  UserCreditState,
+} from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
@@ -55,6 +60,32 @@ const USER_CREDIT_STATE_CHIP_COLOR: Record<
   on_pool_low_balance: "warning",
   capped: "rose",
 };
+
+// Free seats hold a per-user credit with two balance alerts: "low" (≤20%) and
+// "empty" (0). Both are shown beside the balance via the shared `AlertChip`,
+// colored by each alert's Metronome status (ok = green, in alarm = red) and
+// deep-linked. Other seat types draw from the pool and have no such alerts.
+interface FreeSeatBalanceBadgesProps {
+  seatType: MembershipSeatType | null;
+  lowAlert: MetronomeAlertRef | null;
+  emptyAlert: MetronomeAlertRef | null;
+}
+
+function FreeSeatBalanceBadges({
+  seatType,
+  lowAlert,
+  emptyAlert,
+}: FreeSeatBalanceBadgesProps) {
+  if (seatType !== "free") {
+    return null;
+  }
+  return (
+    <>
+      <AlertChip alert={lowAlert} label="low" />
+      <AlertChip alert={emptyAlert} label="empty" />
+    </>
+  );
+}
 
 interface PokeMembersUsageTableProps {
   owner: WorkspaceType;
@@ -158,15 +189,26 @@ function makeColumns({
       header: "Seat balance / allowance",
       enableSorting: false,
       cell: ({ row }) => {
-        const { memberUsageLimit, seatBalanceAwu } = row.original;
+        const {
+          memberUsageLimit,
+          seatBalanceAwu,
+          seatType,
+          freeCreditLowAlert,
+          freeCreditEmptyAlert,
+        } = row.original;
         if (memberUsageLimit === null) {
           return <span>-</span>;
         }
         return (
-          <span>
+          <span className="inline-flex items-center gap-1">
             {seatBalanceAwu !== null ? formatCredits(seatBalanceAwu) : "-"}
             {" / "}
             {formatCredits(memberUsageLimit)}
+            <FreeSeatBalanceBadges
+              seatType={seatType}
+              lowAlert={freeCreditLowAlert}
+              emptyAlert={freeCreditEmptyAlert}
+            />
           </span>
         );
       },

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -1,3 +1,4 @@
+import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { PokeAwuUsageChart } from "@app/components/poke/credits/PokeAwuUsageChart";
 import { PokeMembersUsageTable } from "@app/components/poke/credits/PokeMembersUsageTable";
@@ -9,11 +10,7 @@ import type {
 } from "@app/lib/api/poke/workspace_info";
 import { formatCredits } from "@app/lib/client/credits";
 import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_alerts";
-import type {
-  MetronomeAlertRef,
-  MetronomeAlertStatus,
-} from "@app/lib/metronome/alerts/types";
-import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { usePokeAwuPoolSummary } from "@app/poke/swr/credits";
 import type {
   WorkspacePoolCreditState,
@@ -22,13 +19,7 @@ import type {
 import type { SubscriptionType } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  AlertCircle,
-  Chip,
-  ContentMessage,
-  LinkExternal01,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { AlertCircle, Chip, ContentMessage, Spinner } from "@dust-tt/sparkle";
 
 interface PokeUsageTabProps {
   owner: WorkspaceType;
@@ -41,53 +32,6 @@ interface PokeUsageTabProps {
   programmaticAlerts: PokeProgrammaticAlerts;
   usageCapAlert: MetronomeAlertRef | null;
   defaultAlerts: DefaultMetronomeAlerts;
-}
-
-// Maps a Metronome alert's evaluation status to a Chip color and readable
-// label. `in_alarm` (breached) reads red; `ok` (resolved) green; `evaluating`
-// (pending) amber; `null` (unknown) neutral.
-function alertStatusChip(status: MetronomeAlertStatus): {
-  color: "rose" | "success" | "warning" | "info";
-  label: string;
-} {
-  switch (status) {
-    case "in_alarm":
-      return { color: "rose", label: "in alarm" };
-    case "ok":
-      return { color: "success", label: "ok" };
-    case "evaluating":
-      return { color: "warning", label: "evaluating" };
-    case null:
-      return { color: "info", label: "unknown" };
-    default:
-      assertNeverAndIgnore(status);
-      return { color: "info", label: "unknown" };
-  }
-}
-
-interface AlertChipProps {
-  alert: MetronomeAlertRef | null;
-  label: string;
-}
-
-// A clickable badge deep-linking to a Metronome alert, labelled with the alert
-// name and its current evaluation status and colored by that status. Renders
-// nothing when the alert is unknown (not configured).
-function AlertChip({ alert, label }: AlertChipProps) {
-  if (!alert) {
-    return null;
-  }
-  const { color, label: statusLabel } = alertStatusChip(alert.status);
-  return (
-    <Chip
-      size="xs"
-      color={color}
-      label={`${label}: ${statusLabel}`}
-      icon={LinkExternal01}
-      href={getMetronomeAlertUrl(alert.id)}
-      target="_blank"
-    />
-  );
 }
 
 type CreditStateChipColor = "success" | "warning" | "rose" | "info";

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -2,6 +2,7 @@ import {
   getSeatBarClasses,
   getSeatIconColorClass,
   MUTED_BAR_CLASSES,
+  OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
@@ -150,18 +151,25 @@ function AwuUsageBar({
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
 
-  // The bar is up to four contiguous sections, each with its own tooltip:
-  //   seat consumed · seat remaining · pool consumed · pool remaining
-  // Zero-width sections are skipped, so in practice it renders as:
-  //   - within allowance:   seat consumed · seat remaining · pool remaining
-  //   - overflowed to pool: seat consumed · pool consumed · pool remaining
-  //   - no seat allowance:  pool consumed · pool remaining
-  // `pool remaining` is omitted when the user is uncapped (no finite headroom).
+  // The bar splits consumption into seat → pool → overage:
+  //   seat consumed · seat remaining · pool consumed · pool remaining · overage
+  // `poolLimit` is the headroom on top of the seat allowance (null = uncapped).
+  // A seat with no pool (poolLimit === 0, e.g. free) shows no pool section —
+  // any spend beyond the seat allowance is overage. Zero-width sections are
+  // skipped. `pool remaining` is omitted when uncapped (no finite headroom).
   const seatConsumed = consumedFromAllowance;
   const seatRemaining = Math.max(0, allowance - seatConsumed);
-  const poolConsumed = consumedFromPool;
+  const poolLimit = limit !== null ? Math.max(0, limit - allowance) : null;
+  // Of the pool consumption, the part within the pool limit vs. the overage
+  // beyond it (only capped seats can have overage).
+  const poolConsumed =
+    poolLimit !== null
+      ? Math.min(consumedFromPool, poolLimit)
+      : consumedFromPool;
   const poolRemaining =
-    limit !== null ? Math.max(0, limit - allowance - poolConsumed) : null;
+    poolLimit !== null ? Math.max(0, poolLimit - poolConsumed) : null;
+  const overage =
+    poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
 
   const sections: Array<{
     key: string;
@@ -201,12 +209,16 @@ function AwuUsageBar({
       label: `${formatCredits(poolRemaining)} credits remaining before spend limit`,
     });
   }
+  // Overage is surfaced in the tooltip only, not as a bar segment.
 
   const total = sections.reduce((sum, s) => sum + s.value, 0);
 
   const hasSeatSections = seatConsumed > 0 || seatRemaining > 0;
+  // Only surface the pool when there's actually a pool to spend from: a finite
+  // positive limit, or uncapped (null). A zero pool limit (free) has no pool.
   const hasPoolSections =
-    poolConsumed > 0 || (poolRemaining !== null && poolRemaining > 0);
+    (poolLimit === null || poolLimit > 0) &&
+    (poolConsumed > 0 || (poolRemaining !== null && poolRemaining > 0));
 
   const tooltipLines: Array<{
     track: string;
@@ -223,15 +235,22 @@ function AwuUsageBar({
     });
   }
   if (hasPoolSections) {
-    const poolTotal = limit !== null ? limit - allowance : null;
     tooltipLines.push({
       track: MUTED_BAR_CLASSES.track,
       fill: MUTED_BAR_CLASSES.fill,
       legend: "Pool usage",
       usage:
-        poolTotal !== null
-          ? `${formatCredits(poolConsumed)} credits used out of ${formatCredits(poolTotal)}`
+        poolLimit !== null
+          ? `${formatCredits(poolConsumed)} credits used out of ${formatCredits(poolLimit)}`
           : `${formatCredits(poolConsumed)} credits used`,
+    });
+  }
+  if (overage > 0) {
+    tooltipLines.push({
+      track: OVERAGE_BAR_CLASSES.track,
+      fill: OVERAGE_BAR_CLASSES.fill,
+      legend: "Overage",
+      usage: `${formatCredits(overage)} credits over the spend limit`,
     });
   }
 

--- a/front/components/workspace/seat_styles.ts
+++ b/front/components/workspace/seat_styles.ts
@@ -26,6 +26,13 @@ export const MUTED_BAR_CLASSES = {
   fill: SEAT_TIER_STYLES.muted.barFill,
 };
 
+// Overage bar colors (spend beyond the seat allowance + pool limit) — red, to
+// signal the user is over their cap.
+export const OVERAGE_BAR_CLASSES = {
+  track: "bg-red-200 dark:bg-red-200-night",
+  fill: "bg-red-700 dark:bg-red-700-night",
+};
+
 // Seat icon text color: golden for max, highlight blue for pro, muted grey
 // otherwise (free / none / workspace).
 export function getSeatIconColorClass(seatType: MembershipSeatType): string {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { listPerUserCreditBalanceAlertsForWorkspace } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import type {
   MetronomeCapAlertIds,
   MetronomeCapAlertInfo,
@@ -11,8 +12,15 @@ import {
   listMetronomePerUserCapsForWorkspace,
   listMetronomePerUserWarningAlertsForWorkspace,
 } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
+import {
+  listContractPerUserCreditBalances,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
+import {
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 import {
   fetchPerUserAwuUsage,
   getPerUserAwuUsage,
@@ -91,6 +99,11 @@ export type MemberUsageType = {
   // Id of the companion 80% warning alert for the effective cap. Null when
   // uncapped or no warning alert exists.
   spendLimitWarningAlertId: string | null;
+  // Per-user free-credit balance alerts (low at 20%, empty at 0), each with its
+  // current Metronome status for the `AlertChip` badges. Free seats only, and
+  // only populated when alert links are requested (poke). Null otherwise.
+  freeCreditLowAlert: MetronomeAlertRef | null;
+  freeCreditEmptyAlert: MetronomeAlertRef | null;
   // Per-user credit state machine state (personal-credits → pool → capped
   // progression) persisted on the membership. Surfaced for debugging.
   creditState: UserCreditState;
@@ -279,6 +292,30 @@ async function fetchSeatBalancesForMembersTable({
       balanceByUserId.set(seat.seat_id, awu.balance);
     }
   }
+
+  // Free seats hold a per-user contract credit rather than a seat balance, so
+  // they're absent from `listMetronomeSeatBalances`. Fill their remaining
+  // balance in from the per-user credits — but only when the user has no seat
+  // balance: a user who switched free → pro/max still has a leftover free
+  // credit, and it must not overwrite their (real) pro/max seat balance.
+  // Degrades silently on read failure.
+  const perUserCreditBalances = await listContractPerUserCreditBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (perUserCreditBalances.isOk()) {
+    for (const [userId, { balanceAwu }] of perUserCreditBalances.value) {
+      if (!balanceByUserId.has(userId)) {
+        balanceByUserId.set(userId, balanceAwu);
+      }
+    }
+  } else {
+    logger.warn(
+      { err: perUserCreditBalances.error, metronomeCustomerId },
+      "[MembersUsage] Failed to fetch per-user credit balances, skipping"
+    );
+  }
+
   return balanceByUserId;
 }
 
@@ -623,10 +660,18 @@ export async function getMemberUsage({
           ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
           : 0)
       : null;
+  // Free seats have no pool, so their total spend cap is just the seat
+  // allowance (allowance + 0 pool) — like every other seat the cap includes the
+  // allowance, it just has no pool headroom on top. There's no default cap alert
+  // for free (normalizeToPoolLimitSeatType is null), so we supply it explicitly.
+  const effectiveDefaultAwuCredits =
+    membership.seatType === "free"
+      ? FREE_SEAT_LIFETIME_AWU_CREDITS
+      : (defaultCap?.threshold ?? null);
 
   const spendLimitSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits,
-    defaultAwuCredits: defaultCap?.threshold ?? null,
+    defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
   return {
@@ -648,11 +693,13 @@ export async function getMemberUsage({
       scheduledSeatChangeAt: null,
       spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits,
-        defaultAwuCredits: defaultCap?.threshold ?? null,
+        defaultAwuCredits: effectiveDefaultAwuCredits,
       }),
       spendLimitSource,
       spendLimitAlertId: null,
       spendLimitWarningAlertId: null,
+      freeCreditLowAlert: null,
+      freeCreditEmptyAlert: null,
       creditState: membership.creditState,
     },
   };
@@ -704,6 +751,7 @@ export async function getMembersUsage({
     seatDataByUserId,
     seatBalanceByUserId,
     perUserSpendLimits,
+    freeCreditAlertIdsByUserId,
   ] = await Promise.all([
     MembershipResource.getActiveMemberships({ workspace, users }),
     fetchPerUserUsageCreditsForMembersTable({
@@ -726,7 +774,20 @@ export async function getMembersUsage({
       workspaceId: workspace.sId,
       includeAlertLinks,
     }),
+    // Free-seat balance-alert ids (low + empty) for deep-linking — poke-only,
+    // gated on `includeAlertLinks` so the customer page doesn't pay the extra
+    // alert-list call.
+    includeAlertLinks && metronomeCustomerId
+      ? listPerUserCreditBalanceAlertsForWorkspace({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+        })
+      : Promise.resolve(null),
   ]);
+  const freeCreditAlertIds =
+    freeCreditAlertIdsByUserId?.isOk() === true
+      ? freeCreditAlertIdsByUserId.value
+      : null;
   const {
     perUserOverrideAlerts,
     defaultAwuCreditsBySeatType,
@@ -780,10 +841,17 @@ export async function getMembersUsage({
             ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
             : 0)
         : null;
+    // Free seats have no pool, so their total spend cap is just the seat
+    // allowance (allowance + 0 pool) — the cap includes the allowance like every
+    // other seat, it just has no pool headroom on top.
+    const effectiveDefaultAwuCredits =
+      membership.seatType === "free"
+        ? FREE_SEAT_LIFETIME_AWU_CREDITS
+        : (defaultCap?.threshold ?? null);
 
     const spendLimitSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits,
-      defaultAwuCredits: defaultCap?.threshold ?? null,
+      defaultAwuCredits: effectiveDefaultAwuCredits,
     });
     const effectiveCapAlert =
       spendLimitSource === "override"
@@ -797,6 +865,13 @@ export async function getMembersUsage({
     const spendLimitWarningAlertId = includeAlertLinks
       ? (effectiveCapAlert?.warningAlertId ?? null)
       : null;
+
+    // Free-seat balance-alert deep links (poke-only). Only free seats have
+    // these per-user credit-balance alerts.
+    const freeCreditAlerts =
+      membership.seatType === "free"
+        ? (freeCreditAlertIds?.get(userId) ?? null)
+        : null;
 
     return [
       {
@@ -820,11 +895,13 @@ export async function getMembersUsage({
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
           overrideAwuCredits,
-          defaultAwuCredits: defaultCap?.threshold ?? null,
+          defaultAwuCredits: effectiveDefaultAwuCredits,
         }),
         spendLimitSource,
         spendLimitAlertId,
         spendLimitWarningAlertId,
+        freeCreditLowAlert: freeCreditAlerts?.low ?? null,
+        freeCreditEmptyAlert: freeCreditAlerts?.empty ?? null,
         creditState: membership.creditState,
       },
     ];

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -9,7 +9,10 @@ import {
   getMetronomePerUserCap,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { getNetBalance } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
@@ -62,6 +65,15 @@ async function resolvePoolLimitForUser({
     return null;
   }
 
+  // Free seats have no pool access — their pool limit is always 0, regardless
+  // of any per-user cap override (a cap bounds personal spend; it is not a pool
+  // budget). This is the single source of "free has no pool": downstream
+  // routing (capped vs on_pool) then falls out of `poolLimit === 0` with no
+  // seat-type special-casing.
+  if (seatType === "free") {
+    return 0;
+  }
+
   // 1. Per-user override.
   const userCapResult = await getMetronomePerUserCap({
     metronomeCustomerId,
@@ -108,6 +120,11 @@ async function getSeatAllowance(
   workspace: WorkspaceResource,
   seatType: MembershipSeatType | null | undefined
 ): Promise<number> {
+  // Free seats carry a fixed personal allocation that isn't a contract
+  // recurring credit, so it's a code constant rather than a contract lookup.
+  if (seatType === "free") {
+    return FREE_SEAT_LIFETIME_AWU_CREDITS;
+  }
   const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
   if (!normalizedSeatType) {
     return 0;
@@ -179,12 +196,13 @@ export async function dispatchSeatBalanceExhausted({
 
   const result = await transitionUserCreditState(
     membership,
-    { type: "seat_balance_exhausted", poolLimitAwuCredits },
+    { type: "seat_balance_exhausted" },
     {
       workspaceId: workspace.sId,
       userId,
       seatType: membership.seatType,
       remainingCapCreditsPercentage,
+      poolLimitAwuCredits,
     }
   );
   if (result.isErr()) {
@@ -241,10 +259,25 @@ export async function dispatchSeatBalanceResolved({
     userId,
   });
 
+  // The seat balance came back; the band the user lands in depends on how much
+  // is left. Read the live balance so the state machine can route to
+  // `user_seat` vs `user_seat_low_balance` (or the pool for non-seat users).
+  const liveBalance = await resolveLiveUserBalance({
+    workspace,
+    userId,
+    seatType: membership.seatType,
+    poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+  });
+
   const result = await transitionUserCreditState(
     membership,
     { type: "seat_balance_resolved" },
-    { workspaceId: workspace.sId, userId, seatType: membership.seatType }
+    {
+      workspaceId: workspace.sId,
+      userId,
+      seatType: membership.seatType,
+      liveBalance,
+    }
   );
   if (result.isErr()) {
     logger.warn(
@@ -484,7 +517,7 @@ export async function dispatchPerUserCapResolved({
   // `user_seat_low_balance`; otherwise the pool). When the live read isn't
   // available the transition defaults to `on_pool` and the reconcile / billing
   // webhooks correct it later.
-  const liveBalance = await resolveLiveBalanceForCapResolved({
+  const liveBalance = await resolveLiveUserBalance({
     workspace,
     userId,
     seatType: membership.seatType,
@@ -507,10 +540,11 @@ export async function dispatchPerUserCapResolved({
   return new Ok(undefined);
 }
 
-// Read the live per-user balance snapshot used to resolve the seat↔pool band on
-// cap resolution. Returns `undefined` when there's no Metronome customer or the
-// live read fails — the transition then defaults to `on_pool`.
-async function resolveLiveBalanceForCapResolved({
+// Read the live per-user balance snapshot used to recompute the seat↔pool band
+// when a per-user cap resolves or a seat balance is replenished. Returns
+// `undefined` when there's no Metronome customer or the live read fails — the
+// transition then falls back to its unguarded default.
+async function resolveLiveUserBalance({
   workspace,
   userId,
   seatType,
@@ -542,7 +576,7 @@ async function resolveLiveBalanceForCapResolved({
   if (liveResult.isErr()) {
     logger.warn(
       { workspaceId: workspace.sId, userId, seatType, err: liveResult.error },
-      "[CreditStateDispatcher] per_user_cap_resolved: live balance read failed, defaulting to on_pool"
+      "[CreditStateDispatcher] live balance read failed; transition uses default band"
     );
     return undefined;
   }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -37,6 +37,7 @@ import {
   grantFreeCreditFromMetronomeSegment,
   YEARLY_MULTIPLIER,
 } from "@app/lib/credits/free";
+import { parsePerUserCreditAlertUserId } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import {
   CRITICAL_BALANCE_OFFSET,
   LOW_BALANCE_OFFSET,
@@ -228,6 +229,10 @@ async function stampContractCreditType({
     if (credit.subscription_config?.allocation === "INDIVIDUAL") {
       return new Ok(undefined);
     }
+
+    // Per-user free-seat credits are stamped "free_seat" at creation (see
+    // `addPerUserCreditToContract`), so they hit the already-stamped early
+    // return above and are never re-stamped "pool" here.
 
     if (credit.product.id === getProductExcessCreditsId()) {
       value = CONTRACT_CREDIT_TYPE_EXCESS;
@@ -1085,12 +1090,57 @@ export async function processMetronomeWebhook({
       break;
     }
 
+    // Per-user free-seat credit balance. These alerts are scoped (via the
+    // `DUST_PER_USER_CREDIT_USER` custom field) to a single free user's credit,
+    // so they drive that user's seat↔capped transitions — the seat-balance
+    // alert can't, because the free credit isn't a seat balance. The event
+    // carries no `credit_id` for a custom-field-filtered alert, so the user is
+    // resolved from the alert NAME (see `parsePerUserCreditAlertUserId`); events
+    // for any other alert return null and are ignored. Two thresholds mirror the
+    // seat bands: `threshold === 0` → exhausted (→ capped), else → low balance.
+    case "alerts.low_remaining_contract_credit_balance_reached": {
+      const { alert_name: alertName, threshold } = event.properties;
+      const userId = parsePerUserCreditAlertUserId(alertName);
+      if (!userId || threshold === null || threshold === undefined) {
+        break;
+      }
+      if (threshold === 0) {
+        await dispatchSeatBalanceExhausted({ workspace, userId });
+        logger.info(
+          { eventId: event.id, workspaceId: workspace.sId, userId },
+          "[Metronome Webhook] low_remaining_contract_credit_balance_reached: per-user credit exhausted dispatched"
+        );
+      } else {
+        await dispatchSeatLowBalance({ workspace, userId, threshold });
+        logger.info(
+          {
+            eventId: event.id,
+            workspaceId: workspace.sId,
+            userId,
+            remaining: threshold,
+          },
+          "[Metronome Webhook] low_remaining_contract_credit_balance_reached: per-user credit low balance dispatched"
+        );
+      }
+      break;
+    }
+    case "alerts.low_remaining_contract_credit_balance_resolved": {
+      const userId = parsePerUserCreditAlertUserId(event.properties.alert_name);
+      if (!userId) {
+        break;
+      }
+      await dispatchSeatBalanceResolved({ workspace, userId });
+      logger.info(
+        { eventId: event.id, workspaceId: workspace.sId, userId },
+        "[Metronome Webhook] low_remaining_contract_credit_balance_resolved: per-user credit resolved dispatched"
+      );
+      break;
+    }
+
     case "alerts.invoice_total_reached":
     case "alerts.invoice_total_resolved":
     case "alerts.low_remaining_commit_balance_reached":
     case "alerts.low_remaining_commit_balance_resolved":
-    case "alerts.low_remaining_contract_credit_balance_reached":
-    case "alerts.low_remaining_contract_credit_balance_resolved":
     case "alerts.low_remaining_credit_balance_reached":
     case "alerts.low_remaining_credit_balance_resolved":
     case "alerts.usage_threshold_reached":

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -4,7 +4,10 @@ import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
 import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limits";
 import { getCachedDefaultCapThresholdsBySeatType } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import {
+  listContractPerUserCreditBalances,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
 import {
   awuSeatBalanceForUser,
   fetchLiveUserCreditInputs,
@@ -389,6 +392,25 @@ export async function reconcileWorkspaceUserCreditStates({
   }
   const seatBalances = seatBalancesResult.value;
 
+  // Free seats hold a per-user contract credit, not a seat balance, so they're
+  // absent from `listMetronomeSeatBalances`. Read their balances separately so a
+  // free user with credit remaining lands on `user_seat` (not `on_pool`) and is
+  // moved to `capped` once exhausted. A read failure leaves the map empty —
+  // free users then fall back to the seat-balance path (null) as before.
+  const perUserCreditBalancesResult = await listContractPerUserCreditBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (perUserCreditBalancesResult.isErr()) {
+    logger.warn(
+      { workspaceId, err: perUserCreditBalancesResult.error },
+      "[ReconcileCreditState] Failed to load per-user credit balances"
+    );
+  }
+  const perUserCreditBalances = perUserCreditBalancesResult.isOk()
+    ? perUserCreditBalancesResult.value
+    : new Map<string, { balanceAwu: number; startingBalanceAwu: number }>();
+
   // The cap-threshold caches (Metronome alert list / contract) and the
   // membership query (DB) can genuinely throw, so they stay wrapped — the
   // ERR1-authorised case. The per-user overrides themselves come from the
@@ -454,7 +476,16 @@ export async function reconcileWorkspaceUserCreditStates({
           ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
           : null;
 
-    const seat = awuSeatBalanceForUser(seatBalances, userId);
+    // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
+    // seats read their per-user credit balance instead (not a seat balance).
+    // Pro/max read their seat balance; free seats read their per-user credit
+    // balance (not a seat balance). `expectedUserCreditState` decides routing
+    // from the seat type — a free seat is never `on_pool`, and a null (unknown)
+    // balance leaves it on the seat rather than mis-capping it.
+    const seat =
+      awuSeatBalanceForUser(seatBalances, userId) ??
+      perUserCreditBalances.get(userId) ??
+      null;
     const expectedState = expectedUserCreditState({
       seatType,
       seatBalanceAwu: seat?.balanceAwu ?? null,

--- a/front/lib/metronome/alerts/per_user_credit_balance.ts
+++ b/front/lib/metronome/alerts/per_user_credit_balance.ts
@@ -1,0 +1,231 @@
+import {
+  baseUniquenessKey,
+  clearMetronomeAlert,
+  upsertMetronomeAlert,
+} from "@app/lib/metronome/alerts";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
+import { listMetronomeAlerts } from "@app/lib/metronome/client";
+import {
+  getCreditTypeAwuId,
+  PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
+import logger from "@app/logger/logger";
+import { SEAT_LOW_BALANCE_FRACTION } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// The two per-user credit-balance alerts for one seat (id + current evaluation
+// status), surfaced (e.g. in poke) so the UI can render each balance badge with
+// `AlertChip` — colored by status and deep-linked to Metronome.
+export type PerUserCreditAlerts = {
+  low: MetronomeAlertRef | null;
+  empty: MetronomeAlertRef | null;
+};
+
+// A free seat's AWU credit is a per-user contract credit (not a seat balance),
+// so the seat-balance alert can't track it. Metronome alerts can filter on a
+// credit's custom field but not on its presentation specifier, so we scope a
+// per-user `low_remaining_contract_credit_balance_reached` alert to the credit
+// stamped with this user's sId (`DUST_PER_USER_CREDIT_USER`). Two alerts per
+// user mirror the seat-balance bands, distinguished by `threshold` in the
+// webhook payload (the same way `low_remaining_seat_balance_reached` is
+// handled): the exhaustion alert (threshold 0) drives `capped`, the low-balance
+// alert (threshold = 20% of the allowance) drives `user_seat_low_balance`.
+
+// The webhook event for `low_remaining_contract_credit_balance_reached` carries
+// no `credit_id` for a custom-field-filtered alert, so the handler resolves the
+// seat user from the alert NAME. Build and parse it here so the two never drift
+// — the userId is always the last whitespace-delimited token (sIds have no
+// spaces).
+const PER_USER_CREDIT_ALERT_NAME_PREFIX = "Per-user free credit";
+
+function perUserCreditAlertName(
+  band: "exhausted" | "low balance",
+  workspaceId: string,
+  userId: string
+): string {
+  return `${PER_USER_CREDIT_ALERT_NAME_PREFIX} ${band} ${workspaceId} ${userId}`;
+}
+
+/**
+ * Extract the seat user sId from a per-user credit-balance alert name (the
+ * inverse of `perUserCreditAlertName`). Returns null for any non-matching name.
+ */
+export function parsePerUserCreditAlertUserId(
+  alertName: string | null | undefined
+): string | null {
+  if (!alertName?.startsWith(PER_USER_CREDIT_ALERT_NAME_PREFIX)) {
+    return null;
+  }
+  const tokens = alertName.trim().split(/\s+/);
+  return tokens.at(-1) ?? null;
+}
+
+function exhaustionAlertUniquenessKeyPrefix(workspaceId: string): string {
+  return `per-user-credit-exhausted-${workspaceId}-`;
+}
+
+function lowBalanceAlertUniquenessKeyPrefix(workspaceId: string): string {
+  return `per-user-credit-low-${workspaceId}-`;
+}
+
+function exhaustionAlertUniquenessKey(
+  workspaceId: string,
+  userId: string
+): string {
+  return `${exhaustionAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
+}
+
+function lowBalanceAlertUniquenessKey(
+  workspaceId: string,
+  userId: string
+): string {
+  return `${lowBalanceAlertUniquenessKeyPrefix(workspaceId)}${userId}`;
+}
+
+/**
+ * Map each free-seat user in a workspace to their per-user credit-balance alert
+ * ids (low + empty), built from the alerts whose uniqueness key matches the
+ * per-user-credit patterns for this workspace. Mirrors
+ * `listMetronomePerUserCapsForWorkspace`; used to link the poke balance badges
+ * to their Metronome alerts.
+ */
+export async function listPerUserCreditBalanceAlertsForWorkspace({
+  metronomeCustomerId,
+  workspaceId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+}): Promise<Result<Map<string, PerUserCreditAlerts>, Error>> {
+  const lowPrefix = lowBalanceAlertUniquenessKeyPrefix(workspaceId);
+  const emptyPrefix = exhaustionAlertUniquenessKeyPrefix(workspaceId);
+  const byUser = new Map<string, PerUserCreditAlerts>();
+  try {
+    for await (const entry of listMetronomeAlerts({
+      customer_id: metronomeCustomerId,
+      alert_statuses: ["ENABLED"],
+    })) {
+      const key = entry.alert.uniqueness_key;
+      if (!key) {
+        continue;
+      }
+      const baseKey = baseUniquenessKey(key);
+      const isLow = baseKey.startsWith(lowPrefix);
+      const userId = isLow
+        ? baseKey.slice(lowPrefix.length)
+        : baseKey.startsWith(emptyPrefix)
+          ? baseKey.slice(emptyPrefix.length)
+          : null;
+      if (!userId) {
+        continue;
+      }
+      const ref: MetronomeAlertRef = {
+        id: entry.alert.id,
+        status: entry.customer_status,
+      };
+      const alerts = byUser.get(userId) ?? { low: null, empty: null };
+      if (isLow) {
+        alerts.low = ref;
+      } else {
+        alerts.empty = ref;
+      }
+      byUser.set(userId, alerts);
+    }
+    return new Ok(byUser);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+function perUserCreditFilter(userId: string) {
+  return [
+    {
+      entity: "ContractCredit" as const,
+      key: PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
+      value: userId,
+    },
+  ];
+}
+
+/**
+ * Idempotently ensure the two per-user credit-balance alerts (exhaustion at 0,
+ * low balance at 20% of the allowance) exist for a free seat user. Both filter
+ * on the credit's `DUST_PER_USER_CREDIT_USER` custom field so Metronome
+ * evaluates only that user's credit. Best-effort caller: alert failures must
+ * not fail the grant.
+ */
+export async function upsertPerUserCreditBalanceAlerts({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+  allowanceAwu,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  userId: string;
+  allowanceAwu: number;
+}): Promise<Result<void, Error>> {
+  const creditTypeId = getCreditTypeAwuId();
+
+  const exhaustionResult = await upsertMetronomeAlert({
+    alert_type: "low_remaining_contract_credit_balance_reached",
+    name: perUserCreditAlertName("exhausted", workspaceId, userId),
+    threshold: 0,
+    credit_type_id: creditTypeId,
+    customer_id: metronomeCustomerId,
+    uniqueness_key: exhaustionAlertUniquenessKey(workspaceId, userId),
+    custom_field_filters: perUserCreditFilter(userId),
+  });
+  if (exhaustionResult.isErr()) {
+    return new Err(exhaustionResult.error);
+  }
+
+  const lowBalanceResult = await upsertMetronomeAlert({
+    alert_type: "low_remaining_contract_credit_balance_reached",
+    name: perUserCreditAlertName("low balance", workspaceId, userId),
+    threshold: Math.floor(SEAT_LOW_BALANCE_FRACTION * allowanceAwu),
+    credit_type_id: creditTypeId,
+    customer_id: metronomeCustomerId,
+    uniqueness_key: lowBalanceAlertUniquenessKey(workspaceId, userId),
+    custom_field_filters: perUserCreditFilter(userId),
+  });
+  if (lowBalanceResult.isErr()) {
+    return new Err(lowBalanceResult.error);
+  }
+
+  logger.info(
+    { workspaceId, userId, metronomeCustomerId, allowanceAwu },
+    "[Metronome PerUserCredit] Synced per-user credit-balance alerts"
+  );
+  return new Ok(undefined);
+}
+
+/**
+ * Archive both per-user credit-balance alerts for a user. Idempotent — no-op
+ * when no matching alert exists. Call when a user leaves the free seat so the
+ * alerts don't accumulate.
+ */
+export async function clearPerUserCreditBalanceAlerts({
+  metronomeCustomerId,
+  workspaceId,
+  userId,
+}: {
+  metronomeCustomerId: string;
+  workspaceId: string;
+  userId: string;
+}): Promise<Result<void, Error>> {
+  for (const uniquenessKey of [
+    exhaustionAlertUniquenessKey(workspaceId, userId),
+    lowBalanceAlertUniquenessKey(workspaceId, userId),
+  ]) {
+    const result = await clearMetronomeAlert({
+      metronomeCustomerId,
+      uniquenessKey,
+    });
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+  }
+  return new Ok(undefined);
+}

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1,7 +1,9 @@
 import config from "@app/lib/api/config";
 import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
   CONTRACT_CREDIT_TYPE_POOL,
+  PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
@@ -2281,6 +2283,309 @@ export async function updateMetronomeCreditSegmentAmount({
     logger.error(
       { error, metronomeCustomerId, contractId, creditId, segmentId, amount },
       "[Metronome] Failed to update free credit segment amount"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Add a one-time credit scoped to a single seat (user) on a contract via
+ * `v2.contracts.edit` (`add_credits`).
+ *
+ * The credit is scoped to one seat through a `user_id` presentation specifier:
+ * only usage tagged for that `userId` draws it down. This is how we express a
+ * per-seat credit that the recurring INDIVIDUAL credit mechanism cannot — a
+ * grant issued exactly once per seat, whenever that seat first appears, with no
+ * periodic refill. Idempotency is enforced through `uniquenessKey`: a repeated
+ * edit with the same key returns the existing edit (surfaced here as `Ok(null)`)
+ * rather than granting twice.
+ *
+ * `specifiers` is mutually exclusive with `applicable_product_ids` /
+ * `applicable_product_tags`, so the usage-product scope is passed as
+ * `product_tags` *inside* the specifier rather than as a top-level applicable
+ * filter.
+ *
+ * The `userId` is also stamped as the `DUST_PER_USER_CREDIT_USER` custom field.
+ * Metronome alerts can filter on custom fields but not on a credit's
+ * presentation specifier, so this is what lets a per-user
+ * `low_remaining_contract_credit_balance_reached` alert fire as the user
+ * depletes their credit. The key must be registered with Metronome (see
+ * `scripts/metronome_setup.ts`) or the edit is rejected with "Invalid custom
+ * field keys".
+ */
+export async function addPerUserCreditToContract({
+  metronomeCustomerId,
+  metronomeContractId,
+  productId,
+  creditTypeId,
+  amount,
+  userId,
+  productTags,
+  startingAt,
+  endingBefore,
+  name,
+  priority,
+  uniquenessKey,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  productId: string;
+  creditTypeId: string;
+  amount: number;
+  userId: string;
+  productTags: string[];
+  startingAt: Date;
+  endingBefore: Date;
+  name: string;
+  priority: number;
+  uniquenessKey: string;
+}): Promise<Result<{ editId: string } | null, Error>> {
+  // Metronome requires dates on hour boundaries — round down start, round up end.
+  const roundedStartingAt = floorToHourISO(startingAt);
+  const roundedEndingBefore = floorToHourISO(endingBefore);
+
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      uniqueness_key: uniquenessKey,
+      add_credits: [
+        {
+          product_id: productId,
+          name,
+          priority,
+          custom_fields: {
+            [PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY]: userId,
+            [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]:
+              CONTRACT_CREDIT_TYPE_FREE_SEAT,
+          },
+          access_schedule: {
+            credit_type_id: creditTypeId,
+            schedule_items: [
+              {
+                amount,
+                starting_at: roundedStartingAt,
+                ending_before: roundedEndingBefore,
+              },
+            ],
+          },
+          specifiers: [
+            {
+              presentation_group_values: { user_id: userId },
+              product_tags: productTags,
+            },
+          ],
+        },
+      ],
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        userId,
+        editId: response.data.id,
+        amount,
+      },
+      "[Metronome] Per-user seat credit added to contract"
+    );
+
+    return new Ok({ editId: response.data.id });
+  } catch (err) {
+    const error = normalizeError(err);
+    // Idempotency conflict on the uniqueness key — the credit was already
+    // granted. Metronome surfaces this as a 409 (`ConflictError`) on some
+    // endpoints and as a 422 "Uniqueness key already exists" on
+    // `v2.contracts.edit`, so match both.
+    if (
+      err instanceof ConflictError ||
+      error.message.includes("Uniqueness key already exists")
+    ) {
+      logger.info(
+        { metronomeCustomerId, metronomeContractId, userId, uniquenessKey },
+        "[Metronome] Per-user seat credit already exists (idempotent)"
+      );
+      return new Ok(null);
+    }
+
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId, userId, amount },
+      "[Metronome] Failed to add per-user seat credit to contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Return the set of seat user sIds that already have a per-user credit named
+ * `creditName` on the contract. The seat sId is read back from the credit's
+ * `user_id` presentation specifier — the same specifier that scopes the credit
+ * to the seat (no separate custom field, which would require registering a
+ * managed-field key with Metronome).
+ *
+ * `covering_date` is intentionally dropped and archived credits are included so
+ * EXPIRED and archived grants still count — a per-user credit is once-ever, and
+ * a user whose grant has lapsed must not be re-credited. (The grant's
+ * `uniqueness_key` enforces this server-side regardless; this pre-check just
+ * avoids the redundant edit call.)
+ *
+ * Uses the credits-list endpoint (not `listBalances`): it returns only credits
+ * (no commits) and we pass `include_balance: false`, so Metronome skips balance
+ * computation — lighter than the balances endpoint for this identity-only read.
+ */
+export async function listContractPerUserCreditUserIds({
+  metronomeCustomerId,
+  metronomeContractId,
+  creditName,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  creditName: string;
+}): Promise<Result<Set<string>, Error>> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok(new Set());
+  }
+
+  const client = getMetronomeClient();
+
+  try {
+    const userIds = new Set<string>();
+    for await (const entry of client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      include_balance: false,
+      include_contract_credits: true,
+      include_archived: true,
+    })) {
+      if (
+        entry.contract?.id !== metronomeContractId ||
+        entry.name !== creditName
+      ) {
+        continue;
+      }
+      for (const specifier of entry.specifiers ?? []) {
+        const userId = specifier.presentation_group_values?.user_id;
+        if (userId) {
+          userIds.add(userId);
+        }
+      }
+    }
+    return new Ok(userIds);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId },
+      "[Metronome] Failed to list per-user contract credits"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Return the live AWU balance of each free-seat per-user credit on the contract,
+ * keyed by the seat's user sId (read from the `DUST_PER_USER_CREDIT_USER` custom
+ * field). `balanceAwu` is the amount remaining now; `startingBalanceAwu` is the
+ * full granted allocation (the access-schedule total). Per-user credits aren't
+ * seat balances, so they don't appear in `listMetronomeSeatBalances` — this is
+ * how the seat↔pool/capped state for free seats reads their remaining balance.
+ *
+ * `covering_date` defaults to now and archived credits are excluded, so the
+ * balance reflects only the currently-active credit.
+ *
+ * Uses the credits-list endpoint (not `listBalances`) so Metronome returns only
+ * credits, not commits.
+ */
+export async function listContractPerUserCreditBalances({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<
+  Result<
+    Map<
+      string,
+      { creditId: string; balanceAwu: number; startingBalanceAwu: number }
+    >,
+    Error
+  >
+> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok(new Map());
+  }
+
+  const client = getMetronomeClient();
+
+  try {
+    const byUser = new Map<
+      string,
+      { creditId: string; balanceAwu: number; startingBalanceAwu: number }
+    >();
+    for await (const entry of client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      include_balance: true,
+      include_contract_credits: true,
+    })) {
+      if (entry.contract?.id !== metronomeContractId) {
+        continue;
+      }
+      const userId =
+        entry.custom_fields?.[PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY];
+      if (!userId) {
+        continue;
+      }
+      const startingBalanceAwu = (
+        entry.access_schedule?.schedule_items ?? []
+      ).reduce((sum, item) => sum + item.amount, 0);
+      byUser.set(userId, {
+        creditId: entry.id,
+        balanceAwu: entry.balance ?? 0,
+        startingBalanceAwu,
+      });
+    }
+    return new Ok(byUser);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId },
+      "[Metronome] Failed to list per-user contract credit balances"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Archive a contract credit (e.g. a free-seat per-user credit when the user
+ * leaves the free seat) so it stops drawing against usage. This is a fresh
+ * `v2.contracts.edit` with no `uniqueness_key`, so it does NOT release the
+ * original grant edit's key — the user can never re-claim a free credit on this
+ * contract (re-grant 409/422s, and the archived credit still satisfies the
+ * dedup check).
+ */
+export async function archiveContractCredit({
+  metronomeCustomerId,
+  metronomeContractId,
+  creditId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  creditId: string;
+}): Promise<Result<undefined, Error>> {
+  try {
+    await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      archive_credits: [{ id: creditId }],
+    });
+    logger.info(
+      { metronomeCustomerId, metronomeContractId, creditId },
+      "[Metronome] Archived contract credit"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId, creditId },
+      "[Metronome] Failed to archive contract credit"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -120,6 +120,22 @@ export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
   "DUST_CONTRACT_CREDIT_TYPE";
 export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";
 export const CONTRACT_CREDIT_TYPE_POOL = "pool";
+// Per-user free-seat credits. Stamped at creation so they're explicitly typed
+// (not just "unstamped") and excluded from the pool balance — the pool filter
+// matches "pool", so "free_seat" never counts. Lets the credit.create /
+// credit.segment.start webhook leave them alone via its existing
+// already-stamped early-return, with no per-credit special-casing.
+export const CONTRACT_CREDIT_TYPE_FREE_SEAT = "free_seat";
+
+// Custom field stamped on a per-user (free) seat credit, carrying the seat's
+// user sId. Metronome alerts can filter on custom fields but not on a credit's
+// presentation specifier, so this is what lets a per-user
+// `low_remaining_contract_credit_balance_reached` alert fire as each free
+// user depletes their individual credit. The key must be registered with
+// Metronome (see `CUSTOM_FIELD_KEYS` in `scripts/metronome_setup.ts`) before it
+// can be stamped, or the create is rejected with "Invalid custom field keys".
+export const PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY =
+  "DUST_PER_USER_CREDIT_USER";
 
 // Pricing/billable-metric group key that splits AWU usage into "user",
 // "programmatic", and "free" slices. Emitted on every usage event and used
@@ -225,8 +241,22 @@ export const getProductSeatSubscriptionCommitId = () =>
 
 // AWU commit priorities — lower number is consumed first.
 // Seat allocations are consumed before purchased top-ups.
-export const AWU_PRIORITY_SEAT_ALLOCATION = 200;
+export const AWU_PRIORITY_SEAT_ALLOCATION = 0;
+// Free-seat per-user credits are a non-seat-based credit (created via
+// `add_credits` with a `user_id` specifier, not a SEAT_BASED subscription).
+// Metronome forbids a non-seat-based commit/credit from being prioritized over
+// a seat-based one, so this MUST be strictly greater than
+// `AWU_PRIORITY_SEAT_ALLOCATION`. Kept below `AWU_PRIORITY_PURCHASED_COMMIT` so
+// a free user's free allowance is consumed before any purchased top-up.
+export const AWU_PRIORITY_FREE_SEAT_CREDIT = 100;
 export const AWU_PRIORITY_PURCHASED_COMMIT = 300;
+
+// Per-seat AWU grant for free seats. Granted once per seat as a per-user
+// contract credit at seat-assignment time (see `grantFreeSeatCredits`) rather
+// than via a recurring credit, so this constant is also the authoritative
+// source for the free seat's displayed allowance (see
+// `getAwuAllocationInfoForSeatType`).
+export const FREE_SEAT_LIFETIME_AWU_CREDITS = 300;
 
 // Seat commit/credit priorities
 export const SEAT_PRIORITY_SUBSCRIPTION_COMMIT = 300;

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -11,7 +11,10 @@
 // reconcile module back.
 
 import { getMetronomeDefaultUserCapAlertForSeatType } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import {
+  listContractPerUserCreditBalances,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
@@ -82,24 +85,45 @@ export async function fetchLiveUserCreditInputs({
   metronomeContractId: string | null;
 }): Promise<Result<LiveUserCreditInputs, Error>> {
   // Live per-user seat balance (the seat↔pool dimension's source of truth).
+  // Pro/max read their SEAT_BASED seat balance; free seats hold a per-user
+  // contract credit instead (not a seat balance), so read that.
   let seatBalanceAwu: number | null = null;
   let seatStartingBalanceAwu: number | null = null;
   if (metronomeContractId) {
-    const seatBalancesResult = await listMetronomeSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (seatBalancesResult.isErr()) {
-      return new Err(
-        new Error(
-          `Failed to read seat balances: ${seatBalancesResult.error.message}`
-        )
-      );
-    }
-    const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
-    if (seat) {
-      seatBalanceAwu = seat.balanceAwu;
-      seatStartingBalanceAwu = seat.startingBalanceAwu;
+    if (seatType === "free") {
+      const creditBalancesResult = await listContractPerUserCreditBalances({
+        metronomeCustomerId,
+        metronomeContractId,
+      });
+      if (creditBalancesResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to read per-user credit balances: ${creditBalancesResult.error.message}`
+          )
+        );
+      }
+      const credit = creditBalancesResult.value.get(userId);
+      if (credit) {
+        seatBalanceAwu = credit.balanceAwu;
+        seatStartingBalanceAwu = credit.startingBalanceAwu;
+      }
+    } else {
+      const seatBalancesResult = await listMetronomeSeatBalances({
+        metronomeCustomerId,
+        metronomeContractId,
+      });
+      if (seatBalancesResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to read seat balances: ${seatBalancesResult.error.message}`
+          )
+        );
+      }
+      const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
+      if (seat) {
+        seatBalanceAwu = seat.balanceAwu;
+        seatStartingBalanceAwu = seat.startingBalanceAwu;
+      }
     }
   }
 

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -1,5 +1,8 @@
 import { listMetronomeProducts } from "@app/lib/metronome/client";
-import { SEAT_TYPE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import {
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  SEAT_TYPE_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
@@ -381,6 +384,15 @@ export function getAwuAllocationInfoForSeatType(
   if (!subscription?.id) {
     return { credits: 0, period: "monthly" };
   }
+
+  // Free seats no longer carry a recurring credit — their AWU grant is created
+  // as a per-user contract credit at seat-assignment time (see
+  // `grantFreeSeatCredits`). The allowance is therefore a code constant rather
+  // than something discoverable on the contract's `recurring_credits`.
+  if (seatType === "free") {
+    return { credits: FREE_SEAT_LIFETIME_AWU_CREDITS, period: "lifetime" };
+  }
+
   const credit = (contract.recurring_credits ?? []).find(
     (c) => c.subscription_config?.subscription_id === subscription.id
   );

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1,10 +1,24 @@
 import {
+  clearPerUserCreditBalanceAlerts,
+  upsertPerUserCreditBalanceAlerts,
+} from "@app/lib/metronome/alerts/per_user_credit_balance";
+import {
+  addPerUserCreditToContract,
+  archiveContractCredit,
   getMetronomeContractById,
   getMetronomeSubscriptionAssignedSeatIds,
   getMetronomeSubscriptionSeatState,
+  listContractPerUserCreditBalances,
+  listContractPerUserCreditUserIds,
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
+import {
+  AWU_PRIORITY_FREE_SEAT_CREDIT,
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  getCreditTypeAwuId,
+  getProductSeatSubscriptionCreditsId,
+} from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
@@ -14,6 +28,10 @@ import {
   getSeatTypeForSubscription,
   isMauContract,
 } from "@app/lib/metronome/seat_types";
+import {
+  FREE_SEAT_CREDIT_NAME,
+  USAGE_TAG,
+} from "@app/lib/metronome/setup_common";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -30,6 +48,7 @@ import { isMembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
+import { addYears } from "date-fns";
 
 /**
  * Returns true if the contract is seat-billed (any subscription should be
@@ -423,6 +442,187 @@ export async function remapMembershipSeatTypesForContract({
  * - contract provisioning after creation or migration
  * - admin-driven seat-type changes (via `updateMembershipSeatAndTrack`)
  */
+// The free seat AWU grant is anchored on per-seat first-appearance, not on a
+// recurring schedule: a recurring INDIVIDUAL credit either refills every period
+// or closes its issuance window, so it can't grant "once per seat, ever,
+// whenever the seat is assigned". Instead we grant a standalone contract credit
+// scoped to the user via a `user_id` presentation specifier, idempotent on
+// (workspaceId, userId), valid for one year from the grant.
+//
+// `syncSeatCount` runs on every membership change and reconciles full state, so
+// it calls this for ALL currently-free users on each sync. We first list the
+// contract's existing per-user credits and skip users already granted — so a
+// steady-state sync makes a single read instead of one edit call per free user.
+// The grant's `uniqueness_key` still guards against double-granting on the race
+// between the read and a concurrent sync (a 409 returns `Ok(null)`). Listing
+// includes expired/archived credits so a lapsed grant is not re-issued. This
+// self-heals a grant that failed on a previous sync — a delta-only grant could
+// miss a user permanently once their seat is assigned. Best-effort: a failure
+// is logged but never fails (and retries) the seat reconciliation.
+async function grantFreeSeatCredits({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+  userSIds,
+  startingAt,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+  userSIds: string[];
+  startingAt: Date;
+}): Promise<void> {
+  if (userSIds.length === 0) {
+    return;
+  }
+
+  // Skip users that already have a credit. On a read failure we fall back to
+  // attempting every user — the grant is still idempotent via its uniqueness
+  // key, so we never double-grant, only make redundant (no-op) edit calls.
+  const alreadyGranted = await listContractPerUserCreditUserIds({
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+    creditName: FREE_SEAT_CREDIT_NAME,
+  });
+  if (alreadyGranted.isErr()) {
+    logger.warn(
+      { workspaceId, contractId, error: alreadyGranted.error },
+      "[Metronome] Could not list existing free seat credits; attempting all grants (idempotent)"
+    );
+  }
+  const grantedUserIds = alreadyGranted.isOk()
+    ? alreadyGranted.value
+    : new Set<string>();
+  const toGrant = userSIds.filter((userId) => !grantedUserIds.has(userId));
+
+  // Grant the credit only for users that don't have one yet.
+  await concurrentExecutor(
+    toGrant,
+    async (userId) => {
+      const result = await addPerUserCreditToContract({
+        metronomeCustomerId,
+        metronomeContractId: contractId,
+        productId: getProductSeatSubscriptionCreditsId(),
+        creditTypeId: getCreditTypeAwuId(),
+        amount: FREE_SEAT_LIFETIME_AWU_CREDITS,
+        userId,
+        productTags: [USAGE_TAG],
+        startingAt,
+        endingBefore: addYears(startingAt, 1),
+        name: FREE_SEAT_CREDIT_NAME,
+        priority: AWU_PRIORITY_FREE_SEAT_CREDIT,
+        // Scope the key to the contract, not just the workspace+user: each
+        // contract holds its own credit, so a switch-contract must be able to
+        // grant a fresh credit on the new contract. A workspace+user key would
+        // collide with the prior contract's grant and 422.
+        uniquenessKey: `free-seat-credit:${contractId}:${userId}`,
+      });
+      if (result.isErr()) {
+        logger.error(
+          { workspaceId, contractId, userId, error: result.error },
+          "[Metronome] Failed to grant free seat credit"
+        );
+      }
+    },
+    { concurrency: 4 }
+  );
+
+  // Ensure the per-user credit-balance alerts for EVERY current free user, not
+  // just the ones granted above — they drive each user's low-balance / capped
+  // transitions as they deplete the credit (the seat-balance alert can't, since
+  // this isn't a seat balance). Idempotent upsert run each sync, so users
+  // granted before this existed are backfilled. Best-effort: a failure is
+  // logged and retried next sync.
+  await concurrentExecutor(
+    userSIds,
+    async (userId) => {
+      const alertResult = await upsertPerUserCreditBalanceAlerts({
+        metronomeCustomerId,
+        workspaceId,
+        userId,
+        allowanceAwu: FREE_SEAT_LIFETIME_AWU_CREDITS,
+      });
+      if (alertResult.isErr()) {
+        logger.error(
+          { workspaceId, contractId, userId, error: alertResult.error },
+          "[Metronome] Failed to upsert per-user free credit alerts"
+        );
+      }
+    },
+    { concurrency: 4 }
+  );
+}
+
+// Revoke free-seat credits for users who once had one but are no longer on a
+// free seat (e.g. upgraded to pro): archive the now-stale credit so it stops
+// drawing against their usage, and drop its low/empty alerts. The grant's
+// uniqueness key is left untouched (archive is a separate edit), so the user can
+// never re-claim a free credit on this contract. Best-effort; runs each sync.
+async function revokeFreeSeatCreditsForExFreeUsers({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+  currentFreeUserIds,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+  currentFreeUserIds: Set<string>;
+}): Promise<void> {
+  const activeCreditsResult = await listContractPerUserCreditBalances({
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+  });
+  if (activeCreditsResult.isErr()) {
+    logger.warn(
+      { workspaceId, contractId, error: activeCreditsResult.error },
+      "[Metronome] Could not list per-user credits to revoke; skipping"
+    );
+    return;
+  }
+  const toRevoke = [...activeCreditsResult.value.entries()].filter(
+    ([userId]) => !currentFreeUserIds.has(userId)
+  );
+  if (toRevoke.length === 0) {
+    return;
+  }
+
+  await concurrentExecutor(
+    toRevoke,
+    async ([userId, { creditId }]) => {
+      const archiveResult = await archiveContractCredit({
+        metronomeCustomerId,
+        metronomeContractId: contractId,
+        creditId,
+      });
+      if (archiveResult.isErr()) {
+        logger.error(
+          {
+            workspaceId,
+            contractId,
+            userId,
+            creditId,
+            error: archiveResult.error,
+          },
+          "[Metronome] Failed to archive ex-free-seat credit"
+        );
+      }
+      const clearResult = await clearPerUserCreditBalanceAlerts({
+        metronomeCustomerId,
+        workspaceId,
+        userId,
+      });
+      if (clearResult.isErr()) {
+        logger.error(
+          { workspaceId, contractId, userId, error: clearResult.error },
+          "[Metronome] Failed to clear ex-free-seat credit alerts"
+        );
+      }
+    },
+    { concurrency: 4 }
+  );
+}
+
 export async function syncSeatCount({
   metronomeCustomerId,
   contractId,
@@ -664,6 +864,28 @@ export async function syncSeatCount({
         didMutateSeatData = true;
       }
     }
+
+    // Per-user AWU grant/revoke for free members. Driven off DB membership
+    // state (`desiredSIdsAt`), NOT off a Metronome free-seat subscription: free
+    // seats are never billed and may not be an entitled SEAT_BASED subscription
+    // on the contract, so this runs independently of the seat-subscription loop
+    // above. Best-effort and idempotent. Grant deduped by the grant's uniqueness
+    // key; revoke archives the credit + drops alerts for users who left the free
+    // seat (the uniqueness key stays claimed, so they can't re-claim).
+    const currentFreeUserIds = new Set(desiredSIdsAt("free", baseMs));
+    await grantFreeSeatCredits({
+      metronomeCustomerId,
+      contractId,
+      workspaceId: workspace.sId,
+      userSIds: [...currentFreeUserIds],
+      startingAt: new Date(baseMs),
+    });
+    await revokeFreeSeatCreditsForExFreeUsers({
+      metronomeCustomerId,
+      contractId,
+      workspaceId: workspace.sId,
+      currentFreeUserIds,
+    });
 
     return new Ok(undefined);
   } finally {

--- a/front/lib/metronome/setup_common.ts
+++ b/front/lib/metronome/setup_common.ts
@@ -129,14 +129,24 @@ export interface RecurringCreditDef {
   }>;
   recurrence_frequency?: "MONTHLY" | "QUARTERLY" | "ANNUAL" | "WEEKLY";
   // Optional. Offset relative to the recurring credit start that determines
-  // when the contract will stop creating recurring commits. Use a very small
-  // value (e.g. 1 day) to make the credit one-shot — Metronome fires the
-  // first commit on contract start, then the duration expires before the
-  // next would be issued.
+  // when the contract will stop creating recurring commits. Set the duration to
+  // exactly one recurrence period (e.g. 1 year for an ANNUAL credit) to make the
+  // credit one-shot: Metronome fires the first commit on contract start, and the
+  // schedule closes before the next occurrence would be issued.
+  //
+  // A duration SHORTER than the recurrence period also stops recurrence, but
+  // prorates the single commit down to the duration's fraction of the period
+  // (e.g. ANNUAL + 1 DAY granted 1/365 of the amount). Pair a sub-period
+  // duration with `proration: "NONE"` if you need the full amount.
   duration?: {
     unit: "DAYS" | "WEEKS" | "MONTHS" | "YEARS";
     value: number;
   };
+  // Whether the first and/or last commit is prorated by time. Metronome
+  // defaults to "FIRST_AND_LAST" when omitted, which prorates the first commit
+  // to its share of the recurrence period — set "NONE" to grant the full
+  // `access_amount` on a one-shot credit.
+  proration?: "NONE" | "FIRST" | "LAST" | "FIRST_AND_LAST";
   name?: string;
   // Attach the credit to a SEAT_BASED subscription so each seat gets its own
   // allocation (INDIVIDUAL) or all seats share one pool (POOLED).

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -18,7 +18,6 @@ import {
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {
   BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
-  FREE_SEAT_CREDIT_NAME,
   FREE_SEAT_PRODUCT_NAME,
   getCreditTypeAwuId,
   getFreeExcessRecurringCredits,
@@ -50,10 +49,6 @@ import {
 // so these values aren't referenced anywhere else.
 export const PRO_SEAT_MONTHLY_AWU_CREDITS = 8000;
 export const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
-// Per-seat AWU grant carried by the Free Seat subscription. Granted once
-// per seat on contract start and valid for the lifetime of the contract.
-// Never refilled.
-const FREE_SEAT_LIFETIME_AWU_CREDITS = 300;
 
 export const NEW_METRICS: MetricDef[] = [
   // Tool invocation metric — counts tool uses, group keys cover both user and
@@ -400,38 +395,6 @@ const ALL_SEAT_SUBSCRIPTIONS: PackageSubscription[] = [
   FREE_SEAT_SUBSCRIPTION,
 ];
 
-// Per-seat INDIVIDUAL AWU credit attached to the Free Seat SEAT_BASED
-// subscription. Issued exactly once per seat:
-//   - `duration: { value: 1, unit: "DAYS" }` stops the recurrence after the
-//     first commit (which fires on contract start / seat assignment), so the
-//     credit is never re-issued.
-//   - `commit_duration: { value: 100, unit: "YEARS" }`... not supported by
-//     Metronome (`PERIODS` only), so we approximate with 100 ANNUAL periods
-//     — effectively the lifetime of any reasonable contract.
-//   - Not prorated on seat increase: a new free seat always gets the full
-//     300 AWU grant regardless of when in the period it was added.
-function getFreeSeatLifetimeAwuCredits(): RecurringCreditDef {
-  return {
-    product_name: "Seat Individual Credits",
-    access_amount: {
-      credit_type_id: getCreditTypeAwuId(),
-      unit_price: FREE_SEAT_LIFETIME_AWU_CREDITS,
-    },
-    commit_duration: { value: 100, unit: "PERIODS" },
-    priority: 200,
-    starting_at_offset: { unit: "DAYS", value: 0 },
-    applicable_product_tags: [USAGE_TAG],
-    recurrence_frequency: "ANNUAL",
-    duration: { value: 1, unit: "DAYS" },
-    name: FREE_SEAT_CREDIT_NAME,
-    subscription_config: {
-      subscription_temporary_id: FREE_SEAT_SUBSCRIPTION.temporary_id,
-      allocation: "INDIVIDUAL",
-      apply_seat_increase_config: { is_prorated: false },
-    },
-  };
-}
-
 // Per-seat INDIVIDUAL AWU credits for both the monthly and annual subscription
 // of a seat pair (same per-seat allocation regardless of billing frequency).
 function buildPerSeatCredits(
@@ -450,9 +413,10 @@ function buildPerSeatCredits(
 
 // Full recurring-credit set tied to the seat subscriptions above, carried by
 // every non-legacy package: per-seat INDIVIDUAL AWU allocations for each Pro /
-// Max seat (monthly + annual), the one-shot Free Seat lifetime grant, and the
-// AWU excess credit. A credit attached to a dormant seat never materializes (the
-// subscription has no seats).
+// Max seat (monthly + annual) and the AWU excess credit. A credit attached to a
+// dormant seat never materializes (the subscription has no seats). Free seats
+// get their AWU grant from a per-user contract credit created at seat-assignment
+// time (see `grantFreeSeatCredits`), not from a recurring credit here.
 function getAllSeatRecurringCredits(): RecurringCreditDef[] {
   return [
     ...buildPerSeatCredits(
@@ -465,7 +429,6 @@ function getAllSeatRecurringCredits(): RecurringCreditDef[] {
       MAX_SEAT_MONTHLY_AWU_CREDITS,
       MAX_SEAT_CREDIT_NAME
     ),
-    getFreeSeatLifetimeAwuCredits(),
     getFreeExcessRecurringCredits(
       getCreditTypeAwuId(),
       DEFAULT_AWU_EXCESS_RECURRING_AMOUNT

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -291,8 +291,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "free" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "free", poolLimitAwuCredits: 0 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -313,8 +313,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat_low_balance", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "free" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "free", poolLimitAwuCredits: 0 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -335,8 +335,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
-      { ...baseCtx, seatType: "pro" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: 5000 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -357,8 +357,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: null }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -379,8 +379,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 0 },
-      { ...baseCtx, seatType: "pro" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: 0 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -401,8 +401,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat_low_balance", "max");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "max" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "max", poolLimitAwuCredits: null }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -430,8 +430,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0,
+        poolLimitAwuCredits: 5000,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -448,8 +453,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat_low_balance", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0,
+        poolLimitAwuCredits: 5000,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -466,8 +476,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.1 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.1,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -484,8 +499,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.19 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.19,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -502,8 +522,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.2 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.2,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -520,8 +545,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.5 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.5,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -538,8 +568,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: null }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: null,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -551,13 +586,18 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
   });
 
-  // Guard 1 (free seat) takes precedence regardless of percentage.
-  it("user_seat + free + 50% cap remaining → capped (free-seat guard wins)", async () => {
+  // Pool limit 0 (free has no pool) → capped, regardless of cap percentage.
+  it("user_seat + poolLimit 0 + 50% cap remaining → capped (no pool budget)", async () => {
     const membership = makeMembership("user_seat", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "free", remainingCapCreditsPercentage: 0.5 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "free",
+        remainingCapCreditsPercentage: 0.5,
+        poolLimitAwuCredits: 0,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -617,6 +657,21 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
     );
   });
 
+  it("user_seat + free seat → user_seat_low_balance (no threshold matching)", async () => {
+    const membership = makeMembership("user_seat", "free");
+    // The per-user free-credit alert is scoped to this user, so the free guard
+    // matches on seat type alone — the threshold value is not checked.
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_low_balance", threshold: 60 },
+      { ...baseCtx, seatType: "free" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat_low_balance");
+    }
+  });
+
   it("user_seat + max threshold + pro seat → no transition (guard mismatch)", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
@@ -652,6 +707,106 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
       "u_test",
       "user_seat_low_balance"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seat balance replenished
+// ---------------------------------------------------------------------------
+
+describe("UserCreditStateMachine — seat_balance_resolved", () => {
+  it("free capped → user_seat when the credit is fully replenished", async () => {
+    const membership = makeMembership("capped", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      {
+        ...baseCtx,
+        seatType: "free",
+        liveBalance: {
+          seatBalanceAwu: 300,
+          seatStartingBalanceAwu: 300,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+  });
+
+  it("free capped → user_seat_low_balance when only a low balance is left", async () => {
+    const membership = makeMembership("capped", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      {
+        ...baseCtx,
+        seatType: "free",
+        liveBalance: {
+          seatBalanceAwu: 40,
+          seatStartingBalanceAwu: 300,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat_low_balance");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "user_seat_low_balance",
+      undefined
+    );
+  });
+
+  it("pro user_seat_low_balance → user_seat on a full billing-period renewal", async () => {
+    const membership = makeMembership("user_seat_low_balance", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        liveBalance: {
+          seatBalanceAwu: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          seatStartingBalanceAwu: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+  });
+
+  it("free capped → user_seat without a live balance (default)", async () => {
+    const membership = makeMembership("capped", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      { ...baseCtx, seatType: "free" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+  });
+
+  it("workspace (pool-based) seat → no transition", async () => {
+    const membership = makeMembership("on_pool", "workspace");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      { ...baseCtx, seatType: "workspace" }
+    );
+    expect(result.isErr()).toBe(true);
+    expect(membership.updateCreditState).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -9,6 +9,7 @@ import type {
 import {
   CAP_WARNING_FRACTION,
   expectedUserCreditState,
+  isSeatBased,
   SEAT_LOW_BALANCE_FRACTION,
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
@@ -50,6 +51,14 @@ export type UserCreditContext = {
    * whether to land on `on_pool`, `on_pool_low_balance`, or `capped`.
    */
   remainingCapCreditsPercentage?: number | null;
+  /**
+   * The user's effective pool budget in AWU credits: `0` = no pool access
+   * (e.g. free seats), `> 0` = capped pool, `null` = unlimited. A property of
+   * the user's situation (like `remainingCapCreditsPercentage`), so it lives in
+   * the context — it's what the `seat_balance_exhausted` guards use to route
+   * `capped` vs `on_pool`, with no seat-type special-casing.
+   */
+  poolLimitAwuCredits?: number | null;
 };
 
 export type UserCreditEvent =
@@ -67,13 +76,12 @@ export type UserCreditEvent =
    */
   | { type: "admin_raised_user_cap" }
   /**
-   * This user's personal seat balance is exhausted. The user's effective pool
-   * limit determines the next state:
-   *   - free seats → always `capped` (no pool access)
-   *   - paid seats with `poolLimitAwuCredits === 0` → `capped`
-   *   - paid seats with `poolLimitAwuCredits > 0` or `null` (unlimited) → `on_pool`
+   * This user's personal seat balance is exhausted. The next state is decided
+   * by `ctx.poolLimitAwuCredits`:
+   *   - `0` (no pool access, e.g. free seats) → `capped`
+   *   - `> 0` or `null` (unlimited) → `on_pool` (band depends on cap usage)
    */
-  | { type: "seat_balance_exhausted"; poolLimitAwuCredits: number | null }
+  | { type: "seat_balance_exhausted" }
   /**
    * This user's personal seat balance crossed a low-balance warning threshold
    * (balance > 0). Moves `user_seat` → `user_seat_low_balance`.
@@ -109,12 +117,14 @@ type UserCreditTransition = {
   to: UserCreditState;
 };
 
-// Seat↔pool band a user should land in when their per-user cap resolves,
-// derived from the live balance snapshot carried in the context. Used by the
-// guards on the `per_user_cap_resolved` transitions below (mirroring how the
-// `seat_balance_exhausted` guards branch on seat type / pool limit). Without a
-// snapshot we can't distinguish seat from pool, so default to the pool.
-function targetAfterCapResolved(ctx: UserCreditContext): UserCreditState {
+// Seat↔pool band a user should land in once a blocking dimension clears (a
+// per-user cap resolving, or a seat balance replenishing), derived from the
+// live balance snapshot carried in the context. Used by the guards on the
+// `per_user_cap_resolved` / `seat_balance_resolved` transitions below
+// (mirroring how the `seat_balance_exhausted` guards branch on seat type / pool
+// limit). Without a snapshot we can't distinguish seat from pool, so default to
+// the pool.
+function targetBandFromLiveBalance(ctx: UserCreditContext): UserCreditState {
   if (!ctx.liveBalance) {
     return "on_pool";
   }
@@ -157,7 +167,7 @@ const TRANSITIONS: UserCreditTransition[] = [
       "capped",
     ],
     event: "per_user_cap_resolved",
-    guard: (ctx) => targetAfterCapResolved(ctx) === "user_seat",
+    guard: (ctx) => targetBandFromLiveBalance(ctx) === "user_seat",
     to: "user_seat",
   },
   {
@@ -169,7 +179,7 @@ const TRANSITIONS: UserCreditTransition[] = [
       "capped",
     ],
     event: "per_user_cap_resolved",
-    guard: (ctx) => targetAfterCapResolved(ctx) === "user_seat_low_balance",
+    guard: (ctx) => targetBandFromLiveBalance(ctx) === "user_seat_low_balance",
     to: "user_seat_low_balance",
   },
   {
@@ -181,7 +191,7 @@ const TRANSITIONS: UserCreditTransition[] = [
       "capped",
     ],
     event: "per_user_cap_resolved",
-    guard: (ctx) => targetAfterCapResolved(ctx) === "on_pool_low_balance",
+    guard: (ctx) => targetBandFromLiveBalance(ctx) === "on_pool_low_balance",
     to: "on_pool_low_balance",
   },
   {
@@ -195,43 +205,32 @@ const TRANSITIONS: UserCreditTransition[] = [
     event: "per_user_cap_resolved",
     to: "on_pool",
   },
-  // Seat balance exhausted. Order matters: most specific guard first.
-  //  1. Free seats → always capped (no pool access).
+  // Seat balance exhausted. Routing is driven by `ctx.poolLimitAwuCredits`, not
+  // the seat type — a no-pool seat (free) simply has poolLimit 0. Order matters:
+  // most specific guard first.
+  //  1. No pool budget (poolLimit 0, incl. free) or per-user cap also exhausted
+  //     → capped.
   {
     from: ["user_seat", "user_seat_low_balance", "capped"],
     event: "seat_balance_exhausted",
-    guard: (ctx) => ctx.seatType === "free",
+    guard: (ctx) =>
+      ctx.poolLimitAwuCredits === 0 || ctx.remainingCapCreditsPercentage === 0,
     to: "capped",
   },
-  // 2. Paid seats whose per-user cap is also exhausted (0 % remaining) or with pool limit = 0 → capped (no pool budget).
-  {
-    from: ["user_seat", "user_seat_low_balance", "capped"],
-    event: "seat_balance_exhausted",
-    guard: (ctx, event) =>
-      ctx.seatType !== "free" &&
-      event.type === "seat_balance_exhausted" &&
-      (event.poolLimitAwuCredits === 0 ||
-        ctx.remainingCapCreditsPercentage === 0),
-    to: "capped",
-  },
-  // 3. Paid seats with < 20 % of cap remaining → on_pool_low_balance.
+  //  2. Pool budget left but < 20 % of cap remaining → on_pool_low_balance.
   {
     from: ["user_seat", "user_seat_low_balance"],
     event: "seat_balance_exhausted",
     guard: (ctx) =>
-      ctx.seatType !== "free" &&
       ctx.remainingCapCreditsPercentage != null &&
       ctx.remainingCapCreditsPercentage < 1 - CAP_WARNING_FRACTION,
     to: "on_pool_low_balance",
   },
-  // 4. Paid seats with ≥ 20 % of cap remaining, with pool limit > 0 or null (unlimited) → on_pool
+  //  3. Pool budget left (poolLimit > 0 or null/unlimited) → on_pool.
   {
     from: ["user_seat", "user_seat_low_balance", "on_pool"],
     event: "seat_balance_exhausted",
-    guard: (ctx, event) =>
-      ctx.seatType !== "free" &&
-      event.type === "seat_balance_exhausted" &&
-      event.poolLimitAwuCredits !== 0,
+    guard: (ctx) => ctx.poolLimitAwuCredits !== 0,
     to: "on_pool",
   },
 
@@ -256,6 +255,16 @@ const TRANSITIONS: UserCreditTransition[] = [
       (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
     to: "user_seat_low_balance",
   },
+  // Free seats: the per-user credit-balance alert is scoped to this one user
+  // (not a workspace-wide fan-out), so it's always relevant — no threshold
+  // disambiguation needed. Match on seat type alone, with no hardcoded
+  // threshold value.
+  {
+    from: ["user_seat", "user_seat_low_balance"],
+    event: "seat_low_balance",
+    guard: (ctx) => ctx.seatType === "free",
+    to: "user_seat_low_balance",
+  },
 
   // Per-user cap 80% warning: move on_pool → on_pool_low_balance.
   {
@@ -271,22 +280,37 @@ const TRANSITIONS: UserCreditTransition[] = [
     to: "on_pool",
   },
 
-  // Billing-period renewal for pro/max seats: reset to user_seat regardless
-  // of current state. Workspace seats are reset by per_user_cap_resolved;
-  // free seats are not reset.
+  // Seat balance replenished — for pro/max a billing-period renewal, for free a
+  // fresh credit clearing its low/empty alert. Reset any seat-based user
+  // (pro/max/free) from any state, including `capped` (a free seat exhausted to
+  // 0 is `capped`, so it must be reachable here). The live balance decides the
+  // band: a partial refill that's still under the low-balance threshold lands
+  // in `user_seat_low_balance`, otherwise `user_seat`. Workspace (pool-based)
+  // seats have no seat balance and are reset by per_user_cap_resolved instead.
   {
     from: [
       "user_seat",
       "user_seat_low_balance",
       "on_pool",
       "on_pool_low_balance",
+      "capped",
     ],
     event: "seat_balance_resolved",
     guard: (ctx) =>
-      ctx.seatType === "pro" ||
-      ctx.seatType === "pro_yearly" ||
-      ctx.seatType === "max" ||
-      ctx.seatType === "max_yearly",
+      isSeatBased(ctx.seatType) &&
+      targetBandFromLiveBalance(ctx) === "user_seat_low_balance",
+    to: "user_seat_low_balance",
+  },
+  {
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
+    event: "seat_balance_resolved",
+    guard: (ctx) => isSeatBased(ctx.seatType),
     to: "user_seat",
   },
 ];

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -21,6 +21,7 @@ import {
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
+  PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
@@ -862,6 +863,8 @@ interface ExistingPackage {
     starting_at_offset: { unit: string; value: number };
     applicable_product_tags?: string[];
     recurrence_frequency?: string;
+    duration?: { unit: string; value: number };
+    proration?: "NONE" | "FIRST" | "LAST" | "FIRST_AND_LAST";
     name?: string;
     // Metronome returns the resolved subscription identifier (post-create) plus
     // the allocation mode for credits attached to a SEAT_BASED subscription.
@@ -1119,6 +1122,29 @@ function packageMatches(ex: ExistingPackage, desired: PackageDef): boolean {
       );
       return false;
     }
+    if (
+      (match.duration?.unit ?? undefined) !==
+        (desiredCredit.duration?.unit ?? undefined) ||
+      (match.duration ? Number(match.duration.value) : undefined) !==
+        (desiredCredit.duration ? desiredCredit.duration.value : undefined)
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" duration ${match.duration?.unit}:${match.duration?.value} → ${desiredCredit.duration?.unit}:${desiredCredit.duration?.value}`
+      );
+      return false;
+    }
+    // Metronome defaults an unset proration to "FIRST_AND_LAST", so compare
+    // against that default on both sides to avoid a spurious diff (and to detect
+    // a credit still on the prorated default vs. our desired "NONE").
+    if (
+      (match.proration ?? "FIRST_AND_LAST") !==
+      (desiredCredit.proration ?? "FIRST_AND_LAST")
+    ) {
+      console.log(
+        `    [diff] ${desired.name}: recurring credit "${desiredCredit.name}" proration ${match.proration ?? "FIRST_AND_LAST"} → ${desiredCredit.proration ?? "FIRST_AND_LAST"}`
+      );
+      return false;
+    }
     // Compare subscription_config presence and allocation mode. We can't match
     // the subscription_id directly (the existing credit holds a resolved ID
     // while the desired def references a temporary_id), but the allocation mode
@@ -1323,6 +1349,7 @@ async function syncPackages(): Promise<void> {
                 ? { recurrence_frequency: credit.recurrence_frequency }
                 : {}),
               ...(credit.duration ? { duration: credit.duration } : {}),
+              ...(credit.proration ? { proration: credit.proration } : {}),
               ...(credit.name ? { name: credit.name } : {}),
               ...(subscriptionConfig
                 ? { subscription_config: subscriptionConfig }
@@ -1439,6 +1466,16 @@ const CUSTOM_FIELD_KEYS: Array<{
   {
     entity: "commit",
     key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  },
+  // Stamped per-instance on each free-seat per-user credit, carrying the seat's
+  // user sId (see `addPerUserCreditToContract`). Lets a per-user
+  // `low_remaining_contract_credit_balance_reached` alert filter on the
+  // custom field (the only filter a credit-balance alert supports — presentation
+  // specifiers can't be filtered) so it fires as each free user depletes their
+  // individual credit.
+  {
+    entity: "contract_credit",
+    key: PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
   },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in

--- a/front/types/memberships.test.ts
+++ b/front/types/memberships.test.ts
@@ -106,6 +106,20 @@ describe("expectedUserCreditState", () => {
     ).toBe("capped");
   });
 
+  it("free seat with unknown balance → user_seat (never on_pool)", () => {
+    // A free seat has no pool fallback, so an unknown (null) balance must not
+    // route to on_pool — it stays on the seat until the balance is known 0.
+    expect(
+      expectedUserCreditState({
+        seatType: "free",
+        seatBalanceAwu: null,
+        seatStartingBalanceAwu: null,
+        perUserCapAwuCredits: null,
+        consumedAwuCredits: null,
+      })
+    ).toBe("user_seat");
+  });
+
   it("pool-based (workspace) seat → on_pool (no personal seat balance)", () => {
     expect(
       expectedUserCreditState({

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -256,12 +256,19 @@ export function initialCreditStateForSeatType(
  *     they are seat-based but have no pool fallback, so an exhausted free seat
  *     is `capped`.
  *
- * `seatBalanceAwu` / `seatStartingBalanceAwu` come from the live Metronome
- * per-seat balance (`listMetronomeSeatBalances`); `null` means the user has no
- * individual seat allocation (pool-based seat), so they are treated as
- * spending from the pool. `perUserCapAwuCredits` / `consumedAwuCredits` are
- * `null` when no cap is configured or usage is unknown, in which case the cap
- * bands are skipped.
+ * `seatBalanceAwu` / `seatStartingBalanceAwu` come from the live per-seat /
+ * per-user credit balance; `seatBalanceAwu > 0` means the user still holds
+ * personal credit. `perUserCapAwuCredits` / `consumedAwuCredits` are `null`
+ * when no cap is configured or usage is unknown, in which case the cap bands
+ * are skipped.
+ *
+ * Crucially, where a seat-based user goes once their personal credit is gone is
+ * decided by the SEAT TYPE, not by the balance value: a seat with no pool
+ * fallback (free) is never `on_pool` — it stays on its seat until the balance
+ * is known-exhausted (0), then `capped`. Seats with a pool fallback (pro/max)
+ * fall back to the workspace pool. A `null` (unknown) balance never downgrades
+ * a free user — only a known 0 does — so a transient read miss can't wrongly
+ * cap or pool them; the exhaustion alert is the authoritative capped trigger.
  */
 export function expectedUserCreditState({
   seatType,
@@ -283,28 +290,29 @@ export function expectedUserCreditState({
     return "capped";
   }
 
-  // Seat-based user (pro/max/free) with a known personal balance.
-  if (isSeatBased(seatType) && seatBalanceAwu !== null) {
-    if (seatBalanceAwu > 0) {
-      // Still spending personal credits.
-      if (
-        seatStartingBalanceAwu !== null &&
-        seatBalanceAwu <= SEAT_LOW_BALANCE_FRACTION * seatStartingBalanceAwu
-      ) {
-        return "user_seat_low_balance";
-      }
-      return "user_seat";
+  // Seat-based user still holding personal credit.
+  if (isSeatBased(seatType) && seatBalanceAwu !== null && seatBalanceAwu > 0) {
+    if (
+      seatStartingBalanceAwu !== null &&
+      seatBalanceAwu <= SEAT_LOW_BALANCE_FRACTION * seatStartingBalanceAwu
+    ) {
+      return "user_seat_low_balance";
     }
-    // Personal balance exhausted. Free seats have no pool fallback, so they are
-    // capped; pro/max fall through to the workspace-pool bands below.
-    if (normalizeToPoolLimitSeatType(seatType) === null) {
-      return "capped";
-    }
+    return "user_seat";
   }
 
-  // Otherwise spending from the workspace pool (pool-based seat, or pro/max
-  // whose personal balance is exhausted). Surface the 80% cap warning when
-  // applicable.
+  // Seats with no pool fallback (free) never spend from the pool: they stay on
+  // their personal seat until the balance is known-exhausted (0 → capped). An
+  // unknown (null) balance leaves them on the seat — never `on_pool`.
+  if (
+    isSeatBased(seatType) &&
+    normalizeToPoolLimitSeatType(seatType) === null
+  ) {
+    return seatBalanceAwu === 0 ? "capped" : "user_seat";
+  }
+
+  // Pool-backed seats (pro/max with depleted balance) and pool-based seats spend
+  // from the workspace pool. Surface the 80% cap warning when applicable.
   if (
     capKnown &&
     consumedAwuCredits >= CAP_WARNING_FRACTION * perUserCapAwuCredits


### PR DESCRIPTION
## Description

Fixes the per-seat AWU credit granted to **free** seats. The free-seat lifetime credit (`getFreeSeatLifetimeAwuCredits`) is meant to grant a one-shot **300 AWU** per seat, valid for the contract lifetime and never refilled. It was instead granting **≈0.82 AWU**, and seats assigned mid-contract got **0**.

Two stacked defects, both in how the recurring credit was configured:

1. **Proration (the 0.82).** Metronome defaults a recurring credit's `proration` to `FIRST_AND_LAST`, which prorates the first commit to its share of the recurrence period. Combined with `duration: { value: 1, unit: "DAYS" }` on an `ANNUAL` credit, the single commit was prorated to one day of the year → `300 × 1/365 ≈ 0.82`.
2. **Recurrence window (the 0).** `duration: 1 DAY` closes the recurrence schedule after the first day, so a seat assigned later in the contract has no active recurrence occurrence to grant into → 0 AWU.

Changes:

- **`setup_common.ts`** — add `proration?: "NONE" | "FIRST" | "LAST" | "FIRST_AND_LAST"` to `RecurringCreditDef` (previously not expressible, so always left to Metronome's `FIRST_AND_LAST` default), and document the sub-period-duration proration trap.
- **`setup_new_pricing.ts`** — `getFreeSeatLifetimeAwuCredits`:
  - `duration` `1 DAY` → **`1 YEAR`** (exactly one ANNUAL recurrence period: fires once on contract start, schedule closes before a second occurrence → no refill; the window stays open through year 1 so mid-period seat additions still grant).
  - add **`proration: "NONE"`** → grants the full 300 instead of the prorated 0.82.
  - `commit_duration` stays `100 PERIODS` so the granted balance remains valid ~100 years (it does **not** expire when the one-year recurrence window closes).
- **`metronome_setup.ts`** — thread `proration` into the package-create payload (it was being dropped), and add `duration` + `proration` to the package diff so re-running setup detects the change and recreates the credit. Metronome's unset default is treated as `FIRST_AND_LAST` on both sides to avoid spurious diffs.

Net result: a free seat assigned at contract start — or mid-period within the first contract year — gets the full 300 AWU, granted once, valid for the contract lifetime, never refilled.

## Tests

Validated manually against a Metronome sandbox contract:
- Before: free seat granted ≈0.82 AWU at contract start; pro→free mid-contract granted 0.
- The equivalent credit (proration `NONE`, ANNUAL recurrence, one-year recurrence window) was first created by hand in the Metronome dashboard and confirmed to grant the full 300 at contract start.
- This PR encodes that config into the setup defs so it is reproducible from `metronome_setup`.

`npx tsgo --noEmit` clean; `npm run format:changed` clean.

## Risk

Low. New-pricing seat plans have no real contracts yet, so recreating the free-seat credit via setup is low-risk. Pro/Max credits are untouched (they use a separate monthly recurring-credit builder). The `proration` field is additive and optional on `RecurringCreditDef`; the diff change is gated on the new fields and treats Metronome's unset default as `FIRST_AND_LAST`, so existing packages that don't set proration won't diff spuriously.

## Deploy Plan

1. Merge and deploy normally (code-only; no migration).
2. Re-run `metronome_setup` so the packages pick up the corrected free-seat credit. The package diff will report the `duration` / `proration` change and recreate the credit.
3. Existing test contracts still carry the old credit — re-provision them (or re-grant) to pick up the corrected 300 AWU.

### Known limitation

A seat assigned in **contract year 2+** falls outside the one-year recurrence window and would get 0. Acceptable for annual contracts. If multi-year contracts need it, a non-recurring per-seat commit construct would be required (follow-up).
