### PR TITLE
Allow empty title in confluence folder

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -54,7 +54,7 @@ const ConfluencePageCodec = t.intersection([
       t.undefined,
     ]),
     id: t.string,
-    title: t.string,
+    title: t.union([t.string, t.null]),
     spaceId: t.string,
     version: t.type({
       number: t.number,

--- a/connectors/src/connectors/confluence/lib/content/pages.ts
+++ b/connectors/src/connectors/confluence/lib/content/pages.ts
@@ -38,6 +38,10 @@ import TurndownService from "turndown";
 
 const turndownService = new TurndownService();
 
+function getConfluencePageTitle(page: { title: string | null }): string {
+  return page.title ?? "Untitled";
+}
+
 async function markPageHasVisited({
   connectorId,
   pageId,
@@ -91,6 +95,7 @@ export async function confluenceUpsertPageToDataSource({
   const markdown = turndownService.turndown(page.body.storage.value);
   const pageCreatedAt = new Date(page.createdAt);
   const lastPageVersionCreatedAt = new Date(page.version.createdAt);
+  const title = getConfluencePageTitle(page);
 
   if (!markdown) {
     logger.warn({ ...loggerArgs }, "Upserting page with empty content.");
@@ -115,7 +120,7 @@ export async function confluenceUpsertPageToDataSource({
   const tags = [
     `createdAt:${pageCreatedAt.getTime()}`,
     `space:${spaceName}`,
-    `title:${page.title}`,
+    `title:${title}`,
     `updatedAt:${lastPageVersionCreatedAt.getTime()}`,
     `version:${page.version.number}`,
     ...filterCustomTags(customTags, localLogger),
@@ -123,7 +128,7 @@ export async function confluenceUpsertPageToDataSource({
 
   const renderedPage = await renderDocumentTitleAndContent({
     dataSourceConfig,
-    title: `Page ${page.title}`,
+    title: `Page ${title}`,
     createdAt: pageCreatedAt,
     updatedAt: lastPageVersionCreatedAt,
     content: renderedMarkdown,
@@ -151,7 +156,7 @@ export async function confluenceUpsertPageToDataSource({
     tags,
     timestampMs: lastPageVersionCreatedAt.getTime(),
     upsertContext: { sync_type: syncType },
-    title: page.title,
+    title,
     mimeType: INTERNAL_MIME_TYPES.CONFLUENCE.PAGE,
     async: true,
   });
@@ -178,7 +183,7 @@ export async function upsertConfluencePageInDb(
     parentId: page.parentId,
     parentType: page.parentType,
     spaceId: page.spaceId,
-    title: page.title,
+    title: getConfluencePageTitle(page),
     version: page.version.number,
   });
 }


### PR DESCRIPTION
## Description

Allow title to be empty (from error : Expecting string at results.0.0.title but instead got: null)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors