### PR TITLE
[dust-hive] enh: L7 proxy for marketing+front-api

### DIFF
--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -136,7 +136,14 @@ async function destroySingleEnvironment(
   logger.info(`Destroying environment '${env.name}'...`);
   console.log();
 
-  const portServices: ServiceName[] = ["front-api", "core", "connectors", "oauth"];
+  const portServices: ServiceName[] = [
+    "proxy",
+    "front-api",
+    "marketing",
+    "core",
+    "connectors",
+    "oauth",
+  ];
   const servicePids = await Promise.all(portServices.map((service) => readPid(env.name, service)));
   const allowedPids = new Set(servicePids.filter((pid): pid is number => pid !== null));
 

--- a/x/henry/dust-hive/src/commands/forward.ts
+++ b/x/henry/dust-hive/src/commands/forward.ts
@@ -79,12 +79,12 @@ async function forwardToEnv(name: string): Promise<Result<void>> {
     return Err(new CommandError(`Environment '${name}' not found`));
   }
 
-  // Check if front-api is running (at minimum)
-  const frontRunning = await isServiceRunning(name, "front-api");
-  if (!frontRunning) {
+  // Check if the proxy (public entry on ports.front) is running (at minimum)
+  const proxyRunning = await isServiceRunning(name, "proxy");
+  if (!proxyRunning) {
     return Err(
       new CommandError(
-        `Environment '${name}' does not have front-api running. Run 'dust-hive warm ${name}' first.`
+        `Environment '${name}' does not have the proxy running. Run 'dust-hive warm ${name}' first.`
       )
     );
   }

--- a/x/henry/dust-hive/src/commands/logs.ts
+++ b/x/henry/dust-hive/src/commands/logs.ts
@@ -54,8 +54,8 @@ export const logsCommand = withEnvironment(
       return runInteractiveMode(env.name, serviceArg);
     }
 
-    // Determine target service (default to front-api).
-    let targetService: ServiceName = "front-api";
+    // Determine target service (default to the proxy — the public entry point)
+    let targetService: ServiceName = "proxy";
     if (serviceArg) {
       const result = validateServiceArg(serviceArg);
       if (!result.ok) return result;

--- a/x/henry/dust-hive/src/commands/refresh.ts
+++ b/x/henry/dust-hive/src/commands/refresh.ts
@@ -12,6 +12,7 @@ const WORKSPACE_DIRS = [
   "sdks/js",
   "front",
   "front-api",
+  "marketing",
   "connectors",
   "sparkle",
   "front-spa",

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -21,7 +21,7 @@ interface WarmOptions {
   forcePorts?: boolean;
 }
 
-// Routes to pre-compile when warming the front service
+// Routes to pre-compile when warming front-api
 // These compile in parallel with the health check to minimize total wait time
 const CRITICAL_ROUTES = [
   "/api/auth-context", // Auth context API (no workspace)
@@ -30,22 +30,18 @@ const CRITICAL_ROUTES = [
   "/api/poke/workspaces/precompile/auth-context", // Poke auth context API (with workspace)
 ];
 
+// Marketing routes to pre-compile.
+const MARKETING_ROUTES = ["/", "/home"];
+
 const ENSURE_MCP_SERVER_VIEWS_COMMAND =
   "npx tsx ./scripts/ensure_all_mcp_server_views_created.ts --execute";
 const MCP_SERVER_VIEWS_ERROR_SUMMARY_PATTERN = /Migration completed with \d+ errors/;
 
-// Start pre-warming critical Next.js routes immediately (with retry)
-// Uses curl --retry to wait for server to be available, then triggers compilation
-// This runs IN PARALLEL with health check, so all routes compile simultaneously
-function startPreWarmingImmediately(port: number): void {
-  logger.step("Pre-compiling critical pages (parallel with health check)...");
-
+// Spawn a detached curl that retries until the server accepts the connection,
+// then triggers route compilation. Output is discarded; failures are silent.
+function preWarmRoutes(port: number, routes: readonly string[]): void {
   const baseUrl = `http://localhost:${port}`;
-
-  // Spawn detached curl processes with retry - they'll wait for server then compile
-  // --retry 60 --retry-delay 1 = retry every 1s for up to 60s
-  // --retry-connrefused = retry on connection refused (server not ready yet)
-  for (const route of CRITICAL_ROUTES) {
+  for (const route of routes) {
     Bun.spawn(
       [
         "curl",
@@ -154,8 +150,8 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   const dockerRunning = await isDockerRunning(env.name);
 
   if (dockerRunning) {
-    const frontRunning = await isServiceRunning(env.name, "front-api");
-    if (frontRunning) {
+    const proxyRunning = await isServiceRunning(env.name, "proxy");
+    if (proxyRunning) {
       logger.info(`Environment '${env.name}' is already warm`);
       return Ok(undefined);
     }
@@ -165,7 +161,14 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   console.log();
 
   // Clean up orphaned processes on service ports
-  const portServices: ServiceName[] = ["front-api", "core", "connectors", "oauth"];
+  const portServices: ServiceName[] = [
+    "proxy",
+    "front-api",
+    "marketing",
+    "core",
+    "connectors",
+    "oauth",
+  ];
   const servicePids = await Promise.all(portServices.map((service) => readPid(env.name, service)));
   const allowedPids = new Set(servicePids.filter((pid): pid is number => pid !== null));
   const { killedPorts, blockedPorts } = await cleanupServicePorts(env.ports, {
@@ -189,8 +192,8 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   // Check if first warm (needs initialization)
   const needsInit = !(await isInitialized(env.name));
 
-  // Start Docker + front + pre-warming all in parallel
-  // Front can compile pages while Docker starts and init runs
+  // Start Docker + front-api + marketing + proxy + pre-warming all in parallel
+  // Next.js can compile pages while Docker starts and init runs
   // This maximizes parallelism - by the time init is done, pages are compiled
   logger.info("Starting Docker, services, and page compilation (all parallel)...");
   console.log();
@@ -198,12 +201,20 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   // Start Docker (don't await - let it run in background)
   const dockerPromise = startDocker(env);
 
-  // Start front-api immediately so it can begin building.
-  // It will retry connections to DB/Redis until they're ready
-  await startService(env, "front-api");
+  // Start front-api and marketing immediately to begin page compilation
+  // They will retry connections to DB/Redis until they're ready
+  await Promise.all([startService(env, "front-api"), startService(env, "marketing")]);
 
-  // Start pre-warming immediately - curls will retry until front-api is ready.
-  startPreWarmingImmediately(env.ports.front);
+  // Start pre-warming immediately - curls will retry until Next.js is ready
+  // Pages compile while Docker containers start and init runs
+  logger.step("Pre-compiling critical pages (parallel with health check)...");
+  preWarmRoutes(env.ports.frontApi, CRITICAL_ROUTES);
+  preWarmRoutes(env.ports.marketing, MARKETING_ROUTES);
+
+  // Start the proxy. It listens on ports.front and routes /api/* to front-api,
+  // /m/api/* and /* to marketing. It does not need its upstreams healthy to
+  // start (it returns 502 until they are).
+  await startService(env, "proxy");
 
   // Now wait for Docker and start other services
   await dockerPromise;
@@ -277,14 +288,16 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
 
   // Wait for services with health checks
   // Pre-warming is already running in parallel (started above)
-  // Start forwarder as soon as front-api is healthy (don't wait for core/oauth)
+  // Start forwarder as soon as the proxy is healthy (it owns ports.front).
   logger.step("Waiting for services to be healthy...");
   await Promise.all([
-    waitForServiceReady(env, "front-api").then(async () => {
+    waitForServiceReady(env, "proxy").then(async () => {
       if (!noForward) {
         await startForwarder(env.ports.base, env.name);
       }
     }),
+    waitForServiceReady(env, "front-api"),
+    waitForServiceReady(env, "marketing"),
     waitForServiceReady(env, "core"),
     waitForServiceReady(env, "oauth"),
   ]);
@@ -299,7 +312,9 @@ export const warmCommand = withEnvironments("warm", async (env, options: WarmOpt
   console.log();
   logger.success(`Environment '${env.name}' is now warm! (${elapsed}s)`);
   console.log();
-  console.log(`  front-api:   http://localhost:${env.ports.front}`);
+  console.log(`  Proxy:       http://localhost:${env.ports.front}    (public entry)`);
+  console.log(`  Marketing:   http://localhost:${env.ports.marketing}`);
+  console.log(`  front-api:   http://localhost:${env.ports.frontApi}`);
   console.log(`  Core:        http://localhost:${env.ports.core}`);
   console.log(`  Connectors:  http://localhost:${env.ports.connectors}`);
   console.log(`  Front app:   http://localhost:${env.ports.frontSpaApp}`);

--- a/x/henry/dust-hive/src/forward-daemon.ts
+++ b/x/henry/dust-hive/src/forward-daemon.ts
@@ -3,7 +3,7 @@
 // Usage: bun run forward-daemon.ts <base-port>
 //
 // Port mappings (standard → env):
-//   3000 → base + 0 (front)
+//   3000 → base + 0 (proxy)
 //   3001 → base + 1 (core)
 //   3002 → base + 2 (connectors)
 //   3006 → base + 6 (oauth)

--- a/x/henry/dust-hive/src/lib/forwarderConfig.ts
+++ b/x/henry/dust-hive/src/lib/forwarderConfig.ts
@@ -1,7 +1,7 @@
 import { PORT_OFFSETS } from "./ports";
 
 export const FORWARDER_MAPPINGS = [
-  { listenPort: 3000, targetOffset: PORT_OFFSETS.front, name: "front-api" },
+  { listenPort: 3000, targetOffset: PORT_OFFSETS.front, name: "proxy" },
   { listenPort: 3001, targetOffset: PORT_OFFSETS.core, name: "core" },
   { listenPort: 3002, targetOffset: PORT_OFFSETS.connectors, name: "connectors" },
   { listenPort: 3006, targetOffset: PORT_OFFSETS.oauth, name: "oauth" },

--- a/x/henry/dust-hive/src/lib/multiplexer/types.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/types.ts
@@ -223,6 +223,8 @@ const TAB_NAMES: Record<ServiceName, string> = {
   sparkle: "sparkle",
   sdk: "sdk",
   "front-api": "front-api",
+  marketing: "marketing",
+  proxy: "proxy",
   core: "core",
   oauth: "oauth",
   connectors: "connectors",

--- a/x/henry/dust-hive/src/lib/ports.ts
+++ b/x/henry/dust-hive/src/lib/ports.ts
@@ -11,10 +11,14 @@ import { isProcessRunning, killProcess } from "./process";
 // Offsets chosen so base_port + offset resembles standard ports:
 // postgres: 432 -> 10432 (resembles 5432), redis: 379 -> 10379 (resembles 6379),
 // qdrant: 333 -> 10333 (resembles 6333 HTTP), elasticsearch: 200 -> 10200 (resembles 9200)
+// `front` (offset 0) is the public/main port; it now hosts the in-hive HTTP
+// proxy that routes /api/* to front-api and everything else to marketing.
 export const PORT_OFFSETS = {
   front: 0,
   core: 1,
   connectors: 2,
+  frontApi: 3,
+  marketing: 4,
   oauth: 6,
   viz: 7,
   frontSpaPoke: 10,
@@ -39,6 +43,8 @@ const PortAllocationSchema = z
     front: z.number(),
     core: z.number(),
     connectors: z.number(),
+    frontApi: z.number().optional(),
+    marketing: z.number().optional(),
     oauth: z.number(),
     viz: z.number().optional(),
     frontSpaPoke: z.number().optional(),
@@ -52,6 +58,8 @@ const PortAllocationSchema = z
   })
   .transform((data) => ({
     ...data,
+    frontApi: data.frontApi ?? data.base + PORT_OFFSETS.frontApi,
+    marketing: data.marketing ?? data.base + PORT_OFFSETS.marketing,
     viz: data.viz ?? data.base + PORT_OFFSETS.viz,
     frontSpaPoke: data.frontSpaPoke ?? data.base + PORT_OFFSETS.frontSpaPoke,
     frontSpaApp: data.frontSpaApp ?? data.base + PORT_OFFSETS.frontSpaApp,
@@ -66,6 +74,8 @@ export function calculatePorts(base: number): PortAllocation {
     front: base + PORT_OFFSETS.front,
     core: base + PORT_OFFSETS.core,
     connectors: base + PORT_OFFSETS.connectors,
+    frontApi: base + PORT_OFFSETS.frontApi,
+    marketing: base + PORT_OFFSETS.marketing,
     oauth: base + PORT_OFFSETS.oauth,
     viz: base + PORT_OFFSETS.viz,
     frontSpaPoke: base + PORT_OFFSETS.frontSpaPoke,
@@ -225,9 +235,9 @@ export function isPortInUse(port: number): boolean {
   return getPidsOnPort(port).length > 0;
 }
 
-// Check and clean service ports (front, core, connectors, oauth)
+// Check and clean service ports (proxy, front-api, marketing, core, connectors, oauth)
 export function getServicePorts(ports: PortAllocation): number[] {
-  return [ports.front, ports.core, ports.connectors, ports.oauth];
+  return [ports.front, ports.frontApi, ports.marketing, ports.core, ports.connectors, ports.oauth];
 }
 
 export interface PortProcessInfo {

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -63,11 +63,37 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     // HOSTNAME=127.0.0.1 forces an IPv4 bind: "localhost" resolves to ::1 on
     // macOS, but the port forwarder connects upstream over IPv4, so without
     // this the forwarded port (3000) cannot reach front-api.
-    buildCommand: () =>
-      "HOSTNAME=127.0.0.1 NODE_ENV=development NODE_OPTIONS=--require=./forbid-next.cjs npm run dev",
+    // Inline PORT= shadows the env.sh `PORT=ports.front` export so front-api
+    // binds its own dedicated port instead of stealing the proxy port.
+    buildCommand: (env) =>
+      `HOSTNAME=127.0.0.1 PORT=${env.ports.frontApi} NODE_ENV=development NODE_OPTIONS=--require=./forbid-next.cjs npm run dev`,
     readinessCheck: {
       type: "http",
-      url: (ports) => `http://localhost:${ports.front}/api/healthz`,
+      url: (ports) => `http://localhost:${ports.frontApi}/api/healthz`,
+    },
+    portKey: "frontApi",
+  },
+  marketing: {
+    cwd: "marketing",
+    needsNvm: true,
+    needsEnvSh: true,
+    // -p overrides PORT inherited from env.sh.
+    buildCommand: (env) => `npm run dev -- -p ${env.ports.marketing}`,
+    readinessCheck: {
+      type: "http",
+      url: (ports) => `http://localhost:${ports.marketing}/`,
+    },
+    portKey: "marketing",
+  },
+  proxy: {
+    cwd: "x/henry/dust-hive",
+    needsNvm: false,
+    needsEnvSh: false,
+    buildCommand: (env) =>
+      `bun run src/proxy-daemon.ts ${env.ports.front} ${env.ports.frontApi} ${env.ports.marketing}`,
+    readinessCheck: {
+      type: "http",
+      url: (ports) => `http://localhost:${ports.front}/__hive/healthz`,
     },
     portKey: "front",
   },

--- a/x/henry/dust-hive/src/lib/services.ts
+++ b/x/henry/dust-hive/src/lib/services.ts
@@ -1,10 +1,14 @@
 // Service names - array order defines start order, reverse for stop order.
-// The API is served exclusively by front-api (Hono); the old Next server
-// (`front`) no longer serves any endpoint and is not run by the hive.
+//
+// The "front" service is gone: its public port slot (base+0) now hosts the
+// in-hive HTTP `proxy` that routes /api/* to front-api and everything else to
+// marketing. front-api lives on its own dedicated port (frontApi slot).
 export const ALL_SERVICES = [
   "sdk",
   "sparkle",
   "front-api",
+  "marketing",
+  "proxy",
   "core",
   "oauth",
   "connectors",

--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -187,6 +187,7 @@ const WORKSPACE_NODE_MODULES = [
   { name: "sdks/js", dir: "sdks/js" },
   { name: "front", dir: "front" },
   { name: "front-api", dir: "front-api" },
+  { name: "marketing", dir: "marketing" },
   { name: "connectors", dir: "connectors" },
   { name: "sparkle", dir: "sparkle" },
   { name: "front-spa", dir: "front-spa" },

--- a/x/henry/dust-hive/src/proxy-daemon.ts
+++ b/x/henry/dust-hive/src/proxy-daemon.ts
@@ -1,0 +1,248 @@
+#!/usr/bin/env bun
+// HTTP proxy daemon - the public entry point for a hive env.
+//
+// Usage: bun run proxy-daemon.ts <listen-port> <front-api-port> <marketing-port>
+//
+// Routing:
+//   /__hive/healthz → 200 ok (proxy's own health)
+//   /m/api/*        → marketing (Next.js dev server, internally rewrites to /api/*)
+//   /api/*          → front-api (Hono+Next hybrid)
+//   *               → marketing
+//
+// WebSocket upgrades are forwarded to the same target the HTTP routing would
+// pick, so Next.js HMR keeps working through the proxy.
+//
+// Hostname: we use "localhost" both for listen and upstream. node-server (used
+// by front-api) and Next dev bind to "localhost" by default, and on Node 17+
+// macOS that's IPv6-only (::1) — picking "localhost" everywhere makes the OS
+// resolve both ends the same way.
+
+import type { ServerWebSocket } from "bun";
+
+import { logger } from "./lib/logger";
+
+type Target = "front-api" | "marketing";
+
+// Declarative routing table: first matching pattern wins. Patterns are anchored
+// regexes so they describe the full pathname — `^/api(/.*)?$` matches `/api`,
+// `/api/`, `/api/x` but NOT `/apidocs`. Order matters: more specific patterns
+// (e.g. `/m/api/*`) must come before less specific ones (e.g. `/api/*`).
+const ROUTES: ReadonlyArray<{ pattern: RegExp; target: Target }> = [
+  { pattern: /^\/m\/api(\/.*)?$/, target: "marketing" }, // /m/api/*
+  { pattern: /^\/api(\/.*)?$/, target: "front-api" }, //   /api/*
+];
+
+const DEFAULT_TARGET: Target = "marketing";
+
+export function routeFor(pathname: string): Target {
+  for (const { pattern, target } of ROUTES) {
+    if (pattern.test(pathname)) {
+      return target;
+    }
+  }
+  return DEFAULT_TARGET;
+}
+
+function parsePort(value: string | undefined, label: string): number {
+  if (value === undefined) {
+    logger.error("Usage: proxy-daemon.ts <listen-port> <front-api-port> <marketing-port>");
+    process.exit(1);
+  }
+  const n = Number.parseInt(value, 10);
+  if (Number.isNaN(n) || n < 1 || n > 65535) {
+    logger.error(`Invalid ${label}: ${value}`);
+    process.exit(1);
+  }
+  return n;
+}
+
+// Hop-by-hop headers (RFC 7230 §6.1) must not be forwarded. On top of that:
+// - drop `host` from the request so fetch sets it correctly for the upstream;
+// - drop `content-length` / `content-encoding` from the response so the runtime
+//   is free to re-frame the body it actually delivers to the client.
+const HOP_BY_HOP = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+
+const STRIP_REQUEST = new Set<string>([...HOP_BY_HOP, "host"]);
+const STRIP_RESPONSE = new Set<string>([...HOP_BY_HOP, "content-encoding", "content-length"]);
+
+// IMPORTANT: use `append`, not `set`. Bun's `headers.forEach` emits multi-value
+// headers (notably `Set-Cookie`) as one callback per value; `set` would
+// overwrite earlier values and only the last Set-Cookie would survive, which
+// breaks any session/auth flow that issues more than one cookie at a time.
+function filterHeaders(headers: Headers, blocked: Set<string>): Headers {
+  const out = new Headers();
+  headers.forEach((value, key) => {
+    if (!blocked.has(key.toLowerCase())) {
+      out.append(key, value);
+    }
+  });
+  return out;
+}
+
+type PendingMessage = string | ArrayBufferLike | Uint8Array;
+
+interface WsClientData {
+  upstreamUrl: string;
+  upstream: WebSocket | null;
+  pending: PendingMessage[];
+  closed: boolean;
+}
+
+// Swallow close-on-already-closed errors — both ServerWebSocket and the global
+// WebSocket throw if the peer has already gone away, and that's expected at
+// shutdown / teardown time.
+function safeClose(
+  socket: { close: (code?: number, reason?: string) => void },
+  code?: number,
+  reason?: string
+): void {
+  try {
+    socket.close(code, reason);
+  } catch {
+    // ignore
+  }
+}
+
+export function startProxy(listenPort: number, ports: Record<Target, number>) {
+  return Bun.serve<WsClientData>({
+    port: listenPort,
+    hostname: "localhost",
+    async fetch(req, srv) {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/__hive/healthz") {
+        return new Response("ok", { status: 200 });
+      }
+
+      const target = routeFor(url.pathname);
+      const upstreamPort = ports[target];
+
+      if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
+        const upstreamUrl = `ws://localhost:${upstreamPort}${url.pathname}${url.search}`;
+        logger.info(`[proxy] WS ${url.pathname} → ${target}`);
+        const upgraded = srv.upgrade(req, {
+          data: {
+            upstreamUrl,
+            upstream: null,
+            pending: [],
+            closed: false,
+          } satisfies WsClientData,
+        });
+        if (!upgraded) {
+          return new Response("WebSocket upgrade failed", { status: 426 });
+        }
+        return undefined;
+      }
+
+      const upstreamUrl = `http://localhost:${upstreamPort}${url.pathname}${url.search}`;
+      const init: RequestInit & { duplex?: "half" } = {
+        method: req.method,
+        headers: filterHeaders(req.headers, STRIP_REQUEST),
+        redirect: "manual",
+      };
+      if (req.method !== "GET" && req.method !== "HEAD") {
+        init.body = req.body;
+        init.duplex = "half";
+      }
+
+      const t0 = performance.now();
+      try {
+        const upstream = await fetch(upstreamUrl, init);
+        const dt = (performance.now() - t0).toFixed(0);
+        logger.info(
+          `[proxy] ${req.method} ${url.pathname} → ${target} (${upstream.status}, ${dt}ms)`
+        );
+        // Re-wrap so Bun.serve gets a fresh stream + clean headers (drops
+        // content-encoding/length/transfer-encoding from upstream so the
+        // runtime re-frames the response as it streams to the client).
+        return new Response(upstream.body, {
+          status: upstream.status,
+          statusText: upstream.statusText,
+          headers: filterHeaders(upstream.headers, STRIP_RESPONSE),
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(`[proxy] ${req.method} ${url.pathname} → ${target} failed: ${message}`);
+        return new Response(`Bad Gateway: ${message}`, { status: 502 });
+      }
+    },
+    websocket: {
+      open(ws: ServerWebSocket<WsClientData>) {
+        const upstream = new WebSocket(ws.data.upstreamUrl);
+        upstream.binaryType = "arraybuffer";
+        ws.data.upstream = upstream;
+
+        upstream.addEventListener("open", () => {
+          for (const msg of ws.data.pending) {
+            upstream.send(msg);
+          }
+          ws.data.pending = [];
+        });
+        upstream.addEventListener("message", (event) => {
+          if (ws.data.closed) return;
+          ws.send(event.data as string | ArrayBufferLike | Uint8Array);
+        });
+        upstream.addEventListener("close", (event) => {
+          if (ws.data.closed) return;
+          safeClose(ws, event.code, event.reason);
+        });
+        upstream.addEventListener("error", () => {
+          if (ws.data.closed) return;
+          safeClose(ws, 1011, "upstream error");
+        });
+      },
+      message(ws, message) {
+        const upstream = ws.data.upstream;
+        if (!upstream || upstream.readyState === 0 /* CONNECTING */) {
+          ws.data.pending.push(message);
+          return;
+        }
+        if (upstream.readyState !== 1 /* OPEN */) {
+          return;
+        }
+        upstream.send(message);
+      },
+      close(ws, code, reason) {
+        ws.data.closed = true;
+        const upstream = ws.data.upstream;
+        if (upstream && upstream.readyState <= 1) {
+          safeClose(upstream, code, reason);
+        }
+      },
+    },
+  });
+}
+
+if (import.meta.main) {
+  const [listenPortArg, frontApiPortArg, marketingPortArg] = process.argv.slice(2);
+  const listenPort = parsePort(listenPortArg, "listen port");
+  const ports: Record<Target, number> = {
+    "front-api": parsePort(frontApiPortArg, "front-api port"),
+    marketing: parsePort(marketingPortArg, "marketing port"),
+  };
+
+  const server = startProxy(listenPort, ports);
+
+  logger.info(
+    `proxy daemon listening on http://${server.hostname}:${server.port} ` +
+      `(front-api: ${ports["front-api"]}, marketing: ${ports.marketing})`
+  );
+
+  const shutdown = () => {
+    logger.info("Shutting down proxy daemon...");
+    server.stop();
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+}

--- a/x/henry/dust-hive/tests/lib/ports.test.ts
+++ b/x/henry/dust-hive/tests/lib/ports.test.ts
@@ -10,6 +10,8 @@ describe("ports", () => {
       expect(ports.front).toBe(10000);
       expect(ports.core).toBe(10001);
       expect(ports.connectors).toBe(10002);
+      expect(ports.frontApi).toBe(10003);
+      expect(ports.marketing).toBe(10004);
       expect(ports.oauth).toBe(10006);
       expect(ports.viz).toBe(10007);
       expect(ports.postgres).toBe(10432);
@@ -27,6 +29,8 @@ describe("ports", () => {
       expect(ports.front).toBe(11000);
       expect(ports.core).toBe(11001);
       expect(ports.connectors).toBe(11002);
+      expect(ports.frontApi).toBe(11003);
+      expect(ports.marketing).toBe(11004);
       expect(ports.oauth).toBe(11006);
       expect(ports.postgres).toBe(11432);
       expect(ports.redis).toBe(11379);
@@ -39,6 +43,8 @@ describe("ports", () => {
       expect(ports.front).toBe(base + PORT_OFFSETS.front);
       expect(ports.core).toBe(base + PORT_OFFSETS.core);
       expect(ports.connectors).toBe(base + PORT_OFFSETS.connectors);
+      expect(ports.frontApi).toBe(base + PORT_OFFSETS.frontApi);
+      expect(ports.marketing).toBe(base + PORT_OFFSETS.marketing);
       expect(ports.oauth).toBe(base + PORT_OFFSETS.oauth);
       expect(ports.viz).toBe(base + PORT_OFFSETS.viz);
       expect(ports.postgres).toBe(base + PORT_OFFSETS.postgres);

--- a/x/henry/dust-hive/tests/lib/proxy.test.ts
+++ b/x/henry/dust-hive/tests/lib/proxy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { routeFor } from "../../src/proxy-daemon";
+
+describe("proxy routing", () => {
+  describe("routeFor", () => {
+    it("routes /api/* to front-api", () => {
+      expect(routeFor("/api/auth-context")).toBe("front-api");
+      expect(routeFor("/api/w/wsid/agents")).toBe("front-api");
+      expect(routeFor("/api/")).toBe("front-api");
+      expect(routeFor("/api")).toBe("front-api");
+    });
+
+    it("routes /m/api/* to marketing (despite the /api substring)", () => {
+      expect(routeFor("/m/api/contact")).toBe("marketing");
+      expect(routeFor("/m/api/")).toBe("marketing");
+      expect(routeFor("/m/api")).toBe("marketing");
+    });
+
+    it("routes everything else to marketing", () => {
+      expect(routeFor("/")).toBe("marketing");
+      expect(routeFor("/home")).toBe("marketing");
+      expect(routeFor("/customers/foo")).toBe("marketing");
+      expect(routeFor("/blog/post")).toBe("marketing");
+      expect(routeFor("/m/something-else")).toBe("marketing");
+    });
+
+    it("does not confuse /api with /apiXyz", () => {
+      // Only exact `/api` or `/api/...` should route to front-api.
+      expect(routeFor("/apidocs")).toBe("marketing");
+      expect(routeFor("/api-test")).toBe("marketing");
+    });
+
+    it("does not match /api/m/* as marketing — only /m/api/* does", () => {
+      // /api/m/foo starts with /api/ so it's an API request, not marketing.
+      expect(routeFor("/api/m/foo")).toBe("front-api");
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/lib/registry.test.ts
+++ b/x/henry/dust-hive/tests/lib/registry.test.ts
@@ -23,6 +23,26 @@ describe("registry", () => {
       expect(config.cwd).toBe("front-api");
       expect(config.needsNvm).toBe(true);
       expect(config.needsEnvSh).toBe(true);
+      expect(config.portKey).toBe("frontApi");
+      expect(config.readinessCheck).toBeDefined();
+      expect(config.readinessCheck?.type).toBe("http");
+    });
+
+    it("marketing config has correct settings", () => {
+      const config = SERVICE_REGISTRY.marketing;
+      expect(config.cwd).toBe("marketing");
+      expect(config.needsNvm).toBe(true);
+      expect(config.needsEnvSh).toBe(true);
+      expect(config.portKey).toBe("marketing");
+      expect(config.readinessCheck).toBeDefined();
+      expect(config.readinessCheck?.type).toBe("http");
+    });
+
+    it("proxy config has correct settings", () => {
+      const config = SERVICE_REGISTRY.proxy;
+      expect(config.cwd).toBe("x/henry/dust-hive");
+      expect(config.needsNvm).toBe(false);
+      expect(config.needsEnvSh).toBe(false);
       expect(config.portKey).toBe("front");
       expect(config.readinessCheck).toBeDefined();
       expect(config.readinessCheck?.type).toBe("http");
@@ -75,6 +95,8 @@ describe("registry", () => {
 
     it("includes all other services", () => {
       expect(WARM_SERVICES).toContain("front-api");
+      expect(WARM_SERVICES).toContain("marketing");
+      expect(WARM_SERVICES).toContain("proxy");
       expect(WARM_SERVICES).toContain("core");
       expect(WARM_SERVICES).toContain("oauth");
       expect(WARM_SERVICES).toContain("connectors");
@@ -83,8 +105,8 @@ describe("registry", () => {
       expect(WARM_SERVICES).toContain("front-spa-app");
     });
 
-    it("has 7 services (all except sparkle, sdk, and viz)", () => {
-      expect(WARM_SERVICES).toHaveLength(7);
+    it("has 9 services (all except sparkle, sdk, viz)", () => {
+      expect(WARM_SERVICES).toHaveLength(9);
     });
   });
 
@@ -96,11 +118,25 @@ describe("registry", () => {
       expect(Array.isArray(checks)).toBe(true);
     });
 
-    it("includes the front-api health check", () => {
+    it("includes the proxy health check on the main port", () => {
       const checks = getHealthChecks(ports);
-      const frontCheck = checks.find((c) => c.service === "front-api");
-      expect(frontCheck).toBeDefined();
-      expect(frontCheck?.url).toBe("http://localhost:10000/api/healthz");
+      const proxyCheck = checks.find((c) => c.service === "proxy");
+      expect(proxyCheck).toBeDefined();
+      expect(proxyCheck?.url).toBe("http://localhost:10000/__hive/healthz");
+    });
+
+    it("includes the front-api health check on its own port", () => {
+      const checks = getHealthChecks(ports);
+      const frontApiCheck = checks.find((c) => c.service === "front-api");
+      expect(frontApiCheck).toBeDefined();
+      expect(frontApiCheck?.url).toBe("http://localhost:10003/api/healthz");
+    });
+
+    it("includes the marketing health check on its own port", () => {
+      const checks = getHealthChecks(ports);
+      const marketingCheck = checks.find((c) => c.service === "marketing");
+      expect(marketingCheck).toBeDefined();
+      expect(marketingCheck?.url).toBe("http://localhost:10004/");
     });
 
     it("includes core health check", () => {
@@ -124,8 +160,11 @@ describe("registry", () => {
       const secondPorts = calculatePorts(11000);
       const checks = getHealthChecks(secondPorts);
 
-      const frontCheck = checks.find((c) => c.service === "front-api");
-      expect(frontCheck?.url).toBe("http://localhost:11000/api/healthz");
+      const proxyCheck = checks.find((c) => c.service === "proxy");
+      expect(proxyCheck?.url).toBe("http://localhost:11000/__hive/healthz");
+
+      const frontApiCheck = checks.find((c) => c.service === "front-api");
+      expect(frontApiCheck?.url).toBe("http://localhost:11003/api/healthz");
 
       const coreCheck = checks.find((c) => c.service === "core");
       expect(coreCheck?.url).toBe("http://localhost:11001/");
@@ -151,11 +190,21 @@ describe("registry", () => {
       expect(command).toBe("npm run watch");
     });
 
-    it("front-api binds IPv4, forbids next, and runs npm run dev", () => {
+    it("front-api binds IPv4 on its dedicated port, forbids next, and runs npm run dev", () => {
       const command = SERVICE_REGISTRY["front-api"].buildCommand(mockEnv);
       expect(command).toBe(
-        "HOSTNAME=127.0.0.1 NODE_ENV=development NODE_OPTIONS=--require=./forbid-next.cjs npm run dev"
+        "HOSTNAME=127.0.0.1 PORT=10003 NODE_ENV=development NODE_OPTIONS=--require=./forbid-next.cjs npm run dev"
       );
+    });
+
+    it("marketing passes -p with the marketing port", () => {
+      const command = SERVICE_REGISTRY.marketing.buildCommand(mockEnv);
+      expect(command).toBe("npm run dev -- -p 10004");
+    });
+
+    it("proxy receives all three ports as argv", () => {
+      const command = SERVICE_REGISTRY.proxy.buildCommand(mockEnv);
+      expect(command).toBe("bun run src/proxy-daemon.ts 10000 10003 10004");
     });
 
     it("core returns cargo run --bin core-api", () => {

--- a/x/henry/dust-hive/tests/lib/services.test.ts
+++ b/x/henry/dust-hive/tests/lib/services.test.ts
@@ -7,6 +7,8 @@ describe("services", () => {
       expect(ALL_SERVICES).toContain("sparkle");
       expect(ALL_SERVICES).toContain("sdk");
       expect(ALL_SERVICES).toContain("front-api");
+      expect(ALL_SERVICES).toContain("marketing");
+      expect(ALL_SERVICES).toContain("proxy");
       expect(ALL_SERVICES).toContain("core");
       expect(ALL_SERVICES).toContain("oauth");
       expect(ALL_SERVICES).toContain("connectors");
@@ -16,8 +18,13 @@ describe("services", () => {
       expect(ALL_SERVICES).toContain("viz");
     });
 
-    it("has 10 services total", () => {
-      expect(ALL_SERVICES).toHaveLength(10);
+    it("does not contain the removed front service", () => {
+      // `front` (monolithic Next.js) was replaced by proxy + front-api + marketing.
+      expect(ALL_SERVICES).not.toContain("front" as ServiceName);
+    });
+
+    it("has 12 services total", () => {
+      expect(ALL_SERVICES).toHaveLength(12);
     });
 
     it("has sdk as first service (start order)", () => {
@@ -48,6 +55,15 @@ describe("services", () => {
       expect(frontApiIndex).toBeGreaterThan(sparkleIndex);
       expect(coreIndex).toBeGreaterThan(sparkleIndex);
     });
+
+    it("starts marketing before proxy so the proxy can route to it", () => {
+      const marketingIndex = ALL_SERVICES.indexOf("marketing");
+      const proxyIndex = ALL_SERVICES.indexOf("proxy");
+      const frontApiIndex = ALL_SERVICES.indexOf("front-api");
+      expect(marketingIndex).toBeGreaterThan(-1);
+      expect(proxyIndex).toBeGreaterThan(marketingIndex);
+      expect(proxyIndex).toBeGreaterThan(frontApiIndex);
+    });
   });
 
   describe("ServiceName type", () => {
@@ -56,6 +72,8 @@ describe("services", () => {
         "sdk",
         "sparkle",
         "front-api",
+        "marketing",
+        "proxy",
         "core",
         "oauth",
         "connectors",


### PR DESCRIPTION
## Description

This PR has two things in it:

1. Add marketing as a dust-hive service, nothing fancy here. The marketing service itself is quite fast to compile (nextjs can be fast when you remove 99% of the code+modules 😂 ), very little overhead so far. So I think it's ok to have it run, but not strongly held, can make it opt in.
2. The fancy (controversial ?) part : add a small proxy that listens to the xxxx0 port, and forward to either front-api or marketing depending on the mapping (in the said proxy). Tested hot reload, sse, normal navigation, it works 👍 .
If you're wondering why we put a websocket there, it's for refresh request after a hot reload, not useful for front-api, but def useful for marketing.


Why bother? 
1. When you don't know about /api/workos/login route, you're stuck . Especially problematic for newcomers / onsite
2. Marketing is still going to be something we will have to somewhat maintain, so might as well run it.



## Tests

Tested locally

## Risk

Low

## Deploy Plan

Merge