### PR TITLE
Fix path-based generated files disappearing on conversation reload

### DIFF
--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -397,12 +397,12 @@ AgentMCPActionOutputItemModel.init(
       },
     },
     generatedFilePath: {
-      type: DataTypes.TEXT,
+      type: DataTypes.STRING(4096),
       allowNull: true,
       defaultValue: null,
     },
     generatedFileContentType: {
-      type: DataTypes.TEXT,
+      type: DataTypes.STRING(255),
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -10,6 +10,7 @@ import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type { CitationType } from "@app/types/assistant/conversation";
+import type { AllSupportedFileContentType } from "@app/types/files";
 import type { TimeFrame } from "@app/types/shared/utils/time_frame";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -343,6 +344,8 @@ export class AgentMCPActionOutputItemModel extends WorkspaceAwareModel<AgentMCPA
   declare contentGcsPath: string | null;
   declare fileId: ForeignKey<FileModel["id"]> | null;
   declare citations: Record<string, CitationType> | null;
+  declare generatedFilePath: string | null;
+  declare generatedFileContentType: AllSupportedFileContentType | null;
 
   declare file: NonAttribute<FileModel>;
 }
@@ -392,6 +395,16 @@ AgentMCPActionOutputItemModel.init(
           }
         },
       },
+    },
+    generatedFilePath: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
+    },
+    generatedFileContentType: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -2,6 +2,7 @@ import type {
   LightMCPToolConfigurationType,
   LightServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,7 +29,8 @@ import type {
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 
 // In-memory GCS mock: writes persist content that reads can return.
 const gcsStore = new Map<string, Buffer>();
@@ -585,6 +587,83 @@ describe("Output items with GCS storage", () => {
     expect(items![0].id).toBe(outputItems[0].id);
     expect(items![0].content).toBeUndefined();
     expect(items![0].contentGcsPath).toBeUndefined();
+  });
+
+  it("should store generatedFilePath and generatedFileContentType for path-based output items", async () => {
+    const { action } = await ConversationFactory.createAgentMessage(auth, {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction: { toolConfiguration },
+    });
+    assert(action, "action should be defined");
+
+    const outputResourceItem: ToolGeneratedFilePathType = {
+      text: "file written",
+      uri: "conversation-abc123/analysis.csv",
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+      path: "conversation-abc123/analysis.csv",
+      title: "analysis.csv",
+      contentType: "text/csv",
+    };
+
+    const outputItems = await action.createOutputItems(auth, [
+      {
+        content: {
+          type: "resource",
+          resource: outputResourceItem,
+        },
+      },
+    ]);
+
+    expect(outputItems).toHaveLength(1);
+    expect(outputItems[0].generatedFilePath).toBe(
+      "conversation-abc123/analysis.csv"
+    );
+    expect(outputItems[0].generatedFileContentType).toBe("text/csv");
+  });
+
+  it("should return generatedFilePath and generatedFileContentType when ignoreContent is true", async () => {
+    const { action } = await ConversationFactory.createAgentMessage(auth, {
+      workspace,
+      conversation,
+      agentConfig,
+      mcpAction: { toolConfiguration },
+    });
+    assert(action, "action should be defined");
+
+    const outputResourceItem: ToolGeneratedFilePathType = {
+      text: "file written",
+      uri: "conversation-abc123/analysis.csv",
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+      path: "conversation-abc123/analysis.csv",
+      title: "analysis.csv",
+      contentType: "text/csv",
+    };
+
+    await action.createOutputItems(auth, [
+      {
+        content: {
+          type: "resource",
+          resource: outputResourceItem,
+        },
+      },
+    ]);
+
+    const map = await AgentMCPActionResource.fetchOutputItemsByActionIds(auth, {
+      actionIds: [action.id],
+      ignoreContent: true,
+    });
+
+    const items = map.get(action.id);
+    assert(items !== undefined, "items should be defined");
+    expect(items).toHaveLength(1);
+    // content and contentGcsPath are excluded by ignoreContent.
+    expect(items[0].content).toBeUndefined();
+    expect(items[0].contentGcsPath).toBeUndefined();
+    // Path-based file metadata survives.
+    expect(items[0].generatedFilePath).toBe("conversation-abc123/analysis.csv");
+    expect(items[0].generatedFileContentType).toBe("text/csv");
   });
 
   it("fetchOutputItemsByActionIds mixes metadata-only and full-content actions in one call", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -755,14 +755,26 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }>
   ): Promise<AgentMCPActionOutputItemModel[]> {
     const outputItems = await AgentMCPActionOutputItemModel.bulkCreate(
-      contents.map((c) => ({
-        agentMCPActionId: this.id,
-        // Write content to DB (kept during migration period to ease rollback).
-        content: c.content,
-        citations: getCitationsFromToolOutput([c.content]),
-        fileId: c.fileId,
-        workspaceId: this.workspaceId,
-      }))
+      contents.map((c) => {
+        const { generatedFilePath, generatedFileContentType } =
+          isToolGeneratedFilePath(c.content)
+            ? {
+                generatedFilePath: c.content.resource.path,
+                generatedFileContentType: c.content.resource.contentType,
+              }
+            : { generatedFilePath: null, generatedFileContentType: null };
+
+        return {
+          agentMCPActionId: this.id,
+          // Write content to DB (kept during migration period to ease rollback).
+          content: c.content,
+          citations: getCitationsFromToolOutput([c.content]),
+          fileId: c.fileId,
+          workspaceId: this.workspaceId,
+          generatedFilePath,
+          generatedFileContentType,
+        };
+      })
     );
 
     const gcsResult = await batchWriteContentsToGcs(
@@ -1105,6 +1117,19 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
                     filePath: o.content.resource.path,
                     title: o.content.resource.title,
                     contentType: o.content.resource.contentType,
+                    snippet: null,
+                    hidden: false,
+                  };
+                }
+
+                // Fallback for light rendering (ignoreContent: true excludes the content column).
+                if (o.generatedFilePath && o.generatedFileContentType) {
+                  const filePath = o.generatedFilePath;
+                  return {
+                    fileId: null,
+                    filePath,
+                    title: filePath.split("/").pop() ?? filePath,
+                    contentType: o.generatedFileContentType,
                     snippet: null,
                     hidden: false,
                   };

--- a/front/migrations/db/migration_672.sql
+++ b/front/migrations/db/migration_672.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jun 09, 2026
+ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "generatedFilePath" TEXT DEFAULT NULL;
+ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "generatedFileContentType" TEXT DEFAULT NULL;

--- a/front/migrations/db/migration_672.sql
+++ b/front/migrations/db/migration_672.sql
@@ -1,3 +1,3 @@
 -- Migration created on Jun 09, 2026
-ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "generatedFilePath" TEXT DEFAULT NULL;
-ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "generatedFileContentType" TEXT DEFAULT NULL;
+ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "generatedFilePath" VARCHAR(4096) DEFAULT NULL;
+ALTER TABLE "public"."agent_mcp_action_output_items" ADD COLUMN "generatedFileContentType" VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Path-based files created by agent tools (files with a `filePath` instead of a `fileId`) were only stored in the MCP action output item's content blob. Since the frontend messages endpoint always renders in light mode, content is excluded from the query, causing these files to vanish from `generatedFiles` on reload while DB-backed files (resolved via the fileId FK) remained unaffected.

The fix adds two `TEXT` columns  to `agent_mcp_action_output_items` table:
- `generatedFilePath`
- `generatedFileContentType`.

These are populated at write time and used as a fallback when the content column is unavailable, restoring path-based files correctly on reload.

No plan to backfill previous items.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply SQL migrations
- [ ] Deploy front 
