### PR TITLE
[LLM] Trace actual Anthropic request payload instead of stream parameters

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -101,7 +101,7 @@ function buildSystemBlocks(
   return system;
 }
 
-export class AnthropicLLM extends LLM<LLMStreamParameters> {
+export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
   private client: Anthropic;
   private inferenceClient: Anthropic | AnthropicVertex;
   private omittedThinking: boolean;
@@ -183,22 +183,15 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
     };
   }
 
-  protected buildStreamRequestPayload(
+  protected async buildStreamRequestPayload(
     streamParameters: LLMStreamParameters
-  ): LLMStreamParameters {
-    // Just capture the parameters; message conversion (async) happens in sendRequest.
-    return streamParameters;
-  }
-
-  protected async *sendRequest(
-    streamParameters: LLMStreamParameters
-  ): AsyncGenerator<LLMEvent> {
+  ): Promise<BetaMessageStreamParams> {
     const betas = this.modelConfig.customBetas;
 
     const basePayload = await this.buildBaseRequestPayload(streamParameters);
     const outputFormat = toOutputFormatParam(this.responseFormat);
 
-    const payload: BetaMessageStreamParams = {
+    return {
       ...basePayload,
       stream: true,
       betas,
@@ -208,7 +201,11 @@ export class AnthropicLLM extends LLM<LLMStreamParameters> {
       cache_control: { type: "ephemeral" },
       model: getModel(this.useVertex, { modelId: this.modelId }),
     };
+  }
 
+  protected async *sendRequest(
+    payload: BetaMessageStreamParams
+  ): AsyncGenerator<LLMEvent> {
     try {
       const events = this.inferenceClient.beta.messages.stream(payload);
 

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -385,7 +385,7 @@ export abstract class LLM<TPayload = unknown> {
   ): Promise<string> {
     const batchId = await this.internalSendBatchProcessing(conversations);
     if (this.context) {
-      this.traceBatchInputs(conversations);
+      await this.traceBatchInputs(conversations);
     }
     return batchId;
   }
@@ -404,13 +404,13 @@ export abstract class LLM<TPayload = unknown> {
   /**
    * Traces batch inputs by creating one Langfuse generation per conversation entry.
    */
-  private traceBatchInputs(
+  private async traceBatchInputs(
     conversations: Map<string, LLMStreamParameters>
-  ): void {
+  ): Promise<void> {
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
 
     for (const [customId, params] of conversations) {
-      const payload = this.buildStreamRequestPayload(params);
+      const payload = await this.buildStreamRequestPayload(params);
 
       const generation = startObservation(
         `llm-batch-input-${customId}`,
@@ -647,7 +647,7 @@ export abstract class LLM<TPayload = unknown> {
   protected abstract buildStreamRequestPayload(
     streamParameters: LLMStreamParameters,
     metadata?: LLMStreamMetadata
-  ): TPayload;
+  ): TPayload | Promise<TPayload>;
 
   /**
    * Send the request to the LLM provider and yield events.
@@ -664,7 +664,10 @@ export abstract class LLM<TPayload = unknown> {
     streamParameters: LLMStreamParameters,
     metadata?: LLMStreamMetadata
   ): AsyncGenerator<LLMEvent> {
-    const payload = this.buildStreamRequestPayload(streamParameters, metadata);
+    const payload = await this.buildStreamRequestPayload(
+      streamParameters,
+      metadata
+    );
 
     // Update the generation span with the actual payload.
     this.generation?.update({ input: payload });


### PR DESCRIPTION
## Description

Anthropic's `buildStreamRequestPayload` returned the raw `LLMStreamParameters` (so Langfuse traced the un-converted conversation instead of the real request); this builds the actual `BetaMessageStreamParams` in `buildStreamRequestPayload` — made awaitable in the base `LLM` class — so the `llm-completion` trace `Input` now shows the payload sent to the API.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`