### PR TITLE
[SKILL-BUILDER] Make knowledge nodes draggable

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.ts
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.ts
@@ -46,6 +46,7 @@ export const KnowledgeNode = Node.create<KnowledgeNodeOptions>({
   inline: true,
   atom: false, // Make it editable.
   selectable: false, // Allow text cursor inside.
+  draggable: true,
 
   markdownTokenizer: {
     name: "knowledgeNode",

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -519,7 +519,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
   // Show selected knowledge.
   if (selectedItems.length > 0) {
     return (
-      <NodeViewWrapper className="inline">
+      <NodeViewWrapper className="inline" data-drag-handle="">
         <KnowledgeDisplayComponent
           item={selectedItems[0]}
           owner={owner}


### PR DESCRIPTION
## Description

Enable drag-and-drop for knowledge nodes in the skill builder editor by setting `draggable: true` on the ProseMirror node and adding a `data-drag-handle` attribute to its node view.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`