### PR TITLE
[front] switch_contract: use seat subscription commit instead of credits

### DIFF
--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -18,7 +18,7 @@ import {
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
-  getProductSeatSubscriptionCreditsId,
+  getProductSeatSubscriptionCommitId,
 } from "@app/lib/metronome/constants";
 import {
   applySeatRateOverrides,
@@ -690,7 +690,7 @@ export async function switchContract({
           metronomeContractId,
           // "Seat Individual Credits" — the fiat seat-credit product (named
           // "credit" but denominated in the contract's fiat currency).
-          productId: getProductSeatSubscriptionCreditsId(),
+          productId: getProductSeatSubscriptionCommitId(),
           accessAmount: accessAmountNative,
           accessCreditTypeId: fiatCreditTypeId,
           accessStartingAt: alignedStart,

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -688,8 +688,6 @@ export async function switchContract({
         const commitResult = await addPrepaidCommitToContract({
           metronomeCustomerId,
           metronomeContractId,
-          // "Seat Individual Credits" — the fiat seat-credit product (named
-          // "credit" but denominated in the contract's fiat currency).
           productId: getProductSeatSubscriptionCommitId(),
           accessAmount: accessAmountNative,
           accessCreditTypeId: fiatCreditTypeId,


### PR DESCRIPTION
## Description

switch_contract in poke was using the "Seat subscription credit" product
=> with "Seat subscription commit" product introduced, we can now use it here instead

## Tests

N/A

## Risk

None, simple product change in Metronome

## Deploy Plan

Deploy front
