### PR TITLE
[Skills] Distinguish Dust-provided skills

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -9,7 +9,11 @@ import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import {
+  DUST_PROVIDED_SKILL_LABEL,
+  getSkillAvatarIcon,
+  isDustProvidedSkill,
+} from "@app/lib/skill";
 import {
   useAvailableMCPServers,
   useMCPServerViewsFromSpaces,
@@ -53,6 +57,7 @@ interface CapabilityPickerItemBase {
   id: string;
   label: string;
   sortName: string;
+  tooltip?: string;
 }
 
 type CapabilityPickerItem = CapabilityPickerItemBase &
@@ -234,11 +239,11 @@ function CapabilitiesPickerItemsList({
                 />
               );
 
-            if (item.kind !== "uninstalled_tool" && item.description) {
+            if (item.kind !== "uninstalled_tool" && item.tooltip) {
               return (
                 <DropdownTooltipTrigger
                   key={item.id}
-                  description={item.description}
+                  description={item.tooltip}
                   side="right"
                   sideOffset={8}
                 >
@@ -478,6 +483,7 @@ export function CapabilitiesPicker({
     if (isSkillsDataReady && isToolsDataReady) {
       for (const skill of skills) {
         const description = skill.userFacingDescription;
+        const isDustProvided = isDustProvidedSkill(skill);
 
         if (
           !matchesCapabilityPickerSearchQuery({
@@ -493,10 +499,13 @@ export function CapabilitiesPicker({
           kind: "skill",
           skill,
           id: `skills-picker-${skill.sId}`,
-          icon: getSkillAvatarIcon(skill.icon),
+          icon: getSkillAvatarIcon(skill.icon, { isDustProvided }),
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,
+          tooltip: isDustProvided
+            ? DUST_PROVIDED_SKILL_LABEL
+            : description || undefined,
         });
       }
 
@@ -524,6 +533,7 @@ export function CapabilitiesPicker({
           label,
           sortName: label.toLowerCase(),
           description,
+          tooltip: description || undefined,
         });
       }
     }

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -11,7 +11,7 @@ import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils"
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import {
   DUST_PROVIDED_SKILL_LABEL,
-  getSkillAvatarIcon,
+  getSkillAvatarIconForSkill,
   isDustProvidedSkill,
 } from "@app/lib/skill";
 import {
@@ -504,7 +504,7 @@ export function CapabilitiesPicker({
           kind: "skill",
           skill,
           id: `skills-picker-${skill.sId}`,
-          icon: getSkillAvatarIcon(skill.icon, { isDustProvided }),
+          icon: getSkillAvatarIconForSkill(skill),
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -11,7 +11,7 @@ import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils"
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import {
   DUST_PROVIDED_SKILL_LABEL,
-  getSkillAvatarIconForSkill,
+  getSkillAvatarIcon,
   isDustProvidedSkill,
 } from "@app/lib/skill";
 import {
@@ -504,7 +504,7 @@ export function CapabilitiesPicker({
           kind: "skill",
           skill,
           id: `skills-picker-${skill.sId}`,
-          icon: getSkillAvatarIconForSkill(skill),
+          icon: getSkillAvatarIcon(skill),
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -484,6 +484,11 @@ export function CapabilitiesPicker({
       for (const skill of skills) {
         const description = skill.userFacingDescription;
         const isDustProvided = isDustProvidedSkill(skill);
+        const tooltip = isDustProvided
+          ? description
+            ? `${description}\n\n${DUST_PROVIDED_SKILL_LABEL}`
+            : DUST_PROVIDED_SKILL_LABEL
+          : description || undefined;
 
         if (
           !matchesCapabilityPickerSearchQuery({
@@ -503,9 +508,7 @@ export function CapabilitiesPicker({
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,
-          tooltip: isDustProvided
-            ? DUST_PROVIDED_SKILL_LABEL
-            : description || undefined,
+          tooltip,
         });
       }
 

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
@@ -18,7 +18,7 @@ import type {
   MCPServerTypeWithViews,
   MCPServerViewType,
 } from "@app/lib/api/mcp";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -133,7 +133,7 @@ export function AssistantSkillsToolsSection({
               </div>
             ) : (
               sortedSkills.map((skill) => {
-                const SkillAvatar = getSkillAvatarIcon(skill.icon);
+                const SkillAvatar = getSkillAvatarIconForSkill(skill);
                 return (
                   <div
                     className="flex flex-row items-center gap-2"

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
@@ -18,7 +18,7 @@ import type {
   MCPServerTypeWithViews,
   MCPServerViewType,
 } from "@app/lib/api/mcp";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -133,7 +133,7 @@ export function AssistantSkillsToolsSection({
               </div>
             ) : (
               sortedSkills.map((skill) => {
-                const SkillAvatar = getSkillAvatarIconForSkill(skill);
+                const SkillAvatar = getSkillAvatarIcon(skill);
                 return (
                   <div
                     className="flex flex-row items-center gap-2"

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -1,6 +1,6 @@
 import { KeyboardHints } from "@app/components/command_palette/CommandPaletteItems";
 import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   ArrowLeft,
   Avatar,
@@ -123,7 +123,7 @@ export function CommandPaletteActionPhase({
     item.kind === "agent" ? (
       <Avatar visual={item.agent.pictureUrl} size="xs" />
     ) : (
-      React.createElement(getSkillAvatarIconForSkill(item.skill), {
+      React.createElement(getSkillAvatarIcon(item.skill), {
         size: "xs",
       })
     );

--- a/front/components/command_palette/CommandPaletteActionPhase.tsx
+++ b/front/components/command_palette/CommandPaletteActionPhase.tsx
@@ -1,6 +1,6 @@
 import { KeyboardHints } from "@app/components/command_palette/CommandPaletteItems";
 import type { CommandPaletteItem } from "@app/components/command_palette/CommandPaletteSearchPhase";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import {
   ArrowLeft,
   Avatar,
@@ -123,7 +123,9 @@ export function CommandPaletteActionPhase({
     item.kind === "agent" ? (
       <Avatar visual={item.agent.pictureUrl} size="xs" />
     ) : (
-      React.createElement(getSkillAvatarIcon(item.skill.icon), { size: "xs" })
+      React.createElement(getSkillAvatarIconForSkill(item.skill), {
+        size: "xs",
+      })
     );
 
   return (

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -4,7 +4,7 @@ import {
   ItemTitle,
   KeyboardHints,
 } from "@app/components/command_palette/CommandPaletteItems";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
@@ -234,7 +234,7 @@ export function CommandPaletteSearchPhase({
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
               const globalIndex = agents.length + pods.length + i;
-              const SkillAvatar = getSkillAvatarIcon(skill.icon);
+              const SkillAvatar = getSkillAvatarIconForSkill(skill);
               return (
                 <ItemRow
                   key={skill.sId}

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -4,7 +4,7 @@ import {
   ItemTitle,
   KeyboardHints,
 } from "@app/components/command_palette/CommandPaletteItems";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
@@ -234,7 +234,7 @@ export function CommandPaletteSearchPhase({
             <ItemTitle>Skills</ItemTitle>
             {skills.map((skill, i) => {
               const globalIndex = agents.length + pods.length + i;
-              const SkillAvatar = getSkillAvatarIconForSkill(skill);
+              const SkillAvatar = getSkillAvatarIcon(skill);
               return (
                 <ItemRow
                   key={skill.sId}

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -1,9 +1,12 @@
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { DUST_PROVIDED_SKILL_LABEL } from "@app/lib/skill";
 import { describe, expect, it } from "vitest";
 
 import {
+  getSkillSlashCommandItem,
   getToolSlashCommandItem,
   matchesSlashCommandCapabilityQuery,
+  type SlashCommandSkillSuggestion,
   type SlashCommandToolSuggestion,
   sortSlashCommandCapabilityMatches,
 } from "./SlashCommandCapabilitiesItems";
@@ -52,6 +55,25 @@ function toolSuggestion({
   };
 }
 
+function skillSuggestion({
+  editedBy = 1,
+  icon = null,
+  requestedSpaceIds = [],
+  sId,
+  userFacingDescription = "Draft structured memos.",
+  name,
+}: Pick<SlashCommandSkillSuggestion, "name" | "sId"> &
+  Partial<SlashCommandSkillSuggestion>): SlashCommandSkillSuggestion {
+  return {
+    editedBy,
+    icon,
+    name,
+    requestedSpaceIds,
+    sId,
+    userFacingDescription,
+  };
+}
+
 describe("matchesSlashCommandCapabilityQuery", () => {
   it("matches capability labels with fuzzy slash query matching", () => {
     expect(
@@ -92,6 +114,36 @@ describe("sortSlashCommandCapabilityMatches", () => {
     });
 
     expect(result.map((item) => item.id)).toEqual(["longtest", "testlonger"]);
+  });
+});
+
+describe("getSkillSlashCommandItem", () => {
+  it("uses a Dust-provided tooltip for code-defined skills", () => {
+    const item = getSkillSlashCommandItem(
+      skillSuggestion({
+        editedBy: null,
+        name: "Create Frames",
+        sId: "frames",
+      })
+    );
+
+    expect(item.tooltip).toEqual({
+      description: DUST_PROVIDED_SKILL_LABEL,
+    });
+  });
+
+  it("keeps the description tooltip for user-created skills", () => {
+    const item = getSkillSlashCommandItem(
+      skillSuggestion({
+        name: "Create memo",
+        sId: "skill_create_memo",
+        userFacingDescription: "Draft structured memos.",
+      })
+    );
+
+    expect(item.tooltip).toEqual({
+      description: "Draft structured memos.",
+    });
   });
 });
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -1,5 +1,4 @@
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { DUST_PROVIDED_SKILL_LABEL } from "@app/lib/skill";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -118,31 +117,26 @@ describe("sortSlashCommandCapabilityMatches", () => {
 });
 
 describe("getSkillSlashCommandItem", () => {
-  it("uses a Dust-provided tooltip for code-defined skills", () => {
-    const item = getSkillSlashCommandItem(
-      skillSuggestion({
-        editedBy: null,
-        name: "Create Frames",
-        sId: "frames",
-      })
-    );
-
-    expect(item.tooltip).toEqual({
-      description: DUST_PROVIDED_SKILL_LABEL,
+  it("builds a slash command item that keeps the selected skill", () => {
+    const skill = skillSuggestion({
+      name: "Create memo",
+      sId: "skill_create_memo",
+      userFacingDescription: "Draft structured memos.",
     });
-  });
 
-  it("keeps the description tooltip for user-created skills", () => {
-    const item = getSkillSlashCommandItem(
-      skillSuggestion({
-        name: "Create memo",
-        sId: "skill_create_memo",
-        userFacingDescription: "Draft structured memos.",
-      })
-    );
+    const item = getSkillSlashCommandItem(skill, {
+      sectionLabel: "Capabilities",
+    });
 
-    expect(item.tooltip).toEqual({
+    expect(item).toMatchObject({
+      action: "select-skill",
+      data: {
+        skill,
+      },
       description: "Draft structured memos.",
+      id: "skill_create_memo",
+      label: "Create memo",
+      sectionLabel: "Capabilities",
     });
   });
 });

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -7,7 +7,7 @@ import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   DUST_PROVIDED_SKILL_LABEL,
-  getSkillAvatarIcon,
+  getSkillAvatarIconForSkill,
   isDustProvidedSkill,
 } from "@app/lib/skill";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
@@ -80,7 +80,7 @@ export function getSkillSlashCommandItem(
       skill,
     },
     description: skill.userFacingDescription,
-    icon: getSkillAvatarIcon(skill.icon, { isDustProvided }),
+    icon: getSkillAvatarIconForSkill(skill),
     id: skill.sId,
     label: skill.name,
     sectionLabel,

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -5,7 +5,11 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import {
+  DUST_PROVIDED_SKILL_LABEL,
+  getSkillAvatarIcon,
+  isDustProvidedSkill,
+} from "@app/lib/skill";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 
@@ -14,7 +18,12 @@ export const SELECT_TOOL_SLASH_COMMAND_ACTION = "select-tool";
 
 export type SlashCommandSkillSuggestion = Pick<
   SkillWithoutInstructionsAndToolsType,
-  "icon" | "name" | "requestedSpaceIds" | "sId" | "userFacingDescription"
+  | "editedBy"
+  | "icon"
+  | "name"
+  | "requestedSpaceIds"
+  | "sId"
+  | "userFacingDescription"
 >;
 
 export type SlashCommandToolSuggestion = MCPServerViewType & {
@@ -58,21 +67,25 @@ export function getSkillSlashCommandItem(
   skill: SlashCommandSkillSuggestion,
   { sectionLabel }: { sectionLabel?: string } = {}
 ): SlashCommand {
+  const isDustProvided = isDustProvidedSkill(skill);
+
   return {
     action: SELECT_SKILL_SLASH_COMMAND_ACTION,
     data: {
       skill,
     },
     description: skill.userFacingDescription,
-    icon: getSkillAvatarIcon(skill.icon),
+    icon: getSkillAvatarIcon(skill.icon, { isDustProvided }),
     id: skill.sId,
     label: skill.name,
     sectionLabel,
-    tooltip: skill.userFacingDescription
-      ? {
-          description: skill.userFacingDescription,
-        }
-      : undefined,
+    tooltip: isDustProvided
+      ? { description: DUST_PROVIDED_SKILL_LABEL }
+      : skill.userFacingDescription
+        ? {
+            description: skill.userFacingDescription,
+          }
+        : undefined,
   };
 }
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -7,7 +7,7 @@ import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   DUST_PROVIDED_SKILL_LABEL,
-  getSkillAvatarIconForSkill,
+  getSkillAvatarIcon,
   isDustProvidedSkill,
 } from "@app/lib/skill";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
@@ -80,7 +80,7 @@ export function getSkillSlashCommandItem(
       skill,
     },
     description: skill.userFacingDescription,
-    icon: getSkillAvatarIconForSkill(skill),
+    icon: getSkillAvatarIcon(skill),
     id: skill.sId,
     label: skill.name,
     sectionLabel,

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -68,6 +68,11 @@ export function getSkillSlashCommandItem(
   { sectionLabel }: { sectionLabel?: string } = {}
 ): SlashCommand {
   const isDustProvided = isDustProvidedSkill(skill);
+  const tooltipDescription = isDustProvided
+    ? skill.userFacingDescription
+      ? `${skill.userFacingDescription}\n\n${DUST_PROVIDED_SKILL_LABEL}`
+      : DUST_PROVIDED_SKILL_LABEL
+    : skill.userFacingDescription;
 
   return {
     action: SELECT_SKILL_SLASH_COMMAND_ACTION,
@@ -79,13 +84,9 @@ export function getSkillSlashCommandItem(
     id: skill.sId,
     label: skill.name,
     sectionLabel,
-    tooltip: isDustProvided
-      ? { description: DUST_PROVIDED_SKILL_LABEL }
-      : skill.userFacingDescription
-        ? {
-            description: skill.userFacingDescription,
-          }
-        : undefined,
+    tooltip: tooltipDescription
+      ? { description: tooltipDescription }
+      : undefined,
   };
 }
 

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -22,12 +22,14 @@ const attachKnowledgeItem: SlashCommand = {
 };
 
 const skillSuggestion = ({
+  editedBy = 1,
   icon = null,
   requestedSpaceIds = [],
   userFacingDescription = "",
   ...skill
 }: Pick<SlashCommandSkillSuggestion, "name" | "sId"> &
   Partial<SlashCommandSkillSuggestion>): SlashCommandSkillSuggestion => ({
+  editedBy,
   icon,
   requestedSpaceIds,
   userFacingDescription,

--- a/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
@@ -14,7 +14,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type {
@@ -391,7 +391,7 @@ function SkillSuggestionCard({ agentSuggestion }: SkillSuggestionCardProps) {
   return (
     <ActionCardBlock
       {...labels}
-      visual={<Avatar icon={getSkillAvatarIconForSkill(skill)} size="sm" />}
+      visual={<Avatar icon={getSkillAvatarIcon(skill)} size="sm" />}
       description={analysis ?? undefined}
       state={cardState}
       rejectedTitle={`${skill.name} skill suggestion rejected`}

--- a/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/SidekickSuggestionCard.tsx
@@ -14,7 +14,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type {
@@ -391,7 +391,7 @@ function SkillSuggestionCard({ agentSuggestion }: SkillSuggestionCardProps) {
   return (
     <ActionCardBlock
       {...labels}
-      visual={<Avatar icon={getSkillAvatarIcon(skill.icon)} size="sm" />}
+      visual={<Avatar icon={getSkillAvatarIconForSkill(skill)} size="sm" />}
       description={analysis ?? undefined}
       state={cardState}
       rejectedTitle={`${skill.name} skill suggestion rejected`}

--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -19,6 +19,7 @@ import {
   ConfluenceLogo,
   ContentsquareLogo,
   CostoryLogo,
+  cn,
   DriveLogo,
   FaceSmile,
   FathomLogo,
@@ -109,6 +110,27 @@ import { isCustomResourceIconType } from "@app/components/resources/resources_ic
 
 interface ResourceAvatarProps extends ComponentProps<typeof Avatar> {}
 
+type ResourceAvatarSize = NonNullable<ComponentProps<typeof Avatar>["size"]>;
+
+const AVATAR_BADGE_CLASSES: Record<
+  ResourceAvatarSize,
+  { badge: string; icon: string }
+> = {
+  xxs: { badge: "h-2.5 w-2.5 rounded-[2px]", icon: "h-2 w-2" },
+  xs: { badge: "h-3 w-3 rounded-[3px]", icon: "h-2.5 w-2.5" },
+  sm: { badge: "h-3.5 w-3.5 rounded-[3px]", icon: "h-3 w-3" },
+  md: { badge: "h-4 w-4 rounded", icon: "h-3.5 w-3.5" },
+  lg: { badge: "h-5 w-5 rounded-md", icon: "h-4 w-4" },
+  xl: { badge: "h-6 w-6 rounded-md", icon: "h-5 w-5" },
+  "2xl": { badge: "h-8 w-8 rounded-lg", icon: "h-7 w-7" },
+  auto: { badge: "h-6 w-6 rounded-md", icon: "h-5 w-5" },
+};
+
+interface ResourceAvatarWithBadgeProps extends ResourceAvatarProps {
+  badgeIcon: ComponentType<{ className?: string }>;
+  badgeSize: ResourceAvatarSize;
+}
+
 /**
  * As Avatar are not made to support dark/light mode switch, this renders a `Avatar` component for resources icons with support for dark mode.
  * If `iconColor` or `backgroundColor` are not provided, sensible defaults are applied for both light and dark themes.
@@ -126,6 +148,31 @@ export function ResourceAvatar({
       }
       {...props}
     />
+  );
+}
+
+export function ResourceAvatarWithBadge({
+  badgeIcon: BadgeIcon,
+  badgeSize,
+  className,
+  ...props
+}: ResourceAvatarWithBadgeProps) {
+  const badgeClasses = AVATAR_BADGE_CLASSES[badgeSize];
+
+  return (
+    <div className={cn("relative inline-flex overflow-visible", className)}>
+      <ResourceAvatar className={className} {...props} />
+      <span
+        className={cn(
+          "pointer-events-none absolute bottom-0 right-0",
+          "flex items-center justify-center bg-background shadow-sm ring-1 ring-border",
+          "dark:bg-background-night dark:ring-border-night",
+          badgeClasses.badge
+        )}
+      >
+        <BadgeIcon className={badgeClasses.icon} />
+      </span>
+    </div>
   );
 }
 

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,5 +1,5 @@
 import { LinkWrapper } from "@app/lib/platform";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Icon, LinkExternal01, Spinner } from "@dust-tt/sparkle";
@@ -38,7 +38,7 @@ export function SimilarSkillsDisplay({
       </div>
       <div className="space-y-3">
         {similarSkills.map((skill) => {
-          const SkillAvatar = getSkillAvatarIcon(skill.icon);
+          const SkillAvatar = getSkillAvatarIconForSkill(skill);
 
           return (
             <div key={skill.sId} className="flex items-start gap-3">

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,5 +1,5 @@
 import { LinkWrapper } from "@app/lib/platform";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Icon, LinkExternal01, Spinner } from "@dust-tt/sparkle";
@@ -38,7 +38,7 @@ export function SimilarSkillsDisplay({
       </div>
       <div className="space-y-3">
         {similarSkills.map((skill) => {
-          const SkillAvatar = getSkillAvatarIconForSkill(skill);
+          const SkillAvatar = getSkillAvatarIcon(skill);
 
           return (
             <div key={skill.sId} className="flex items-start gap-3">

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -3,7 +3,7 @@ import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
-import { getSkillAvatarIcon, hasRelations } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill, hasRelations } from "@app/lib/skill";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 import type {
   SkillRelations,
@@ -157,7 +157,7 @@ const DescriptionSection = ({
       day: "2-digit",
     });
 
-  const SkillAvatar = getSkillAvatarIcon(skill.icon);
+  const SkillAvatar = getSkillAvatarIconForSkill(skill);
 
   return (
     <div className="flex flex-col items-center gap-4 pt-4">

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -3,7 +3,7 @@ import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
-import { getSkillAvatarIconForSkill, hasRelations } from "@app/lib/skill";
+import { getSkillAvatarIcon, hasRelations } from "@app/lib/skill";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 import type {
   SkillRelations,
@@ -157,7 +157,7 @@ const DescriptionSection = ({
       day: "2-digit",
     });
 
-  const SkillAvatar = getSkillAvatarIconForSkill(skill);
+  const SkillAvatar = getSkillAvatarIcon(skill);
 
   return (
     <div className="flex flex-col items-center gap-4 pt-4">

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -9,7 +9,7 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -173,7 +173,7 @@ export function SkillInfoTab({
           </div>
           <div className="grid grid-cols-2 gap-2">
             {childSkills.map((childSkill) => {
-              const SkillAvatar = getSkillAvatarIcon(childSkill.icon);
+              const SkillAvatar = getSkillAvatarIconForSkill(childSkill);
 
               return (
                 <Tooltip
@@ -227,7 +227,7 @@ export function SkillInfoTab({
           ) : (
             <div className="grid grid-cols-2 gap-2">
               {discoverableSkills.map((s) => {
-                const SkillAvatar = getSkillAvatarIcon(s.icon);
+                const SkillAvatar = getSkillAvatarIconForSkill(s);
                 return (
                   <Tooltip
                     key={s.sId}

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -9,7 +9,7 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
@@ -173,7 +173,7 @@ export function SkillInfoTab({
           </div>
           <div className="grid grid-cols-2 gap-2">
             {childSkills.map((childSkill) => {
-              const SkillAvatar = getSkillAvatarIconForSkill(childSkill);
+              const SkillAvatar = getSkillAvatarIcon(childSkill);
 
               return (
                 <Tooltip
@@ -227,7 +227,7 @@ export function SkillInfoTab({
           ) : (
             <div className="grid grid-cols-2 gap-2">
               {discoverableSkills.map((s) => {
-                const SkillAvatar = getSkillAvatarIconForSkill(s);
+                const SkillAvatar = getSkillAvatarIcon(s);
                 return (
                   <Tooltip
                     key={s.sId}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -2,7 +2,7 @@ import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
@@ -19,6 +19,7 @@ import { useMemo, useState } from "react";
 type RowData = {
   name: string;
   icon: string | null;
+  editedBy: number | null;
   description: string;
   editors: UserType[] | null;
   usage: SkillUsageType;
@@ -32,7 +33,7 @@ const nameColumn = {
   header: "Name",
   accessorKey: "name",
   cell: (info: CellContext<RowData, string>) => {
-    const SkillAvatar = getSkillAvatarIcon(info.row.original.icon);
+    const SkillAvatar = getSkillAvatarIconForSkill(info.row.original);
 
     return (
       <DataTable.CellContent>
@@ -180,6 +181,7 @@ export function SkillsTable({
       skills.map((skill) => ({
         name: skill.name,
         icon: skill.icon,
+        editedBy: skill.editedBy,
         description: skill.userFacingDescription,
         editors: skill.relations.editors,
         usage: skill.relations.usage,

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -2,7 +2,7 @@ import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
@@ -33,7 +33,7 @@ const nameColumn = {
   header: "Name",
   accessorKey: "name",
   cell: (info: CellContext<RowData, string>) => {
-    const SkillAvatar = getSkillAvatarIconForSkill(info.row.original);
+    const SkillAvatar = getSkillAvatarIcon(info.row.original);
 
     return (
       <DataTable.CellContent>

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -1,6 +1,6 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { useAppRouter } from "@app/lib/platform";
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import { useUpdateSkillEditors } from "@app/lib/swr/skill_editors";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
@@ -31,7 +31,7 @@ function SuggestedSkillCard({
   const router = useAppRouter();
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
   const [isAddingSkill, setIsAddingSkill] = useState(false);
-  const SkillAvatar = getSkillAvatarIcon(skill.icon);
+  const SkillAvatar = getSkillAvatarIconForSkill(skill);
   const updateSkillEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -1,6 +1,6 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
 import { useAppRouter } from "@app/lib/platform";
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useUpdateSkillEditors } from "@app/lib/swr/skill_editors";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { SkillWithoutInstructionsAndToolsWithRelationsType } from "@app/types/assistant/skill_configuration";
@@ -31,7 +31,7 @@ function SuggestedSkillCard({
   const router = useAppRouter();
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
   const [isAddingSkill, setIsAddingSkill] = useState(false);
-  const SkillAvatar = getSkillAvatarIconForSkill(skill);
+  const SkillAvatar = getSkillAvatarIcon(skill);
   const updateSkillEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,

--- a/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
+++ b/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
@@ -1,4 +1,4 @@
-import { getSkillAvatarIconForSkill } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   useSkillsWithRelations,
   useUpdateSkillReinforcement,
@@ -65,7 +65,7 @@ const COLUMNS: ColumnDef<RowData, unknown>[] = [
     header: "Name",
     accessorKey: "name",
     cell: (info: CellContext<RowData, unknown>) => {
-      const SkillAvatar = getSkillAvatarIconForSkill(info.row.original);
+      const SkillAvatar = getSkillAvatarIcon(info.row.original);
       return (
         <DataTable.CellContent>
           <div className="flex flex-row items-center gap-2 py-3">

--- a/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
+++ b/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
@@ -1,4 +1,4 @@
-import { getSkillAvatarIcon } from "@app/lib/skill";
+import { getSkillAvatarIconForSkill } from "@app/lib/skill";
 import {
   useSkillsWithRelations,
   useUpdateSkillReinforcement,
@@ -34,6 +34,7 @@ type RowData = {
   sId: string;
   name: string;
   icon: string | null;
+  editedBy: number | null;
   editors: UserType[] | null;
   enabled: boolean;
   pendingEnabled: boolean | null;
@@ -64,7 +65,7 @@ const COLUMNS: ColumnDef<RowData, unknown>[] = [
     header: "Name",
     accessorKey: "name",
     cell: (info: CellContext<RowData, unknown>) => {
-      const SkillAvatar = getSkillAvatarIcon(info.row.original.icon);
+      const SkillAvatar = getSkillAvatarIconForSkill(info.row.original);
       return (
         <DataTable.CellContent>
           <div className="flex flex-row items-center gap-2 py-3">
@@ -379,6 +380,7 @@ export function SelfImprovingSkillsListSection({
             sId: skill.sId,
             name: skill.name,
             icon: skill.icon,
+            editedBy: skill.editedBy,
             editors: skill.relations.editors,
             enabled,
             pendingEnabled: pendingEnabledBySkillId[skill.sId] ?? null,

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -29,9 +29,10 @@ interface SkillAvatarIconProps {
   name?: string;
 }
 
-interface SkillAvatarIconOptions {
-  isDustProvided?: boolean;
-}
+type SkillAvatarIconInput =
+  | string
+  | null
+  | Pick<SkillWithoutInstructionsAndToolsType, "editedBy" | "icon">;
 
 export function isDustProvidedSkill(
   skill: Pick<SkillWithoutInstructionsAndToolsType, "editedBy">
@@ -39,10 +40,25 @@ export function isDustProvidedSkill(
   return skill.editedBy === null;
 }
 
+function isSkillAvatarIconSkill(
+  input: SkillAvatarIconInput
+): input is Pick<SkillWithoutInstructionsAndToolsType, "editedBy" | "icon"> {
+  return input !== null && typeof input === "object";
+}
+
 export function getSkillAvatarIcon(
-  iconString: string | null,
-  { isDustProvided = false }: SkillAvatarIconOptions = {}
+  input: SkillAvatarIconInput
 ): React.ComponentType<SkillAvatarIconProps> {
+  let iconString: string | null;
+  let isDustProvided = false;
+
+  if (isSkillAvatarIconSkill(input)) {
+    iconString = input.icon;
+    isDustProvided = isDustProvidedSkill(input);
+  } else {
+    iconString = input;
+  }
+
   let SkillAvatar: React.ComponentType<SkillAvatarIconProps>;
   let skillIcon: React.ComponentType<{ className?: string }> = SKILL_ICON;
 
@@ -90,14 +106,6 @@ export function getSkillAvatarIcon(
       ...props,
     });
   };
-}
-
-export function getSkillAvatarIconForSkill(
-  skill: Pick<SkillWithoutInstructionsAndToolsType, "editedBy" | "icon">
-) {
-  return getSkillAvatarIcon(skill.icon, {
-    isDustProvided: isDustProvidedSkill(skill),
-  });
 }
 
 export function getSkillIcon(

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -92,7 +92,7 @@ export function getSkillAvatarIcon(
   }
 
   return ({ className, size, ...props }) => {
-    const avatarSize = size ?? "sm";
+    const avatarSize = size ?? (className ? "xxs" : "sm");
     const badgeSize = size ?? (className ? "xxs" : "sm");
 
     return React.createElement(ResourceAvatarWithBadge, {

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -72,26 +72,25 @@ export function getSkillAvatarIcon(
     return SkillAvatar;
   }
 
-  return ({ className, ...props }) =>
+  return ({ className, size, ...props }) =>
     React.createElement(
       "div",
       {
-        className: cn("relative inline-flex", className),
-        title: DUST_PROVIDED_SKILL_LABEL,
+        className: cn("relative inline-flex overflow-visible", className),
       },
-      React.createElement(SkillAvatar, { className, ...props }),
+      React.createElement(SkillAvatar, { size: size ?? "xxs", ...props }),
       React.createElement(
         "span",
         {
           className: cn(
-            "pointer-events-none absolute -bottom-0.5 -right-0.5",
-            "flex h-3 w-3 items-center justify-center rounded-[3px]",
+            "pointer-events-none absolute bottom-0 right-0",
+            "flex h-2 w-2 items-center justify-center rounded-[2px]",
             "bg-background shadow-sm ring-1 ring-border",
             "dark:bg-background-night dark:ring-border-night"
           ),
         },
         React.createElement(DustLogoSquare, {
-          className: "h-2.5 w-2.5",
+          className: "h-1.5 w-1.5",
         })
       )
     );

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -3,6 +3,7 @@ import {
   isCustomResourceIconType,
   isInternalAllowedIcon,
   ResourceAvatar,
+  ResourceAvatarWithBadge,
 } from "@app/components/resources/resources_icons";
 import type {
   SkillRelations,
@@ -22,15 +23,15 @@ export const SKILL_AVATAR_BACKGROUND_COLOR =
 export const SKILL_AVATAR_ICON_COLOR =
   "text-highlight dark:text-highlight-night";
 
-type SkillAvatarIconProps = {
+interface SkillAvatarIconProps {
   className?: string;
   size?: AvatarSizeType;
   name?: string;
-};
+}
 
-type SkillAvatarIconOptions = {
+interface SkillAvatarIconOptions {
   isDustProvided?: boolean;
-};
+}
 
 export function isDustProvidedSkill(
   skill: Pick<SkillWithoutInstructionsAndToolsType, "editedBy">
@@ -43,12 +44,14 @@ export function getSkillAvatarIcon(
   { isDustProvided = false }: SkillAvatarIconOptions = {}
 ): React.ComponentType<SkillAvatarIconProps> {
   let SkillAvatar: React.ComponentType<SkillAvatarIconProps>;
+  let skillIcon: React.ComponentType<{ className?: string }> = SKILL_ICON;
 
   if (
     iconString &&
     (isCustomResourceIconType(iconString) || isInternalAllowedIcon(iconString))
   ) {
     const icon = getIcon(iconString);
+    skillIcon = icon;
     SkillAvatar = (props) =>
       React.createElement(ResourceAvatar, {
         icon,
@@ -72,28 +75,29 @@ export function getSkillAvatarIcon(
     return SkillAvatar;
   }
 
-  return ({ className, size, ...props }) =>
-    React.createElement(
-      "div",
-      {
-        className: cn("relative inline-flex overflow-visible", className),
-      },
-      React.createElement(SkillAvatar, { size: size ?? "xxs", ...props }),
-      React.createElement(
-        "span",
-        {
-          className: cn(
-            "pointer-events-none absolute bottom-0 right-0",
-            "flex h-2.5 w-2.5 items-center justify-center rounded-[2px]",
-            "bg-background shadow-sm ring-1 ring-border",
-            "dark:bg-background-night dark:ring-border-night"
-          ),
-        },
-        React.createElement(DustLogoSquare, {
-          className: "h-2 w-2",
-        })
-      )
-    );
+  return ({ className, size, ...props }) => {
+    const avatarSize = size ?? "sm";
+    const badgeSize = size ?? (className ? "xxs" : "sm");
+
+    return React.createElement(ResourceAvatarWithBadge, {
+      badgeIcon: DustLogoSquare,
+      badgeSize,
+      className,
+      icon: skillIcon,
+      size: avatarSize,
+      backgroundColor: SKILL_AVATAR_BACKGROUND_COLOR,
+      iconColor: SKILL_AVATAR_ICON_COLOR,
+      ...props,
+    });
+  };
+}
+
+export function getSkillAvatarIconForSkill(
+  skill: Pick<SkillWithoutInstructionsAndToolsType, "editedBy" | "icon">
+) {
+  return getSkillAvatarIcon(skill.icon, {
+    isDustProvided: isDustProvidedSkill(skill),
+  });
 }
 
 export function getSkillIcon(

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -7,32 +7,49 @@ import {
 import type {
   SkillRelations,
   SkillType,
+  SkillWithoutInstructionsAndToolsType,
   SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
-import { cn, PuzzlePiece01 } from "@dust-tt/sparkle";
+import { cn, DustLogoSquare, PuzzlePiece01 } from "@dust-tt/sparkle";
 import type { AvatarSizeType } from "@dust-tt/sparkle/dist/esm/components/Avatar";
 import React from "react";
 
 export const SKILL_ICON = PuzzlePiece01;
+export const DUST_PROVIDED_SKILL_LABEL = "Dust-provided skill";
 
 export const SKILL_AVATAR_BACKGROUND_COLOR =
   "bg-highlight-50 dark:bg-highlight-50-night";
 export const SKILL_AVATAR_ICON_COLOR =
   "text-highlight dark:text-highlight-night";
 
-export function getSkillAvatarIcon(
-  iconString: string | null
-): React.ComponentType<{
+type SkillAvatarIconProps = {
   className?: string;
   size?: AvatarSizeType;
   name?: string;
-}> {
+};
+
+type SkillAvatarIconOptions = {
+  isDustProvided?: boolean;
+};
+
+export function isDustProvidedSkill(
+  skill: Pick<SkillWithoutInstructionsAndToolsType, "editedBy">
+) {
+  return skill.editedBy === null;
+}
+
+export function getSkillAvatarIcon(
+  iconString: string | null,
+  { isDustProvided = false }: SkillAvatarIconOptions = {}
+): React.ComponentType<SkillAvatarIconProps> {
+  let SkillAvatar: React.ComponentType<SkillAvatarIconProps>;
+
   if (
     iconString &&
     (isCustomResourceIconType(iconString) || isInternalAllowedIcon(iconString))
   ) {
     const icon = getIcon(iconString);
-    return (props) =>
+    SkillAvatar = (props) =>
       React.createElement(ResourceAvatar, {
         icon,
         size: "sm",
@@ -40,16 +57,44 @@ export function getSkillAvatarIcon(
         iconColor: SKILL_AVATAR_ICON_COLOR,
         ...props,
       });
+  } else {
+    SkillAvatar = (props) =>
+      React.createElement(ResourceAvatar, {
+        icon: SKILL_ICON,
+        size: "sm",
+        backgroundColor: SKILL_AVATAR_BACKGROUND_COLOR,
+        iconColor: SKILL_AVATAR_ICON_COLOR,
+        ...props,
+      });
   }
 
-  return (props) =>
-    React.createElement(ResourceAvatar, {
-      icon: SKILL_ICON,
-      size: "sm",
-      backgroundColor: SKILL_AVATAR_BACKGROUND_COLOR,
-      iconColor: SKILL_AVATAR_ICON_COLOR,
-      ...props,
-    });
+  if (!isDustProvided) {
+    return SkillAvatar;
+  }
+
+  return ({ className, ...props }) =>
+    React.createElement(
+      "div",
+      {
+        className: cn("relative inline-flex", className),
+        title: DUST_PROVIDED_SKILL_LABEL,
+      },
+      React.createElement(SkillAvatar, { className, ...props }),
+      React.createElement(
+        "span",
+        {
+          className: cn(
+            "pointer-events-none absolute -bottom-0.5 -right-0.5",
+            "flex h-3 w-3 items-center justify-center rounded-[3px]",
+            "bg-background shadow-sm ring-1 ring-border",
+            "dark:bg-background-night dark:ring-border-night"
+          ),
+        },
+        React.createElement(DustLogoSquare, {
+          className: "h-2.5 w-2.5",
+        })
+      )
+    );
 }
 
 export function getSkillIcon(

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -84,13 +84,13 @@ export function getSkillAvatarIcon(
         {
           className: cn(
             "pointer-events-none absolute bottom-0 right-0",
-            "flex h-2 w-2 items-center justify-center rounded-[2px]",
+            "flex h-2.5 w-2.5 items-center justify-center rounded-[2px]",
             "bg-background shadow-sm ring-1 ring-border",
             "dark:bg-background-night dark:ring-border-night"
           ),
         },
         React.createElement(DustLogoSquare, {
-          className: "h-1.5 w-1.5",
+          className: "h-2 w-2",
         })
       )
     );


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8743

Dust-provided and user-created skills looked identical in the skill surfaces. This adds a small Dust badge to Dust-provided skill avatars when `editedBy` is `null`, using a reusable `ResourceAvatarWithBadge` helper for avatar badge overlays.

This does not reuse `DoubleIcon` because `DoubleIcon` composes two plain icons, while skill visuals are `ResourceAvatar`s with their own background, border, color, and sizing. Passing a `DoubleIcon` as the centered avatar icon would place the Dust mark inside the avatar glyph box instead of as an external bottom-right badge, and would not preserve the skill avatar styling.

The badge now appears in capability pickers and other skill avatar surfaces that have the full skill object, including skill details, skill info sections, command palette results, skill tables, similar/suggested skills, sidekick skill suggestions, and agent details.

Capability picker tooltips keep the existing skill description and append `Dust-provided skill` instead of replacing the description.
<img width="642" height="576" alt="image" src="https://github.com/user-attachments/assets/5c1fbca0-1327-49df-baae-c29ed784f648" />
<img width="642" height="576" alt="image" src="https://github.com/user-attachments/assets/c4acc24a-6346-482f-bd2f-d10a0f63f623" />

## Risks
Blast radius: skill avatar rendering across front surfaces that display full skill objects, plus capability picker tooltip text.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `NODE_ENV=test npm test components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts`
- [x] local