### PR TITLE
feat(credits): add upgrade-request API endpoints and audit events

### DIFF
--- a/front-api/routes/w/[wId]/credits/index.ts
+++ b/front-api/routes/w/[wId]/credits/index.ts
@@ -15,6 +15,7 @@ import membersUsage from "./members-usage";
 import metronomeBalances from "./metronome-balances";
 import myUsage from "./my-usage";
 import purchase from "./purchase";
+import upgradeRequests from "./upgrade-requests";
 import usageConfiguration from "./usage-configuration";
 
 // Mounted at /api/w/:wId/credits.
@@ -26,6 +27,7 @@ app.route("/members-usage", membersUsage);
 app.route("/metronome-balances", metronomeBalances);
 app.route("/my-usage", myUsage);
 app.route("/purchase", purchase);
+app.route("/upgrade-requests", upgradeRequests);
 app.route("/usage-configuration", usageConfiguration);
 
 /** @ignoreswagger */

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -1,0 +1,175 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function upgradeRequestsUrl(wId: string) {
+  return `/api/w/${wId}/credits/upgrade-requests`;
+}
+
+async function metronomeWorkspace(): Promise<WorkspaceType> {
+  return WorkspaceFactory.metronome({ metronomeCustomerId: "cust_test_xxx" });
+}
+
+async function createMemberRequest(workspace: WorkspaceType) {
+  const { user, membership } = await createPrivateApiMockRequest({
+    method: "POST",
+    role: "user",
+    workspace,
+  });
+  const response = await honoApp.request(upgradeRequestsUrl(workspace.sId), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+  return { user, membership, response };
+}
+
+describe("/api/w/[wId]/credits/upgrade-requests", () => {
+  describe("auth", () => {
+    it("GET returns 403 when caller is not an admin", async () => {
+      const workspace = await metronomeWorkspace();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+        workspace,
+      });
+
+      const response = await honoApp.request(upgradeRequestsUrl(workspace.sId));
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+  });
+
+  describe("POST (member-initiated)", () => {
+    it("returns 403 when workspace is not credit-priced", async () => {
+      const { workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
+
+      const response = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }
+      );
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("plan_limit_error");
+    });
+
+    it("creates a pending request for a member", async () => {
+      const workspace = await metronomeWorkspace();
+      const { user, response } = await createMemberRequest(workspace);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.request.status).toBe("pending");
+      expect(body.request.resolvedAt).toBeNull();
+      expect(body.request.requester.sId).toBe(user.sId);
+    });
+
+    it("is idempotent — a second request reuses the pending one", async () => {
+      const workspace = await metronomeWorkspace();
+      const { membership, response: first } =
+        await createMemberRequest(workspace);
+      const firstSId = (await first.json()).request.sId;
+
+      // Same authenticated member requests again.
+      await membership.updateCreditState("capped");
+      const second = await honoApp.request(upgradeRequestsUrl(workspace.sId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      expect(second.status).toBe(200);
+      expect((await second.json()).request.sId).toBe(firstSId);
+    });
+  });
+
+  describe("GET + PATCH (admin)", () => {
+    it("lists pending requests and resolves them", async () => {
+      const workspace = await metronomeWorkspace();
+      const { user: member } = await createMemberRequest(workspace);
+
+      // Re-authenticate as an admin of the same workspace.
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const listResponse = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      expect(listResponse.status).toBe(200);
+      const { requests } = await listResponse.json();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].requester.sId).toBe(member.sId);
+
+      const requestId = requests[0].sId;
+      const patchResponse = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "approved" }),
+        }
+      );
+      expect(patchResponse.status).toBe(200);
+      expect((await patchResponse.json()).request.status).toBe("approved");
+
+      // The resolved request no longer appears in the pending list.
+      const afterResponse = await honoApp.request(
+        upgradeRequestsUrl(workspace.sId)
+      );
+      expect((await afterResponse.json()).requests).toHaveLength(0);
+    });
+
+    it("PATCH returns 404 for an unknown request id", async () => {
+      const workspace = await metronomeWorkspace();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/mur_nonexistent`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      expect(response.status).toBe(404);
+    });
+
+    it("PATCH returns 403 when caller is not an admin", async () => {
+      const workspace = await metronomeWorkspace();
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+        workspace,
+      });
+
+      const response = await honoApp.request(
+        `${upgradeRequestsUrl(workspace.sId)}/mur_whatever`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "denied" }),
+        }
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -1,0 +1,112 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import type {
+  GetUpgradeRequestsResponseBody,
+  PatchUpgradeRequestResponseBody,
+  PostUpgradeRequestResponseBody,
+  UpgradeRequestError,
+} from "@app/lib/api/credits/upgrade_requests";
+import {
+  createUpgradeRequest,
+  listPendingUpgradeRequests,
+  resolveUpgradeRequest,
+} from "@app/lib/api/credits/upgrade_requests";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  requestId: z.string(),
+});
+
+const ResolveBodySchema = z.object({
+  status: z.union([z.literal("approved"), z.literal("denied")]),
+});
+
+function upgradeRequestErrorToApiError(
+  error: UpgradeRequestError
+): APIErrorWithContentfulStatusCode {
+  switch (error.type) {
+    case "workspace_not_metronome_billed":
+      return {
+        status_code: 403,
+        api_error: { type: "plan_limit_error", message: error.message },
+      };
+    case "user_not_found":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "workspace_user_not_found",
+          message: error.message,
+        },
+      };
+    case "request_not_found":
+      return {
+        status_code: 404,
+        api_error: { type: "invalid_request_error", message: error.message },
+      };
+    case "request_not_pending":
+      return {
+        status_code: 409,
+        api_error: { type: "invalid_request_error", message: error.message },
+      };
+    default:
+      assertNever(error.type);
+  }
+}
+
+// Mounted at /api/w/:wId/credits/upgrade-requests.
+const app = workspaceApp();
+
+// Admin-only: list pending upgrade requests for the workspace.
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetUpgradeRequestsResponseBody> => {
+    const auth = ctx.get("auth");
+    const requests = await listPendingUpgradeRequests(auth);
+    return ctx.json({ requests });
+  }
+);
+
+// Member-initiated: request an upgrade of the current user's spend limit.
+/** @ignoreswagger */
+app.post("/", async (ctx): HandlerResult<PostUpgradeRequestResponseBody> => {
+  const auth = ctx.get("auth");
+  const result = await createUpgradeRequest(auth, {
+    auditContext: getAuditLogContext(auth),
+  });
+  if (result.isErr()) {
+    return apiError(ctx, upgradeRequestErrorToApiError(result.error));
+  }
+  return ctx.json({ request: result.value });
+});
+
+// Admin-only: resolve (approve/deny) a pending request.
+/** @ignoreswagger */
+app.patch(
+  "/:requestId",
+  ensureIsAdmin(),
+  validate("param", ParamsSchema),
+  validate("json", ResolveBodySchema),
+  async (ctx): HandlerResult<PatchUpgradeRequestResponseBody> => {
+    const auth = ctx.get("auth");
+    const { requestId } = ctx.req.valid("param");
+    const { status } = ctx.req.valid("json");
+    const result = await resolveUpgradeRequest(auth, {
+      requestId,
+      status,
+      auditContext: getAuditLogContext(auth),
+    });
+    if (result.isErr()) {
+      return apiError(ctx, upgradeRequestErrorToApiError(result.error));
+    }
+    return ctx.json({ request: result.value });
+  }
+);
+
+export default app;

--- a/front/admin/audit_log_schemas/membership.upgrade_request_created.json
+++ b/front/admin/audit_log_schemas/membership.upgrade_request_created.json
@@ -1,0 +1,14 @@
+{
+  "action": "membership.upgrade_request_created",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "request_sid": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/membership.upgrade_request_resolved.json
+++ b/front/admin/audit_log_schemas/membership.upgrade_request_resolved.json
@@ -1,0 +1,15 @@
+{
+  "action": "membership.upgrade_request_resolved",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "status": "string",
+    "request_sid": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -39,6 +39,8 @@
   "membership.origin_updated": 5,
   "membership.revoked": 4,
   "membership.role_updated": 6,
+  "membership.upgrade_request_created": 1,
+  "membership.upgrade_request_resolved": 1,
   "oauth.authorized": 3,
   "oauth.initiated": 3,
   "oauth.revoked": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -47,6 +47,8 @@ export const AUDIT_ACTIONS = [
   "member.bulk_invited",
   "member.bulk_revoked",
   "member.spend_limit_updated",
+  "membership.upgrade_request_created",
+  "membership.upgrade_request_resolved",
   // Domains & SSO.
   "domain.verified",
   "domain.verification_failed",

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -142,7 +142,7 @@ export async function resolveUpgradeRequest(
   }
 
   const resolvedByUser = auth.getNonNullableUser();
-  const result = await request.resolve(auth, { status, resolvedByUser });
+  const result = await request.markAsResolved(auth, { status, resolvedByUser });
   if (result.isErr()) {
     return new Err(
       new UpgradeRequestError("request_not_pending", result.error.message)

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -1,0 +1,167 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
+import type {
+  MembershipUpgradeRequestStatus,
+  MembershipUpgradeRequestType,
+} from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type UpgradeRequestErrorType =
+  | "workspace_not_metronome_billed"
+  | "user_not_found"
+  | "request_not_found"
+  | "request_not_pending";
+
+export class UpgradeRequestError extends Error {
+  constructor(
+    readonly type: UpgradeRequestErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export type GetUpgradeRequestsResponseBody = {
+  requests: MembershipUpgradeRequestType[];
+};
+
+export type PostUpgradeRequestResponseBody = {
+  request: MembershipUpgradeRequestType;
+};
+
+export type PatchUpgradeRequestResponseBody = {
+  request: MembershipUpgradeRequestType;
+};
+
+// Member-initiated: create (or return the already-pending) upgrade request for
+// the current user. Gated on the workspace being credit-priced and the member
+// actually being near/at their limit.
+export async function createUpgradeRequest(
+  auth: Authenticator,
+  { auditContext }: { auditContext?: AuditLogContext } = {}
+): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
+  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+    return new Err(
+      new UpgradeRequestError(
+        "workspace_not_metronome_billed",
+        "Upgrade requests are only available on credit-priced workspaces."
+      )
+    );
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return new Err(
+      new UpgradeRequestError("user_not_found", "No authenticated user.")
+    );
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return new Err(
+      new UpgradeRequestError(
+        "user_not_found",
+        "You are not an active member of this workspace."
+      )
+    );
+  }
+
+  const result = await MembershipUpgradeRequestResource.createPending(auth, {
+    user,
+  });
+  if (result.isErr()) {
+    return new Err(
+      new UpgradeRequestError("request_not_found", result.error.message)
+    );
+  }
+  const request = result.value;
+
+  void emitAuditLogEvent({
+    auth,
+    action: "membership.upgrade_request_created",
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() ?? "unknown",
+      }),
+    ],
+    context: auditContext,
+    metadata: { request_sid: request.sId },
+  });
+
+  // TODO(upgrade-requests PR5): notify workspace admins by email (gated on the
+  // `upgradeRequestEmail` notification toggle).
+
+  return new Ok(request.toJSON());
+}
+
+// Admin-only: list pending upgrade requests for the workspace.
+export async function listPendingUpgradeRequests(
+  auth: Authenticator
+): Promise<MembershipUpgradeRequestType[]> {
+  const requests =
+    await MembershipUpgradeRequestResource.listPendingByWorkspace(auth);
+  return requests.map((r) => r.toJSON());
+}
+
+// Admin-only: record the outcome of a request. The actual spend-limit / seat
+// change is performed by the existing flows; this only marks the request.
+export async function resolveUpgradeRequest(
+  auth: Authenticator,
+  {
+    requestId,
+    status,
+    auditContext,
+  }: {
+    requestId: string;
+    status: Exclude<MembershipUpgradeRequestStatus, "pending">;
+    auditContext?: AuditLogContext;
+  }
+): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
+  const request = await MembershipUpgradeRequestResource.fetchById(
+    auth,
+    requestId
+  );
+  if (!request) {
+    return new Err(
+      new UpgradeRequestError("request_not_found", "Upgrade request not found.")
+    );
+  }
+
+  const resolvedByUser = auth.getNonNullableUser();
+  const result = await request.resolve(auth, { status, resolvedByUser });
+  if (result.isErr()) {
+    return new Err(
+      new UpgradeRequestError("request_not_pending", result.error.message)
+    );
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "membership.upgrade_request_resolved",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("user", {
+        sId: request.requester.sId,
+        name: request.requester.name,
+      }),
+    ],
+    context: auditContext,
+    metadata: { status, request_sid: request.sId },
+  });
+
+  return new Ok(request.toJSON());
+}

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -6,7 +7,6 @@ import {
   type MembershipUpgradeRequestStatus,
 } from "@app/types/memberships";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
 
 // A member-initiated request to have their per-user spend limit raised by a
 // workspace admin. A member can have at most one `pending` request at a time

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -1,4 +1,3 @@
-import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -72,9 +71,13 @@ export const createPrivateApiMockRequest = async ({
     ? UserFactory.superUser()
     : UserFactory.basic());
 
-  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
-  const systemSpace = await SpaceFactory.system(workspace, systemGroup);
-  const globalSpace = await SpaceFactory.global(workspace, globalGroup);
+  // Use the idempotent defaults so this helper can be called more than once on
+  // the same workspace (e.g. to re-authenticate as a different role).
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  const { globalGroup, systemGroup, globalSpace, systemSpace } =
+    await SpaceFactory.defaults(adminAuth);
 
   const membership = await MembershipFactory.associate(workspace, user, {
     role,


### PR DESCRIPTION
## Description

API layer for member-initiated spend-limit upgrade requests (PR 1b of the feature), stacked on
top of the data model in #27052. In credit-priced workspaces, a capped/warned non-admin currently
has no in-product way to ask for a higher limit. This PR adds the endpoints, audit trail, and
functional tests; the member CTA and admin Requests UI land in later PRs.

- **Business module** — `lib/api/credits/upgrade_requests.ts` returning domain `Result`s
  (`createUpgradeRequest`, `listPendingUpgradeRequests`, `resolveUpgradeRequest`); gated on the
  workspace being credit-priced.
- **API endpoints** (`front-api`, mounted at `/api/w/:wId/credits/upgrade-requests`):
  member-initiated `POST /`, admin-only `GET /`, admin-only `PATCH /:requestId`
  (`approved`/`denied`).
- **Audit events** — `membership.upgrade_request_created` and
  `membership.upgrade_request_resolved` (schema JSON + `AUDIT_ACTIONS` union + emit at the
  mutation sites).

A test helper change in `generic_private_api_tests.ts` switches setup to the idempotent
`SpaceFactory.defaults(adminAuth)` so the helper can be called more than once on the same
workspace (needed to re-authenticate as a different role within a single test).

## Tests

- `front-api/routes/w/[wId]/credits/upgrade-requests.test.ts` covers the three endpoints:
  member create (idempotent re-request returns the existing pending row), admin list, and admin
  resolve (approve/deny), including auth/role gating and non-credit-priced rejection.

## Deploy Plan

- Stacked on #27052 — merge that first (it runs `migration_671.sql`).
- Register the new audit log schemas after merge and before deploy:
  `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`.
