### PR TITLE
[front] business-activation: fix user for coupon redemption

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -206,7 +206,10 @@ export async function createPaymentGatedBusinessActivation({
     if (validation.isErr()) {
       return new Err({ type: "invalid_coupon" });
     }
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const auth = userId
+      ? await Authenticator.fromUserIdAndWorkspaceId(userId, workspace.sId)
+      : await Authenticator.internalAdminForWorkspace(workspace.sId);
     const existing =
       await CouponRedemptionResource.findActiveOrPendingByCouponAndWorkspace(
         auth,


### PR DESCRIPTION
## Description

Fix the retrieval of the user in business-activation in order to properly redeem a coupon with this user

## Tests

Tested locally => we now have a user set in "redeemedBy" field for a redemption during business activation

## Risk

Low, very specific for business activation and coupon redemption

## Deploy Plan

Deploy front
