### PR TITLE
[Skills] Fix Skill Builder inline reference chips

### DIFF
--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -11,7 +11,6 @@ export { SKILL_NODE_TYPE };
 
 interface SkillNodeOptions {
   onSkillDetails?: (skillId: string) => void;
-  removable?: boolean;
 }
 
 // Interactive variant of SkillNode that adds the React node view. The
@@ -22,7 +21,6 @@ export const SkillNode = SkillNodeBase.extend<SkillNodeOptions>({
     return {
       ...this.parent?.(),
       onSkillDetails: undefined,
-      removable: false,
     };
   },
 
@@ -33,11 +31,7 @@ export const SkillNode = SkillNodeBase.extend<SkillNodeOptions>({
           attrs: props.node.attrs,
         }}
         onDetails={this.options.onSkillDetails}
-        onRemove={
-          this.options.removable && props.editor.isEditable
-            ? props.deleteNode
-            : undefined
-        }
+        onRemove={props.editor.isEditable ? props.deleteNode : undefined}
       />
     ));
   },

--- a/front/components/editor/extensions/input_bar/SkillNode.tsx
+++ b/front/components/editor/extensions/input_bar/SkillNode.tsx
@@ -11,6 +11,7 @@ export { SKILL_NODE_TYPE };
 
 interface SkillNodeOptions {
   onSkillDetails?: (skillId: string) => void;
+  removable?: boolean;
 }
 
 // Interactive variant of SkillNode that adds the React node view. The
@@ -21,6 +22,7 @@ export const SkillNode = SkillNodeBase.extend<SkillNodeOptions>({
     return {
       ...this.parent?.(),
       onSkillDetails: undefined,
+      removable: false,
     };
   },
 
@@ -31,6 +33,11 @@ export const SkillNode = SkillNodeBase.extend<SkillNodeOptions>({
           attrs: props.node.attrs,
         }}
         onDetails={this.options.onSkillDetails}
+        onRemove={
+          this.options.removable && props.editor.isEditable
+            ? props.deleteNode
+            : undefined
+        }
       />
     ));
   },

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -65,7 +65,11 @@ interface InlineKnowledgeChipProps {
   title: string;
 }
 
-function InlineKnowledgeIcon({ node }: { node: KnowledgeNode }) {
+interface InlineKnowledgeIconProps {
+  node: KnowledgeNode;
+}
+
+function InlineKnowledgeIcon({ node }: InlineKnowledgeIconProps) {
   if (
     isWebsite(node.dataSourceView.dataSource) ||
     isFolder(node.dataSourceView.dataSource)

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -2,7 +2,13 @@ import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_provide
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
 import type { DataSourceViewContentNode } from "@app/lib/swr/search";
-import { AlertCircle, AttachmentChip, DoubleIcon } from "@dust-tt/sparkle";
+import {
+  AlertCircle,
+  AttachmentChip,
+  Chip,
+  DoubleIcon,
+  Icon,
+} from "@dust-tt/sparkle";
 import type React from "react";
 
 type KnowledgeNode = Omit<
@@ -52,6 +58,64 @@ export function KnowledgeChip({
   );
 }
 
+interface InlineKnowledgeChipProps {
+  color?: React.ComponentProps<typeof Chip>["color"];
+  node: KnowledgeNode;
+  onRemove?: () => void;
+  title: string;
+}
+
+function InlineKnowledgeIcon({ node }: { node: KnowledgeNode }) {
+  if (
+    isWebsite(node.dataSourceView.dataSource) ||
+    isFolder(node.dataSourceView.dataSource)
+  ) {
+    return (
+      <Icon visual={getVisualForDataSourceViewContentNode(node)} size="xs" />
+    );
+  }
+
+  return (
+    <DoubleIcon
+      size="sm"
+      mainIcon={getVisualForDataSourceViewContentNode(node)}
+      secondaryIcon={getConnectorProviderLogoWithFallback({
+        provider: node.dataSourceView.dataSource.connectorProvider,
+      })}
+    />
+  );
+}
+
+export function InlineKnowledgeChip({
+  color = "white",
+  node,
+  title,
+  onRemove,
+}: InlineKnowledgeChipProps) {
+  const children = <InlineKnowledgeIcon node={node} />;
+
+  if (node.sourceUrl) {
+    return (
+      <Chip
+        label={title}
+        href={node.sourceUrl}
+        target="_blank"
+        color={color}
+        onRemove={onRemove}
+        size="xs"
+      >
+        {children}
+      </Chip>
+    );
+  }
+
+  return (
+    <Chip label={title} color={color} onRemove={onRemove} size="xs">
+      {children}
+    </Chip>
+  );
+}
+
 interface KnowledgeErrorChipProps {
   errorMessage?: string;
   onRemove?: () => void;
@@ -63,10 +127,9 @@ export function KnowledgeErrorChip({
   title,
 }: KnowledgeErrorChipProps) {
   return (
-    <AttachmentChip
+    <Chip
       label={title}
-      icon={{ visual: AlertCircle }}
-      target="_blank"
+      icon={AlertCircle}
       color="white"
       onRemove={onRemove}
       size="xs"

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -1,6 +1,6 @@
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import {
-  KnowledgeChip,
+  InlineKnowledgeChip,
   KnowledgeErrorChip,
 } from "@app/components/editor/extensions/skill_builder/KnowledgeChip";
 import type { KnowledgeNodeAttributes } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
@@ -24,6 +24,7 @@ import { useSpaceDataSourceView, useSpaces } from "@app/lib/swr/spaces";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  Chip,
   cn,
   DoubleIcon,
   DropdownMenu,
@@ -128,21 +129,19 @@ export function KnowledgeDisplayComponent({
   // Show loading state while fetching node data or waiting for upgrade to full item.
   if (isFetchingNode || (needsFetch && !isFullKnowledgeItem(item))) {
     return (
-      <span
-        className={cn(
-          "inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-1",
-          "text-sm text-gray-600"
-        )}
-      >
+      <Chip label={item.label} color="white" size="xs">
         <Spinner size="xs" />
-        <span>{item.label}</span>
-      </span>
+      </Chip>
     );
   }
 
   // At this point we must have a full item with node data.
   return (
-    <KnowledgeChip node={item.node} onRemove={onRemove} title={item.label} />
+    <InlineKnowledgeChip
+      node={item.node}
+      onRemove={onRemove}
+      title={item.label}
+    />
   );
 }
 

--- a/front/components/editor/extensions/skill_builder/ToolChip.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolChip.tsx
@@ -3,12 +3,7 @@ import {
   isCustomResourceIconType,
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
-import {
-  AlertCircle,
-  AttachmentChip,
-  Chip,
-  ShapesPlus,
-} from "@dust-tt/sparkle";
+import { AlertCircle, Chip, ShapesPlus } from "@dust-tt/sparkle";
 import type React from "react";
 
 function getToolIcon(toolIcon: string | null) {
@@ -23,7 +18,7 @@ function getToolIcon(toolIcon: string | null) {
 }
 
 interface ToolChipProps {
-  color?: React.ComponentProps<typeof AttachmentChip>["color"];
+  color?: React.ComponentProps<typeof Chip>["color"];
   onClick?: () => void;
   onRemove?: () => void;
   title: string;
@@ -56,9 +51,9 @@ interface ToolErrorChipProps {
 
 export function ToolErrorChip({ onRemove, title }: ToolErrorChipProps) {
   return (
-    <AttachmentChip
+    <Chip
       label={title}
-      icon={{ visual: AlertCircle }}
+      icon={AlertCircle}
       color="white"
       onRemove={onRemove}
       size="xs"

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -9,7 +9,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 interface ToolNodeWithViewOptions {
   onToolDetails?: (tool: MCPServerViewType) => void;
@@ -59,7 +59,12 @@ function useToolNodeDisplay(attrs: ToolNodeAttributes) {
   }, [attrs.mcpServerViewId, attrs.toolIcon, attrs.toolName, ctx]);
 }
 
-function ToolNodeView({ node, onToolDetails }: ToolNodeViewProps) {
+function ToolNodeView({
+  deleteNode,
+  editor,
+  node,
+  onToolDetails,
+}: ToolNodeViewProps) {
   const attrs: ToolNodeAttributes = {
     mcpServerViewId: node.attrs.mcpServerViewId,
     toolIcon: node.attrs.toolIcon,
@@ -70,16 +75,21 @@ function ToolNodeView({ node, onToolDetails }: ToolNodeViewProps) {
     display.kind === "tool" && display.view && onToolDetails
       ? () => onToolDetails(display.view)
       : undefined;
+  const handleRemove = useCallback(() => {
+    deleteNode();
+  }, [deleteNode]);
+  const onRemove = editor.isEditable ? handleRemove : undefined;
 
   return (
     <NodeViewWrapper className="inline-flex align-middle">
       {display.kind === "error" ? (
-        <ToolErrorChip title={display.title} />
+        <ToolErrorChip title={display.title} onRemove={onRemove} />
       ) : (
         <ToolChip
           title={display.title}
           toolIcon={display.toolIcon}
           onClick={handleClick}
+          onRemove={onRemove}
         />
       )}
     </NodeViewWrapper>

--- a/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/ToolNodeWithView.tsx
@@ -9,7 +9,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeViewProps } from "@tiptap/react";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 
 interface ToolNodeWithViewOptions {
   onToolDetails?: (tool: MCPServerViewType) => void;
@@ -75,10 +75,7 @@ function ToolNodeView({
     display.kind === "tool" && display.view && onToolDetails
       ? () => onToolDetails(display.view)
       : undefined;
-  const handleRemove = useCallback(() => {
-    deleteNode();
-  }, [deleteNode]);
-  const onRemove = editor.isEditable ? handleRemove : undefined;
+  const onRemove = editor.isEditable ? deleteNode : undefined;
 
   return (
     <NodeViewWrapper className="inline-flex align-middle">

--- a/front/components/editor/input_bar/SkillNodeComponent.tsx
+++ b/front/components/editor/input_bar/SkillNodeComponent.tsx
@@ -16,11 +16,13 @@ interface SkillNodeComponentProps {
     };
   };
   onDetails?: (skillId: string) => void;
+  onRemove?: () => void;
 }
 
 export function SkillNodeComponent({
   node,
   onDetails,
+  onRemove,
 }: SkillNodeComponentProps) {
   if (node.attrs.skillUnavailable === true) {
     return (
@@ -36,6 +38,7 @@ export function SkillNodeComponent({
                 icon={AlertCircle}
                 color="warning"
                 size="xs"
+                onRemove={onRemove}
               />
             </span>
           }
@@ -57,6 +60,7 @@ export function SkillNodeComponent({
         icon={getSkillIcon(skillIcon)}
         color="white"
         onClick={handleClick}
+        onRemove={onRemove}
         size="xs"
       />
     </NodeViewWrapper>

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -99,7 +99,10 @@ export function buildSkillInstructionsExtensions(
     BlockIdExtension,
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
     ToolNodeWithView.configure({ onToolDetails }),
-    SkillNode.configure({ onSkillDetails: onSkillNodeDetails }),
+    SkillNode.configure({
+      onSkillDetails: onSkillNodeDetails,
+      removable: !isReadOnly,
+    }),
   ];
 
   baseExtensions.push(

--- a/front/lib/editor/build_skill_instructions_extensions.ts
+++ b/front/lib/editor/build_skill_instructions_extensions.ts
@@ -99,10 +99,7 @@ export function buildSkillInstructionsExtensions(
     BlockIdExtension,
     KnowledgeNodeWithView.configure({ readOnly: isReadOnly }),
     ToolNodeWithView.configure({ onToolDetails }),
-    SkillNode.configure({
-      onSkillDetails: onSkillNodeDetails,
-      removable: !isReadOnly,
-    }),
+    SkillNode.configure({ onSkillDetails: onSkillNodeDetails }),
   ];
 
   baseExtensions.push(

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -264,7 +264,7 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
         {onRemove && (
           <ChipButton
             icon={XClose}
-            size={size === "mini" ? "xs" : "sm"}
+            size={size === "sm" ? "sm" : "xs"}
             className={cn("-s-mr-1", closeIconVariants[color || "primary"])}
             aria-label="Remove"
             onClick={(e) => {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8742

Skill Builder inline references used two different chip implementations: knowledge references used the attachment chip styling while tool and skill references used the smaller chip styling. Tools and skills also did not receive a remove handler from their node views, so only knowledge references exposed a close control.

This updates inline knowledge references to use the compact chip shape, wires close controls for inline tool and skill references, and keeps regular input-bar skill mentions unchanged by making skill-chip removal opt-in for the skill instructions editor.

## Risks
Blast radius: Skill Builder instruction editor inline knowledge, tool, and skill reference chips.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `NODE_ENV=test npm test -- components/editor/extensions/skill_builder/ToolNode.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts lib/editor/skill_instructions_preprocessing.test.ts`