### PR TITLE
Detect file format, fix utf16 upload

### DIFF
--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -11,6 +11,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { File } from "formidable";
 import { IncomingForm } from "formidable";
 import type { IncomingMessage } from "http";
+import * as iconv from "iconv-lite";
 import type { Writable } from "stream";
 
 export const parseUploadRequest = async (
@@ -102,6 +103,44 @@ export const parseUploadRequest = async (
   }
 };
 
+/**
+ * Detects the encoding of a buffer and decodes it to a string.
+ * Checks for UTF-16 BOM markers and falls back to UTF-8.
+ *
+ * Files exported from Windows tools (Notepad, Excel CSV) are frequently UTF-16
+ * with a BOM; decoding those as UTF-8 produces interleaved NUL bytes (0x00)
+ * that PostgreSQL later rejects ("invalid byte sequence for encoding UTF8:
+ * 0x00"). iconv-lite strips the BOM as part of decoding.
+ *
+ * Mirrors `decodeBuffer` in connectors (`src/connectors/shared/file.ts`).
+ */
+export function decodeBuffer(data: Uint8Array): string {
+  const buffer = Buffer.from(data);
+
+  // Check for UTF-16 LE BOM (FF FE)
+  if (buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xfe) {
+    return iconv.decode(buffer, "utf16le");
+  }
+
+  // Check for UTF-16 BE BOM (FE FF)
+  if (buffer.length >= 2 && buffer[0] === 0xfe && buffer[1] === 0xff) {
+    return iconv.decode(buffer, "utf16be");
+  }
+
+  // Check for UTF-8 BOM (EF BB BF)
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xef &&
+    buffer[1] === 0xbb &&
+    buffer[2] === 0xbf
+  ) {
+    return iconv.decode(buffer, "utf8");
+  }
+
+  // Default to UTF-8 without BOM
+  return buffer.toString("utf-8");
+}
+
 export async function getFileContent(
   auth: Authenticator,
   file: FileResource,
@@ -116,7 +155,7 @@ export async function getFileContent(
     return null;
   }
 
-  return bufferResult.value.toString("utf-8");
+  return decodeBuffer(bufferResult.value);
 }
 
 export function getUpdatedContentAndOccurrences({

--- a/front/package.json
+++ b/front/package.json
@@ -163,6 +163,7 @@
     "hot-shots": "^12.1.0",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^9.1.0",
+    "iconv-lite": "^0.6.3",
     "image-size": "^2.0.2",
     "io-ts": "^2.2.20",
     "io-ts-reporters": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -609,6 +609,7 @@
         "hot-shots": "^12.1.0",
         "html-escaper": "^3.0.3",
         "htmlparser2": "^9.1.0",
+        "iconv-lite": "^0.6.3",
         "image-size": "^2.0.2",
         "io-ts": "^2.2.20",
         "io-ts-reporters": "^2.0.1",


### PR DESCRIPTION
## Description

Fixes the upsert-queue Temporal activity failures:

```
Upsert error: Failed to upsert document (error: db error: ERROR: invalid byte sequence for encoding "UTF8": 0x00)
```

**Root cause:** `getFileContent` (`front/lib/api/files/utils.ts`) decoded every uploaded file with
`Buffer.toString("utf-8")` unconditionally. When the source is UTF-16 — typically a `.txt`/`.csv`
exported from a Windows tool (Notepad, Excel), which defaults to UTF-16 with a BOM — this mis-decodes
the bytes: each character becomes `char + 0x00`, so the resulting string is riddled with NUL bytes
(`0x00`). That string becomes the document section, gets enqueued, and when the upsert activity hands
it to core, PostgreSQL rejects the `0x00` byte (it is not valid in a `text` column), failing the
activity on every retry.

**Fix:** introduce a `decodeBuffer` helper that inspects the leading byte order mark and decodes with
the matching encoding (`utf16le` / `utf16be` / `utf8`), falling back to UTF-8 when no BOM is present.
`iconv-lite` strips the BOM as part of decoding. `getFileContent` now uses it instead of
`toString("utf-8")`.

This mirrors the existing `decodeBuffer` in connectors (`connectors/src/connectors/shared/file.ts`),
which already handles this for the connector ingestion path — `front` was missing the equivalent for
file-upload ingestion. Adds `iconv-lite` (already used by connectors) as a `front` dependency.

## Tests

- Manually verified the decode logic against `iconv-lite`: UTF-8 (plain + BOM), UTF-16LE (BOM) and
  UTF-16BE (BOM) buffers all round-trip to the original string with no NUL bytes, while the previous
  `toString("utf-8")` on UTF-16 input reproduces the NUL bytes that triggered the incident.
- `tsgo --noEmit` clean for the changed file.

## Risk

Low. The change only affects how uploaded file bytes are decoded to text:
- No BOM → identical behavior to before (`buffer.toString("utf-8")`).
- BOM present → now decoded correctly instead of producing corrupted text.

Rollback is safe (revert the commit); it only restores the previous decoding behavior.

**Known limitation:** detection is BOM-based. A BOM-less UTF-16 file would still be mis-decoded. If
the incident document turns out to lack a BOM, a byte-frequency heuristic would be needed as a
follow-up.

## Deploy Plan

Standard deploy. No migration or coordination required. Existing already-corrupted documents are not
retroactively fixed — they need to be re-uploaded after deploy; the stuck workflow for this incident
is being cancelled.
