### PR TITLE
pricing: add a page to select the subscription

### DIFF
--- a/front-spa/src/app/layouts/WorkspacePage.tsx
+++ b/front-spa/src/app/layouts/WorkspacePage.tsx
@@ -1,4 +1,5 @@
 import { AppAuthContextLayout } from "@dust-tt/front/components/sparkle/AppAuthContextLayout";
+import { useKillSwitches } from "@dust-tt/front/lib/swr/kill";
 import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
 import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useAppReadyContext } from "@spa/app/contexts/AppReadyContext";
@@ -26,6 +27,7 @@ export function WorkspacePage({ children }: WorkspacePageProps) {
   const { authContext, isAuthenticated, authContextError } = useAuthContext({
     workspaceId: wId,
   });
+  const { killSwitches } = useKillSwitches();
 
   const signalAppReady = useAppReadyContext();
 
@@ -50,9 +52,21 @@ export function WorkspacePage({ children }: WorkspacePageProps) {
 
   // Paywall enforcement: redirect when canUseProduct is false
   // and the current route requires canUseProduct (via route handle).
-  // Mirrors the Next.js session.ts logic: redirect to /trial if eligible, /subscribe otherwise.
+  // Mirrors the Next.js session.ts logic: redirect to the trial / plan
+  // selection page if eligible, /subscribe otherwise.
   if (!canUseProduct && isRequireCanUseProduct) {
-    const target = authContext.isEligibleForTrial ? "trial" : "subscribe";
+    const isMetronomeEnabled =
+      authContext.featureFlags.includes("metronome_billing") ||
+      !killSwitches?.includes("global_disable_metronome_billing");
+    const isMetronomeCheckout =
+      isMetronomeEnabled &&
+      authContext.featureFlags.includes("metronome_cp_checkout");
+
+    const target = authContext.isEligibleForTrial
+      ? isMetronomeCheckout
+        ? "select-subscription"
+        : "trial"
+      : "subscribe";
     return <Navigate to={`/w/${wId}/${target}`} replace />;
   }
 

--- a/front-spa/src/app/routes/onboardingRoutes.tsx
+++ b/front-spa/src/app/routes/onboardingRoutes.tsx
@@ -13,6 +13,13 @@ const TrialPage = withSuspense(
   () => import("@dust-tt/front/components/pages/onboarding/TrialPage"),
   "TrialPage"
 );
+const SelectSubscriptionPage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/onboarding/SelectSubscriptionPage"
+    ),
+  "SelectSubscriptionPage"
+);
 const TrialEndedPage = withSuspense(
   () => import("@dust-tt/front/components/pages/onboarding/TrialEndedPage"),
   "TrialEndedPage"
@@ -46,6 +53,11 @@ export const onboardingRoutes: RouteObject[] = [
   {
     path: "trial",
     element: <TrialPage />,
+    handle: { requireCanUseProduct: false },
+  },
+  {
+    path: "select-subscription",
+    element: <SelectSubscriptionPage />,
     handle: { requireCanUseProduct: false },
   },
   {

--- a/front-spa/src/app/routes/onboardingRoutes.tsx
+++ b/front-spa/src/app/routes/onboardingRoutes.tsx
@@ -15,9 +15,7 @@ const TrialPage = withSuspense(
 );
 const SelectSubscriptionPage = withSuspense(
   () =>
-    import(
-      "@dust-tt/front/components/pages/onboarding/SelectSubscriptionPage"
-    ),
+    import("@dust-tt/front/components/pages/onboarding/SelectSubscriptionPage"),
   "SelectSubscriptionPage"
 );
 const TrialEndedPage = withSuspense(

--- a/front/components/pages/onboarding/SelectSubscriptionPage.tsx
+++ b/front/components/pages/onboarding/SelectSubscriptionPage.tsx
@@ -1,0 +1,270 @@
+import {
+  getSeatBarClasses,
+  getSeatIconColorClass,
+} from "@app/components/workspace/seat_styles";
+import { UserMenu } from "@app/components/UserMenu";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  CP_MAX_SEAT_COST_MONTHLY,
+  CP_MAX_SEAT_COST_YEARLY,
+  CP_PRO_SEAT_COST_MONTHLY,
+  CP_PRO_SEAT_COST_YEARLY,
+} from "@app/lib/client/subscription";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { useAppRouter } from "@app/lib/platform";
+import { useUser } from "@app/lib/swr/user";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import type { MembershipSeatType } from "@app/types/memberships";
+import type { BillingPeriod } from "@app/types/plan";
+import {
+  BarHeader,
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  Check,
+  Chip,
+  cn,
+  Icon,
+  LayerSingle,
+  LayersThree01,
+  LayersTwo01,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+type PlanTier = "free" | "pro" | "max";
+
+interface PlanCardProps {
+  icon: React.ComponentType<{ className?: string }>;
+  seatType: Extract<MembershipSeatType, "free" | "pro" | "max">;
+  name: string;
+  credits: string;
+  creditsLabel: string;
+  priceLabel: string;
+  features: string[];
+  action: React.ReactNode;
+  footnote?: string;
+}
+
+function PlanCard({
+  icon,
+  seatType,
+  name,
+  credits,
+  creditsLabel,
+  priceLabel,
+  features,
+  action,
+  footnote,
+}: PlanCardProps) {
+  // The "free" seat maps to the muted bar track, which matches the card
+  // background (invisible in dark mode), so use a contrasting neutral instead.
+  const iconBackgroundClass =
+    seatType === "free"
+      ? "bg-muted dark:bg-muted-night"
+      : getSeatBarClasses(seatType).track;
+  const iconColorClass = getSeatIconColorClass(seatType);
+
+  return (
+    <div className="flex w-full flex-col rounded-2xl border border-border bg-background p-6 dark:border-border-night dark:bg-muted-background-night">
+      <div className="flex items-center gap-2">
+        <div
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-lg",
+            iconBackgroundClass
+          )}
+        >
+          <Icon visual={icon} size="sm" className={iconColorClass} />
+        </div>
+        <span className="text-lg font-semibold text-foreground dark:text-foreground-night">
+          {name}
+        </span>
+      </div>
+
+      <div className="mt-6 flex items-baseline gap-2">
+        <span className="text-4xl font-bold text-foreground dark:text-foreground-night">
+          {credits}
+        </span>
+        <span className="whitespace-nowrap text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {creditsLabel}
+        </span>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {priceLabel}
+      </p>
+
+      <ul className="mt-6 flex flex-col gap-3">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <Icon visual={Check} size="sm" className="mt-0.5 text-primary-500" />
+            <span className="text-sm text-foreground dark:text-foreground-night">
+              {feature}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto flex flex-col items-center gap-2 pt-12">
+        {action}
+        {footnote && (
+          <p className="text-center text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {footnote}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SelectSubscriptionPage() {
+  const { workspace, user: authUser } = useAuth();
+  const router = useAppRouter();
+  const { user } = useUser();
+
+  const [billingPeriod, setBillingPeriod] =
+    React.useState<BillingPeriod>("monthly");
+
+  const { submit: startFreePlan } = useSubmitFunction(async () => {
+    await router.push(`/w/${workspace.sId}/verify`);
+  });
+
+  const { submit: handleSubscribe } = useSubmitFunction(
+    async (seatType: Exclude<PlanTier, "free">) => {
+      const query = new URLSearchParams({
+        seatType,
+        billingPeriod,
+        targetUserId: authUser.sId,
+      });
+      await router.push(
+        `/w/${workspace.sId}/subscription/checkout?${query.toString()}`
+      );
+    }
+  );
+
+  const isYearly = billingPeriod === "yearly";
+  const period = isYearly ? "yearly" : "monthly";
+  const proSeatCost = isYearly ? CP_PRO_SEAT_COST_YEARLY : CP_PRO_SEAT_COST_MONTHLY;
+  const maxSeatCost = isYearly ? CP_MAX_SEAT_COST_YEARLY : CP_MAX_SEAT_COST_MONTHLY;
+
+  return (
+    <>
+      <BarHeader
+        title="Choose your plan"
+        className="ml-10 lg:ml-0"
+        rightActions={
+          user && <UserMenu user={user} owner={workspace} subscription={null} />
+        }
+      />
+      <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4 py-16">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-4xl font-bold text-foreground dark:text-foreground-night">
+            Choose how you want to start
+          </h1>
+          <p className="text-lg text-muted-foreground dark:text-muted-foreground-night">
+            Free to begin. Upgrade you and your team anytime.
+          </p>
+        </div>
+
+        <ButtonsSwitchList
+          defaultValue="monthly"
+          onValueChange={(value) => setBillingPeriod(value as BillingPeriod)}
+        >
+          <ButtonsSwitch value="monthly" label="Monthly" />
+          <div className="flex items-center gap-1.5">
+            <ButtonsSwitch value="yearly" label="Yearly" />
+            <Chip size="xs" color="blue" label="Save 20%" />
+          </div>
+        </ButtonsSwitchList>
+
+        <div className="flex w-full max-w-4xl flex-col items-stretch gap-4 md:flex-row">
+          <div className="flex flex-1">
+            <PlanCard
+              icon={LayerSingle}
+              seatType="free"
+              name="Free"
+              credits="300"
+              creditsLabel="credits"
+              priceLabel="One-time · never expires"
+              features={[
+                "Credits never reset",
+                "Full access to every Dust feature",
+              ]}
+              footnote="One-time phone verification required"
+              action={
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  label="Start Free"
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "cp_free_start",
+                    () => {
+                      void startFreePlan();
+                    }
+                  )}
+                />
+              }
+            />
+          </div>
+
+          {/* Paid plans share a subtle wrapper to group them visually. */}
+          <div className="flex flex-[2] flex-col gap-3 rounded-3xl border border-border bg-muted-background p-3 dark:border-border-night dark:bg-muted-background-night sm:flex-row">
+            <PlanCard
+              icon={LayersTwo01}
+              seatType="pro"
+              name="Pro"
+              credits="8,000"
+              creditsLabel="credits/mo"
+              priceLabel={`$${proSeatCost}/seat/mo · billed ${period}`}
+              features={[
+                "Refills every month",
+                "Full access to every Dust feature",
+              ]}
+              action={
+                <Button
+                  className="w-full"
+                  variant="highlight"
+                  label="Subscribe to Pro"
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "cp_subscription_start",
+                    () => {
+                      void handleSubscribe("pro");
+                    },
+                    { seat_type: "pro", billing_period: billingPeriod }
+                  )}
+                />
+              }
+            />
+            <PlanCard
+              icon={LayersThree01}
+              seatType="max"
+              name="Max"
+              credits="40,000"
+              creditsLabel="credits/mo"
+              priceLabel={`$${maxSeatCost}/seat/mo · billed ${period}`}
+              features={[
+                "Refills every month",
+                "Full access to every Dust feature",
+              ]}
+              action={
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  label="Subscribe to Max"
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "cp_subscription_start",
+                    () => {
+                      void handleSubscribe("max");
+                    },
+                    { seat_type: "max", billing_period: billingPeriod }
+                  )}
+                />
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front/components/pages/onboarding/SelectSubscriptionPage.tsx
+++ b/front/components/pages/onboarding/SelectSubscriptionPage.tsx
@@ -1,8 +1,8 @@
+import { UserMenu } from "@app/components/UserMenu";
 import {
   getSeatBarClasses,
   getSeatIconColorClass,
 } from "@app/components/workspace/seat_styles";
-import { UserMenu } from "@app/components/UserMenu";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import {
   CP_MAX_SEAT_COST_MONTHLY,
@@ -95,7 +95,11 @@ function PlanCard({
       <ul className="mt-6 flex flex-col gap-3">
         {features.map((feature) => (
           <li key={feature} className="flex items-start gap-2">
-            <Icon visual={Check} size="sm" className="mt-0.5 text-primary-500" />
+            <Icon
+              visual={Check}
+              size="sm"
+              className="mt-0.5 text-primary-500"
+            />
             <span className="text-sm text-foreground dark:text-foreground-night">
               {feature}
             </span>
@@ -142,8 +146,12 @@ export function SelectSubscriptionPage() {
 
   const isYearly = billingPeriod === "yearly";
   const period = isYearly ? "yearly" : "monthly";
-  const proSeatCost = isYearly ? CP_PRO_SEAT_COST_YEARLY : CP_PRO_SEAT_COST_MONTHLY;
-  const maxSeatCost = isYearly ? CP_MAX_SEAT_COST_YEARLY : CP_MAX_SEAT_COST_MONTHLY;
+  const proSeatCostDollars = isYearly
+    ? CP_PRO_SEAT_COST_YEARLY
+    : CP_PRO_SEAT_COST_MONTHLY;
+  const maxSeatCostDollars = isYearly
+    ? CP_MAX_SEAT_COST_YEARLY
+    : CP_MAX_SEAT_COST_MONTHLY;
 
   return (
     <>
@@ -166,7 +174,9 @@ export function SelectSubscriptionPage() {
 
         <ButtonsSwitchList
           defaultValue="monthly"
-          onValueChange={(value) => setBillingPeriod(value as BillingPeriod)}
+          onValueChange={(value) =>
+            setBillingPeriod(value === "yearly" ? "yearly" : "monthly")
+          }
         >
           <ButtonsSwitch value="monthly" label="Monthly" />
           <div className="flex items-center gap-1.5">
@@ -214,7 +224,7 @@ export function SelectSubscriptionPage() {
               name="Pro"
               credits="8,000"
               creditsLabel="credits/mo"
-              priceLabel={`$${proSeatCost}/seat/mo · billed ${period}`}
+              priceLabel={`$${proSeatCostDollars}/seat/mo · billed ${period}`}
               features={[
                 "Refills every month",
                 "Full access to every Dust feature",
@@ -241,7 +251,7 @@ export function SelectSubscriptionPage() {
               name="Max"
               credits="40,000"
               creditsLabel="credits/mo"
-              priceLabel={`$${maxSeatCost}/seat/mo · billed ${period}`}
+              priceLabel={`$${maxSeatCostDollars}/seat/mo · billed ${period}`}
               features={[
                 "Refills every month",
                 "Full access to every Dust feature",

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -1,3 +1,4 @@
+import { isMetronomeCheckoutEnabled } from "@app/lib/api/subscription";
 import { getUserWithWorkspaces } from "@app/lib/api/user";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -189,10 +190,15 @@ export function makeGetServerSidePropsRequirementsWrapper<
 
         const redirectTrialPage = await isWorkspaceEligibleForTrial(auth!);
         if (redirectTrialPage) {
+          // With the Metronome credit-priced checkout flow, the trial page is
+          // replaced by the new plan selection page.
+          const metronomeCheckout = await isMetronomeCheckoutEnabled(auth!);
           return {
             redirect: {
               permanent: false,
-              destination: `/w/${context.query.wId}/trial`,
+              destination: metronomeCheckout
+                ? `/w/${context.query.wId}/select-subscription`
+                : `/w/${context.query.wId}/trial`,
             },
           };
         }


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/8727

Instead of the /trial page, when using the metronome checkout flags we are now redirected to the new /select-subscription page.
This page let's you pick between 
 - Start free -> redirected to existing phone flow
 - subscribe to pro/max -> redirected to existing /subscription/checkout with corresponding params

<img width="3828" height="1806" alt="image" src="https://github.com/user-attachments/assets/efe2665b-7514-4df4-889a-fa98d7aefc67" />


<img width="3838" height="1810" alt="image" src="https://github.com/user-attachments/assets/9e35b49b-bf1f-40fe-bc7f-6776952d2f1f" />


## Tests

tested locally

## Risk

low, only UI and behind Feature Flag

## Deploy Plan

deploy front
