### PR TITLE
Fix: right padding on agent builder description

### DIFF
--- a/front/components/agent_builder/settings/AgentBuilderDescriptionSection.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderDescriptionSection.tsx
@@ -108,6 +108,7 @@ export function AgentBuilderDescriptionSection({
           <Input
             ref={registerRef}
             placeholder="Enter agent description"
+            className="pr-10"
             onChange={(e) => {
               userSetDescriptionRef.current = true;
               onChange(e);


### PR DESCRIPTION
## Description

Adds `pr-10` (Tailwind right padding) to the `Input` in `AgentBuilderDescriptionSection` to prevent text from overlapping any icon or control rendered on the right side of the field.


## Tests

Tested locally in the agent builder: confirmed the description field no longer clips content against the right edge.

## Risk

Low. Single-class addition, no logic change, no data impact.

## Deploy Plan

Deploy front.
