### PR TITLE
[Skills] Fix fuzzy capability sort order

### DIFF
--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -81,6 +81,18 @@ describe("sortSlashCommandCapabilityMatches", () => {
 
     expect(result.map((item) => item.id)).toEqual(["a", "z"]);
   });
+
+  it("breaks fuzzy ties alphabetically when a query is provided", () => {
+    const result = sortSlashCommandCapabilityMatches({
+      normalizedQuery: "test",
+      items: [
+        { id: "testlonger", sortName: "testlonger" },
+        { id: "longtest", sortName: "longtest" },
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["longtest", "testlonger"]);
+  });
 });
 
 describe("getToolSlashCommandItem", () => {

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -40,10 +40,7 @@ export function sortSlashCommandCapabilityMatches<
 >({ items, normalizedQuery }: { items: T[]; normalizedQuery: string }): T[] {
   return items.toSorted((a, b) => {
     if (normalizedQuery.length > 0) {
-      return (
-        compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
-        a.sortName.localeCompare(b.sortName)
-      );
+      return compareForFuzzySort(normalizedQuery, a.sortName, b.sortName);
     }
 
     return a.sortName.localeCompare(b.sortName);

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -6,7 +6,7 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import { compareForFuzzySortLex, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
@@ -40,7 +40,7 @@ export function sortSlashCommandCapabilityMatches<
 >({ items, normalizedQuery }: { items: T[]; normalizedQuery: string }): T[] {
   return items.toSorted((a, b) => {
     if (normalizedQuery.length > 0) {
-      return compareForFuzzySort(normalizedQuery, a.sortName, b.sortName);
+      return compareForFuzzySortLex(normalizedQuery, a.sortName, b.sortName);
     }
 
     return a.sortName.localeCompare(b.sortName);

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -6,7 +6,7 @@ import {
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import { compareForFuzzySortLex, subFilter } from "@app/lib/utils";
+import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
@@ -40,7 +40,10 @@ export function sortSlashCommandCapabilityMatches<
 >({ items, normalizedQuery }: { items: T[]; normalizedQuery: string }): T[] {
   return items.toSorted((a, b) => {
     if (normalizedQuery.length > 0) {
-      return compareForFuzzySortLex(normalizedQuery, a.sortName, b.sortName);
+      return (
+        compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
+        a.sortName.localeCompare(b.sortName)
+      );
     }
 
     return a.sortName.localeCompare(b.sortName);

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -254,8 +254,7 @@ export function subFilter(a: string, b: string) {
 
 /**
  * Compares two strings for fuzzy sorting against a query
- * First sort by substring, then by spread of subfilter, then by first index of subfilter, then length, then by
- * lexicographic order
+ * First sort by substring, then by spread of subfilter, then exact match, then lexicographic order.
  */
 export function compareForFuzzySort(query: string, a: string, b: string) {
   const normalizedQuery = query.toLowerCase();
@@ -289,12 +288,6 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return spreadA - spreadB;
   }
 
-  const subFilterLastIndexA = subFilterLastIndex(normalizedQuery, normalizedA);
-  const subFilterLastIndexB = subFilterLastIndex(normalizedQuery, normalizedB);
-  if (subFilterLastIndexA !== subFilterLastIndexB) {
-    return subFilterLastIndexA - subFilterLastIndexB;
-  }
-
   const isExactMatchA = normalizedA === normalizedQuery;
   const isExactMatchB = normalizedB === normalizedQuery;
   if (isExactMatchA && !isExactMatchB) {
@@ -304,7 +297,7 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return 1;
   }
 
-  return 0;
+  return normalizedA.localeCompare(normalizedB);
 }
 
 export function filterAndSortAgents(

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -253,8 +253,8 @@ export function subFilter(a: string, b: string) {
 }
 
 /**
- * Compares two strings for fuzzy sorting against a query
- * First sort by substring, then by spread of subfilter, then exact match, then lexicographic order.
+ * Compares two strings for fuzzy relevance against a query.
+ * First sort by substring, then by spread of subfilter, then exact match.
  */
 export function compareForFuzzySort(query: string, a: string, b: string) {
   const normalizedQuery = query.toLowerCase();
@@ -297,7 +297,14 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
     return 1;
   }
 
-  return normalizedA.localeCompare(normalizedB);
+  return 0;
+}
+
+export function compareForFuzzySortLex(query: string, a: string, b: string) {
+  return (
+    compareForFuzzySort(query, a, b) ||
+    a.toLowerCase().localeCompare(b.toLowerCase())
+  );
 }
 
 export function filterAndSortAgents(

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -300,13 +300,6 @@ export function compareForFuzzySort(query: string, a: string, b: string) {
   return 0;
 }
 
-export function compareForFuzzySortLex(query: string, a: string, b: string) {
-  return (
-    compareForFuzzySort(query, a, b) ||
-    a.toLowerCase().localeCompare(b.toLowerCase())
-  );
-}
-
 export function filterAndSortAgents(
   agents: LightAgentConfigurationType[],
   searchText: string

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { compareForFuzzySort, compareForFuzzySortLex } from "@app/lib/utils";
+import { compareForFuzzySort } from "@app/lib/utils";
 import { expect, test } from "vitest";
 
 test("compareForFuzzySort should correctly compare strings", () => {
@@ -46,13 +46,4 @@ test("compareForFuzzySort stays symmetric for normalized exact matches", () => {
 
   expect(compareForFuzzySort(query, query, normalizedExactMatch)).toBe(0);
   expect(compareForFuzzySort(query, normalizedExactMatch, query)).toBe(0);
-});
-
-test("compareForFuzzySortLex breaks fuzzy ties lexicographically", () => {
-  expect(compareForFuzzySortLex("eng", "eng1", "eng2")).toBeLessThan(0);
-  expect(compareForFuzzySortLex("gp", "gpt-4", "gpt-5")).toBeLessThan(0);
-  expect(compareForFuzzySortLex("test", "testl", "testlong")).toBeLessThan(0);
-  expect(
-    compareForFuzzySortLex("test", "testlonger", "longtest")
-  ).toBeGreaterThan(0);
 });

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { compareForFuzzySort } from "@app/lib/utils";
+import { compareForFuzzySort, compareForFuzzySortLex } from "@app/lib/utils";
 import { expect, test } from "vitest";
 
 test("compareForFuzzySort should correctly compare strings", () => {
@@ -15,14 +15,15 @@ test("compareForFuzzySort should correctly compare strings", () => {
     { query: "c", a: "c", b: "RadicalFeedback" },
     { query: "issuebot", a: "issueBot", b: "FDEIssueBot" },
     { query: "issuebot", a: "ISSUEBOT", b: "FDEIssueBot" },
+  ];
+
+  const dataEqual = [
+    { query: "sql", a: "sqlGod", b: "sqlGod" },
     { query: "eng", a: "eng1", b: "eng2" },
     { query: "gp", a: "gpt-4", b: "gpt-5" },
     { query: "test", a: "testl", b: "testlong" },
+    { query: "test", a: "testlonger", b: "longtest" },
   ];
-
-  const dataEqual = [{ query: "sql", a: "sqlGod", b: "sqlGod" }];
-
-  const dataGreaterThan = [{ query: "test", a: "testlonger", b: "longtest" }];
 
   for (const d of dataLessThan) {
     expect(
@@ -37,13 +38,6 @@ test("compareForFuzzySort should correctly compare strings", () => {
       `Expected compareForFuzzySort("${d.query}", "${d.a}", "${d.b}") to return 0`
     ).toBe(0);
   }
-
-  for (const d of dataGreaterThan) {
-    expect(
-      compareForFuzzySort(d.query, d.a, d.b),
-      `Expected compareForFuzzySort("${d.query}", "${d.a}", "${d.b}") to be greater than 0`
-    ).toBeGreaterThan(0);
-  }
 });
 
 test("compareForFuzzySort stays symmetric for normalized exact matches", () => {
@@ -52,4 +46,13 @@ test("compareForFuzzySort stays symmetric for normalized exact matches", () => {
 
   expect(compareForFuzzySort(query, query, normalizedExactMatch)).toBe(0);
   expect(compareForFuzzySort(query, normalizedExactMatch, query)).toBe(0);
+});
+
+test("compareForFuzzySortLex breaks fuzzy ties lexicographically", () => {
+  expect(compareForFuzzySortLex("eng", "eng1", "eng2")).toBeLessThan(0);
+  expect(compareForFuzzySortLex("gp", "gpt-4", "gpt-5")).toBeLessThan(0);
+  expect(compareForFuzzySortLex("test", "testl", "testlong")).toBeLessThan(0);
+  expect(
+    compareForFuzzySortLex("test", "testlonger", "longtest")
+  ).toBeGreaterThan(0);
 });

--- a/front/tests/lib/utils.test.ts
+++ b/front/tests/lib/utils.test.ts
@@ -11,19 +11,18 @@ test("compareForFuzzySort should correctly compare strings", () => {
     { query: "start", a: "robotstart", b: "strongrt" },
     { query: "mygod", a: "ohmygodbot", b: "moatmode" },
     { query: "test", a: "test", b: "testlong" },
-    { query: "test", a: "testlonger", b: "longtest" },
     { query: "eng", a: "eng", b: "slack-engineering-highlights" },
     { query: "c", a: "c", b: "RadicalFeedback" },
     { query: "issuebot", a: "issueBot", b: "FDEIssueBot" },
     { query: "issuebot", a: "ISSUEBOT", b: "FDEIssueBot" },
-  ];
-
-  const dataEqual = [
-    { query: "sql", a: "sqlGod", b: "sqlGod" },
     { query: "eng", a: "eng1", b: "eng2" },
     { query: "gp", a: "gpt-4", b: "gpt-5" },
     { query: "test", a: "testl", b: "testlong" },
   ];
+
+  const dataEqual = [{ query: "sql", a: "sqlGod", b: "sqlGod" }];
+
+  const dataGreaterThan = [{ query: "test", a: "testlonger", b: "longtest" }];
 
   for (const d of dataLessThan) {
     expect(
@@ -37,6 +36,13 @@ test("compareForFuzzySort should correctly compare strings", () => {
       compareForFuzzySort(d.query, d.a, d.b),
       `Expected compareForFuzzySort("${d.query}", "${d.a}", "${d.b}") to return 0`
     ).toBe(0);
+  }
+
+  for (const d of dataGreaterThan) {
+    expect(
+      compareForFuzzySort(d.query, d.a, d.b),
+      `Expected compareForFuzzySort("${d.query}", "${d.a}", "${d.b}") to be greater than 0`
+    ).toBeGreaterThan(0);
   }
 });
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8615

The skill/tool slash dropdown sorted queried capabilities with fuzzy relevance only. Ties could keep input order because `compareForFuzzySort` does not provide lexicographic ordering; it also used the last fuzzy match index as an unintuitive tie-breaker.

This removes the last-index tie-breaker from `compareForFuzzySort` and keeps that helper relevance-only so existing agent sort fallbacks still run. The slash capability sorter now keeps its explicit lexical tie-breaker after fuzzy relevance, which gives the Skill Builder and input bar dropdowns stable alphabetical ordering for fuzzy ties.

## Risks
Blast radius: slash command capability dropdown ordering and shared fuzzy comparator tie behavior.
Risk: standard

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `NODE_ENV=test npm test tests/lib/utils.test.ts components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts`