### PR TITLE
[front] coupons: added as credits to the contract not the customer

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -403,6 +403,7 @@ export async function handleSubscriptionActivationSuccess({
         const { creditTypeId, currency } = creditTypeResult.value;
         const creditResult = await createCouponCredit({
           metronomeCustomerId: workspace.metronomeCustomerId!,
+          metronomeContractId: contractId,
           coupon,
           redemptionId: redemption.sId,
           redeemedAt: redemption.redeemedAt,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -24,6 +24,7 @@ import type {
 } from "@metronome/sdk/resources/v1/customers";
 import type { ContractEditParams } from "@metronome/sdk/resources/v2/contracts";
 import type { IncomingHttpHeaders } from "http";
+import { z } from "zod";
 import type {
   MetronomeBalance,
   MetronomeEvent,
@@ -2301,6 +2302,16 @@ export async function createMetronomeCredit({
   }
 }
 
+// The SDK types ContractEditResponse as { data: { id } } but the actual payload
+// includes edit.add_credits[].id — this schema parses the undocumented fields.
+const CONTRACT_EDIT_WITH_CREDITS_RESPONSE_SCHEMA = z.object({
+  data: z.object({
+    edit: z.object({
+      add_credits: z.array(z.object({ id: z.string() })),
+    }),
+  }),
+});
+
 /**
  * Add a credit grant to a Metronome contract.
  * Uses v2.contracts.edit with add_credits, so uniqueness_key applies to the
@@ -2363,11 +2374,12 @@ export async function addCreditToContract({
     });
 
     // The SDK types ContractEditResponse as { data: { id } } but the actual
-    // payload includes edit.add_credits[].id — cast to extract the credit id.
-    const raw = response as unknown as {
-      data: { edit: { add_credits: Array<{ id: string }> } };
-    };
-    const creditId = raw.data.edit.add_credits[0]?.id ?? null;
+    // payload includes edit.add_credits[].id — parse at runtime to extract it.
+    const parsed =
+      CONTRACT_EDIT_WITH_CREDITS_RESPONSE_SCHEMA.safeParse(response);
+    const creditId = parsed.success
+      ? (parsed.data.data.edit.add_credits[0]?.id ?? null)
+      : null;
 
     logger.info(
       {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2302,6 +2302,158 @@ export async function createMetronomeCredit({
 }
 
 /**
+ * Add a credit grant to a Metronome contract.
+ * Uses v2.contracts.edit with add_credits, so uniqueness_key applies to the
+ * whole edit operation (not per-credit). On 409 the edit already exists and
+ * the credit is considered granted.
+ */
+export async function addCreditToContract({
+  metronomeCustomerId,
+  metronomeContractId,
+  productId,
+  creditTypeId,
+  amount,
+  startingAt,
+  endingBefore,
+  name,
+  uniquenessKey,
+  applicableProductTags,
+  priority,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  productId: string;
+  creditTypeId: string;
+  amount: number;
+  startingAt: string;
+  endingBefore: string;
+  name: string;
+  uniquenessKey: string;
+  applicableProductTags?: string[];
+  priority: number;
+}): Promise<Result<{ creditId: string } | null, Error>> {
+  const roundedStartingAt = floorToHourISO(new Date(startingAt));
+  const roundedEndingBefore = floorToHourISO(new Date(endingBefore));
+
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      uniqueness_key: uniquenessKey,
+      add_credits: [
+        {
+          product_id: productId,
+          name,
+          priority,
+          ...(applicableProductTags && applicableProductTags.length > 0
+            ? { applicable_product_tags: applicableProductTags }
+            : {}),
+          access_schedule: {
+            credit_type_id: creditTypeId,
+            schedule_items: [
+              {
+                amount,
+                starting_at: roundedStartingAt,
+                ending_before: roundedEndingBefore,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    // The SDK types ContractEditResponse as { data: { id } } but the actual
+    // payload includes edit.add_credits[].id — cast to extract the credit id.
+    const raw = response as unknown as {
+      data: { edit: { add_credits: Array<{ id: string }> } };
+    };
+    const creditId = raw.data.edit.add_credits[0]?.id ?? null;
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        creditId,
+        amount,
+        name,
+        uniquenessKey,
+      },
+      "[Metronome] Credit added to contract"
+    );
+
+    return new Ok(creditId ? { creditId } : null);
+  } catch (err) {
+    const error = normalizeError(err);
+    if (err instanceof ConflictError) {
+      // Idempotency key conflict — credit already granted, look it up via
+      // edit history so the caller can persist the existing credit id.
+      const existing = await findContractCreditByUniquenessKey({
+        metronomeCustomerId,
+        metronomeContractId,
+        uniquenessKey,
+      });
+      if (existing.isOk() && existing.value) {
+        logger.info(
+          {
+            metronomeCustomerId,
+            metronomeContractId,
+            uniquenessKey,
+            creditId: existing.value.creditId,
+          },
+          "[Metronome] Contract credit edit already exists (idempotent), reusing credit id"
+        );
+        return new Ok({ creditId: existing.value.creditId });
+      }
+      logger.info(
+        { metronomeCustomerId, metronomeContractId, uniquenessKey },
+        "[Metronome] Contract credit edit already exists (idempotent) but lookup did not find it"
+      );
+      return new Ok(null);
+    }
+
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId, name, uniquenessKey },
+      "[Metronome] Failed to add credit to contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Find a contract-level credit id by the edit's uniqueness_key.
+ * Used to recover the credit id after a 409 conflict on addCreditToContract.
+ */
+async function findContractCreditByUniquenessKey({
+  metronomeCustomerId,
+  metronomeContractId,
+  uniquenessKey,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  uniquenessKey: string;
+}): Promise<Result<{ creditId: string } | null, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.getEditHistory({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+    });
+    logger.info({ response }, "findContractCreditByUniquenessKey response");
+    const match = response.data.find(
+      (edit) => edit.uniqueness_key === uniquenessKey
+    );
+    const creditId = match?.add_credits?.[0]?.id ?? null;
+    return new Ok(creditId ? { creditId } : null);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId, uniquenessKey },
+      "[Metronome] Failed to look up contract credit by uniqueness key"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Find a customer-level credit by its uniqueness_key.
  * Used to recover the id after a 409 conflict on creation.
  * Scoped via covering_date so we don't paginate through expired credits.

--- a/front/lib/metronome/coupons.ts
+++ b/front/lib/metronome/coupons.ts
@@ -5,6 +5,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
+  addCreditToContract,
   ceilToHourISO,
   createMetronomeCredit,
   floorToHourISO,
@@ -106,6 +107,7 @@ function getApplicableProductTagsForDiscountType(
 
 export async function createCouponCredit({
   metronomeCustomerId,
+  metronomeContractId,
   coupon,
   redemptionId,
   redeemedAt,
@@ -113,6 +115,7 @@ export async function createCouponCredit({
   currency,
 }: {
   metronomeCustomerId: string;
+  metronomeContractId?: string;
   coupon: CouponResource;
   redemptionId: string;
   redeemedAt: Date;
@@ -120,7 +123,7 @@ export async function createCouponCredit({
   currency: SupportedCurrency;
 }): Promise<Result<string[], Error>> {
   const durationMonths = coupon.durationMonths ?? 1;
-  const result = await createMetronomeCredit({
+  const sharedParams = {
     metronomeCustomerId,
     productId: getProductSeatSubscriptionCreditsId(),
     creditTypeId,
@@ -128,11 +131,27 @@ export async function createCouponCredit({
     startingAt: floorToHourISO(redeemedAt),
     endingBefore: ceilToHourISO(addMonths(redeemedAt, durationMonths)),
     name: `Coupon: ${coupon.code}`,
-    idempotencyKey: `coupon-${redemptionId}-0`,
     priority: SEAT_PRIORITY_COUPON_CREDIT,
     applicableProductTags: getApplicableProductTagsForDiscountType(
       coupon.discountType
     ),
+  };
+
+  if (metronomeContractId) {
+    const result = await addCreditToContract({
+      ...sharedParams,
+      metronomeContractId,
+      uniquenessKey: `coupon-${redemptionId}-0`,
+    });
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+    return new Ok(result.value !== null ? [result.value.creditId] : []);
+  }
+
+  const result = await createMetronomeCredit({
+    ...sharedParams,
+    idempotencyKey: `coupon-${redemptionId}-0`,
   });
 
   if (result.isErr()) {


### PR DESCRIPTION
## Description

* Add function `addCreditToContract` to add a credit to a contract using getMetronomeClient().v2.contracts.edit
* Allow to set a contractId in createCouponCredit so that the coupon credit is attached to contract if present
* Use contractId in new checkout flow (in business_activation) so that the coupon credit is added to the contract

## Tests

Tested locally with dedicated scripts + in checkout flow with coupon

## Risk

Low, additive change, only used for new checkout flow

## Deploy Plan

Deploy front
