### PR TITLE
[front] feat: add get_top_users to workspace_analytics

### DIFF
--- a/front-api/routes/w/[wId]/analytics/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/top-users.ts
@@ -1,48 +1,16 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { GetWorkspaceTopUsersResponse } from "@app/lib/api/analytics/workspace_analytics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
-import { UserResource } from "@app/lib/resources/user_resource";
-import type { estypes } from "@elastic/elasticsearch";
+import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   limit: z.coerce.number().positive().max(100).optional().default(25),
 });
-
-type TopUsersAggs = {
-  by_user?: estypes.AggregationsMultiBucketAggregateBase<{
-    key: string;
-    doc_count: number;
-    unique_agents?: estypes.AggregationsCardinalityAggregate;
-  }>;
-};
-
-type TopUserBucket = {
-  key: string;
-  doc_count: number;
-  unique_agents?: estypes.AggregationsCardinalityAggregate;
-};
-
-function getUserDisplayName(user: UserResource | undefined): string {
-  if (!user) {
-    return "Programmatic usage";
-  }
-  const fullName = user.fullName();
-  if (fullName) {
-    return fullName;
-  }
-  if (user.username) {
-    return user.username;
-  }
-  return user.email || "Programmatic usage";
-}
 
 // Mounted at /api/w/:wId/analytics/top-users.
 const app = workspaceApp();
@@ -52,71 +20,20 @@ app.get("/", ensureIsAdmin(), validate("query", QuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
 
   const { days, limit } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    days,
-  });
-
-  const result = await searchAnalytics<never, TopUsersAggs>(
-    {
-      bool: {
-        filter: [baseQuery, { exists: { field: "user_id" } }],
-      },
-    },
-    {
-      aggregations: {
-        by_user: {
-          terms: {
-            field: "user_id",
-            size: limit,
-          },
-          aggs: {
-            unique_agents: {
-              cardinality: {
-                field: "agent_id",
-              },
-            },
-          },
-        },
-      },
-      size: 0,
-    }
-  );
+  const result = await fetchTopUsers(auth, { days, limit });
 
   if (result.isErr()) {
     return apiError(ctx, {
       status_code: 500,
       api_error: {
         type: "internal_server_error",
-        message: `Failed to retrieve top users: ${fromError(result.error).toString()}`,
+        message: `Failed to retrieve top users: ${result.error.message}`,
       },
     });
   }
 
-  const buckets = bucketsToArray<TopUserBucket>(
-    result.value.aggregations?.by_user?.buckets
-  );
-
-  const userIds = buckets.map((bucket) => String(bucket.key));
-  const users =
-    userIds.length > 0 ? await UserResource.fetchByIds(userIds) : [];
-  const usersById = new Map(users.map((user) => [user.sId, user]));
-
-  const rows = buckets.map((bucket) => {
-    const userId = String(bucket.key);
-    const user = usersById.get(userId);
-    return {
-      userId,
-      name: getUserDisplayName(user),
-      imageUrl: user?.imageUrl ?? null,
-      messageCount: bucket.doc_count ?? 0,
-      agentCount: Math.round(bucket.unique_agents?.value ?? 0),
-    };
-  });
-
-  const body: GetWorkspaceTopUsersResponse = { users: rows };
+  const body: GetWorkspaceTopUsersResponse = { users: result.value };
   return ctx.json(body);
 });
 

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -703,6 +703,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "workspace_analytics": {
     "get_top_agents": "never_ask",
+    "get_top_users": "never_ask",
   },
   "zendesk": {
     "draft_reply": "low",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -20,6 +20,18 @@ const getTopAgentsSchema = {
     .describe("Maximum number of agents to return (default 25, max 100)."),
 };
 
+const getTopUsersSchema = {
+  ...timeWindowSchemaShape,
+  ...usageFilterSchema,
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .optional()
+    .describe("Maximum number of users to return (default 25, max 100)."),
+};
+
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_top_agents: {
     description:
@@ -33,6 +45,20 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving top agents",
       done: "Retrieved top agents",
+    },
+  },
+  get_top_users: {
+    description:
+      "Return the workspace's most active users over a time window (defaults " +
+      "to the current calendar month), ranked by number of messages sent, " +
+      "with the count of distinct agents each used. Each row includes the " +
+      "user's id. Optionally filter by source (context_origin), agent, or " +
+      "user. Use this to answer who the most active users are. Admin-only.",
+    schema: getTopUsersSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top users",
+      done: "Retrieved top users",
     },
   },
 });

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -25,6 +25,7 @@ function createTestExtra(auth: Authenticator) {
 describe("workspace_analytics tools", () => {
   it.each([
     "get_top_agents",
+    "get_top_users",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -5,6 +5,7 @@ import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
+import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { Err, Ok } from "@app/types/shared/result";
 
 const DEFAULT_LIMIT = 25;
@@ -61,6 +62,62 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Top agents for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_top_users: async (
+    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const result = await fetchTopUsers(auth, {
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      limit: limit ?? DEFAULT_LIMIT,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to retrieve top users: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+
+    if (result.value.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No user activity recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = result.value.map(
+      (user, index) =>
+        `${index + 1}. ${user.name} [${user.userId}] — ` +
+        `${user.messageCount} messages, ${user.agentCount} agents`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Top users for ${label} (${tz}), most active first:\n` +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/assistant/observability/top_users.ts
+++ b/front/lib/api/assistant/observability/top_users.ts
@@ -1,0 +1,114 @@
+import type { WorkspaceTopUserRow } from "@app/lib/api/analytics/workspace_analytics";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+type TopUserBucket = {
+  key: string;
+  doc_count: number;
+  unique_agents?: estypes.AggregationsCardinalityAggregate;
+};
+
+type TopUsersAggs = {
+  by_user?: estypes.AggregationsMultiBucketAggregateBase<TopUserBucket>;
+};
+
+function getUserDisplayName(user: UserResource | undefined): string {
+  if (!user) {
+    return "Programmatic usage";
+  }
+  const fullName = user.fullName();
+  if (fullName) {
+    return fullName;
+  }
+  if (user.username) {
+    return user.username;
+  }
+  return user.email || "Programmatic usage";
+}
+
+export async function fetchTopUsers(
+  auth: Authenticator,
+  {
+    days,
+    startDate,
+    endDate,
+    limit,
+    contextOrigin,
+    agentIds,
+    userIds,
+  }: {
+    days?: number;
+    startDate?: string;
+    endDate?: string;
+    limit: number;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+  }
+): Promise<Result<WorkspaceTopUserRow[], ElasticsearchError>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    days,
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+
+  const result = await searchAnalytics<never, TopUsersAggs>(
+    {
+      bool: {
+        filter: [baseQuery, { exists: { field: "user_id" } }],
+      },
+    },
+    {
+      aggregations: {
+        by_user: {
+          terms: { field: "user_id", size: limit },
+          aggs: {
+            unique_agents: { cardinality: { field: "agent_id" } },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<TopUserBucket>(
+    result.value.aggregations?.by_user?.buckets
+  );
+
+  const bucketUserIds = buckets.map((bucket) => String(bucket.key));
+  const users =
+    bucketUserIds.length > 0
+      ? await UserResource.fetchByIds(bucketUserIds)
+      : [];
+  const usersById = new Map(users.map((user) => [user.sId, user]));
+
+  const rows = buckets.map((bucket) => {
+    const userId = String(bucket.key);
+    const user = usersById.get(userId);
+    return {
+      userId,
+      name: getUserDisplayName(user),
+      imageUrl: user?.imageUrl ?? null,
+      messageCount: bucket.doc_count ?? 0,
+      agentCount: Math.round(bucket.unique_agents?.value ?? 0),
+    };
+  });
+
+  return new Ok(rows);
+}


### PR DESCRIPTION
## Description

Extract the top-users Elasticsearch query out of the Hono route into fetchTopUsers (lib/api/assistant/observability/top_users), reusing the row type from lib/api/analytics/workspace_analytics, and add an admin-only get_top_users tool that ranks the most active users by messages with their distinct-agent count. Refactor the analytics route to call the shared function.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, just moving code around and plugging a new tool to a feature flagged mcp

## Deploy Plan

front
