### PR TITLE
[front] Render the final agent message view on the server and let the client trust it

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -567,7 +567,7 @@ describe("useAgentMessageStream", () => {
     expect(currentMessage.content).toBe("");
   });
 
-  it("keeps the success payload content when only activity tokens streamed", () => {
+  it("applies the server-rendered content view at success", () => {
     let currentMessage = makeInitialMessageStreamState(
       makeLightAgentMessage({ content: null, chainOfThought: null })
     );
@@ -605,6 +605,8 @@ describe("useAgentMessageStream", () => {
     );
 
     act(() => {
+      // Some activity streamed live, but the final view is whatever the server
+      // renders and ships on the terminal event; the client trusts it.
       onEventCallback!(
         JSON.stringify({
           eventId: "1-0",
@@ -633,6 +635,17 @@ describe("useAgentMessageStream", () => {
               }),
               actions: [],
             },
+            contentView: {
+              content: "Here is the final answer from the model.",
+              chainOfThought: "I should inspect the tool results first.",
+              activitySteps: [
+                {
+                  type: "thinking",
+                  content: "I should inspect the tool results first.",
+                  id: "cot-0-0",
+                },
+              ],
+            },
           },
         })
       );
@@ -641,12 +654,15 @@ describe("useAgentMessageStream", () => {
     expect(currentMessage.content).toBe(
       "Here is the final answer from the model."
     );
+    expect(currentMessage.chainOfThought).toBe(
+      "I should inspect the tool results first."
+    );
     expect(currentMessage.streaming.agentState).toBe("done");
     expect(currentMessage.streaming.inlineActivitySteps).toEqual([
       {
         type: "thinking",
         content: "I should inspect the tool results first.",
-        id: expect.stringContaining("thinking-final-"),
+        id: "cot-0-0",
       },
     ]);
   });
@@ -878,7 +894,8 @@ describe("useAgentMessageStream", () => {
           },
         })
       );
-      // Retry 2 completes successfully.
+      // Retry 2 completes successfully; the terminal event carries the
+      // server-rendered view, which the client trusts for the final timeline.
       onEventCallback!(
         JSON.stringify({
           eventId: "3-0",
@@ -894,6 +911,17 @@ describe("useAgentMessageStream", () => {
               }),
               actions: [],
             },
+            contentView: {
+              content: null,
+              chainOfThought: "I need to search the web.",
+              activitySteps: [
+                {
+                  type: "thinking",
+                  content: "I need to search the web.",
+                  id: "cot-0-0",
+                },
+              ],
+            },
           },
         })
       );
@@ -901,12 +929,12 @@ describe("useAgentMessageStream", () => {
 
     // chainOfThought never went blank — no empty string between the two runs.
     expect(chainOfThoughtSnapshots).not.toContain("");
-    // appendThinkingStep deduplicates exact matches — only one thinking step.
+    // Final timeline comes from the server-rendered content view.
     expect(currentMessage.streaming.inlineActivitySteps).toEqual([
       {
         type: "thinking",
         content: "I need to search the web.",
-        id: expect.stringContaining("thinking-final-"),
+        id: "cot-0-0",
       },
     ]);
   });

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -802,54 +802,31 @@ export function useAgentMessageStream({
           isStreamTerminated.current = true;
           updateMessageThrottled.cancel();
           const messageSuccess = eventPayload.data;
-          // Flush any remaining CoT (but not content — the final text segment
-          // becomes the message body via the server's canonical message).
-          const cotAtSuccess = chainOfThought.current;
-          chainOfThought.current = "";
-          retryCoTBuffer.current = null;
-          // content.current tracks only the final text segment (intermediate
-          // segments were flushed to content steps). The server's full message
-          // includes ALL text, so we override with the tracked final segment.
-          // Only override when final answer tokens were actually streamed.
-          // Reasoning/activity-only streams still receive the canonical answer
-          // in the success payload; overriding those with the empty token
-          // buffer would hide the final generation until reload.
-          const finalSegment = content.current;
-          const hadStreamedTokens = lastClassification.current === "tokens";
-          lastClassification.current = null;
+          // Trust the server-rendered content view: it is computed from the
+          // same persisted step contents reload uses, so it matches reload
+          // exactly. If an older server omitted it during a deploy window, fall
+          // back to the server's full message (its content/chainOfThought) and
+          // keep the live-built steps; this self-heals on the next reload.
+          const contentView = messageSuccess.contentView;
           mapMessagesWithAutoScroll((m) => {
             if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
               return m;
             }
-            let steps = cotAtSuccess
-              ? appendThinkingStep(
-                  m.streaming.inlineActivitySteps,
-                  cotAtSuccess,
-                  `thinking-final-${Date.now()}`
-                )
-              : m.streaming.inlineActivitySteps;
-            // When no tokens streamed after the last tool call (e.g. the agent
-            // handed off or otherwise terminated right after a tool), the text
-            // we flushed as a content step at the last `tool_params` is also
-            // what the server keeps as the message body. Drop that trailing
-            // content step so the same text isn't rendered twice — aligning
-            // with `contentsToActivitySteps`, which is what runs after reload.
-            if (!hadStreamedTokens) {
-              for (let i = steps.length - 1; i >= 0; i--) {
-                if (steps[i].type === "content") {
-                  steps = [...steps.slice(0, i), ...steps.slice(i + 1)];
-                  break;
-                }
-              }
-            }
             return {
               ...m,
               ...getLightAgentMessageFromAgentMessage(messageSuccess.message),
-              ...(hadStreamedTokens ? { content: finalSegment || null } : {}),
+              ...(contentView
+                ? {
+                    content: contentView.content,
+                    chainOfThought: contentView.chainOfThought,
+                    activitySteps: contentView.activitySteps,
+                  }
+                : {}),
               streaming: {
                 ...m.streaming,
                 agentState: "done",
-                inlineActivitySteps: steps,
+                inlineActivitySteps:
+                  contentView?.activitySteps ?? m.streaming.inlineActivitySteps,
                 pendingToolCalls: [],
               },
             };

--- a/front/lib/api/assistant/activity_steps.test.ts
+++ b/front/lib/api/assistant/activity_steps.test.ts
@@ -1,0 +1,118 @@
+import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import { describe, expect, it } from "vitest";
+
+// Minimal, real (non-DeepSeek) agent configuration so the parser resolves the
+// standard <thinking>/<response> chain-of-thought delimiters. No DB needed:
+// `renderAgentMessageContentView` is pure.
+const agentConfiguration: LightAgentConfigurationType = {
+  id: 1,
+  versionCreatedAt: null,
+  sId: "agent_test",
+  version: 0,
+  versionAuthorId: null,
+  instructions: null,
+  model: {
+    providerId: "anthropic",
+    modelId: "claude-haiku-4-5-20251001",
+    temperature: 0,
+  },
+  status: "active",
+  scope: "visible",
+  userFavorite: false,
+  name: "Test Agent",
+  description: "Test Agent",
+  pictureUrl: "",
+  maxStepsPerRun: 8,
+  tags: [],
+  templateId: null,
+  requestedGroupIds: [],
+  requestedSpaceIds: [],
+  canRead: true,
+  canEdit: false,
+};
+
+function render(
+  contents: Array<{ step: number; content: AgentContentItemType }>
+) {
+  return renderAgentMessageContentView(
+    contents,
+    [],
+    agentConfiguration,
+    "msg_test"
+  );
+}
+
+describe("renderAgentMessageContentView", () => {
+  it("treats a single plain text content as the body, with no steps", async () => {
+    expect(
+      await render([
+        { step: 0, content: { type: "text_content", value: "Hello" } },
+      ])
+    ).toEqual({
+      content: "Hello",
+      chainOfThought: null,
+      activitySteps: [],
+    });
+  });
+
+  it("selects native reasoning as CoT and the last text as the body", async () => {
+    expect(
+      await render([
+        {
+          step: 0,
+          content: {
+            type: "reasoning",
+            value: {
+              reasoning: "Let me think",
+              metadata: "",
+              tokens: 0,
+              provider: "anthropic",
+            },
+          },
+        },
+        { step: 0, content: { type: "text_content", value: "The answer" } },
+      ])
+    ).toEqual({
+      content: "The answer",
+      chainOfThought: "Let me think",
+      activitySteps: [
+        { type: "thinking", content: "Let me think", id: "reasoning-0-0" },
+      ],
+    });
+  });
+
+  it("extracts CoT from <thinking> delimiters when there is no native reasoning", async () => {
+    expect(
+      await render([
+        {
+          step: 0,
+          content: {
+            type: "text_content",
+            value: "<thinking>pondering</thinking><response>Answer</response>",
+          },
+        },
+      ])
+    ).toEqual({
+      content: "Answer",
+      chainOfThought: "pondering\n",
+      activitySteps: [
+        { type: "thinking", content: "pondering\n", id: "cot-0-0" },
+      ],
+    });
+  });
+
+  it("turns an intermediate text into a content step and joins the body", async () => {
+    expect(
+      await render([
+        { step: 0, content: { type: "text_content", value: "first" } },
+        { step: 1, content: { type: "text_content", value: "second" } },
+      ])
+    ).toEqual({
+      content: "first\nsecond",
+      chainOfThought: null,
+      activitySteps: [{ type: "content", content: "first", id: "content-0-0" }],
+    });
+  });
+});

--- a/front/lib/api/assistant/activity_steps.ts
+++ b/front/lib/api/assistant/activity_steps.ts
@@ -3,7 +3,10 @@ import {
   getCoTDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentMessageContentView,
+  LightAgentConfigurationType,
+} from "@app/types/assistant/agent";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 import {
   isAgentFunctionCallContent,
@@ -37,19 +40,47 @@ export function getActionOneLineLabel(
   );
 }
 
+// Ensure at least one whitespace boundary between adjacent text fragments when
+// reconstructing content from step contents. If neither the previous fragment
+// ends with whitespace nor the next fragment starts with whitespace, insert a
+// single "\n" between them. This avoids words being concatenated across step
+// boundaries without altering content that already contains spacing.
+function interleaveConditionalNewlines(parts: string[]): string[] {
+  if (parts.length === 0) {
+    return [];
+  }
+  const out: string[] = [];
+  out.push(parts[0]);
+  for (let i = 1; i < parts.length; i++) {
+    const prev = parts[i - 1];
+    const curr = parts[i];
+    const prevLast = prev.length ? prev[prev.length - 1] : "";
+    const currFirst = curr.length ? curr[0] : "";
+    const prevEndsWs = /\s/.test(prevLast);
+    const currStartsWs = /\s/.test(currFirst);
+    if (!prevEndsWs && !currStartsWs) {
+      out.push("\n");
+    }
+    out.push(curr);
+  }
+  return out;
+}
+
 /**
- * Convert an agent message's contents array into a flat list of lightweight
- * activity steps suitable for the inline activity timeline.
+ * Compute the full display state of an agent message from its ordered contents:
+ * the answer body, the chain of thought, and the inline activity steps. This is
+ * the single source of truth for the body/steps boundary rule, shared by reload
+ * (server render) and the terminal streaming events (so live matches reload).
  *
- * This mirrors the parsing logic in AgentActionsPanel (side panel) but produces
- * `InlineActivityStep[]` with labels only — no full action objects.
+ * `activitySteps` mirrors the parsing logic in AgentActionsPanel (side panel)
+ * but produces `InlineActivityStep[]` with labels only — no full action objects.
  */
-export async function contentsToActivitySteps(
+export async function renderAgentMessageContentView(
   contents: Array<{ step: number; content: AgentContentItemType }>,
   actions: AgentMCPActionWithOutputType[],
   agentConfiguration: LightAgentConfigurationType,
   messageId: string
-): Promise<InlineActivityStep[]> {
+): Promise<AgentMessageContentView> {
   const actionsByCallId = new Map(actions.map((a) => [a.functionCallId, a]));
 
   // Find the last text_content index — that item stays as the message body
@@ -62,13 +93,13 @@ export async function contentsToActivitySteps(
     }
   }
 
-  const steps: InlineActivityStep[] = [];
+  const activitySteps: InlineActivityStep[] = [];
 
   for (const [index, c] of contents.entries()) {
     if (isAgentReasoningContent(c.content)) {
       const reasoning = c.content.value.reasoning;
       if (reasoning?.trim()) {
-        steps.push({
+        activitySteps.push({
           type: "thinking",
           content: reasoning,
           id: `reasoning-${c.step}-${index}`,
@@ -88,7 +119,7 @@ export async function contentsToActivitySteps(
       ]);
 
       if (parsedContent.chainOfThought?.trim()) {
-        steps.push({
+        activitySteps.push({
           type: "thinking",
           content: parsedContent.chainOfThought,
           id: `cot-${c.step}-${index}`,
@@ -98,7 +129,7 @@ export async function contentsToActivitySteps(
       // Create a content step for every intermediate text segment.
       // The last text_content stays as the message body and is not a step.
       if (index !== lastTextContentIndex && parsedContent.content?.trim()) {
-        steps.push({
+        activitySteps.push({
           type: "content",
           content: parsedContent.content,
           id: `content-${c.step}-${index}`,
@@ -112,7 +143,7 @@ export async function contentsToActivitySteps(
       const matchingAction = actionsByCallId.get(functionCallId);
 
       if (matchingAction) {
-        steps.push({
+        activitySteps.push({
           type: "action",
           label: getActionOneLineLabel(matchingAction),
           id: `action-${matchingAction.id}`,
@@ -124,5 +155,56 @@ export async function contentsToActivitySteps(
     }
   }
 
-  return steps;
+  const { content, chainOfThought } = await selectBodyAndChainOfThought(
+    contents,
+    agentConfiguration,
+    messageId
+  );
+
+  return { content, chainOfThought, activitySteps };
+}
+
+// Body = the last text fragment (final answer); chain of thought = native
+// reasoning when present, otherwise the parsed CoT from the text fragments.
+// This branching is preserved exactly from the previous reload implementation
+// (messages.ts) so live === reload.
+async function selectBodyAndChainOfThought(
+  contents: Array<{ step: number; content: AgentContentItemType }>,
+  agentConfiguration: LightAgentConfigurationType,
+  messageId: string
+): Promise<{ content: string | null; chainOfThought: string | null }> {
+  const reasoningValues: Array<string | undefined> = [];
+  const textValues: string[] = [];
+  for (const c of contents) {
+    if (isAgentReasoningContent(c.content)) {
+      reasoningValues.push(c.content.value.reasoning);
+    } else if (isAgentTextContent(c.content)) {
+      textValues.push(c.content.value);
+    }
+  }
+
+  const textFragments = interleaveConditionalNewlines(textValues);
+
+  if (reasoningValues.length > 0) {
+    return {
+      // For multiple steps outputting text content, we want to display only the
+      // last one as the final answer.
+      content:
+        textFragments.length > 0 ? textFragments[textFragments.length - 1] : "",
+      chainOfThought: reasoningValues
+        .filter((r): r is string => !!r)
+        .join("\n\n"),
+    };
+  }
+
+  const contentParser = new AgentMessageContentParser(
+    agentConfiguration,
+    messageId,
+    getCoTDelimitersConfiguration({ agentConfiguration })
+  );
+  const parsedContent = await contentParser.parseContents(textFragments);
+  return {
+    content: parsedContent.content,
+    chainOfThought: parsedContent.chainOfThought,
+  };
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,12 +1,8 @@
-import { contentsToActivitySteps } from "@app/lib/api/assistant/activity_steps";
+import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getMessagesReactions } from "@app/lib/api/assistant/reaction";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  AgentMessageContentParser,
-  getCoTDelimitersConfiguration,
-} from "@app/lib/llms/agent_message_content_parser";
 import {
   MentionModel,
   MessageModel,
@@ -21,10 +17,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentReasoningContentType,
-  AgentTextContentType,
-} from "@app/types/assistant/agent_message_content";
 import type {
   AgentMessageStatus,
   AgentMessageType,
@@ -155,32 +147,6 @@ export function getRichMentionsWithStatusForMessage(
         }
       })
   );
-}
-
-// Ensure at least one whitespace boundary between adjacent text fragments when
-// reconstructing content from step contents. If neither the previous fragment
-// ends with whitespace nor the next fragment starts with whitespace, insert a
-// single "\n" between them. This avoids words being concatenated across step
-// boundaries without altering content that already contains spacing.
-function interleaveConditionalNewlines(parts: string[]): string[] {
-  if (parts.length === 0) {
-    return [];
-  }
-  const out: string[] = [];
-  out.push(parts[0]);
-  for (let i = 1; i < parts.length; i++) {
-    const prev = parts[i - 1];
-    const curr = parts[i];
-    const prevLast = prev.length ? prev[prev.length - 1] : "";
-    const currFirst = curr.length ? curr[0] : "";
-    const prevEndsWs = /\s/.test(prevLast);
-    const currStartsWs = /\s/.test(currFirst);
-    if (!prevEndsWs && !currStartsWs) {
-      out.push("\n");
-    }
-    out.push(curr);
-  }
-  return out;
 }
 
 /**
@@ -753,59 +719,16 @@ async function renderSingleAgentMessage(
         content: sc.value,
       })) ?? [];
 
-  const textContents: Array<{
-    step: number;
-    content: AgentTextContentType;
-  }> = [];
-  for (const content of agentStepContents) {
-    if (content.content.type === "text_content") {
-      textContents.push({ step: content.step, content: content.content });
-    }
-  }
-
-  const reasoningContents: Array<{
-    step: number;
-    content: AgentReasoningContentType;
-  }> = [];
-  for (const content of agentStepContents) {
-    if (content.content.type === "reasoning") {
-      reasoningContents.push({
-        step: content.step,
-        content: content.content,
-      });
-    }
-  }
-
-  const { content, chainOfThought } = await (async () => {
-    const textFragments = interleaveConditionalNewlines(
-      textContents.map((c) => c.content.value)
+  // Single source of truth for the body, chain of thought, and activity steps:
+  // the body/steps boundary rule lives in `renderAgentMessageContentView` only. The
+  // terminal streaming events derive their display state from the same function.
+  const { content, chainOfThought, activitySteps } =
+    await renderAgentMessageContentView(
+      agentStepContents,
+      actions,
+      agentConfiguration,
+      message.sId
     );
-
-    if (reasoningContents.length > 0) {
-      return {
-        content:
-          // For mutliple steps outputing text content, we want to display only the last one as the final answer.
-          textFragments.length > 0
-            ? textFragments[textFragments.length - 1]
-            : "",
-        chainOfThought: reasoningContents
-          .map((sc) => sc.content.value.reasoning)
-          .filter((r) => !!r)
-          .join("\n\n"),
-      };
-    } else {
-      const contentParser = new AgentMessageContentParser(
-        agentConfiguration,
-        message.sId,
-        getCoTDelimitersConfiguration({ agentConfiguration })
-      );
-      const parsedContent = await contentParser.parseContents(textFragments);
-      return {
-        content: parsedContent.content,
-        chainOfThought: parsedContent.chainOfThought,
-      };
-    }
-  })();
 
   assert(message.parentId !== null, "Agent message must have a parentId.");
 
@@ -878,13 +801,6 @@ async function renderSingleAgentMessage(
   if (viewType === "full") {
     return new Ok(renderedMessage);
   }
-
-  const activitySteps = await contentsToActivitySteps(
-    agentStepContents,
-    actions,
-    agentConfiguration,
-    message.sId
-  );
 
   return new Ok({
     ...getLightAgentMessageFromAgentMessage(renderedMessage),

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,3 +1,4 @@
+import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
@@ -411,6 +412,12 @@ export async function updateResourceAndPublishEvent(
     conversation,
   });
 
+  // For terminal "succeeded" events, attach the fully-rendered content view
+  // (body, chain of thought, activity steps) computed from the persisted step
+  // contents — the same source reload uses. This lets the client trust it
+  // wholesale instead of reconciling its incrementally-built streaming view.
+  const eventToPublish = await withContentView(auth, event, agentMessage);
+
   // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;
   const flushIntervalMs =
@@ -422,11 +429,52 @@ export async function updateResourceAndPublishEvent(
 
   await globalCoalescer.handleEvent({
     conversationId: conversation.sId,
-    event,
+    event: eventToPublish,
     key,
     step,
     flushIntervalMs,
   });
+}
+
+// Enrich `agent_message_success` / `agent_message_gracefully_stopped` events with
+// the server-rendered content view. Reads the latest persisted step contents
+// (authoritative, identical to reload) so the rendered view never drifts from a
+// reload. Other event types pass through unchanged.
+async function withContentView(
+  auth: Authenticator,
+  event: AgentMessageEvents,
+  agentMessage: AgentMessageType
+): Promise<AgentMessageEvents> {
+  if (
+    event.type !== "agent_message_success" &&
+    event.type !== "agent_message_gracefully_stopped"
+  ) {
+    return event;
+  }
+
+  // Reads the latest persisted step contents (authoritative, identical to
+  // reload). A failure here throws and Temporal retries the activity, like the
+  // other DB operations in this publish path.
+  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+    auth,
+    {
+      agentMessageIds: [agentMessage.agentMessageId],
+      latestVersionsOnly: true,
+    }
+  );
+  const contents = stepContents.map((sc) => ({
+    step: sc.step,
+    content: sc.value,
+  }));
+
+  const contentView = await renderAgentMessageContentView(
+    contents,
+    agentMessage.actions,
+    agentMessage.configuration,
+    agentMessage.sId
+  );
+
+  return { ...event, contentView };
 }
 
 const DEFAULT_WORKFLOW_ERROR_MESSAGE =

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -9,7 +9,10 @@ import type {
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
-import type { AgentMessageType } from "@app/types/assistant/conversation";
+import type {
+  AgentMessageType,
+  InlineActivityStep,
+} from "@app/types/assistant/conversation";
 import type { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type { ModelIdType } from "@app/types/assistant/models/types";
@@ -354,6 +357,16 @@ export type AgentGenerationCancelledEvent = {
   status: "cancelled" | "interrupted";
 };
 
+// Server-rendered view of a finished agent message (the displayed body, chain of
+// thought, and activity steps). Computed from the persisted step contents (the
+// same source reload uses), so the client can trust it wholesale at stream end
+// instead of reconciling its incrementally-built view.
+export type AgentMessageContentView = {
+  content: string | null;
+  chainOfThought: string | null;
+  activitySteps: InlineActivityStep[];
+};
+
 // Event sent when the agent loop was gracefully stopped (current step completed, then exited).
 export type AgentMessageGracefullyStoppedEvent = {
   type: "agent_message_gracefully_stopped";
@@ -361,6 +374,8 @@ export type AgentMessageGracefullyStoppedEvent = {
   configurationId: string;
   messageId: string;
   message: AgentMessageType;
+  // Optional: absent on events from an older server during a deploy window.
+  contentView?: AgentMessageContentView;
   runIds: string[];
 };
 
@@ -371,6 +386,8 @@ export type AgentMessageSuccessEvent = {
   configurationId: string;
   messageId: string;
   message: AgentMessageType;
+  // Optional: absent on events from an older server during a deploy window.
+  contentView?: AgentMessageContentView;
   runIds: string[];
 };
 


### PR DESCRIPTION
At the end of a streamed agent message, the client used to hand-roll the final view (answer body, chain of thought, activity timeline) with a pile of heuristics, because the `agent_message_success` event did not carry a rendered view and its `message.content` used a different selection rule than reload. 

This PR makes the server compute that view once (from the same persisted step contents reload uses) and ship it on the terminal events. The client now trusts it. The `agent_message_success` handler goes from ~55 lines of special cases back to a plain spread.

No change to live streaming behavior. This only changes how the message is finalized at stream end.

## Background: why the old handler was complex

The displayed state has three parts: the body `content`, the `chainOfThought`, and the activity timeline (`inlineActivitySteps`).

- On reload, the server renders all three from the persisted step contents and sends a fully rendered message. This works well and is our source of truth.
- During live streaming, the client builds the timeline incrementally.
- At stream end, `agent_message_success` carried the full `AgentMessageType` but NOT the rendered timeline (`getLightAgentMessageFromAgentMessage` returns `activitySteps: []`), and its `message.content` is all text concatenated, while the rendered body is the last text fragment only.

Because the success event did not carry the timeline and used a different body rule, the client reconciled its incrementally built view with heuristics (flush a trailing chain-of-thought segment, override the body with the last streamed segment, drop a trailing duplicate content step). Each was a partial re-implementation of the server render and a source of streaming-vs-reload drift.

## The change

### Server

1. One render function. `contentsToActivitySteps` is renamed to `renderAgentMessageContentView` and returns the full view: `AgentMessageContentView = { content, chainOfThought, activitySteps }`. The body/CoT selection (and `interleaveConditionalNewlines`) moved into it verbatim from `messages.ts`, so the body/steps boundary rule lives in one place.
2. Reload consumes it. `renderSingleAgentMessage` now calls the one function instead of selecting body/CoT inline and computing steps separately (pure refactor, same output).
3. New contract field. `AgentMessageSuccessEvent` and `AgentMessageGracefullyStoppedEvent` get an optional `contentView?: AgentMessageContentView`.
4. Single enrichment point. `updateResourceAndPublishEvent` (the one publish path every terminal event flows through, including the `run_tool` early-exit path) attaches `contentView` for those two event types only, reading the latest persisted step contents (same source and ordering as reload). Gated to terminal events, so it never runs per token.

### Client

5. `useAgentMessageStream` collapses the terminal handler to: spread the message, apply `contentView` (`content`, `chainOfThought`, `activitySteps`), mark done. The CoT-flush, `finalSegment` override, `hadStreamedTokens` guard, and trailing-step-drop heuristics are deleted. If `contentView` is absent (older server during a deploy), it falls back to the server's full message plus the live-built steps, which self-heals on reload. Live streaming is untouched.

## Why this is safe

- The success view and the reload view are now produced by the same function over the same source, so they cannot drift.
- Body/CoT selection moved without behavior change (reasoning branch takes the raw last fragment; no-reasoning branch parses all fragments). Existing reload tests cover this and still pass.
- All terminal emit paths persist step contents before publishing, so the read always sees a complete message.
- The read may throw; Temporal retries the activity, consistent with the other DB operations in that path.

## Deploy notes

`contentView` is additive and optional, so it is backward compatible. Deploy server before client: a new server to an old client is fine (ignored), and an old server to a new client hits the documented fallback. Not exposed in the public SDK in this PR (SDK consumers get the full message and do not need the rendered view); can follow up for parity.

## Out of scope

- Live streaming reconciliation is unchanged; this fixes drift at stream end only.
- `run_agent` nested progress (the `actionProgress` path) is unchanged. Will do on a next PR. 

## Testing

New unit test `activity_steps.test.ts`. 
Will also test on front-edge before deploying. 
