### PR TITLE
fix(temporal): add shutdownGraceTime to all front workers for graceful drain on deploy

### DIFF
--- a/front/poke/temporal/worker.ts
+++ b/front/poke/temporal/worker.ts
@@ -9,6 +9,9 @@ import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runPokeWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -21,6 +24,7 @@ export async function runPokeWorker() {
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runAnalyticsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runAnalyticsWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/conversation_fork_queue/worker.ts
+++ b/front/temporal/conversation_fork_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runConversationForkQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -24,6 +27,7 @@ export async function runConversationForkQueueWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/credit_alerts/worker.ts
+++ b/front/temporal/credit_alerts/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runCreditAlertsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runCreditAlertsWorker() {
     maxConcurrentActivityTaskExecutions: 4,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/data_retention/worker.ts
+++ b/front/temporal/data_retention/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runDataRetentionWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runDataRetentionWorker() {
     maxConcurrentActivityTaskExecutions: 4,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/es_indexation/worker.ts
+++ b/front/temporal/es_indexation/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runESIndexationQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runESIndexationQueueWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/hard_delete/worker.ts
+++ b/front/temporal/hard_delete/worker.ts
@@ -12,6 +12,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runHardDeleteWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -25,6 +28,7 @@ export async function runHardDeleteWorker() {
     maxConcurrentActivityTaskExecutions: 32,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/invitations/worker.ts
+++ b/front/temporal/invitations/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runInvitationsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runInvitationsWorker() {
     maxConcurrentActivityTaskExecutions: 4,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => ({

--- a/front/temporal/labs/transcripts/worker.ts
+++ b/front/temporal/labs/transcripts/worker.ts
@@ -8,6 +8,9 @@ import { Worker } from "@temporalio/worker";
 
 import { TRANSCRIPTS_QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runLabsTranscriptsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -20,6 +23,7 @@ export async function runLabsTranscriptsWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/mentions_count_queue/worker.ts
+++ b/front/temporal/mentions_count_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runMentionsCountWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -24,6 +27,7 @@ export async function runMentionsCountWorker() {
     maxConcurrentActivityTaskExecutions: 2,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/mentions_queue/worker.ts
+++ b/front/temporal/mentions_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runMentionsQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runMentionsQueueWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/metronome_events_queue/worker.ts
+++ b/front/temporal/metronome_events_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runMetronomeEventsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -24,6 +27,7 @@ export async function runMetronomeEventsWorker() {
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/notifications_queue/worker.ts
+++ b/front/temporal/notifications_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runNotificationsQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runNotificationsQueueWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/production_checks/worker.ts
+++ b/front/temporal/production_checks/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runProductionChecksWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -23,6 +26,7 @@ export async function runProductionChecksWorker() {
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/project_task/worker.ts
+++ b/front/temporal/project_task/worker.ts
@@ -12,6 +12,9 @@ import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runProjectTaskWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -30,6 +33,7 @@ export async function runProjectTaskWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/reinforcement/worker.ts
+++ b/front/temporal/reinforcement/worker.ts
@@ -23,6 +23,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runReinforcementWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -43,6 +46,7 @@ export async function runReinforcementWorker() {
     maxConcurrentActivityTaskExecutions: 8,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       workflowModules: removeNulls([
         !isDevelopment() || process.env.USE_TEMPORAL_BUNDLES === "true"

--- a/front/temporal/relocation/worker.ts
+++ b/front/temporal/relocation/worker.ts
@@ -14,6 +14,9 @@ import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runRelocationWorker() {
   const currentRegion = config.getCurrentRegion();
 
@@ -36,6 +39,7 @@ export async function runRelocationWorker() {
     maxConcurrentActivityTaskExecutions: 8,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/remote_tools/worker.ts
+++ b/front/temporal/remote_tools/worker.ts
@@ -11,6 +11,9 @@ import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runRemoteToolsSyncWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -23,6 +26,7 @@ export async function runRemoteToolsSyncWorker() {
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/sandbox_reaper/worker.ts
+++ b/front/temporal/sandbox_reaper/worker.ts
@@ -13,6 +13,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runSandboxReaperWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -25,6 +28,7 @@ export async function runSandboxReaperWorker() {
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/scrub_workspace/worker.ts
+++ b/front/temporal/scrub_workspace/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runScrubWorkspaceQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -24,6 +27,7 @@ export async function runScrubWorkspaceQueueWorker() {
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/triggers/worker.ts
+++ b/front/temporal/triggers/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 import * as activities from "./activities";
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runAgentTriggerWorker() {
   const { connection, namespace } = await getTemporalAgentWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runAgentTriggerWorker() {
     maxConcurrentActivityTaskExecutions: 2,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/triggers_garbage_collect/worker.ts
+++ b/front/temporal/triggers_garbage_collect/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 import * as activities from "./activities";
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runAgentTriggerWebhookWorker() {
   const { connection, namespace } = await getTemporalAgentWorkerConnection();
 
@@ -25,6 +28,7 @@ export async function runAgentTriggerWebhookWorker() {
     maxConcurrentActivityTaskExecutions: 4,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/upsert_queue/worker.ts
+++ b/front/temporal/upsert_queue/worker.ts
@@ -8,6 +8,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runUpsertQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -22,6 +25,7 @@ export async function runUpsertQueueWorker() {
     maxConcurrentActivityTaskExecutions: 32,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/upsert_tables/worker.ts
+++ b/front/temporal/upsert_tables/worker.ts
@@ -9,6 +9,9 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runUpsertTableQueueWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -23,6 +26,7 @@ export async function runUpsertTableQueueWorker() {
     maxConcurrentActivityTaskExecutions: 20,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -10,6 +10,9 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runUpdateWorkspaceUsageWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -22,6 +25,7 @@ export async function runUpdateWorkspaceUsageWorker() {
     maxConcurrentActivityTaskExecutions: 32,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {

--- a/front/temporal/workos_events_queue/worker.ts
+++ b/front/temporal/workos_events_queue/worker.ts
@@ -11,6 +11,9 @@ import { Worker } from "@temporalio/worker";
 
 import { QUEUE_NAME } from "./config";
 
+// Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+
 export async function runWorkOSEventsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
   const worker = await Worker.create({
@@ -24,6 +27,7 @@ export async function runWorkOSEventsWorker() {
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     interceptors: {
       activity: [
         (ctx: Context) => {


### PR DESCRIPTION
## Description

The Temporal SDK defaults `shutdownGraceTime` to `0`, which means when a pod receives SIGTERM during a rolling deploy, the SDK calls `worker.shutdown()` and immediately abandons all in-flight activities. Combined with the global `terminationGracePeriodSeconds: 30` default, any activity running at pod termination time is killed. Temporal then waits the full `startToCloseTimeout` (1 minute) before rescheduling, producing the activity timeout errors seen during deploys.

The `agent_loop` worker was already correctly configured with `shutdownGraceTime: 120s`. This PR applies the same fix to all 26 remaining front workers: set `shutdownGraceTime: 70_000` (70s, covering the 1-minute activity timeout with a 10s buffer). The infra side (`terminationGracePeriodSeconds: 80`, PDBs) is in dust-infra/pull/859.

## Tests

Manually verified that `npx tsgo --noEmit` passes with no type errors. The change is a single scalar option in `Worker.create()` — no logic change, no new code paths.

## Risk

Low. The only behavioral change is that workers now wait up to 70 seconds for in-flight activities to complete before exiting, instead of killing them instantly. This strictly improves availability: fewer forced activity timeouts during deploys, no new failure modes.

Rollback: revert the `shutdownGraceTime` lines. Workers return to instant-kill behavior.

## Deploy Plan

Deploy this PR first (app code), then the infra PR which raises `terminationGracePeriodSeconds` to 80s. The 10s buffer means even if infra lags, the existing 30s grace period still allows activities running <30s to complete gracefully; the full benefit lands once infra is deployed.
