### PR TITLE
Redirect some API paths to the two SPAs

### DIFF
--- a/front-api/app.ts
+++ b/front-api/app.ts
@@ -2,6 +2,7 @@ import { createHono } from "@front-api/lib/hono";
 
 import { cors } from "./middlewares/cors";
 import { requestLogger } from "./middlewares/request_logger";
+import { spaRedirect } from "./middlewares/spa_redirect";
 import { unhandledErrorHandler } from "./middlewares/utils";
 import preStopApp from "./routes/[preStopSecret]";
 import { appStatusApp } from "./routes/app-status";
@@ -86,6 +87,7 @@ apiApp.route("/:preStopSecret", preStopApp);
 export const honoApp = createHono();
 honoApp.use("*", requestLogger);
 honoApp.use("*", cors);
+honoApp.use("*", spaRedirect);
 
 // Dust as MCP Server — inbound from remote clients (Inspector, Cursor, etc.).
 // Mounted at root level so /.well-known/* and /mcp are not under /api/.

--- a/front-api/middlewares/spa_redirect.test.ts
+++ b/front-api/middlewares/spa_redirect.test.ts
@@ -1,0 +1,47 @@
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+// `config.getAppUrl()` / `config.getPokeAppUrl()` are mocked in vite.setup.ts to
+// "http://localhost:3000" and "http://localhost:3000/poke" respectively.
+
+describe("spaRedirect middleware", () => {
+  it("redirects SPA paths to the main SPA app", async () => {
+    const response = await honoApp.request("/w/123");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/w/123"
+    );
+  });
+
+  it("preserves the query string when redirecting SPA paths", async () => {
+    const response = await honoApp.request("/share/abc?foo=bar");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/share/abc?foo=bar"
+    );
+  });
+
+  it("redirects /poke/* to the poke SPA app", async () => {
+    const response = await honoApp.request("/poke/admin");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/poke/admin"
+    );
+  });
+
+  it("redirects the bare /poke path to the poke SPA app", async () => {
+    const response = await honoApp.request("/poke");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("http://localhost:3000/poke");
+  });
+
+  it("does not redirect non-SPA paths", async () => {
+    const response = await honoApp.request("/api/healthz");
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/front-api/middlewares/spa_redirect.test.ts
+++ b/front-api/middlewares/spa_redirect.test.ts
@@ -44,4 +44,10 @@ describe("spaRedirect middleware", () => {
 
     expect(response.status).toBe(200);
   });
+
+  it("does not redirect /api routes", async () => {
+    const response = await honoApp.request("/api/healthz");
+
+    expect(response.headers.get("location")).toBeNull();
+  });
 });

--- a/front-api/middlewares/spa_redirect.ts
+++ b/front-api/middlewares/spa_redirect.ts
@@ -33,10 +33,19 @@ function isPokePath(pathname: string): boolean {
  * front-edge.dust.tt) and must be 302-redirected to the appropriate SPA origin.
  */
 export const spaRedirect: MiddlewareHandler = async (ctx, next) => {
-  const { pathname, search } = new URL(ctx.req.url);
+  // `ctx.req.path` is the parsed pathname without the cost of building a URL.
+  const pathname = ctx.req.path;
+
+  // SPA redirects never apply to API routes, which are by far the hottest path.
+  // Bail out before any further checks (and before parsing the URL for its query
+  // string) so /api requests don't pay for these checks on every request.
+  if (pathname.startsWith("/api/")) {
+    return next();
+  }
 
   // Redirect /poke/* to the poke SPA app (the poke server handles its own auth).
   if (isPokePath(pathname)) {
+    const { search } = new URL(ctx.req.url);
     const pathAfterPoke = pathname.slice("/poke".length); // leading slash or empty
     return ctx.redirect(
       `${config.getPokeAppUrl()}${pathAfterPoke}${search}`,
@@ -46,6 +55,7 @@ export const spaRedirect: MiddlewareHandler = async (ctx, next) => {
 
   // Redirect SPA paths to the main SPA app.
   if (isSpaPath(pathname)) {
+    const { search } = new URL(ctx.req.url);
     return ctx.redirect(`${config.getAppUrl()}${pathname}${search}`, 302);
   }
 

--- a/front-api/middlewares/spa_redirect.ts
+++ b/front-api/middlewares/spa_redirect.ts
@@ -1,0 +1,53 @@
+import config from "@app/lib/api/config";
+import type { MiddlewareHandler } from "hono";
+
+// Paths served by the main SPA app (front-spa) — redirect these to the SPA
+// origin. Mirrors `SPA_PATH_PREFIXES` in `front/middleware.ts`.
+const SPA_PATH_PREFIXES = [
+  "/w",
+  "/invite-choose",
+  "/no-workspace",
+  "/sso-enforced",
+  "/logout",
+  "/login-error",
+  "/maintenance",
+  "/oauth",
+  "/share",
+  "/email",
+];
+
+function isSpaPath(pathname: string): boolean {
+  return SPA_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
+function isPokePath(pathname: string): boolean {
+  return pathname === "/poke" || pathname.startsWith("/poke/");
+}
+
+/**
+ * Mirrors the SPA / poke redirects in `front/middleware.ts` (the Next.js Edge
+ * middleware) for requests served natively by Hono. Browser paths served by
+ * the separate SPA apps (front-spa, poke) reach this origin (e.g.
+ * front-edge.dust.tt) and must be 302-redirected to the appropriate SPA origin.
+ */
+export const spaRedirect: MiddlewareHandler = async (ctx, next) => {
+  const { pathname, search } = new URL(ctx.req.url);
+
+  // Redirect /poke/* to the poke SPA app (the poke server handles its own auth).
+  if (isPokePath(pathname)) {
+    const pathAfterPoke = pathname.slice("/poke".length); // leading slash or empty
+    return ctx.redirect(
+      `${config.getPokeAppUrl()}${pathAfterPoke}${search}`,
+      302
+    );
+  }
+
+  // Redirect SPA paths to the main SPA app.
+  if (isSpaPath(pathname)) {
+    return ctx.redirect(`${config.getAppUrl()}${pathname}${search}`, 302);
+  }
+
+  await next();
+};


### PR DESCRIPTION
## Description

This matches the behavior that we had with Next ([Next code](https://github.com/dust-tt/dust/blob/01df0a45eee522e2ceb271aa0b5dd892c8fe80fa/front/middleware.ts#L101-L108)).

## Tests

Added

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front