### PR TITLE
Restore image generation placeholder in conversation UI

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -78,6 +78,7 @@ import type {
 } from "@app/types/assistant/mentions";
 import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
+import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   isInteractiveContentType,
   isSupportedImageContentType,
@@ -1327,6 +1328,29 @@ function AgentMessageContent({
     .filter((file) => isSupportedImageContentType(file.contentType))
     .filter((file) => file.fileId && !referencedFileIds.has(file.fileId));
 
+  const inProgressImageCount = Array.from(
+    agentMessage.streaming.actionProgress.values()
+  ).filter(({ progress }) => {
+    const output = progress?._meta?.data?.output;
+    return output !== undefined && isImageProgressOutput(output);
+  }).length;
+
+  const allImages = [
+    ...completedImages.map((image) => ({
+      imageUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=view&version=processed`,
+      downloadUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
+      alt: image.title,
+      title: image.title,
+      isLoading: false as const,
+    })),
+    ...Array.from({ length: inProgressImageCount }, (_, i) => ({
+      imageUrl: "",
+      alt: `Generating image ${i + 1}`,
+      title: `Generating image ${i + 1}`,
+      isGenerating: true as const,
+    })),
+  ];
+
   const generatedFiles = filesFromMessage.filter(
     (file) =>
       !isSupportedImageContentType(file.contentType) &&
@@ -1353,16 +1377,8 @@ function AgentMessageContent({
         <AgentMessageInteractiveContentGeneratedFiles
           files={interactiveFiles}
         />
-        {completedImages.length > 0 && (
-          <InteractiveImageGrid
-            images={completedImages.map((image) => ({
-              imageUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=view&version=processed`,
-              downloadUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
-              alt: image.title,
-              title: image.title,
-              isLoading: false,
-            }))}
-          />
+        {allImages.length > 0 && (
+          <InteractiveImageGrid images={allImages} />
         )}
 
         {agentMessage.content !== null &&

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -53,6 +53,7 @@ import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
 import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
+import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import type { FetchConversationMessageResponseLight } from "@app/lib/api/assistant/messages";
 import config from "@app/lib/api/config";
@@ -78,7 +79,6 @@ import type {
 } from "@app/types/assistant/mentions";
 import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
-import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   isInteractiveContentType,
   isSupportedImageContentType,
@@ -1377,9 +1377,7 @@ function AgentMessageContent({
         <AgentMessageInteractiveContentGeneratedFiles
           files={interactiveFiles}
         />
-        {allImages.length > 0 && (
-          <InteractiveImageGrid images={allImages} />
-        )}
+        {allImages.length > 0 && <InteractiveImageGrid images={allImages} />}
 
         {agentMessage.content !== null &&
           agentMessage.content !== "" &&

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1341,13 +1341,13 @@ function AgentMessageContent({
       downloadUrl: `${config.getApiBaseUrl()}/api/w/${owner.sId}/files/${image.fileId}?action=download`,
       alt: image.title,
       title: image.title,
-      isLoading: false as const,
+      isLoading: false,
     })),
     ...Array.from({ length: inProgressImageCount }, (_, i) => ({
       imageUrl: "",
       alt: `Generating image ${i + 1}`,
       title: `Generating image ${i + 1}`,
-      isGenerating: true as const,
+      isGenerating: true,
     })),
   ];
 

--- a/sparkle/src/components/ImageGenerationPlaceholder.tsx
+++ b/sparkle/src/components/ImageGenerationPlaceholder.tsx
@@ -186,6 +186,7 @@ export interface ImageGenerationPlaceholderProps {
   alt?: string;
   label?: string;
   size?: number;
+  fill?: boolean;
   className?: string;
 }
 
@@ -196,6 +197,7 @@ export function ImageGenerationPlaceholder({
   alt = "Generated image",
   label = "Creating image",
   size = 260,
+  fill = false,
   className,
 }: ImageGenerationPlaceholderProps) {
   const shouldReduceMotion = useReducedMotion();
@@ -225,11 +227,12 @@ export function ImageGenerationPlaceholder({
   return (
     <div
       className={cn(
-        "s-relative s-overflow-hidden s-shrink-0 s-rounded-2xl",
+        "s-overflow-hidden s-rounded-2xl",
         "s-bg-muted-background dark:s-bg-muted-background-night",
+        fill ? "s-absolute s-inset-0" : "s-relative s-shrink-0",
         className
       )}
-      style={{ width: size, height: size }}
+      style={fill ? undefined : { width: size, height: size }}
     >
       <div
         style={{

--- a/sparkle/src/components/ImagePreview.tsx
+++ b/sparkle/src/components/ImagePreview.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@sparkle/components/Button";
+import { ImageGenerationPlaceholder } from "@sparkle/components/ImageGenerationPlaceholder";
 import { ImageWrapper } from "@sparkle/components/ImageWrapper";
+import { Spinner } from "@sparkle/components/Spinner";
 import {
   downloadFile,
   ImageZoomDialog,
 } from "@sparkle/components/ImageZoomDialog";
-import { Spinner } from "@sparkle/components/Spinner";
 import { Download01, XClose } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -94,6 +95,7 @@ interface ImagePreviewProps
   title?: string;
   downloadUrl?: string;
   isLoading?: boolean;
+  isGenerating?: boolean;
   onClose?: (e: React.MouseEvent) => void;
   onClick?: (e: React.MouseEvent) => void;
   className?: string;
@@ -108,6 +110,7 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
       title = "",
       downloadUrl,
       isLoading,
+      isGenerating,
       onClose,
       onClick,
       className,
@@ -143,7 +146,7 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
       (e: React.MouseEvent) => {
         e.stopPropagation();
         e.preventDefault();
-        if (!isLoading) {
+        if (!isLoading && !isGenerating) {
           if (onClick) {
             onClick(e);
           } else if (manageZoomDialog) {
@@ -151,7 +154,7 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
           }
         }
       },
-      [isLoading, onClick, manageZoomDialog]
+      [isLoading, isGenerating, onClick, manageZoomDialog]
     );
 
     return (
@@ -161,7 +164,9 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
           onClick={handleImageClick}
           className={cn(containerVariants({ variant }), className)}
         >
-          {isLoading ? (
+          {isGenerating ? (
+            <ImageGenerationPlaceholder fill />
+          ) : isLoading ? (
             <div
               className={cn(
                 "s-flex s-h-full s-w-full s-items-center s-justify-center",

--- a/sparkle/src/components/ImagePreview.tsx
+++ b/sparkle/src/components/ImagePreview.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@sparkle/components/Button";
 import { ImageGenerationPlaceholder } from "@sparkle/components/ImageGenerationPlaceholder";
 import { ImageWrapper } from "@sparkle/components/ImageWrapper";
-import { Spinner } from "@sparkle/components/Spinner";
 import {
   downloadFile,
   ImageZoomDialog,
 } from "@sparkle/components/ImageZoomDialog";
+import { Spinner } from "@sparkle/components/Spinner";
 import { Download01, XClose } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/sparkle/src/components/InteractiveImageGrid.tsx
+++ b/sparkle/src/components/InteractiveImageGrid.tsx
@@ -18,6 +18,7 @@ interface InteractiveImageGridProps {
     downloadUrl?: string;
     imageUrl?: string;
     isLoading?: boolean;
+    isGenerating?: boolean;
     title: string;
   }[];
   onClose?: () => void;
@@ -82,6 +83,7 @@ function InteractiveImageGrid({
               title={images[0].title}
               downloadUrl={images[0].downloadUrl}
               isLoading={images[0].isLoading}
+              isGenerating={images[0].isGenerating}
               onClick={() => setCurrentImageIndex(0)}
               onClose={onClose ? () => onClose() : undefined}
               variant="embedded"
@@ -99,6 +101,7 @@ function InteractiveImageGrid({
                 title={image.title}
                 downloadUrl={image.downloadUrl}
                 isLoading={image.isLoading}
+                isGenerating={image.isGenerating}
                 onClick={() => setCurrentImageIndex(idx)}
                 variant="standalone"
                 titlePosition="center"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Image generation progress notifications were previously wired to show a loading state in the conversation grid, but that logic was dropped in #20371. This restores it using the `ImageGenerationPlaceholder` component added in #25852.

During generation, the `actionProgress` map is checked for entries where `isImageProgressOutput` is true. Each in-progress image is fed into a single `InteractiveImageGrid` alongside any already-completed images, using a new `isGenerating` prop that renders the animated placeholder instead of the spinner. The spinner is preserved for `isLoading` (image fetched but not yet rendered). The fill prop was added to `ImageGenerationPlaceholder` to let it stretch into its grid cell rather than use a fixed size.

https://github.com/user-attachments/assets/a87c9cf7-12be-4d97-bae3-d5ac523bf528

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
