### PR TITLE
[Microsoft] Keep child file 404s local to the file

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -849,11 +849,14 @@ export async function syncFiles({
         nextLink: undefined,
       };
     }
-    // A 404 means the synced drive/folder was deleted upstream ("404 FILE NOT
-    // FOUND"), or the hosting SharePoint site is gone ("Target
-    // '<tenant>.sharepoint.com' is not found."). The resource can no longer be
-    // synced, so skip it instead of throwing, which would otherwise wedge the
-    // workflow in an infinite retry loop.
+    // A 404 while listing children means the synced drive/folder was deleted
+    // upstream ("404 FILE NOT FOUND"), or the hosting SharePoint site is gone
+    // ("Target '<tenant>.sharepoint.com' is not found."). The resource can no
+    // longer be synced, so skip it instead of throwing, which would otherwise
+    // wedge the workflow in an infinite retry loop.
+    // The childrenListed gate keeps this catch at the parent-listing boundary:
+    // a child file disappearing later during syncOneFile is local to that file
+    // and should not short-circuit the whole page.
     if (
       !childrenListed &&
       ((e instanceof GraphError && e.statusCode === 404) ||

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -688,6 +688,7 @@ export async function syncFiles({
   );
   const client = await getMicrosoftClient(connector.connectionId);
 
+  let childrenListed = false;
   try {
     const childrenResult = await getFilesAndFolders(
       logger,
@@ -696,6 +697,7 @@ export async function syncFiles({
       nextPageLink,
       (providerConfig.allowedSensitivityLabels ?? []).length > 0
     );
+    childrenListed = true;
 
     const children = childrenResult.results;
 
@@ -852,8 +854,9 @@ export async function syncFiles({
     // synced, so skip it instead of throwing, which would otherwise wedge the
     // workflow in an infinite retry loop.
     if (
-      (e instanceof GraphError && e.statusCode === 404) ||
-      isSiteNotFoundError(e)
+      !childrenListed &&
+      ((e instanceof GraphError && e.statusCode === 404) ||
+        isSiteNotFoundError(e))
     ) {
       logger.warn(
         {

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -727,6 +727,7 @@ export async function syncFiles({
           file: child,
           parentInternalId,
           startSyncTs,
+          skipMissingFile: true,
           heartbeat,
         }),
       { concurrency }

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -154,6 +154,7 @@ export async function syncOneFile({
   parentInternalId,
   startSyncTs,
   isBatchSync = false,
+  skipMissingFile = false,
   heartbeat,
 }: {
   connectorId: ModelId;
@@ -163,6 +164,7 @@ export async function syncOneFile({
   parentInternalId: string;
   startSyncTs: number;
   isBatchSync?: boolean;
+  skipMissingFile?: boolean;
   heartbeat: () => Promise<void>;
 }) {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -252,8 +254,9 @@ export async function syncOneFile({
       )) as DriveItem;
     } catch (error) {
       if (
-        (error instanceof GraphError && error.statusCode === 404) ||
-        isSiteNotFoundError(error)
+        skipMissingFile &&
+        ((error instanceof GraphError && error.statusCode === 404) ||
+          isSiteNotFoundError(error))
       ) {
         localLogger.warn(
           { error: normalizeError(error).message },

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -14,6 +14,7 @@ import {
   getColumnsFromListItem,
   typeAndPathFromInternalId,
 } from "@connectors/connectors/microsoft/lib/utils";
+import { isSiteNotFoundError } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import { getMimeTypesToSync } from "@connectors/connectors/microsoft/temporal/mime_types";
 import {
   deleteAllSheets,
@@ -57,9 +58,11 @@ import {
   cacheWithRedis,
   concurrentExecutor,
   INTERNAL_MIME_TYPES,
+  normalizeError,
   WithRetriesError,
 } from "@connectors/types";
 import type { Result } from "@dust-tt/client";
+import { GraphError } from "@microsoft/microsoft-graph-client";
 import axios from "axios";
 
 const PARENT_SYNC_CACHE_TTL_MS = 30 * 60 * 1000;
@@ -240,11 +243,26 @@ export async function syncOneFile({
       statsDClient.increment("microsoft.file.missing_fields");
     }
 
-    const item = (await getItem(
-      localLogger,
-      client,
-      `${itemAPIPath}?${allowedLabels.length > 0 ? DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS : DRIVE_ITEM_EXPANDS_AND_SELECTS}`
-    )) as DriveItem;
+    let item: DriveItem;
+    try {
+      item = (await getItem(
+        localLogger,
+        client,
+        `${itemAPIPath}?${allowedLabels.length > 0 ? DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS : DRIVE_ITEM_EXPANDS_AND_SELECTS}`
+      )) as DriveItem;
+    } catch (error) {
+      if (
+        (error instanceof GraphError && error.statusCode === 404) ||
+        isSiteNotFoundError(error)
+      ) {
+        localLogger.warn(
+          { error: normalizeError(error).message },
+          "File not found while refreshing Microsoft metadata, skipping"
+        );
+        return false;
+      }
+      throw error;
+    }
 
     url = item["@microsoft.graph.downloadUrl"];
     fields = item.listItem?.fields;


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/27024 and https://github.com/dust-tt/dust/pull/27038.

When `syncFiles` syncs a Microsoft folder, it first lists the folder children and then syncs each file from that list. The previous 404 handling covered the whole activity. That meant one listed file disappearing while we refreshed its metadata could look like the parent folder disappeared. In that case the activity returned no child folders and no next page, and the workflow could mark the parent as done even though sibling folders or later pages were never visited.

This keeps the "parent folder is gone" handling only for the initial children listing. During full sync, if one listed file disappears during its own metadata refresh, we skip that file only and keep syncing the rest of the page. Other sync paths keep their existing behavior, so delta processing can still turn a missing file into a deletion.

## Risks
Blast radius: Microsoft connector full sync handling for files that disappear after being listed.
Risk: low

## Deploy Plan
- pmrr
- deploy connectors