### PR TITLE
[marketing] chore: Add marketing-edge.dust.tt in CORS

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -2,6 +2,8 @@ const STATIC_ALLOWED_ORIGINS = [
   // Front edge.
   "https://front-edge.dust.tt",
   "https://eu.front-edge.dust.tt",
+  // Marketing edge.
+  "https://marketing-edge.dust.tt",
   // Front extension.
   "https://front-ext.dust.tt",
   // Chrome extension.


### PR DESCRIPTION
## Description

Add marketing-edge to CORS allowed domains in front-api

## Tests

N/A

## Risk

N/A

## Deploy Plan

Deploy front