### PR TITLE
[front] fix spacing in space tab

### DIFF
--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -154,42 +154,42 @@ export default function SpaceSideBarMenu({
     <div className="flex h-0 min-h-full w-full overflow-y-auto">
       <NavigationList className="w-full">
         <div className=" mx-sidebar-side-spacing">
-           {sortedGroupedSpaces.map(({ section, spaces }, index) => {
-          if (section === "restricted" && !spaces.length && !isAdmin) {
-            return null;
-          }
+          {sortedGroupedSpaces.map(({ section, spaces }, index) => {
+            if (section === "restricted" && !spaces.length && !isAdmin) {
+              return null;
+            }
 
-          const sectionDetails = getSpaceSectionDetails(section);
+            const sectionDetails = getSpaceSectionDetails(section);
 
-          return (
-            <Fragment key={`space-section-${index}`}>
-              <div className="flex items-center justify-between pr-1">
-                <NavigationListLabel label={sectionDetails.label} />
-                {sectionDetails.displayCreateSpaceButton &&
-                  isAdmin &&
-                  openSpaceCreationModal && (
-                    <Button
-                      className="mt-1"
-                      size="xs"
-                      variant="ghost"
-                      label="New"
-                      icon={Plus}
-                      onClick={() =>
-                        openSpaceCreationModal({
-                          defaultRestricted: sectionDetails.defaultRestricted,
-                        })
-                      }
-                    />
-                  )}
-              </div>
-              {renderSpaceItems(
-                spaces.toSorted(compareSpaces),
-                spacesAsUser,
-                owner
-              )}
-            </Fragment>
-          );
-        })}
+            return (
+              <Fragment key={`space-section-${index}`}>
+                <div className="flex items-center justify-between pr-1">
+                  <NavigationListLabel label={sectionDetails.label} />
+                  {sectionDetails.displayCreateSpaceButton &&
+                    isAdmin &&
+                    openSpaceCreationModal && (
+                      <Button
+                        className="mt-1"
+                        size="xs"
+                        variant="ghost"
+                        label="New"
+                        icon={Plus}
+                        onClick={() =>
+                          openSpaceCreationModal({
+                            defaultRestricted: sectionDetails.defaultRestricted,
+                          })
+                        }
+                      />
+                    )}
+                </div>
+                {renderSpaceItems(
+                  spaces.toSorted(compareSpaces),
+                  spacesAsUser,
+                  owner
+                )}
+              </Fragment>
+            );
+          })}
         </div>
       </NavigationList>
     </div>

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -152,8 +152,9 @@ export default function SpaceSideBarMenu({
 
   return (
     <div className="flex h-0 min-h-full w-full overflow-y-auto">
-      <NavigationList className="w-full mx-sidebar-side-spacing">
-        {sortedGroupedSpaces.map(({ section, spaces }, index) => {
+      <NavigationList className="w-full">
+        <div className=" mx-sidebar-side-spacing">
+           {sortedGroupedSpaces.map(({ section, spaces }, index) => {
           if (section === "restricted" && !spaces.length && !isAdmin) {
             return null;
           }
@@ -189,6 +190,7 @@ export default function SpaceSideBarMenu({
             </Fragment>
           );
         })}
+        </div>
       </NavigationList>
     </div>
   );

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -153,7 +153,7 @@ export default function SpaceSideBarMenu({
   return (
     <div className="flex h-0 min-h-full w-full overflow-y-auto">
       <NavigationList className="w-full">
-        <div className=" mx-sidebar-side-spacing">
+        <div className="mx-sidebar-side-spacing">
           {sortedGroupedSpaces.map(({ section, spaces }, index) => {
             if (section === "restricted" && !spaces.length && !isAdmin) {
               return null;


### PR DESCRIPTION
## Description
This PR is fixing spacing in space's sidebar 
before:
<img width="682" height="490" alt="CleanShot 2026-06-08 at 18 21 27@2x" src="https://github.com/user-attachments/assets/20f72888-3d74-4a66-a925-04135559ed1b" />


after:
<img width="648" height="420" alt="CleanShot 2026-06-08 at 18 21 47@2x" src="https://github.com/user-attachments/assets/6b936eb4-c36f-45fa-8f1f-e79d28719f3a" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
