### PR TITLE
Analyics: Reduce time to sync feedback charts

### DIFF
--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,4 +1,8 @@
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+} from "@app/lib/models/agent/conversation";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
@@ -11,10 +15,37 @@ import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
+import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+// Resolves the agent configuration id backing an agent message (referenced by its
+// message sId). Used to decide whether the feedback workflow needs to wait for
+// Langfuse trace ingestion, which only applies to global agents.
+async function getAgentConfigurationIdForAgentMessage(
+  auth: Authenticator,
+  { agentMessageId }: { agentMessageId: string }
+): Promise<string | null> {
+  const messageRow = await MessageModel.findOne({
+    attributes: ["id"],
+    where: {
+      sId: agentMessageId,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    include: [
+      {
+        model: AgentMessageModel,
+        as: "agentMessage",
+        attributes: ["agentConfigurationId"],
+        required: true,
+      },
+    ],
+  });
+
+  return messageRow?.agentMessage?.agentConfigurationId ?? null;
+}
 
 export async function launchStoreAgentAnalyticsWorkflow({
   authType,
@@ -88,13 +119,24 @@ export async function launchAgentMessageFeedbackWorkflow(
       workspaceId,
     }) + "-feedback";
 
+  // The startDelay exists only to let Langfuse ingest traces before the workflow
+  // appends negative-feedback traces to the Langfuse dataset, which only happens for
+  // global agents. For non-global agents the workflow merely updates the Elasticsearch
+  // analytics document (no trace dependency), so we skip the delay to keep the feedback
+  // chart/overview in sync without a multi-minute lag.
+  const agentConfigurationId = await getAgentConfigurationIdForAgentMessage(
+    auth,
+    { agentMessageId }
+  );
+  const needsLangfuseTraceDelay =
+    agentConfigurationId !== null && isGlobalAgentId(agentConfigurationId);
+
   try {
     await client.workflow.start(storeAgentMessageFeedbackWorkflow, {
       args: [authType, { message }],
       taskQueue: QUEUE_NAME,
       workflowId,
-      // Delay to allow Langfuse to ingest traces before we query for them
-      startDelay: "2 minutes",
+      startDelay: needsLangfuseTraceDelay ? "2 minutes" : undefined,
       memo: {
         agentMessageId,
         workspaceId,


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/8716

There is a delay when processing feedback for agent.
The delay is only needed for global agents where we query the langfuse traces.
This PR remove the delay for non global agents so insight analytics are instantly processed

## Tests

tested locally

## Risk

low, easy to revert

## Deploy Plan

deploy front
