### PR TITLE
Add: poke plug in to diagnose MCP server.

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
@@ -33,7 +33,17 @@ app.get(
     }
 
     return ctx.json({
-      serverViews: mcpServerViews.map((sv) => sv.toJSON()),
+      serverViews: mcpServerViews.map((sv) => {
+        const space = sv.space.toJSON();
+        return {
+          ...sv.toJSON(),
+          space: {
+            sId: space.sId,
+            name: space.name,
+            kind: space.kind,
+          },
+        };
+      }),
     });
   }
 );

--- a/front-api/routes/poke/workspaces/[wId]/memberships.ts
+++ b/front-api/routes/poke/workspaces/[wId]/memberships.ts
@@ -1,12 +1,91 @@
-import type { PokeGetMemberships } from "@app/lib/api/poke/memberships";
+import type {
+  PokeGetMemberships,
+  PokeSearchWorkspaceMembers,
+} from "@app/lib/api/poke/memberships";
 import { getMembers } from "@app/lib/api/workspace";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { getMembershipInvitationUrl } from "@app/lib/utils/invitation_token";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const SearchMembersQuerySchema = z.object({
+  q: z.string().optional().default(""),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(25),
+});
+
+function formatMemberSearchResults(
+  members: { sId: string; fullName: string | null; email: string }[]
+): PokeSearchWorkspaceMembers["members"] {
+  return members.map((member) => ({
+    sId: member.sId,
+    fullName: member.fullName,
+    email: member.email,
+  }));
+}
+
+function filterMembersByQuery(
+  members: { sId: string; fullName: string | null; email: string }[],
+  query: string
+) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return members;
+  }
+
+  return members.filter((member) => {
+    const haystack = `${member.fullName ?? ""} ${member.email}`.toLowerCase();
+    return haystack.includes(normalizedQuery);
+  });
+}
 
 // Mounted at /api/poke/workspaces/:wId/memberships.
 const app = pokeApp();
+
+/** @ignoreswagger */
+// Poke-only member search for plugin comboboxes (name/email prefix via Elasticsearch).
+app.get("/search", validate("query", SearchMembersQuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { q, limit } = ctx.req.valid("query");
+
+  const searchResult = await UserResource.searchUsers(auth, {
+    searchTerm: q,
+    offset: 0,
+    limit,
+    orderBy: q.trim()
+      ? undefined
+      : {
+          field: "name",
+          direction: "asc",
+        },
+  });
+
+  if (searchResult.isOk()) {
+    return ctx.json({
+      members: formatMemberSearchResults(
+        searchResult.value.users.map((user) => {
+          const json = user.toJSON();
+          return {
+            sId: json.sId,
+            fullName: json.fullName,
+            email: json.email,
+          };
+        })
+      ),
+      total: searchResult.value.total,
+    } satisfies PokeSearchWorkspaceMembers);
+  }
+
+  const { members } = await getMembers(auth, { activeOnly: true });
+  const filteredMembers = filterMembersByQuery(members, q).slice(0, limit);
+
+  return ctx.json({
+    members: formatMemberSearchResults(filteredMembers),
+    total: filteredMembers.length,
+  } satisfies PokeSearchWorkspaceMembers);
+});
 
 /** @ignoreswagger */
 app.get("/", async (ctx): HandlerResult<PokeGetMemberships> => {

--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -1,20 +1,10 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
+import type { PokeMCPServerViewListItemType } from "@app/lib/api/poke/mcp_server_views";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
-interface MCPServerView {
-  sId: string;
-  name: string | null;
-  createdAt: number;
-  updatedAt: number;
-  spaceId: string;
-  serverType: string;
-  server: {
-    sId: string;
-    name: string;
-    description: string;
-  };
+interface MCPServerView extends PokeMCPServerViewListItemType {
   editedAt?: number;
   editedBy?: string;
   mcpServerViewLink: string;
@@ -70,10 +60,10 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
       ),
     },
     {
-      accessorKey: "space",
+      accessorKey: "space.name",
       cell: ({ row }) => {
-        const { spaceLink, spaceId } = row.original;
-        return <LinkWrapper href={spaceLink}>{spaceId}</LinkWrapper>;
+        const { spaceLink, space } = row.original;
+        return <LinkWrapper href={spaceLink}>{space.name}</LinkWrapper>;
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Space" />

--- a/front/components/poke/mcp_server_views/table.tsx
+++ b/front/components/poke/mcp_server_views/table.tsx
@@ -1,7 +1,7 @@
 import { makeColumnsForMCPServerViews } from "@app/components/poke/mcp_server_views/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { PokeMCPServerViewListItemType } from "@app/lib/api/poke/mcp_server_views";
 import { usePokeMCPServerViews } from "@app/poke/swr/mcp_server_views";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -13,7 +13,7 @@ interface MCPServerViewsDataTableProps {
 
 function prepareMCPServerViewsForDisplay(
   owner: LightWorkspaceType,
-  mcpServerViews: MCPServerViewType[],
+  mcpServerViews: PokeMCPServerViewListItemType[],
   spaceId?: string
 ) {
   return mcpServerViews

--- a/front/components/poke/plugins/PluginForm.tsx
+++ b/front/components/poke/plugins/PluginForm.tsx
@@ -1,4 +1,5 @@
 import { EnumSelect } from "@app/components/poke/plugins/EnumSelect";
+import { ServerSideSearchEnumSelect } from "@app/components/poke/plugins/ServerSideSearchEnumSelect";
 import {
   PokeForm,
   PokeFormControl,
@@ -12,7 +13,11 @@ import {
   PokeFormUpload,
 } from "@app/components/poke/shadcn/ui/form";
 import type { PokeGetPluginDetailsResponseBody } from "@app/lib/api/poke/plugins/manifest";
-import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
+import type {
+  AsyncEnumValues,
+  EnumValues,
+  PluginResourceTarget,
+} from "@app/types/poke/plugins";
 import { createZodSchemaFromArgs } from "@app/types/poke/plugins";
 import { Button, Checkbox, SliderToggle } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -32,6 +37,7 @@ interface PluginFormProps {
   disabled?: boolean;
   manifest: PokeGetPluginDetailsResponseBody["manifest"];
   onSubmit: (args: FormValues<any>) => Promise<void>;
+  pluginResourceTarget: PluginResourceTarget;
 }
 
 export function PluginForm({
@@ -39,6 +45,7 @@ export function PluginForm({
   disabled,
   manifest,
   onSubmit,
+  pluginResourceTarget,
 }: PluginFormProps) {
   const [isSubmitted, setIsSubmitted] = useState(false);
 
@@ -152,6 +159,11 @@ export function PluginForm({
     return null;
   }
 
+  const workspaceId =
+    "workspace" in pluginResourceTarget
+      ? pluginResourceTarget.workspace.sId
+      : null;
+
   return (
     <PokeForm {...form}>
       <form
@@ -250,18 +262,33 @@ export function PluginForm({
                                 onCheckedChange={field.onChange}
                               />
                             )}
-                          {arg.type === "enum" && (
-                            <EnumSelect
-                              label={arg.label}
-                              onValuesChange={(values) =>
-                                field.onChange(values)
-                              }
-                              options={options ?? []}
-                              placeholder="Select value"
-                              values={field.value}
-                              multiple={arg.multiple}
-                            />
-                          )}
+                          {arg.type === "enum" &&
+                            arg.serverSideSearch &&
+                            workspaceId && (
+                              <ServerSideSearchEnumSelect
+                                label={arg.label}
+                                onValuesChange={(values) =>
+                                  field.onChange(values)
+                                }
+                                placeholder="Search by name or email"
+                                staticOptions={options ?? arg.values}
+                                values={field.value}
+                                workspaceId={workspaceId}
+                              />
+                            )}
+                          {arg.type === "enum" &&
+                            !(arg.serverSideSearch && workspaceId) && (
+                              <EnumSelect
+                                label={arg.label}
+                                onValuesChange={(values) =>
+                                  field.onChange(values)
+                                }
+                                options={options ?? []}
+                                placeholder="Select value"
+                                values={field.value}
+                                multiple={arg.multiple}
+                              />
+                            )}
                           {arg.type === "file" && (
                             <PokeFormUpload type="file" {...field} />
                           )}

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -164,6 +164,7 @@ export function RunPluginDialog({
                 manifest={manifest}
                 asyncArgs={asyncArgs}
                 onSubmit={onSubmit}
+                pluginResourceTarget={pluginResourceTarget}
               />
               {manifest.warning && (
                 <PokeAlert variant="destructive">

--- a/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
+++ b/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
@@ -1,0 +1,218 @@
+import { PokeButton } from "@app/components/poke/shadcn/ui/button";
+import {
+  PokeCommand,
+  PokeCommandEmpty,
+  PokeCommandGroup,
+  PokeCommandInput,
+  PokeCommandItem,
+  PokeCommandList,
+} from "@app/components/poke/shadcn/ui/command";
+import { PokeFormControl } from "@app/components/poke/shadcn/ui/form";
+import { useDebounce } from "@app/hooks/useDebounce";
+import type { PokeSearchWorkspaceMember } from "@app/lib/api/poke/memberships";
+import { usePokeWorkspaceMembersSearch } from "@app/poke/swr/memberships";
+import type { EnumValue } from "@app/types/poke/plugins";
+import {
+  ChevronDown,
+  cn,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "@dust-tt/sparkle";
+import { Loader2 } from "lucide-react";
+import React from "react";
+
+function formatMemberLabel(member: PokeSearchWorkspaceMember) {
+  return member.fullName
+    ? `${member.fullName} (${member.email})`
+    : `${member.email} (${member.sId})`;
+}
+
+interface ServerSideSearchEnumSelectProps {
+  label?: string;
+  onValuesChange: (values: string[]) => void;
+  placeholder?: string;
+  staticOptions?: readonly EnumValue[];
+  values?: string[];
+  workspaceId: string;
+}
+
+export function ServerSideSearchEnumSelect({
+  label,
+  onValuesChange,
+  placeholder = "Select value",
+  staticOptions = [],
+  values,
+  workspaceId,
+}: ServerSideSearchEnumSelectProps) {
+  const [open, setOpen] = React.useState(false);
+  const {
+    debouncedValue: debouncedSearchQuery,
+    inputValue: searchQuery,
+    setValue: setSearchQuery,
+  } = useDebounce("");
+  const [selectedMemberLabel, setSelectedMemberLabel] = React.useState<
+    string | null
+  >(null);
+
+  const {
+    members: searchResults,
+    isLoading,
+    isError,
+  } = usePokeWorkspaceMembersSearch({
+    owner: { sId: workspaceId },
+    query: debouncedSearchQuery,
+    disabled: !open,
+  });
+
+  const selectedValue = values?.[0] ?? "";
+
+  const staticOptionByValue = React.useMemo(
+    () => new Map(staticOptions.map((option) => [option.value, option])),
+    [staticOptions]
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      setSearchQuery("");
+    }
+  }, [open, setSearchQuery]);
+
+  React.useEffect(() => {
+    if (!selectedValue) {
+      setSelectedMemberLabel(null);
+      return;
+    }
+
+    const staticOption = staticOptionByValue.get(selectedValue);
+    if (staticOption) {
+      setSelectedMemberLabel(staticOption.label);
+      return;
+    }
+
+    const matchingResult = searchResults.find(
+      (member) => member.sId === selectedValue
+    );
+    if (matchingResult) {
+      setSelectedMemberLabel(formatMemberLabel(matchingResult));
+    }
+  }, [searchResults, selectedValue, staticOptionByValue]);
+
+  const title =
+    selectedMemberLabel ??
+    staticOptionByValue.get(selectedValue)?.label ??
+    placeholder;
+
+  return (
+    <PopoverRoot modal={false} open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <PokeFormControl>
+          <PokeButton
+            variant="outline"
+            role="combobox"
+            className={cn(
+              "w-auto justify-between border-border-dark bg-background " +
+                "dark:border-border-darker-night dark:bg-background-night",
+              !selectedValue &&
+                "text-muted-foreground dark:text-muted-foreground-night"
+            )}
+          >
+            {title}
+            <ChevronDown className="opacity-50" />
+          </PokeButton>
+        </PokeFormControl>
+      </PopoverTrigger>
+      <PopoverContent
+        className="z-[100] w-[var(--radix-popover-trigger-width)] min-w-[320px]"
+        mountPortal={false}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+        }}
+        onWheelCapture={(e) => {
+          e.stopPropagation();
+        }}
+        onTouchMoveCapture={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <PokeCommand className="gap-2 py-3" shouldFilter={false}>
+          <PokeCommandInput
+            placeholder={label ?? "Search by name or email"}
+            className="h-9 p-2"
+            value={searchQuery}
+            onValueChange={setSearchQuery}
+            onKeyDown={(e) => e.stopPropagation()}
+          />
+          <PokeCommandList>
+            {isLoading ? (
+              <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Searching members…
+              </div>
+            ) : isError ? (
+              <div className="px-2 py-3 text-sm text-warning-500">
+                Failed to search workspace members.
+              </div>
+            ) : (
+              <>
+                <PokeCommandEmpty>No members found.</PokeCommandEmpty>
+                <PokeCommandGroup>
+                  {staticOptions.map((option) => {
+                    const isSelected = selectedValue === option.value;
+                    return (
+                      <PokeCommandItem
+                        value={option.label}
+                        key={`static-${option.value}`}
+                        onSelect={() => {
+                          onValuesChange([option.value]);
+                          setSelectedMemberLabel(option.label);
+                          setOpen(false);
+                        }}
+                      >
+                        <span
+                          className={cn(
+                            isSelected && "font-medium",
+                            "text-gray-900 dark:text-gray-900-night"
+                          )}
+                        >
+                          {option.label}
+                        </span>
+                      </PokeCommandItem>
+                    );
+                  })}
+                  {searchResults
+                    .filter((member) => !staticOptionByValue.has(member.sId))
+                    .map((member) => {
+                      const memberLabel = formatMemberLabel(member);
+                      const isSelected = selectedValue === member.sId;
+
+                      return (
+                        <PokeCommandItem
+                          value={memberLabel}
+                          key={member.sId}
+                          onSelect={() => {
+                            onValuesChange([member.sId]);
+                            setSelectedMemberLabel(memberLabel);
+                            setOpen(false);
+                          }}
+                        >
+                          <span
+                            className={cn(
+                              isSelected && "font-medium",
+                              "text-gray-900 dark:text-gray-900-night"
+                            )}
+                          >
+                            {memberLabel}
+                          </span>
+                        </PokeCommandItem>
+                      );
+                    })}
+                </PokeCommandGroup>
+              </>
+            )}
+          </PokeCommandList>
+        </PokeCommand>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/lib/api/poke/mcp_diagnostics.test.ts
+++ b/front/lib/api/poke/mcp_diagnostics.test.ts
@@ -1,0 +1,163 @@
+import {
+  createOAuthCheckSkippedNoUseCase,
+  deriveDiagnosticSummary,
+  resolveConnectionTypesToTest,
+} from "@app/lib/api/poke/mcp_diagnostics";
+import { parseMCPDiagnosticReport } from "@app/lib/api/poke/mcp_diagnostics_types";
+import { describe, expect, it } from "vitest";
+
+describe("resolveConnectionTypesToTest", () => {
+  it("defaults platform_actions to workspace only", () => {
+    expect(
+      resolveConnectionTypesToTest({ oAuthUseCase: "platform_actions" })
+    ).toEqual(["workspace"]);
+  });
+
+  it("tests workspace and personal for personal_actions when user_id is set", () => {
+    expect(
+      resolveConnectionTypesToTest({
+        oAuthUseCase: "personal_actions",
+        userId: "user_123",
+      })
+    ).toEqual(["workspace", "personal"]);
+  });
+
+  it("respects explicit connection_type override", () => {
+    expect(
+      resolveConnectionTypesToTest({
+        oAuthUseCase: "platform_actions",
+        connectionType: "both",
+      })
+    ).toEqual(["workspace", "personal"]);
+  });
+});
+
+describe("createOAuthCheckSkippedNoUseCase", () => {
+  it("marks oauth checks as skipped when oAuthUseCase is not configured", () => {
+    expect(createOAuthCheckSkippedNoUseCase("oauth_metadata")).toMatchObject({
+      check: "oauth_metadata",
+      status: "skipped",
+      oAuthUseCase: null,
+      details: { reason: "no_oauth_use_case" },
+    });
+    expect(
+      createOAuthCheckSkippedNoUseCase("oauth_metadata").message
+    ).toContain("no oAuthUseCase configured");
+  });
+});
+
+describe("deriveDiagnosticSummary", () => {
+  it("returns ok when all checks pass", () => {
+    expect(
+      deriveDiagnosticSummary(
+        [
+          { check: "connection_inventory", status: "ok" },
+          { check: "oauth_token_fetch", status: "ok" },
+        ],
+        "platform_actions"
+      )
+    ).toEqual({
+      overall: "ok",
+      primary_issue: null,
+      recommended_action: null,
+    });
+  });
+
+  it("detects personal vs workspace mismatch", () => {
+    expect(
+      deriveDiagnosticSummary(
+        [
+          {
+            check: "connection_inventory",
+            status: "warn",
+          },
+          {
+            check: "sync_simulation",
+            status: "error",
+            details: { mismatch: true },
+          },
+        ],
+        "personal_actions"
+      )
+    ).toMatchObject({
+      overall: "failed",
+      primary_issue: "personal_vs_workspace_mismatch",
+    });
+  });
+
+  it("returns ok when oauth checks are skipped due to missing oAuthUseCase", () => {
+    expect(
+      deriveDiagnosticSummary(
+        [
+          { check: "connection_inventory", status: "ok" },
+          {
+            check: "oauth_metadata",
+            status: "skipped",
+            details: { reason: "no_oauth_use_case" },
+          },
+          {
+            check: "oauth_token_fetch",
+            status: "skipped",
+            details: { reason: "no_oauth_use_case" },
+          },
+        ],
+        null
+      )
+    ).toEqual({
+      overall: "ok",
+      primary_issue: null,
+      recommended_action: null,
+    });
+  });
+
+  it("detects oauth token refresh failure", () => {
+    expect(
+      deriveDiagnosticSummary(
+        [
+          {
+            check: "oauth_token_fetch",
+            status: "error",
+            error: { code: "token_revoked" },
+          },
+        ],
+        "platform_actions"
+      )
+    ).toMatchObject({
+      overall: "failed",
+      primary_issue: "oauth_token_refresh_failure",
+    });
+  });
+});
+
+describe("parseMCPDiagnosticReport", () => {
+  it("parses a valid diagnostic report", () => {
+    const report = parseMCPDiagnosticReport(
+      JSON.stringify({
+        workspace_id: "w1",
+        mcp_server_id: "rms_1",
+        server_view: null,
+        checks_requested: ["connection_inventory"],
+        connection_types_tested: ["workspace"],
+        summary: {
+          overall: "ok",
+          primary_issue: null,
+          recommended_action: null,
+        },
+        checks: [
+          {
+            check: "connection_inventory",
+            status: "ok",
+          },
+        ],
+        poke_url: "https://poke.dust.tt/w1",
+      })
+    );
+
+    expect(report?.mcp_server_id).toBe("rms_1");
+    expect(report?.checks).toHaveLength(1);
+  });
+
+  it("returns null for invalid json", () => {
+    expect(parseMCPDiagnosticReport("not json")).toBeNull();
+  });
+});

--- a/front/lib/api/poke/mcp_diagnostics.ts
+++ b/front/lib/api/poke/mcp_diagnostics.ts
@@ -1,0 +1,851 @@
+import {
+  getMCPServerAdminAuthenticationReason,
+  MCPServerPersonalAuthenticationRequiredError,
+  MCPServerRequiresAdminAuthenticationError,
+} from "@app/lib/actions/mcp_authentication";
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import {
+  getInternalMCPServerInfo,
+  getInternalMCPServerNameFromSId,
+  type InternalMCPServerNameType,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  connectToMCPServer,
+  fetchRemoteServerMetaDataByServerId,
+} from "@app/lib/actions/mcp_metadata";
+import { getMCPConnectionAccessToken } from "@app/lib/actions/mcp_oauth_access_token";
+import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import config from "@app/lib/api/config";
+import {
+  MCP_DIAGNOSTIC_CHECK_NAMES,
+  type MCPDiagnosticCheckName,
+  type MCPDiagnosticSummary,
+} from "@app/lib/api/poke/mcp_diagnostics_types";
+import { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import logger from "@app/logger/logger";
+import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import type { OAuthAPIError } from "@app/types/oauth/oauth_api";
+import { OAuthAPI } from "@app/types/oauth/oauth_api";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { z } from "zod";
+
+const MCPDiagnosticCheckNameSchema = z.enum(MCP_DIAGNOSTIC_CHECK_NAMES);
+
+const DEFAULT_CHECKS: MCPDiagnosticCheckName[] = [
+  "connection_inventory",
+  "oauth_metadata",
+  "oauth_token_fetch",
+  "connect_list_tools",
+  "sync_simulation",
+];
+
+const NO_OAUTH_USE_CASE_SKIP_MESSAGE =
+  "Skipped: this server view has no oAuthUseCase configured. OAuth is not expected for this server (it may use API key auth instead).";
+
+type CheckStatus = "ok" | "warn" | "error" | "skipped";
+
+type DiagnosticCheckResult = {
+  check: MCPDiagnosticCheckName;
+  status: CheckStatus;
+  duration_ms?: number;
+  connection_type?: MCPServerConnectionConnectionType;
+  oAuthUseCase?: MCPOAuthUseCase | null;
+  message?: string;
+  error?: Record<string, unknown>;
+  details?: Record<string, unknown>;
+};
+
+type OAuthDiagnosticCheckName = "oauth_metadata" | "oauth_token_fetch";
+
+export function createOAuthCheckSkippedNoUseCase(
+  check: OAuthDiagnosticCheckName
+): DiagnosticCheckResult {
+  return {
+    check,
+    status: "skipped",
+    oAuthUseCase: null,
+    message: NO_OAUTH_USE_CASE_SKIP_MESSAGE,
+    details: {
+      reason: "no_oauth_use_case",
+    },
+  };
+}
+
+export type { MCPDiagnosticSummary };
+
+function isRemoteMCPServer(mcpServerId: string): boolean {
+  return getServerTypeAndIdFromSId(mcpServerId).serverType === "remote";
+}
+
+function formatExpiryIso(expiryMs: number | null | undefined): string | null {
+  if (expiryMs == null) {
+    return null;
+  }
+  return new Date(expiryMs).toISOString();
+}
+
+function expiryDiagnostics(expiryMs: number | null | undefined): {
+  access_token_expiry: string | null;
+  expires_in_seconds: number | null;
+  within_refresh_buffer: boolean;
+} {
+  if (expiryMs == null) {
+    return {
+      access_token_expiry: null,
+      expires_in_seconds: null,
+      within_refresh_buffer: false,
+    };
+  }
+
+  const expiresInSeconds = Math.round((expiryMs - Date.now()) / 1000);
+  const refreshBufferSeconds = 5 * 60;
+
+  return {
+    access_token_expiry: formatExpiryIso(expiryMs),
+    expires_in_seconds: expiresInSeconds,
+    within_refresh_buffer: expiresInSeconds <= refreshBufferSeconds,
+  };
+}
+
+function hasRefreshTokenHint(scrubbedRawJson: unknown): boolean | null {
+  if (scrubbedRawJson == null || typeof scrubbedRawJson !== "object") {
+    return null;
+  }
+
+  return "refresh_token" in (scrubbedRawJson as Record<string, unknown>);
+}
+
+function serializeConnectError(error: unknown): Record<string, unknown> {
+  if (MCPServerRequiresAdminAuthenticationError.is(error)) {
+    return {
+      layer: "mcp_connect",
+      type: error.name,
+      reason: error.reason,
+      message: error.message,
+    };
+  }
+
+  if (MCPServerPersonalAuthenticationRequiredError.is(error)) {
+    return {
+      layer: "mcp_connect",
+      type: error.name,
+      provider: error.provider,
+      scope: error.scope,
+      message: error.message,
+    };
+  }
+
+  if (error instanceof DustError) {
+    return {
+      layer: "dust",
+      code: error.code,
+      message: error.message,
+    };
+  }
+
+  const normalized = normalizeError(error);
+  return {
+    layer: "unknown",
+    message: normalized.message,
+    name: normalized.name,
+  };
+}
+
+function serializeOAuthError(error: OAuthAPIError): Record<string, unknown> {
+  return {
+    layer: "oauth_api",
+    code: error.code,
+    message: error.message,
+  };
+}
+
+export function resolveConnectionTypesToTest({
+  oAuthUseCase,
+  connectionType,
+  userId,
+}: {
+  oAuthUseCase: MCPOAuthUseCase | null;
+  connectionType?: "workspace" | "personal" | "both";
+  userId?: string;
+}): MCPServerConnectionConnectionType[] {
+  if (connectionType === "workspace") {
+    return ["workspace"];
+  }
+  if (connectionType === "personal") {
+    return ["personal"];
+  }
+  if (connectionType === "both") {
+    return ["workspace", "personal"];
+  }
+
+  if (oAuthUseCase === "platform_actions") {
+    return ["workspace"];
+  }
+
+  if (oAuthUseCase === "personal_actions" && userId) {
+    return ["workspace", "personal"];
+  }
+
+  return ["workspace"];
+}
+
+async function getAuthForConnectionType(
+  adminAuth: Authenticator,
+  workspaceId: string,
+  connectionType: MCPServerConnectionConnectionType,
+  userId?: string
+): Promise<Authenticator> {
+  if (connectionType === "workspace") {
+    return adminAuth;
+  }
+
+  if (!userId) {
+    return adminAuth;
+  }
+
+  return Authenticator.fromUserIdAndWorkspaceId(userId, workspaceId);
+}
+
+function connectionRowSummary(
+  connection: MCPServerConnectionResource | undefined
+): Record<string, unknown> | null {
+  if (!connection) {
+    return null;
+  }
+
+  return {
+    sId: connection.sId,
+    connectionId: connection.connectionId ?? null,
+    credentialId: connection.credentialId ?? null,
+    connectionType: connection.connectionType,
+    authType: connection.connectionId ? "oauth" : "keypair",
+    userId: connection.user?.sId ?? null,
+    createdAt: connection.createdAt.toISOString(),
+  };
+}
+
+async function runConnectionInventoryCheck(
+  auth: Authenticator,
+  mcpServerId: string
+): Promise<DiagnosticCheckResult> {
+  const connectionsRes = await MCPServerConnectionResource.listByMCPServer(
+    auth,
+    { mcpServerId }
+  );
+
+  if (connectionsRes.isErr()) {
+    return {
+      check: "connection_inventory",
+      status: "error",
+      error: {
+        layer: "dust",
+        code: connectionsRes.error.code,
+        message: connectionsRes.error.message,
+      },
+    };
+  }
+
+  const connections = connectionsRes.value;
+  const workspaceConnections = connections.filter(
+    (c) => c.connectionType === "workspace"
+  );
+  const personalConnections = connections.filter(
+    (c) => c.connectionType === "personal"
+  );
+
+  const latestWorkspace = workspaceConnections[0];
+  const workspaceHasOAuthConnectionId = !!latestWorkspace?.connectionId;
+
+  const personalOnlySetup =
+    personalConnections.some((c) => !!c.connectionId) &&
+    !workspaceHasOAuthConnectionId;
+
+  let setupVsReconnectHint: "setup" | "reconnect" | null = null;
+  if (!latestWorkspace) {
+    setupVsReconnectHint = "setup";
+  } else if (!workspaceHasOAuthConnectionId && !latestWorkspace.credentialId) {
+    setupVsReconnectHint = "setup";
+  }
+
+  return {
+    check: "connection_inventory",
+    status: personalOnlySetup ? "warn" : "ok",
+    details: {
+      workspace: connectionRowSummary(latestWorkspace),
+      personal: personalConnections.map((c) => connectionRowSummary(c)),
+      counts: {
+        workspace: workspaceConnections.length,
+        personal: personalConnections.length,
+      },
+    },
+    message: personalOnlySetup
+      ? "Personal OAuth connection(s) exist but no workspace OAuth connectionId — sync and shared mode will fail."
+      : undefined,
+    error: personalOnlySetup
+      ? {
+          diagnosis: {
+            sync_will_use: "workspace",
+            personal_only_setup: true,
+            setup_vs_reconnect_hint: setupVsReconnectHint ?? "setup",
+          },
+        }
+      : {
+          diagnosis: {
+            sync_will_use: "workspace",
+            personal_only_setup: false,
+            setup_vs_reconnect_hint: setupVsReconnectHint,
+          },
+        },
+  };
+}
+
+async function runOAuthMetadataCheck(
+  auth: Authenticator,
+  connectionId: string,
+  connectionType: MCPServerConnectionConnectionType
+): Promise<DiagnosticCheckResult> {
+  const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+  const metadataRes = await oauthApi.getConnectionMetadata({ connectionId });
+
+  if (metadataRes.isErr()) {
+    return {
+      check: "oauth_metadata",
+      status: "error",
+      connection_type: connectionType,
+      error: serializeOAuthError(metadataRes.error),
+    };
+  }
+
+  const connection = metadataRes.value.connection;
+
+  return {
+    check: "oauth_metadata",
+    status: "ok",
+    connection_type: connectionType,
+    details: {
+      connectionId: connection.connection_id,
+      provider: connection.provider,
+      status: connection.status,
+      metadata: connection.metadata,
+    },
+  };
+}
+
+async function runOAuthTokenFetchCheck(
+  auth: Authenticator,
+  connectionId: string,
+  connectionType: MCPServerConnectionConnectionType
+): Promise<DiagnosticCheckResult> {
+  const startedAt = Date.now();
+
+  const tokenRes = await getMCPConnectionAccessToken(auth, {
+    connectionId,
+    localLogger: logger,
+  });
+  const duration_ms = Date.now() - startedAt;
+
+  if (tokenRes.isErr()) {
+    return {
+      check: "oauth_token_fetch",
+      status: "error",
+      duration_ms,
+      connection_type: connectionType,
+      error: serializeOAuthError(tokenRes.error),
+    };
+  }
+
+  const { access_token_expiry, scrubbed_raw_json } = tokenRes.value;
+
+  return {
+    check: "oauth_token_fetch",
+    status: "ok",
+    duration_ms,
+    connection_type: connectionType,
+    details: {
+      token_length: tokenRes.value.access_token.length,
+      expiry: expiryDiagnostics(access_token_expiry),
+      has_scrubbed_refresh_token_hint: hasRefreshTokenHint(scrubbed_raw_json),
+      scrubbed_raw_json,
+    },
+  };
+}
+
+async function runConnectListToolsCheck(
+  auth: Authenticator,
+  {
+    mcpServerId,
+    oAuthUseCase,
+    connectionType,
+  }: {
+    mcpServerId: string;
+    oAuthUseCase: MCPOAuthUseCase | null;
+    connectionType: MCPServerConnectionConnectionType;
+  }
+): Promise<DiagnosticCheckResult> {
+  const startedAt = Date.now();
+
+  const agentLoopContext =
+    connectionType === "personal"
+      ? { runContext: {} as AgentLoopRunContextType }
+      : undefined;
+
+  const connectRes = await connectToMCPServer(auth, {
+    params: {
+      type: "mcpServerId",
+      mcpServerId,
+      oAuthUseCase,
+    },
+    agentLoopContext,
+  });
+
+  if (connectRes.isErr()) {
+    return {
+      check: "connect_list_tools",
+      status: "error",
+      duration_ms: Date.now() - startedAt,
+      connection_type: connectionType,
+      oAuthUseCase,
+      error: serializeConnectError(connectRes.error),
+    };
+  }
+
+  const client = connectRes.value;
+
+  try {
+    const toolsResult = await client.listTools();
+    const serverVersion = client.getServerVersion();
+
+    return {
+      check: "connect_list_tools",
+      status: "ok",
+      duration_ms: Date.now() - startedAt,
+      connection_type: connectionType,
+      oAuthUseCase,
+      details: {
+        tools_count: toolsResult.tools.length,
+        server_version: serverVersion ?? null,
+        tool_names: toolsResult.tools.map((t) => t.name).slice(0, 20),
+      },
+    };
+  } catch (error) {
+    return {
+      check: "connect_list_tools",
+      status: "error",
+      duration_ms: Date.now() - startedAt,
+      connection_type: connectionType,
+      oAuthUseCase,
+      error: serializeConnectError(error),
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+async function runSyncSimulationCheck(
+  auth: Authenticator,
+  {
+    mcpServerId,
+    serverViewOAuthUseCase,
+  }: {
+    mcpServerId: string;
+    serverViewOAuthUseCase: MCPOAuthUseCase | null;
+  }
+): Promise<DiagnosticCheckResult> {
+  if (!isRemoteMCPServer(mcpServerId)) {
+    return {
+      check: "sync_simulation",
+      status: "skipped",
+      message: "Weekly/manual sync only applies to remote MCP servers.",
+      details: {
+        server_type: "internal",
+      },
+    };
+  }
+
+  const startedAt = Date.now();
+  const syncRes = await fetchRemoteServerMetaDataByServerId(auth, mcpServerId);
+  const duration_ms = Date.now() - startedAt;
+
+  const mismatch =
+    serverViewOAuthUseCase === "personal_actions" &&
+    syncRes.isErr() &&
+    syncRes.error.message.includes("set up the workspace connection");
+
+  if (syncRes.isErr()) {
+    return {
+      check: "sync_simulation",
+      status: "error",
+      duration_ms,
+      oAuthUseCase: "platform_actions",
+      error: serializeConnectError(syncRes.error),
+      details: {
+        uses_oauth_use_case: "platform_actions",
+        server_view_oauth_use_case: serverViewOAuthUseCase,
+        mismatch,
+      },
+    };
+  }
+
+  return {
+    check: "sync_simulation",
+    status: "ok",
+    duration_ms,
+    oAuthUseCase: "platform_actions",
+    details: {
+      uses_oauth_use_case: "platform_actions",
+      server_view_oauth_use_case: serverViewOAuthUseCase,
+      mismatch: false,
+      cached_name: syncRes.value.name,
+      tools_count: syncRes.value.tools.length,
+    },
+  };
+}
+
+export function deriveDiagnosticSummary(
+  checks: DiagnosticCheckResult[],
+  oAuthUseCase: MCPOAuthUseCase | null
+): MCPDiagnosticSummary {
+  const errors = checks.filter((c) => c.status === "error");
+  const warnings = checks.filter((c) => c.status === "warn");
+
+  if (errors.length === 0 && warnings.length === 0) {
+    return {
+      overall: "ok",
+      primary_issue: null,
+      recommended_action: null,
+    };
+  }
+
+  const inventory = checks.find((c) => c.check === "connection_inventory");
+  const sync = checks.find((c) => c.check === "sync_simulation");
+  const tokenFetch = checks.find((c) => c.check === "oauth_token_fetch");
+
+  if (
+    inventory?.status === "warn" ||
+    (sync?.details?.mismatch === true && oAuthUseCase === "personal_actions")
+  ) {
+    return {
+      overall: "failed",
+      primary_issue: "personal_vs_workspace_mismatch",
+      recommended_action:
+        "Configure a workspace-level OAuth connection (shared credentials). Personal user OAuth alone is insufficient for sync and platform_actions paths.",
+    };
+  }
+
+  if (tokenFetch?.status === "error") {
+    const code =
+      typeof tokenFetch.error?.code === "string"
+        ? tokenFetch.error.code
+        : "unknown";
+    return {
+      overall: "failed",
+      primary_issue: "oauth_token_refresh_failure",
+      recommended_action:
+        code === "token_revoked"
+          ? "Reconnect the OAuth connection — the refresh token is revoked or expired."
+          : "Inspect OAuth refresh logs in core for this connectionId (provider error, timeout, or missing refresh_token in provider response).",
+    };
+  }
+
+  if (sync?.status === "error") {
+    return {
+      overall: "failed",
+      primary_issue: "sync_path_failure",
+      recommended_action:
+        "Fix the workspace OAuth connection used by sync (platform_actions). See connect_list_tools and oauth_token_fetch results for the same connection.",
+    };
+  }
+
+  if (errors.some((c) => c.check === "connect_list_tools")) {
+    return {
+      overall: "failed",
+      primary_issue: "mcp_connect_failure",
+      recommended_action:
+        "Review the connect_list_tools error — distinguish admin setup vs reconnect vs personal auth required.",
+    };
+  }
+
+  return {
+    overall: warnings.length > 0 ? "warn" : "failed",
+    primary_issue: "mcp_diagnostic_issues",
+    recommended_action:
+      "Review individual check results for details on each failing step.",
+  };
+}
+
+async function resolveServerContext(
+  auth: Authenticator,
+  {
+    mcpServerId,
+    serverViewId,
+  }: {
+    mcpServerId: string;
+    serverViewId?: string;
+  }
+): Promise<
+  | {
+      mcpServerId: string;
+      serverView: {
+        sId: string;
+        oAuthUseCase: MCPOAuthUseCase | null;
+        serverType: "internal" | "remote";
+        url: string | null;
+        name: string | null;
+      } | null;
+    }
+  | { error: string }
+> {
+  const { serverType } = getServerTypeAndIdFromSId(mcpServerId);
+
+  let serverViewResource: MCPServerViewResource | null = null;
+  if (serverViewId) {
+    serverViewResource = await MCPServerViewResource.fetchById(
+      auth,
+      serverViewId
+    );
+    if (!serverViewResource) {
+      return {
+        error: `MCP server view "${serverViewId}" not found in workspace.`,
+      };
+    }
+    if (serverViewResource.mcpServerId !== mcpServerId) {
+      return {
+        error: `MCP server view "${serverViewId}" belongs to ${serverViewResource.mcpServerId}, not ${mcpServerId}.`,
+      };
+    }
+  } else {
+    const views = await MCPServerViewResource.listByMCPServer(
+      auth,
+      mcpServerId
+    );
+    serverViewResource = views[0] ?? null;
+  }
+
+  let url: string | null = null;
+  let name: string | null = null;
+
+  if (serverType === "remote") {
+    const remoteServer = await RemoteMCPServerResource.fetchById(
+      auth,
+      mcpServerId
+    );
+    url = remoteServer?.url ?? null;
+    name = remoteServer?.cachedName ?? null;
+  } else {
+    const internalServerName = getInternalMCPServerNameFromSId(mcpServerId);
+    if (internalServerName) {
+      try {
+        const info = getInternalMCPServerInfo(
+          internalServerName as InternalMCPServerNameType
+        );
+        name = info.name;
+      } catch {
+        name = null;
+      }
+    }
+  }
+
+  return {
+    mcpServerId,
+    serverView: serverViewResource
+      ? {
+          sId: serverViewResource.sId,
+          oAuthUseCase: serverViewResource.oAuthUseCase,
+          serverType,
+          url,
+          name,
+        }
+      : null,
+  };
+}
+
+export async function runMCPDiagnostics(
+  auth: Authenticator,
+  {
+    workspaceId,
+    mcpServerId,
+    serverViewId,
+    userId,
+    checks,
+    connectionType,
+  }: {
+    workspaceId: string;
+    mcpServerId: string;
+    serverViewId?: string;
+    userId?: string;
+    checks?: MCPDiagnosticCheckName[];
+    connectionType?: "workspace" | "personal" | "both";
+  }
+): Promise<Record<string, unknown>> {
+  const selectedChecks = checks ?? DEFAULT_CHECKS;
+  const invalidChecks = selectedChecks.filter(
+    (c) => !MCPDiagnosticCheckNameSchema.safeParse(c).success
+  );
+  if (invalidChecks.length > 0) {
+    throw new Error(`Unknown diagnostic checks: ${invalidChecks.join(", ")}`);
+  }
+
+  const serverContext = await resolveServerContext(auth, {
+    mcpServerId,
+    serverViewId,
+  });
+
+  if ("error" in serverContext) {
+    throw new Error(serverContext.error);
+  }
+
+  const oAuthUseCase = serverContext.serverView?.oAuthUseCase ?? null;
+  const connectionTypes = resolveConnectionTypesToTest({
+    oAuthUseCase,
+    connectionType,
+    userId,
+  });
+
+  const results: DiagnosticCheckResult[] = [];
+
+  for (const checkName of selectedChecks) {
+    if (checkName === "connection_inventory") {
+      results.push(await runConnectionInventoryCheck(auth, mcpServerId));
+      continue;
+    }
+
+    if (checkName === "sync_simulation") {
+      results.push(
+        await runSyncSimulationCheck(auth, {
+          mcpServerId,
+          serverViewOAuthUseCase: oAuthUseCase,
+        })
+      );
+      continue;
+    }
+
+    if (
+      (checkName === "oauth_metadata" || checkName === "oauth_token_fetch") &&
+      oAuthUseCase === null
+    ) {
+      results.push(createOAuthCheckSkippedNoUseCase(checkName));
+      continue;
+    }
+
+    for (const connType of connectionTypes) {
+      if (connType === "personal" && !userId) {
+        if (
+          checkName === "oauth_metadata" ||
+          checkName === "oauth_token_fetch" ||
+          checkName === "connect_list_tools"
+        ) {
+          results.push({
+            check: checkName,
+            status: "skipped",
+            connection_type: connType,
+            message:
+              "Provide user_id to run personal connection checks (personal OAuth is user-scoped).",
+          });
+        }
+        continue;
+      }
+
+      const checkAuth = await getAuthForConnectionType(
+        auth,
+        workspaceId,
+        connType,
+        userId
+      );
+
+      if (checkName === "oauth_metadata" || checkName === "oauth_token_fetch") {
+        const connectionRes = await MCPServerConnectionResource.findByMCPServer(
+          checkAuth,
+          {
+            mcpServerId,
+            connectionType: connType,
+          }
+        );
+
+        if (connectionRes.isErr()) {
+          results.push({
+            check: checkName,
+            status: "error",
+            connection_type: connType,
+            error: {
+              layer: "dust",
+              code: connectionRes.error.code,
+              message: connectionRes.error.message,
+              admin_reason:
+                connType === "workspace"
+                  ? getMCPServerAdminAuthenticationReason(
+                      new DustError(
+                        connectionRes.error.code === "connection_not_found"
+                          ? "connection_not_found"
+                          : "mcp_access_token_error",
+                        connectionRes.error.message
+                      )
+                    )
+                  : undefined,
+            },
+          });
+          continue;
+        }
+
+        const connectionId = connectionRes.value.connectionId;
+        if (!connectionId) {
+          results.push({
+            check: checkName,
+            status: "error",
+            connection_type: connType,
+            error: {
+              layer: "dust",
+              message: "Connection row missing connectionId.",
+            },
+          });
+          continue;
+        }
+
+        if (checkName === "oauth_metadata") {
+          results.push(
+            await runOAuthMetadataCheck(checkAuth, connectionId, connType)
+          );
+        } else {
+          results.push(
+            await runOAuthTokenFetchCheck(checkAuth, connectionId, connType)
+          );
+        }
+        continue;
+      }
+
+      if (checkName === "connect_list_tools") {
+        const effectiveOAuthUseCase: MCPOAuthUseCase | null =
+          oAuthUseCase === null
+            ? null
+            : connType === "personal"
+              ? "personal_actions"
+              : "platform_actions";
+
+        results.push(
+          await runConnectListToolsCheck(checkAuth, {
+            mcpServerId,
+            oAuthUseCase: effectiveOAuthUseCase,
+            connectionType: connType,
+          })
+        );
+      }
+    }
+  }
+
+  const summary = deriveDiagnosticSummary(results, oAuthUseCase);
+
+  return {
+    workspace_id: workspaceId,
+    mcp_server_id: mcpServerId,
+    server_view: serverContext.serverView,
+    checks_requested: selectedChecks,
+    connection_types_tested: connectionTypes,
+    summary,
+    checks: results,
+    poke_url: `${config.getPokeAppUrl()}/${workspaceId}`,
+  };
+}

--- a/front/lib/api/poke/mcp_diagnostics_types.ts
+++ b/front/lib/api/poke/mcp_diagnostics_types.ts
@@ -1,0 +1,109 @@
+import { isValidJSON } from "@app/lib/utils/json";
+import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import { z } from "zod";
+
+export const MCP_DIAGNOSTIC_CHECK_NAMES = [
+  "connection_inventory",
+  "oauth_metadata",
+  "oauth_token_fetch",
+  "connect_list_tools",
+  "sync_simulation",
+] as const;
+
+export type MCPDiagnosticCheckName =
+  (typeof MCP_DIAGNOSTIC_CHECK_NAMES)[number];
+
+export type MCPDiagnosticCheckStatus = "ok" | "warn" | "error" | "skipped";
+
+export type MCPDiagnosticSummary = {
+  overall: "ok" | "warn" | "failed";
+  primary_issue: string | null;
+  recommended_action: string | null;
+};
+
+export type MCPDiagnosticCheckResult = {
+  check: MCPDiagnosticCheckName;
+  status: MCPDiagnosticCheckStatus;
+  duration_ms?: number;
+  connection_type?: "workspace" | "personal";
+  oAuthUseCase?: MCPOAuthUseCase | null;
+  message?: string;
+  error?: Record<string, unknown>;
+  details?: Record<string, unknown>;
+};
+
+export type MCPDiagnosticServerView = {
+  sId: string;
+  oAuthUseCase: MCPOAuthUseCase | null;
+  serverType: "internal" | "remote";
+  url: string | null;
+  name: string | null;
+};
+
+export type MCPDiagnosticReport = {
+  workspace_id: string;
+  mcp_server_id: string;
+  server_view: MCPDiagnosticServerView | null;
+  checks_requested: MCPDiagnosticCheckName[];
+  connection_types_tested: ("workspace" | "personal")[];
+  summary: MCPDiagnosticSummary;
+  checks: MCPDiagnosticCheckResult[];
+  poke_url: string;
+};
+
+const diagnosticCheckResultSchema = z.object({
+  check: z.enum(MCP_DIAGNOSTIC_CHECK_NAMES),
+  status: z.enum(["ok", "warn", "error", "skipped"]),
+  duration_ms: z.number().optional(),
+  connection_type: z.enum(["workspace", "personal"]).optional(),
+  oAuthUseCase: z
+    .enum(["platform_actions", "personal_actions"])
+    .nullable()
+    .optional(),
+  message: z.string().optional(),
+  error: z.record(z.unknown()).optional(),
+  details: z.record(z.unknown()).optional(),
+});
+
+const diagnosticReportSchema = z.object({
+  workspace_id: z.string(),
+  mcp_server_id: z.string(),
+  server_view: z
+    .object({
+      sId: z.string(),
+      oAuthUseCase: z.enum(["platform_actions", "personal_actions"]).nullable(),
+      serverType: z.enum(["internal", "remote"]),
+      url: z.string().nullable(),
+      name: z.string().nullable(),
+    })
+    .nullable(),
+  checks_requested: z.array(z.enum(MCP_DIAGNOSTIC_CHECK_NAMES)),
+  connection_types_tested: z.array(z.enum(["workspace", "personal"])),
+  summary: z.object({
+    overall: z.enum(["ok", "warn", "failed"]),
+    primary_issue: z.string().nullable(),
+    recommended_action: z.string().nullable(),
+  }),
+  checks: z.array(diagnosticCheckResultSchema),
+  poke_url: z.string(),
+});
+
+export function parseMCPDiagnosticReport(
+  text: string | null | undefined
+): MCPDiagnosticReport | null {
+  if (!text || !isValidJSON(text)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(text);
+    const result = diagnosticReportSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatDiagnosticCheckName(check: string): string {
+  return check.replaceAll("_", " ");
+}

--- a/front/lib/api/poke/mcp_server_views.ts
+++ b/front/lib/api/poke/mcp_server_views.ts
@@ -1,8 +1,13 @@
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { PokeMCPServerViewType } from "@app/types/poke";
+import type { SpaceType } from "@app/types/space";
+
+export type PokeMCPServerViewListItemType = MCPServerViewType & {
+  space: Pick<SpaceType, "sId" | "name" | "kind">;
+};
 
 export type PokeListMCPServerViews = {
-  serverViews: MCPServerViewType[];
+  serverViews: PokeMCPServerViewListItemType[];
 };
 
 export type PokeGetMCPServerViewDetails = {

--- a/front/lib/api/poke/memberships.ts
+++ b/front/lib/api/poke/memberships.ts
@@ -1,7 +1,40 @@
 import type { MembershipInvitationTypeWithLink } from "@app/types/membership_invitation";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
+import { z } from "zod";
 
 export type PokeGetMemberships = {
   members: UserTypeWithWorkspaces[];
   pendingInvitations: MembershipInvitationTypeWithLink[];
 };
+
+export type PokeSearchWorkspaceMember = {
+  sId: string;
+  fullName: string | null;
+  email: string;
+};
+
+export type PokeSearchWorkspaceMembers = {
+  members: PokeSearchWorkspaceMember[];
+  total: number;
+};
+
+export const pokeSearchWorkspaceMemberSchema = z.object({
+  sId: z.string(),
+  fullName: z.string().nullable(),
+  email: z.string(),
+});
+
+export const pokeSearchWorkspaceMembersSchema = z.object({
+  members: z.array(pokeSearchWorkspaceMemberSchema),
+  total: z.number(),
+});
+
+export function parsePokeSearchWorkspaceMembers(
+  data: unknown
+): PokeSearchWorkspaceMembers {
+  const result = pokeSearchWorkspaceMembersSchema.safeParse(data);
+  if (!result.success) {
+    throw new Error("Failed to parse workspace members response.");
+  }
+  return result.data;
+}

--- a/front/lib/api/poke/plugins/mcp_server_views/diagnose-mcp-server-view.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/diagnose-mcp-server-view.ts
@@ -1,0 +1,60 @@
+import { runMCPDiagnostics } from "@app/lib/api/poke/mcp_diagnostics";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export const diagnoseMcpServerViewPlugin = createPlugin({
+  manifest: {
+    id: "diagnose-mcp-server-view",
+    name: "Diagnose MCP Server View",
+    description:
+      "Run diagnostic checks on this MCP server view: connection rows, OAuth token health, connect/listTools, and sync path. Returns detailed per-step errors without exposing tokens.",
+    resourceTypes: ["mcp_server_views"],
+    readonly: true,
+    args: {
+      userId: {
+        type: "enum",
+        label: "User",
+        description:
+          "Optional. Search by name or email to run personal OAuth checks on personal_actions servers.",
+        values: [
+          {
+            label: "None (workspace checks only)",
+            value: "",
+            checked: true,
+          },
+        ],
+        multiple: false,
+        serverSideSearch: true,
+      },
+    },
+  },
+  isApplicableTo: (_auth, resource) => {
+    return !!resource;
+  },
+  execute: async (auth, mcpServerView, args) => {
+    if (!mcpServerView) {
+      return new Err(new Error("MCP server view not found."));
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const selectedUserId = args.userId?.[0]?.trim();
+    const userId = selectedUserId || undefined;
+
+    try {
+      const report = await runMCPDiagnostics(auth, {
+        workspaceId: workspace.sId,
+        mcpServerId: mcpServerView.mcpServerId,
+        serverViewId: mcpServerView.sId,
+        userId,
+      });
+
+      return new Ok({
+        display: "json",
+        value: report,
+      });
+    } catch (error) {
+      return new Err(new Error(normalizeError(error).message));
+    }
+  },
+});

--- a/front/lib/api/poke/plugins/mcp_server_views/index.ts
+++ b/front/lib/api/poke/plugins/mcp_server_views/index.ts
@@ -1,3 +1,4 @@
+export * from "./diagnose-mcp-server-view";
 export * from "./get-mcp-server-view-connection-metadata";
 export * from "./get-mcp-server-view-credentials";
 export * from "./update-mcp-url";

--- a/front/poke/swr/memberships.ts
+++ b/front/poke/swr/memberships.ts
@@ -1,6 +1,12 @@
 import type { PokeGetMemberships } from "@app/lib/api/poke/memberships";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  type PokeSearchWorkspaceMembers,
+  parsePokeSearchWorkspaceMembers,
+} from "@app/lib/api/poke/memberships";
+import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 export function usePokeMemberships({
@@ -20,5 +26,47 @@ export function usePokeMemberships({
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
+  };
+}
+
+export function usePokeWorkspaceMembersSearch({
+  disabled,
+  limit = 25,
+  owner,
+  query,
+}: {
+  disabled?: boolean;
+  limit?: number;
+  owner: Pick<LightWorkspaceType, "sId">;
+  query: string;
+}) {
+  const { fetcher } = useFetcher();
+
+  const searchFetcher: Fetcher<PokeSearchWorkspaceMembers> = useCallback(
+    async (url: string) => {
+      const json = await fetcher(url);
+      return parsePokeSearchWorkspaceMembers(json);
+    },
+    [fetcher]
+  );
+
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (query.trim()) {
+    params.set("q", query.trim());
+  }
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/memberships/search?${params.toString()}`,
+    searchFetcher,
+    { disabled, keepPreviousData: true, revalidateOnFocus: false }
+  );
+
+  return {
+    members: data?.members ?? emptyArray(),
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    isValidating,
   };
 }

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -44,9 +44,11 @@ export function mapToEnumValues<T>(
 
 interface EnumArgDefinition extends BaseArgDefinition {
   type: "enum";
-  values: EnumValues;
+  values: EnumValues | readonly [EnumValue];
   async?: false;
   multiple: boolean;
+  /** Fetch enum options from the workspace member search API as the user types. */
+  serverSideSearch?: true;
 }
 
 interface AsyncEnumArgDefinition extends BaseArgDefinition {
@@ -54,6 +56,7 @@ interface AsyncEnumArgDefinition extends BaseArgDefinition {
   values: AsyncEnumValues;
   async: true;
   multiple: boolean;
+  serverSideSearch?: true;
 }
 
 interface StringArgDefinition extends BaseArgDefinition {
@@ -184,9 +187,9 @@ export function createZodSchemaFromArgs(
           throw new Error(`Enum argument "${key}" must be an array`);
         }
 
-        // For async enums, allow empty arrays initially
-        // For non-async enums, require at least 2 values.
-        if (!arg.async && arg.values.length < 2) {
+        // For non-async enums, require at least 2 values unless server-side search
+        // is enabled (static values are optional placeholders such as "None").
+        if (!arg.async && !arg.serverSideSearch && arg.values.length < 2) {
           throw new Error(
             `Non-async enum argument "${key}" must have at least two values`
           );
@@ -195,9 +198,9 @@ export function createZodSchemaFromArgs(
         // Extract values from EnumValue objects.
         const enumValues = arg.values.map((v) => v.value) as string[];
 
-        // Handle empty async enums
-        if (enumValues.length === 0) {
-          schemaProps[key] = z.array(z.string()); // Allow any string for async enums initially.
+        // Server-side search enums load options dynamically (e.g. workspace members).
+        if (enumValues.length === 0 || arg.serverSideSearch) {
+          schemaProps[key] = z.array(z.string());
         } else if (enumValues.length === 1) {
           schemaProps[key] = z.array(z.literal(enumValues[0]));
         } else {


### PR DESCRIPTION
## Description

Adds a `diagnose-mcp-server-view` Poke plugin that runs structured diagnostic checks on an MCP server view directly from Poke — no SSH, no manual log digging.

The plugin (`diagnose-mcp-server-view.ts`) invokes `runMCPDiagnostics`, which runs five checks in order: `connection_inventory`, `oauth_metadata`, `oauth_token_fetch`, `connect_list_tools`, and `sync_simulation`. Results include per-check status, duration, error details (without exposing tokens), and a `summary` with `primary_issue` + `recommended_action`.

Supporting changes:
- New `GET /api/poke/workspaces/:wId/memberships/search` endpoint backed by `UserResource.searchUsers` (with fallback to in-memory filter) to power the user picker.
- New `ServerSideSearchEnumSelect` component — debounced combobox that hits the search endpoint as the user types, used to optionally scope personal OAuth checks to a specific user.
- `serverSideSearch?: true` flag added to plugin enum arg definitions, bypassing the "≥2 static values" constraint.
- `PokeMCPServerViewListItemType` enriches the Poke MCP server views API response with `space.{sId, name, kind}`; the table now renders `space.name` instead of the raw `spaceId`.

## Tests

- Unit tests in `mcp_diagnostics.test.ts` cover `resolveConnectionTypesToTest`, `createOAuthCheckSkippedNoUseCase`, `deriveDiagnosticSummary`, and `parseMCPDiagnosticReport`.
- Tested manually in Poke against a remote MCP server with workspace + personal OAuth connections.

## Risk

Low. Plugin is readonly, Poke-only, and gated behind Poke admin access. No new DB writes. The membership search endpoint falls back to in-memory filtering if `UserResource.searchUsers` fails. Rollback-safe.

## Deploy Plan

Deploy front.
