### PR TITLE
rateLimiter: add support for `incrementBy`

### DIFF
--- a/front/lib/utils/rate_limiter.test.ts
+++ b/front/lib/utils/rate_limiter.test.ts
@@ -1,0 +1,218 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.unmock("@app/lib/api/redis");
+
+vi.mock("@app/lib/utils/statsd", () => ({
+  getStatsDClient: () => ({
+    decrement: vi.fn(),
+    distribution: vi.fn(),
+    increment: vi.fn(),
+  }),
+}));
+
+const logger = {
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+  trace: () => undefined,
+};
+
+const keysToExpire = new Set<string>();
+
+type RedisModule = typeof import("@app/lib/api/redis");
+type RateLimiterModule = typeof import("@app/lib/utils/rate_limiter");
+
+let closeRedisClients: RedisModule["closeRedisClients"];
+let runOnRedis: RedisModule["runOnRedis"];
+let expireRateLimiterKey: RateLimiterModule["expireRateLimiterKey"];
+let getRateLimiterCount: RateLimiterModule["getRateLimiterCount"];
+let rateLimiter: RateLimiterModule["rateLimiter"];
+let RATE_LIMITER_PREFIX: RateLimiterModule["RATE_LIMITER_PREFIX"];
+
+async function expireTestKey(key: string) {
+  keysToExpire.add(key);
+  await expireRateLimiterKey({ key });
+}
+
+describe("rateLimiter", () => {
+  beforeAll(async () => {
+    const redisModule = await import("@app/lib/api/redis");
+    const rateLimiterModule = await import("@app/lib/utils/rate_limiter");
+
+    closeRedisClients = redisModule.closeRedisClients;
+    runOnRedis = redisModule.runOnRedis;
+    expireRateLimiterKey = rateLimiterModule.expireRateLimiterKey;
+    getRateLimiterCount = rateLimiterModule.getRateLimiterCount;
+    RATE_LIMITER_PREFIX = rateLimiterModule.RATE_LIMITER_PREFIX;
+    rateLimiter = rateLimiterModule.rateLimiter;
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      [...keysToExpire].map((key) => expireRateLimiterKey({ key }))
+    );
+    keysToExpire.clear();
+  });
+
+  afterAll(async () => {
+    await closeRedisClients();
+  });
+
+  it("keeps the existing consume-one behavior", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    await expect(
+      rateLimiter({
+        key,
+        maxPerTimeframe: 2,
+        timeframeSeconds: 60,
+        logger,
+      })
+    ).resolves.toBe(2);
+
+    await expect(
+      rateLimiter({
+        key,
+        maxPerTimeframe: 2,
+        timeframeSeconds: 60,
+        logger,
+      })
+    ).resolves.toBe(1);
+
+    await expect(
+      rateLimiter({
+        key,
+        maxPerTimeframe: 2,
+        timeframeSeconds: 60,
+        logger,
+      })
+    ).resolves.toBe(0);
+  });
+
+  it("can consume more than one unit atomically", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    const remaining = await rateLimiter({
+      key,
+      maxPerTimeframe: 5,
+      timeframeSeconds: 60,
+      incrementBy: 3,
+      logger,
+    });
+    expect(remaining).toBe(5);
+
+    const count = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(3);
+    }
+
+    const blocked = await rateLimiter({
+      key,
+      maxPerTimeframe: 5,
+      timeframeSeconds: 60,
+      incrementBy: 3,
+      logger,
+    });
+    expect(blocked).toBe(0);
+
+    const countAfterBlockedIncrement = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(countAfterBlockedIncrement.isOk()).toBe(true);
+    if (countAfterBlockedIncrement.isOk()) {
+      expect(countAfterBlockedIncrement.value).toBe(3);
+    }
+  });
+
+  it("allows a zero limit to block all consumption", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    const remaining = await rateLimiter({
+      key,
+      maxPerTimeframe: 0,
+      timeframeSeconds: 60,
+      logger,
+    });
+    expect(remaining).toBe(0);
+  });
+
+  it("can read usage without creating the key", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    const count = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(0);
+    }
+
+    const exists = await runOnRedis({ origin: "rate_limiter" }, async (redis) =>
+      redis.exists(`${RATE_LIMITER_PREFIX}:${key}`)
+    );
+    expect(exists).toBe(0);
+  });
+
+  it("reads usage after consuming multiple units", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    await rateLimiter({
+      key,
+      maxPerTimeframe: 5,
+      timeframeSeconds: 60,
+      incrementBy: 3,
+      logger,
+    });
+
+    const count = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(3);
+    }
+  });
+
+  it("counts plain Redis members as one unit", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+    const redisKey = `${RATE_LIMITER_PREFIX}:${key}`;
+
+    await runOnRedis({ origin: "rate_limiter" }, async (redis) =>
+      redis.zAdd(redisKey, {
+        score: Date.now(),
+        value: crypto.randomUUID(),
+      })
+    );
+
+    const count = await getRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(1);
+    }
+  });
+});

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -1,6 +1,9 @@
 import { getRedisStreamClient } from "@app/lib/api/redis";
 import { getStatsDClient } from "@app/lib/utils/statsd";
-import type { MaxMessagesTimeframeType } from "@app/types/plan";
+import type {
+  MaxAwuCreditsTimeframeType,
+  MaxMessagesTimeframeType,
+} from "@app/types/plan";
 import type { LoggerInterface } from "@app/types/shared/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -14,26 +17,43 @@ export const RATE_LIMITER_PREFIX = "rate_limiter";
 
 const makeRateLimiterKey = (key: string) => `${RATE_LIMITER_PREFIX}:${key}`;
 
+type RateLimiterArgs = {
+  key: string;
+  logger: LoggerInterface;
+  maxPerTimeframe: number;
+  timeframeSeconds: number;
+  incrementBy?: number;
+  readOnly?: boolean;
+};
+
 export async function rateLimiter({
   key,
   maxPerTimeframe,
   timeframeSeconds,
   logger,
-}: {
-  key: string;
-  logger: LoggerInterface;
-  maxPerTimeframe: number;
-  timeframeSeconds: number;
-}): Promise<number> {
+  incrementBy = 1,
+  readOnly = false,
+}: RateLimiterArgs): Promise<number> {
   const now = new Date();
   const redisKey = makeRateLimiterKey(key);
   const tags: string[] = [];
+
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    throw new Error("incrementBy must be a positive integer.");
+  }
+  if (!Number.isInteger(maxPerTimeframe) || maxPerTimeframe < 0) {
+    throw new Error("maxPerTimeframe must be a non-negative integer.");
+  }
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    throw new Error("timeframeSeconds must be a positive integer.");
+  }
 
   const luaScript = `
     local key = KEYS[1]
     local window_seconds = tonumber(ARGV[1])
     local limit = tonumber(ARGV[2])
-    local value = ARGV[3]
+    local increment_by = tonumber(ARGV[3])
+    local read_only = ARGV[4] == '1'
 
     -- Use Redis server time to avoid client clock skew
     local t = redis.call('TIME') -- { seconds, microseconds }
@@ -44,12 +64,22 @@ export async function rateLimiter({
     local window_ms = window_seconds * 1000
     local trim_before = now_ms - window_ms
 
-    -- Current count in window
     local count = redis.call('ZCOUNT', key, trim_before, '+inf')
 
-    if count < limit then
-      -- Allow: record this request at now_ms
-      redis.call('ZADD', key, now_ms, value)
+    if read_only then
+      local remaining = limit - count
+      if remaining > 0 then
+        return remaining
+      else
+        return 0
+      end
+    end
+
+    if count + increment_by <= limit then
+      -- Allow: record one entry per consumed unit at now_ms.
+      for i = 1, increment_by do
+        redis.call('ZADD', key, now_ms, ARGV[4 + i])
+      end
       -- Keep the key around a bit longer than the window to allow trims
       local ttl_ms = window_ms + 60000
       redis.call('PEXPIRE', key, ttl_ms)
@@ -64,12 +94,17 @@ export async function rateLimiter({
 
   try {
     const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const values = readOnly
+      ? []
+      : Array.from({ length: incrementBy }, () => uuidv4());
     const remaining = (await redis.eval(luaScript, {
       keys: [redisKey],
       arguments: [
         timeframeSeconds.toString(),
         maxPerTimeframe.toString(),
-        uuidv4(),
+        incrementBy.toString(),
+        readOnly ? "1" : "0",
+        ...values,
       ],
     })) as number;
 
@@ -80,7 +115,7 @@ export async function rateLimiter({
       tags
     );
 
-    if (remaining <= 0) {
+    if (!readOnly && remaining <= 0) {
       getStatsDClient().increment("ratelimiter.exceeded.count", 1, tags);
     }
 
@@ -92,6 +127,8 @@ export async function rateLimiter({
         key,
         maxPerTimeframe,
         timeframeSeconds,
+        incrementBy,
+        readOnly,
         error: e,
       },
       `RateLimiter error`
@@ -124,6 +161,10 @@ export async function getRateLimiterCount({
   key: string;
   timeframeSeconds: number;
 }): Promise<Result<number, Error>> {
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    return new Err(new Error("timeframeSeconds must be a positive integer."));
+  }
+
   try {
     const redis = await getRedisStreamClient({ origin: "rate_limiter" });
     const redisKey = makeRateLimiterKey(key);
@@ -140,12 +181,16 @@ export async function getRateLimiterCount({
 }
 
 export function getTimeframeSecondsFromLiteral(
-  timeframeLiteral: MaxMessagesTimeframeType
+  timeframeLiteral: MaxMessagesTimeframeType | MaxAwuCreditsTimeframeType
 ): number {
   switch (timeframeLiteral) {
     case "day":
       return 60 * 60 * 24; // 1 day.
 
+    case "week":
+      return 60 * 60 * 24 * 7; // 7 days.
+
+    case "month":
     // Lifetime is intentionally mapped to a 30-day period.
     case "lifetime":
       return 60 * 60 * 24 * 30; // 30 days.

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -23,7 +23,6 @@ type RateLimiterArgs = {
   maxPerTimeframe: number;
   timeframeSeconds: number;
   incrementBy?: number;
-  readOnly?: boolean;
 };
 
 export async function rateLimiter({
@@ -32,7 +31,6 @@ export async function rateLimiter({
   timeframeSeconds,
   logger,
   incrementBy = 1,
-  readOnly = false,
 }: RateLimiterArgs): Promise<number> {
   const now = new Date();
   const redisKey = makeRateLimiterKey(key);
@@ -53,7 +51,6 @@ export async function rateLimiter({
     local window_seconds = tonumber(ARGV[1])
     local limit = tonumber(ARGV[2])
     local increment_by = tonumber(ARGV[3])
-    local read_only = ARGV[4] == '1'
 
     -- Use Redis server time to avoid client clock skew
     local t = redis.call('TIME') -- { seconds, microseconds }
@@ -66,19 +63,10 @@ export async function rateLimiter({
 
     local count = redis.call('ZCOUNT', key, trim_before, '+inf')
 
-    if read_only then
-      local remaining = limit - count
-      if remaining > 0 then
-        return remaining
-      else
-        return 0
-      end
-    end
-
     if count + increment_by <= limit then
       -- Allow: record one entry per consumed unit at now_ms.
       for i = 1, increment_by do
-        redis.call('ZADD', key, now_ms, ARGV[4 + i])
+        redis.call('ZADD', key, now_ms, ARGV[3 + i])
       end
       -- Keep the key around a bit longer than the window to allow trims
       local ttl_ms = window_ms + 60000
@@ -94,16 +82,13 @@ export async function rateLimiter({
 
   try {
     const redis = await getRedisStreamClient({ origin: "rate_limiter" });
-    const values = readOnly
-      ? []
-      : Array.from({ length: incrementBy }, () => uuidv4());
+    const values = Array.from({ length: incrementBy }, () => uuidv4());
     const remaining = (await redis.eval(luaScript, {
       keys: [redisKey],
       arguments: [
         timeframeSeconds.toString(),
         maxPerTimeframe.toString(),
         incrementBy.toString(),
-        readOnly ? "1" : "0",
         ...values,
       ],
     })) as number;
@@ -115,7 +100,7 @@ export async function rateLimiter({
       tags
     );
 
-    if (!readOnly && remaining <= 0) {
+    if (remaining <= 0) {
       getStatsDClient().increment("ratelimiter.exceeded.count", 1, tags);
     }
 
@@ -128,7 +113,6 @@ export async function rateLimiter({
         maxPerTimeframe,
         timeframeSeconds,
         incrementBy,
-        readOnly,
         error: e,
       },
       `RateLimiter error`


### PR DESCRIPTION
## Description

Adds `incrementBy` optional argument to `rateLimiter`.

- Does not move away from ZCOUNT which is `log N` (vs moving to ZRANGEBYSCORE which is `(log N) + M`) to avoid any performance hit.
- The incrementBy is expected to be rather small hence we instead add `incrementBy` entries instead of one and keep the rest of the logic unchanged.

## Tests

Added tests. Tested locally. In particular tested while switching back and forth between main.

## Risk

Low since the redis state is not changed.

## Deploy Plan

- deploy `front`