### PR TITLE
[front] Add stale-stream watchdog to self-heal missed terminal SSE events (infinite streaming)

### DIFF
--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -41,6 +41,13 @@ vi.mock("@app/hooks/conversations", () => ({
   }),
 }));
 
+const mockClientFetch = vi.fn();
+
+vi.mock("@app/lib/egress/client", () => ({
+  clientFetch: (...args: unknown[]) => mockClientFetch(...args),
+  clientEventSource: vi.fn(),
+}));
+
 vi.mock("@virtuoso.dev/message-list", () => ({
   useVirtuosoMethods: () => mockUseVirtuosoMethods(),
 }));
@@ -140,6 +147,7 @@ beforeEach(() => {
   mockUseEventSource.mockReset();
   mockMutateContextUsage.mockReset();
   mockUseVirtuosoMethods.mockReset();
+  mockClientFetch.mockReset();
 });
 
 afterEach(() => {
@@ -937,5 +945,186 @@ describe("useAgentMessageStream", () => {
         id: "cot-0-0",
       },
     ]);
+  });
+});
+
+describe("useAgentMessageStream stale-stream watchdog", () => {
+  function setupHook() {
+    let currentMessage = makeInitialMessageStreamState(
+      makeLightAgentMessage({ content: null, chainOfThought: null })
+    );
+    let onEventCallback: ((event: string) => void) | null = null;
+
+    mockUseVirtuosoMethods.mockReturnValue(
+      makeVirtuosoMethodsMock(
+        (
+          updater: (message: typeof currentMessage) => typeof currentMessage
+        ) => {
+          currentMessage = updater(currentMessage);
+          return [currentMessage];
+        }
+      )
+    );
+
+    mockUseEventSource.mockImplementation(
+      (
+        _buildURL: unknown,
+        callback: (event: string) => void
+      ): { isError: null } => {
+        onEventCallback = callback;
+        return { isError: null };
+      }
+    );
+
+    renderHook(() =>
+      useAgentMessageStream({
+        agentMessage: currentMessage,
+        conversationId: "conv_123",
+        isAutoScrollEnabledRef: mockIsAutoScrollEnabledRef,
+        owner: mockOwner,
+        streamId: "stream_123",
+      })
+    );
+
+    return {
+      getMessage: () => currentMessage,
+      sendEvent: (event: object) => onEventCallback!(JSON.stringify(event)),
+    };
+  }
+
+  it("reconciles a silently finished message with the persisted state", async () => {
+    vi.useFakeTimers();
+    const { getMessage } = setupHook();
+
+    mockClientFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: makeLightAgentMessage({
+          status: "succeeded",
+          content: "Persisted final answer.",
+          chainOfThought: "Persisted final thinking.",
+          activitySteps: [
+            {
+              type: "thinking",
+              content: "Persisted final thinking.",
+              id: "cot-0-0",
+            },
+          ],
+        }),
+      }),
+    });
+
+    // No event ever arrives. The tick at 60s passes the staleness threshold
+    // and reconciles with the persisted (terminal) message.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(mockClientFetch).toHaveBeenCalledWith(
+      "/api/w/w_test/assistant/conversations/conv_123/messages/msg_123?viewType=light"
+    );
+    const message = getMessage();
+    expect(message.status).toBe("succeeded");
+    expect(message.content).toBe("Persisted final answer.");
+    expect(message.streaming.agentState).toBe("done");
+    expect(message.streaming.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "Persisted final thinking.",
+        id: "cot-0-0",
+      },
+    ]);
+  });
+
+  it("does not reconcile while events are still flowing", async () => {
+    vi.useFakeTimers();
+    const { sendEvent } = setupHook();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    act(() => {
+      sendEvent({
+        eventId: "1-0",
+        data: {
+          type: "generation_tokens",
+          created: Date.now(),
+          configurationId: "agent_123",
+          messageId: "msg_123",
+          text: "Hello",
+          classification: "tokens",
+        },
+      });
+    });
+    // Ticks at 60s and 90s are both within the staleness threshold of the
+    // event received at 45s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+
+    expect(mockClientFetch).not.toHaveBeenCalled();
+  });
+
+  it("leaves the stream alone when the persisted message is still running", async () => {
+    vi.useFakeTimers();
+    const { getMessage } = setupHook();
+
+    mockClientFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: makeLightAgentMessage({ status: "created" }),
+      }),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(mockClientFetch).toHaveBeenCalledTimes(1);
+    const message = getMessage();
+    expect(message.status).toBe("created");
+    expect(message.streaming.agentState).toBe("thinking");
+
+    // The watchdog keeps checking on subsequent ticks.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(mockClientFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reconcile after a terminal event was processed", async () => {
+    vi.useFakeTimers();
+    const { sendEvent, getMessage } = setupHook();
+
+    act(() => {
+      sendEvent({
+        eventId: "1-0",
+        data: {
+          type: "agent_message_success",
+          created: Date.now(),
+          configurationId: "agent_123",
+          messageId: "msg_123",
+          message: {
+            ...makeLightAgentMessage({
+              status: "succeeded",
+              content: "Live final answer.",
+            }),
+            actions: [],
+          },
+          contentView: {
+            content: "Live final answer.",
+            chainOfThought: null,
+            activitySteps: [],
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180_000);
+    });
+
+    expect(mockClientFetch).not.toHaveBeenCalled();
+    expect(getMessage().streaming.agentState).toBe("done");
   });
 });

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -5,7 +5,10 @@ import type {
   VirtuosoMessage,
   VirtuosoMessageListContext,
 } from "@app/components/assistant/conversation/types";
-import { isAgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import {
+  isAgentMessageWithStreaming,
+  makeInitialMessageStreamState,
+} from "@app/components/assistant/conversation/types";
 import { useConversationContextUsage } from "@app/hooks/conversations";
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
@@ -15,10 +18,16 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
+import type { FetchConversationMessageResponseLight } from "@app/lib/api/assistant/messages";
+import { clientFetch } from "@app/lib/egress/client";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   InlineActivityStep,
   LightAgentMessageWithActionsType,
+} from "@app/types/assistant/conversation";
+import {
+  isLightAgentMessageType,
+  isTerminalAgentMessageStatus,
 } from "@app/types/assistant/conversation";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -34,6 +43,16 @@ import {
 } from "react";
 
 const TOKEN_BUFFER_THRESHOLD_MS = 500;
+
+// Stale-stream watchdog (see effect in useAgentMessageStream): how often we
+// check for a silent stream, and how long the stream must have been silent
+// before we reconcile against the persisted message. A healthy live stream
+// delivers events far more often than the threshold; a stream waiting on a
+// long silent tool call legitimately goes quiet, in which case the
+// reconciliation fetch is a cheap no-op (the persisted status is still
+// "created").
+const STALE_STREAM_CHECK_INTERVAL_MS = 30_000;
+const STALE_STREAM_RECONCILE_THRESHOLD_MS = 60_000;
 
 type VirtuosoMethods = VirtuosoMessageListMethods<
   VirtuosoMessage,
@@ -395,6 +414,13 @@ export function useAgentMessageStream({
   // Returning null from buildEventSourceURL breaks the loop at the source.
   const isStreamTerminated = useRef(false);
 
+  // Timestamp of the last SSE event actually processed (not deduplicated) for
+  // this message. Used by the stale-stream watchdog below to detect a stream
+  // that looks alive from the connection's point of view but no longer
+  // delivers events.
+  const lastEventReceivedAt = useRef<number>(Date.now());
+  const isReconcileInFlight = useRef(false);
+
   useEffect(() => {
     return () => {
       updateMessageThrottled.cancel();
@@ -462,6 +488,7 @@ export function useAgentMessageStream({
         }
         seenEventIds.current.add(eventPayload.eventId);
       }
+      lastEventReceivedAt.current = Date.now();
       const eventType = eventPayload.data.type;
       switch (eventType) {
         case "end-of-stream":
@@ -850,6 +877,107 @@ export function useAgentMessageStream({
       updateMessageThrottled,
     ]
   );
+
+  // Stale-stream watchdog — self-healing safety net for the "infinite
+  // streaming" class of bugs.
+  //
+  // The Virtuoso entry for a message is only ever finalized by a terminal SSE
+  // event (agent_message_success & co). If the client permanently misses that
+  // event, the message stays visually "streaming" until a full page reload,
+  // even though the agent finished long ago. There are real-world ways to
+  // permanently miss it: the Redis stream backing replays has a 10-minute TTL
+  // (a laptop asleep / tab frozen / network partition longer than that and
+  // the terminal event is gone from history), transient pub/sub delivery loss
+  // right before the stream expires, or any future client-side race — several
+  // have been fixed already and the class keeps resurfacing.
+  //
+  // Instead of chasing each trigger, reconcile with the source of truth: when
+  // the stream has been silent for STALE_STREAM_RECONCILE_THRESHOLD_MS while
+  // the message is still "created", fetch the persisted message. If it
+  // reached a terminal status, apply the server-rendered view (the exact data
+  // a reload would show) and terminate the stream. If it is still running
+  // (long tool call, pending validation, ...), this is a no-op and the live
+  // stream is left untouched.
+  useEffect(() => {
+    if (!shouldStream || !conversationId) {
+      return;
+    }
+
+    const reconcileWithPersistedMessage = async () => {
+      if (isStreamTerminated.current || isReconcileInFlight.current) {
+        return;
+      }
+      if (
+        Date.now() - lastEventReceivedAt.current <
+        STALE_STREAM_RECONCILE_THRESHOLD_MS
+      ) {
+        return;
+      }
+      isReconcileInFlight.current = true;
+      try {
+        const response = await clientFetch(
+          `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${sId}?viewType=light`
+        );
+        if (!response.ok) {
+          return;
+        }
+        const { message }: FetchConversationMessageResponseLight =
+          await response.json();
+        if (
+          !isLightAgentMessageType(message) ||
+          message.sId !== sId ||
+          !isTerminalAgentMessageStatus(message.status)
+        ) {
+          // The agent is genuinely still running — leave the live stream
+          // alone and let the next tick check again.
+          return;
+        }
+        // A terminal event may have raced us while the fetch was in flight;
+        // it already finalized the message, nothing left to do.
+        if (isStreamTerminated.current) {
+          return;
+        }
+        isStreamTerminated.current = true;
+        updateMessageThrottled.cancel();
+        methods.data.map((m) =>
+          isAgentMessageWithStreaming(m) && m.sId === sId
+            ? makeInitialMessageStreamState(message)
+            : m
+        );
+      } catch {
+        // Network errors are fine to swallow: the next watchdog tick retries.
+      } finally {
+        isReconcileInFlight.current = false;
+      }
+    };
+
+    const intervalId = setInterval(
+      () => void reconcileWithPersistedMessage(),
+      STALE_STREAM_CHECK_INTERVAL_MS
+    );
+
+    // Coming back from sleep / app switch is the most common way to end up
+    // past the replay window — check immediately instead of waiting for the
+    // next tick (the staleness threshold still gates the actual fetch).
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void reconcileWithPersistedMessage();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [
+    shouldStream,
+    conversationId,
+    owner.sId,
+    sId,
+    methods,
+    updateMessageThrottled,
+  ]);
 
   const { isError } = useEventSource(
     buildEventSourceURL,


### PR DESCRIPTION
## Description

Another instance of the recurring "infinite streaming" bug was reported (message stuck visually streaming forever, fixed by a page refresh). Several specific triggers have been fixed already (#25726, #25944, #26403, #27007), but the class keeps resurfacing because the architecture has a single point of failure: **the Virtuoso entry for a message is only ever finalized by a terminal SSE event**. Virtuoso is seeded once from the SWR snapshot and never re-synced; after that, only SSE events update the message. If the client permanently misses `agent_message_success` (or any terminal event), nothing in the system will ever finalize the message; the UI streams forever while reconnects keep "succeeding" against an empty stream.

There are real-world ways to permanently miss the terminal event:

- **Redis replay TTL (10 min).** The Redis stream backing SSE replays expires 10 minutes after the last publish (`redis-hybrid-manager.ts`). Laptop asleep / tab frozen (bfcache) / network partition past that window → on wake, the client reconnects with its old `lastEventId`, `xRead` finds nothing, and the terminal event is gone from history forever. The client then cycles connect → 60s idle timeout → EOF → reconnect, indefinitely. No `streamError` is ever set (each reconnect succeeds, resetting the attempt counter), so the existing "Connection lost" recovery UI never shows.
- **Transient pub/sub delivery loss** right before stream expiry (Redis pub/sub is fire-and-forget; history normally self-heals, but not past the TTL).
- **`seenEventIds` poisoning**: an event is marked seen before its Virtuoso map applies; replays of that event are then deduped forever.
- Any future client-side race in the event pipeline.

## The fix: stale-stream watchdog (reconcile with the source of truth)

Instead of chasing each trigger, do automatically what the user's refresh does manually. In `useAgentMessageStream`:

- Track the timestamp of the last processed (non-deduplicated) SSE event.
- While `shouldStream` is true, every 30s (and immediately on `visibilitychange` → visible, the common wake-from-sleep path), check staleness: if no event for 60s, fetch the persisted message (`GET .../messages/:mId?viewType=light`, the same server-rendered view a reload uses, which since #27007 is the single source of truth).
  - If the persisted status is **terminal**: apply `makeInitialMessageStreamState(message)` to the Virtuoso entry (exactly the reload representation: terminal status, rendered content/CoT, `activitySteps` as the timeline) and set `isStreamTerminated` so the SSE machinery winds down. Cannot drift from reload by construction.
  - If the persisted status is still **"created"** (long tool call, pending validation, genuinely slow step): no-op, the live stream is left completely untouched, next tick checks again.

Guards: one fetch in flight at a time; a terminal event racing the fetch wins (checked after the fetch resolves); the watchdog tears down when `shouldStream` flips false or the component unmounts; failed fetches are swallowed and retried on the next tick.

Cost: at most one light message GET per 30s per message that is both still "created" and silent for 60+ s. Healthy live streams never trigger it.

## Side observations from the investigation (not changed here, possible follow-ups)

- Since the front-api/Hono SSE migration, conversation/message event routes no longer write the `data: done` sentinel (`stream_events.ts`, only MCP opts in via `writeDoneSentinel`). The webapp's `useEventSource` used `done` as its *clean immediate reconnect* signal; every normal stream end (60s idle timeout, `hasMore` history-pagination close, end-of-stream break) now goes down the `onerror` path instead: 3-8s jittered delay + `reconnectAttempts` increment + a warn log per cycle. Not the root cause of the stuck state, but it makes replay of large histories slow (50 events per connection with a 3-8s gap) and makes the `MAX_RECONNECT_ATTEMPTS` latch easier to hit during deploys. Worth considering restoring the sentinel on these routes.
- `agent_message_gracefully_stopped`, `agent_generation_cancelled` and `tool_error` do not publish `end-of-stream` (`isEndOfAgentMessageStreamEvent` only covers success/error), so those streams always run to the 60s server timeout.

## Tests

4 new unit tests in `useAgentMessageStream.test.ts` (fake timers, mocked `clientFetch`):
- reconciles a silently finished message with the persisted state (status, content, agentState, inlineActivitySteps);
- does not reconcile while events are still flowing;
- leaves the stream alone when the persisted message is still "created", and keeps checking;
- does not reconcile after a terminal event was processed live.

Authored with an agent: local test run was not possible in the sandbox (npm unavailable); a standalone `tsc` syntax check passed on both files. Validation is delegated to PR CI; @PopDaph will run the suite locally before review.

## Risk

Additive and client-only. The watchdog only acts when the message is "created" AND the stream has been silent for 60s AND the persisted status is terminal, a state that is unambiguously a stuck UI today. Worst case regression is a redundant light GET every 30s for silent in-flight messages. Safe to rollback.

## Deploy Plan

Deploy front.