### PR TITLE
 Auto-open file explorer panel when agent generates files

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -10,8 +10,8 @@ import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMe
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
-import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { useAutoOpenFilesPanel } from "@app/components/assistant/conversation/files_panel/useAutoOpenFilesPanel";
+import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import type {
   AgentMessageStateWithControlEvent,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -11,6 +11,7 @@ import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessag
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { useGenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { useAutoOpenFilesPanel } from "@app/components/assistant/conversation/files_panel/useAutoOpenFilesPanel";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import type {
   AgentMessageStateWithControlEvent,
@@ -1280,6 +1281,9 @@ function AgentMessageContent({
     agentMessage,
     isLastMessage,
   });
+
+  // Auto-open file explorer panel when regular generated files are available.
+  useAutoOpenFilesPanel({ agentMessage, isLastMessage });
 
   const blockedActionElement = blockedAction ? (
     <BlockedAction

--- a/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
+++ b/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
@@ -1,0 +1,48 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import { isInteractiveContentType } from "@app/types/files";
+import React from "react";
+
+interface UseAutoOpenFilesPanelProps {
+  isLastMessage: boolean;
+  agentMessage: AgentMessageWithStreaming;
+}
+
+/**
+ * Auto-opens the file explorer panel when the agent generates regular files
+ * (non-image, non-interactive-content) on the last message.
+ */
+export function useAutoOpenFilesPanel({
+  isLastMessage,
+  agentMessage,
+}: UseAutoOpenFilesPanelProps) {
+  const { openPanel, currentPanel } = useConversationSidePanelContext();
+
+  const hasAutoOpenedRef = React.useRef(false);
+
+  // Reset per message so a new message can trigger auto-open again.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+  React.useEffect(() => {
+    hasAutoOpenedRef.current = false;
+  }, [agentMessage.sId]);
+
+  const regularGeneratedFiles = React.useMemo(
+    () =>
+      agentMessage.generatedFiles.filter(
+        (file) => !file.hidden && !isInteractiveContentType(file.contentType)
+      ),
+    [agentMessage.generatedFiles]
+  );
+
+  React.useEffect(() => {
+    if (
+      regularGeneratedFiles.length > 0 &&
+      isLastMessage &&
+      !hasAutoOpenedRef.current &&
+      currentPanel !== "files"
+    ) {
+      hasAutoOpenedRef.current = true;
+      openPanel({ type: "files" });
+    }
+  }, [regularGeneratedFiles, isLastMessage, openPanel, currentPanel]);
+}

--- a/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
+++ b/front/components/assistant/conversation/files_panel/useAutoOpenFilesPanel.ts
@@ -18,13 +18,9 @@ export function useAutoOpenFilesPanel({
 }: UseAutoOpenFilesPanelProps) {
   const { openPanel, currentPanel } = useConversationSidePanelContext();
 
-  const hasAutoOpenedRef = React.useRef(false);
-
-  // Reset per message so a new message can trigger auto-open again.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  React.useEffect(() => {
-    hasAutoOpenedRef.current = false;
-  }, [agentMessage.sId]);
+  // Stores the sId of the last message that triggered auto-open, so the comparison itself encodes
+  // "already opened for this message" without a separate reset effect.
+  const autoOpenedForRef = React.useRef<string | null>(null);
 
   const regularGeneratedFiles = React.useMemo(
     () =>
@@ -38,11 +34,17 @@ export function useAutoOpenFilesPanel({
     if (
       regularGeneratedFiles.length > 0 &&
       isLastMessage &&
-      !hasAutoOpenedRef.current &&
+      autoOpenedForRef.current !== agentMessage.sId &&
       currentPanel !== "files"
     ) {
-      hasAutoOpenedRef.current = true;
+      autoOpenedForRef.current = agentMessage.sId;
       openPanel({ type: "files" });
     }
-  }, [regularGeneratedFiles, isLastMessage, openPanel, currentPanel]);
+  }, [
+    regularGeneratedFiles,
+    isLastMessage,
+    agentMessage.sId,
+    openPanel,
+    currentPanel,
+  ]);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/8295.

When an agent generates files (documents, images, etc.), the file explorer side panel now opens automatically, matching the existing behavior for interactive content (frames). The logic mirrors `useAutoOpenInteractiveContent`: it only triggers on the last message, opens once per message via a ref guard, and skips the open if the files panel is already visible to avoid toggling it closed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
