### PR TITLE
Sharepoint: new tool to rename files/folder

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -238,7 +238,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_comments": "never_ask",
     "list_drives": "never_ask",
     "list_file_permissions": "never_ask",
-    "rename_drive_item": "medium"
     "revoke_file_sharing": "medium",
     "search_files": "never_ask",
     "share_file": "medium",
@@ -368,6 +367,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "copy_file": "never_ask",
     "get_file_content": "never_ask",
     "list_drive_items": "never_ask",
+    "rename_drive_item": "medium",
     "search_drive_items": "never_ask",
     "search_in_files": "never_ask",
     "update_word_document": "high",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -238,6 +238,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_comments": "never_ask",
     "list_drives": "never_ask",
     "list_file_permissions": "never_ask",
+    "rename_drive_item": "medium"
     "revoke_file_sharing": "medium",
     "search_files": "never_ask",
     "share_file": "medium",

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -211,6 +211,31 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
       done: "Upload file to OneDrive/SharePoint",
     },
   },
+  rename_drive_item: {
+    description:
+      "Rename a file or folder in OneDrive or SharePoint. Uses driveId if provided, otherwise falls back to siteId.",
+    schema: {
+      itemId: z.string().describe("The ID of the file or folder to rename."),
+      driveId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the drive containing the item. Takes priority over siteId if provided."
+        ),
+      siteId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the SharePoint site containing the item. Used if driveId is not provided."
+        ),
+      name: z.string().describe("The new name for the file or folder."),
+    },
+    stake: "medium",
+    displayLabels: {
+      running: "Renaming OneDrive/SharePoint item",
+      done: "Rename OneDrive/SharePoint item",
+    },
+  },
   copy_file: {
     description:
       "Copy a file or folder to a new location in OneDrive or SharePoint.",

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -658,6 +658,47 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
+  rename_drive_item: async (
+    { itemId, driveId, siteId, name },
+    { authInfo }
+  ) => {
+    const client = await getGraphClient(authInfo);
+    if (!client) {
+      return new Err(
+        new MCPError("Failed to authenticate with Microsoft Graph")
+      );
+    }
+
+    try {
+      const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
+      const response = await client.api(endpoint).patch({ name });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              success: true,
+              message: "Item renamed successfully",
+              item: {
+                id: response.id,
+                name: response.name,
+                webUrl: response.webUrl,
+                lastModifiedDateTime: response.lastModifiedDateTime,
+              },
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      return new Err(
+        new MCPError(normalizeError(err).message || "Failed to rename item")
+      );
+    }
+  },
+
   copy_file: async (
     { itemId, driveId, siteId, parentReference, name },
     { authInfo }


### PR DESCRIPTION
## Description

Adds a new `rename_drive_item` tool to the Microsoft Drive MCP server, allowing agents to rename files and folders in OneDrive and SharePoint. The tool accepts an `itemId`, an optional `driveId` (takes priority) or `siteId` to resolve the correct drive endpoint via the existing `getDriveItemEndpoint` helper, and a `name` for the new item name. It issues a `PATCH` to the Microsoft Graph API and returns the updated item metadata. This rounds out the Microsoft Drive write toolset and directly unblocks nomenclature audit workflows (e.g. customers auditing and fixing file naming across SharePoint).

## Tests

Manual testing against OneDrive/SharePoint.

## Risk

Low — scoped to a new tool handler; no existing logic modified. Stake is set to `medium` (requires user confirmation).

## Deploy Plan

Deploy front.