### PR TITLE
[sparkle] Add Pagination stories and enrich primitive stories

### DIFF
--- a/sparkle/src/stories/Checkbox.stories.tsx
+++ b/sparkle/src/stories/Checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { expect } from "storybook/test";
 
 import { CHECKBOX_SIZES } from "@sparkle/components/Checkbox";
 
@@ -113,5 +114,31 @@ export const Default: Story = {
       return <CheckboxWithText text={text} {...props} />;
     }
     return <Checkbox {...props} />;
+  },
+};
+
+export const Checked: Story = {
+  args: { checked: true },
+  tags: ["ai-generated", "needs-work"],
+};
+
+export const Indeterminate: Story = {
+  args: { checked: "partial" },
+  tags: ["ai-generated", "needs-work"],
+};
+
+export const Disabled: Story = {
+  args: { checked: true, disabled: true },
+  tags: ["ai-generated", "needs-work"],
+};
+
+// Interaction: an uncontrolled checkbox must flip its aria-checked state on click.
+export const Interactive: Story = {
+  tags: ["ai-generated", "needs-work"],
+  play: async ({ canvas, userEvent }) => {
+    const checkbox = canvas.getByRole("checkbox");
+    await expect(checkbox).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(checkbox);
+    await expect(checkbox).toHaveAttribute("aria-checked", "true");
   },
 };

--- a/sparkle/src/stories/Counter.stories.tsx
+++ b/sparkle/src/stories/Counter.stories.tsx
@@ -1,4 +1,6 @@
-import type { Meta } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import { expect } from "storybook/test";
 
 import { Counter } from "../components/Counter";
 
@@ -37,5 +39,43 @@ export const Default = {
     value: 4,
     variant: "primary",
     isInButton: false,
+  },
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Highlight: Story = {
+  args: { variant: "highlight" },
+  tags: ["ai-generated", "needs-work"],
+};
+
+export const Warning: Story = {
+  args: { variant: "warning" },
+  tags: ["ai-generated", "needs-work"],
+};
+
+export const Outline: Story = {
+  args: { variant: "outline" },
+  tags: ["ai-generated", "needs-work"],
+};
+
+// All three counter sizes side by side.
+export const Sizes: Story = {
+  tags: ["ai-generated", "needs-work"],
+  render: () => (
+    <div className="s-flex s-items-center s-gap-2">
+      <Counter value={3} size="xs" />
+      <Counter value={42} size="sm" />
+      <Counter value={128} size="md" />
+    </div>
+  ),
+};
+
+// Smoke play: the numeric `value` prop must be rendered as text.
+export const DisplaysValue: Story = {
+  args: { value: 99 },
+  tags: ["ai-generated", "needs-work"],
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("99")).toBeVisible();
   },
 };

--- a/sparkle/src/stories/Label.stories.tsx
+++ b/sparkle/src/stories/Label.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { expect } from "storybook/test";
 
 import { Checkbox, Label } from "../index_with_tw_base";
 
@@ -22,4 +23,29 @@ export const LabelDemo = () => {
       </div>
     </div>
   );
+};
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: "Email address", htmlFor: "email" },
+  tags: ["ai-generated", "needs-work"],
+};
+
+export const Muted: Story = {
+  args: { children: "Optional", isMuted: true },
+  tags: ["ai-generated", "needs-work"],
+};
+
+// Smoke play: `htmlFor` must surface as the DOM `for` attribute so clicking the
+// label focuses its associated control.
+export const AssociatedWithControl: Story = {
+  args: { children: "Workspace name", htmlFor: "workspace-input" },
+  tags: ["ai-generated", "needs-work"],
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Workspace name")).toHaveAttribute(
+      "for",
+      "workspace-input"
+    );
+  },
 };

--- a/sparkle/src/stories/Pagination.stories.tsx
+++ b/sparkle/src/stories/Pagination.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { PaginationState } from "@tanstack/react-table";
+import React, { useState } from "react";
+import { expect } from "storybook/test";
+
+import { Pagination } from "@sparkle/components/Pagination";
+
+// Pagination is controlled. Each story wraps it so the `pagination` state lives locally and is
+// fed back in — mirroring real callers and making the interaction play meaningful. The defaults
+// below seed the initial state; `render` replaces `setPagination` with the local state setter.
+const meta: Meta<typeof Pagination> = {
+  component: Pagination,
+  args: {
+    rowCount: 95,
+    pagination: { pageIndex: 0, pageSize: 10 },
+    setPagination: () => {},
+  },
+  render: (args) => {
+    const [pagination, setPagination] = useState(args.pagination);
+    return (
+      <Pagination
+        {...args}
+        pagination={pagination}
+        setPagination={setPagination}
+      />
+    );
+  },
+  tags: ["ai-generated", "needs-work"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SinglePage: Story = {
+  args: { rowCount: 4 },
+};
+
+// Interaction: selecting page 2 must advance the controlled state and update the range summary.
+export const NavigatesPages: Story = {
+  play: async ({ canvas, userEvent }) => {
+    await expect(canvas.getByText(/showing 1-10 of 95/i)).toBeVisible();
+    await userEvent.click(canvas.getByRole("button", { name: "2" }));
+    await expect(canvas.getByText(/showing 11-20 of 95/i)).toBeVisible();
+  },
+};
+
+// Single project-wide CssCheck. Pagination's page-number buttons use `s-font-medium`, which
+// Tailwind compiles to `font-weight: 500`. A concrete computed value is the only proof that the
+// shared preview actually loaded Sparkle's stylesheet — `toBeVisible` would pass even unstyled.
+export const CssCheck: Story = {
+  play: async ({ canvas }) => {
+    const pageButton = canvas.getByRole("button", { name: "1" });
+    await expect(getComputedStyle(pageButton).fontWeight).toBe("500");
+  },
+};

--- a/sparkle/src/stories/Separator.stories.tsx
+++ b/sparkle/src/stories/Separator.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import * as React from "react";
+import { expect } from "storybook/test";
 
 import { Separator } from "@sparkle/index_with_tw_base";
 
@@ -29,3 +30,30 @@ export const SeparatorExample = () => (
     </div>
   </div>
 );
+
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  tags: ["ai-generated", "needs-work"],
+  render: () => (
+    <div className="s-w-64">
+      <Separator />
+    </div>
+  ),
+};
+
+// A semantic (non-decorative) vertical separator must expose role="separator" and
+// aria-orientation="vertical" — proving the orientation prop drives the accessibility tree.
+export const Vertical: Story = {
+  args: { orientation: "vertical", decorative: false },
+  tags: ["ai-generated", "needs-work"],
+  render: (args) => (
+    <div className="s-flex s-h-16">
+      <Separator {...args} />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const separator = canvas.getByRole("separator");
+    await expect(separator).toHaveAttribute("aria-orientation", "vertical");
+  },
+};


### PR DESCRIPTION
Add a new Pagination story (no prior coverage) with a controlled-state wrapper, a page-navigation interaction play, and a single CssCheck that verifies the shared preview loaded Sparkle's stylesheet.

Enrich the thin Counter, Label, Checkbox, and Separator stories with variant coverage and one focused play each (value rendering, htmlFor association, uncontrolled aria-checked toggle, separator orientation).

New story exports are tagged ['ai-generated', 'needs-work']; the tag stays until play functions are executed by a Storybook test runner (not yet configured in this package).

