### PR TITLE
docs(sdks/js): fix AbortError detection in streaming example

### DIFF
--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -142,7 +142,7 @@ if (r.isErr()) {
       }
     }
   } catch (error) {
-    if (error instanceof Error && error.message.includes("AbortError")) {
+    if (error instanceof Error && error.name === "AbortError") {
       // Stream aborted
     } else {
       // Other error


### PR DESCRIPTION
## Summary

This updates the JavaScript SDK README streaming example to detect caller-initiated aborts through `error.name === "AbortError"` instead of matching the error message text.

## Why

`AbortError` is the DOMException/Error name used for aborts. Checking the error name is more robust than relying on message text, which can vary by runtime.

## Scope

Documentation/example only. No runtime code changes.