### PR TITLE
 allow API key auth to compute authorized file access

### DIFF
--- a/front-api/middlewares/public_api_auth.ts
+++ b/front-api/middlewares/public_api_auth.ts
@@ -217,10 +217,11 @@ export const publicApiAuth = createMiddleware<PublicApiCtx>(
     if (apiKeyNameFromHeader && key && key.isSystem) {
       workspaceAuth = workspaceAuth.exchangeKey({
         id: key.id,
-        name: apiKeyNameFromHeader,
         isSystem: key.isSystem,
-        role: key.role,
         monthlyCapMicroUsd: key.monthlyCapMicroUsd,
+        name: apiKeyNameFromHeader,
+        role: key.role,
+        userModelId: key.userModelId,
       });
     }
 

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -15,7 +15,9 @@ import {
   isAuthorizedFileRef,
   resolveAllowlistedCanonicalPath,
 } from "@app/lib/api/viz/authorized_file_access_policy";
+import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { AuthorizedFileAccessModel } from "@app/lib/resources/storage/models/files";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -357,6 +359,65 @@ describe("computeAuthorizedFileAccess", () => {
         fileName: "report.csv",
       },
     ]);
+  });
+
+  it("uses the key owner's user when auth has no user (API key auth)", async () => {
+    const { authenticator: userAuth, workspace, user, globalGroup } =
+      await createResourceTest({});
+
+    const key = await KeyResource.makeNew(
+      {
+        name: "test-api-key",
+        workspaceId: globalGroup.workspaceId,
+        isSystem: false,
+        status: "active",
+        role: "builder",
+        userId: user.id,
+      },
+      [globalGroup]
+    );
+
+    const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
+      key,
+      workspace.sId
+    );
+    expect(apiKeyAuth.user()).toBeNull();
+
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const accessibleFile = await FileFactory.create(userAuth, null, {
+      contentType: "text/plain",
+      fileName: "data.txt",
+      fileSize: 10,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const frameFile = await FileFactory.create(userAuth, null, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+
+    const frameContent = `
+      export default function Frame() {
+        const data = useFile("${accessibleFile.sId}");
+        return data;
+      }
+    `;
+
+    const result = await frameFile.computeAuthorizedFileAccess(apiKeyAuth, {
+      frameContent,
+    });
+
+    expect(result.computedByUserId).toBe(user.sId);
   });
 });
 

--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -362,8 +362,12 @@ describe("computeAuthorizedFileAccess", () => {
   });
 
   it("uses the key owner's user when auth has no user (API key auth)", async () => {
-    const { authenticator: userAuth, workspace, user, globalGroup } =
-      await createResourceTest({});
+    const {
+      authenticator: userAuth,
+      workspace,
+      user,
+      globalGroup,
+    } = await createResourceTest({});
 
     const key = await KeyResource.makeNew(
       {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1745,7 +1745,14 @@ export class FileResource extends BaseResource<FileModel> {
         visited: new Set(),
       });
 
-    const computedByUserId = auth.user()?.sId;
+    let computedByUserId = auth.user()?.sId;
+    if (!computedByUserId) {
+      const keyUserId = auth.key()?.userId;
+      if (keyUserId) {
+        const keyUser = await UserResource.fetchByModelId(keyUserId);
+        computedByUserId = keyUser?.sId;
+      }
+    }
     if (!computedByUserId) {
       throw new Error("Cannot compute authorized file access without a user");
     }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1747,9 +1747,11 @@ export class FileResource extends BaseResource<FileModel> {
 
     let computedByUserId = auth.user()?.sId;
     if (!computedByUserId) {
-      const keyUserId = auth.key()?.userId;
-      if (keyUserId) {
-        const keyUser = await UserResource.fetchByModelId(keyUserId);
+      // Temporary: API keys carry a userId FK to their owner, fall back to it
+      // until authorized file access is reworked to not require a user identity.
+      const keyUserModelId = auth.key()?.userModelId;
+      if (keyUserModelId) {
+        const keyUser = await UserResource.fetchByModelId(keyUserModelId);
         computedByUserId = keyUser?.sId;
       }
     }

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -36,7 +36,7 @@ type CachedKeyData = Omit<
 
 export interface KeyAuthType {
   id: ModelId;
-  userModelId?: ModelId | null;
+  userModelId: ModelId | null;
   name: string;
   isSystem: boolean;
   role: RoleType;

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -36,7 +36,7 @@ type CachedKeyData = Omit<
 
 export interface KeyAuthType {
   id: ModelId;
-  userId: ModelId | null;
+  userModelId: ModelId | null;
   name: string;
   isSystem: boolean;
   role: RoleType;
@@ -337,7 +337,7 @@ export class KeyResource extends BaseResource<KeyModel> {
   toAuthJSON(): KeyAuthType {
     return {
       id: this.id,
-      userId: this.userId ?? null,
+      userModelId: this.userId ?? null,
       name: this.name,
       isSystem: this.isSystem,
       role: this.role,

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -36,7 +36,7 @@ type CachedKeyData = Omit<
 
 export interface KeyAuthType {
   id: ModelId;
-  userModelId: ModelId | null;
+  userModelId?: ModelId | null;
   name: string;
   isSystem: boolean;
   role: RoleType;

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -36,6 +36,7 @@ type CachedKeyData = Omit<
 
 export interface KeyAuthType {
   id: ModelId;
+  userId: ModelId | null;
   name: string;
   isSystem: boolean;
   role: RoleType;
@@ -336,6 +337,7 @@ export class KeyResource extends BaseResource<KeyModel> {
   toAuthJSON(): KeyAuthType {
     return {
       id: this.id,
+      userId: this.userId ?? null,
       name: this.name,
       isSystem: this.isSystem,
       role: this.role,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://dust4ai.slack.com/archives/C050SM8NSPK/p1780933400020839.

API key auth (`auth.user()` is null) was throwing when calling `computeAuthorizedFileAccess` because the function required a user to store as `computedByUserId`.

API keys carry a `userId` FK pointing to their owning user. This exposes it via `KeyAuthType` and uses it as a fallback in `computeAuthorizedFileAccess` by fetching the user by model ID when no session user is present.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
