### PR TITLE
 prevent agent from generating broken download links for fs files

### DIFF
--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -102,7 +102,7 @@ export async function createHandler(
   > = [
     {
       type: "text",
-      text: `${verb} \`${path}\` (${content_type}, ${sizeKb} KB)`,
+      text: `${verb} \`${path}\` (${content_type}, ${sizeKb} KB). The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
     },
   ];
 

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -75,7 +75,7 @@ describe("moveHandler", () => {
     }
     expect(result.value[0]).toEqual({
       type: "text",
-      text: `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`.`,
+      text: `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
     });
   });
 

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -101,7 +101,7 @@ export async function moveHandler(
   > = [
     {
       type: "text",
-      text: `Moved \`${source}\` to \`${dest}\`.`,
+      text: `Moved \`${source}\` to \`${dest}\`. The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
     },
   ];
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Attempts at fixing https://github.com/dust-tt/tasks/issues/8551.

When an agent creates or moves a file via the file system MCP tools (`files_create`, `files_move`), it was writing broken download links in its message text. The URLs were missing the `/path/` segment:
- Broken: `/api/w/{wId}/files/conversation-{cId}/file.md`
- Working: `/api/w/{wId}/files/path/conversation-{cId}/file.md`

Root cause: The tool result only returned the scoped path (e.g. conversation-{cId}/file.md) with no instruction about how or whether to construct a download URL. The model inferred a URL from the path and got the format wrong.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
