### PR TITLE
[front] Register DUST_CONTRACT_CREDIT_TYPE custom field key for commits

### DIFF
--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -1423,6 +1423,15 @@ const CUSTOM_FIELD_KEYS: Array<{
     entity: "contract_credit",
     key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   },
+  // Same key on commits: AWU commits are stamped "pool" so the pool balance
+  // alert's Commit filter counts them alongside pool credits (a ContractCredit-
+  // only filter drops commits). The key must be shared with the contract_credit
+  // registration above — Metronome requires every entity in an alert's
+  // custom_field_filters to use the same key/value.
+  {
+    entity: "commit",
+    key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in
   // Redis) instead of comparing product names/IDs, which change on every


### PR DESCRIPTION
## Description

Register the DUST_CONTRACT_CREDIT_TYPE custom field key for the `commit` entity in Metronome. AWU commits will be stamped "pool" (follow-up) so the pool balance alert's Commit filter can match them, the same way contract credits are tagged. The key is shared with the contract_credit registration: Metronome requires every entity in an alert's custom_field_filters to use the same key/value.

Purely additive — nothing reads or writes the field on commits yet, so this is safe to deploy on its own.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy: after merge, run `npx tsx scripts/metronome_setup.ts --execute`.
