### PR TITLE
[front] checkout: Metronome & Stripe webhook hardening + billing currency fix

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -58,6 +58,8 @@ import {
   CONTRACT_CREDIT_TYPE_POOL,
   getCreditTypeAwuId,
   getProductExcessCreditsId,
+  PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
+  PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
@@ -1275,6 +1277,21 @@ export async function processMetronomeWebhook({
         logger.info(
           { contractId, workspaceId: workspace.sId },
           `[Metronome Webhook] contract.start: no ${PLAN_CODE_CUSTOM_FIELD_KEY} custom field, leaving subscription alone`
+        );
+        break;
+      }
+
+      // Payment-gated subscription activation: skip the automatic swap here.
+      // The payment_gate.payment_status webhook handles the plan switch once
+      // payment succeeds, ensuring the workspace stays on CP_FREE_PLAN until paid.
+      const paymentGateType =
+        contractResult.value.custom_fields?.[
+          PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY
+        ];
+      if (paymentGateType === PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION) {
+        logger.info(
+          { contractId, workspaceId: workspace.sId },
+          "[Metronome Webhook] contract.start: payment-gated activation contract, skipping — payment_gate.payment_status will activate"
         );
         break;
       }

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -45,6 +45,7 @@ import {
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
   isFirstPeriodInvoice,
+  isSubscriptionActivationInvoice,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -883,6 +884,12 @@ export async function processStripeWebhookEvent({
       // First-invoice failures during metronomone checkout are handled
       // directly in return to failure of pay API — nothing to do.
       if (isFirstPeriodInvoice(invoice)) {
+        break;
+      }
+
+      // Subscription activation invoices are directly handled using
+      // Metronome "payment_gate.payment_status" webhook
+      if (isSubscriptionActivationInvoice(invoice)) {
         break;
       }
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -744,6 +744,7 @@ export async function createMetronomeContract({
   startingAt,
   enableStripeBilling,
   planCode,
+  additionalCustomFields,
 }: {
   metronomeCustomerId: string;
   /** Mutually exclusive with `packageId`. */
@@ -758,6 +759,11 @@ export async function createMetronomeContract({
   // webhook can swap the workspace's subscription onto this plan when the
   // contract becomes active.
   planCode: string;
+  // Additional custom fields merged with PLAN_CODE_CUSTOM_FIELD_KEY when
+  // stamping the contract. Used to signal payment-gated activation flows
+  // (DUST_PAYMENT_GATE_TYPE) so the contract.start webhook can skip the
+  // automatic subscription swap.
+  additionalCustomFields?: Record<string, string>;
 }): Promise<Result<{ contractId: string }, Error>> {
   if (!packageAlias === !packageId) {
     return new Err(
@@ -831,7 +837,10 @@ export async function createMetronomeContract({
 
   const customFieldsResult = await setMetronomeContractCustomFields({
     contractId,
-    customFields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: planCode },
+    customFields: {
+      [PLAN_CODE_CUSTOM_FIELD_KEY]: planCode,
+      ...additionalCustomFields,
+    },
   });
   if (customFieldsResult.isErr()) {
     return new Err(customFieldsResult.error);

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -84,6 +84,13 @@ export const CREDIT_TYPE_EUR_ID = "58f0be15-cc47-4220-bdaf-072ab0e44f96";
 
 export const PLAN_CODE_CUSTOM_FIELD_KEY = "DUST_PLAN_CODE";
 
+// Custom field stamped on payment-gated contracts to identify the activation
+// flow type. The contract.start webhook checks this field and skips the
+// automatic subscription swap when set — payment_gate.payment_status handles it.
+export const PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY = "DUST_PAYMENT_GATE_TYPE";
+export const PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION =
+  "subscription_activation";
+
 // Custom field stamped on every seat-style product (Workspace / Pro / Max /
 // Free / future seat tiers). Value is the membership seat type ("workspace"
 // | "pro" | "max" | "free"). Lets runtime code identify which subscription

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -223,6 +223,7 @@ export async function provisionMetronomeContract({
   swapAt = "current-hour",
   enableStripeBilling = true,
   planCode,
+  additionalCustomFields,
 }: {
   metronomeCustomerId: string;
   workspace: LightWorkspaceType;
@@ -232,6 +233,7 @@ export async function provisionMetronomeContract({
   swapAt?: "current-hour" | "next-hour";
   enableStripeBilling?: boolean;
   planCode: string;
+  additionalCustomFields?: Record<string, string>;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   const alignedStart = new Date(
     swapAt === "current-hour"
@@ -258,6 +260,7 @@ export async function provisionMetronomeContract({
     startingAt: alignedStart,
     enableStripeBilling,
     planCode,
+    additionalCustomFields,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);

--- a/front/lib/plans/billing_currency.ts
+++ b/front/lib/plans/billing_currency.ts
@@ -93,6 +93,7 @@ export function resolvePackageAliasForCurrency(
     "legacy-business": "legacy-business-eur",
     "legacy-pro-annual": "legacy-pro-annual-eur",
     "legacy-enterprise": "legacy-enterprise-eur",
+    "business-usd": "business-eur",
   };
 
   return eurAliases[baseAlias] ?? baseAlias;

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1087,6 +1087,15 @@ export function isCreditPurchaseInvoice(invoice: Stripe.Invoice): boolean {
 }
 
 /**
+ * Checks if a Stripe invoice is for a Metronome subscription activation.
+ */
+export function isSubscriptionActivationInvoice(
+  invoice: Stripe.Invoice
+): boolean {
+  return invoice.metadata?.subscription_activation === "true";
+}
+
+/**
  * Checks if a Stripe invoice is for a Metronome first-period charge.
  */
 export function isFirstPeriodInvoice(invoice: Stripe.Invoice): boolean {

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -19,6 +19,7 @@ import {
   CONTRACT_CREDIT_TYPE_POOL,
   CREDIT_TYPE_USD_ID,
   DEV_CREDIT_TYPE_AWU_ID,
+  PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   PROD_CREDIT_TYPE_AWU_ID,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
@@ -1407,6 +1408,7 @@ const CUSTOM_FIELD_KEYS: Array<{
   { entity: "contract", key: "MAU_TIERS" },
   { entity: "contract", key: "MAU_THRESHOLD" },
   { entity: "contract", key: PLAN_CODE_CUSTOM_FIELD_KEY },
+  { entity: "contract", key: PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY },
   // Stamped on individual contract_credit instances to identify excess
   // recurring credits ("excess") vs. workspace-pool credits ("pool"). Lets
   // the default ContractCredit-balance alerts filter on value="pool" to


### PR DESCRIPTION
## Description

PR3 of https://github.com/dust-tt/tasks/issues/8594
See the issue for the global view of the Checkout changes

Goal: harden the webhook layer so activation contracts are not mishandled by existing webhook
paths, and fix the billing currency package alias for USD.

**Metronome webhook** (`lib/api/metronome/process_webhook.ts`, `lib/metronome/constants.ts`,
`lib/metronome/client.ts`, `lib/metronome/contracts.ts`, `scripts/metronome_setup.ts`):

- Added `PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY` / `PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION` constants.
- Extended `provisionMetronomeContract` with `additionalCustomFields` to stamp contracts.
- `contract.start` webhook: when the contract carries `DUST_PAYMENT_GATE_TYPE=subscription_activation`,
  skip the automatic plan swap — `payment_gate.payment_status` handles activation.

**Stripe webhook** (`lib/api/stripe/webhook_handler.ts`, `lib/plans/stripe.ts`):

- Added `isSubscriptionActivationInvoice(invoice)` helper (checks `metadata.subscription_activation`).
- Stripe `invoice.payment_failed` handler: skip activation-commit invoices so Metronome's own
  `payment_gate.payment_status` remains the authoritative signal.

**Billing currency** (`lib/plans/billing_currency.ts`):

- Added `business-usd` to the recognised Metronome package alias list so currency resolution works
  for USD Business contracts.

## Tests

No impact (only additive changes, with path that are not yet called)
* npx tsgo --noEmit
* npm run format:changed

## Risk

No impact (only additive changes, with path that are not yet called)

## Deploy Plan

Deploy front