### PR TITLE
[Skills] Fix slash dropdown filtering

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -114,11 +114,8 @@ describe("buildSkillBuilderSlashCommandItems", () => {
       ],
     });
 
-    expect(result.map((item) => item.id)).toEqual([
-      "add-knowledge",
-      "skill_create_memo",
-    ]);
-    expect(result[1]).toMatchObject({
+    expect(result.map((item) => item.id)).toEqual(["skill_create_memo"]);
+    expect(result[0]).toMatchObject({
       action: "select-skill",
       data: {
         skill: {

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -167,6 +167,7 @@ export function buildSkillBuilderSlashCommandItems({
     return baseItems;
   }
 
+  const visibleBaseItems = query.trim().length === 0 ? baseItems : [];
   const capabilityItems = filterSkillBuilderSlashCommandCapabilities({
     currentSkillId,
     query,
@@ -180,7 +181,7 @@ export function buildSkillBuilderSlashCommandItems({
       : getToolSlashCommandItem(capability.tool, { sectionLabel });
   });
 
-  return [...baseItems, ...capabilityItems];
+  return [...visibleBaseItems, ...capabilityItems];
 }
 
 interface SkillBuilderSlashCommandDropdownProps


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C05BUSJQP5W/p1780929735680119?thread_ts=1780927937.337549&cid=C05BUSJQP5W)

The skill instructions slash dropdown kept "Attach knowledge" ahead of matching skills/tools after the user typed a query because base slash commands were prepended before capability matches.

This keeps "Attach knowledge" available for an empty `/` only, and switches typed queries to skills/tools capability results.

## Risks
Blast radius: skill builder instructions slash-command dropdown.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `NODE_ENV=test npm test -- components/editor/extensions/skill_builder/SlashCommandExtension.test.ts`