### PR TITLE
Feedback: allow feedback on cancelled message

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -465,9 +465,7 @@ export function AgentMessage({
   });
 
   const isDeleted = agentMessage.visibility === "deleted";
-  const isCancelled = agentMessage.status === "cancelled";
   const isGracefullyStopped = agentMessage.status === "gracefully_stopped";
-  const isCancelledOrDeleted = isDeleted || isCancelled;
   const cancelMessage = useCancelMessage({ owner, conversationId });
 
   const references = useMemo(
@@ -1010,7 +1008,7 @@ export function AgentMessage({
     </ConversationMessageContent>
   );
 
-  const footerButtons = !isCancelledOrDeleted &&
+  const footerButtons = !isDeleted &&
     !isGracefullyStopped &&
     (alwaysVisibleButtons.length > 0 || hoverButtons.length > 0) && (
       <div className="flex items-center gap-2">
@@ -1408,13 +1406,19 @@ function AgentMessageContent({
             ))}
           </div>
         )}
-        {(agentMessage.status === "cancelled" ||
-          agentMessage.status === "interrupted") && (
+        {/*
+         * Cancelled messages render the standard message footer (feedback + full menu,
+         * including Retry), so we only show the "Generation stopped." note here.
+         */}
+        {agentMessage.status === "cancelled" && (
+          <div className="text-sm text-faint dark:text-faint-night">
+            Generation stopped.
+          </div>
+        )}
+        {agentMessage.status === "interrupted" && (
           <div className="flex flex-col gap-2">
             <div className="text-sm text-faint dark:text-faint-night">
-              {agentMessage.status === "interrupted"
-                ? "Skipped. Running your next message."
-                : "Generation stopped."}
+              Skipped. Running your next message.
             </div>
             <div>
               <ButtonGroupDropdown


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/8713

Add the whole message menu when the message is cancelled (clicked on "stop").
In particular, this allows the "Improve this agent" button to be available.



<img width="935" height="345" alt="Screenshot 2026-06-09 at 11 51 15" src="https://github.com/user-attachments/assets/440f3896-1492-4d37-8164-dbc91fc71fb2" />

I think the whole menu actions make sense even. for a cancelled message:

<img width="320" height="365" alt="Screenshot 2026-06-09 at 11 51 29" src="https://github.com/user-attachments/assets/72ff2787-ecf3-41cb-819b-5289c6259f9a" />


## Tests

tested lcoally, the feedback button is being displayed and it works as expected

## Risk

low, easy to revert

## Deploy Plan
deploy front
