### PR TITLE
[front] Fix Gamma MCP endpoint URL

### DIFF
--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -1933,7 +1933,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     name: "Gamma",
     description:
       "Create and manage Gamma presentations directly from your conversations.",
-    url: "https://mcp.gamma.app",
+    url: "https://mcp.gamma.app/mcp",
     icon: "GammaLogo",
     documentationUrl: "https://developers.gamma.app",
     authMethod: "oauth-dynamic",


### PR DESCRIPTION
## Summary

- Fixes the Gamma MCP server URL from `https://mcp.gamma.app` to `https://mcp.gamma.app/mcp` — the root path has no POST handler, confirmed by testing the OAuth protected resource metadata and the actual endpoint.

## Test plan

- [ ] Connect Gamma in the assistant builder — the "Cannot POST /" error should no longer appear
- [ ] Confirm tool listing works after OAuth

Follows #27017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)