### PR TITLE
Show banner on low balance

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -7,6 +7,7 @@ import {
   getWorkspaceProgrammaticCreditStatus,
   isUserAwuWarned,
   isUserBlocked,
+  isWorkspaceBalanceThresholdReached,
 } from "@app/lib/metronome/user_block";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -31,15 +32,21 @@ app.get(
         awuStatus: "normal",
         poolCreditState: "active",
         programmaticCreditStatus: "active",
+        balanceThresholdReached: false,
       });
     }
 
-    const [poolCreditState, blockedReason, programmaticState] =
-      await Promise.all([
-        getWorkspaceCreditPoolStatus(workspace.sId),
-        isUserBlocked(workspace.sId, user.sId),
-        getWorkspaceProgrammaticCreditStatus(workspace.sId),
-      ]);
+    const [
+      poolCreditState,
+      blockedReason,
+      programmaticState,
+      balanceThresholdReached,
+    ] = await Promise.all([
+      getWorkspaceCreditPoolStatus(workspace.sId),
+      isUserBlocked(workspace.sId, user.sId),
+      getWorkspaceProgrammaticCreditStatus(workspace.sId),
+      isWorkspaceBalanceThresholdReached(workspace.sId),
+    ]);
 
     let awuStatus: GetWorkspaceUsageStatusResponseBody["awuStatus"] = "normal";
     if (blockedReason === "user_cap_reached") {
@@ -58,7 +65,12 @@ app.get(
       programmaticCreditStatus = "warned";
     }
 
-    return ctx.json({ awuStatus, poolCreditState, programmaticCreditStatus });
+    return ctx.json({
+      awuStatus,
+      poolCreditState,
+      programmaticCreditStatus,
+      balanceThresholdReached,
+    });
   }
 );
 

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -206,12 +206,17 @@ interface UsageStatusBannerProps {
 }
 
 function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
-  const { awuStatus, poolCreditState, programmaticCreditStatus } =
-    useWorkspaceUsageStatus({ owner });
+  const {
+    awuStatus,
+    poolCreditState,
+    programmaticCreditStatus,
+    balanceThresholdReached,
+  } = useWorkspaceUsageStatus({ owner });
 
   // Pool balance and programmatic cap banners are only shown to admins who
   // manage workspace credits. The AWU cap banner is shown to any user subject
-  // to a per-user usage cap. All can be displayed at the same time.
+  // to a per-user usage cap. At most one banner is shown at a time (see the
+  // priority selection below).
   //
   // The low/critical pool states are internal throttling signals and are not
   // surfaced. Admins are alerted when the pool is fully depleted (agents
@@ -238,72 +243,89 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
   const showAwuBanner = awuStatus !== "normal";
   const showProgrammaticBanner =
     isAdmin(owner) && programmaticCreditStatus !== "active";
+  // The admin-configured balance-threshold warning is only relevant before the
+  // pool is depleted/overage — those states have their own (stronger) banner.
+  const showBalanceThresholdBanner =
+    isAdmin(owner) &&
+    balanceThresholdReached &&
+    !isPoolDepleted &&
+    !isPoolOverage;
 
-  if (!showPoolBanner && !showAwuBanner && !showProgrammaticBanner) {
+  // Only a single usage banner is shown at a time, picked by priority. The
+  // pool banner takes precedence over the lower-severity balance-threshold
+  // warning, which is why "Your credit balance is running low" never shows
+  // alongside it.
+  const manageCreditsFooter = (
+    <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">
+      Manage credits
+    </LinkWrapper>
+  );
+
+  const banner = ((): StatusBannerProps | null => {
+    if (showPoolBanner) {
+      return {
+        variant: isPoolDepleted ? "danger" : "warning",
+        title: isPoolDepleted
+          ? "Your workspace is out of credits"
+          : "Your workspace has used all its credits",
+        description: isPoolDepleted
+          ? "Your workspace has run out of credits. Agents are blocked until you top up."
+          : "Your workspace has used all of its included credits and is now billed pay-as-you-go. Top up to avoid overage charges.",
+        footer: manageCreditsFooter,
+      };
+    }
+
+    if (showAwuBanner) {
+      return {
+        variant: awuStatus === "blocked" ? "danger" : "warning",
+        title:
+          awuStatus === "blocked"
+            ? "You've reached your usage limit"
+            : "You've used 80% of your usage limit",
+        description:
+          awuStatus === "blocked"
+            ? "You can no longer run agents. Contact your admin to increase your limit."
+            : "Contact your admin to increase your limit before you are blocked.",
+      };
+    }
+
+    if (showProgrammaticBanner) {
+      return {
+        variant: programmaticCreditStatus === "depleted" ? "danger" : "warning",
+        title:
+          programmaticCreditStatus === "depleted"
+            ? "Programmatic API cap reached"
+            : "Programmatic API cap at 80%",
+        description:
+          programmaticCreditStatus === "depleted"
+            ? "Your workspace has exhausted its monthly programmatic API credit cap. Programmatic API calls are blocked until the billing cycle resets or the cap is raised."
+            : "Your workspace has used 80% of its monthly programmatic API credit cap. Consider raising the cap to avoid interruptions.",
+        footer: (
+          <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">
+            Manage usage
+          </LinkWrapper>
+        ),
+      };
+    }
+
+    if (showBalanceThresholdBanner) {
+      return {
+        variant: "warning",
+        title: "Your credit balance is running low",
+        description:
+          "Your workspace's remaining credit balance has dropped below the threshold you set. Top up to avoid running out of credits.",
+        footer: manageCreditsFooter,
+      };
+    }
+
+    return null;
+  })();
+
+  if (!banner) {
     return null;
   }
 
-  return (
-    <>
-      {showPoolBanner && (
-        <StatusBanner
-          variant={isPoolDepleted ? "danger" : "warning"}
-          title={
-            isPoolDepleted
-              ? "Your workspace is out of credits"
-              : "Your workspace has used all its credits"
-          }
-          description={
-            isPoolDepleted
-              ? "Your workspace has run out of credits. Agents are blocked until you top up."
-              : "Your workspace has used all of its included credits and is now billed pay-as-you-go. Top up to avoid overage charges."
-          }
-          footer={
-            <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">
-              Manage credits
-            </LinkWrapper>
-          }
-        />
-      )}
-      {showAwuBanner && (
-        <StatusBanner
-          variant={awuStatus === "blocked" ? "danger" : "warning"}
-          title={
-            awuStatus === "blocked"
-              ? "You've reached your usage limit"
-              : "You've used 80% of your usage limit"
-          }
-          description={
-            awuStatus === "blocked"
-              ? "You can no longer run agents. Contact your admin to increase your limit."
-              : "Contact your admin to increase your limit before you are blocked."
-          }
-        />
-      )}
-      {showProgrammaticBanner && (
-        <StatusBanner
-          variant={
-            programmaticCreditStatus === "depleted" ? "danger" : "warning"
-          }
-          title={
-            programmaticCreditStatus === "depleted"
-              ? "Programmatic API cap reached"
-              : "Programmatic API cap at 80%"
-          }
-          description={
-            programmaticCreditStatus === "depleted"
-              ? "Your workspace has exhausted its monthly programmatic API credit cap. Programmatic API calls are blocked until the billing cycle resets or the cap is raised."
-              : "Your workspace has used 80% of its monthly programmatic API credit cap. Consider raising the cap to avoid interruptions."
-          }
-          footer={
-            <LinkWrapper href={`/w/${owner.sId}/usage`} className="underline">
-              Manage usage
-            </LinkWrapper>
-          }
-        />
-      )}
-    </>
-  );
+  return <StatusBanner {...banner} />;
 }
 
 export function SidebarBanners() {

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -5,6 +5,10 @@ import {
   getCachedWorkspaceBalanceThreshold,
   upsertMetronomeBalanceThresholdAlert,
 } from "@app/lib/metronome/alerts/balance_threshold";
+import {
+  clearWorkspaceBalanceThresholdReached,
+  setWorkspaceBalanceThresholdReached,
+} from "@app/lib/metronome/user_block";
 import { notifyAdminsBalanceThresholdReached } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
@@ -143,6 +147,10 @@ export async function maybeNotifyAdminsBalanceThresholdReached({
       return;
     }
 
+    // Surface the in-app warning banner (admins read this via /usage-status).
+    // Cleared on the matching `..._resolved` event when the balance recovers.
+    void setWorkspaceBalanceThresholdReached(workspaceId);
+
     const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
     const workspace = auth.workspace();
     if (!workspace) {
@@ -183,6 +191,49 @@ export async function maybeNotifyAdminsBalanceThresholdReached({
     logger.error(
       { workspaceId, error: normalizeError(err).message },
       "[Balance Threshold] Failed to notify admins of balance threshold"
+    );
+  }
+}
+
+/**
+ * Clear the credit-balance-threshold warning banner when the balance recovers,
+ * but only when the firing Metronome alert (`alertId`) is the workspace's own
+ * balance-threshold alert — the same `low_remaining_*` event type also resolves
+ * for unrelated pool alerts, which must not clear this warning prematurely.
+ *
+ * Best-effort: any failure is logged and swallowed so it never disrupts the
+ * webhook's credit-state processing.
+ */
+export async function maybeClearAdminsBalanceThresholdReached({
+  metronomeCustomerId,
+  workspaceId,
+  alertId,
+}: {
+  metronomeCustomerId: string | null;
+  workspaceId: string;
+  alertId: string | null;
+}): Promise<void> {
+  try {
+    if (!metronomeCustomerId || !alertId) {
+      return;
+    }
+
+    const { alertId: configuredAlertId } =
+      await getCachedWorkspaceBalanceThreshold({
+        metronomeCustomerId,
+        workspaceId,
+      });
+
+    // Only clear for the workspace's own configured balance-threshold alert.
+    if (configuredAlertId === null || configuredAlertId !== alertId) {
+      return;
+    }
+
+    void clearWorkspaceBalanceThresholdReached(workspaceId);
+  } catch (err) {
+    logger.error(
+      { workspaceId, error: normalizeError(err).message },
+      "[Balance Threshold] Failed to clear balance threshold warning"
     );
   }
 }

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -2,7 +2,10 @@ import {
   handleSubscriptionActivationFailure,
   handleSubscriptionActivationSuccess,
 } from "@app/lib/api/checkout/business_activation";
-import { maybeNotifyAdminsBalanceThresholdReached } from "@app/lib/api/credits/balance_threshold_alert";
+import {
+  maybeClearAdminsBalanceThresholdReached,
+  maybeNotifyAdminsBalanceThresholdReached,
+} from "@app/lib/api/credits/balance_threshold_alert";
 import {
   dispatchCreditsAdded,
   dispatchLowBalance,
@@ -1008,6 +1011,14 @@ export async function processMetronomeWebhook({
       await dispatchCreditsAdded({
         workspace,
         newBalanceAwu: event.properties.remaining_balance ?? 0,
+      });
+
+      // If this is the workspace's own configured balance-threshold alert,
+      // clear the warning banner now that the balance has recovered.
+      await maybeClearAdminsBalanceThresholdReached({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        workspaceId: workspace.sId,
+        alertId: event.properties.alert_id ?? null,
       });
       logger.info(
         {

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -46,6 +46,7 @@ export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditStatus: ProgrammaticCreditStatus;
+  balanceThresholdReached: boolean;
 };
 
 const REDIS_ORIGIN = "metronome_limit" as const;
@@ -64,6 +65,10 @@ function buildWorkspaceProgrammaticCreditStatusKey(
   return `metronome:programmatic_credit_status:${workspaceId}`;
 }
 
+function buildWorkspaceBalanceThresholdReachedKey(workspaceId: string): string {
+  return `metronome:balance_threshold_warning:${workspaceId}`;
+}
+
 async function setFlag(key: string, value: string): Promise<void> {
   await runOnRedis({ origin: REDIS_ORIGIN }, async (client) => {
     await client.set(key, value);
@@ -79,6 +84,34 @@ export async function isUserAwuWarned(
 ): Promise<boolean> {
   const state = await getUserCreditState(workspaceId, userId);
   return state === "on_pool_low_balance" || state === "user_seat_low_balance";
+}
+
+// Workspace credit-balance threshold reached (admin-configured early warning).
+// Unlike the other warnings this cannot be derived from a credit state: the
+// threshold is an arbitrary amount the admin picks, not a system pool state, so
+// it gets its own flag — set by the webhook when the workspace's own
+// balance-threshold alert fires and cleared when the balance recovers. No DB
+// fallback: a cold-cache miss reads as "not reached" until the next webhook.
+
+export async function setWorkspaceBalanceThresholdReached(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(buildWorkspaceBalanceThresholdReachedKey(workspaceId), "1");
+}
+
+export async function clearWorkspaceBalanceThresholdReached(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(buildWorkspaceBalanceThresholdReachedKey(workspaceId), "0");
+}
+
+export async function isWorkspaceBalanceThresholdReached(
+  workspaceId: string
+): Promise<boolean> {
+  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceBalanceThresholdReachedKey(workspaceId))
+  );
+  return val === "1";
 }
 
 // Unified read

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -275,6 +275,7 @@ export function useWorkspaceUsageStatus({
     awuStatus: data?.awuStatus ?? "normal",
     poolCreditState: data?.poolCreditState ?? "active",
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
+    balanceThresholdReached: data?.balanceThresholdReached ?? false,
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }


### PR DESCRIPTION
## Description

Adds an in-app **banner that warns admins when their workspace credit balance drops below the admin-configured threshold** — the same threshold that already triggers the balance-threshold email. Until now, approaching that threshold only sent an email; there was no persistent in-app surface. This mirrors the existing programmatic-cap and pool-credit banners.

How it works (driven by the existing Metronome `low_remaining_contract_credit_and_commit_balance_*` webhook events):

- When the workspace's **own** configured balance-threshold alert fires, the webhook sets a Redis flag (`metronome:balance_threshold_warning:<ws>`) in addition to sending the email.
- When the balance recovers (the matching `..._resolved` event for that same alert), the flag is cleared.
- `/api/w/[wId]/usage-status` returns `balanceThresholdReached`, the `useWorkspaceUsageStatus` SWR hook exposes it, and `AppStatusBanner` renders an admin-only warning banner ("Your credit balance is running low") with a "Manage credits" link. It's suppressed when the pool is already `depleted`/`overage`, since those have their own stronger banners.

Why a dedicated flag (vs. deriving from credit state like the other warnings): the threshold is an arbitrary amount the admin picks, not a system pool state, so it cannot be derived from `poolCreditState` — it gets its own webhook-driven flag with no DB fallback (a cold-cache miss reads as "not reached" until the next webhook re-asserts it).

Channels for this notification are now **email + banner** (no in-app notification), matching the programmatic-cap pattern.

### Changes

- `front/lib/metronome/user_block.ts` — `set/clear/isWorkspaceBalanceThresholdReached` helpers + the `balanceThresholdReached` field on `GetWorkspaceUsageStatusResponseBody`.
- `front/lib/api/credits/balance_threshold_alert.ts` — set the flag when the configured alert fires; new `maybeClearAdminsBalanceThresholdReached` (gated on the workspace's own alert id) for recovery.
- `front/lib/api/metronome/process_webhook.ts` — clear the flag on the matching `..._resolved` event.
- `front-api/routes/w/[wId]/usage-status.ts` — return `balanceThresholdReached`.
- `front/lib/swr/user.ts` — expose it from `useWorkspaceUsageStatus`.
- `front/components/navigation/AppStatusBanner.tsx` — the new admin-only warning banner.

## Tests

Manually exercised the webhook → flag → endpoint → banner path. No automated tests added yet — the warning is set/cleared from the Metronome webhook handler, which is functionally testable; happy to add an endpoint-level test for the set/clear path if wanted.

## Risk

Low. Additive only:
- New response field is optional client-side (defaults to `false`), so it's backward compatible for any client that hasn't refreshed.
- The flag is Redis-only with a safe default (`false` on cold miss) — no schema/DB migration, no behavior change to access control or throttling. It is purely a display signal.
- Banner is admin-only and self-clearing on balance recovery.

Safe to roll back: reverting removes the banner and the flag reads/writes with no residual effect (stale Redis keys are harmless and self-correct on the next webhook).

## Deploy Plan

Standard deploy — no migration or coordinated steps required. The flag is only ever set/cleared by the Metronome webhook, so existing workspaces will start showing the banner the next time their configured threshold alert fires (or clearing it on the next resolve).
