### PR TITLE
Pricing: clean the usage page's table

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1,17 +1,25 @@
+import {
+  getSeatBarClasses,
+  getSeatIconColorClass,
+  MUTED_BAR_CLASSES,
+} from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import {
   isMembershipSeatType,
   type MembershipSeatType,
+  SEAT_TYPE_ORDER,
 } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   AlertCircle,
+  Clock,
   Cube01,
   DataTable,
   Hexagon01,
+  Icon,
   LoadingBlock,
   type MenuItem,
   SeatMax,
@@ -46,7 +54,7 @@ type RowData = {
 type Info = CellContext<RowData, string>;
 
 const SEAT_TYPE_ICONS: Partial<
-  Record<MembershipSeatType, React.ComponentType>
+  Record<MembershipSeatType, React.ComponentType<{ className?: string }>>
 > = {
   none: AlertCircle,
   max: SeatMax,
@@ -65,6 +73,33 @@ function getDisplaySeatType(seatType: MembershipSeatType): MembershipSeatType {
   return seatType;
 }
 
+// Builds the tooltip explaining a scheduled seat change, e.g.
+// "This user will be downgraded to Free at the end of the billing period (July 1)".
+function getScheduledSeatChangeLabel(
+  currentSeatType: MembershipSeatType | null,
+  scheduledSeatType: MembershipSeatType,
+  scheduledSeatChangeAt: string | null
+): string {
+  const currentRank = currentSeatType ? SEAT_TYPE_ORDER[currentSeatType] : 0;
+  const scheduledRank = SEAT_TYPE_ORDER[scheduledSeatType];
+  const verb =
+    scheduledRank > currentRank
+      ? "upgraded"
+      : scheduledRank < currentRank
+        ? "downgraded"
+        : "changed";
+  const target = getDisplaySeatType(scheduledSeatType);
+  const targetLabel = target.charAt(0).toUpperCase() + target.slice(1);
+  const dateSuffix = scheduledSeatChangeAt
+    ? ` (${new Date(scheduledSeatChangeAt).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        timeZone: "UTC",
+      })})`
+    : "";
+  return `This user will be ${verb} to ${targetLabel} at the end of the billing period${dateSuffix}`;
+}
+
 interface SeatTypeIconProps {
   seatType: MembershipSeatType | null;
 }
@@ -73,11 +108,18 @@ function SeatTypeIcon({ seatType }: SeatTypeIconProps) {
   if (!seatType) {
     return null;
   }
-  const Icon = SEAT_TYPE_ICONS[getDisplaySeatType(seatType)];
-  if (!Icon) {
+  const displaySeatType = getDisplaySeatType(seatType);
+  const visual = SEAT_TYPE_ICONS[displaySeatType];
+  if (!visual) {
     return null;
   }
-  return <Icon />;
+  return (
+    <Icon
+      visual={visual}
+      size="sm"
+      className={getSeatIconColorClass(displaySeatType)}
+    />
+  );
 }
 
 interface AwuUsageBarProps {
@@ -90,27 +132,6 @@ interface AwuUsageBarProps {
   memberUsageLimit: number | null;
   limit: number | null;
   seatType: MembershipSeatType | null;
-}
-
-const MUTED_BAR_CLASSES = {
-  track: "bg-muted-background dark:bg-muted-background-night",
-  fill: "bg-muted-foreground dark:bg-muted-foreground-night",
-};
-
-function getSeatBarClasses(seatType: MembershipSeatType | null) {
-  if (seatType?.startsWith("pro")) {
-    return {
-      track: "bg-blue-100 dark:bg-blue-100-night",
-      fill: "bg-highlight dark:bg-highlight-night",
-    };
-  }
-  if (seatType?.startsWith("max")) {
-    return {
-      track: "bg-golden-100 dark:bg-golden-100-night",
-      fill: "bg-brand-orange-golden",
-    };
-  }
-  return MUTED_BAR_CLASSES;
 }
 
 function AwuUsageBar({
@@ -245,31 +266,32 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
     const seatType = info.row.original.seatType;
     const scheduledSeatType = info.row.original.scheduledSeatType;
     const scheduledSeatChangeAt = info.row.original.scheduledSeatChangeAt;
-    const scheduledDate = scheduledSeatChangeAt
-      ? new Date(scheduledSeatChangeAt).toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-          timeZone: "UTC",
-        })
-      : null;
     return (
       <DataTable.CellContent>
-        <span className="flex flex-col">
-          <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
-            <SeatTypeIcon seatType={seatType} />
-            {seatType ? getDisplaySeatType(seatType) : "—"}
-          </span>
-          {scheduledSeatType && scheduledDate && (
-            <span className="text-xs capitalize text-amber-600 dark:text-amber-400">
-              → {getDisplaySeatType(scheduledSeatType)} on {scheduledDate}
-            </span>
+        <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
+          <SeatTypeIcon seatType={seatType} />
+          {seatType ? getDisplaySeatType(seatType) : "—"}
+          {scheduledSeatType && (
+            <Tooltip
+              label={getScheduledSeatChangeLabel(
+                seatType,
+                scheduledSeatType,
+                scheduledSeatChangeAt
+              )}
+              tooltipTriggerAsChild
+              trigger={
+                <span className="cursor-default">
+                  <Icon visual={Clock} size="xs" />
+                </span>
+              }
+            />
           )}
         </span>
       </DataTable.CellContent>
     );
   },
   meta: {
-    className: "w-28",
+    className: "w-36",
   },
 };
 
@@ -442,17 +464,6 @@ export function MembersUsageTable({
                   label: m.seatType ? "Change seat type" : "Assign seat",
                   onClick: () => onChangeSeat(m),
                 },
-                // Only members who currently hold a billable seat can have it removed.
-                ...(m.seatType && m.seatType !== "none"
-                  ? [
-                      {
-                        kind: "item" as const,
-                        label: "Remove seat",
-                        variant: "warning" as const,
-                        onClick: () => onRemoveSeat(m),
-                      },
-                    ]
-                  : []),
               ]
             : []),
           {
@@ -460,6 +471,17 @@ export function MembersUsageTable({
             label: "Edit spend limit",
             onClick: () => onEditSpendLimit(m),
           },
+          // Only members who currently hold a billable seat can have it removed.
+          ...(isSeatBased && m.seatType && m.seatType !== "none"
+            ? [
+                {
+                  kind: "item" as const,
+                  label: "Remove seat",
+                  variant: "warning" as const,
+                  onClick: () => onRemoveSeat(m),
+                },
+              ]
+            : []),
         ],
       })),
     [filtered, isSeatBased, onChangeSeat, onRemoveSeat, onEditSpendLimit]

--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -3,6 +3,7 @@ import { useMembersSeats, useSeatPlan } from "@app/lib/swr/credits";
 import {
   isMembershipSeatType,
   type MembershipSeatType,
+  SEAT_TYPE_ORDER,
 } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -16,12 +17,6 @@ import {
   User01,
 } from "@dust-tt/sparkle";
 import type React from "react";
-
-const SEAT_TYPE_ORDER: Record<string, number> = {
-  free: 0,
-  pro: 1,
-  max: 2,
-};
 
 const SEAT_TYPE_ICONS: Record<string, React.ComponentType> = {
   free: Hexagon01,

--- a/front/components/workspace/seat_styles.ts
+++ b/front/components/workspace/seat_styles.ts
@@ -1,0 +1,71 @@
+import type { MembershipSeatType } from "@app/types/memberships";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+
+const SEAT_TIER_STYLES = {
+  max: {
+    icon: "text-brand-orange-golden",
+    barFill: "bg-brand-orange-golden",
+    barTrack: "bg-golden-100 dark:bg-golden-100-night",
+  },
+  pro: {
+    icon: "text-highlight dark:text-highlight-night",
+    barFill: "bg-highlight dark:bg-highlight-night",
+    barTrack: "bg-blue-100 dark:bg-blue-100-night",
+  },
+  muted: {
+    icon: "text-muted-foreground dark:text-muted-foreground-night",
+    barFill: "bg-muted-foreground dark:bg-muted-foreground-night",
+    barTrack: "bg-muted-background dark:bg-muted-background-night",
+  },
+};
+
+// Muted bar colors, for bar sections that are not tied to a seat tier (e.g. the
+// workspace pool or an empty bar).
+export const MUTED_BAR_CLASSES = {
+  track: SEAT_TIER_STYLES.muted.barTrack,
+  fill: SEAT_TIER_STYLES.muted.barFill,
+};
+
+// Seat icon text color: golden for max, highlight blue for pro, muted grey
+// otherwise (free / none / workspace).
+export function getSeatIconColorClass(seatType: MembershipSeatType): string {
+  switch (seatType) {
+    case "max":
+    case "max_yearly":
+      return SEAT_TIER_STYLES.max.icon;
+    case "pro":
+    case "pro_yearly":
+      return SEAT_TIER_STYLES.pro.icon;
+    case "none":
+    case "free":
+    case "workspace":
+    case "workspace_yearly":
+      return SEAT_TIER_STYLES.muted.icon;
+    default:
+      assertNeverAndIgnore(seatType);
+      return SEAT_TIER_STYLES.muted.icon;
+  }
+}
+
+// Usage-bar track/fill colors, matching the seat icon colors.
+export function getSeatBarClasses(seatType: MembershipSeatType | null): {
+  track: string;
+  fill: string;
+} {
+  if (seatType?.startsWith("max")) {
+    return {
+      track: SEAT_TIER_STYLES.max.barTrack,
+      fill: SEAT_TIER_STYLES.max.barFill,
+    };
+  }
+  if (seatType?.startsWith("pro")) {
+    return {
+      track: SEAT_TIER_STYLES.pro.barTrack,
+      fill: SEAT_TIER_STYLES.pro.barFill,
+    };
+  }
+  return {
+    track: SEAT_TIER_STYLES.muted.barTrack,
+    fill: SEAT_TIER_STYLES.muted.barFill,
+  };
+}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -101,6 +101,23 @@ export type GetMembersUsageResponseBody = {
   total: number;
 };
 
+// Workspace seats have a zero AWU allocation, so `buildSeatDataByUserId` skips
+// them and we never get a Metronome-derived billing frequency. The cadence is
+// still encoded in the seat type itself, so derive it from there as a fallback
+// to display the period like for other seats.
+function deriveWorkspaceSeatBillingFrequency(
+  seatType: MembershipSeatType | null
+): BillingFrequency | null {
+  switch (seatType) {
+    case "workspace":
+      return "MONTHLY";
+    case "workspace_yearly":
+      return "ANNUAL";
+    default:
+      return null;
+  }
+}
+
 export const DEFAULT_MEMBERS_USAGE_PAGE_LIMIT = 50;
 export const MAX_MEMBERS_USAGE_PAGE_LIMIT = 150;
 
@@ -678,7 +695,9 @@ export async function getMembersUsage({
         consumedAwuCredits: totalConsumedCredits,
         consumedFromAllowanceAwuCredits,
         consumedFromPoolAwuCredits,
-        billingFrequency: seatData?.billingFrequency ?? null,
+        billingFrequency:
+          seatData?.billingFrequency ??
+          deriveWorkspaceSeatBillingFrequency(membership.seatType ?? null),
         scheduledSeatType: scheduled?.seatType ?? null,
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -52,6 +52,21 @@ export function isMembershipSeatType(
   );
 }
 
+// Relative tier ordering of seat types, from lowest to highest. Yearly variants
+// share their base tier. Used both to sort seat plans for display and to tell
+// whether a scheduled seat change is an upgrade or a downgrade. `none` is the
+// lowest (no seat) and `workspace` the highest (platform/enterprise seat).
+export const SEAT_TYPE_ORDER: Record<MembershipSeatType, number> = {
+  none: 0,
+  free: 1,
+  pro: 2,
+  pro_yearly: 2,
+  max: 3,
+  max_yearly: 3,
+  workspace: 4,
+  workspace_yearly: 4,
+};
+
 // Normalized seat types for pool credit limits. Monthly and yearly variants
 // share a single pool limit. Free seats are excluded (lifetime allocation,
 // no pool access).


### PR DESCRIPTION
## Description

A bunch of improvements to the usage page table to match the design better:

 - Add the colors to the icon of the Usage page (Pro and Max)
 - Extract the color to a standalone file so they are isolated
 - Change the display for the seat change in the future (Clock icon with on hover)
 - Make the seat column slightly bigger
 - DIsplay the seat frequency for "Workspace" seats
 - Move the "Remove seat" button at the bottom of the menu

Sorry for not splitting, I think it's of to have it all in one but let me know if not

### Before

<img width="2252" height="534" alt="image" src="https://github.com/user-attachments/assets/67c956c0-bea8-486c-8a04-635e0e36ac6f" />

<img width="320" height="240" alt="image" src="https://github.com/user-attachments/assets/a87d7e88-1e27-4daa-b1bc-61843963a74a" />


### After

<img width="2256" height="540" alt="image" src="https://github.com/user-attachments/assets/f26cf5f8-6f43-42b3-9f57-ebdecf69570f" />

<img width="2300" height="530" alt="image" src="https://github.com/user-attachments/assets/96490fd0-a8cd-4c8b-bb6d-aa878c0a0672" />

<img width="260" height="235" alt="image" src="https://github.com/user-attachments/assets/2d0bf4a3-c5ad-49f3-b78b-07309e6f54af" />



## Tests

tested locally

## Risk

low:
 - just UI
 - easy to revert

## Deploy Plan

deploy front
