### PR TITLE
Refactor dust desktop discovery

### DIFF
--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -1,3 +1,4 @@
+import { maybePersistDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
@@ -36,23 +37,6 @@ export function getMCPServerRegistryKey({
 }
 
 /**
- * Redis SCAN pattern for all registry keys sharing a server name's base id.
- * Used only by {@link getLatestMCPServerRegistrationByName} (temporary).
- */
-export function getMCPServerRegistryKeyPatternForServerName({
-  workspaceId,
-  userId,
-  serverName,
-}: {
-  workspaceId: string;
-  userId: string;
-  serverName: string;
-}): string {
-  const baseServerId = getMCPServerIdFromServerName({ serverName });
-  return `w:${workspaceId}:mcp:reg:u:${userId}:s:${baseServerId}*`;
-}
-
-/**
  * Get the base serverId by removing any numeric suffix.
  * For example: "mcp-client-side:my-server.1" -> "mcp-client-side:my-server"
  * This is safe because:
@@ -71,16 +55,6 @@ export function getMCPServerIdFromServerName({
   serverName: string;
 }): string {
   return `mcp-client-side:${slugify(serverName)}`;
-}
-
-/** Registration name used by Dust Desktop (slug → mcp-client-side:dust_desktop). */
-export const DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME = "dust-desktop";
-
-function clientSideMCPServerNamesMatch(
-  requestedName: string,
-  storedName: string
-): boolean {
-  return slugify(requestedName) === slugify(storedName);
 }
 
 /**
@@ -170,6 +144,11 @@ export async function registerMCPServer(
     now + MCP_SERVER_REGISTRATION_TTL_SECONDS * 1000
   ).toISOString();
 
+  await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
+    serverName,
+    serverId,
+  });
+
   return new Ok({
     expiresAt,
     serverId,
@@ -208,90 +187,6 @@ export async function getMCPServersMetadata(
         return [serverId, result ? JSON.parse(result) : null];
       })
     );
-  });
-}
-
-/**
- * Return the registered instance with the most recent heartbeat for a server name.
- *
- * TODO: Temporary helper to make Dust Desktop testing easier (reconnect without a
- * persisted serverId). Do not keep long term — it relies on a Redis SCAN over the
- * full keyspace. Replace with client-side serverId persistence or a bounded lookup.
- */
-export async function getLatestMCPServerRegistrationByName(
-  auth: Authenticator,
-  {
-    serverName,
-    workspaceId,
-  }: {
-    serverName: string;
-    workspaceId?: string;
-  }
-): Promise<MCPServerRegistration | null> {
-  const user = auth.getNonNullableUser();
-  const userId = user.id.toString();
-  const resolvedWorkspaceId = workspaceId ?? auth.getNonNullableWorkspace().sId;
-
-  const pattern = getMCPServerRegistryKeyPatternForServerName({
-    workspaceId: resolvedWorkspaceId,
-    userId,
-    serverName,
-  });
-
-  return runOnRedis({ origin: "mcp_client_side_request" }, async (redis) => {
-    const keys: string[] = [];
-    for await (const key of redis.scanIterator({ MATCH: pattern })) {
-      keys.push(key);
-    }
-
-    if (keys.length === 0) {
-      return null;
-    }
-
-    const results = await redis.mGet(keys);
-    let latest: MCPServerRegistration | null = null;
-    const scannedRegistrations: Array<{
-      key: string;
-      serverId: string;
-      storedServerName: string;
-      lastHeartbeat: number;
-      matchesRequestedName: boolean;
-    }> = [];
-
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i];
-      const key = keys[i];
-      if (!result) {
-        scannedRegistrations.push({
-          key,
-          serverId: "missing",
-          storedServerName: "missing",
-          lastHeartbeat: 0,
-          matchesRequestedName: false,
-        });
-        continue;
-      }
-      const metadata = JSON.parse(result) as MCPServerRegistration;
-      const matchesRequestedName = clientSideMCPServerNamesMatch(
-        serverName,
-        metadata.serverName
-      );
-      scannedRegistrations.push({
-        key,
-        serverId: metadata.serverId,
-        storedServerName: metadata.serverName,
-        lastHeartbeat: metadata.lastHeartbeat,
-        matchesRequestedName,
-      });
-      if (!matchesRequestedName) {
-        continue;
-      }
-      if (!latest || metadata.lastHeartbeat > latest.lastHeartbeat) {
-        latest = metadata;
-      }
-    }
-
-    return latest;
   });
 }
 
@@ -336,13 +231,18 @@ export async function updateMCPServerHeartbeat(
         EX: MCP_SERVER_REGISTRATION_TTL_SECONDS,
       });
 
-      return true;
+      return metadata;
     }
   );
 
   if (!result) {
     return null;
   }
+
+  await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
+    serverName: result.serverName,
+    serverId: result.serverId,
+  });
 
   const expiresAt = new Date(
     now + MCP_SERVER_REGISTRATION_TTL_SECONDS * 1000

--- a/front/lib/api/actions/mcp/dust_desktop.ts
+++ b/front/lib/api/actions/mcp/dust_desktop.ts
@@ -1,0 +1,121 @@
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { slugify } from "@app/types/shared/utils/string_utils";
+import { z } from "zod";
+
+export const DUST_DESKTOP_FEATURE_FLAG = "dust_desktop" as const;
+
+/** Client-side MCP server name registered by Dust Desktop. */
+export const DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME = "dust-desktop";
+
+export const DUST_DESKTOP_MCP_SERVER_METADATA_KEY = "dust_desktop:mcp_server";
+
+/** Match Dust Desktop heartbeat interval (5 minutes). */
+export const DUST_DESKTOP_MCP_SERVER_TTL_MS = 5 * 60 * 1000;
+
+const DustDesktopMcpServerMetadataSchema = z.object({
+  serverId: z.string(),
+  updatedAt: z.number(),
+});
+
+type DustDesktopMcpServerMetadata = z.infer<
+  typeof DustDesktopMcpServerMetadataSchema
+>;
+
+export function isDustDesktopClientSideMCPServerName(
+  serverName: string
+): boolean {
+  return (
+    slugify(serverName) === slugify(DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME)
+  );
+}
+
+/**
+ * Persist the latest Dust Desktop client-side MCP server id for the current user
+ * in this workspace. No-op unless the feature flag is enabled.
+ */
+export async function maybePersistDustDesktopClientSideMCPServerRegistration(
+  auth: Authenticator,
+  {
+    serverName,
+    serverId,
+  }: {
+    serverName: string;
+    serverId: string;
+  }
+): Promise<void> {
+  const user = auth.user();
+  if (!user) {
+    return;
+  }
+  if (!isDustDesktopClientSideMCPServerName(serverName)) {
+    return;
+  }
+
+  const hasDustDesktopFeatureFlag = await hasFeatureFlag(
+    auth,
+    DUST_DESKTOP_FEATURE_FLAG
+  );
+  if (!hasDustDesktopFeatureFlag) {
+    return;
+  }
+
+  await user.setMetadata(
+    DUST_DESKTOP_MCP_SERVER_METADATA_KEY,
+    JSON.stringify(
+      DustDesktopMcpServerMetadataSchema.parse({
+        serverId,
+        updatedAt: Date.now(),
+      })
+    ),
+    auth.getNonNullableWorkspace().id
+  );
+}
+
+/**
+ * Return the Dust Desktop client-side MCP server id for the current user when the
+ * feature flag is enabled and the stored heartbeat is recent enough.
+ */
+export async function getActiveDustDesktopClientSideMCPServerId(
+  auth: Authenticator
+): Promise<string | null> {
+  const user = auth.user();
+  if (!user) {
+    return null;
+  }
+
+  const hasDustDesktopFeatureFlag = await hasFeatureFlag(
+    auth,
+    DUST_DESKTOP_FEATURE_FLAG
+  );
+  if (!hasDustDesktopFeatureFlag) {
+    return null;
+  }
+
+  const metadataRow = await user.getMetadata(
+    DUST_DESKTOP_MCP_SERVER_METADATA_KEY,
+    auth.getNonNullableWorkspace().id
+  );
+  if (!metadataRow) {
+    return null;
+  }
+
+  let metadata: DustDesktopMcpServerMetadata;
+  try {
+    const parsed = DustDesktopMcpServerMetadataSchema.safeParse(
+      JSON.parse(metadataRow.value)
+    );
+    if (!parsed.success) {
+      return null;
+    }
+    metadata = parsed.data;
+  } catch {
+    return null;
+  }
+
+  if (Date.now() - metadata.updatedAt > DUST_DESKTOP_MCP_SERVER_TTL_MS) {
+    return null;
+  }
+
+  return metadata.serverId;
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -7,10 +7,7 @@ import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
-import {
-  DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME,
-  getLatestMCPServerRegistrationByName,
-} from "@app/lib/api/actions/mcp/client_side_registry";
+import { getActiveDustDesktopClientSideMCPServerId } from "@app/lib/api/actions/mcp/dust_desktop";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
@@ -251,18 +248,13 @@ export async function runModel(
     const clientSideMCPServerIds = [
       ...(userMessage.context.clientSideMCPServerIds ?? []),
     ];
-    const featureFlags = await getFeatureFlags(auth);
-    if (featureFlags.includes("dust_desktop")) {
-      const dustDesktopRegistration =
-        await getLatestMCPServerRegistrationByName(auth, {
-          serverName: DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME,
-        });
-      if (
-        dustDesktopRegistration &&
-        !clientSideMCPServerIds.includes(dustDesktopRegistration.serverId)
-      ) {
-        clientSideMCPServerIds.push(dustDesktopRegistration.serverId);
-      }
+    const dustDesktopServerId =
+      await getActiveDustDesktopClientSideMCPServerId(auth);
+    if (
+      dustDesktopServerId &&
+      !clientSideMCPServerIds.includes(dustDesktopServerId)
+    ) {
+      clientSideMCPServerIds.push(dustDesktopServerId);
     }
 
     const clientSideMCPActionConfigurations =


### PR DESCRIPTION
## Description

Replaces the temporary Redis SCAN-based Dust Desktop discovery (`getLatestMCPServerRegistrationByName`) with a proper user-metadata approach. On every `registerMCPServer` and `updateMCPServerHeartbeat` call, `maybePersistDustDesktopClientSideMCPServerRegistration` snapshots the `serverId` + timestamp into user metadata (keyed `dust_desktop:mcp_server`, scoped to workspace). `runModel` now calls `getActiveDustDesktopClientSideMCPServerId`, which reads that metadata, validates the TTL (5 min, matching the heartbeat interval), and returns the `serverId` — no keyspace scan needed. All Dust Desktop logic is isolated in the new `dust_desktop.ts` module and remains gated by the `dust_desktop` FF.

## Tests

Tested locally. The Redis SCAN path was a temporary scaffolding and had no dedicated tests.

## Risk

Low. The FF gate (`dust_desktop`) ensures this is a no-op for all non-flagged users. `updateMCPServerHeartbeat` now returns `metadata` instead of `true`, but the return value is only consumed internally. Rollback is safe.

## Deploy Plan

Deploy front.
