### PR TITLE
feat(credits): add admin toggles for member upgrade requests

### DIFF
--- a/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
@@ -1,0 +1,96 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function usageConfigurationUrl(wId: string) {
+  return `/api/w/${wId}/credits/usage-configuration`;
+}
+
+describe("/api/w/[wId]/credits/usage-configuration", () => {
+  it("GET returns 403 when caller is not an admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      usageConfigurationUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("GET defaults the upgrade-request toggles to true when no config row exists", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      usageConfigurationUrl(workspace.sId)
+    );
+
+    expect(response.status).toBe(200);
+    const { configuration } = await response.json();
+    expect(configuration.allowMemberUpgradeRequests).toBe(true);
+    expect(configuration.upgradeRequestEmailEnabled).toBe(true);
+  });
+
+  it("PATCH persists the upgrade-request toggles and GET reflects them", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const patchResponse = await honoApp.request(
+      usageConfigurationUrl(workspace.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          allowMemberUpgradeRequests: false,
+          upgradeRequestEmailEnabled: false,
+        }),
+      }
+    );
+
+    expect(patchResponse.status).toBe(200);
+    const { configuration } = await patchResponse.json();
+    expect(configuration.allowMemberUpgradeRequests).toBe(false);
+    expect(configuration.upgradeRequestEmailEnabled).toBe(false);
+
+    // Re-authenticate as an admin of the same workspace and confirm the change
+    // was persisted.
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const getResponse = await honoApp.request(
+      usageConfigurationUrl(workspace.sId)
+    );
+    const getBody = await getResponse.json();
+    expect(getBody.configuration.allowMemberUpgradeRequests).toBe(false);
+    expect(getBody.configuration.upgradeRequestEmailEnabled).toBe(false);
+  });
+
+  it("PATCH returns 403 when caller is not an admin", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    const response = await honoApp.request(
+      usageConfigurationUrl(workspace.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowMemberUpgradeRequests: false }),
+      }
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -1,12 +1,12 @@
 import type {
   GetCreditUsageConfigurationResponseBody,
   PatchCreditUsageConfigurationResponseBody,
-} from "@app/lib/api/credits/balance_threshold_alert";
+} from "@app/lib/api/credits/usage_configuration";
 import {
-  getWorkspaceBalanceThreshold,
+  getUsageConfiguration,
   PatchCreditUsageConfigurationRequestBody,
-  syncMetronomeBalanceThresholdAlert,
-} from "@app/lib/api/credits/balance_threshold_alert";
+  updateUsageConfiguration,
+} from "@app/lib/api/credits/usage_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -22,14 +22,13 @@ app.get(
   async (ctx): HandlerResult<GetCreditUsageConfigurationResponseBody> => {
     const auth = ctx.get("auth");
 
-    const balanceThresholdCredits = await getWorkspaceBalanceThreshold(auth);
+    const configuration = await getUsageConfiguration(auth);
 
-    return ctx.json({
-      configuration: { balanceThresholdCredits },
-    });
+    return ctx.json({ configuration });
   }
 );
 
+/** @ignoreswagger */
 app.patch(
   "/",
   ensureIsAdmin(),
@@ -37,30 +36,18 @@ app.patch(
   async (ctx): HandlerResult<PatchCreditUsageConfigurationResponseBody> => {
     const auth = ctx.get("auth");
 
-    const { balanceThresholdCredits } = ctx.req.valid("json");
-    // Normalize 0 to null — both mean "no threshold / warning off".
-    const threshold =
-      balanceThresholdCredits && balanceThresholdCredits > 0
-        ? balanceThresholdCredits
-        : null;
-
-    const syncResult = await syncMetronomeBalanceThresholdAlert({
-      auth,
-      balanceThresholdCredits: threshold,
-    });
-    if (syncResult.isErr()) {
+    const result = await updateUsageConfiguration(auth, ctx.req.valid("json"));
+    if (result.isErr()) {
       return apiError(ctx, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: syncResult.error.message,
+          message: result.error.message,
         },
       });
     }
 
-    return ctx.json({
-      configuration: { balanceThresholdCredits: threshold },
-    });
+    return ctx.json({ configuration: result.value });
   }
 );
 

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -2,7 +2,7 @@ import {
   useUpdateUsageNotifications,
   useUsageNotifications,
 } from "@app/lib/swr/usage_settings";
-import { Input, Page, SettingsList } from "@dust-tt/sparkle";
+import { Input, Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 interface UsageNotificationsCardProps {
@@ -22,6 +22,19 @@ export function UsageNotificationsCard({
     useState<string>("");
   const [isSavingBalanceThreshold, setIsSavingBalanceThreshold] =
     useState(false);
+  const [isSavingUpgradeRequestEmail, setIsSavingUpgradeRequestEmail] =
+    useState(false);
+
+  const handleToggleUpgradeRequestEmail = async () => {
+    setIsSavingUpgradeRequestEmail(true);
+    try {
+      await doUpdateUsageNotifications({
+        upgradeRequestEmail: !usageNotifications.upgradeRequestEmail,
+      });
+    } finally {
+      setIsSavingUpgradeRequestEmail(false);
+    }
+  };
 
   useEffect(() => {
     // Defaults to 0 when no threshold is configured (warning off).
@@ -90,6 +103,19 @@ export function UsageNotificationsCard({
                 credits
               </span>
             </div>
+          }
+        />
+        <SettingsList.Row
+          title="Upgrade request"
+          description="Email all workspace admins when a member requests a spend-limit upgrade."
+          action={
+            <SliderToggle
+              selected={usageNotifications.upgradeRequestEmail}
+              disabled={
+                isSavingUpgradeRequestEmail || isUsageNotificationsLoading
+              }
+              onClick={() => void handleToggleUpgradeRequestEmail()}
+            />
           }
         />
       </SettingsList>

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -1,12 +1,20 @@
 import {
   useDefaultUserSpendLimit,
   useUpdateDefaultUserSpendLimit,
+  useUpdateUsageSettings,
+  useUsageSettings,
 } from "@app/lib/swr/usage_settings";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/types/credits";
-import { Input, Page, SettingsList, Spinner } from "@dust-tt/sparkle";
+import {
+  Input,
+  Page,
+  SettingsList,
+  SliderToggle,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 interface UsageSettingsCardProps {
@@ -19,9 +27,26 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
   const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
     workspaceId,
   });
+  const { usageSettings, isUsageSettingsLoading } = useUsageSettings({
+    workspaceId,
+  });
+  const { doUpdateUsageSettings } = useUpdateUsageSettings({ workspaceId });
 
   const [defaultLimitInput, setDefaultLimitInput] = useState<string>("");
   const [isSavingLimit, setIsSavingLimit] = useState(false);
+  const [isSavingAllowUpgradeRequest, setIsSavingAllowUpgradeRequest] =
+    useState(false);
+
+  const handleToggleAllowUpgradeRequest = async () => {
+    setIsSavingAllowUpgradeRequest(true);
+    try {
+      await doUpdateUsageSettings({
+        allowUpgradeRequest: !usageSettings.allowUpgradeRequest,
+      });
+    } finally {
+      setIsSavingAllowUpgradeRequest(false);
+    }
+  };
 
   useEffect(() => {
     if (defaultUserSpendLimit?.awuCredits !== undefined) {
@@ -92,6 +117,17 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
                 </span>
               )}
             </div>
+          }
+        />
+        <SettingsList.Row
+          title="Upgrade request"
+          description="Allow members who reach their pool credit limit to request an upgrade. Workspace admins review requests on the Usage page."
+          action={
+            <SliderToggle
+              selected={usageSettings.allowUpgradeRequest}
+              disabled={isSavingAllowUpgradeRequest || isUsageSettingsLoading}
+              onClick={() => void handleToggleAllowUpgradeRequest()}
+            />
           }
         />
       </SettingsList>

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -15,27 +15,6 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { z } from "zod";
-
-export type CreditUsageConfigurationBody = {
-  // Credit balance (in AWU credits) below which workspace admins are emailed.
-  // `null` means no threshold is configured (the warning is off). Derived from
-  // the workspace's Metronome balance-threshold alert.
-  balanceThresholdCredits: number | null;
-};
-
-export type GetCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export type PatchCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export const PatchCreditUsageConfigurationRequestBody = z.object({
-  // 0 (or null) clears the threshold; a positive value enables the alert.
-  balanceThresholdCredits: z.number().int().min(0).nullable(),
-});
 
 /**
  * Read the workspace's credit-balance-threshold notification setting.

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,0 +1,144 @@
+import {
+  getWorkspaceBalanceThreshold,
+  syncMetronomeBalanceThresholdAlert,
+} from "@app/lib/api/credits/balance_threshold_alert";
+import type { Authenticator } from "@app/lib/auth";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+// Combined workspace-level usage configuration surfaced to admins on the Usage
+// page. `balanceThresholdCredits` is derived from the workspace's Metronome
+// balance-threshold alert (see `balance_threshold_alert.ts`); the upgrade-request
+// toggles are stored on the `credit_usage_configurations` row.
+export type CreditUsageConfigurationBody = {
+  // Credit balance (in AWU credits) below which workspace admins are emailed.
+  // `null` means no threshold is configured (the warning is off).
+  balanceThresholdCredits: number | null;
+  // Whether non-admin members who reach their per-user spend limit can request a
+  // spend-limit upgrade from the product.
+  allowMemberUpgradeRequests: boolean;
+  // Whether workspace admins are emailed when a member requests an upgrade.
+  upgradeRequestEmailEnabled: boolean;
+};
+
+export type GetCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export type PatchCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export const PatchCreditUsageConfigurationRequestBody = z.object({
+  // 0 (or null) clears the threshold; a positive value enables the alert.
+  balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
+  allowMemberUpgradeRequests: z.boolean().optional(),
+  upgradeRequestEmailEnabled: z.boolean().optional(),
+});
+
+export type PatchCreditUsageConfigurationBody = z.infer<
+  typeof PatchCreditUsageConfigurationRequestBody
+>;
+
+const DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS = true;
+const DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED = true;
+
+/**
+ * Read the full usage configuration for a workspace: the Metronome-derived
+ * balance threshold plus the upgrade-request toggles. Toggles fall back to their
+ * defaults when no configuration row exists yet.
+ */
+export async function getUsageConfiguration(
+  auth: Authenticator
+): Promise<CreditUsageConfigurationBody> {
+  const [balanceThresholdCredits, config] = await Promise.all([
+    getWorkspaceBalanceThreshold(auth),
+    CreditUsageConfigurationResource.fetchByWorkspaceId(auth),
+  ]);
+
+  return {
+    balanceThresholdCredits,
+    allowMemberUpgradeRequests:
+      config?.allowMemberUpgradeRequests ??
+      DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS,
+    upgradeRequestEmailEnabled:
+      config?.upgradeRequestEmailEnabled ??
+      DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+  };
+}
+
+async function setUpgradeRequestToggles(
+  auth: Authenticator,
+  toggles: {
+    allowMemberUpgradeRequests?: boolean;
+    upgradeRequestEmailEnabled?: boolean;
+  }
+): Promise<Result<undefined, Error>> {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if (config) {
+    return config.updateConfiguration(auth, toggles);
+  }
+
+  // No configuration row yet — create one carrying the requested toggles, with
+  // defaults for the remaining (purchase-related) fields.
+  const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
+    defaultDiscountPercent: 0,
+    usageCapCredits: null,
+    allowMemberUpgradeRequests:
+      toggles.allowMemberUpgradeRequests ??
+      DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS,
+    upgradeRequestEmailEnabled:
+      toggles.upgradeRequestEmailEnabled ??
+      DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+  });
+  if (createResult.isErr()) {
+    return new Err(createResult.error);
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Persist a partial usage-configuration update. Only the fields present in the
+ * patch are touched: `balanceThresholdCredits` syncs the Metronome alert, and
+ * the upgrade-request toggles update (or create) the configuration row. Returns
+ * the resulting configuration.
+ */
+export async function updateUsageConfiguration(
+  auth: Authenticator,
+  patch: PatchCreditUsageConfigurationBody
+): Promise<Result<CreditUsageConfigurationBody, Error>> {
+  if (patch.balanceThresholdCredits !== undefined) {
+    // Normalize 0 to null — both mean "no threshold / warning off".
+    const threshold =
+      patch.balanceThresholdCredits && patch.balanceThresholdCredits > 0
+        ? patch.balanceThresholdCredits
+        : null;
+
+    const syncResult = await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits: threshold,
+    });
+    if (syncResult.isErr()) {
+      return new Err(syncResult.error);
+    }
+  }
+
+  if (
+    patch.allowMemberUpgradeRequests !== undefined ||
+    patch.upgradeRequestEmailEnabled !== undefined
+  ) {
+    const toggleResult = await setUpgradeRequestToggles(auth, {
+      allowMemberUpgradeRequests: patch.allowMemberUpgradeRequests,
+      upgradeRequestEmailEnabled: patch.upgradeRequestEmailEnabled,
+    });
+    if (toggleResult.isErr()) {
+      return new Err(toggleResult.error);
+    }
+  }
+
+  return new Ok(await getUsageConfiguration(auth));
+}

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -107,6 +107,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultDiscountPercent: number;
       paygEnabled: boolean;
       usageCapCredits: number | null;
+      allowMemberUpgradeRequests: boolean;
+      upgradeRequestEmailEnabled: boolean;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -166,6 +168,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultDiscountPercent: this.defaultDiscountPercent,
       paygEnabled: this.paygEnabled,
       usageCapCredits: this.usageCapCredits,
+      allowMemberUpgradeRequests: this.allowMemberUpgradeRequests,
+      upgradeRequestEmailEnabled: this.upgradeRequestEmailEnabled,
     };
   }
 
@@ -176,6 +180,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultDiscountPercent: this.defaultDiscountPercent,
       paygEnabled: String(this.paygEnabled),
       usageCapCredits: this.usageCapCredits,
+      allowMemberUpgradeRequests: String(this.allowMemberUpgradeRequests),
+      upgradeRequestEmailEnabled: String(this.upgradeRequestEmailEnabled),
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -20,6 +20,11 @@ import type { CreationOptional } from "sequelize";
  *   Metronome `spend_threshold_reached` alert on the workspace's customer.
  *   Independent from `paygEnabled` — the cap can be set even when PAYG is
  *   disabled, and PAYG can be enabled without a cap.
+ * - allowMemberUpgradeRequests: Whether non-admin members who reach their
+ *   per-user spend limit can request a spend-limit upgrade from the product.
+ *   Defaults to true.
+ * - upgradeRequestEmailEnabled: Whether workspace admins are emailed when a
+ *   member requests an upgrade. Defaults to true.
  *
  * The credit-cap-warning notification settings (whether to warn, and at which
  * balance) are NOT stored here: they are derived from the workspace's Metronome
@@ -32,6 +37,8 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare defaultDiscountPercent: number;
   declare paygEnabled: CreationOptional<boolean>;
   declare usageCapCredits: number | null;
+  declare allowMemberUpgradeRequests: CreationOptional<boolean>;
+  declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
 }
 
 CreditUsageConfigurationModel.init(
@@ -73,6 +80,16 @@ CreditUsageConfigurationModel.init(
           }
         },
       },
+    },
+    allowMemberUpgradeRequests: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    upgradeRequestEmailEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
     },
   },
   {

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -1,9 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { GetCreditUsageConfigurationResponseBody } from "@app/lib/api/credits/balance_threshold_alert";
 import type {
   GetProgrammaticUsageLimitResponseBody,
   PutProgrammaticUsageLimitResponseBody,
 } from "@app/lib/api/credits/programmatic_usage_limit";
+import type { GetCreditUsageConfigurationResponseBody } from "@app/lib/api/credits/usage_configuration";
 import type {
   GetDefaultUserSpendLimitResponseBody,
   PutDefaultUserSpendLimitResponseBody,
@@ -16,7 +16,7 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 import { mutate } from "swr";
 import { z } from "zod";
@@ -41,7 +41,7 @@ export interface UsageNotifications {
 }
 
 const DEFAULT_USAGE_SETTINGS: UsageSettings = {
-  allowUpgradeRequest: false,
+  allowUpgradeRequest: true,
   autoUpgradeFreeToPro: false,
 };
 
@@ -51,42 +51,56 @@ const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
   upgradeRequestEmail: true,
 };
 
-const usageSettingsStore = new Map<string, UsageSettings>();
-const usageNotificationsStore = new Map<string, UsageNotifications>();
-const listeners = new Set<() => void>();
-
-function subscribe(callback: () => void) {
-  listeners.add(callback);
-  return () => {
-    listeners.delete(callback);
-  };
+function getCreditUsageConfigurationEndpoint(workspaceId: string): string {
+  return `/api/w/${workspaceId}/credits/usage-configuration`;
 }
 
-function notify() {
-  listeners.forEach((listener) => listener());
-}
-
-function getUsageSettings(workspaceId: string): UsageSettings {
-  return usageSettingsStore.get(workspaceId) ?? DEFAULT_USAGE_SETTINGS;
-}
-
-function getUsageNotifications(workspaceId: string): UsageNotifications {
-  return (
-    usageNotificationsStore.get(workspaceId) ?? DEFAULT_USAGE_NOTIFICATIONS
-  );
+// Shared PATCH against the usage-configuration endpoint. Both the settings and
+// notifications update hooks write to the same endpoint with disjoint fields.
+async function patchCreditUsageConfiguration(
+  workspaceId: string,
+  body: Record<string, unknown>
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  try {
+    const res = await clientFetch(
+      getCreditUsageConfigurationEndpoint(workspaceId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    );
+    if (!res.ok) {
+      const errorData = await getErrorFromResponse(res);
+      return { ok: false, message: errorData.message };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, message: normalizeError(e).message };
+  }
 }
 
 export function useUsageSettings({ workspaceId }: { workspaceId: string }) {
-  const settings = useSyncExternalStore(
-    subscribe,
-    () => getUsageSettings(workspaceId),
-    () => DEFAULT_USAGE_SETTINGS
+  const { fetcher } = useFetcher();
+  const configurationFetcher: Fetcher<GetCreditUsageConfigurationResponseBody> =
+    fetcher;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    getCreditUsageConfigurationEndpoint(workspaceId),
+    configurationFetcher
   );
 
+  const usageSettings: UsageSettings = {
+    ...DEFAULT_USAGE_SETTINGS,
+    ...(data
+      ? { allowUpgradeRequest: data.configuration.allowMemberUpgradeRequests }
+      : {}),
+  };
+
   return {
-    usageSettings: settings,
-    isUsageSettingsLoading: false,
-    isUsageSettingsError: false,
+    usageSettings,
+    isUsageSettingsLoading: !data && !error && isValidating,
+    isUsageSettingsError: !!error,
   };
 }
 
@@ -96,28 +110,44 @@ export function useUpdateUsageSettings({
   workspaceId: string;
 }) {
   const sendNotification = useSendNotification();
+  const { mutate } = useSWRWithDefaults(
+    getCreditUsageConfigurationEndpoint(workspaceId),
+    null
+  );
 
   const doUpdateUsageSettings = useCallback(
     async (patch: Partial<UsageSettings>): Promise<boolean> => {
-      const next = { ...getUsageSettings(workspaceId), ...patch };
-      usageSettingsStore.set(workspaceId, next);
-      notify();
-      // TODO: replace with a real POST request once the backend is available.
+      const body: Record<string, unknown> = {};
+      if (patch.allowUpgradeRequest !== undefined) {
+        body.allowMemberUpgradeRequests = patch.allowUpgradeRequest;
+      }
+      // TODO: `autoUpgradeFreeToPro` is intentionally not persisted (out of scope).
+
+      if (Object.keys(body).length === 0) {
+        return true;
+      }
+
+      const result = await patchCreditUsageConfiguration(workspaceId, body);
+      if (!result.ok) {
+        sendNotification({
+          type: "error",
+          title: "Failed to update usage settings",
+          description: result.message,
+        });
+        return false;
+      }
+
+      await mutate();
       sendNotification({
         type: "success",
         title: "Usage settings updated",
-        description: "Changes are not persisted yet — backend coming soon.",
       });
       return true;
     },
-    [workspaceId, sendNotification]
+    [workspaceId, sendNotification, mutate]
   );
 
   return { doUpdateUsageSettings };
-}
-
-function getCreditUsageConfigurationEndpoint(workspaceId: string): string {
-  return `/api/w/${workspaceId}/credits/usage-configuration`;
 }
 
 export function useUsageNotifications({
@@ -134,13 +164,14 @@ export function useUsageNotifications({
     configurationFetcher
   );
 
-  const fromServer: Partial<UsageNotifications> = data
-    ? { balanceThresholdCredits: data.configuration.balanceThresholdCredits }
-    : {};
-
   const usageNotifications: UsageNotifications = {
     ...DEFAULT_USAGE_NOTIFICATIONS,
-    ...fromServer,
+    ...(data
+      ? {
+          balanceThresholdCredits: data.configuration.balanceThresholdCredits,
+          upgradeRequestEmail: data.configuration.upgradeRequestEmailEnabled,
+        }
+      : {}),
   };
 
   return {
@@ -167,40 +198,25 @@ export function useUpdateUsageNotifications({
       if (patch.balanceThresholdCredits !== undefined) {
         body.balanceThresholdCredits = patch.balanceThresholdCredits;
       }
-
-      if (Object.keys(body).length > 0) {
-        try {
-          const res = await clientFetch(
-            getCreditUsageConfigurationEndpoint(workspaceId),
-            {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(body),
-            }
-          );
-          if (!res.ok) {
-            const errorData = await getErrorFromResponse(res);
-            sendNotification({
-              type: "error",
-              title: "Failed to update notification settings",
-              description: errorData.message,
-            });
-            return false;
-          }
-        } catch (e) {
-          sendNotification({
-            type: "error",
-            title: "Failed to update notification settings",
-            description: normalizeError(e).message,
-          });
-          return false;
-        }
-        await mutate();
+      if (patch.upgradeRequestEmail !== undefined) {
+        body.upgradeRequestEmailEnabled = patch.upgradeRequestEmail;
       }
 
-      const next = { ...getUsageNotifications(workspaceId), ...patch };
-      usageNotificationsStore.set(workspaceId, next);
-      notify();
+      if (Object.keys(body).length === 0) {
+        return true;
+      }
+
+      const result = await patchCreditUsageConfiguration(workspaceId, body);
+      if (!result.ok) {
+        sendNotification({
+          type: "error",
+          title: "Failed to update notification settings",
+          description: result.message,
+        });
+        return false;
+      }
+
+      await mutate();
       sendNotification({
         type: "success",
         title: "Notification settings updated",

--- a/front/migrations/db/migration_674.sql
+++ b/front/migrations/db/migration_674.sql
@@ -1,0 +1,9 @@
+-- Migration created on Jun 09, 2026
+-- Add member-upgrade-request toggles to credit_usage_configurations:
+-- "allowMemberUpgradeRequests" (members can request a spend-limit upgrade) and
+-- "upgradeRequestEmailEnabled" (admins are emailed on each request). Both
+-- default to true.
+SET statement_timeout = '2s';
+SET lock_timeout = '2s';
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "allowMemberUpgradeRequests" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "upgradeRequestEmailEnabled" BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
## Description

Adds two workspace-level admin toggles for the member upgrade-request flow, surfaced on the Usage page:

- **`allowMemberUpgradeRequests`** — whether non-admin members who hit their per-user spend limit can request a spend-limit upgrade (Usage Settings card).
- **`upgradeRequestEmailEnabled`** — whether workspace admins are emailed when a member submits a request (Usage Notifications card).

Both columns are added to `credit_usage_configurations` (migration 674) and default to `true`.

Backend changes:
- New `front/lib/api/credits/usage_configuration.ts` module that combines the Metronome-derived balance threshold with the upgrade-request toggles. The request/response types and `PatchCreditUsageConfigurationRequestBody` move here out of `balance_threshold_alert.ts`. `updateUsageConfiguration` applies partial patches: `balanceThresholdCredits` syncs the Metronome alert, and the toggles update (or lazily create) the configuration row.
- `usage-configuration` route now reads/writes via the combined module.
- `CreditUsageConfigurationResource` and the Sequelize model expose the two new fields.

Frontend changes:
- `useUsageSettings` / `useUsageNotifications` now read from the real `/credits/usage-configuration` endpoint via SWR, replacing the previous in-memory `useSyncExternalStore` placeholder store. Both update hooks share a single `patchCreditUsageConfiguration` helper writing disjoint fields.
- New `SliderToggle` rows in the Usage Settings and Usage Notifications cards.

## Tests

Added `front-api/routes/w/[wId]/credits/usage-configuration.test.ts` covering: admin-only access (403 for non-admins on GET/PATCH), toggle defaults to `true` when no config row exists, and PATCH persistence round-tripped through a subsequent GET.


## Deploy Plan 

merge, migration file executed, then deploy