### PR TITLE
Fix Confluence search title validation

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -70,7 +70,9 @@ const ConfluencePageCodec = t.intersection([
 const SearchBaseContentCodec = t.type({
   id: t.string,
   status: t.string,
-  title: t.string,
+  // Some Confluence search results can have a null or missing title. The
+  // sync only needs titles when fetching full pages, not when building refs.
+  title: t.union([t.string, t.null, t.undefined]),
 
   // Version info.
   version: t.type({
@@ -96,7 +98,7 @@ const SearchBaseContentCodec = t.type({
     t.type({
       id: t.string,
       type: t.string,
-      title: t.union([t.undefined, t.string]),
+      title: t.union([t.string, t.null, t.undefined]),
     })
   ),
 });


### PR DESCRIPTION
## Description

Fixes Confluence sync failures where the legacy search endpoint returns root content or ancestor entries with a null or missing title.

The failing workflow was retrying `fetchAndUpsertRootContentActivity` with `Response validation failed` while decoding `SearchConfluenceContentCodec`. The sync only needs titles when fetching full pages, not when building root/child content refs, so this makes titles from the search endpoint nullable/missing-tolerant.

## Tests

- `git diff --check`

No local unit tests were run in the Computer. Validation is expected through PR CI.

## Risk

Low. This only loosens Confluence legacy search response validation for title fields that are not used when building `ConfluenceContentRef`. If Confluence returns null or omits a title, the sync can keep enumerating the content tree instead of retrying indefinitely.

## Deploy Plan

Deploy connectors.
