### PR TITLE
[front] checkout: Subscribe and Checkout pages for cp checkout

### DIFF
--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -1,8 +1,12 @@
 import { PaymentMethodRow } from "@app/components/checkout/PaymentMethodRow";
 import config from "@app/lib/api/config";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   BUSINESS_PLAN_COST_MONTHLY,
+  CP_MAX_SEAT_COST_MONTHLY,
+  CP_MAX_SEAT_COST_YEARLY,
+  CP_PRO_SEAT_COST_MONTHLY,
+  CP_PRO_SEAT_COST_YEARLY,
   getPriceAsString,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
@@ -10,10 +14,13 @@ import {
 } from "@app/lib/client/subscription";
 import { isWhitelistedBusinessPlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   useAuthContext,
+  useCheckBusinessActivation,
   useConfirmPayment,
   useCreateCheckoutSession,
+  useInitiateBusinessActivation,
   usePreparePayment,
   useValidateCoupon,
   useWorkspaceSeatsCount,
@@ -63,7 +70,8 @@ type CheckoutPhase =
   | "card_capture" // Phase 1 — Stripe setup iframe
   | "payment_review" // Phase 2 — tax breakdown + confirm button
   | "confirming" // Phase 3 — POST /payment in progress
-  | "activating" // Phase 4 — mutating auth context, redirecting
+  | "waiting_for_payment" // Phase 4 — polling Redis for Metronome webhook result
+  | "activating" // Phase 5 — mutating auth context, redirecting
   | "error"; // Terminal error
 
 type PhaseError =
@@ -72,6 +80,7 @@ type PhaseError =
   | { kind: "metronome_error" }
   | { kind: "internal_error" }
   | { kind: "invalid_coupon" }
+  | { kind: "activation_failed" }
   | { kind: "generic" };
 
 function useBillingPeriodParam(): BillingPeriod {
@@ -79,15 +88,35 @@ function useBillingPeriodParam(): BillingPeriod {
   return raw === "yearly" ? "yearly" : "monthly";
 }
 
+function useSeatTypeParam(): "pro" | "max" | null {
+  const raw = useSearchParam("seatType");
+  return raw === "pro" || raw === "max" ? raw : null;
+}
+
 export function CheckoutPage() {
   const owner = useWorkspace();
   const router = useAppRouter();
   const billingPeriod = useBillingPeriodParam();
+  const seatType = useSeatTypeParam();
+  const targetUserId = useSearchParam("targetUserId");
   const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
+
+  // Determine if CP checkout is enabled.
+  const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
+  const isMetronomeEnabled =
+    hasFeature("metronome_billing") ||
+    !killSwitches?.includes("global_disable_metronome_billing");
+  const isMetronomeCheckout =
+    isMetronomeEnabled && hasFeature("metronome_cp_checkout") && !!seatType;
 
   const [phase, setPhase] = useState<CheckoutPhase>("card_capture");
   const [phaseError, setPhaseError] = useState<PhaseError | null>(null);
   const [setupSessionId, setSetupSessionId] = useState<string | null>(null);
+  // For the waiting_for_payment phase: contract id to poll.
+  const [pendingContractId, setPendingContractId] = useState<string | null>(
+    null
+  );
   // Prevents initSession from firing before URL params have been read on mount.
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -122,9 +151,13 @@ export function CheckoutPage() {
   const { createSession, isCreating } = useCreateCheckoutSession({
     workspaceId: owner.sId,
   });
-  const { confirmPayment, isConfirming } = useConfirmPayment({
-    workspaceId: owner.sId,
-  });
+  const { confirmPayment, isConfirming: isConfirmingLegacy } =
+    useConfirmPayment({
+      workspaceId: owner.sId,
+    });
+  const { initiateBusinessActivation, isInitiating } =
+    useInitiateBusinessActivation({ workspaceId: owner.sId });
+  const isConfirming = isMetronomeCheckout ? isInitiating : isConfirmingLegacy;
   const { validateCoupon } = useValidateCoupon({ workspaceId: owner.sId });
 
   const {
@@ -145,6 +178,35 @@ export function CheckoutPage() {
     }
   }, [livePreparePayment]);
 
+  // Poll checkout payment status while in waiting_for_payment phase.
+  const { checkoutPayment } = useCheckBusinessActivation({
+    workspaceId: owner.sId,
+    contractId: pendingContractId,
+    disabled: phase !== "waiting_for_payment",
+    pollIntervalMs: phase === "waiting_for_payment" ? 1500 : 0,
+  });
+
+  // React to Redis activation status.
+  useEffect(() => {
+    if (phase !== "waiting_for_payment" || !checkoutPayment) {
+      return;
+    }
+    if (checkoutPayment.status === "succeeded") {
+      setPhase("activating");
+      void (async () => {
+        await Promise.all([
+          mutateAuthContext(),
+          new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+        ]);
+        void router.replace(`/w/${owner.sId}`);
+      })();
+    } else if (checkoutPayment.status === "failed") {
+      setPhaseError({ kind: "activation_failed" });
+      setPhase("error");
+    }
+    // pending: keep polling
+  }, [phase, checkoutPayment, mutateAuthContext, router, owner.sId]);
+
   const {
     register: registerCoupon,
     handleSubmit: handleCouponSubmit,
@@ -159,12 +221,20 @@ export function CheckoutPage() {
 
   const couponCodeValue = watchCoupon("couponCode");
 
+  const fallbackCurrency = useUserBillingCurrency();
+
   const initSession = useCallback(
     async (couponCodeArg?: string) => {
       setClientSecret(null);
       const result = await createSession({
         billingPeriod,
         couponCode: couponCodeArg,
+        ...(isMetronomeCheckout && seatType
+          ? {
+              seatType,
+              targetUserId: targetUserId ?? undefined,
+            }
+          : {}),
       });
       if (!result) {
         void router.back();
@@ -182,7 +252,14 @@ export function CheckoutPage() {
           assertNeverAndIgnore(result);
       }
     },
-    [billingPeriod, createSession, router]
+    [
+      billingPeriod,
+      createSession,
+      router,
+      isMetronomeCheckout,
+      seatType,
+      targetUserId,
+    ]
   );
 
   // Force light mode — Stripe embedded checkout does not support dark mode.
@@ -228,6 +305,45 @@ export function CheckoutPage() {
     confirmCalledRef.current = true;
     setPhase("confirming");
 
+    if (isMetronomeCheckout) {
+      // CP path: dedicated business activation endpoint — always returns
+      // activationPending or an error, never a direct success.
+      const result = await initiateBusinessActivation({ setupSessionId });
+      if (!result) {
+        setPhaseError({ kind: "generic" });
+        setPhase("error");
+        return;
+      }
+      if ("error" in result) {
+        switch (result.error) {
+          case "setup_failed":
+            setPhaseError({ kind: "setup_failed" });
+            break;
+          case "payment_failed":
+            setPhaseError({ kind: "payment_failed" });
+            break;
+          case "metronome_error":
+            setPhaseError({ kind: "metronome_error" });
+            break;
+          case "internal_error":
+            setPhaseError({ kind: "internal_error" });
+            break;
+          case "invalid_coupon":
+            setPhaseError({ kind: "invalid_coupon" });
+            break;
+          default:
+            assertNeverAndIgnore(result.error);
+            setPhaseError({ kind: "generic" });
+        }
+        setPhase("error");
+        return;
+      }
+      setPendingContractId(result.contractId);
+      setPhase("waiting_for_payment");
+      return;
+    }
+
+    // Legacy path.
     const result = await confirmPayment({ setupSessionId });
     if (!result) {
       setPhaseError({ kind: "generic" });
@@ -266,7 +382,15 @@ export function CheckoutPage() {
       new Promise<void>((resolve) => setTimeout(resolve, 2000)),
     ]);
     void router.replace(`/w/${owner.sId}`);
-  }, [setupSessionId, confirmPayment, mutateAuthContext, router, owner.sId]);
+  }, [
+    setupSessionId,
+    isMetronomeCheckout,
+    initiateBusinessActivation,
+    confirmPayment,
+    mutateAuthContext,
+    router,
+    owner.sId,
+  ]);
 
   const handleCardCaptureComplete = useCallback(() => {
     setPhase("payment_review");
@@ -279,6 +403,7 @@ export function CheckoutPage() {
     setPhaseError(null);
     setAppliedCoupon(null);
     setPreparePayment(null);
+    setPendingContractId(null);
     resetCoupon();
     confirmCalledRef.current = false;
     setPhase("card_capture");
@@ -305,27 +430,52 @@ export function CheckoutPage() {
     setIsSessionRefreshing(false);
   });
 
-  const fallbackCurrency = useUserBillingCurrency();
-
   const showActualTax = preparePayment !== null;
 
   const currency = showActualTax ? preparePayment.currency : fallbackCurrency;
   const seats = seatsCount ?? 1;
   const isBusiness = isWhitelistedBusinessPlan(owner);
-  const seatPricePerMonthCents =
-    (isBusiness
-      ? BUSINESS_PLAN_COST_MONTHLY
-      : billingPeriod === "monthly"
-        ? PRO_PLAN_COST_MONTHLY
-        : PRO_PLAN_COST_YEARLY) * 100;
-  const monthsInPeriod = billingPeriod === "yearly" ? 12 : 1;
-  const seatPriceCents = seatPricePerMonthCents * monthsInPeriod;
-  const subtotalCents = seatPriceCents * seats;
+
+  // Compute seat price for order summary.
+  // CP checkout: USD prices only. Yearly = per-month price × 12.
+  // Legacy: use existing plan cost constants.
+  let seatPriceCents: number;
+  if (isMetronomeCheckout && seatType) {
+    const monthlyPrice =
+      seatType === "pro" ? CP_PRO_SEAT_COST_MONTHLY : CP_MAX_SEAT_COST_MONTHLY;
+    const yearlyMonthlyPrice =
+      seatType === "pro" ? CP_PRO_SEAT_COST_YEARLY : CP_MAX_SEAT_COST_YEARLY;
+    seatPriceCents =
+      billingPeriod === "monthly"
+        ? monthlyPrice * 100
+        : yearlyMonthlyPrice * 12 * 100;
+  } else {
+    const seatPricePerMonthCents =
+      (isBusiness
+        ? BUSINESS_PLAN_COST_MONTHLY
+        : billingPeriod === "monthly"
+          ? PRO_PLAN_COST_MONTHLY
+          : PRO_PLAN_COST_YEARLY) * 100;
+    const monthsInPeriod = billingPeriod === "yearly" ? 12 : 1;
+    seatPriceCents = seatPricePerMonthCents * monthsInPeriod;
+  }
+
+  const seatCountForSummary = isMetronomeCheckout ? 1 : seats;
+  const subtotalCents = seatPriceCents * seatCountForSummary;
   const couponDiscountCents =
     appliedCoupon !== null
       ? Math.min(appliedCoupon.amount * 100, subtotalCents)
       : 0;
   const totalDueTodayCents = subtotalCents - couponDiscountCents;
+
+  // Plan display name.
+  const planDisplayName = isMetronomeCheckout
+    ? seatType === "pro"
+      ? "Pro seat"
+      : "Max seat"
+    : isBusiness
+      ? "Business plan"
+      : "Pro plan";
 
   if (!isInitialized) {
     return null;
@@ -356,7 +506,7 @@ export function CheckoutPage() {
           <div className="flex flex-col">
             <span className="text-base text-muted-foreground">Your plan</span>
             <h1 className="text-5xl font-semibold text-foreground">
-              {isBusiness ? "Business plan" : "Pro plan"}
+              {planDisplayName}
             </h1>
             <span className="text-sm text-muted-foreground">
               {billingPeriod === "yearly"
@@ -381,7 +531,9 @@ export function CheckoutPage() {
             </div>
             <div className="mt-3 flex justify-between">
               <span className="text-muted-foreground">Number of seats</span>
-              <span>{showActualTax ? preparePayment.seatCount : seats}</span>
+              <span>
+                {showActualTax ? preparePayment.seatCount : seatCountForSummary}
+              </span>
             </div>
             <div className="mt-6 flex justify-between border-t border-separator pt-3 font-medium">
               <span>Subtotal (excl. taxes)</span>
@@ -649,6 +801,14 @@ function RightPane({
         </div>
       );
 
+    case "waiting_for_payment":
+      return (
+        <div className="flex flex-col items-center gap-4">
+          <Spinner size="lg" />
+          <p className="text-sm text-muted-foreground">Processing payment…</p>
+        </div>
+      );
+
     case "activating":
       return (
         <div className="flex flex-col items-center gap-6 text-center">
@@ -680,6 +840,32 @@ function RightPane({
                 and we&apos;ll get this sorted out right away.
               </p>
             </div>
+          </div>
+        );
+      }
+      if (phaseError?.kind === "activation_failed") {
+        return (
+          <div className="flex flex-col items-center gap-6 text-center">
+            <Icon visual={XCircle} size="2xl" className="text-warning-500" />
+            <div className="flex flex-col gap-3">
+              <h2 className="text-2xl font-semibold text-foreground">
+                Payment could not be processed
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Your subscription could not be activated. You have not been
+                charged. Please try again.
+                <br />
+                If the issue persists, contact us at{" "}
+                <a
+                  href="mailto:support@dust.tt"
+                  className="text-primary underline"
+                >
+                  support@dust.tt
+                </a>
+                .
+              </p>
+            </div>
+            <Button label="Try again" onClick={onRestart} />
           </div>
         );
       }

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -1,10 +1,17 @@
 import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import {
+  CP_MAX_SEAT_COST_MONTHLY,
+  CP_MAX_SEAT_COST_YEARLY,
+  CP_PRO_SEAT_COST_MONTHLY,
+  CP_PRO_SEAT_COST_YEARLY,
+} from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isFreeTrialPhonePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { useUser } from "@app/lib/swr/user";
 import {
   useSubscriptionStatus,
@@ -13,11 +20,237 @@ import {
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { BillingPeriod } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
-import { BarHeader, Button, Lock01, Page, Spinner } from "@dust-tt/sparkle";
+import {
+  BarHeader,
+  Button,
+  ButtonGroup,
+  Chip,
+  Lock01,
+  Page,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import React, { useEffect } from "react";
 
-export function SubscribePage() {
+function CPSubscribePage() {
+  const { workspace, isAdmin, user: authUser } = useAuth();
+  const router = useAppRouter();
+  const { user } = useUser();
+  const { shouldRedirect, redirectUrl, isSubscriptionStatusLoading } =
+    useSubscriptionStatus({ workspaceId: workspace.sId });
+
+  const [billingPeriod, setBillingPeriod] =
+    React.useState<BillingPeriod>("monthly");
+  const [seatType, setSeatType] = React.useState<"pro" | "max">("pro");
+
+  const { submit: handleSubscribe } = useSubmitFunction(
+    async (params: {
+      seatType: "pro" | "max";
+      billingPeriod: BillingPeriod;
+    }) => {
+      const query = new URLSearchParams({
+        seatType: params.seatType,
+        billingPeriod: params.billingPeriod,
+        targetUserId: authUser.sId,
+      });
+      await router.push(
+        `/w/${workspace.sId}/subscription/checkout?${query.toString()}`
+      );
+    }
+  );
+
+  useEffect(() => {
+    if (shouldRedirect && redirectUrl) {
+      void router.replace(redirectUrl);
+    }
+  }, [shouldRedirect, redirectUrl, router]);
+
+  if (isSubscriptionStatusLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <>
+        <BarHeader
+          title="Joining Dust"
+          className="ml-10 lg:ml-0"
+          rightActions={
+            user && (
+              <UserMenu user={user} owner={workspace} subscription={null} />
+            )
+          }
+        />
+        <Page>
+          <div className="flex h-full flex-col justify-center">
+            <Page.Horizontal>
+              <Page.Vertical sizing="grow" gap="lg">
+                <Page.Header icon={Lock01} title="Workspace locked" />
+                <Page.P>
+                  <span className="font-bold">
+                    The subscription for this workspace is not active.
+                  </span>
+                </Page.P>
+                <Page.P>
+                  To unlock premium features, your workspace needs to be
+                  upgraded by an admin.
+                </Page.P>
+              </Page.Vertical>
+            </Page.Horizontal>
+          </div>
+        </Page>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <BarHeader
+        title="Subscribe to Business"
+        className="ml-10 lg:ml-0"
+        rightActions={
+          <div className="flex flex-row items-center">
+            {user && (
+              <UserMenu user={user} owner={workspace} subscription={null} />
+            )}
+          </div>
+        }
+      />
+      <Page>
+        <div className="flex h-full flex-col items-center justify-center gap-8">
+          {/* Placeholder banner */}
+          <div className="w-full max-w-xl rounded-xl border border-warning-200 bg-warning-100 p-4 text-center dark:border-warning-200-night dark:bg-warning-100-night">
+            <p className="text-lg font-bold text-foreground dark:text-foreground-night">
+              Placeholder — Page to be designed
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              This page has not been designed yet.
+            </p>
+          </div>
+          <div className="flex flex-col items-center gap-2 text-center">
+            <Page.Header
+              icon={CreditCardIcon}
+              title="Choose your Business plan"
+            />
+            <Page.P>
+              Select a seat type and billing period to get started.
+            </Page.P>
+          </div>
+
+          {/* Billing period toggle */}
+          <div className="flex items-center gap-3">
+            <ButtonGroup>
+              <Button
+                size="sm"
+                variant={billingPeriod === "monthly" ? "primary" : "outline"}
+                label="Monthly"
+                onClick={() => setBillingPeriod("monthly")}
+              />
+              <Button
+                size="sm"
+                variant={billingPeriod === "yearly" ? "primary" : "outline"}
+                label="Yearly"
+                onClick={() => setBillingPeriod("yearly")}
+              />
+            </ButtonGroup>
+            {billingPeriod === "yearly" && (
+              <Chip size="xs" color="green" label="Save 20%" />
+            )}
+          </div>
+
+          {/* Seat type cards */}
+          <div className="flex w-full max-w-xl flex-col gap-4">
+            {(
+              [
+                {
+                  type: "pro" as const,
+                  name: "Pro",
+                  monthlyPrice: `$${CP_PRO_SEAT_COST_MONTHLY}/mo`,
+                  yearlyPrice: `$${CP_PRO_SEAT_COST_YEARLY}/mo`,
+                  yearlyTotal: `$${CP_PRO_SEAT_COST_YEARLY * 12} billed yearly`,
+                  creditsLabel: "8,000 credits/month",
+                },
+                {
+                  type: "max" as const,
+                  name: "Max",
+                  monthlyPrice: `$${CP_MAX_SEAT_COST_MONTHLY}/mo`,
+                  yearlyPrice: `$${CP_MAX_SEAT_COST_YEARLY}/mo`,
+                  yearlyTotal: `$${CP_MAX_SEAT_COST_YEARLY * 12} billed yearly`,
+                  creditsLabel: "40,000 credits/month",
+                },
+              ] satisfies Array<{
+                type: "pro" | "max";
+                name: string;
+                monthlyPrice: string;
+                yearlyPrice: string;
+                yearlyTotal: string;
+                creditsLabel: string;
+              }>
+            ).map((seat) => (
+              <button
+                key={seat.type}
+                type="button"
+                onClick={() => setSeatType(seat.type)}
+                className={`flex w-full flex-col gap-2 rounded-xl border-2 p-5 text-left transition-colors ${
+                  seatType === seat.type
+                    ? "border-highlight-500 bg-highlight-500/10"
+                    : "border-separator dark:border-separator-night hover:border-muted-foreground/40"
+                }`}
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex flex-col gap-1">
+                    <span className="text-lg font-semibold text-foreground dark:text-foreground-night">
+                      {seat.name}
+                    </span>
+                    <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      {seat.creditsLabel}
+                    </span>
+                  </div>
+                  <div className="flex flex-col items-end gap-0.5">
+                    <span className="text-xl font-bold text-foreground dark:text-foreground-night">
+                      {billingPeriod === "monthly"
+                        ? seat.monthlyPrice
+                        : seat.yearlyPrice}
+                    </span>
+                    {billingPeriod === "yearly" && (
+                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        {seat.yearlyTotal}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          <Button
+            variant="primary"
+            label="Continue to checkout"
+            icon={CreditCardIcon}
+            size="sm"
+            onClick={withTracking(
+              TRACKING_AREAS.AUTH,
+              "cp_subscription_start",
+              () => {
+                void handleSubscribe({ seatType, billingPeriod });
+              },
+              {
+                seat_type: seatType,
+                billing_period: billingPeriod,
+              }
+            )}
+          />
+        </div>
+      </Page>
+    </>
+  );
+}
+
+function LegacySubscribePage() {
   const { workspace, isAdmin } = useAuth();
   const router = useAppRouter();
   const { user } = useUser();
@@ -243,4 +476,21 @@ export function SubscribePage() {
       </Page>
     </>
   );
+}
+
+export function SubscribePage() {
+  const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
+
+  const isMetronomeEnabled =
+    hasFeature("metronome_billing") ||
+    !killSwitches?.includes("global_disable_metronome_billing");
+  const isMetronomeCheckout =
+    isMetronomeEnabled && hasFeature("metronome_cp_checkout");
+
+  if (isMetronomeCheckout) {
+    return <CPSubscribePage />;
+  }
+
+  return <LegacySubscribePage />;
 }


### PR DESCRIPTION
## Description

PR5 of https://github.com/dust-tt/tasks/issues/8594
See the issue for the global view of the Checkout changes

Goal: complete the user-facing CP checkout flow for onboarding subscription.

**`CheckoutPage.tsx`**:

- Added `waiting_for_payment` phase between `confirming` and `activating`.
- Under `metronome_cp_checkout`: `handleConfirmPayment` calls `useInitiateBusinessActivation`
  (POST `/checkout/business-activation`) instead of `useConfirmPayment`; on
  `{ activationPending, contractId }` response enters `waiting_for_payment` and polls via
  `useCheckBusinessActivation` at 1.5 s; on `succeeded` mutates auth and redirects; on `failed`
  shows retry UI.
- Legacy path (`useConfirmPayment` → `POST /checkout/payment`) unchanged.

**`SubscribePage.tsx`**:

- Exported `SubscribePage` now dispatches on `isMetronomeCheckout`:
  - **`CPSubscribePage`**: Pro/Max seat cards with monthly/yearly toggle and "Save 20%" chip;
    routes to `/subscription/checkout?seatType=...&billingPeriod=...&targetUserId=currentUser.sId`.
  - **`LegacySubscribePage`**: unchanged existing page.

Expected behavior after merge:

- Flagged workspaces can complete the full onboarding Free → Business flow end-to-end.
- Placeholder "Subscribe" page integrated in the current flow to enable to have end to end experience => will need to be replaced with the new signup flow

## Tests

Checkout flow tested locally with the different cases : success, failure, with or without coupons
* on failure => commit is not applied + user stays on free seat + subscription stays on CP_FREE_PLAN
* on success => commit applied + user switch to chosen seat + subscription switch to CP_BUSINESS_PLAN
* on success with coupons => coupon is applied to customer

## Risk

Low, under metronome_cp_checkout feature flag

## Deploy Plan

Deploy front