### PR TITLE
Cleaner registration/unregistration for dust desktop

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -2741,6 +2741,61 @@
         }
       }
     },
+    "/api/v1/w/{wId}/mcp/deregister": {
+      "post": {
+        "summary": "Deregister a client-side MCP server",
+        "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nRemove a previously registered client-side MCP server registration.\n",
+        "tags": [
+          "MCP"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string",
+                    "description": "The ID of the registered MCP server"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Server deregistered successfully"
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "403": {
+            "description": "Forbidden. User does not have access to the workspace."
+          }
+        }
+      }
+    },
     "/api/v1/w/{wId}/mcp/heartbeat": {
       "post": {
         "summary": "Update heartbeat for a client-side MCP server",

--- a/front-api/routes/v1/w/[wId]/mcp/deregister.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/deregister.ts
@@ -1,0 +1,68 @@
+import { deregisterMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import { clearDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
+import { publicApiApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const PublicDeregisterMCPRequestBodySchema = z.object({
+  serverId: z.string(),
+});
+
+// Mounted at /api/v1/w/:wId/mcp/deregister.
+const app = publicApiApp();
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/mcp/deregister:
+ *   post:
+ *     summary: Deregister a client-side MCP server
+ *     description: |
+ *       [Documentation](https://docs.dust.tt/docs/client-side-mcp-server)
+ *       Remove a previously registered client-side MCP server registration.
+ *     tags:
+ *       - MCP
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - serverId
+ *             properties:
+ *               serverId:
+ *                 type: string
+ *                 description: The ID of the registered MCP server
+ *     responses:
+ *       200:
+ *         description: Server deregistered successfully
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       403:
+ *         description: Forbidden. User does not have access to the workspace.
+ */
+app.post(
+  "/",
+  validate("json", PublicDeregisterMCPRequestBodySchema),
+  async (ctx): HandlerResult<{ success: true }> => {
+    const auth = ctx.get("auth");
+    const { serverId } = ctx.req.valid("json");
+
+    await deregisterMCPServer(auth, { serverId });
+    await clearDustDesktopClientSideMCPServerRegistration(auth, { serverId });
+
+    return ctx.json({ success: true as const });
+  }
+);
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/mcp/heartbeat.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/heartbeat.ts
@@ -1,4 +1,5 @@
 import { updateMCPServerHeartbeat } from "@app/lib/api/actions/mcp/client_side_registry";
+import { maybePersistDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import type { HeartbeatMCPResponseType } from "@dust-tt/client";
 import { PublicHeartbeatMCPRequestBodySchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -85,6 +86,10 @@ app.post(
         },
       });
     }
+
+    await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
+      serverId,
+    });
 
     return ctx.json(result);
   }

--- a/front-api/routes/v1/w/[wId]/mcp/index.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/index.ts
@@ -1,5 +1,6 @@
 import { publicApiApp } from "@front-api/middlewares/ctx";
 
+import deregister from "./deregister";
 import heartbeat from "./heartbeat";
 import register from "./register";
 import requests from "./requests";
@@ -8,6 +9,7 @@ import results from "./results";
 // Mounted at /api/v1/w/:wId/mcp.
 const app = publicApiApp();
 
+app.route("/deregister", deregister);
 app.route("/heartbeat", heartbeat);
 app.route("/register", register);
 app.route("/requests", requests);

--- a/front-api/routes/v1/w/[wId]/mcp/register.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/register.ts
@@ -2,6 +2,7 @@ import {
   MCPServerInstanceLimitError,
   registerMCPServer,
 } from "@app/lib/api/actions/mcp/client_side_registry";
+import { maybePersistDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import type { RegisterMCPResponseType } from "@dust-tt/client";
 import { PublicRegisterMCPRequestBodySchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -111,6 +112,11 @@ app.post(
         },
       });
     }
+
+    await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
+      serverName,
+      serverId: registration.value.serverId,
+    });
 
     return ctx.json(registration.value);
   }

--- a/front-api/routes/w/[wId]/mcp/deregister.test.ts
+++ b/front-api/routes/w/[wId]/mcp/deregister.test.ts
@@ -5,9 +5,19 @@ const { mockDeregisterMCPServer } = vi.hoisted(() => ({
   mockDeregisterMCPServer: vi.fn(),
 }));
 
-vi.mock("@app/lib/api/actions/mcp/client_side_registry", () => ({
-  deregisterMCPServer: mockDeregisterMCPServer,
-}));
+vi.mock(
+  "@app/lib/api/actions/mcp/client_side_registry",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/actions/mcp/client_side_registry")
+      >();
+    return {
+      ...actual,
+      deregisterMCPServer: mockDeregisterMCPServer,
+    };
+  }
+);
 
 import { honoApp } from "@front-api/app";
 
@@ -30,7 +40,7 @@ function post(workspace: { sId: string }, body: unknown) {
 describe("POST /api/w/:wId/mcp/deregister", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDeregisterMCPServer.mockResolvedValue(undefined);
+    mockDeregisterMCPServer.mockResolvedValue(true);
   });
 
   it("should deregister a server successfully", async () => {

--- a/front-api/routes/w/[wId]/mcp/deregister.ts
+++ b/front-api/routes/w/[wId]/mcp/deregister.ts
@@ -1,4 +1,5 @@
 import { deregisterMCPServer } from "@app/lib/api/actions/mcp/client_side_registry";
+import { clearDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -23,6 +24,7 @@ app.post(
     const { serverId } = ctx.req.valid("json");
 
     await deregisterMCPServer(auth, { serverId });
+    await clearDustDesktopClientSideMCPServerRegistration(auth, { serverId });
 
     return ctx.json({ success: true });
   }

--- a/front-api/routes/w/[wId]/mcp/heartbeat.ts
+++ b/front-api/routes/w/[wId]/mcp/heartbeat.ts
@@ -1,4 +1,5 @@
 import { updateMCPServerHeartbeat } from "@app/lib/api/actions/mcp/client_side_registry";
+import { maybePersistDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -46,6 +47,10 @@ app.post(
       // connections).
       return ctx.json({ success: false });
     }
+
+    await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
+      serverId,
+    });
 
     return ctx.json(result);
   }

--- a/front-api/routes/w/[wId]/mcp/register.ts
+++ b/front-api/routes/w/[wId]/mcp/register.ts
@@ -2,6 +2,7 @@ import {
   MCPServerInstanceLimitError,
   registerMCPServer,
 } from "@app/lib/api/actions/mcp/client_side_registry";
+import { maybePersistDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -54,6 +55,11 @@ app.post(
         api_error: { type: "internal_server_error", message: error.message },
       });
     }
+
+    await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
+      serverName,
+      serverId: registration.value.serverId,
+    });
 
     return ctx.json(registration.value);
   }

--- a/front/lib/api/actions/mcp/client_side_registry.ts
+++ b/front/lib/api/actions/mcp/client_side_registry.ts
@@ -1,4 +1,3 @@
-import { maybePersistDustDesktopClientSideMCPServerRegistration } from "@app/lib/api/actions/mcp/dust_desktop";
 import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
@@ -144,11 +143,6 @@ export async function registerMCPServer(
     now + MCP_SERVER_REGISTRATION_TTL_SECONDS * 1000
   ).toISOString();
 
-  await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
-    serverName,
-    serverId,
-  });
-
   return new Ok({
     expiresAt,
     serverId,
@@ -239,11 +233,6 @@ export async function updateMCPServerHeartbeat(
     return null;
   }
 
-  await maybePersistDustDesktopClientSideMCPServerRegistration(auth, {
-    serverName: result.serverName,
-    serverId: result.serverId,
-  });
-
   const expiresAt = new Date(
     now + MCP_SERVER_REGISTRATION_TTL_SECONDS * 1000
   ).toISOString();
@@ -274,6 +263,7 @@ export async function deregisterMCPServer(
     { origin: "mcp_client_side_request" },
     async (redis) => redis.del(key)
   );
+
   return deleted === 1;
 }
 

--- a/front/lib/api/actions/mcp/dust_desktop.ts
+++ b/front/lib/api/actions/mcp/dust_desktop.ts
@@ -1,3 +1,8 @@
+import {
+  getBaseServerId,
+  getMCPServerIdFromServerName,
+  validateMCPServerAccess,
+} from "@app/lib/api/actions/mcp/client_side_registry";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { slugify } from "@app/types/shared/utils/string_utils";
@@ -30,6 +35,15 @@ export function isDustDesktopClientSideMCPServerName(
   );
 }
 
+export function isDustDesktopClientSideMCPServerId(serverId: string): boolean {
+  return (
+    getBaseServerId(serverId) ===
+    getMCPServerIdFromServerName({
+      serverName: DUST_DESKTOP_CLIENT_SIDE_MCP_SERVER_NAME,
+    })
+  );
+}
+
 /**
  * Persist the latest Dust Desktop client-side MCP server id for the current user
  * in this workspace. No-op unless the feature flag is enabled.
@@ -40,7 +54,7 @@ export async function maybePersistDustDesktopClientSideMCPServerRegistration(
     serverName,
     serverId,
   }: {
-    serverName: string;
+    serverName?: string;
     serverId: string;
   }
 ): Promise<void> {
@@ -48,15 +62,13 @@ export async function maybePersistDustDesktopClientSideMCPServerRegistration(
   if (!user) {
     return;
   }
-  if (!isDustDesktopClientSideMCPServerName(serverName)) {
-    return;
-  }
 
-  const hasDustDesktopFeatureFlag = await hasFeatureFlag(
-    auth,
-    DUST_DESKTOP_FEATURE_FLAG
-  );
-  if (!hasDustDesktopFeatureFlag) {
+  const isDustDesktop =
+    (serverName !== undefined &&
+      isDustDesktopClientSideMCPServerName(serverName)) ||
+    isDustDesktopClientSideMCPServerId(serverId);
+
+  if (!isDustDesktop) {
     return;
   }
 
@@ -70,6 +82,54 @@ export async function maybePersistDustDesktopClientSideMCPServerRegistration(
     ),
     auth.getNonNullableWorkspace().id
   );
+}
+
+/**
+ * Remove persisted Dust Desktop MCP metadata when a server instance is deregistered.
+ */
+export async function clearDustDesktopClientSideMCPServerRegistration(
+  auth: Authenticator,
+  { serverId }: { serverId: string }
+): Promise<void> {
+  if (!isDustDesktopClientSideMCPServerId(serverId)) {
+    return;
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return;
+  }
+
+  const workspaceModelId = auth.getNonNullableWorkspace().id;
+  const metadataRow = await user.getMetadata(
+    DUST_DESKTOP_MCP_SERVER_METADATA_KEY,
+    workspaceModelId
+  );
+  if (!metadataRow) {
+    return;
+  }
+
+  let metadata: DustDesktopMcpServerMetadata;
+  try {
+    const parsed = DustDesktopMcpServerMetadataSchema.safeParse(
+      JSON.parse(metadataRow.value)
+    );
+    if (!parsed.success) {
+      return;
+    }
+    metadata = parsed.data;
+  } catch {
+    return;
+  }
+
+  if (metadata.serverId !== serverId) {
+    return;
+  }
+
+  await user.deleteMetadata({
+    key: DUST_DESKTOP_MCP_SERVER_METADATA_KEY,
+    workspaceId: workspaceModelId,
+  });
 }
 
 /**
@@ -114,6 +174,13 @@ export async function getActiveDustDesktopClientSideMCPServerId(
   }
 
   if (Date.now() - metadata.updatedAt > DUST_DESKTOP_MCP_SERVER_TTL_MS) {
+    return null;
+  }
+
+  const isRegistered = await validateMCPServerAccess(auth, {
+    serverId: metadata.serverId,
+  });
+  if (!isRegistered) {
     return null;
   }
 


### PR DESCRIPTION
## Description

Cleans up the lifecycle management for Dust Desktop client-side MCP server registrations:

- Moves `maybePersistDustDesktopClientSideMCPServerRegistration` calls out of `client_side_registry.ts` and into the `register`/`heartbeat` route handlers (both public v1 and internal workspace routes), keeping the generic registry layer free of Dust Desktop concerns.
- Adds `clearDustDesktopClientSideMCPServerRegistration` — deletes the user metadata when a Dust Desktop server is explicitly deregistered via `/mcp/deregister`. Deregister routes in both surfaces now call it. Also adds a new public API route `POST /api/v1/w/:wId/mcp/deregister` that was previously missing.
- Adds `isDustDesktopClientSideMCPServerId` to identify a Dust Desktop server by `serverId` (via `getBaseServerId` comparison), enabling `maybePersistDustDesktopClientSideMCPServerRegistration` to work at heartbeat time when `serverName` is not available; `serverName` is now optional.
- `getActiveDustDesktopClientSideMCPServerId` now calls `validateMCPServerAccess` to confirm the persisted `serverId` is still live in Redis, preventing stale metadata from surfacing a ghost registration.

## Tests

Tested locally with Dust Desktop.

## Risk

Low. All changes are additive or move existing logic to a cleaner call site. The `clearDustDesktopClientSideMCPServerRegistration` is a no-op for non-Dust-Desktop server IDs. The stale-registration guard in `getActiveDustDesktopClientSideMCPServerId` can only reduce phantom server IDs, never break active ones.

## Deploy Plan

Deploy front.
