### PR TITLE
[Microsoft] Handle missing sites during root discovery

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -342,7 +342,7 @@ export async function getRootNodesToSyncFromResources(
         );
       } else if (isSiteNotFoundError(error)) {
         logger.warn(
-          { error: error.message },
+          { error: normalizeError(error).message },
           "SharePoint site target not found, skipping sites-root"
         );
       } else {

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -244,7 +244,18 @@ export async function getRootNodesToSyncFromResources(
             name: node.name,
           };
         } catch (error) {
-          if (error instanceof GraphError && error.statusCode === 404) {
+          if (
+            (error instanceof GraphError && error.statusCode === 404) ||
+            isSiteNotFoundError(error)
+          ) {
+            logger.warn(
+              {
+                connectorId,
+                internalId: resource.internalId,
+                error: normalizeError(error).message,
+              },
+              "Root resource not found, skipping"
+            );
             return null;
           }
           if (isAccessBlockedError(error)) {
@@ -329,6 +340,11 @@ export async function getRootNodesToSyncFromResources(
           { error: error.message },
           "Billing policy error from Microsoft, skipping sites-root"
         );
+      } else if (isSiteNotFoundError(error)) {
+        logger.warn(
+          { error: error.message },
+          "SharePoint site target not found, skipping sites-root"
+        );
       } else {
         throw error;
       }
@@ -351,8 +367,11 @@ export async function getRootNodesToSyncFromResources(
               nextLink
             );
           } catch (error) {
-            if (isItemNotFoundError(error)) {
-              logger.warn({ sitePath }, "Site not found, skipping drives");
+            if (isItemNotFoundError(error) || isSiteNotFoundError(error)) {
+              logger.warn(
+                { sitePath, error: normalizeError(error).message },
+                "Site not found, skipping drives"
+              );
               return { results: [] };
             }
             if (isAccessBlockedError(error)) {


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/27024.

Handles Microsoft site-not-found Graph errors during root node discovery, before full sync launch, incremental sync, or sensitivity reconciliation reach the sync activities. Deleted SharePoint site hosts now skip selected root resources, sites-root discovery, and per-site drive listing instead of throwing and retrying.

## Risks
Blast radius: Microsoft connector root discovery for missing SharePoint sites and selected root resources.
Risk: low

## Deploy Plan
- deploy connectors