### PR TITLE
[Skills] Sort capability dropdown skills

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -9,6 +9,10 @@ import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+import {
+  compareCapabilitiesByName,
+  getCapabilitySortName,
+} from "@app/lib/capabilities/sort";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   useAvailableMCPServers,
@@ -495,7 +499,7 @@ export function CapabilitiesPicker({
           id: `skills-picker-${skill.sId}`,
           icon: getSkillAvatarIcon(skill.icon),
           label: skill.name,
-          sortName: skill.name.toLowerCase(),
+          sortName: getCapabilitySortName(skill.name),
           description,
         });
       }
@@ -522,7 +526,7 @@ export function CapabilitiesPicker({
           id: `capabilities-picker-${serverView.sId}`,
           icon: () => getAvatar(serverView.server),
           label,
-          sortName: label.toLowerCase(),
+          sortName: getCapabilitySortName(label),
           description,
         });
       }
@@ -555,7 +559,7 @@ export function CapabilitiesPicker({
           id: `tools-to-install-${server.sId}`,
           icon: () => getAvatar(server),
           label,
-          sortName: label.toLowerCase(),
+          sortName: getCapabilitySortName(label),
           description,
         });
       }
@@ -570,7 +574,7 @@ export function CapabilitiesPicker({
         return groupComparison;
       }
 
-      return a.sortName.localeCompare(b.sortName);
+      return compareCapabilitiesByName(a, b);
     });
   })();
 

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -61,4 +61,29 @@ describe("filterInputBarSlashSuggestions", () => {
       )
     ).toEqual(["Google Drive", "Generate Daily Report"]);
   });
+
+  it("orders skills alphabetically without a query", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const zedSkill = await SkillFactory.create(auth, {
+      name: "Zed",
+      userFacingDescription: "",
+    });
+    const alphaSkill = await SkillFactory.create(auth, {
+      name: "Alpha",
+      userFacingDescription: "",
+    });
+
+    const result = filterInputBarSlashSuggestions({
+      query: "",
+      selectedMCPServerViewIds: new Set(),
+      serverViews: [],
+      skills: [zedSkill.toJSON(auth), alphaSkill.toJSON(auth)],
+    });
+
+    expect(
+      result.map((capability) =>
+        capability.kind === "skill" ? capability.skill.name : ""
+      )
+    ).toEqual(["Alpha", "Zed"]);
+  });
 });

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -12,6 +12,7 @@ import type {
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { getCapabilitySortName } from "@app/lib/capabilities/sort";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -58,7 +59,7 @@ export function filterInputBarSlashSuggestions({
       .map((skill) => ({
         kind: "skill" as const,
         skill,
-        sortName: skill.name.toLowerCase(),
+        sortName: getCapabilitySortName(skill.name),
       })),
     ...serverViews
       .filter((serverView) => isJITMCPServerView(serverView))
@@ -72,7 +73,7 @@ export function filterInputBarSlashSuggestions({
       .map((serverView) => ({
         kind: "tool" as const,
         serverView,
-        sortName: getToolSlashCommandLabel(serverView).toLowerCase(),
+        sortName: getCapabilitySortName(getToolSlashCommandLabel(serverView)),
       })),
   ];
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -5,8 +5,9 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { sortCapabilityMatches } from "@app/lib/capabilities/sort";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import { subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
@@ -38,16 +39,7 @@ export function matchesSlashCommandCapabilityQuery({
 export function sortSlashCommandCapabilityMatches<
   T extends { sortName: string },
 >({ items, normalizedQuery }: { items: T[]; normalizedQuery: string }): T[] {
-  return items.toSorted((a, b) => {
-    if (normalizedQuery.length > 0) {
-      return (
-        compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
-        a.sortName.localeCompare(b.sortName)
-      );
-    }
-
-    return a.sortName.localeCompare(b.sortName);
-  });
+  return sortCapabilityMatches({ items, normalizedQuery });
 }
 
 export function getToolSlashCommandLabel(tool: SlashCommandToolSuggestion) {

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -169,6 +169,26 @@ describe("buildSkillBuilderSlashCommandItems", () => {
     });
   });
 
+  it("orders skills alphabetically without a query", () => {
+    const result = buildSkillBuilderSlashCommandItems({
+      baseItems: [],
+      includeSkillSuggestions: true,
+      query: "",
+      skills: [
+        skillSuggestion({
+          name: "Zed",
+          sId: "skill_zed",
+        }),
+        skillSuggestion({
+          name: "Alpha",
+          sId: "skill_alpha",
+        }),
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["skill_alpha", "skill_zed"]);
+  });
+
   it("labels the first tool section when there are no matching skills", () => {
     const result = buildSkillBuilderSlashCommandItems({
       baseItems: [],

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -17,6 +17,7 @@ import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_bu
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { getCapabilitySortName } from "@app/lib/capabilities/sort";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Attachment01 } from "@dust-tt/sparkle";
@@ -130,7 +131,7 @@ function filterSkillBuilderSlashCommandCapabilities({
         .map((skill) => ({
           kind: "skill" as const,
           skill,
-          sortName: skill.name.toLowerCase(),
+          sortName: getCapabilitySortName(skill.name),
         })),
       ...tools
         .filter((tool) =>
@@ -142,7 +143,7 @@ function filterSkillBuilderSlashCommandCapabilities({
         .map((tool) => ({
           kind: "tool" as const,
           tool,
-          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
+          sortName: getCapabilitySortName(getToolSlashCommandLabel(tool)),
         })),
     ],
   });

--- a/front/lib/capabilities/sort.test.ts
+++ b/front/lib/capabilities/sort.test.ts
@@ -1,0 +1,19 @@
+import {
+  getCapabilitySortName,
+  sortCapabilityMatches,
+} from "@app/lib/capabilities/sort";
+import { describe, expect, it } from "vitest";
+
+describe("sortCapabilityMatches", () => {
+  it("sorts by normalized capability name without a query", () => {
+    const result = sortCapabilityMatches({
+      normalizedQuery: "",
+      items: [
+        { id: "z", sortName: getCapabilitySortName("Zed") },
+        { id: "a", sortName: getCapabilitySortName("Alpha") },
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["a", "z"]);
+  });
+});

--- a/front/lib/capabilities/sort.ts
+++ b/front/lib/capabilities/sort.ts
@@ -1,0 +1,35 @@
+import { compareForFuzzySort } from "@app/lib/utils";
+
+export type CapabilitySortItem = {
+  sortName: string;
+};
+
+export function getCapabilitySortName(name: string) {
+  return name.toLowerCase();
+}
+
+export function compareCapabilitiesByName<T extends CapabilitySortItem>(
+  a: T,
+  b: T
+) {
+  return a.sortName.localeCompare(b.sortName);
+}
+
+export function sortCapabilityMatches<T extends CapabilitySortItem>({
+  items,
+  normalizedQuery,
+}: {
+  items: T[];
+  normalizedQuery: string;
+}): T[] {
+  return items.toSorted((a, b) => {
+    if (normalizedQuery.length > 0) {
+      return (
+        compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
+        compareCapabilitiesByName(a, b)
+      );
+    }
+
+    return compareCapabilitiesByName(a, b);
+  });
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8615

Adds a shared capability ordering helper used by the Skill Builder slash capability dropdown, the input-bar slash dropdown, and the input-bar capabilities picker. Skill options now use the same normalized alphabetical sort key across these surfaces while preserving existing fuzzy relevance when a query is typed.

I did not add usage ranking because the nearby usage data is analytics or reinforcement-oriented, not a cheap per-user signal for these dropdowns.

## Risks

Blast radius: capability dropdown ordering in Skill Builder and the conversation input bar.
Risk: low

## Deploy Plan

- deploy front

## Tests

- [x] NODE_ENV=test npm test components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts lib/capabilities/sort.test.ts