### PR TITLE
feat: split people and security page in two

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -50,6 +50,13 @@ const MembersPage = withSuspense(
   () => import("@dust-tt/front/components/pages/workspace/MembersPage"),
   "MembersPage"
 );
+const WorkspaceIdentityProvisioningPage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.js"
+    ),
+  "WorkspaceIdentityProvisioningPage"
+);
 const ManageSubscriptionPage = withSuspense(
   () =>
     import(
@@ -91,6 +98,10 @@ export const adminRoutes: RouteObject[] = [
     element: <AdminRouterLayout />,
     children: [
       { path: "members", element: <MembersPage /> },
+      {
+        path: "identity-and-provisioning",
+        element: <WorkspaceIdentityProvisioningPage />,
+      },
       { path: "model-providers", element: <ModelProvidersPage /> },
       { path: "workspace", element: <WorkspaceSettingsPage /> },
       { path: "analytics", element: <AnalyticsPage /> },

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -11,6 +11,7 @@ import {
   Building04,
   CreditCard01,
   File04,
+  Fingerprint04,
   FolderOpen,
   Globe01,
   IntersectDust,
@@ -21,7 +22,7 @@ import {
   Shapes,
   Stars02,
   Terminal,
-  User01,
+  Users01,
   Zap,
 } from "@dust-tt/sparkle";
 
@@ -82,6 +83,7 @@ export type SubNavigationAdminId =
   | "workspace"
   | "model_providers"
   | "members"
+  | "identity_and_provisioning"
   | "providers"
   | "api_keys"
   | "dev_secrets"
@@ -93,6 +95,7 @@ export type SubNavigationAdminId =
 
 export const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   members: ["/w/[wId]/members"],
+  identity_and_provisioning: ["/w/[wId]/identity-and-provisioning"],
   workspace: ["/w/[wId]/workspace"],
   model_providers: ["/w/[wId]/model-providers"],
   analytics: ["/w/[wId]/analytics"],
@@ -201,6 +204,7 @@ export const getTopNavigationTabs = (
       isCurrent: (currentRoute) =>
         matchesRoutePattern(currentRoute, [
           "/w/[wId]/members",
+          "/w/[wId]/identity-and-provisioning",
           "/w/[wId]/workspace",
           "/w/[wId]/model-providers",
           "/w/[wId]/subscription",
@@ -249,10 +253,17 @@ export const subNavigationAdmin = ({
       menus: [
         {
           id: "members",
-          label: "People & Security",
-          icon: User01,
+          label: "People",
+          icon: Users01,
           href: `/w/${owner.sId}/members`,
           current: isCurrent("members"),
+        },
+        {
+          id: "identity_and_provisioning",
+          label: "Identity & Provisioning",
+          icon: Fingerprint04,
+          href: `/w/${owner.sId}/identity-and-provisioning`,
+          current: isCurrent("identity_and_provisioning"),
         },
         {
           id: "workspace",

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -8,8 +8,6 @@ import {
 } from "@app/components/members/MemberSelectionTable";
 import { MembersList } from "@app/components/members/MembersList";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
-import WorkspaceAccessPanel from "@app/components/workspace/WorkspaceAccessPanel";
-import { WorkspaceSection } from "@app/components/workspace/WorkspaceSection";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSearchMembers } from "@app/lib/swr/memberships";
@@ -32,7 +30,7 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
-  User01,
+  Users01,
 } from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
 import { useCallback, useEffect, useState } from "react";
@@ -206,43 +204,36 @@ export function MembersPage() {
     <div className="mb-4">
       <Page.Vertical gap="lg" align="stretch">
         <Page.Header
-          title="People & Security"
-          icon={User01}
-          description="Verify your domain, manage team members and their permissions."
+          title="People"
+          icon={Users01}
+          description="Manage team members and their roles."
         />
-        <WorkspaceAccessPanel
-          workspaceVerifiedDomains={verifiedDomains}
-          owner={owner}
-          plan={plan}
-        />
-        <WorkspaceSection title="Members" icon={User01}>
-          <div className="flex flex-row gap-2">
-            <SearchInput
-              placeholder={
-                isProvisioningEnabled ? "Search" : "Search members (email)"
-              }
-              value={searchTerm}
-              name="search"
-              onChange={setSearchTerm}
-              className="w-full"
-            />
-            {isManualInvitationsEnabled && (
-              <InviteEmailButtonWithModal
-                owner={owner}
-                prefillText=""
-                perSeatPricing={perSeatPricing}
-                onInviteClick={onInviteClick}
-              />
-            )}
-          </div>
-          <WorkspaceMembersGroupsList
-            currentUser={user}
-            owner={owner}
-            searchTerm={searchTerm}
-            isProvisioningEnabled={isProvisioningEnabled}
-            isManualInvitationsEnabled={isManualInvitationsEnabled}
+        <div className="flex flex-row gap-2">
+          <SearchInput
+            placeholder={
+              isProvisioningEnabled ? "Search" : "Search members (email)"
+            }
+            value={searchTerm}
+            name="search"
+            onChange={setSearchTerm}
+            className="w-full"
           />
-        </WorkspaceSection>
+          {isManualInvitationsEnabled && (
+            <InviteEmailButtonWithModal
+              owner={owner}
+              prefillText=""
+              perSeatPricing={perSeatPricing}
+              onInviteClick={onInviteClick}
+            />
+          )}
+        </div>
+        <WorkspaceMembersGroupsList
+          currentUser={user}
+          owner={owner}
+          searchTerm={searchTerm}
+          isProvisioningEnabled={isProvisioningEnabled}
+          isManualInvitationsEnabled={isManualInvitationsEnabled}
+        />
         {inviteBlockedPopupReason && (
           <ReachedLimitPopup
             isAdmin={isAdmin(owner)}

--- a/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
+++ b/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
@@ -1,0 +1,38 @@
+import WorkspaceAccessPanel from "@app/components/workspace/WorkspaceAccessPanel";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspaceVerifiedDomains } from "@app/lib/swr/workspaces";
+import { Fingerprint04, Page, Spinner } from "@dust-tt/sparkle";
+
+export function WorkspaceIdentityProvisioningPage() {
+  const owner = useWorkspace();
+  const { subscription } = useAuth();
+  const plan = subscription.plan;
+
+  const { verifiedDomains, isVerifiedDomainsLoading } =
+    useWorkspaceVerifiedDomains({ workspaceId: owner.sId });
+
+  if (isVerifiedDomainsLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-4">
+      <Page.Vertical gap="lg" align="stretch">
+        <Page.Header
+          title="Identity and Provisioning"
+          icon={Fingerprint04}
+          description="Verify your domain, manage team members and their permissions."
+        />
+        <WorkspaceAccessPanel
+          workspaceVerifiedDomains={verifiedDomains}
+          owner={owner}
+          plan={plan}
+        />
+      </Page.Vertical>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This PR splits the "People & Security" admin page into two separate pages: "People" (for managing team members and roles) and "Identity & Provisioning" (for domain verification and provisioning settings). This is the first step to grant business admins permission to manage people.

## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.