### PR TITLE
Enforce bounded text columns in Sequelize models

### DIFF
--- a/.grit/patterns/noSequelizeDataTypesImport.grit
+++ b/.grit/patterns/noSequelizeDataTypesImport.grit
@@ -1,0 +1,15 @@
+engine biome(1.0)
+language js
+
+// Disallows importing DataTypes directly from "sequelize".
+// Use DataTypes and DANGEROUSLY_UNBOUNDED_TEXT from
+// "@app/lib/resources/storage/data_types" instead — this wrapper removes
+// the unbounded TEXT type and forces an explicit opt-in for unbounded columns.
+`import { $specs } from "sequelize"` as $import where {
+    $specs <: contains `DataTypes`,
+    register_diagnostic(
+        span = $import,
+        message = "Do not import DataTypes from 'sequelize' directly. Use DataTypes (and DANGEROUSLY_UNBOUNDED_TEXT if needed) from '@app/lib/resources/storage/data_types' instead.",
+        severity = "error"
+    )
+}

--- a/biome.json
+++ b/biome.json
@@ -168,7 +168,8 @@
         "front/lib/models/**/*.ts",
         "front/lib/resources/storage/models/**/*.ts",
         "front/lib/resources/storage/wrappers/**/*.ts",
-        "!front/lib/resources/storage/data_types.ts"
+        "!front/lib/resources/storage/data_types.ts",
+        "!connectors/src/resources/storage/data_types.ts"
       ],
       "plugins": [
         "./.grit/patterns/tooLongIndexName.grit",

--- a/biome.json
+++ b/biome.json
@@ -167,9 +167,13 @@
         "connectors/src/resources/storage/models/**/*.ts",
         "front/lib/models/**/*.ts",
         "front/lib/resources/storage/models/**/*.ts",
-        "front/lib/resources/storage/wrappers/**/*.ts"
+        "front/lib/resources/storage/wrappers/**/*.ts",
+        "!front/lib/resources/storage/data_types.ts"
       ],
-      "plugins": ["./.grit/patterns/tooLongIndexName.grit"]
+      "plugins": [
+        "./.grit/patterns/tooLongIndexName.grit",
+        "./.grit/patterns/noSequelizeDataTypesImport.grit"
+      ]
     },
     {
       "includes": ["cli/dust-cli/**", "sparkle/**"],

--- a/connectors/src/lib/models/bigquery.ts
+++ b/connectors/src/lib/models/bigquery.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class BigQueryConfigurationModel extends ConnectorBaseModel<BigQueryConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/bigquery.ts
+++ b/connectors/src/lib/models/bigquery.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class BigQueryConfigurationModel extends ConnectorBaseModel<BigQueryConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class ConfluenceConfigurationModel extends ConnectorBaseModel<ConfluenceConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -152,7 +152,7 @@ ConfluencePageModel.init(
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     externalUrl: {
@@ -230,7 +230,7 @@ ConfluenceFolderModel.init(
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     externalUrl: {

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -1,7 +1,10 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class ConfluenceConfigurationModel extends ConnectorBaseModel<ConfluenceConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/discord.ts
+++ b/connectors/src/lib/models/discord.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class DiscordConfigurationModel extends ConnectorBaseModel<DiscordConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/discord.ts
+++ b/connectors/src/lib/models/discord.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class DiscordConfigurationModel extends ConnectorBaseModel<DiscordConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class DustProjectConfigurationModel extends ConnectorBaseModel<DustProjectConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class DustProjectConfigurationModel extends ConnectorBaseModel<DustProjectConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -1,7 +1,10 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class GithubConnectorStateModel extends ConnectorBaseModel<GithubConnectorStateModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/github.ts
+++ b/connectors/src/lib/models/github.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class GithubConnectorStateModel extends ConnectorBaseModel<GithubConnectorStateModel> {
   declare createdAt: CreationOptional<Date>;
@@ -191,7 +191,7 @@ GithubCodeRepositoryModel.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },
@@ -257,7 +257,7 @@ GithubCodeFileModel.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     contentHash: {
@@ -331,7 +331,7 @@ GithubCodeDirectoryModel.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class GongConfigurationModel extends ConnectorBaseModel<GongConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -147,15 +147,15 @@ GongTranscriptModel.init(
       allowNull: false,
     },
     callId: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -1,7 +1,10 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class GongConfigurationModel extends ConnectorBaseModel<GongConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -3,7 +3,7 @@ import { connectorsSequelize } from "@connectors/resources/storage";
 import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class GoogleDriveConfigModel extends ConnectorBaseModel<GoogleDriveConfigModel> {
   declare createdAt: CreationOptional<Date>;
@@ -127,7 +127,7 @@ GoogleDriveFilesModel.init(
       allowNull: false,
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
       defaultValue: "",
     },
@@ -181,11 +181,11 @@ GoogleDriveSheetModel.init(
       allowNull: false,
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     notUpsertedReason: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -1,9 +1,12 @@
 import type { TablesErrorType } from "@connectors/lib/error";
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class GoogleDriveConfigModel extends ConnectorBaseModel<GoogleDriveConfigModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -1,8 +1,11 @@
 import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/intercom/lib/types";
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export const DEFAULT_CONVERSATIONS_SLIDING_WINDOW = 180;
 

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -2,7 +2,7 @@ import type { IntercomSyncAllConversationsStatus } from "@connectors/connectors/
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export const DEFAULT_CONVERSATIONS_SLIDING_WINDOW = 180;
 
@@ -194,7 +194,7 @@ IntercomCollectionModel.init(
       allowNull: false,
     },
     description: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     url: {

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -2,7 +2,7 @@ import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/typ
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export type SelectedSiteMetadata = {
   siteId: string;
@@ -161,7 +161,7 @@ MicrosoftNodeModel.init(
       allowNull: false,
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     mimeType: {

--- a/connectors/src/lib/models/microsoft.ts
+++ b/connectors/src/lib/models/microsoft.ts
@@ -1,8 +1,11 @@
 import type { MicrosoftNodeType } from "@connectors/connectors/microsoft/lib/types";
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export type SelectedSiteMetadata = {
   siteId: string;

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class MicrosoftBotConfigurationModel extends ConnectorBaseModel<MicrosoftBotConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/microsoft_bot.ts
+++ b/connectors/src/lib/models/microsoft_bot.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class MicrosoftBotConfigurationModel extends ConnectorBaseModel<MicrosoftBotConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -1,8 +1,11 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { NotionBlockType, PageObjectProperties } from "@connectors/types";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class NotionConnectorStateModel extends ConnectorBaseModel<NotionConnectorStateModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -2,7 +2,7 @@ import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { NotionBlockType, PageObjectProperties } from "@connectors/types";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class NotionConnectorStateModel extends ConnectorBaseModel<NotionConnectorStateModel> {
   declare createdAt: CreationOptional<Date>;
@@ -115,7 +115,7 @@ NotionPageModel.init(
       allowNull: true,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     titleSearchVector: {
@@ -222,7 +222,7 @@ NotionDatabaseModel.init(
       allowNull: true,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     titleSearchVector: {
@@ -306,7 +306,7 @@ NotionConnectorPageCacheEntryModel.init(
       allowNull: true,
     },
     pagePropertiesText: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
       defaultValue: "{}",
     },
@@ -400,7 +400,7 @@ NotionConnectorBlockCacheEntryModel.init(
       allowNull: false,
     },
     blockText: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     blockType: {
@@ -416,7 +416,7 @@ NotionConnectorBlockCacheEntryModel.init(
       allowNull: false,
     },
     childDatabaseTitle: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     workflowId: {

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -1,7 +1,10 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 type AllowedPermissions = "selected" | "unselected" | "inherited";
 

--- a/connectors/src/lib/models/remote_databases.ts
+++ b/connectors/src/lib/models/remote_databases.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 type AllowedPermissions = "selected" | "unselected" | "inherited";
 
@@ -116,19 +116,19 @@ export class RemoteTableModel extends ConnectorBaseModel<RemoteTableModel> {
 RemoteTableModel.init(
   {
     internalId: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     schemaName: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     databaseName: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     permission: {

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class SalesforceConfigurationModel extends ConnectorBaseModel<SalesforceConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -52,23 +52,23 @@ SalesforceSyncedQueryModel.init(
       defaultValue: DataTypes.NOW,
     },
     rootNodeName: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     soql: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     titleTemplate: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     contentTemplate: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     tagsTemplate: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     lastSeenModifiedDate: {

--- a/connectors/src/lib/models/salesforce.ts
+++ b/connectors/src/lib/models/salesforce.ts
@@ -1,7 +1,10 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class SalesforceConfigurationModel extends ConnectorBaseModel<SalesforceConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -1,4 +1,8 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type {
   ConnectorPermission,
@@ -6,7 +10,6 @@ import type {
   SlackbotWhitelistType,
 } from "@connectors/types";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class SlackConfigurationModel extends ConnectorBaseModel<SlackConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -6,7 +6,7 @@ import type {
   SlackbotWhitelistType,
 } from "@connectors/types";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class SlackConfigurationModel extends ConnectorBaseModel<SlackConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -239,7 +239,7 @@ SlackChatBotMessageModel.init(
       allowNull: true,
     },
     message: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     slackUserId: {

--- a/connectors/src/lib/models/snowflake.ts
+++ b/connectors/src/lib/models/snowflake.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class SnowflakeConfigurationModel extends ConnectorBaseModel<SnowflakeConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/snowflake.ts
+++ b/connectors/src/lib/models/snowflake.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export class SnowflakeConfigurationModel extends ConnectorBaseModel<SnowflakeConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -1,9 +1,12 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CrawlingFrequency, DepthOption } from "@connectors/types";
 import type { Action } from "@mendable/firecrawl-js";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class WebCrawlerConfigurationModel extends ConnectorBaseModel<WebCrawlerConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -3,7 +3,7 @@ import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model
 import type { CrawlingFrequency, DepthOption } from "@connectors/types";
 import type { Action } from "@mendable/firecrawl-js";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 export class WebCrawlerConfigurationModel extends ConnectorBaseModel<WebCrawlerConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -154,7 +154,7 @@ WebCrawlerFolderModel.init(
       defaultValue: DataTypes.NOW,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     urlMd5: {
@@ -162,7 +162,7 @@ WebCrawlerFolderModel.init(
       allowNull: false,
     },
     parentUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     internalId: {
@@ -222,7 +222,7 @@ WebCrawlerPageModel.init(
       defaultValue: DataTypes.NOW,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     urlMd5: {
@@ -230,11 +230,11 @@ WebCrawlerPageModel.init(
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     parentUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     documentId: {

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -1,7 +1,10 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@connectors/resources/storage/data_types";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 function throwOnUnsafeInteger(value: number | null) {
   if (value !== null && !Number.isSafeInteger(value)) {

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -1,7 +1,7 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
 import { ConnectorBaseModel } from "@connectors/resources/storage/wrappers/model_with_connectors";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@connectors/resources/storage/data_types";
 
 function throwOnUnsafeInteger(value: number | null) {
   if (value !== null && !Number.isSafeInteger(value)) {
@@ -167,7 +167,7 @@ ZendeskBrandModel.init(
       allowNull: false,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     subdomain: {
@@ -239,15 +239,15 @@ ZendeskCategoryModel.init(
       validate: { throwOnUnsafeInteger },
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     description: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     permission: {
@@ -320,11 +320,11 @@ ZendeskArticleModel.init(
       validate: { throwOnUnsafeInteger },
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     permission: {
@@ -386,11 +386,11 @@ ZendeskTicketModel.init(
       defaultValue: DataTypes.NOW,
     },
     url: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     subject: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     ticketId: {

--- a/connectors/src/resources/storage/data_types.ts
+++ b/connectors/src/resources/storage/data_types.ts
@@ -1,0 +1,17 @@
+// This module re-exports everything from sequelize with one override: DataTypes.TEXT is removed.
+// Import from this module instead of from "sequelize" directly.
+//
+// Use DataTypes.STRING(n) for bounded columns (preferred).
+// Use DANGEROUSLY_UNBOUNDED_TEXT when an unbounded column is intentional.
+//
+// A grit rule enforces that DataTypes is never imported from "sequelize" directly.
+// See .grit/patterns/noSequelizeDataTypesImport.grit.
+
+import { DataTypes as SequelizeDataTypes } from "sequelize";
+
+const { TEXT, ...rest } = SequelizeDataTypes;
+
+export const DANGEROUSLY_UNBOUNDED_TEXT = TEXT;
+
+export * from "sequelize";
+export const DataTypes = rest as Omit<typeof SequelizeDataTypes, "TEXT">;

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -6,7 +6,7 @@ import type {
 } from "@connectors/types";
 import type { ConnectorProvider } from "@dust-tt/client";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export interface ConnectorMetadata {
   rateLimited?: { at: Date } | null;

--- a/connectors/src/resources/storage/models/connector_model.ts
+++ b/connectors/src/resources/storage/models/connector_model.ts
@@ -1,4 +1,5 @@
 import { connectorsSequelize } from "@connectors/resources/storage";
+import { DataTypes } from "@connectors/resources/storage/data_types";
 import { BaseModel } from "@connectors/resources/storage/wrappers/base";
 import type {
   ConnectorErrorType,
@@ -6,7 +7,6 @@ import type {
 } from "@connectors/types";
 import type { ConnectorProvider } from "@dust-tt/client";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@connectors/resources/storage/data_types";
 
 export interface ConnectorMetadata {
   rateLimited?: { at: Date } | null;

--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -5,9 +5,9 @@ import {
   ConversationModel,
 } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
 
 export class AgentStepContentToolExecutionModel extends WorkspaceAwareModel<AgentStepContentToolExecutionModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/agent/actions/conversation_mcp_server_view.ts
+++ b/front/lib/models/agent/actions/conversation_mcp_server_view.ts
@@ -1,10 +1,10 @@
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class ConversationMCPServerViewModel extends WorkspaceAwareModel<ConversationMCPServerViewModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/conversation_mcp_server_view.ts
+++ b/front/lib/models/agent/actions/conversation_mcp_server_view.ts
@@ -4,7 +4,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class ConversationMCPServerViewModel extends WorkspaceAwareModel<ConversationMCPServerViewModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/data_sources.ts
+++ b/front/lib/models/agent/actions/data_sources.ts
@@ -4,7 +4,7 @@ import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /**
  * Configuration of Data Sources used for Retrieval, Process and MCP server actions.

--- a/front/lib/models/agent/actions/data_sources.ts
+++ b/front/lib/models/agent/actions/data_sources.ts
@@ -1,10 +1,10 @@
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /**
  * Configuration of Data Sources used for Retrieval, Process and MCP server actions.

--- a/front/lib/models/agent/actions/internal_mcp_server_credentials.ts
+++ b/front/lib/models/agent/actions/internal_mcp_server_credentials.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class InternalMCPServerCredentialModel extends WorkspaceAwareModel<InternalMCPServerCredentialModel> {
   declare createdAt: CreationOptional<Date>;
@@ -30,7 +30,7 @@ InternalMCPServerCredentialModel.init(
       allowNull: false,
     },
     sharedSecret: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     customHeaders: {
@@ -39,7 +39,7 @@ InternalMCPServerCredentialModel.init(
       defaultValue: null,
     },
     encryptedKey: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/models/agent/actions/internal_mcp_server_credentials.ts
+++ b/front/lib/models/agent/actions/internal_mcp_server_credentials.ts
@@ -1,7 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class InternalMCPServerCredentialModel extends WorkspaceAwareModel<InternalMCPServerCredentialModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -16,7 +16,7 @@ import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export type AdditionalConfigurationValueType =
   | boolean
@@ -378,7 +378,7 @@ AgentMCPActionOutputItemModel.init(
       },
     },
     contentGcsPath: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     citations: {

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -6,6 +6,10 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { validateJsonSchema } from "@app/lib/utils/json_schemas";
@@ -16,7 +20,6 @@ import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export type AdditionalConfigurationValueType =
   | boolean

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -1,11 +1,11 @@
 import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConnectionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -5,7 +5,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConnectionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/mcp_server_view.ts
+++ b/front/lib/models/agent/actions/mcp_server_view.ts
@@ -7,7 +7,7 @@ import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wra
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServerViewModel> {
   declare createdAt: CreationOptional<Date>;
@@ -95,7 +95,7 @@ MCPServerViewModel.init(
       },
     },
     oauthScope: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/front/lib/models/agent/actions/mcp_server_view.ts
+++ b/front/lib/models/agent/actions/mcp_server_view.ts
@@ -1,13 +1,16 @@
 import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServerViewModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/projects.ts
+++ b/front/lib/models/agent/actions/projects.ts
@@ -1,9 +1,9 @@
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /**
  * Configuration of Projects (Spaces) used for MCP server actions.

--- a/front/lib/models/agent/actions/projects.ts
+++ b/front/lib/models/agent/actions/projects.ts
@@ -3,7 +3,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /**
  * Configuration of Projects (Spaces) used for MCP server actions.

--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -8,7 +8,7 @@ import type { MCPToolType } from "@app/lib/api/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerModel> {
   declare createdAt: CreationOptional<Date>;
@@ -52,7 +52,7 @@ RemoteMCPServerModel.init(
       allowNull: false,
     },
     version: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
       defaultValue: DEFAULT_MCP_ACTION_VERSION,
     },
@@ -61,7 +61,7 @@ RemoteMCPServerModel.init(
       allowNull: false,
     },
     cachedDescription: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     cachedTools: {
@@ -74,12 +74,12 @@ RemoteMCPServerModel.init(
       allowNull: true,
     },
     lastError: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },
     sharedSecret: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     authorization: {

--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -6,9 +6,12 @@ import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server_tool_metadata.ts
@@ -3,7 +3,7 @@ import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_s
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<RemoteMCPServerToolMetadataModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server_tool_metadata.ts
@@ -1,9 +1,9 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<RemoteMCPServerToolMetadataModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/tables_query.ts
+++ b/front/lib/models/agent/actions/tables_query.ts
@@ -1,10 +1,10 @@
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AgentTablesQueryConfigurationTableModel extends WorkspaceAwareModel<AgentTablesQueryConfigurationTableModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/tables_query.ts
+++ b/front/lib/models/agent/actions/tables_query.ts
@@ -4,7 +4,7 @@ import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AgentTablesQueryConfigurationTableModel extends WorkspaceAwareModel<AgentTablesQueryConfigurationTableModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -1,5 +1,9 @@
 import type { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -15,7 +19,6 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 /**
  * Agent configuration

--- a/front/lib/models/agent/agent.ts
+++ b/front/lib/models/agent/agent.ts
@@ -15,7 +15,7 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 /**
  * Agent configuration
@@ -95,19 +95,19 @@ AgentConfigurationModel.init(
       defaultValue: "workspace",
     },
     name: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     description: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     instructions: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     instructionsHtml: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     providerId: {
@@ -158,7 +158,7 @@ AgentConfigurationModel.init(
       defaultValue: false,
     },
     pictureUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     reinforcement: {

--- a/front/lib/models/agent/agent_data_retention.ts
+++ b/front/lib/models/agent/agent_data_retention.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AgentDataRetentionModel extends WorkspaceAwareModel<AgentDataRetentionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_data_retention.ts
+++ b/front/lib/models/agent/agent_data_retention.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AgentDataRetentionModel extends WorkspaceAwareModel<AgentDataRetentionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -6,7 +6,7 @@ import {
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class AgentSkillModel extends WorkspaceAwareModel<AgentSkillModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -4,9 +4,9 @@ import {
   SkillConfigurationModel,
 } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class AgentSkillModel extends WorkspaceAwareModel<AgentSkillModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -3,7 +3,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -1,9 +1,9 @@
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -8,7 +8,7 @@ import type {
   SuggestionPayload,
 } from "@app/types/suggestions/agent_suggestion";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionModel> {
   declare createdAt: CreationOptional<Date>;
@@ -56,7 +56,7 @@ AgentSuggestionModel.init(
         "JSONB payload containing the suggestion details, structure depends on kind",
     },
     analysis: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       comment:
         "Optional analysis/reasoning explaining why this suggestion was made",

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -1,6 +1,10 @@
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   AgentSuggestionKind,
@@ -8,7 +12,6 @@ import type {
   SuggestionPayload,
 } from "@app/types/suggestions/agent_suggestion";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -20,7 +20,7 @@ import type {
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, literal, Op } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT, literal, Op } from "@app/lib/resources/storage/data_types";
 
 export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -60,7 +60,7 @@ ConversationModel.init(
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     visibility: {
@@ -309,7 +309,7 @@ UserMessageModel.init(
       defaultValue: DataTypes.NOW,
     },
     content: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     // TODO(MCP Clean-up): Remove these once we have migrated to the new MCP server ids.
@@ -480,7 +480,7 @@ AgentMessageModel.init(
       allowNull: true,
     },
     errorMessage: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     errorMetadata: {
@@ -598,7 +598,7 @@ AgentMessageFeedbackModel.init(
       allowNull: true,
     },
     content: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     isConversationShared: {
@@ -707,7 +707,7 @@ CompactionMessageModel.init(
       defaultValue: "created",
     },
     content: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -4,6 +4,12 @@ import type { ConversationBranchModel } from "@app/lib/models/agent/conversation
 import type { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+  literal,
+  Op,
+} from "@app/lib/resources/storage/data_types";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -20,7 +26,6 @@ import type {
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT, literal, Op } from "@app/lib/resources/storage/data_types";
 
 export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/conversation_branch.ts
+++ b/front/lib/models/agent/conversation_branch.ts
@@ -3,10 +3,10 @@ import {
   MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export type ConversationBranchState = "open" | "merged" | "closed";
 

--- a/front/lib/models/agent/conversation_branch.ts
+++ b/front/lib/models/agent/conversation_branch.ts
@@ -6,7 +6,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export type ConversationBranchState = "open" | "merged" | "closed";
 

--- a/front/lib/models/agent/conversation_fork.ts
+++ b/front/lib/models/agent/conversation_fork.ts
@@ -3,10 +3,10 @@ import {
   MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ConversationForkModel extends WorkspaceAwareModel<ConversationForkModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/conversation_fork.ts
+++ b/front/lib/models/agent/conversation_fork.ts
@@ -6,7 +6,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ConversationForkModel extends WorkspaceAwareModel<ConversationForkModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/group_agent.ts
+++ b/front/lib/models/agent/group_agent.ts
@@ -7,7 +7,7 @@ import type {
   CreationOptional,
   ForeignKey,
 } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/agent/group_agent.ts
+++ b/front/lib/models/agent/group_agent.ts
@@ -1,5 +1,6 @@
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -7,7 +8,6 @@ import type {
   CreationOptional,
   ForeignKey,
 } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupAgentModel extends WorkspaceAwareModel<GroupAgentModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/agent/tag_agent.ts
+++ b/front/lib/models/agent/tag_agent.ts
@@ -9,7 +9,7 @@ import type {
   ForeignKey,
   NonAttribute,
 } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class TagAgentModel extends WorkspaceAwareModel<TagAgentModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/agent/tag_agent.ts
+++ b/front/lib/models/agent/tag_agent.ts
@@ -1,6 +1,7 @@
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TagModel } from "@app/lib/models/tags";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import type { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -9,7 +10,6 @@ import type {
   ForeignKey,
   NonAttribute,
 } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class TagAgentModel extends WorkspaceAwareModel<TagAgentModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -1,6 +1,10 @@
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WebhookSourcesViewModel } from "@app/lib/models/agent/triggers/webhook_sources_view";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -15,7 +19,6 @@ import {
   isValidTriggerStatus,
 } from "@app/types/assistant/triggers";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -15,7 +15,7 @@ import {
   isValidTriggerStatus,
 } from "@app/types/assistant/triggers";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
   declare createdAt: CreationOptional<Date>;
@@ -70,12 +70,12 @@ TriggerModel.init(
       allowNull: false,
     },
     naturalLanguageDescription: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },
     customPrompt: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/models/agent/triggers/webhook_request.ts
+++ b/front/lib/models/agent/triggers/webhook_request.ts
@@ -2,7 +2,7 @@ import type { WebhookRequestTriggerModel } from "@app/lib/models/agent/triggers/
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 import { WebhookSourceModel } from "./webhook_source";
 
@@ -64,7 +64,7 @@ WebhookRequestModel.init(
       allowNull: true,
     },
     errorMessage: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/front/lib/models/agent/triggers/webhook_request.ts
+++ b/front/lib/models/agent/triggers/webhook_request.ts
@@ -1,8 +1,11 @@
 import type { WebhookRequestTriggerModel } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 import { WebhookSourceModel } from "./webhook_source";
 

--- a/front/lib/models/agent/triggers/webhook_request_trigger.ts
+++ b/front/lib/models/agent/triggers/webhook_request_trigger.ts
@@ -1,8 +1,11 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 import { TriggerModel } from "./triggers";
 import { WebhookRequestModel } from "./webhook_request";

--- a/front/lib/models/agent/triggers/webhook_request_trigger.ts
+++ b/front/lib/models/agent/triggers/webhook_request_trigger.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 import { TriggerModel } from "./triggers";
 import { WebhookRequestModel } from "./webhook_request";
@@ -43,7 +43,7 @@ WebhookRequestTriggerModel.init(
       defaultValue: "not_matched",
     },
     errorMessage: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/models/agent/triggers/webhook_source.ts
+++ b/front/lib/models/agent/triggers/webhook_source.ts
@@ -5,7 +5,7 @@ import type {
   WebhookSourceSignatureAlgorithm,
 } from "@app/types/triggers/webhooks";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WebhookSourceModel extends WorkspaceAwareModel<WebhookSourceModel> {
   declare createdAt: CreationOptional<Date>;
@@ -41,11 +41,11 @@ WebhookSourceModel.init(
       allowNull: false,
     },
     secret: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     urlSecret: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     signatureHeader: {
@@ -69,7 +69,7 @@ WebhookSourceModel.init(
       allowNull: true,
     },
     oauthConnectionId: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/front/lib/models/agent/triggers/webhook_source.ts
+++ b/front/lib/models/agent/triggers/webhook_source.ts
@@ -1,11 +1,14 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   WebhookProvider,
   WebhookSourceSignatureAlgorithm,
 } from "@app/types/triggers/webhooks";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WebhookSourceModel extends WorkspaceAwareModel<WebhookSourceModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/triggers/webhook_sources_view.ts
+++ b/front/lib/models/agent/triggers/webhook_sources_view.ts
@@ -1,10 +1,13 @@
 import { WebhookSourceModel } from "@app/lib/models/agent/triggers/webhook_source";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WebhookSourcesViewModel extends SoftDeletableWorkspaceAwareModel<WebhookSourcesViewModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/triggers/webhook_sources_view.ts
+++ b/front/lib/models/agent/triggers/webhook_sources_view.ts
@@ -4,7 +4,7 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WebhookSourcesViewModel extends SoftDeletableWorkspaceAwareModel<WebhookSourcesViewModel> {
   declare createdAt: CreationOptional<Date>;
@@ -51,7 +51,7 @@ WebhookSourcesViewModel.init(
       allowNull: true,
     },
     description: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     icon: {

--- a/front/lib/models/dust_app_secret.ts
+++ b/front/lib/models/dust_app_secret.ts
@@ -1,8 +1,11 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class DustAppSecretModel extends WorkspaceAwareModel<DustAppSecretModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/dust_app_secret.ts
+++ b/front/lib/models/dust_app_secret.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class DustAppSecretModel extends WorkspaceAwareModel<DustAppSecretModel> {
   declare createdAt: CreationOptional<Date>;
@@ -26,7 +26,7 @@ DustAppSecretModel.init(
       allowNull: false,
     },
     hash: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/front/lib/models/extension.ts
+++ b/front/lib/models/extension.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ExtensionConfigurationModel extends WorkspaceAwareModel<ExtensionConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/extension.ts
+++ b/front/lib/models/extension.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ExtensionConfigurationModel extends WorkspaceAwareModel<ExtensionConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -3,7 +3,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class FeatureFlagModel extends WorkspaceAwareModel<FeatureFlagModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/feature_flag.ts
+++ b/front/lib/models/feature_flag.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class FeatureFlagModel extends WorkspaceAwareModel<FeatureFlagModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/global_feature_flag.ts
+++ b/front/lib/models/global_feature_flag.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GlobalFeatureFlagModel extends BaseModel<GlobalFeatureFlagModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/global_feature_flag.ts
+++ b/front/lib/models/global_feature_flag.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GlobalFeatureFlagModel extends BaseModel<GlobalFeatureFlagModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/membership_invitation.ts
+++ b/front/lib/models/membership_invitation.ts
@@ -3,7 +3,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { RoleType } from "@app/types/user";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class MembershipInvitationModel extends WorkspaceAwareModel<MembershipInvitationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/membership_invitation.ts
+++ b/front/lib/models/membership_invitation.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { RoleType } from "@app/types/user";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class MembershipInvitationModel extends WorkspaceAwareModel<MembershipInvitationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -16,7 +17,6 @@ import type {
   NonAttribute,
   Transaction,
 } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class PlanModel extends BaseModel<PlanModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -16,7 +16,7 @@ import type {
   NonAttribute,
   Transaction,
 } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class PlanModel extends BaseModel<PlanModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/provider_credential.ts
+++ b/front/lib/models/provider_credential.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ProviderCredentialModel extends WorkspaceAwareModel<ProviderCredentialModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/provider_credential.ts
+++ b/front/lib/models/provider_credential.ts
@@ -3,7 +3,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ByokModelProviderIdType } from "@app/types/assistant/models/types";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ProviderCredentialModel extends WorkspaceAwareModel<ProviderCredentialModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -13,7 +13,7 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import isNil from "lodash/isNil";
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 const SKILL_MODEL_ATTRIBUTES = {
   createdAt: {
@@ -31,23 +31,23 @@ const SKILL_MODEL_ATTRIBUTES = {
     allowNull: false,
   },
   name: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: false,
   },
   agentFacingDescription: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: false,
   },
   userFacingDescription: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
   },
   instructions: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: false,
   },
   instructionsHtml: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
   },
   requestedSpaceIds: {
@@ -55,11 +55,11 @@ const SKILL_MODEL_ATTRIBUTES = {
     allowNull: false,
   },
   icon: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
   },
   extendedSkillId: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
   },
   source: {
@@ -345,7 +345,7 @@ SkillFileAttachmentModel.init(
       },
     },
     fileName: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -1,5 +1,9 @@
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -13,7 +17,6 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import isNil from "lodash/isNil";
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 const SKILL_MODEL_ATTRIBUTES = {
   createdAt: {

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -7,6 +7,7 @@ import {
   SkillConfigurationModel,
 } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ConversationSkillOrigin } from "@app/types/assistant/conversation_skills";
@@ -16,7 +17,6 @@ import type {
   ModelAttributes,
   NonAttribute,
 } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 const SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES = {
   createdAt: {

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -16,7 +16,7 @@ import type {
   ModelAttributes,
   NonAttribute,
 } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 const SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES = {
   createdAt: {

--- a/front/lib/models/skill/group_skill.ts
+++ b/front/lib/models/skill/group_skill.ts
@@ -1,9 +1,9 @@
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupSkillModel extends WorkspaceAwareModel<GroupSkillModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/skill/group_skill.ts
+++ b/front/lib/models/skill/group_skill.ts
@@ -3,7 +3,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupSkillModel extends WorkspaceAwareModel<GroupSkillModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/models/skill/self_improving_skills_usage.ts
+++ b/front/lib/models/skill/self_improving_skills_usage.ts
@@ -3,7 +3,7 @@ import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class SelfImprovingSkillsUsageModel extends WorkspaceAwareModel<SelfImprovingSkillsUsageModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill/self_improving_skills_usage.ts
+++ b/front/lib/models/skill/self_improving_skills_usage.ts
@@ -1,9 +1,9 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class SelfImprovingSkillsUsageModel extends WorkspaceAwareModel<SelfImprovingSkillsUsageModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill/skill_reference.ts
+++ b/front/lib/models/skill/skill_reference.ts
@@ -5,7 +5,7 @@ import {
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class SkillReferenceModel extends WorkspaceAwareModel<SkillReferenceModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill/skill_reference.ts
+++ b/front/lib/models/skill/skill_reference.ts
@@ -3,9 +3,9 @@ import {
   SkillConfigurationModel,
 } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class SkillReferenceModel extends WorkspaceAwareModel<SkillReferenceModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -1,6 +1,11 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+  Op,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -10,7 +15,6 @@ import type {
   SkillSuggestionState,
 } from "@app/types/suggestions/skill_suggestion";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT, Op } from "@app/lib/resources/storage/data_types";
 
 export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill/skill_suggestion.ts
+++ b/front/lib/models/skill/skill_suggestion.ts
@@ -10,7 +10,7 @@ import type {
   SkillSuggestionState,
 } from "@app/types/suggestions/skill_suggestion";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT, Op } from "@app/lib/resources/storage/data_types";
 
 export class SkillSuggestionModel extends WorkspaceAwareModel<SkillSuggestionModel> {
   declare createdAt: CreationOptional<Date>;
@@ -61,7 +61,7 @@ SkillSuggestionModel.init(
       allowNull: false,
     },
     analysis: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     title: {

--- a/front/lib/models/tags.ts
+++ b/front/lib/models/tags.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { TagKind } from "@app/types/tag";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class TagModel extends WorkspaceAwareModel<TagModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/tags.ts
+++ b/front/lib/models/tags.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { TagKind } from "@app/types/tag";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class TagModel extends WorkspaceAwareModel<TagModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/workspace_sensitivity_label_config.ts
+++ b/front/lib/models/workspace_sensitivity_label_config.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export type SensitivityLabelSourceType = "connector" | "mcp_connection";
 

--- a/front/lib/models/workspace_sensitivity_label_config.ts
+++ b/front/lib/models/workspace_sensitivity_label_config.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export type SensitivityLabelSourceType = "connector" | "mcp_connection";
 

--- a/front/lib/resources/storage/data_types.ts
+++ b/front/lib/resources/storage/data_types.ts
@@ -1,0 +1,17 @@
+// This module re-exports everything from sequelize with one override: DataTypes.TEXT is removed.
+// Import from this module instead of from "sequelize" directly.
+//
+// Use DataTypes.STRING(n) for bounded columns (preferred).
+// Use DANGEROUSLY_UNBOUNDED_TEXT when an unbounded column is intentional.
+//
+// A grit rule enforces that DataTypes is never imported from "sequelize" directly.
+// See .grit/patterns/noSequelizeDataTypesImport.grit.
+
+import { DataTypes as SequelizeDataTypes } from "sequelize";
+
+const { TEXT, ...rest } = SequelizeDataTypes;
+
+export const DANGEROUSLY_UNBOUNDED_TEXT = TEXT;
+
+export * from "sequelize";
+export const DataTypes = rest as Omit<typeof SequelizeDataTypes, "TEXT">;

--- a/front/lib/resources/storage/models/academy_chapter_visit.ts
+++ b/front/lib/resources/storage/models/academy_chapter_visit.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AcademyChapterVisitModel extends BaseModel<AcademyChapterVisitModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/academy_chapter_visit.ts
+++ b/front/lib/resources/storage/models/academy_chapter_visit.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class AcademyChapterVisitModel extends BaseModel<AcademyChapterVisitModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/academy_quiz_attempt.ts
+++ b/front/lib/resources/storage/models/academy_quiz_attempt.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export const ACADEMY_CONTENT_TYPES = ["course", "lesson", "chapter"] as const;
 export type AcademyContentType = (typeof ACADEMY_CONTENT_TYPES)[number];

--- a/front/lib/resources/storage/models/academy_quiz_attempt.ts
+++ b/front/lib/resources/storage/models/academy_quiz_attempt.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export const ACADEMY_CONTENT_TYPES = ["course", "lesson", "chapter"] as const;
 export type AcademyContentType = (typeof ACADEMY_CONTENT_TYPES)[number];

--- a/front/lib/resources/storage/models/agent_memories.ts
+++ b/front/lib/resources/storage/models/agent_memories.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class AgentMemoryModel extends WorkspaceAwareModel<AgentMemoryModel> {
   declare createdAt: CreationOptional<Date>;
@@ -31,7 +31,7 @@ AgentMemoryModel.init(
       allowNull: false,
     },
     content: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/front/lib/resources/storage/models/agent_memories.ts
+++ b/front/lib/resources/storage/models/agent_memories.ts
@@ -1,8 +1,11 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class AgentMemoryModel extends WorkspaceAwareModel<AgentMemoryModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -7,7 +7,7 @@ import {
 import type { AppVisibility } from "@app/types/app";
 import type { DatasetSchema } from "@app/types/dataset";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 // TODO(2024-10-04 flav) Remove visibility from here.
 export class AppModel extends SoftDeletableWorkspaceAwareModel<AppModel> {
@@ -58,13 +58,13 @@ AppModel.init(
       allowNull: false,
     },
     savedSpecification: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     savedConfig: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     savedRun: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     dustAPIProjectId: {
       type: DataTypes.STRING,
@@ -116,7 +116,7 @@ ProviderModel.init(
       allowNull: false,
     },
     config: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -1,4 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import {
   SoftDeletableWorkspaceAwareModel,
@@ -7,7 +11,6 @@ import {
 import type { AppVisibility } from "@app/types/app";
 import type { DatasetSchema } from "@app/types/dataset";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 // TODO(2024-10-04 flav) Remove visibility from here.
 export class AppModel extends SoftDeletableWorkspaceAwareModel<AppModel> {

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -11,7 +11,7 @@ import type {
 } from "@app/types/content_fragment";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentModel> {
   declare createdAt: CreationOptional<Date>;
@@ -61,7 +61,7 @@ ContentFragmentModel.init(
       allowNull: false,
     },
     title: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     contentType: {
@@ -69,7 +69,7 @@ ContentFragmentModel.init(
       allowNull: false,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     textBytes: {

--- a/front/lib/resources/storage/models/content_fragment.ts
+++ b/front/lib/resources/storage/models/content_fragment.ts
@@ -1,4 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import type { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -11,7 +15,6 @@ import type {
 } from "@app/types/content_fragment";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class ContentFragmentModel extends WorkspaceAwareModel<ContentFragmentModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/coupon_redemptions.ts
+++ b/front/lib/resources/storage/models/coupon_redemptions.ts
@@ -3,7 +3,7 @@ import { CouponModel } from "@app/lib/resources/storage/models/coupons";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class CouponRedemptionModel extends WorkspaceAwareModel<CouponRedemptionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/coupon_redemptions.ts
+++ b/front/lib/resources/storage/models/coupon_redemptions.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { CouponModel } from "@app/lib/resources/storage/models/coupons";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class CouponRedemptionModel extends WorkspaceAwareModel<CouponRedemptionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/coupons.ts
+++ b/front/lib/resources/storage/models/coupons.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class CouponModel extends BaseModel<CouponModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/coupons.ts
+++ b/front/lib/resources/storage/models/coupons.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class CouponModel extends BaseModel<CouponModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /*
  * Workspace-level configuration for AWU credit purchases. Distinct from

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /*
  * Workspace-level configuration for AWU credit purchases. Distinct from

--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -1,10 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreditType } from "@app/types/credits";
 import { CREDIT_TYPES } from "@app/types/credits";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 /**
  * CreditModel stores consumable monetary credits for programmatic API usage.

--- a/front/lib/resources/storage/models/credits.ts
+++ b/front/lib/resources/storage/models/credits.ts
@@ -4,7 +4,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type { CreditType } from "@app/types/credits";
 import { CREDIT_TYPES } from "@app/types/credits";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 /**
  * CreditModel stores consumable monetary credits for programmatic API usage.

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -5,7 +5,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class DataSourceModel extends SoftDeletableWorkspaceAwareModel<DataSourceModel> {
   declare id: CreationOptional<number>;
@@ -55,7 +55,7 @@ DataSourceModel.init(
       allowNull: false,
     },
     description: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     assistantDefaultSelected: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -1,11 +1,14 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class DataSourceModel extends SoftDeletableWorkspaceAwareModel<DataSourceModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -6,7 +7,6 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { DataSourceViewKind } from "@app/types/data_source_view";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class DataSourceViewModel extends SoftDeletableWorkspaceAwareModel<DataSourceViewModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/data_source_view.ts
+++ b/front/lib/resources/storage/models/data_source_view.ts
@@ -6,7 +6,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { DataSourceViewKind } from "@app/types/data_source_view";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class DataSourceViewModel extends SoftDeletableWorkspaceAwareModel<DataSourceViewModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -1,4 +1,13 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  type CreationOptional,
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+  type ForeignKey,
+  literal,
+  type NonAttribute,
+  Op,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -9,14 +18,6 @@ import type {
   FileUseCase,
   FileUseCaseMetadata,
 } from "@app/types/files";
-import {
-  type CreationOptional,
-  DataTypes, DANGEROUSLY_UNBOUNDED_TEXT,
-  type ForeignKey,
-  literal,
-  type NonAttribute,
-  Op,
-} from "@app/lib/resources/storage/data_types";
 
 export class FileModel extends WorkspaceAwareModel<FileModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -11,12 +11,12 @@ import type {
 } from "@app/types/files";
 import {
   type CreationOptional,
-  DataTypes,
+  DataTypes, DANGEROUSLY_UNBOUNDED_TEXT,
   type ForeignKey,
   literal,
   type NonAttribute,
   Op,
-} from "sequelize";
+} from "@app/lib/resources/storage/data_types";
 
 export class FileModel extends WorkspaceAwareModel<FileModel> {
   declare createdAt: CreationOptional<Date>;
@@ -79,7 +79,7 @@ FileModel.init(
       defaultValue: null,
     },
     snippet: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/lib/resources/storage/models/group_memberships.ts
+++ b/front/lib/resources/storage/models/group_memberships.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupMembershipModel extends WorkspaceAwareModel<GroupMembershipModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/group_memberships.ts
+++ b/front/lib/resources/storage/models/group_memberships.ts
@@ -3,7 +3,7 @@ import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupMembershipModel extends WorkspaceAwareModel<GroupMembershipModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -4,7 +4,7 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { GroupSpaceKind } from "@app/types/space";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupSpaceModel extends WorkspaceAwareModel<GroupSpaceModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -1,10 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { GroupSpaceKind } from "@app/types/space";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupSpaceModel extends WorkspaceAwareModel<GroupSpaceModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { GroupKind } from "@app/types/groups";
 import { isGlobalGroupKind, isSystemGroupKind } from "@app/types/groups";
 import type { CreationOptional, Transaction } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -3,7 +3,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type { GroupKind } from "@app/types/groups";
 import { isGlobalGroupKind, isSystemGroupKind } from "@app/types/groups";
 import type { CreationOptional, Transaction } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -4,7 +4,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type { ModelId } from "@app/types/shared/model_id";
 import type { RoleType } from "@app/types/user";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class KeyModel extends WorkspaceAwareModel<KeyModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -1,10 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { RoleType } from "@app/types/user";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class KeyModel extends WorkspaceAwareModel<KeyModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/kill_switches.ts
+++ b/front/lib/resources/storage/models/kill_switches.ts
@@ -2,7 +2,7 @@ import type { KillSwitchType } from "@app/lib/poke/types";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class KillSwitchModel extends BaseModel<KillSwitchModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/kill_switches.ts
+++ b/front/lib/resources/storage/models/kill_switches.ts
@@ -1,8 +1,8 @@
 import type { KillSwitchType } from "@app/lib/poke/types";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class KillSwitchModel extends BaseModel<KillSwitchModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -1,5 +1,6 @@
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -8,7 +9,6 @@ import type {
   LabsTranscriptsProviderType,
 } from "@app/types/labs";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class LabsTranscriptsConfigurationModel extends WorkspaceAwareModel<LabsTranscriptsConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/labs_transcripts.ts
+++ b/front/lib/resources/storage/models/labs_transcripts.ts
@@ -8,7 +8,7 @@ import type {
   LabsTranscriptsProviderType,
 } from "@app/types/labs";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class LabsTranscriptsConfigurationModel extends WorkspaceAwareModel<LabsTranscriptsConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -8,7 +8,7 @@ import type {
   UserCreditState,
 } from "@app/types/memberships";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -8,7 +9,6 @@ import type {
   UserCreditState,
 } from "@app/types/memberships";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/onboarding_tasks.ts
+++ b/front/lib/resources/storage/models/onboarding_tasks.ts
@@ -1,8 +1,11 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export const ONBOARDING_TASK_KINDS = [
   "tool_setup_admin",

--- a/front/lib/resources/storage/models/onboarding_tasks.ts
+++ b/front/lib/resources/storage/models/onboarding_tasks.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export const ONBOARDING_TASK_KINDS = [
   "tool_setup_admin",
@@ -40,7 +40,7 @@ OnboardingTaskModel.init(
       defaultValue: DataTypes.NOW,
     },
     context: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     kind: {

--- a/front/lib/resources/storage/models/plugin_runs.ts
+++ b/front/lib/resources/storage/models/plugin_runs.ts
@@ -3,7 +3,7 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { SupportedResourceType } from "@app/types/poke/plugins";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export const POKE_PLUGIN_RUN_MAX_RESULT_AND_ERROR_LENGTH = 4096;
 export const POKE_PLUGIN_RUN_MAX_ARGS_LENGTH = 1024;

--- a/front/lib/resources/storage/models/plugin_runs.ts
+++ b/front/lib/resources/storage/models/plugin_runs.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { SupportedResourceType } from "@app/types/poke/plugins";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export const POKE_PLUGIN_RUN_MAX_RESULT_AND_ERROR_LENGTH = 4096;
 export const POKE_PLUGIN_RUN_MAX_ARGS_LENGTH = 1024;

--- a/front/lib/resources/storage/models/programmatic_usage_configurations.ts
+++ b/front/lib/resources/storage/models/programmatic_usage_configurations.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /*
  * Fields:

--- a/front/lib/resources/storage/models/programmatic_usage_configurations.ts
+++ b/front/lib/resources/storage/models/programmatic_usage_configurations.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /*
  * Fields:

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -1,8 +1,11 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataModel> {
   declare id: CreationOptional<number>;
@@ -33,7 +33,7 @@ ProjectMetadataModel.init(
       defaultValue: DataTypes.NOW,
     },
     description: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     archivedAt: {

--- a/front/lib/resources/storage/models/project_task.ts
+++ b/front/lib/resources/storage/models/project_task.ts
@@ -10,7 +10,7 @@ import type {
   PodTaskStatus,
 } from "@app/types/project_task";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 // ── Shared attributes ───────────────────────────────────────────────────────
 // Used by both the main table and the version snapshot table so that
@@ -74,7 +74,7 @@ const PROJECT_TODO_MODEL_ATTRIBUTES = {
     comment: "Category of the todo: to_do, to_know.",
   },
   text: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: false,
   },
   status: {
@@ -87,12 +87,12 @@ const PROJECT_TODO_MODEL_ATTRIBUTES = {
     allowNull: true,
   },
   actorRationale: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
     comment: "Explanation for why the actor made a change.",
   },
   agentInstructions: {
-    type: DataTypes.TEXT,
+    type: DANGEROUSLY_UNBOUNDED_TEXT,
     allowNull: true,
     comment:
       "Optional kickoff instructions for the agent when this todo is started.",
@@ -437,11 +437,11 @@ ProjectTaskSourceModel.init(
         "String identifier of the source (conversation sId, external URL/ID, etc.) that led to creating this todo.",
     },
     sourceTitle: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/front/lib/resources/storage/models/project_task.ts
+++ b/front/lib/resources/storage/models/project_task.ts
@@ -1,5 +1,9 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -10,7 +14,6 @@ import type {
   PodTaskStatus,
 } from "@app/types/project_task";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 // ── Shared attributes ───────────────────────────────────────────────────────
 // Used by both the main table and the version snapshot table so that

--- a/front/lib/resources/storage/models/project_task_state.ts
+++ b/front/lib/resources/storage/models/project_task_state.ts
@@ -3,7 +3,7 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ProjectTaskStateModel extends WorkspaceAwareModel<ProjectTaskStateModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/project_task_state.ts
+++ b/front/lib/resources/storage/models/project_task_state.ts
@@ -1,9 +1,9 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class ProjectTaskStateModel extends WorkspaceAwareModel<ProjectTaskStateModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class RunModel extends WorkspaceAwareModel<RunModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class RunModel extends WorkspaceAwareModel<RunModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -1,8 +1,8 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export type SandboxStatus =
   | "running"

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -2,7 +2,7 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export type SandboxStatus =
   | "running"

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -4,7 +4,7 @@ import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wra
 import type { SpaceKind } from "@app/types/space";
 import { isUniqueSpaceKind } from "@app/types/space";
 import type { CreationOptional, NonAttribute, Transaction } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 // Note, "Spaces" used to be called "Vaults" in the first release but where renamed to "Spaces" right after.
 // This is why the model is called "SpaceModel" but the table is called "vaults" and foreign key are called "vaultId" in ResourceWithSpace.

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,10 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import type { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { SpaceKind } from "@app/types/space";
 import { isUniqueSpaceKind } from "@app/types/space";
 import type { CreationOptional, NonAttribute, Transaction } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 // Note, "Spaces" used to be called "Vaults" in the first release but where renamed to "Spaces" right after.
 // This is why the model is called "SpaceModel" but the table is called "vaults" and foreign key are called "vaultId" in ResourceWithSpace.

--- a/front/lib/resources/storage/models/takeaways.ts
+++ b/front/lib/resources/storage/models/takeaways.ts
@@ -4,7 +4,7 @@ import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspa
 import type { PodTaskSourceType } from "@app/types/project_task";
 import type { TaskVersionedActionItem } from "@app/types/takeaways";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 // ── Shared attributes ────────────────────────────────────────────────────────
 // Used by both the main table and the version snapshot table so that
@@ -171,11 +171,11 @@ TakeawaySourcesModel.init(
         "String identifier of the source (internal SID or external URL/ID) that produced this takeaway.",
     },
     sourceTitle: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
     sourceUrl: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
     },
   },

--- a/front/lib/resources/storage/models/takeaways.ts
+++ b/front/lib/resources/storage/models/takeaways.ts
@@ -1,10 +1,13 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { PodTaskSourceType } from "@app/types/project_task";
 import type { TaskVersionedActionItem } from "@app/types/takeaways";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 // ── Shared attributes ────────────────────────────────────────────────────────
 // Used by both the main table and the version snapshot table so that

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -1,4 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import type { AssistantCreativityLevel } from "@app/types/assistant/builder";
 import type {
@@ -12,7 +16,6 @@ import type {
 } from "@app/types/assistant/templates";
 import type { TimeframeUnit } from "@app/types/shared/utils/time_frame";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class TemplateModel extends BaseModel<TemplateModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/templates.ts
+++ b/front/lib/resources/storage/models/templates.ts
@@ -12,7 +12,7 @@ import type {
 } from "@app/types/assistant/templates";
 import type { TimeframeUnit } from "@app/types/shared/utils/time_frame";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class TemplateModel extends BaseModel<TemplateModel> {
   declare createdAt: CreationOptional<Date>;
@@ -57,10 +57,10 @@ TemplateModel.init(
       defaultValue: DataTypes.NOW,
     },
     userFacingDescription: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     agentFacingDescription: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     backgroundColor: {
       type: DataTypes.STRING,
@@ -79,10 +79,10 @@ TemplateModel.init(
       allowNull: false,
     },
     presetDescription: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     presetInstructions: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     presetTemperature: {
       type: DataTypes.STRING,
@@ -110,13 +110,13 @@ TemplateModel.init(
       allowNull: true,
     },
     helpInstructions: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     helpActions: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     sidekickInstructions: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
     },
     tags: {
       type: DataTypes.ARRAY(DataTypes.STRING),

--- a/front/lib/resources/storage/models/user.ts
+++ b/front/lib/resources/storage/models/user.ts
@@ -4,7 +4,7 @@ import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { UserProviderType } from "@app/types/user";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT, Op } from "@app/lib/resources/storage/data_types";
 
 export class UserModel extends BaseModel<UserModel> {
   declare createdAt: CreationOptional<Date>;
@@ -132,7 +132,7 @@ UserMetadataModel.init(
       allowNull: false,
     },
     value: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/front/lib/resources/storage/models/user.ts
+++ b/front/lib/resources/storage/models/user.ts
@@ -1,10 +1,14 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+  Op,
+} from "@app/lib/resources/storage/data_types";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { UserProviderType } from "@app/types/user";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT, Op } from "@app/lib/resources/storage/data_types";
 
 export class UserModel extends BaseModel<UserModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/user_project_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_preferences.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -7,7 +8,6 @@ import {
   type NotificationCondition,
 } from "@app/types/notification_preferences";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class UserProjectPreferencesModel extends WorkspaceAwareModel<UserProjectPreferencesModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/user_project_preferences.ts
+++ b/front/lib/resources/storage/models/user_project_preferences.ts
@@ -7,7 +7,7 @@ import {
   type NotificationCondition,
 } from "@app/types/notification_preferences";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class UserProjectPreferencesModel extends WorkspaceAwareModel<UserProjectPreferencesModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -1,6 +1,10 @@
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -8,7 +12,6 @@ import type {
   WakeUpStatus,
 } from "@app/types/assistant/wakeups";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WakeUpModel extends WorkspaceAwareModel<WakeUpModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/wakeup.ts
+++ b/front/lib/resources/storage/models/wakeup.ts
@@ -8,7 +8,7 @@ import type {
   WakeUpStatus,
 } from "@app/types/assistant/wakeups";
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WakeUpModel extends WorkspaceAwareModel<WakeUpModel> {
   declare createdAt: CreationOptional<Date>;
@@ -68,17 +68,17 @@ WakeUpModel.init(
       defaultValue: null,
     },
     cronExpression: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },
     cronTimezone: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: true,
       defaultValue: null,
     },
     reason: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
     status: {

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -1,5 +1,6 @@
 import type { SubscriptionModel } from "@app/lib/models/plan";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
@@ -12,7 +13,6 @@ import type {
   WorkspaceSharingPolicy,
 } from "@app/types/user";
 import type { CreationOptional, NonAttribute } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 const DEFAULT_SHARING_POLICY: WorkspaceSharingPolicy = "all_scopes";
 

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -12,7 +12,7 @@ import type {
   WorkspaceSharingPolicy,
 } from "@app/types/user";
 import type { CreationOptional, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 const DEFAULT_SHARING_POLICY: WorkspaceSharingPolicy = "all_scopes";
 

--- a/front/lib/resources/storage/models/workspace_has_domain.ts
+++ b/front/lib/resources/storage/models/workspace_has_domain.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class WorkspaceHasDomainModel extends WorkspaceAwareModel<WorkspaceHasDomainModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/workspace_has_domain.ts
+++ b/front/lib/resources/storage/models/workspace_has_domain.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 export class WorkspaceHasDomainModel extends WorkspaceAwareModel<WorkspaceHasDomainModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
+++ b/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
@@ -3,7 +3,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WorkspaceSandboxEnvVarKind } from "@app/types/sandbox/env_var";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WorkspaceSandboxEnvVarModel extends WorkspaceAwareModel<WorkspaceSandboxEnvVarModel> {
   declare id: CreationOptional<number>;
@@ -39,7 +39,7 @@ WorkspaceSandboxEnvVarModel.init(
       allowNull: false,
     },
     kind: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
       defaultValue: "config",
     },
@@ -49,12 +49,12 @@ WorkspaceSandboxEnvVarModel.init(
       field: "placeholder_nonce",
     },
     allowedDomains: {
-      type: DataTypes.ARRAY(DataTypes.TEXT),
+      type: DataTypes.ARRAY(DANGEROUSLY_UNBOUNDED_TEXT),
       allowNull: true,
       field: "allowed_domains",
     },
     encryptedValue: {
-      type: DataTypes.TEXT,
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
       allowNull: false,
     },
   },

--- a/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
+++ b/front/lib/resources/storage/models/workspace_sandbox_env_var.ts
@@ -1,9 +1,12 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { WorkspaceSandboxEnvVarKind } from "@app/types/sandbox/env_var";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes, DANGEROUSLY_UNBOUNDED_TEXT } from "@app/lib/resources/storage/data_types";
 
 export class WorkspaceSandboxEnvVarModel extends WorkspaceAwareModel<WorkspaceSandboxEnvVarModel> {
   declare id: CreationOptional<number>;

--- a/front/lib/resources/storage/models/workspace_seat_limit.ts
+++ b/front/lib/resources/storage/models/workspace_seat_limit.ts
@@ -2,7 +2,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /**
  * Per-(workspace, seat-type) seat configuration.

--- a/front/lib/resources/storage/models/workspace_seat_limit.ts
+++ b/front/lib/resources/storage/models/workspace_seat_limit.ts
@@ -1,8 +1,8 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { CreationOptional } from "sequelize";
-import { DataTypes } from "@app/lib/resources/storage/data_types";
 
 /**
  * Per-(workspace, seat-type) seat configuration.

--- a/front/lib/resources/storage/models/workspace_verification_attempt.ts
+++ b/front/lib/resources/storage/models/workspace_verification_attempt.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class WorkspaceVerificationAttemptModel extends WorkspaceAwareModel<WorkspaceVerificationAttemptModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/models/workspace_verification_attempt.ts
+++ b/front/lib/resources/storage/models/workspace_verification_attempt.ts
@@ -1,7 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 
 export class WorkspaceVerificationAttemptModel extends WorkspaceAwareModel<WorkspaceVerificationAttemptModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/storage/wrappers/base.ts
+++ b/front/lib/resources/storage/wrappers/base.ts
@@ -6,7 +6,7 @@ import type {
   ModelAttributes,
   ModelStatic,
 } from "sequelize";
-import { DataTypes, Model } from "sequelize";
+import { DataTypes, Model } from "@app/lib/resources/storage/data_types";
 
 interface BaseModelAttributes {
   id?: {

--- a/front/lib/resources/storage/wrappers/base.ts
+++ b/front/lib/resources/storage/wrappers/base.ts
@@ -1,3 +1,4 @@
+import { DataTypes, Model } from "@app/lib/resources/storage/data_types";
 import type {
   CreationOptional,
   InferAttributes,
@@ -6,7 +7,6 @@ import type {
   ModelAttributes,
   ModelStatic,
 } from "sequelize";
-import { DataTypes, Model } from "@app/lib/resources/storage/data_types";
 
 interface BaseModelAttributes {
   id?: {

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -1,3 +1,4 @@
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import logger from "@app/logger/logger";
@@ -19,7 +20,6 @@ import type {
   UpdateOptions,
   WhereOptions,
 } from "sequelize";
-import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import type { ModelHooks } from "sequelize/lib/hooks";
 
 // Log only 1 time out of 100 on average.

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -19,7 +19,7 @@ import type {
   UpdateOptions,
   WhereOptions,
 } from "sequelize";
-import { DataTypes, Op } from "sequelize";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
 import type { ModelHooks } from "sequelize/lib/hooks";
 
 // Log only 1 time out of 100 on average.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
`DataTypes.TEXT` is an unbounded column type with no way to distinguish intentional from accidental usage. This introduces a `DataTypes` wrapper that re-exports everything from sequelize with `TEXT` removed. Unbounded columns must now explicitly use `DANGEROUSLY_UNBOUNDED_TEXT`, making the intent visible in code review. A grit rule enforces that `DataTypes` is never imported directly from sequelize in model files, and all 76 existing model files have been migrated to the new import path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

No migrations required, just changing imports.
