### PR TITLE
[front] checkout: bypass payment-gated commit when amount is 0

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -257,7 +257,27 @@ export async function createPaymentGatedBusinessActivation({
     uniquenessKey,
   });
 
-  // Step 6: create payment-gated commit.
+  // Step 6: zero-amount fast path — no invoice to create, activate immediately.
+  if (effectiveAmountCents === 0) {
+    await handleSubscriptionActivationSuccess({
+      workspace,
+      contractId: metronomeContractId,
+      invoiceId: "free-activation",
+    });
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeContractId,
+        seatType,
+        billingPeriod,
+        currency,
+      },
+      "[Business Activation] Zero-amount activation — skipped payment-gated commit, activated directly"
+    );
+    return new Ok({ activationPending: true, contractId: metronomeContractId });
+  }
+
+  // Step 7: create payment-gated commit.
   // Access side: fiat credit that offsets the first period's seat subscription invoice.
   // Invoice side: same amount charged to the customer via Stripe.
   const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[currency];


### PR DESCRIPTION
## Description

PR6 of https://github.com/dust-tt/tasks/issues/8594
See the issue for the global view of the Checkout changes

Goal: handle the case where a coupon covers the full subscription price, making `effectiveAmountCents === 0`.
As It is not possible to do a $0 payment-gated commit in metronome, so the current flow based on the payment-gated commit webhook wont work.
=> in this case, we do not create the payment gate commit and directly validate the activation, using function handleSubscriptionActivationSuccess that is called by the webhook.

**`lib/api/checkout/business-activation.ts`**:

- In `createPaymentGatedBusinessActivation`, after writing the Redis `pending` state (step 5),
  check `effectiveAmountCents === 0`.
- If zero: call `handleSubscriptionActivationSuccess` directly with a synthetic
  `invoiceId: "free-activation"`, log the bypass, and return
  `{ activationPending: true, contractId }` immediately — no payment-gated commit is created.
- The frontend polling loop still works unchanged: the first poll finds `succeeded`.

Expected behavior after merge:

- Full-coupon checkouts activate immediately without going through Metronome payment gate.
- All other paths (non-zero amount) are unchanged.

## Tests

Tested locally for a coupon that covers more than the cost => 0 amount for activation
=> activation is OK and we can see the full coupon as a contract credit

## Risk

Low, only for checkout that is under a feature flag

## Deploy Plan

Deploy front