### PR TITLE
Skip sync for missing nodes / 404

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -33,6 +33,7 @@ import {
   isItemNotFoundError,
   isJSONParsingError,
   isMalformedDriveError,
+  isSiteNotFoundError,
 } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import { launchMicrosoftFullSyncWorkflow } from "@connectors/connectors/microsoft/temporal/client";
@@ -819,6 +820,30 @@ export async function syncFiles({
           error: e.message,
         },
         "Billing policy error from Microsoft, skipping syncFiles"
+      );
+      return {
+        count: 0,
+        childNodes: [],
+        nextLink: undefined,
+      };
+    }
+    // A 404 means the synced drive/folder was deleted upstream ("404 FILE NOT
+    // FOUND"), or the hosting SharePoint site is gone ("Target
+    // '<tenant>.sharepoint.com' is not found."). The resource can no longer be
+    // synced, so skip it instead of throwing, which would otherwise wedge the
+    // workflow in an infinite retry loop.
+    if (
+      (e instanceof GraphError && e.statusCode === 404) ||
+      isSiteNotFoundError(e)
+    ) {
+      logger.warn(
+        {
+          connectorId,
+          dataSourceId: dataSourceConfig.dataSourceId,
+          parent,
+          error: e.message,
+        },
+        "Resource not found (404) from Microsoft, skipping syncFiles"
       );
       return {
         count: 0,
@@ -1772,6 +1797,23 @@ async function getDeltaData({
         "Billing policy error from Microsoft, skipping delta sync for node"
       );
       // Return empty results with current deltaLink so we retry next cycle.
+      return { results: [], deltaLink: node.deltaLink };
+    }
+    // A 404 means the delta-synced drive/folder was deleted upstream ("404 FILE
+    // NOT FOUND"), or the hosting SharePoint site is gone ("Target
+    // '<tenant>.sharepoint.com' is not found."). Skip gracefully so we do not
+    // wedge the incremental sync in an infinite retry loop.
+    if (
+      (e instanceof GraphError && e.statusCode === 404) ||
+      isSiteNotFoundError(e)
+    ) {
+      logger.warn(
+        {
+          internalId: node.internalId,
+          error: e.message,
+        },
+        "Resource not found (404) from Microsoft, skipping delta sync for node"
+      );
       return { results: [], deltaLink: node.deltaLink };
     }
     throw e;

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -68,6 +68,14 @@ export function isGeneralExceptionError(err: unknown): err is GraphError {
   );
 }
 
+// A "... is not found" message indicates the targeted SharePoint site host
+// (e.g. "tenant.sharepoint.com") no longer exists, e.g. "Target
+// 'tenant.sharepoint.com' is not found.". The status code varies, so we match on
+// the message. The site is gone for good, so the sync should skip it gracefully.
+export function isSiteNotFoundError(err: unknown): err is GraphError {
+  return err instanceof GraphError && err.message.includes("is not found");
+}
+
 // "Billing Policy Not Found Or Invalid" errors indicate a Microsoft 365
 // billing/licensing misconfiguration on the customer's tenant. These are not
 // actionable on our side and should be skipped gracefully.


### PR DESCRIPTION
## Description

Microsoft connectors could get stuck in an infinite Temporal retry loop when a synced resource was deleted upstream, surfacing as two `GraphError`s:

- `404 FILE NOT FOUND` — a deleted drive/folder/file (a bare 404 with no `itemNotFound` code, so the existing `isItemNotFoundError` didn't match it).
- `Target '<tenant>.sharepoint.com' is not found.` — the whole SharePoint site host was deleted.

Neither was handled in `syncFiles` (full sync) or `getDeltaData` (incremental sync), so the error propagated, the activity failed, and Temporal retried it forever.

This adds an `isSiteNotFoundError` classifier and makes both activities skip these "resource gone" 404s gracefully (log a warning, return empty results) — the same pattern already used in `getRootNodesToSync`, `processDeltaChangesFromGCS`, and `reconcileSensitivityLabelsForParent`.

## Tests

Typecheck and lint pass. Behavior verified against the existing graceful-skip pattern for the same error shapes elsewhere in the connector.

## Risk

Low. The change only widens error handling to skip already-broken resources instead of throwing; no behavior change for healthy syncs. Safe to roll back.

## Deploy Plan

Standard connectors deploy.
