### PR TITLE
Fix poke plugins for programmatic credits

### DIFF
--- a/front/lib/api/credits/programmatic_usage_limit.test.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.test.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 
 describe("syncProgrammaticUsageLimit audit", () => {
   it("emits an audit event with previous and new cap", async () => {
-    const workspace = await WorkspaceFactory.metronome({
+    const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -72,7 +72,7 @@ describe("syncProgrammaticUsageLimit audit", () => {
   });
 
   it("records previous as 'unset' when no cap existed", async () => {
-    const workspace = await WorkspaceFactory.metronome({
+    const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -94,7 +94,7 @@ describe("syncProgrammaticUsageLimit audit", () => {
   });
 
   it("records new as 'unset' when clearing the cap", async () => {
-    const workspace = await WorkspaceFactory.metronome({
+    const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -119,7 +119,7 @@ describe("syncProgrammaticUsageLimit audit", () => {
   });
 
   it("skips audit when upsert fails", async () => {
-    const workspace = await WorkspaceFactory.metronome({
+    const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -9,6 +9,7 @@ import {
   getMetronomeProgrammaticCap,
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -70,6 +71,18 @@ export async function syncProgrammaticUsageLimit({
   if (!workspace.metronomeCustomerId) {
     return new Err(
       new Error(`Workspace ${workspace.sId} has no Metronome customer ID.`)
+    );
+  }
+
+  // Programmatic cap alerts are AWU-credit based and only meaningful on
+  // credit-priced (new-pricing) plans. Legacy programmatic usage is billed in
+  // USD via Stripe PAYG and must never create Metronome alerts.
+  const plan = auth.plan();
+  if (!plan || !isCreditPricedPlan(plan)) {
+    return new Err(
+      new Error(
+        `Programmatic usage limit only applies to credit-priced plans (workspace ${workspace.sId}).`
+      )
     );
   }
 

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
@@ -10,6 +10,7 @@ import {
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
@@ -47,6 +48,14 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
         async: true,
       },
     },
+  },
+
+  // Programmatic cap alerts are AWU-credit based: only meaningful on
+  // credit-priced (new-pricing) plans. Legacy programmatic usage is billed in
+  // USD via Stripe PAYG and must never create Metronome alerts.
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
   },
 
   populateAsyncArgs: async (_auth, workspace) => {
@@ -96,6 +105,16 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
   execute: async (auth, workspace, rawArgs) => {
     if (!workspace) {
       return new Err(new Error("Cannot find workspace."));
+    }
+
+    const plan = auth.plan();
+    if (!plan || !isCreditPricedPlan(plan)) {
+      return new Err(
+        new Error(
+          "Programmatic monthly cap only applies to credit-priced plans. " +
+            "Legacy programmatic usage is billed in USD via Stripe PAYG."
+        )
+      );
     }
 
     const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -1,8 +1,4 @@
 import { MAX_DISCOUNT_PERCENT } from "@app/lib/api/assistant/token_pricing";
-import {
-  dispatchPaygDisabled,
-  dispatchPaygEnabled,
-} from "@app/lib/api/metronome/credit_state_dispatcher";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { getDefaultDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import type { Authenticator } from "@app/lib/auth";
@@ -24,7 +20,6 @@ import {
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -381,7 +376,6 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       }
     }
 
-    const workspace = auth.getNonNullableWorkspace();
     if (paygEnabled) {
       assert(
         paygCapDollars !== undefined,
@@ -408,15 +402,9 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
             return updateResult;
           }
         }
-        // Note: the Metronome AWU PAYG cap alert is no longer driven from
-        // here. AWU concerns live on `credit_usage_configuration` and are
-        // managed via the "Manage Credit Usage Configuration" plugin.
-        const workspaceResource = await WorkspaceResource.fetchById(
-          workspace.sId
-        );
-        if (workspaceResource) {
-          await dispatchPaygEnabled({ workspace: workspaceResource });
-        }
+        // Legacy programmatic usage is billed in USD (Stripe PAYG /
+        // CreditResource). It must never touch the new-pricing workspace pool
+        // credit state machine or create any Metronome alert.
       }
     } else {
       const refreshedConfig =
@@ -436,14 +424,6 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
           });
           if (clearResult.isErr()) {
             return clearResult;
-          }
-          // Note: clearing the Metronome AWU PAYG cap alert lives on the
-          // "Manage Credit Usage Configuration" plugin now.
-          const workspaceResource = await WorkspaceResource.fetchById(
-            workspace.sId
-          );
-          if (workspaceResource) {
-            await dispatchPaygDisabled({ workspace: workspaceResource });
           }
         }
       }


### PR DESCRIPTION
## Description

Gate programmatic credits cap plugin and api to credit based plans, avoid sending credit state update when setting up legacy programmatic.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
