### PR TITLE
[API] Support public conversation title updates

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -1571,8 +1571,8 @@
         }
       },
       "patch": {
-        "summary": "Update conversation read status",
-        "description": "Mark a conversation as read or unread in the workspace identified by {wId}.",
+        "summary": "Update a conversation",
+        "description": "Update a conversation's title or mark it as read or unread in the workspace identified by {wId}.",
         "tags": [
           "Conversations"
         ],
@@ -1606,19 +1606,37 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "read": {
-                    "type": "boolean"
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "read"
+                    ],
+                    "properties": {
+                      "read": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "title"
+                    ],
+                    "properties": {
+                      "title": {
+                        "type": "string"
+                      }
+                    }
                   }
-                }
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Conversation marked as read successfully.",
+            "description": "Conversation updated successfully.",
             "content": {
               "application/json": {
                 "schema": {

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -42,6 +42,25 @@ function getConversation(
   );
 }
 
+function patchConversation(
+  workspace: { sId: string },
+  key: { secret: string },
+  cId: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/assistant/conversations/${cId}`,
+    {
+      method: "PATCH",
+      headers: {
+        authorization: `Bearer ${key.secret}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
 describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
   it("returns 200 when private conversation URLs are disabled", async () => {
     const { workspace, key, conversation } = await setupGetRequest();
@@ -106,5 +125,25 @@ describe("GET /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
     const response = await getConversation(workspace, key, conversation.sId);
 
     expect(response.status).toBe(200);
+  });
+});
+
+describe("PATCH /api/v1/w/[wId]/assistant/conversations/[cId]", () => {
+  it("updates a conversation title with API key auth", async () => {
+    const { workspace, key, conversation } = await setupGetRequest();
+
+    const response = await patchConversation(workspace, key, conversation.sId, {
+      title: "Updated Conversation Title",
+    });
+
+    const data = await response.json();
+    expect(response.status, JSON.stringify(data)).toBe(200);
+    expect(data.success).toBe(true);
+
+    const getResponse = await getConversation(workspace, key, conversation.sId);
+    const getData = await getResponse.json();
+
+    expect(getResponse.status, JSON.stringify(getData)).toBe(200);
+    expect(getData.conversation.title).toBe("Updated Conversation Title");
   });
 });

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,4 +1,5 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import type { PatchConversationResponseBody } from "@app/lib/api/assistant/conversation/types";
 import { addBackwardCompatibleConversationFields } from "@app/lib/api/v1/backward_compatibility";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -80,8 +81,8 @@ const app = publicApiApp();
  *       500:
  *         description: Internal Server Error.
  *   patch:
- *     summary: Update conversation read status
- *     description: Mark a conversation as read or unread in the workspace identified by {wId}.
+ *     summary: Update a conversation
+ *     description: Update a conversation's title or mark it as read or unread in the workspace identified by {wId}.
  *     tags:
  *       - Conversations
  *     security:
@@ -104,13 +105,22 @@ const app = publicApiApp();
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               read:
- *                 type: boolean
+ *             oneOf:
+ *               - type: object
+ *                 required:
+ *                   - read
+ *                 properties:
+ *                   read:
+ *                     type: boolean
+ *               - type: object
+ *                 required:
+ *                   - title
+ *                 properties:
+ *                   title:
+ *                     type: string
  *     responses:
  *       200:
- *         description: Conversation marked as read successfully.
+ *         description: Conversation updated successfully.
  *         content:
  *           application/json:
  *             schema:
@@ -195,16 +205,32 @@ app.patch(
       return apiErrorForConversation(ctx, conversationRes.error);
     }
 
-    const { read } = ctx.req.valid("json");
-    if (read) {
-      await ConversationResource.markAsReadForAuthUser(auth, {
-        conversation: conversationRes.value,
-      });
-    } else {
-      await ConversationResource.markAsUnreadForAuthUser(auth, {
-        conversation: conversationRes.value,
-      });
+    const data = ctx.req.valid("json");
+    if ("read" in data) {
+      if (data.read) {
+        await ConversationResource.markAsReadForAuthUser(auth, {
+          conversation: conversationRes.value,
+        });
+      } else {
+        await ConversationResource.markAsUnreadForAuthUser(auth, {
+          conversation: conversationRes.value,
+        });
+      }
+      return ctx.json({ success: true });
     }
+
+    const titleUpdateRes = await updateConversationTitle(auth, {
+      conversationId: conversationRes.value.sId,
+      title: data.title,
+    });
+    if (titleUpdateRes.isErr()) {
+      return apiErrorForConversation(ctx, titleUpdateRes.error);
+    }
+
+    await ConversationResource.markAsReadForAuthUser(auth, {
+      conversation: conversationRes.value,
+    });
+
     return ctx.json({ success: true });
   }
 );

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2250,9 +2250,14 @@ export type GetConversationResponseType = z.infer<
   typeof GetConversationResponseSchema
 >;
 
-export const PatchConversationRequestSchema = z.object({
-  read: z.boolean(),
-});
+export const PatchConversationRequestSchema = z.union([
+  z.object({
+    read: z.boolean(),
+  }),
+  z.object({
+    title: z.string(),
+  }),
+]);
 
 export type PatchConversationRequestType = z.infer<
   typeof PatchConversationRequestSchema


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8320

Public `PATCH /api/v1/w/{wId}/assistant/conversations/{cId}` now accepts `{ "title": "..." }` in addition to the existing read/unread body. It reuses the existing conversation title update path and updates the public SDK request schema and OpenAPI docs.

## Risks
Blast radius: public conversation PATCH endpoint and generated API docs.
Risk: low

## Deploy Plan
- pmrr
- deploy front-api

## Tests
- [x] `NODE_ENV=test npm run test -- 'routes/v1/w/[[]wId[]]/assistant/conversations/[[]cId[]]/index.test.ts'`
- local