### PR TITLE
Trust the server-rendered content view in the nested run_agent stream (and remove orphaned run_agent progress code)

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -9,10 +9,6 @@ import { isAgentMessageWithStreaming } from "@app/components/assistant/conversat
 import { useConversationContextUsage } from "@app/hooks/conversations";
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
-import {
-  isRunAgentChainOfThoughtProgressOutput,
-  isRunAgentGenerationTokensProgressOutput,
-} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getActionOneLineLabel } from "@app/lib/api/assistant/activity_steps";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
@@ -183,55 +179,6 @@ export function updateProgress(
   const actionId = event.action.id;
   const currentProgress = agentMessage.streaming.actionProgress.get(actionId);
 
-  const output = event.notification._meta?.data?.output;
-  const prevOutput = currentProgress?.progress?._meta?.data?.output;
-
-  // The server sends deltas (not full state) for run_agent CoT/content tokens.
-  // We accumulate by reading the previous value from the stored progress output.
-  //
-  // Note: progress only holds one output type at a time. When the output switches from CoT
-  // to content, the accumulated CoT is lost here. The component's React state retains it,
-  // which is good enough for live streaming. On replay (page reload), CoT may be lost if content
-  // tokens have already started. This also means interleaved CoT/content/CoT is not supported.
-  let notificationWithAccumulated = event.notification;
-
-  if (output) {
-    if (isRunAgentChainOfThoughtProgressOutput(output)) {
-      const prevCoT =
-        prevOutput && isRunAgentChainOfThoughtProgressOutput(prevOutput)
-          ? prevOutput.chainOfThought
-          : "";
-      notificationWithAccumulated = {
-        ...event.notification,
-        _meta: {
-          ...event.notification._meta,
-          data: {
-            ...event.notification._meta.data,
-            output: {
-              ...output,
-              chainOfThought: prevCoT + output.chainOfThought,
-            },
-          },
-        },
-      };
-    } else if (isRunAgentGenerationTokensProgressOutput(output)) {
-      const prevText =
-        prevOutput && isRunAgentGenerationTokensProgressOutput(prevOutput)
-          ? prevOutput.text
-          : "";
-      notificationWithAccumulated = {
-        ...event.notification,
-        _meta: {
-          ...event.notification._meta,
-          data: {
-            ...event.notification._meta.data,
-            output: { ...output, text: prevText + output.text },
-          },
-        },
-      };
-    }
-  }
-
   return {
     ...agentMessage,
     streaming: {
@@ -242,10 +189,10 @@ export function updateProgress(
           action: event.action,
           progress: {
             ...currentProgress?.progress,
-            ...notificationWithAccumulated,
+            ...event.notification,
             _meta: {
               ...currentProgress?.progress?._meta,
-              ...notificationWithAccumulated._meta,
+              ...event.notification._meta,
             },
           },
         }

--- a/front/hooks/useChildAgentStream.test.ts
+++ b/front/hooks/useChildAgentStream.test.ts
@@ -1,0 +1,163 @@
+import { useChildAgentStream } from "@app/hooks/useChildAgentStream";
+import type { LightWorkspaceType } from "@app/types/user";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseEventSource = vi.fn();
+
+vi.mock("@app/hooks/useEventSource", () => ({
+  useEventSource: (...args: unknown[]) => mockUseEventSource(...args),
+}));
+
+const mockOwner: LightWorkspaceType = {
+  id: 1,
+  sId: "w_test",
+  name: "Test Workspace",
+  role: "admin",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  regionalModelsOnly: false,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+const childStreamIds = {
+  conversationId: "child_conv_123",
+  agentMessageId: "child_msg_123",
+};
+
+// Renders the hook and returns `{ result, emit }`, where `emit` dispatches a raw
+// child-stream event (the same JSON the SSE endpoint sends).
+function renderChildStream() {
+  let onEventCallback: ((event: string) => void) | null = null;
+  mockUseEventSource.mockImplementation(
+    (_buildURL: unknown, callback: (event: string) => void) => {
+      onEventCallback = callback;
+    }
+  );
+
+  const { result } = renderHook(() =>
+    useChildAgentStream({ childStreamIds, owner: mockOwner, disabled: false })
+  );
+
+  const emit = (data: unknown) => {
+    act(() => {
+      onEventCallback!(JSON.stringify({ eventId: "1-0", data }));
+    });
+  };
+
+  return { result, emit };
+}
+
+describe("useChildAgentStream", () => {
+  beforeEach(() => {
+    mockUseEventSource.mockReset();
+  });
+
+  it("trusts the server-rendered content view at the terminal event", () => {
+    const { result, emit } = renderChildStream();
+
+    // Some CoT streamed live before the terminal event.
+    emit({
+      type: "generation_tokens",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+      text: "Let me think.",
+      classification: "chain_of_thought",
+    });
+
+    emit({
+      type: "agent_message_success",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+      message: { content: "all text concatenated body", actions: [] },
+      contentView: {
+        content: "The final answer.",
+        chainOfThought: "Let me think.",
+        activitySteps: [
+          { type: "thinking", content: "Let me think.", id: "cot-0-0" },
+        ],
+      },
+    });
+
+    expect(result.current.isDone).toBe(true);
+    // Body comes from the content view, not the message's all-text content.
+    expect(result.current.response).toBe("The final answer.");
+    expect(result.current.inlineActivitySteps).toEqual([
+      { type: "thinking", content: "Let me think.", id: "cot-0-0" },
+    ]);
+  });
+
+  it("falls back to flushing the CoT buffer when the content view is absent", () => {
+    const { result, emit } = renderChildStream();
+
+    emit({
+      type: "generation_tokens",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+      text: "Thinking from the stream.",
+      classification: "chain_of_thought",
+    });
+
+    // Older server: no contentView on the terminal event.
+    emit({
+      type: "agent_message_success",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+      message: { content: "Body from the message.", actions: [] },
+    });
+
+    expect(result.current.isDone).toBe(true);
+    expect(result.current.response).toBe("Body from the message.");
+    expect(result.current.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "Thinking from the stream.",
+        id: expect.stringContaining("thinking-final-"),
+      },
+    ]);
+  });
+
+  it("accumulates response tokens and flushes CoT to a thinking step at tool_params", () => {
+    const { result, emit } = renderChildStream();
+
+    emit({
+      type: "generation_tokens",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+      text: "Hello ",
+      classification: "tokens",
+    });
+    emit({
+      type: "generation_tokens",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+      text: "I should search.",
+      classification: "chain_of_thought",
+    });
+    emit({
+      type: "tool_params",
+      created: Date.now(),
+      configurationId: "agent_123",
+      messageId: childStreamIds.agentMessageId,
+    });
+
+    expect(result.current.response).toBe("Hello ");
+    expect(result.current.inlineActivitySteps).toEqual([
+      {
+        type: "thinking",
+        content: "I should search.",
+        id: expect.stringContaining("thinking-"),
+      },
+    ]);
+    // CoT buffer flushed, no longer active.
+    expect(result.current.activeCotContent).toBe("");
+  });
+});

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -120,6 +120,19 @@ function childAgentStreamReducer(
 
     case "agent_message_gracefully_stopped":
     case "agent_message_success": {
+      // Trust the server-rendered content view: it is computed from the same
+      // persisted step contents reload uses, so it matches reload exactly (same
+      // as the top-level stream). Fall back to the locally flushed view only if
+      // an older server omitted it during a deploy window.
+      if (event.contentView) {
+        return {
+          response: event.contentView.content ?? state.response,
+          cotBuffer: "",
+          inlineActivitySteps: event.contentView.activitySteps,
+          pendingToolCalls: [],
+          status: "done",
+        };
+      }
       // Flush any remaining CoT buffer as a final thinking step.
       const trimmedCot = state.cotBuffer.trim();
       const finalSteps: InlineActivityStep[] = trimmedCot

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -903,62 +903,6 @@ export function isRunAgentQueryProgressOutput(
   );
 }
 
-const NotificationRunAgentChainOfThoughtSchema = z.object({
-  type: z.literal("run_agent_chain_of_thought"),
-  childAgentId: z.string(),
-  conversationId: z.string(),
-  chainOfThought: z.string(),
-});
-
-const NotificationRunAgentGenerationTokensSchema = z.object({
-  type: z.literal("run_agent_generation_tokens"),
-  childAgentId: z.string(),
-  conversationId: z.string(),
-  text: z.string(),
-});
-
-type RunAgentChainOfThoughtProgressOutput = z.infer<
-  typeof NotificationRunAgentChainOfThoughtSchema
->;
-
-export function isRunAgentChainOfThoughtProgressOutput(
-  output: ProgressNotificationOutput
-): output is RunAgentChainOfThoughtProgressOutput {
-  return (
-    output !== undefined &&
-    output.type === "run_agent_chain_of_thought" &&
-    "chainOfThought" in output
-  );
-}
-
-type RunAgentGenerationTokensProgressOutput = z.infer<
-  typeof NotificationRunAgentGenerationTokensSchema
->;
-
-export function isRunAgentGenerationTokensProgressOutput(
-  output: ProgressNotificationOutput
-): output is RunAgentGenerationTokensProgressOutput {
-  return (
-    output !== undefined &&
-    output.type === "run_agent_generation_tokens" &&
-    "text" in output &&
-    !("chainOfThought" in output)
-  );
-}
-
-export function isRunAgentProgressOutput(
-  output: ProgressNotificationOutput
-): output is
-  | RunAgentQueryProgressOutput
-  | RunAgentChainOfThoughtProgressOutput
-  | RunAgentGenerationTokensProgressOutput {
-  return (
-    isRunAgentQueryProgressOutput(output) ||
-    isRunAgentChainOfThoughtProgressOutput(output) ||
-    isRunAgentGenerationTokensProgressOutput(output)
-  );
-}
-
 type StoreResourceProgressOutput = z.infer<
   typeof NotificationStoreResourceContentSchema
 >;
@@ -973,9 +917,7 @@ export const ProgressNotificationOutputSchema = z
   .union([
     NotificationImageContentSchema,
     NotificationInteractiveContentFileContentSchema,
-    NotificationRunAgentChainOfThoughtSchema,
     NotificationRunAgentContentSchema,
-    NotificationRunAgentGenerationTokensSchema,
     NotificationStoreResourceContentSchema,
     NotificationTextContentSchema,
     NotificationToolApproveBubbleUpContentSchema,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1352,20 +1352,6 @@ export type NotificationRunAgentContent = z.infer<
   typeof NotificationRunAgentContentSchema
 >;
 
-const NotificationRunAgentChainOfThoughtSchema = z.object({
-  type: z.literal("run_agent_chain_of_thought"),
-  childAgentId: z.string(),
-  conversationId: z.string(),
-  chainOfThought: z.string(),
-});
-
-const NotificationRunAgentGenerationTokensSchema = z.object({
-  type: z.literal("run_agent_generation_tokens"),
-  childAgentId: z.string(),
-  conversationId: z.string(),
-  text: z.string(),
-});
-
 const NotificationStoreResourceContentSchema = z.object({
   type: z.literal("store_resource"),
   contents: z.array(
@@ -1385,9 +1371,7 @@ const NotificationStoreResourceContentSchema = z.object({
 const NotificationContentSchema = z.union([
   NotificationInteractiveContentFileContentSchema,
   NotificationImageContentSchema,
-  NotificationRunAgentChainOfThoughtSchema,
   NotificationRunAgentContentSchema,
-  NotificationRunAgentGenerationTokensSchema,
   NotificationStoreResourceContentSchema,
   NotificationTextContentSchema,
   NotificationToolApproveBubbleUpContentSchema,


### PR DESCRIPTION
## TL;DR

Follow up from PR https://github.com/dust-tt/dust/pull/27007 made the top-level agent stream trust a server-rendered `contentView` (body, chain of thought, activity steps) at the terminal event instead of reconstructing the final view on the client. This PR does two related things:

1. Applies the same treatment to the nested run_agent child stream (`useChildAgentStream`), so the child's finished view also matches reload by construction.
2. Removes the now-orphaned `run_agent_chain_of_thought` / `run_agent_generation_tokens` progress-notification code, which a prior PR (#22084) stopped emitting but left behind on the consumer side.

No change to live streaming behavior; only how the nested child message is finalized at stream end.

## What

**Child stream trusts the content view.** In `useChildAgentStream`, the `agent_message_success` / `agent_message_gracefully_stopped` case now uses `event.contentView` (body from `contentView.content`, timeline from `contentView.activitySteps`) when present, and falls back to the old local CoT-flush logic only when it is absent (older server during a deploy). The child message already runs the full loop and emits its terminal event through the same `updateResourceAndPublishEvent` choke point, so it already carries `contentView`; the child stream just was not using it. This is the only path rendering the child timeline in the run_agent side panel (no reload fallback there), so it now matches what the full child conversation shows on reload.

**Remove orphaned run_agent progress code.** #22084 ("Remove run agent cot/generation events") removed the emission of `run_agent_chain_of_thought` / `run_agent_generation_tokens` but left the schemas, type guards, the `updateProgress` accumulation branches, and a now-false comment in place. Nothing in the repo emits these anymore (verified across front, SDK, extension, connectors, core). Removed:
- `front/lib/actions/mcp_internal_actions/output_schemas.ts`: the two schemas, their types, the two guards, the unused `isRunAgentProgressOutput` aggregate, and both union members.
- `front/hooks/useAgentMessageStream.ts`: the two imports, the dead `updateProgress` branches, and the stale comment. `updateProgress` now just stores the notification (the run_agent CoT/tokens were the only delta-accumulated outputs; everything else is full-state).
- `sdks/js/src/types.ts`: the two schemas and their `NotificationContentSchema` union members.
