### PR TITLE
[front] Remove stale skill reference switches

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -18,8 +18,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 function useEditorService(
-  editor: Editor | null,
-  { enableSkillReferences }: { enableSkillReferences: boolean }
+  editor: Editor | null
 ) {
   return useMemo(() => {
     return {
@@ -48,9 +47,7 @@ function useEditorService(
         // Safety check for Safari: ensure editor and docView are available
         if (editor && !editor.isDestroyed) {
           editor.commands.setContent(
-            preprocessMarkdownForEditor(content, {
-              enableSkillReferences,
-            }),
+            preprocessMarkdownForEditor(content),
             {
               emitUpdate: false,
               contentType: "markdown",
@@ -93,12 +90,11 @@ function useEditorService(
         return editor?.isDestroyed ?? true;
       },
     };
-  }, [editor, enableSkillReferences]);
+  }, [editor]);
 }
 
 interface SkillInstructionsSkillReferencesOptions {
   currentSkillId?: string | null;
-  enableSkillReferences: boolean;
   onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
   onSelectTool?: (tool: MCPServerViewType) => void;
   onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
@@ -165,7 +161,6 @@ export function useSkillInstructionsEditor({
   onBlur,
   onDelete,
 }: UseSkillInstructionsEditorProps) {
-  const enableSkillReferences = skillReferences?.enableSkillReferences === true;
   const currentSkillId = skillReferences?.currentSkillId ?? null;
   const onSelectSkill = skillReferences?.onSelectSkill;
   const onSelectTool = skillReferences?.onSelectTool;
@@ -173,7 +168,7 @@ export function useSkillInstructionsEditor({
   const onSkillNodeDetails = skillReferences?.onSkillNodeDetails;
   const onToolDetails = skillReferences?.onToolDetails;
   const owner = skillReferences?.owner;
-  const includeSkillSuggestions = enableSkillReferences && !!owner;
+  const includeSkillSuggestions = !!owner;
   const editableExtensions = useMemo(
     () =>
       buildSkillInstructionsEditableExtensions({
@@ -199,13 +194,11 @@ export function useSkillInstructionsEditor({
   const extensions = useMemo(
     () =>
       buildSkillInstructionsExtensions(isReadOnly, editableExtensions, {
-        enableSkillReferences,
         onSkillNodeDetails,
         onToolDetails,
       }),
     [
       editableExtensions,
-      enableSkillReferences,
       isReadOnly,
       onSkillNodeDetails,
       onToolDetails,
@@ -228,7 +221,7 @@ export function useSkillInstructionsEditor({
     [extensions, isReadOnly]
   );
 
-  const editorService = useEditorService(editor, { enableSkillReferences });
+  const editorService = useEditorService(editor);
 
   // Set initial content after editor is created
   useEffect(() => {
@@ -247,9 +240,7 @@ export function useSkillInstructionsEditor({
             editor.commands.setContent(htmlContent, { emitUpdate: false });
           } else {
             editor.commands.setContent(
-              preprocessMarkdownForEditor(content, {
-                enableSkillReferences,
-              }),
+              preprocessMarkdownForEditor(content),
               {
                 emitUpdate: false,
                 contentType: "markdown",
@@ -261,7 +252,7 @@ export function useSkillInstructionsEditor({
         }
       });
     }
-  }, [editor, content, htmlContent, enableSkillReferences]);
+  }, [editor, content, htmlContent]);
 
   return { editor, editorService, isContentReady };
 }

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -17,9 +17,7 @@ import type { Editor } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-function useEditorService(
-  editor: Editor | null
-) {
+function useEditorService(editor: Editor | null) {
   return useMemo(() => {
     return {
       getMarkdown() {
@@ -46,13 +44,10 @@ function useEditorService(
       setContent(content: string) {
         // Safety check for Safari: ensure editor and docView are available
         if (editor && !editor.isDestroyed) {
-          editor.commands.setContent(
-            preprocessMarkdownForEditor(content),
-            {
-              emitUpdate: false,
-              contentType: "markdown",
-            }
-          );
+          editor.commands.setContent(preprocessMarkdownForEditor(content), {
+            emitUpdate: false,
+            contentType: "markdown",
+          });
         }
       },
 
@@ -197,12 +192,7 @@ export function useSkillInstructionsEditor({
         onSkillNodeDetails,
         onToolDetails,
       }),
-    [
-      editableExtensions,
-      isReadOnly,
-      onSkillNodeDetails,
-      onToolDetails,
-    ]
+    [editableExtensions, isReadOnly, onSkillNodeDetails, onToolDetails]
   );
 
   // Track if initial content has been set
@@ -239,13 +229,10 @@ export function useSkillInstructionsEditor({
           if (htmlContent) {
             editor.commands.setContent(htmlContent, { emitUpdate: false });
           } else {
-            editor.commands.setContent(
-              preprocessMarkdownForEditor(content),
-              {
-                emitUpdate: false,
-                contentType: "markdown",
-              }
-            );
+            editor.commands.setContent(preprocessMarkdownForEditor(content), {
+              emitUpdate: false,
+              contentType: "markdown",
+            });
           }
           initialContentSetRef.current = true;
           setIsContentReady(true);

--- a/front/components/editor/extensions/skill_builder/ToolNode.test.ts
+++ b/front/components/editor/extensions/skill_builder/ToolNode.test.ts
@@ -131,14 +131,9 @@ describe("ToolNode", () => {
       name: TOOL_ATTRS.toolName,
     })} now.`;
 
-    editor.commands.setContent(
-      preprocessMarkdownForEditor(markdown, {
-        enableSkillReferences: true,
-      }),
-      {
-        contentType: "markdown",
-      }
-    );
+    editor.commands.setContent(preprocessMarkdownForEditor(markdown), {
+      contentType: "markdown",
+    });
 
     expect(toolNodes(editor)).toEqual([
       {

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -58,19 +58,17 @@ const SKILL_REFERENCE_ALLOWED_TAGS = [
 ];
 const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
 
-function getSkillInstructionsSanitizeConfig(): Config {
-  return {
-    ADD_TAGS: [
-      ...BASE_ALLOWED_INSTRUCTIONS_TAGS,
-      ...SKILL_REFERENCE_ALLOWED_TAGS,
-    ],
-    ADD_ATTR: [
-      ...BASE_ALLOWED_INSTRUCTIONS_ATTRS,
-      ...SKILL_REFERENCE_ALLOWED_ATTRS,
-    ],
-    FORBID_ATTR: ["style", "class"],
-  };
-}
+const SKILL_INSTRUCTIONS_SANITIZE_CONFIG: Config = {
+  ADD_TAGS: [
+    ...BASE_ALLOWED_INSTRUCTIONS_TAGS,
+    ...SKILL_REFERENCE_ALLOWED_TAGS,
+  ],
+  ADD_ATTR: [
+    ...BASE_ALLOWED_INSTRUCTIONS_ATTRS,
+    ...SKILL_REFERENCE_ALLOWED_ATTRS,
+  ],
+  FORBID_ATTR: ["style", "class"],
+};
 
 function collectKnowledgeItems(editor: Editor): KnowledgeItem[] {
   const items: KnowledgeItem[] = [];
@@ -229,7 +227,7 @@ function toReferencedSkill(
 
 function sanitizeSkillInstructionsHtml(html: string): string {
   try {
-    return DOMPurify.sanitize(html, getSkillInstructionsSanitizeConfig());
+    return DOMPurify.sanitize(html, SKILL_INSTRUCTIONS_SANITIZE_CONFIG);
   } catch {
     return html;
   }

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -60,7 +60,10 @@ const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
 
 function getSkillInstructionsSanitizeConfig(): Config {
   return {
-    ADD_TAGS: [...BASE_ALLOWED_INSTRUCTIONS_TAGS, ...SKILL_REFERENCE_ALLOWED_TAGS],
+    ADD_TAGS: [
+      ...BASE_ALLOWED_INSTRUCTIONS_TAGS,
+      ...SKILL_REFERENCE_ALLOWED_TAGS,
+    ],
     ADD_ATTR: [
       ...BASE_ALLOWED_INSTRUCTIONS_ATTRS,
       ...SKILL_REFERENCE_ALLOWED_ATTRS,
@@ -825,13 +828,10 @@ export function SkillBuilderInstructionsEditor({
         const compareText = compareVersion.instructions ?? "";
         const currentText = instructionsField.value ?? "";
 
-        editor.commands.setContent(
-          preprocessMarkdownForEditor(currentText),
-          {
-            emitUpdate: false,
-            contentType: "markdown",
-          }
-        );
+        editor.commands.setContent(preprocessMarkdownForEditor(currentText), {
+          emitUpdate: false,
+          contentType: "markdown",
+        });
         editor.commands.applyDiff(
           preprocessMarkdownForEditor(compareText),
           preprocessMarkdownForEditor(currentText)

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -58,18 +58,13 @@ const SKILL_REFERENCE_ALLOWED_TAGS = [
 ];
 const SKILL_REFERENCE_ALLOWED_ATTRS = ["id", "name", "icon"];
 
-function getSkillInstructionsSanitizeConfig({
-  enableSkillReferences,
-}: {
-  enableSkillReferences: boolean;
-}): Config {
+function getSkillInstructionsSanitizeConfig(): Config {
   return {
-    ADD_TAGS: enableSkillReferences
-      ? [...BASE_ALLOWED_INSTRUCTIONS_TAGS, ...SKILL_REFERENCE_ALLOWED_TAGS]
-      : [...BASE_ALLOWED_INSTRUCTIONS_TAGS],
-    ADD_ATTR: enableSkillReferences
-      ? [...BASE_ALLOWED_INSTRUCTIONS_ATTRS, ...SKILL_REFERENCE_ALLOWED_ATTRS]
-      : [...BASE_ALLOWED_INSTRUCTIONS_ATTRS],
+    ADD_TAGS: [...BASE_ALLOWED_INSTRUCTIONS_TAGS, ...SKILL_REFERENCE_ALLOWED_TAGS],
+    ADD_ATTR: [
+      ...BASE_ALLOWED_INSTRUCTIONS_ATTRS,
+      ...SKILL_REFERENCE_ALLOWED_ATTRS,
+    ],
     FORBID_ATTR: ["style", "class"],
   };
 }
@@ -229,15 +224,9 @@ function toReferencedSkill(
   };
 }
 
-function sanitizeSkillInstructionsHtml(
-  html: string,
-  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
-): string {
+function sanitizeSkillInstructionsHtml(html: string): string {
   try {
-    return DOMPurify.sanitize(
-      html,
-      getSkillInstructionsSanitizeConfig({ enableSkillReferences })
-    );
+    return DOMPurify.sanitize(html, getSkillInstructionsSanitizeConfig());
   } catch {
     return html;
   }
@@ -411,9 +400,7 @@ export function SkillBuilderInstructionsEditor({
         postProcessMarkdown(editor.getMarkdown()).trim()
       );
       instructionsHtmlField.onChange(
-        sanitizeSkillInstructionsHtml(editor.getHTML(), {
-          enableSkillReferences: true,
-        })
+        sanitizeSkillInstructionsHtml(editor.getHTML())
       );
       syncAttachedKnowledgeFromEditor(editor);
       syncInlineReferencesFromEditor(editor);
@@ -530,7 +517,6 @@ export function SkillBuilderInstructionsEditor({
     isReadOnly: hasSuggestions,
     skillReferences: {
       currentSkillId: skillId,
-      enableSkillReferences: true,
       onSkillDetails: handleSkillDetails,
       onSkillNodeDetails: setSelectedSkillIdForDetails,
       onSelectSkill: handleSelectSkillReference,
@@ -815,9 +801,7 @@ export function SkillBuilderInstructionsEditor({
     }
 
     const incomingHtml = instructionsHtmlField.value;
-    const currentHtml = sanitizeSkillInstructionsHtml(editor.getHTML(), {
-      enableSkillReferences: true,
-    });
+    const currentHtml = sanitizeSkillInstructionsHtml(editor.getHTML());
     if (currentHtml !== incomingHtml) {
       editor.commands.setContent(incomingHtml, { emitUpdate: false });
     }
@@ -842,21 +826,15 @@ export function SkillBuilderInstructionsEditor({
         const currentText = instructionsField.value ?? "";
 
         editor.commands.setContent(
-          preprocessMarkdownForEditor(currentText, {
-            enableSkillReferences: true,
-          }),
+          preprocessMarkdownForEditor(currentText),
           {
             emitUpdate: false,
             contentType: "markdown",
           }
         );
         editor.commands.applyDiff(
-          preprocessMarkdownForEditor(compareText, {
-            enableSkillReferences: true,
-          }),
-          preprocessMarkdownForEditor(currentText, {
-            enableSkillReferences: true,
-          })
+          preprocessMarkdownForEditor(compareText),
+          preprocessMarkdownForEditor(currentText)
         );
         editor.setEditable(false);
       } else if (editor.storage.agentInstructionDiff?.isDiffMode) {
@@ -869,9 +847,7 @@ export function SkillBuilderInstructionsEditor({
           });
         } else {
           editor.commands.setContent(
-            preprocessMarkdownForEditor(instructionsField.value ?? "", {
-              enableSkillReferences: true,
-            }),
+            preprocessMarkdownForEditor(instructionsField.value ?? ""),
             {
               emitUpdate: false,
               contentType: "markdown",

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -134,9 +134,7 @@ function InstructionEditDiffBlock({
   const editor = useEditor(
     {
       extensions: [
-        ...buildSkillInstructionsExtensions(true, [], {
-          enableSkillReferences: true,
-        }),
+        ...buildSkillInstructionsExtensions(true),
       ],
       editable: false,
       content: blockHtml,

--- a/front/components/skill_builder/SkillSuggestionCard.tsx
+++ b/front/components/skill_builder/SkillSuggestionCard.tsx
@@ -133,9 +133,7 @@ function InstructionEditDiffBlock({
 
   const editor = useEditor(
     {
-      extensions: [
-        ...buildSkillInstructionsExtensions(true),
-      ],
+      extensions: [...buildSkillInstructionsExtensions(true)],
       editable: false,
       content: blockHtml,
       immediatelyRender: false,

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -125,7 +125,6 @@ export function SkillInfoTab({
           <SkillInstructionsReadOnlyEditor
             content={skill.instructions}
             htmlContent={skill.instructionsHtml ?? ""}
-            enableSkillReferences
             owner={owner}
             onKnowledgeItemsChange={handleKnowledgeItemsChange}
             className="max-h-150 overflow-y-auto"

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -11,7 +11,6 @@ import { useEffect } from "react";
 interface SkillInstructionsReadOnlyEditorProps {
   content: string;
   htmlContent?: string;
-  enableSkillReferences?: boolean;
   owner: LightWorkspaceType;
   onKnowledgeItemsChange?: (items: KnowledgeItem[]) => void;
   className?: string;
@@ -20,7 +19,6 @@ interface SkillInstructionsReadOnlyEditorProps {
 export function SkillInstructionsReadOnlyEditor({
   content,
   htmlContent,
-  enableSkillReferences = false,
   owner,
   onKnowledgeItemsChange,
   className,
@@ -32,9 +30,6 @@ export function SkillInstructionsReadOnlyEditor({
     content,
     htmlContent: htmlForEditor,
     isReadOnly: true,
-    skillReferences: {
-      enableSkillReferences,
-    },
   });
 
   useEffect(() => {

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -22,7 +22,6 @@ import { StarterKit } from "@tiptap/starter-kit";
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 interface BuildSkillInstructionsExtensionsOptions {
-  enableSkillReferences?: boolean;
   onSkillNodeDetails?: (skillId: string) => void;
   onToolDetails?: (tool: MCPServerViewType) => void;
 }
@@ -36,11 +35,7 @@ interface BuildSkillInstructionsExtensionsOptions {
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
   editableExtensions: Extensions = [],
-  {
-    enableSkillReferences = false,
-    onSkillNodeDetails,
-    onToolDetails,
-  }: BuildSkillInstructionsExtensionsOptions = {}
+  { onSkillNodeDetails, onToolDetails }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
     InstructionsDocumentExtension,
@@ -100,11 +95,8 @@ export function buildSkillInstructionsExtensions(
     }),
     BlockIdExtension,
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
+    ToolNodeWithView.configure({ onToolDetails }),
   ];
-
-  if (enableSkillReferences) {
-    baseExtensions.push(ToolNodeWithView.configure({ onToolDetails }));
-  }
 
   baseExtensions.push(
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
@@ -112,11 +104,7 @@ export function buildSkillInstructionsExtensions(
     ...rawMarkdownBlockParsers
   );
 
-  if (enableSkillReferences) {
-    baseExtensions.push(
-      SkillNode.configure({ onSkillDetails: onSkillNodeDetails })
-    );
-  }
+  baseExtensions.push(SkillNode.configure({ onSkillDetails: onSkillNodeDetails }));
 
   if (!isReadOnly) {
     baseExtensions.push(...editableExtensions);

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -35,7 +35,10 @@ interface BuildSkillInstructionsExtensionsOptions {
 export function buildSkillInstructionsExtensions(
   isReadOnly: boolean,
   editableExtensions: Extensions = [],
-  { onSkillNodeDetails, onToolDetails }: BuildSkillInstructionsExtensionsOptions = {}
+  {
+    onSkillNodeDetails,
+    onToolDetails,
+  }: BuildSkillInstructionsExtensionsOptions = {}
 ): Extensions {
   const baseExtensions: Extensions = [
     InstructionsDocumentExtension,
@@ -104,7 +107,9 @@ export function buildSkillInstructionsExtensions(
     ...rawMarkdownBlockParsers
   );
 
-  baseExtensions.push(SkillNode.configure({ onSkillDetails: onSkillNodeDetails }));
+  baseExtensions.push(
+    SkillNode.configure({ onSkillDetails: onSkillNodeDetails })
+  );
 
   if (!isReadOnly) {
     baseExtensions.push(...editableExtensions);

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -99,16 +99,13 @@ export function buildSkillInstructionsExtensions(
     BlockIdExtension,
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
     ToolNodeWithView.configure({ onToolDetails }),
+    SkillNode.configure({ onSkillDetails: onSkillNodeDetails }),
   ];
 
   baseExtensions.push(
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),
     RawMarkdownBlock,
     ...rawMarkdownBlockParsers
-  );
-
-  baseExtensions.push(
-    SkillNode.configure({ onSkillDetails: onSkillNodeDetails })
   );
 
   if (!isReadOnly) {

--- a/front/lib/editor/skill_instructions_preprocessing.test.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.test.ts
@@ -15,33 +15,14 @@ describe("skill instructions preprocessing", () => {
     editor = null;
   });
 
-  it("escapes skill tags by default", () => {
-    expect(
-      preprocessMarkdownForEditor(
-        'Use <skill id="skill_123" name="Create memo" /> here.'
-      )
-    ).toContain("<\u200Bskill");
-  });
-
-  it("escapes tool tags by default", () => {
-    expect(
-      preprocessMarkdownForEditor(
-        '<tool id="mcp_server_view_123" name="GitHub Search" />'
-      )
-    ).toContain("<\u200Btool");
-  });
-
-  it("preserves skill tags when skill references are enabled", () => {
+  it("preserves skill tags", () => {
     editor = new Editor({
-      extensions: buildSkillInstructionsExtensions(false, [], {
-        enableSkillReferences: true,
-      }),
+      extensions: buildSkillInstructionsExtensions(false),
     });
 
     editor.commands.setContent(
       preprocessMarkdownForEditor(
-        'Use <skill id="skill_123" name="Create memo" /> here.',
-        { enableSkillReferences: true }
+        'Use <skill id="skill_123" name="Create memo" /> here.'
       ),
       {
         contentType: "markdown",
@@ -65,34 +46,24 @@ describe("skill instructions preprocessing", () => {
     });
 
     editor = new Editor({
-      extensions: buildSkillInstructionsExtensions(false, [], {
-        enableSkillReferences: true,
-      }),
+      extensions: buildSkillInstructionsExtensions(false),
     });
 
-    editor.commands.setContent(
-      preprocessMarkdownForEditor(`Use ${toolTag}.`, {
-        enableSkillReferences: true,
-      }),
-      {
-        contentType: "markdown",
-      }
-    );
+    editor.commands.setContent(preprocessMarkdownForEditor(`Use ${toolTag}.`), {
+      contentType: "markdown",
+    });
 
     expect(postProcessMarkdown(editor.getMarkdown())).toContain(toolTag);
   });
 
-  it("preserves unavailable skill tags when skill references are enabled", () => {
+  it("preserves unavailable skill tags", () => {
     editor = new Editor({
-      extensions: buildSkillInstructionsExtensions(false, [], {
-        enableSkillReferences: true,
-      }),
+      extensions: buildSkillInstructionsExtensions(false),
     });
 
     editor.commands.setContent(
       preprocessMarkdownForEditor(
-        'Use <unavailable_skill id="skill_123" /> here.',
-        { enableSkillReferences: true }
+        'Use <unavailable_skill id="skill_123" /> here.'
       ),
       {
         contentType: "markdown",

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -52,13 +52,9 @@ function withPreservedToolTags(
  * Preprocess markdown before loading it into the TipTap editor.
  */
 export function preprocessMarkdownForEditor(
-  markdown: string,
-  { enableSkillReferences = false }: { enableSkillReferences?: boolean } = {}
+  markdown: string
 ): string {
-  const preservedTags = ["knowledge"];
-  if (enableSkillReferences) {
-    preservedTags.push("skill", "unavailable_skill");
-  }
+  const preservedTags = ["knowledge", "skill", "unavailable_skill"];
   const preservedTagsPattern = preservedTags.join("|");
   const escapeUnsupportedTags = (markdownToProcess: string) =>
     escapeMathEmphasis(
@@ -68,9 +64,7 @@ export function preprocessMarkdownForEditor(
       )
     );
 
-  return enableSkillReferences
-    ? withPreservedToolTags(markdown, escapeUnsupportedTags)
-    : escapeUnsupportedTags(markdown);
+  return withPreservedToolTags(markdown, escapeUnsupportedTags);
 }
 
 /**

--- a/front/lib/editor/skill_instructions_preprocessing.ts
+++ b/front/lib/editor/skill_instructions_preprocessing.ts
@@ -51,9 +51,7 @@ function withPreservedToolTags(
 /**
  * Preprocess markdown before loading it into the TipTap editor.
  */
-export function preprocessMarkdownForEditor(
-  markdown: string
-): string {
+export function preprocessMarkdownForEditor(markdown: string): string {
   const preservedTags = ["knowledge", "skill", "unavailable_skill"];
   const preservedTagsPattern = preservedTags.join("|");
   const escapeUnsupportedTags = (markdownToProcess: string) =>

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -217,25 +217,11 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("Previously rejected suggestions");
   });
 
-  it("system prompt mentions the suggestion tool when inline tools are disabled", () => {
+  it("system prompt mentions inline tool references", () => {
     const { systemPrompt } = buildSkillAggregationPrompt(
       makeSkill(),
       [makeInstructionSuggestion()],
-      { pending: [], rejected: [] },
-      { useInlineTools: false }
-    );
-
-    expect(systemPrompt).toContain("edit_skill");
-    expect(systemPrompt).not.toContain("inline <tool>");
-    expect(systemPrompt).not.toContain('Do NOT include "toolEdits"');
-  });
-
-  it("system prompt mentions inline tool references when inline tools are enabled", () => {
-    const { systemPrompt } = buildSkillAggregationPrompt(
-      makeSkill(),
-      [makeInstructionSuggestion()],
-      { pending: [], rejected: [] },
-      { useInlineTools: true }
+      { pending: [], rejected: [] }
     );
 
     expect(systemPrompt).toContain("edit_skill");
@@ -302,7 +288,7 @@ describe("buildSkillAggregationPrompt", () => {
     expect(userMessage).not.toContain("<title>");
   });
 
-  it("includes skill tools as a separate user message block when inline tools are disabled", () => {
+  it("does not include skill tools as a separate user message block", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -314,29 +300,7 @@ describe("buildSkillAggregationPrompt", () => {
     const { userMessage } = buildSkillAggregationPrompt(
       skill,
       [makeInstructionSuggestion()],
-      { pending: [], rejected: [] },
-      { useInlineTools: false }
-    );
-
-    expect(userMessage).toContain("<tools>");
-    expect(userMessage).toContain('name="web_search"');
-    expect(userMessage).toContain('sId="tool-ws"');
-  });
-
-  it("does not include skill tools as a separate user message block when inline tools are enabled", () => {
-    const skill = makeSkill({
-      tools: [
-        {
-          sId: "tool-ws",
-          name: "web_search",
-        } as SkillType["tools"][number],
-      ],
-    });
-    const { userMessage } = buildSkillAggregationPrompt(
-      skill,
-      [makeInstructionSuggestion()],
-      { pending: [], rejected: [] },
-      { useInlineTools: true }
+      { pending: [], rejected: [] }
     );
 
     expect(userMessage).not.toContain("<tools>");

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -29,7 +29,10 @@ const AGGREGATION_ASSEMBLY_ORDER = [
 
 type AggregationSectionKey = (typeof AGGREGATION_ASSEMBLY_ORDER)[number];
 
-function getReinforcedSkillAggregationSections(): Record<AggregationSectionKey, string> {
+function getReinforcedSkillAggregationSections(): Record<
+  AggregationSectionKey,
+  string
+> {
   return {
     primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -29,12 +29,11 @@ const AGGREGATION_ASSEMBLY_ORDER = [
 
 type AggregationSectionKey = (typeof AGGREGATION_ASSEMBLY_ORDER)[number];
 
-function getReinforcedSkillAggregationSections(): Record<
+const REINFORCED_SKILL_AGGREGATION_SECTIONS: Record<
   AggregationSectionKey,
   string
-> {
-  return {
-    primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
+> = {
+  primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
 You have access to the following tools:
@@ -50,7 +49,7 @@ IMPORTANT: Both edit_skill and reject_suggestion are terminal calls — you will
 It is ok to simply call no tool if all suggestions are minor.
 `,
 
-    aggregation_rules: `
+  aggregation_rules: `
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
 - For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits.
@@ -74,7 +73,7 @@ You SHOULD ignore suggestions that only have minor impact and are only supported
 
 There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires adding an inline <tool> tag to be effective. In this case, NEVER create one suggestion without the other.`,
 
-    suggestion_tool_calls: `
+  suggestion_tool_calls: `
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.
 The exceptions are:
 - The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
@@ -86,13 +85,11 @@ For "title": You MUST provide a short, action-oriented, user-facing title that s
 
 For "sourceSuggestionIds": You MUST include the sIds of ALL the source suggestions that were consolidated into this final suggestion. Each suggestion has an sId attribute. Every final suggestion MUST reference at least one source suggestion.
 `,
-  };
-}
+};
 
 export function buildSkillAggregationSystemPrompt(): string {
-  const sections = getReinforcedSkillAggregationSections();
   return AGGREGATION_ASSEMBLY_ORDER.map((key) => {
-    const body = sections[key].trim();
+    const body = REINFORCED_SKILL_AGGREGATION_SECTIONS[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
   }).join("\n\n");
 }

--- a/front/lib/reinforcement/aggregate_suggestions.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.ts
@@ -29,21 +29,13 @@ const AGGREGATION_ASSEMBLY_ORDER = [
 
 type AggregationSectionKey = (typeof AGGREGATION_ASSEMBLY_ORDER)[number];
 
-function getReinforcedSkillAggregationSections({
-  useInlineTools,
-}: {
-  useInlineTools: boolean;
-}): Record<AggregationSectionKey, string> {
+function getReinforcedSkillAggregationSections(): Record<AggregationSectionKey, string> {
   return {
     primary: `You improve a skill's configuration by consolidating many draft suggestions. Each draft was produced from a single conversation that used the skill.
 Your job is to produce a subset of the highest quality suggestions for the skill builder to review.
 
 You have access to the following tools:
-- edit_skill: ${
-      useInlineTools
-        ? "For suggesting instruction edits, inline tool reference changes, and/or agent-facing description changes for one skill."
-        : "For suggesting instruction edits, tool add/remove, and/or agent-facing description changes for one skill."
-    }
+- edit_skill: For suggesting instruction edits, inline tool reference changes, and/or agent-facing description changes for one skill.
 - reject_suggestion: For discarding source suggestions that are invalid, not actionable, or too similar to already declined suggestions. Do NOT reject minor but valid suggestions, simply ignore them.
 
 Your goal is to keep the most impactful suggestions. NEVER create more than 5 suggestions.
@@ -58,11 +50,7 @@ It is ok to simply call no tool if all suggestions are minor.
     aggregation_rules: `
 Start by grouping suggestions by skill, then within each skill group by topic:
 - For instruction edits, group by coherent theme within the skill (e.g. tone, tool usage, formatting). Suggestions that address different topics MUST be kept as separate suggestions — do NOT merge unrelated topics into one suggestion.
-- ${
-      useInlineTools
-        ? "For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits."
-        : "For tool changes, group by the target tool within each skill. NEVER create more than one suggestion per tool."
-    }
+- For inline tool reference changes, group by the target <tool> reference within each skill. Tool references are instruction edits, so NEVER output separate tool edits.
 - For agent-facing description edits, create AT MOST ONE description-edit suggestion per skill. When multiple drafts target the description, merge them into a single coherent replacement.
 NEVER create more than one suggestion per (skill, topic) pair.
 
@@ -81,17 +69,13 @@ Classify the groups in these 3 categories:
 
 You SHOULD ignore suggestions that only have minor impact and are only supported by a single conversation (don't reject them, do NOT call reject_suggestion, just take no action for these suggestions).
 
-There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires ${
-      useInlineTools ? "adding an inline <tool> tag" : "a tool suggestion"
-    } to be effective. In this case, NEVER create one suggestion without the other.`,
+There may be situations where suggestions are co-dependent. For example, there may be an instruction suggestion that requires adding an inline <tool> tag to be effective. In this case, NEVER create one suggestion without the other.`,
 
     suggestion_tool_calls: `
 You are provided all of the attributes associated with a conversation suggestion. You MUST use these EXACT attributes to create the final suggestion.
-The ${
-      useInlineTools
-        ? 'exceptions are:\n- The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.\n- Legacy "toolEdits"; convert these into instruction edits that add or remove the corresponding inline <tool> tag. Do NOT include "toolEdits" in the final edit_skill call.'
-        : 'only exceptions are the "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.'
-    }
+The exceptions are:
+- The "analysis", "title", and "sourceSuggestionIds" attributes; these MUST be newly authored for each final suggestion.
+- Legacy "toolEdits"; convert these into instruction edits that add or remove the corresponding inline <tool> tag. Do NOT include "toolEdits" in the final edit_skill call.
 
 For "analysis": Provide a user-facing explanation of why the suggestion is impactful and how many conversations support it. The end user does NOT care about the technical considerations behind your thought process.
 
@@ -102,12 +86,8 @@ For "sourceSuggestionIds": You MUST include the sIds of ALL the source suggestio
   };
 }
 
-export function buildSkillAggregationSystemPrompt({
-  useInlineTools = true,
-}: {
-  useInlineTools?: boolean;
-} = {}): string {
-  const sections = getReinforcedSkillAggregationSections({ useInlineTools });
+export function buildSkillAggregationSystemPrompt(): string {
+  const sections = getReinforcedSkillAggregationSections();
   return AGGREGATION_ASSEMBLY_ORDER.map((key) => {
     const body = sections[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
@@ -153,12 +133,11 @@ export function buildSkillAggregationPrompt(
   existingSuggestions: {
     pending: SkillSuggestionType[];
     rejected: SkillSuggestionType[];
-  },
-  { useInlineTools = true }: { useInlineTools?: boolean } = {}
+  }
 ): { systemPrompt: string; userMessage: string } {
-  const systemPrompt = buildSkillAggregationSystemPrompt({ useInlineTools });
+  const systemPrompt = buildSkillAggregationSystemPrompt();
 
-  let userMessage = `${formatSkillContext(skill, { useInlineTools })}
+  let userMessage = `${formatSkillContext(skill)}
 
 ## Synthetic suggestions from conversation analyses
 
@@ -187,13 +166,11 @@ interface SkillAggregationContext {
   skill: SkillResource;
   syntheticSuggestions: SkillSuggestionResource[];
   prompt: { systemPrompt: string; userMessage: string };
-  useInlineTools: boolean;
 }
 
 export async function loadSkillAggregationContext(
   auth: Authenticator,
-  skillId: string,
-  { useInlineTools }: { useInlineTools?: boolean } = {}
+  skillId: string
 ): Promise<SkillAggregationContext | null> {
   const syntheticSuggestions =
     await SkillSuggestionResource.listBySkillConfigurationId(auth, skillId, {
@@ -238,7 +215,6 @@ export async function loadSkillAggregationContext(
   );
 
   const skillType = skill.toJSON(auth);
-  const resolvedUseInlineTools = useInlineTools ?? true;
 
   const prompt = buildSkillAggregationPrompt(
     skillType,
@@ -246,15 +222,13 @@ export async function loadSkillAggregationContext(
     {
       pending: pendingSuggestions.map((s) => s.toJSON()),
       rejected: recentRejectedSuggestions.map((s) => s.toJSON()),
-    },
-    { useInlineTools: resolvedUseInlineTools }
+    }
   );
 
   return {
     skill,
     syntheticSuggestions,
     prompt,
-    useInlineTools: resolvedUseInlineTools,
   };
 }
 
@@ -276,8 +250,7 @@ export async function buildSkillAggregationBatchMap(
       "aggregation",
       buildReinforcedSkillsLLMParams(
         ctx.prompt,
-        "reinforcement_aggregate_suggestions",
-        { useInlineTools: ctx.useInlineTools }
+        "reinforcement_aggregate_suggestions"
       ),
     ],
   ]);

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -123,24 +123,10 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(userMessage).toContain("</skill_context>");
   });
 
-  it("system prompt mentions suggestion and exploration tools when inline tools are disabled", () => {
-    const { systemPrompt } = buildSkillAnalysisPrompt(
-      "User: hello",
-      [makeSkill()],
-      { useInlineTools: false }
-    );
-
-    expect(systemPrompt).toContain("edit_skill");
-    expect(systemPrompt).toContain("get_available_tools");
-    expect(systemPrompt).not.toContain("inline <tool>");
-  });
-
-  it("system prompt mentions inline tool references when inline tools are enabled", () => {
-    const { systemPrompt } = buildSkillAnalysisPrompt(
-      "User: hello",
-      [makeSkill()],
-      { useInlineTools: true }
-    );
+  it("system prompt mentions inline tool references", () => {
+    const { systemPrompt } = buildSkillAnalysisPrompt("User: hello", [
+      makeSkill(),
+    ]);
 
     expect(systemPrompt).toContain("edit_skill");
     expect(systemPrompt).toContain("get_available_tools");
@@ -157,7 +143,7 @@ describe("buildSkillAnalysisPrompt", () => {
     expect(systemPrompt).toMatch(/routing|when to enable/i);
   });
 
-  it("includes skill tools as a separate user message block when inline tools are disabled", () => {
+  it("does not include skill tools as a separate user message block", () => {
     const skill = makeSkill({
       tools: [
         {
@@ -166,27 +152,7 @@ describe("buildSkillAnalysisPrompt", () => {
         } as SkillType["tools"][number],
       ],
     });
-    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill], {
-      useInlineTools: false,
-    });
-
-    expect(userMessage).toContain("<tools>");
-    expect(userMessage).toContain('sId="tool-ws"');
-    expect(userMessage).toContain('name="web_search"');
-  });
-
-  it("does not include skill tools as a separate user message block when inline tools are enabled", () => {
-    const skill = makeSkill({
-      tools: [
-        {
-          sId: "tool-ws",
-          name: "web_search",
-        } as SkillType["tools"][number],
-      ],
-    });
-    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill], {
-      useInlineTools: true,
-    });
+    const { userMessage } = buildSkillAnalysisPrompt("User: hello", [skill]);
 
     expect(userMessage).not.toContain("<tools>");
     expect(userMessage).not.toContain('sId="tool-ws"');

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -21,11 +21,7 @@ const ASSEMBLY_ORDER = [
 
 type SectionKey = (typeof ASSEMBLY_ORDER)[number];
 
-function getReinforcedSkillAnalysisSections({
-  useInlineTools,
-}: {
-  useInlineTools: boolean;
-}): Record<SectionKey, string> {
+function getReinforcedSkillAnalysisSections(): Record<SectionKey, string> {
   return {
     primary_goal: `You are a Dust skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
 A skill bundles tools and instructions that are used by a Dust agent to perform a specific task.
@@ -40,11 +36,7 @@ In most conversations, the correct outcome is no configuration change. This mean
 Propose configuration changes only when <analysis_workflow> yields concrete evidence. If you are unsure, do not call edit_skill.
 
 ## Exploration tools (optional — use these if you need more context)
-- get_available_tools: ${
-      useInlineTools
-        ? "ALWAYS call this before embedding any <tool> tag in an instruction edit — the tag requires an MCP server view ID and name that must come from this tool. See <tool_references> for more details."
-        : "Use this to discover tools you could suggest adding or to verify that suggested tools exist."
-    }
+- get_available_tools: ALWAYS call this before embedding any <tool> tag in an instruction edit — the tag requires an MCP server view ID and name that must come from this tool. See <tool_references> for more details.
 - describe_mcp: ALWAYS call this before suggesting instruction changes that reference specific tool names or workflows for a given MCP — you need to know the exact tool names and their inputs to write accurate instructions.
 - search_knowledge: ALWAYS call this before embedding any <knowledge> tag in an instruction edit — the tag requires node attributes (id, space, dsv, hasChildren) that must come from this tool. Use this whenever the conversation shows the agent navigating or retrieving specific data nodes that the skill instructions should directly reference. See <knowledge_nodes> for more details.
 `,
@@ -52,22 +44,14 @@ Propose configuration changes only when <analysis_workflow> yields concrete evid
     skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
 When enabled, skill instructions are rendered in the conversation as dedicated <dust_system> user messages.
 This means that every subsequent agent action can be influenced by each enabled skill in addition to the agent's system prompt.
-The only strong signal of skill influence on the agent behavior is when the agent calls a tool that ${
-      useInlineTools
-        ? "the skill references in its instructions"
-        : "the skill provides"
-    }.
+The only strong signal of skill influence on the agent behavior is when the agent calls a tool that the skill references in its instructions.
 You will need to infer the impact of the skill on the agent behavior by checking tool calls and agent messages.`,
 
     analysis_workflow: `Follow this process for every conversation you analyze:
 
 Step 1: Determine which skills were relevant to the conversation.
 For each skill in <skill_context>, ask yourself these questions:
-- ${
-      useInlineTools
-        ? "Were any tools referenced by the skill's instructions called in <conversation>? Match inline <tool> tags and their described MCP tools against the functionCallName in actions."
-        : "Were any of the skill's configured tools called in <conversation>? Match the skill's tool names/IDs against the functionCallName in actions."
-    }
+- Were any tools referenced by the skill's instructions called in <conversation>? Match inline <tool> tags and their described MCP tools against the functionCallName in actions.
 - Does the conversation topic match the skill's purpose and instructions? Use <agentFacingDescription> and <instructions> inside each <skill> in <skill_context>.
 - Was there an enable_skill tool call for the skill? If so, note when. This means the agent made an explicit decision to enable the skill for the rest of the conversation.
 
@@ -83,14 +67,8 @@ A key consideration is that conversations can be user-specific, but skills share
 Step 4: For each skill improvement identified in Step 3, formulate a suggestion.
 ALWAYS ensure that the suggestion is inline with the skill's purpose and instructions. Skills SHOULD be single purpose and not be overloaded with multiple responsibilities.
 Consider the following improvements to a skill:
-- Review instructions to determine if the skill is meeting the user intent and properly utilizing ${
-      useInlineTools ? "its inline tool references" : "the configured tools"
-    }: <instructions_guidance>.
-- ${
-      useInlineTools
-        ? "If the skill references or requires external actions or knowledge, inline <tool> or <knowledge> references may need to be added or removed from its instructions. See <tools_guidance>."
-        : "If the skill references or requires external actions or knowledge, then tools may need to be added or removed. See <tools_guidance>."
-    }
+- Review instructions to determine if the skill is meeting the user intent and properly utilizing its inline tool references: <instructions_guidance>.
+- If the skill references or requires external actions or knowledge, inline <tool> or <knowledge> references may need to be added or removed from its instructions. See <tools_guidance>.
 - If the conversation reveals that the agent enabled the skill in the wrong situation, or failed to enable it when it should have, the agent-facing description may need to be improved. See <agent_facing_description_guidance>.
 All improvements that should be treated as a single atomic unit should be grouped together in a single suggestion.
 NEVER group things that are not related to each other.
@@ -118,35 +96,21 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 
 - Focus on actionable information that changes what the skill does.
 - Preserve the skill's existing goals — NEVER change what the goal is, only improve HOW it achieves it.
-- Instructions SHOULD reference how to use tools that are ${
-      useInlineTools
-        ? "inlined in the skill instructions"
-        : "configured in the skill"
-    }.
+- Instructions SHOULD reference how to use tools that are inlined in the skill instructions.
 - Suggestions ALWAYS need to be using the same language as the existing instructions OR, for new skills, the language of the user conversation.
 - Prefer small, focused changes over large rewrites.
 - Extract the INTENT from examples, not the literal pattern.
 - Filter out information only relevant for humans, not the LLM.`,
 
-    instruction_editing: buildSkillInstructionHtmlEditPrompt({
-      useInlineTools,
-    }),
+    instruction_editing: buildSkillInstructionHtmlEditPrompt(),
 
-    tools_guidance: useInlineTools
-      ? `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
+    tools_guidance: `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
 
 - Discover available tools by calling get_available_tools.
 - Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
 - Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
 - When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
 - Suggest tool additions by creating an instruction edit that embeds a self-closing <tool> tag in the relevant instruction block. Suggest tool removals by creating an instruction edit that removes the obsolete <tool> tag and related usage instructions. NEVER use separate tool edits.
-- When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`
-      : `Tools provide capabilities to the skill. When evaluating tool changes:
-
-- Discover available tools by calling get_available_tools.
-- Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
-- Only suggest removing a tool if there is clear evidence the tool is causing confusion or is unused and cluttering the skill configuration.
-- When suggesting a tool addition, ensure the tool exists in the workspace by checking available tools first.
 - When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
 
     agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.
@@ -164,12 +128,8 @@ When suggesting a description edit:
   };
 }
 
-export function buildSkillAnalysisSystemPrompt({
-  useInlineTools = true,
-}: {
-  useInlineTools?: boolean;
-} = {}): string {
-  const sections = getReinforcedSkillAnalysisSections({ useInlineTools });
+export function buildSkillAnalysisSystemPrompt(): string {
+  const sections = getReinforcedSkillAnalysisSections();
   return ASSEMBLY_ORDER.map((key) => {
     const body = sections[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
@@ -178,14 +138,11 @@ export function buildSkillAnalysisSystemPrompt({
 
 export function buildSkillAnalysisPrompt(
   conversationText: string,
-  skills: SkillType[],
-  { useInlineTools = true }: { useInlineTools?: boolean } = {}
+  skills: SkillType[]
 ): { systemPrompt: string; userMessage: string } {
-  const systemPrompt = buildSkillAnalysisSystemPrompt({ useInlineTools });
+  const systemPrompt = buildSkillAnalysisSystemPrompt();
 
-  const skillContexts = skills
-    .map((s) => formatSkillContext(s, { useInlineTools }))
-    .join("\n\n---\n\n");
+  const skillContexts = skills.map((s) => formatSkillContext(s)).join("\n\n---\n\n");
 
   const userMessage = `<skill_context>
 ${skillContexts}
@@ -205,11 +162,9 @@ ${conversationText}
  */
 export async function buildSkillConversationAnalysisBatchMap(
   auth: Authenticator,
-  conversationsWithSkills: { conversationId: string; skillIds: string[] }[],
-  { useInlineTools }: { useInlineTools?: boolean } = {}
+  conversationsWithSkills: { conversationId: string; skillIds: string[] }[]
 ): Promise<Map<string, LLMStreamParameters> | null> {
   const batchMap = new Map<string, LLMStreamParameters>();
-  const resolvedUseInlineTools = useInlineTools ?? true;
 
   // Collect all unique skill sIds across all conversations.
   const allSkillIds = [
@@ -247,18 +202,10 @@ export async function buildSkillConversationAnalysisBatchMap(
 
     const skillTypes = resolvedSkills.map((s) => s.toJSON(auth));
 
-    const prompt = buildSkillAnalysisPrompt(
-      conversationRes.value.text,
-      skillTypes,
-      { useInlineTools: resolvedUseInlineTools }
-    );
+    const prompt = buildSkillAnalysisPrompt(conversationRes.value.text, skillTypes);
     batchMap.set(
       conversationId,
-      buildReinforcedSkillsLLMParams(
-        prompt,
-        "reinforcement_analyze_conversation",
-        { useInlineTools: resolvedUseInlineTools }
-      )
+      buildReinforcedSkillsLLMParams(prompt, "reinforcement_analyze_conversation")
     );
   }
 

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -3,7 +3,7 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { formatSkillContext } from "@app/lib/reinforcement/format_skill_context";
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
-import { buildSkillInstructionHtmlEditPrompt } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
+import { SKILL_INSTRUCTION_HTML_EDIT_PROMPT } from "@app/lib/reinforcement/skill_instruction_edit_prompt";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -21,9 +21,8 @@ const ASSEMBLY_ORDER = [
 
 type SectionKey = (typeof ASSEMBLY_ORDER)[number];
 
-function getReinforcedSkillAnalysisSections(): Record<SectionKey, string> {
-  return {
-    primary_goal: `You are a Dust skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
+const REINFORCED_SKILL_ANALYSIS_SECTIONS: Record<SectionKey, string> = {
+  primary_goal: `You are a Dust skill improvement analyst. Your job is to analyze a conversation that used one or more skills and suggest concrete improvements to those skills.
 A skill bundles tools and instructions that are used by a Dust agent to perform a specific task.
 
 See <skill_usage_analysis> for guidance on how to analyze the relevance of a skill in the conversation.
@@ -41,13 +40,13 @@ Propose configuration changes only when <analysis_workflow> yields concrete evid
 - search_knowledge: ALWAYS call this before embedding any <knowledge> tag in an instruction edit — the tag requires node attributes (id, space, dsv, hasChildren) that must come from this tool. Use this whenever the conversation shows the agent navigating or retrieving specific data nodes that the skill instructions should directly reference. See <knowledge_nodes> for more details.
 `,
 
-    skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
+  skill_usage_analysis: `In <skill_context>, you have received all custom skills that were enabled in the conversation.
 When enabled, skill instructions are rendered in the conversation as dedicated <dust_system> user messages.
 This means that every subsequent agent action can be influenced by each enabled skill in addition to the agent's system prompt.
 The only strong signal of skill influence on the agent behavior is when the agent calls a tool that the skill references in its instructions.
 You will need to infer the impact of the skill on the agent behavior by checking tool calls and agent messages.`,
 
-    analysis_workflow: `Follow this process for every conversation you analyze:
+  analysis_workflow: `Follow this process for every conversation you analyze:
 
 Step 1: Determine which skills were relevant to the conversation.
 For each skill in <skill_context>, ask yourself these questions:
@@ -85,14 +84,14 @@ Step 7: Make suggestions.
 ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmetic-only fixes.
 `,
 
-    conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Agent messages may include an Actions section listing tool calls with their inputs and outputs, and a User feedback section with sentiment and comments. Here are key signals of areas where the agent behavior could be improved:
+  conversation_analysis: `ALWAYS inspect the full conversation, which is a chronological timeline of messages. Agent messages may include an Actions section listing tool calls with their inputs and outputs, and a User feedback section with sentiment and comments. Here are key signals of areas where the agent behavior could be improved:
 1. Feedback - If the user provided feedback, it will be included after the agent message in a "User feedback:" section with thumbs up/down ratings and optional comments. This is the MOST important signal as it is directly provided by the user and an explicit signal.
 2. User reaction - Any user indication of confusion, disagreement, or correction is a signal of dissatisfaction. A user follow-up question or request could mean the skill response was useful, but a skill could be improved in terms of proactively providing that information or performing the action without user intervention.
 3. Tool calls - If the tool calls needed to be retried, could a skill's instructions be more clear on how to use that tool?
 4. Sequence - Did the agent call the tools in the correct order?
 `,
 
-    instructions_guidance: `When suggesting instruction improvements for skills, follow these principles:
+  instructions_guidance: `When suggesting instruction improvements for skills, follow these principles:
 
 - Focus on actionable information that changes what the skill does.
 - Preserve the skill's existing goals — NEVER change what the goal is, only improve HOW it achieves it.
@@ -102,9 +101,9 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 - Extract the INTENT from examples, not the literal pattern.
 - Filter out information only relevant for humans, not the LLM.`,
 
-    instruction_editing: buildSkillInstructionHtmlEditPrompt(),
+  instruction_editing: SKILL_INSTRUCTION_HTML_EDIT_PROMPT,
 
-    tools_guidance: `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
+  tools_guidance: `Tools provide capabilities to the skill through inline <tool> tags in the instructions. When evaluating tool changes:
 
 - Discover available tools by calling get_available_tools.
 - Only suggest adding a tool if there is clear evidence from the conversation that the skill needed a capability it did not have.
@@ -113,7 +112,7 @@ ONLY make suggestions that will affect the skill behavior. NEVER suggest cosmeti
 - Suggest tool additions by creating an instruction edit that embeds a self-closing <tool> tag in the relevant instruction block. Suggest tool removals by creating an instruction edit that removes the obsolete <tool> tag and related usage instructions. NEVER use separate tool edits.
 - When the conversation involves a tool call that failed or produced unexpected results, call describe_mcp for the relevant MCP to understand the full list of available tools and their correct usage before suggesting instruction changes.`,
 
-    agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.
+  agent_facing_description_guidance: `The agent-facing description (\`<agentFacingDescription>\` in the skill context) is what the agent reads to decide WHEN to enable the skill. It is NOT the skill's behavior — that lives in \`<instructions>\`.
 
 Suggest editing it only when the conversation surfaces clear evidence of a routing problem:
 - The agent enabled the skill in a situation it does not actually cover.
@@ -125,13 +124,11 @@ When suggesting a description edit:
 - Preserve the skill's actual purpose. Sharpen the trigger conditions; do not redefine the skill.
 - Keep it focused on routing signals (when to use, what scenarios). Do not duplicate the instructions.
 - Use the same language as the existing description.`,
-  };
-}
+};
 
 export function buildSkillAnalysisSystemPrompt(): string {
-  const sections = getReinforcedSkillAnalysisSections();
   return ASSEMBLY_ORDER.map((key) => {
-    const body = sections[key].trim();
+    const body = REINFORCED_SKILL_ANALYSIS_SECTIONS[key].trim();
     return `<${key}>\n${body}\n</${key}>`;
   }).join("\n\n");
 }

--- a/front/lib/reinforcement/analyze_conversation.ts
+++ b/front/lib/reinforcement/analyze_conversation.ts
@@ -142,7 +142,9 @@ export function buildSkillAnalysisPrompt(
 ): { systemPrompt: string; userMessage: string } {
   const systemPrompt = buildSkillAnalysisSystemPrompt();
 
-  const skillContexts = skills.map((s) => formatSkillContext(s)).join("\n\n---\n\n");
+  const skillContexts = skills
+    .map((s) => formatSkillContext(s))
+    .join("\n\n---\n\n");
 
   const userMessage = `<skill_context>
 ${skillContexts}
@@ -202,10 +204,16 @@ export async function buildSkillConversationAnalysisBatchMap(
 
     const skillTypes = resolvedSkills.map((s) => s.toJSON(auth));
 
-    const prompt = buildSkillAnalysisPrompt(conversationRes.value.text, skillTypes);
+    const prompt = buildSkillAnalysisPrompt(
+      conversationRes.value.text,
+      skillTypes
+    );
     batchMap.set(
       conversationId,
-      buildReinforcedSkillsLLMParams(prompt, "reinforcement_analyze_conversation")
+      buildReinforcedSkillsLLMParams(
+        prompt,
+        "reinforcement_analyze_conversation"
+      )
     );
   }
 

--- a/front/lib/reinforcement/format_skill_context.ts
+++ b/front/lib/reinforcement/format_skill_context.ts
@@ -3,20 +3,7 @@ import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { escapeXml } from "@app/types/shared/utils/string_utils";
 
-export function formatSkillContext(
-  skill: SkillType,
-  { useInlineTools = false }: { useInlineTools?: boolean } = {}
-): string {
-  const toolsBlock =
-    !useInlineTools && skill.tools.length > 0
-      ? `<tools>${skill.tools
-          .map(
-            (t) =>
-              `<tool sId="${escapeXml(t.sId)}" name="${escapeXml(t.name ?? "")}"/>`
-          )
-          .join("")}</tools>`
-      : "";
-
+export function formatSkillContext(skill: SkillType): string {
   const descBlock = skill.agentFacingDescription
     ? `<agentFacingDescription>${escapeXml(skill.agentFacingDescription)}</agentFacingDescription>`
     : "";
@@ -27,5 +14,5 @@ export function formatSkillContext(
       )}</instructions>`
     : "";
 
-  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${toolsBlock}${descBlock}${instructionsBlock}</skill>`;
+  return `<skill ID="${escapeXml(skill.sId)}" name="${escapeXml(skill.name)}">${descBlock}${instructionsBlock}</skill>`;
 }

--- a/front/lib/reinforcement/run_reinforced_analysis.test.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.test.ts
@@ -1,8 +1,5 @@
 import { buildReinforcedSkillsLLMParams } from "@app/lib/reinforcement/run_reinforced_analysis";
-import {
-  getEditSkillToolSchema,
-  TOOL_SCHEMAS,
-} from "@app/lib/reinforcement/types";
+import { TOOL_SCHEMAS } from "@app/lib/reinforcement/types";
 import { describe, expect, it } from "vitest";
 
 describe("buildReinforcedSkillsLLMParams", () => {
@@ -119,19 +116,6 @@ describe("TOOL_SCHEMAS.edit_skill agentFacingDescriptionEdit", () => {
   });
 });
 
-describe("getEditSkillToolSchema", () => {
-  it("accepts legacy tool edits when inline tools are disabled", () => {
-    const parsed = getEditSkillToolSchema({
-      useInlineTools: false,
-    }).safeParse({
-      skillId: "skl_abc",
-      toolEdits: [{ action: "add", toolId: "tool_x" }],
-    });
-
-    expect(parsed.success).toBe(true);
-  });
-});
-
 describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
   it("exposes agentFacingDescriptionEdit on the analyze edit_skill input schema", () => {
     const params = buildReinforcedSkillsLLMParams(
@@ -163,25 +147,10 @@ describe("buildReinforcedSkillsLLMParams edit_skill spec", () => {
     );
   });
 
-  it("exposes toolEdits when inline tools are disabled", () => {
+  it("does not expose legacy toolEdits", () => {
     const params = buildReinforcedSkillsLLMParams(
       { systemPrompt: "System.", userMessage: "User." },
-      "reinforcement_analyze_conversation",
-      { useInlineTools: false }
-    );
-    const editSkillSpec = params.specifications?.find(
-      (s) => s.name === "edit_skill"
-    );
-
-    expect(editSkillSpec).toBeDefined();
-    expect(JSON.stringify(editSkillSpec?.inputSchema)).toContain("toolEdits");
-  });
-
-  it("does not expose toolEdits when inline tools are enabled", () => {
-    const params = buildReinforcedSkillsLLMParams(
-      { systemPrompt: "System.", userMessage: "User." },
-      "reinforcement_analyze_conversation",
-      { useInlineTools: true }
+      "reinforcement_analyze_conversation"
     );
     const editSkillSpec = params.specifications?.find(
       (s) => s.name === "edit_skill"

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -43,19 +43,14 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const REINFORCEMENT_SKILLS_AGENT_ID = "reinforcement";
 
 // Tool schemas for reinforced skills (exploration + terminal).
-function buildReinforcedSkillsToolDefinitions({
-  useInlineTools,
-}: {
-  useInlineTools: boolean;
-}): Record<
+function buildReinforcedSkillsToolDefinitions(): Record<
   string,
   { description: string; schema: z.ZodObject<z.ZodRawShape> }
 > {
   return {
     get_available_tools: {
-      description: useInlineTools
-        ? "Get the list of available tools (MCP servers) that can be referenced in skill instructions with inline <tool> tags."
-        : "Get the list of available tools (MCP servers) that can be added to skills.",
+      description:
+        "Get the list of available tools (MCP servers) that can be referenced in skill instructions with inline <tool> tags.",
       schema: z.object({}),
     },
     [DESCRIBE_MCP_TOOL_NAME]: {
@@ -84,10 +79,9 @@ function buildReinforcedSkillsToolDefinitions({
       }),
     },
     edit_skill: {
-      description: useInlineTools
-        ? "Suggest edits to a skill's instructions and/or agent-facing description."
-        : "Suggest edits to a skill's instructions and/or configured tools.",
-      schema: getEditSkillToolSchema({ useInlineTools }),
+      description:
+        "Suggest edits to a skill's instructions and/or agent-facing description.",
+      schema: getEditSkillToolSchema(),
     },
     reject_suggestion: {
       description:
@@ -106,28 +100,6 @@ function buildReinforcedSkillsToolDefinitions({
   };
 }
 
-function getToolEdits(data: Record<string, unknown>) {
-  const toolEdits = data.toolEdits;
-  if (!Array.isArray(toolEdits)) {
-    return undefined;
-  }
-
-  return toolEdits.filter(
-    (
-      edit
-    ): edit is {
-      action: "add" | "remove";
-      toolId: string;
-    } =>
-      edit !== null &&
-      typeof edit === "object" &&
-      "action" in edit &&
-      (edit.action === "add" || edit.action === "remove") &&
-      "toolId" in edit &&
-      typeof edit.toolId === "string"
-  );
-}
-
 const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
   sourceSuggestionIds: z
     .array(z.string())
@@ -139,13 +111,10 @@ const AGGREGATION_EXTRA_FIELDS: z.ZodRawShape = {
 };
 
 export function buildReinforcedSkillsSpecifications(
-  operationType: ReinforcedSkillsOperationType,
-  { useInlineTools = true }: { useInlineTools?: boolean } = {}
+  operationType: ReinforcedSkillsOperationType
 ): AgentActionSpecification[] {
   const isAggregation = operationType === "reinforcement_aggregate_suggestions";
-  const toolDefinitions = buildReinforcedSkillsToolDefinitions({
-    useInlineTools,
-  });
+  const toolDefinitions = buildReinforcedSkillsToolDefinitions();
 
   return ALL_TOOLS.filter((toolName) => {
     // reject_suggestion is only available during aggregation.
@@ -240,8 +209,7 @@ export function buildReinforcedSkillsLLMParams(
     systemPrompt: string;
     userMessage: string;
   },
-  operationType: ReinforcedSkillsOperationType,
-  { useInlineTools = true }: { useInlineTools?: boolean } = {}
+  operationType: ReinforcedSkillsOperationType
 ): LLMStreamParameters {
   return {
     conversation: {
@@ -254,9 +222,7 @@ export function buildReinforcedSkillsLLMParams(
       ],
     },
     prompt: systemPrompt,
-    specifications: buildReinforcedSkillsSpecifications(operationType, {
-      useInlineTools,
-    }),
+    specifications: buildReinforcedSkillsSpecifications(operationType),
   };
 }
 
@@ -270,19 +236,14 @@ export async function createReinforcedSkillsConversation(
     operationType,
     contextId,
     skillIds,
-    useInlineTools,
   }: {
     prompt: { systemPrompt: string; userMessage: string };
     operationType: ReinforcedSkillsOperationType;
     contextId: string;
     skillIds: string[];
-    useInlineTools?: boolean;
   }
 ): Promise<string> {
-  const resolvedUseInlineTools = useInlineTools ?? true;
-  const llmParams = buildReinforcedSkillsLLMParams(prompt, operationType, {
-    useInlineTools: resolvedUseInlineTools,
-  });
+  const llmParams = buildReinforcedSkillsLLMParams(prompt, operationType);
   const { conversation: llmConversation, ...llmParamsWithoutConversation } =
     llmParams;
   const writeResult = await writeBatchUserMessages(auth, {
@@ -341,7 +302,6 @@ export async function processSkillReinforcedEvents({
   contextId,
   conversation,
   eligibleSkillIds,
-  useInlineTools,
 }: {
   auth: Authenticator;
   events: LLMEvent[];
@@ -350,7 +310,6 @@ export async function processSkillReinforcedEvents({
   contextId: string;
   conversation?: ConversationResource;
   eligibleSkillIds: string[];
-  useInlineTools?: boolean;
 }): Promise<ProcessReinforcedSkillsEventsResult> {
   const errorEvents = events.filter((e) => e.type === "error");
   if (errorEvents.length > 0) {
@@ -394,7 +353,6 @@ export async function processSkillReinforcedEvents({
   const approvedSourceSuggestionIds: string[] = [];
   const successfulToolCalls: TerminalToolCallSuccess[] = [];
   const failedToolCalls: TerminalToolCallFailure[] = [];
-  const resolvedUseInlineTools = useInlineTools ?? true;
 
   for (const event of toolCallEvents) {
     const { id, name, arguments: args } = event.content;
@@ -408,7 +366,6 @@ export async function processSkillReinforcedEvents({
       contextId,
       conversation,
       eligibleSkillIds,
-      useInlineTools: resolvedUseInlineTools,
     });
     switch (result.type) {
       case "created": {
@@ -465,7 +422,6 @@ async function createSkillSuggestionsFromToolCall({
   contextId,
   conversation,
   eligibleSkillIds,
-  useInlineTools,
 }: {
   auth: Authenticator;
   toolName: string;
@@ -475,13 +431,10 @@ async function createSkillSuggestionsFromToolCall({
   contextId: string;
   conversation?: ConversationResource;
   eligibleSkillIds: string[];
-  useInlineTools: boolean;
 }): Promise<ToolCallResult> {
   switch (toolName) {
     case "edit_skill": {
-      const parsed = getEditSkillToolSchema({ useInlineTools }).safeParse(
-        actionArguments
-      );
+      const parsed = getEditSkillToolSchema().safeParse(actionArguments);
       if (!parsed.success) {
         logger.warn(
           { contextId, toolName, error: parsed.error },
@@ -515,20 +468,13 @@ async function createSkillSuggestionsFromToolCall({
 
       const hasInstructionEdits =
         (parsed.data.instructionEdits?.length ?? 0) > 0;
-      const toolEdits = useInlineTools ? undefined : getToolEdits(parsed.data);
-      const hasToolEdits = (toolEdits?.length ?? 0) > 0;
       const hasAgentFacingDescriptionEdit =
         parsed.data.agentFacingDescriptionEdit !== undefined;
-      if (
-        !hasInstructionEdits &&
-        !hasToolEdits &&
-        !hasAgentFacingDescriptionEdit
-      ) {
+      if (!hasInstructionEdits && !hasAgentFacingDescriptionEdit) {
         return {
           type: "error",
-          errorMessage: useInlineTools
-            ? "edit_skill requires at least one instruction edit or description edit."
-            : "edit_skill requires at least one instruction edit, tool edit, or description edit.",
+          errorMessage:
+            "edit_skill requires at least one instruction edit or description edit.",
         };
       }
 
@@ -544,7 +490,6 @@ async function createSkillSuggestionsFromToolCall({
         hasSuggestionSelfConflict(
           {
             instructionEdits: parsed.data.instructionEdits,
-            toolEdits,
             agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           skill.instructionsHtml
@@ -552,9 +497,8 @@ async function createSkillSuggestionsFromToolCall({
       ) {
         return {
           type: "error",
-          errorMessage: useInlineTools
-            ? "Suggestion has conflicting edits (overlapping block targets)."
-            : "Suggestion has conflicting edits (overlapping block targets or duplicate tool IDs).",
+          errorMessage:
+            "Suggestion has conflicting edits (overlapping block targets).",
         };
       }
 
@@ -584,7 +528,6 @@ async function createSkillSuggestionsFromToolCall({
           kind: "edit",
           suggestion: {
             instructionEdits: parsed.data.instructionEdits,
-            ...(toolEdits !== undefined ? { toolEdits } : {}),
             agentFacingDescriptionEdit: parsed.data.agentFacingDescriptionEdit,
           },
           analysis: parsed.data.analysis ?? null,

--- a/front/lib/reinforcement/skill_instruction_edit_prompt.ts
+++ b/front/lib/reinforcement/skill_instruction_edit_prompt.ts
@@ -102,11 +102,6 @@ Example:
 \`\`\`
 </tool_references>`;
 
-export function buildSkillInstructionHtmlEditPrompt(): string {
-  return `${BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT}
+export const SKILL_INSTRUCTION_HTML_EDIT_PROMPT = `${BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT}
 
 ${SKILL_TOOL_REFERENCES_INSTRUCTION_PROMPT}`;
-}
-
-export const SKILL_INSTRUCTION_HTML_EDIT_PROMPT =
-  buildSkillInstructionHtmlEditPrompt();

--- a/front/lib/reinforcement/skill_instruction_edit_prompt.ts
+++ b/front/lib/reinforcement/skill_instruction_edit_prompt.ts
@@ -102,19 +102,11 @@ Example:
 \`\`\`
 </tool_references>`;
 
-export function buildSkillInstructionHtmlEditPrompt({
-  useInlineTools,
-}: {
-  useInlineTools: boolean;
-}): string {
-  if (!useInlineTools) {
-    return BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT;
-  }
-
+export function buildSkillInstructionHtmlEditPrompt(): string {
   return `${BASE_SKILL_INSTRUCTION_HTML_EDIT_PROMPT}
 
 ${SKILL_TOOL_REFERENCES_INSTRUCTION_PROMPT}`;
 }
 
 export const SKILL_INSTRUCTION_HTML_EDIT_PROMPT =
-  buildSkillInstructionHtmlEditPrompt({ useInlineTools: true });
+  buildSkillInstructionHtmlEditPrompt();

--- a/front/lib/reinforcement/skill_instructions_html.ts
+++ b/front/lib/reinforcement/skill_instructions_html.ts
@@ -178,9 +178,7 @@ function recoverCustomInlineNodes(node: JSONContent): JSONContent {
  * Uses the same extension schema as the browser editor, then strips CSS class attrs.
  */
 export function convertMarkdownToBlockHtml(markdown: string): string {
-  const preprocessed = preprocessMarkdownForEditor(markdown, {
-    enableSkillReferences: true,
-  });
+  const preprocessed = preprocessMarkdownForEditor(markdown);
   const parsedDoc = preprocessed.trim()
     ? MARKDOWN_MANAGER.parse(preprocessed)
     : null;

--- a/front/lib/reinforcement/types.ts
+++ b/front/lib/reinforcement/types.ts
@@ -50,36 +50,15 @@ const SkillInstructionEditArgSchema = z.object({
   type: z.literal("replace"),
 });
 
-const SkillToolEditArgSchema = z.object({
-  action: z
-    .enum(["add", "remove"])
-    .describe("Whether to add or remove the tool"),
-  toolId: z.string().describe("The identifier of the tool to add or remove"),
-});
-
-export function getEditSkillToolSchema({
-  useInlineTools,
-}: {
-  useInlineTools: boolean;
-}): z.ZodObject<z.ZodRawShape> {
+export function getEditSkillToolSchema(): z.ZodObject<z.ZodRawShape> {
   return z.object({
     skillId: z.string().describe("The sId of the skill to modify"),
     instructionEdits: z
       .array(SkillInstructionEditArgSchema)
       .optional()
       .describe(
-        useInlineTools
-          ? "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
-          : "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id."
+        "Block-targeted edits to the skill instructions. Each item targets one block by its data-block-id. Tool changes must be represented by adding or removing inline <tool> tags in these instruction edits."
       ),
-    ...(useInlineTools
-      ? {}
-      : {
-          toolEdits: z
-            .array(SkillToolEditArgSchema)
-            .optional()
-            .describe("Tools to add or remove from the skill."),
-        }),
     agentFacingDescriptionEdit: z
       .object({
         content: z
@@ -91,9 +70,7 @@ export function getEditSkillToolSchema({
       })
       .optional()
       .describe(
-        useInlineTools
-          ? "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
-          : "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction or tool edits."
+        "Replacement for the skill's agent-facing description. Should typically be its own suggestion, not bundled with instruction edits."
       ),
     analysis: z
       .string()
@@ -121,7 +98,7 @@ export const TOOL_SCHEMAS: Record<
   TerminalToolName,
   z.ZodObject<z.ZodRawShape>
 > = {
-  edit_skill: getEditSkillToolSchema({ useInlineTools: true }),
+  edit_skill: getEditSkillToolSchema(),
   reject_suggestion: z.object({
     sourceSuggestionIds: z
       .array(z.string())

--- a/front/scripts/migrate_skill_instructions_html.ts
+++ b/front/scripts/migrate_skill_instructions_html.ts
@@ -22,9 +22,7 @@ import { MarkdownManager } from "@tiptap/markdown";
 import { unescape } from "html-escaper";
 import { Op } from "sequelize";
 
-const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true, [], {
-  enableSkillReferences: true,
-});
+const SKILL_EDITOR_EXTENSIONS = buildSkillInstructionsExtensions(true);
 const MARKDOWN_MANAGER = new MarkdownManager({
   extensions: SKILL_EDITOR_EXTENSIONS,
 });

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -167,7 +167,6 @@ async function runReinforcedSkillsStep({
   source,
   conversation,
   eligibleSkillIds,
-  useInlineTools,
 }: {
   auth: Authenticator;
   reinforcementConversationId: string;
@@ -177,7 +176,6 @@ async function runReinforcedSkillsStep({
   source: "synthetic" | "reinforcement";
   conversation?: ConversationResource;
   eligibleSkillIds: string[];
-  useInlineTools: boolean;
 }): Promise<{
   isTerminal: boolean;
   suggestionsCreated: number;
@@ -207,9 +205,7 @@ async function runReinforcedSkillsStep({
     throw conversationRes.error;
   }
 
-  const specifications = buildReinforcedSkillsSpecifications(operationType, {
-    useInlineTools,
-  });
+  const specifications = buildReinforcedSkillsSpecifications(operationType);
   const modelConfig = llm.getModelConfig();
   const toolsJson = JSON.stringify(
     specifications.map((s) => ({
@@ -293,7 +289,6 @@ async function runReinforcedSkillsStep({
       contextId,
       conversation,
       eligibleSkillIds,
-      useInlineTools,
     });
 
     // Store results for all terminal tool calls so the conversation is complete.
@@ -698,7 +693,6 @@ export async function analyzeConversationStepActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = true;
 
   // On first step, build the analysis prompt and create a reinforcement conversation.
   if (!reinforcementConversationId) {
@@ -737,8 +731,7 @@ export async function analyzeConversationStepActivity({
 
     const prompt = buildSkillAnalysisPrompt(
       conversationRes.value.text,
-      skillTypes,
-      { useInlineTools }
+      skillTypes
     );
     reinforcementConversationId = await createReinforcedSkillsConversation(
       auth,
@@ -747,7 +740,6 @@ export async function analyzeConversationStepActivity({
         operationType: "reinforcement_analyze_conversation",
         contextId: conversationId,
         skillIds: skillIds,
-        useInlineTools,
       }
     );
   }
@@ -760,12 +752,11 @@ export async function analyzeConversationStepActivity({
     auth,
     reinforcementConversationId,
     operationType: "reinforcement_analyze_conversation",
-    systemPrompt: buildSkillAnalysisSystemPrompt({ useInlineTools }),
+    systemPrompt: buildSkillAnalysisSystemPrompt(),
     contextId: conversationId,
     source: "synthetic",
     conversation,
     eligibleSkillIds: skillIds,
-    useInlineTools,
   });
   return { ...result, reinforcementConversationId };
 }
@@ -835,13 +826,10 @@ export async function aggregateSuggestionsForSkillStepActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = true;
 
   // On first step, load aggregation context and create a reinforcement conversation.
   if (!reinforcementConversationId) {
-    const ctx = await loadSkillAggregationContext(auth, skillId, {
-      useInlineTools,
-    });
+    const ctx = await loadSkillAggregationContext(auth, skillId);
     if (!ctx) {
       return {
         isTerminal: true,
@@ -857,7 +845,6 @@ export async function aggregateSuggestionsForSkillStepActivity({
         operationType: "reinforcement_aggregate_suggestions",
         contextId: skillId,
         skillIds: [skillId],
-        useInlineTools,
       }
     );
   }
@@ -866,11 +853,10 @@ export async function aggregateSuggestionsForSkillStepActivity({
     auth,
     reinforcementConversationId,
     operationType: "reinforcement_aggregate_suggestions",
-    systemPrompt: buildSkillAggregationSystemPrompt({ useInlineTools }),
+    systemPrompt: buildSkillAggregationSystemPrompt(),
     contextId: skillId,
     source: "reinforcement",
     eligibleSkillIds: [skillId],
-    useInlineTools,
   });
   return { ...result, reinforcementConversationId };
 }
@@ -992,7 +978,6 @@ export async function startSkillConversationAnalysisBatchActivity({
   reinforcementConversationMap: Record<string, string>;
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1016,15 +1001,13 @@ export async function startSkillConversationAnalysisBatchActivity({
   if (firstTimeConversations.length > 0) {
     batchMap = await buildSkillConversationAnalysisBatchMap(
       auth,
-      firstTimeConversations,
-      { useInlineTools }
+      firstTimeConversations
     );
   }
 
-  const systemPrompt = buildSkillAnalysisSystemPrompt({ useInlineTools });
+  const systemPrompt = buildSkillAnalysisSystemPrompt();
   const specifications = buildReinforcedSkillsSpecifications(
-    "reinforcement_analyze_conversation",
-    { useInlineTools }
+    "reinforcement_analyze_conversation"
   );
 
   const batchConversations: LlmConversationOptions[] = [];
@@ -1128,7 +1111,6 @@ export async function processSkillConversationAnalysisBatchResultActivity({
   conversationSkillMap: Record<string, string[]>;
 }): Promise<ConversationContinuationInfo[]> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1220,7 +1202,6 @@ export async function processSkillConversationAnalysisBatchResultActivity({
         contextId: analysedConvId,
         conversation: conversationById.get(analysedConvId),
         eligibleSkillIds: conversationSkillMap[analysedConvId] ?? [],
-        useInlineTools,
       });
       totalCreated += result.suggestionsCreated;
 
@@ -1294,7 +1275,6 @@ export async function startSkillAggregationBatchActivity({
   reinforcementConversationIds: string[];
 } | null> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1309,10 +1289,9 @@ export async function startSkillAggregationBatchActivity({
     return null;
   }
 
-  const systemPrompt = buildSkillAggregationSystemPrompt({ useInlineTools });
+  const systemPrompt = buildSkillAggregationSystemPrompt();
   const specifications = buildReinforcedSkillsSpecifications(
-    "reinforcement_aggregate_suggestions",
-    { useInlineTools }
+    "reinforcement_aggregate_suggestions"
   );
 
   let batchConversations: LlmConversationOptions[];
@@ -1407,7 +1386,6 @@ export async function processSkillAggregationBatchResultActivity({
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
   const auth = await getAuthForWorkspace(workspaceId);
-  const useInlineTools = true;
 
   const llm = await getReinforcedSkillsLLM(
     auth,
@@ -1480,7 +1458,6 @@ export async function processSkillAggregationBatchResultActivity({
       operationType: "reinforcement_aggregate_suggestions",
       contextId: skillId,
       eligibleSkillIds: [skillId],
-      useInlineTools,
     });
 
     // Store results for all terminal tool calls.

--- a/front/tests/reinforcement-evals/lib/judge.ts
+++ b/front/tests/reinforcement-evals/lib/judge.ts
@@ -52,8 +52,8 @@ IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST ap
 
 1. **Correct Tool Usage**: Did the analyst call edit_skill with the right fields?
    - instructionEdits for instruction improvements (search-and-replace edits)
-   - toolEdits for tool additions/removals
-   - Both can appear in a single edit_skill call
+   - Inline <tool> tag additions/removals inside instructionEdits for tool reference changes
+   - toolEdits should not be used in final edit_skill calls
 2. **Suggestion Quality**: Are the suggestions specific, actionable, and well-reasoned?
    - Does the analysis field explain WHY the change is needed?
    - Is the suggested content appropriate and well-written?
@@ -64,9 +64,9 @@ IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST ap
    - Do the edits directly address the identified issue?
    - Are the old_string values accurate matches of the existing instructions?
    - Would the new_string replacements meaningfully improve the skill?
-5. **If toolEdits are present**:
-   - Is the correct toolId used?
-   - Is the action (add/remove) appropriate?
+5. **If tool reference changes are present**:
+   - Is the correct inline <tool> tag used?
+   - Is the add/remove behavior appropriate?
    - Does the analysis explain the use case?
 
 Provide your evaluation using the REASONING: and SCORE: format described above.`;

--- a/front/tests/reinforcement-evals/lib/judge.ts
+++ b/front/tests/reinforcement-evals/lib/judge.ts
@@ -51,8 +51,8 @@ IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST ap
 ## General Evaluation Checklist (apply to all scenarios)
 
 1. **Correct Tool Usage**: Did the analyst call edit_skill with the right fields?
-   - instructionEdits for instruction improvements (search-and-replace edits)
-   - Inline <tool> tag additions/removals inside instructionEdits for tool reference changes
+   - instructionEdits for instruction improvements and tool reference changes
+   - Tool reference changes must add/remove inline <tool id="..." name="..."/> tags in instructionEdits content
    - toolEdits should not be used in final edit_skill calls
 2. **Suggestion Quality**: Are the suggestions specific, actionable, and well-reasoned?
    - Does the analysis field explain WHY the change is needed?
@@ -65,8 +65,8 @@ IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST ap
    - Are the old_string values accurate matches of the existing instructions?
    - Would the new_string replacements meaningfully improve the skill?
 5. **If tool reference changes are present**:
-   - Is the correct inline <tool> tag used?
-   - Is the add/remove behavior appropriate?
+   - Is the correct inline <tool id="..." name="..."/> tag added/removed in the edited instruction content?
+   - Is the add/remove behavior appropriate for the conversation evidence?
    - Does the analysis explain the use case?
 
 Provide your evaluation using the REASONING: and SCORE: format described above.`;

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -101,16 +101,13 @@ function buildPromptForTestCase(testCase: TestCase): {
   if (isAnalysisTestCase(testCase)) {
     const skillTypes = testCase.skillConfigs.map(makeSkillType);
     const conversationText = buildConversationText(testCase.conversation);
-    return buildSkillAnalysisPrompt(conversationText, skillTypes, {
-      useInlineTools: testCase.useInlineTools,
-    });
+    return buildSkillAnalysisPrompt(conversationText, skillTypes);
   }
   const skillType = makeSkillType(testCase.skillConfig);
   return buildSkillAggregationPrompt(
     skillType,
     testCase.syntheticSuggestions,
-    testCase.existingSuggestions ?? { pending: [], rejected: [] },
-    { useInlineTools: testCase.useInlineTools }
+    testCase.existingSuggestions ?? { pending: [], rejected: [] }
   );
 }
 
@@ -330,9 +327,7 @@ export async function executeReinforced(
   const operationType = isAggregationTestCase(testCase)
     ? "reinforcement_aggregate_suggestions"
     : "reinforcement_analyze_conversation";
-  const params = buildReinforcedSkillsLLMParams(prompt, operationType, {
-    useInlineTools: testCase.useInlineTools,
-  });
+  const params = buildReinforcedSkillsLLMParams(prompt, operationType);
 
   return executeMultiStep(
     llm,
@@ -385,9 +380,7 @@ export async function executeBatch(
       : "reinforcement_analyze_conversation";
     pendingParams.set(
       tc.scenarioId,
-      buildReinforcedSkillsLLMParams(prompt, operationType, {
-        useInlineTools: tc.useInlineTools,
-      })
+      buildReinforcedSkillsLLMParams(prompt, operationType)
     );
   }
 

--- a/front/tests/reinforcement-evals/lib/types.ts
+++ b/front/tests/reinforcement-evals/lib/types.ts
@@ -127,7 +127,6 @@ export interface MockSkillConfig {
 
 interface BaseTestCase {
   scenarioId: string;
-  useInlineTools?: boolean;
   expectedToolCalls?: ToolCallAssertion[];
   judgeCriteria: string;
   workspaceContext: WorkspaceContext;

--- a/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
+++ b/front/tests/reinforcement-evals/test-suites/aggregate-suggestions.ts
@@ -188,7 +188,6 @@ Score 3 if well-merged with all themes, clear structure, and analysis referencin
     {
       scenarioId: "merge-duplicate-tools",
       type: "aggregation",
-      useInlineTools: true,
       skillConfig: {
         name: "Engineering Helper",
         sId: "skill_engineering",
@@ -462,7 +461,6 @@ Score 3 if no edit_skill suggestion is created AND reject_suggestion is not call
     {
       scenarioId: "merge-description-edits-keep-tool-separate",
       type: "aggregation",
-      useInlineTools: true,
       skillConfig: {
         name: "Payment Issue Resolver",
         sId: "skill_payment_resolver",

--- a/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
+++ b/front/tests/reinforcement-evals/test-suites/analyze-conversation.ts
@@ -168,7 +168,6 @@ Score 3 if the suggestion provides clear, actionable instructions that would pre
     {
       scenarioId: "missing-tool",
       type: "analysis",
-      useInlineTools: true,
       skillConfigs: [
         {
           name: "Research Assistant",
@@ -221,7 +220,6 @@ Score 3 if the correct inline tool reference is suggested with a clear, well-rea
     {
       scenarioId: "unused-tool",
       type: "analysis",
-      useInlineTools: true,
       skillConfigs: [
         {
           name: "Code Review Helper",
@@ -287,7 +285,6 @@ Score 3 if the correct removal is suggested with a clear analysis referencing th
     {
       scenarioId: "instruction-and-tool-gap",
       type: "analysis",
-      useInlineTools: true,
       skillConfigs: [
         {
           name: "Bug Reporter",
@@ -433,7 +430,6 @@ Score 3 if the suggestion addresses both brand voice and remedy guidance with a 
     {
       scenarioId: "wrong-tool-order-linkedin-enrich",
       type: "analysis",
-      useInlineTools: true,
       skillConfigs: [
         {
           name: "Enrich user info with LinkedIn",


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/26668.

Removes the now-stale `enableSkillReferences` plumbing from the skill instructions editor path: skill/tool references are always parsed and rendered in skill instructions.

Removes the now-stale `useInlineTools` mode from reinforced skill analysis/aggregation: prompts and schemas always use inline `<tool>` references, while aggregation still reads legacy source `toolEdits` and asks the model to convert them into instruction edits.

## Risks
Blast radius: skill instructions editing/rendering and self-improving skills prompt/schema generation.
Risk: standard

## Deploy Plan
- deploy front
- deploy front workers

## Tests
- [x] `cd front && NODE_ENV=test npm test lib/reinforcement/analyze_conversation.test.ts lib/reinforcement/aggregate_suggestions.test.ts lib/reinforcement/run_reinforced_analysis.test.ts lib/editor/skill_instructions_preprocessing.test.ts components/editor/extensions/skill_builder/ToolNode.test.ts`