### PR TITLE
feat: replace personal settings beta with popover

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -228,13 +228,11 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
 
   return (
     <>
-      {hasFeature("user_settings_v2") && (
-        <UserSettingsPopover
-          open={settingsOpen}
-          onOpenChange={setSettingsOpen}
-          owner={owner}
-        />
-      )}
+      <UserSettingsPopover
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        owner={owner}
+      />
       <DropdownMenu>
         <DropdownMenuTrigger className="hover:bg-sidebar-hover data-[state=open]:bg-sidebar-hover dark:hover:bg-sidebar-hover-night dark:data-[state=open]:bg-sidebar-hover-night rounded-xl p-2 m-2">
           <div className="group flex cursor-pointer items-center justify-between gap-2">
@@ -374,20 +372,13 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
 
           <DropdownMenuLabel label="Account" />
           {subscription?.plan.limits.canUseProduct && (
-            <>
-              <DropdownMenuItem
-                label="Personal Settings"
-                icon={User01}
-                href={`/w/${owner.sId}/me`}
-              />
-              {hasFeature("user_settings_v2") && (
-                <DropdownMenuItem
-                  label="Personal Settings — Beta"
-                  icon={User01}
-                  onSelect={() => setSettingsOpen(true)}
-                />
-              )}
-            </>
+            <DropdownMenuItem
+              label="Personal Settings"
+              icon={User01}
+              {...(hasFeature("user_settings_v2")
+                ? { onSelect: () => setSettingsOpen(true) }
+                : { href: `/w/${owner.sId}/me` })}
+            />
           )}
 
           <DropdownMenuItem


### PR DESCRIPTION
## Description

Removes the "Personal Settings — Beta" duplicate menu item and promotes the `UserSettingsPopover` to the primary personal settings entry point when the \`user_settings_v2\` feature flag is enabled.

**Before:** two items in the Account section — "Personal Settings" (link to \`/me\`) and "Personal Settings — Beta" (opens popover). The popover also had a feature-flag guard around its render.

**After:**
- A single "Personal Settings" item that opens the popover when \`user_settings_v2\` is enabled, or navigates to \`/w/:wId/me\` when it is not.
- The \`UserSettingsPopover\` is always rendered (controlled by \`settingsOpen\` state), removing the unnecessary flag guard around the component itself.

## Risk

Low — UI-only change. The feature flag still gates the new behaviour; the old \`/me\` page is untouched and remains the fallback.

## Deploy Plan

No special deployment steps required.