### PR TITLE
Keep track of credits consumption through rateLimiter per User

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -177,12 +177,11 @@ function getLimitPromptForCode(
             validateLabel: "Ok",
             children: (
               <p className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                We've paused messaging for your workspace due to our fair usage
-                policy. Your workspace has reached its shared limit of{" "}
-                {assistantLimits.maxAwuCredits} credits per user{" "}
+                We've paused messaging for your account due to our fair usage
+                policy. Your account has reached its limit of{" "}
+                {assistantLimits.maxAwuCredits} credits{" "}
                 {formatLimitTimeframe(assistantLimits.maxAwuCreditsTimeframe)}.
-                This total limit is collectively shared by all users in the
-                workspace. Check our{" "}
+                Check our{" "}
                 <Hoverable
                   variant="highlight"
                   onClick={() => displayFairUseModal()}

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -28,6 +28,21 @@ export type WorkspaceLimit =
   | "user_credits_exhausted"
   | "no_seat";
 
+function formatLimitTimeframe(timeframe: string): string {
+  switch (timeframe) {
+    case "day":
+      return "over the past 24 hours";
+    case "week":
+      return "over the past 7 days";
+    case "month":
+      return "over the past 30 days";
+    case "lifetime":
+      return "for your current plan";
+    default:
+      return `per ${timeframe}`;
+  }
+}
+
 function getLimitPromptForCode(
   router: AppRouter,
   owner: WorkspaceType,
@@ -110,6 +125,9 @@ function getLimitPromptForCode(
       };
 
     case "message_limit": {
+      const assistantLimits = subscription.plan.limits.assistant;
+      const isAwuCreditsFairUseLimit = assistantLimits.maxAwuCredits !== -1;
+
       if (isFreeTrialPhonePlan(subscription.plan.code)) {
         return {
           title: "Dust trial message limit reached",
@@ -153,26 +171,54 @@ function getLimitPromptForCode(
           ),
         };
       } else {
-        return {
-          title: "Message quota exceeded",
-          validateLabel: "Ok",
-          children: (
-            <p className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-              We've paused messaging for your workspace due to our fair usage
-              policy. Your workspace has reached its shared limit of{" "}
-              {subscription.plan.limits.assistant.maxMessages} messages per user
-              over the past 24 hours. This total limit is collectively shared by
-              all users in the workspace. Check our{" "}
-              <Hoverable
-                variant="highlight"
-                onClick={() => displayFairUseModal()}
-              >
-                Fair Use policy
-              </Hoverable>
-              &nbsp; to learn more.
-            </p>
-          ),
-        };
+        if (isAwuCreditsFairUseLimit) {
+          return {
+            title: "Credit quota exceeded",
+            validateLabel: "Ok",
+            children: (
+              <p className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                We've paused messaging for your workspace due to our fair usage
+                policy. Your workspace has reached its shared limit of{" "}
+                {assistantLimits.maxAwuCredits} credits per user{" "}
+                {formatLimitTimeframe(assistantLimits.maxAwuCreditsTimeframe)}.
+                This total limit is collectively shared by all users in the
+                workspace. Check our{" "}
+                <Hoverable
+                  variant="highlight"
+                  onClick={() => displayFairUseModal()}
+                >
+                  Fair Use policy
+                </Hoverable>
+                &nbsp; to learn more.
+              </p>
+            ),
+          };
+        } else {
+          return {
+            title: "Message quota exceeded",
+            validateLabel: "Ok",
+            children: (
+              <p className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                We've paused messaging for your workspace due to our fair usage
+                policy. Your workspace has reached its shared limit of{" "}
+                {subscription.plan.limits.assistant.maxMessages} messages per
+                user{" "}
+                {formatLimitTimeframe(
+                  subscription.plan.limits.assistant.maxMessagesTimeframe
+                )}
+                . This total limit is collectively shared by all users in the
+                workspace. Check our{" "}
+                <Hoverable
+                  variant="highlight"
+                  onClick={() => displayFairUseModal()}
+                >
+                  Fair Use policy
+                </Hoverable>
+                &nbsp; to learn more.
+              </p>
+            ),
+          };
+        }
       }
     }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -34,6 +34,7 @@ import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE,
   MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
   makeAgentMentionsRateLimitKeyForWorkspace,
+  makeFairUseAwuCreditsRateLimitKeyForUser,
   makeKeyCapRateLimitKey,
   makeMessageRateLimitKeyForWorkspace,
   makeMessageRateLimitKeyForWorkspaceActor,
@@ -100,6 +101,7 @@ import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
+  getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
   rateLimiter,
 } from "@app/lib/utils/rate_limiter";
@@ -2897,7 +2899,42 @@ async function isMessagesLimitReached(
   }
 
   // Checking plan limit
-  const { maxMessages, maxMessagesTimeframe } = plan.limits.assistant;
+  const {
+    maxAwuCredits,
+    maxAwuCreditsTimeframe,
+    maxMessages,
+    maxMessagesTimeframe,
+  } = plan.limits.assistant;
+
+  const user = auth.user();
+  if (user && maxAwuCredits !== -1) {
+    const result = await getRateLimiterCount({
+      key: makeFairUseAwuCreditsRateLimitKeyForUser(
+        owner,
+        user.toJSON(),
+        maxAwuCreditsTimeframe
+      ),
+      timeframeSeconds: getTimeframeSecondsFromLiteral(maxAwuCreditsTimeframe),
+    });
+
+    if (result.isOk() && result.value >= maxAwuCredits) {
+      return {
+        isLimitReached: true,
+        limitType: "plan_message_limit_exceeded",
+      };
+    }
+
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: owner.sId,
+          userId: user.sId,
+          error: result.error,
+        },
+        "Failed to read fair-use AWU credits rate limit."
+      );
+    }
+  }
 
   if (plan.limits.assistant.maxMessages === -1) {
     return {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -109,25 +109,29 @@ export async function computeAndStoreAgentMessageCredits(
 
   const user = auth.user();
   const plan = auth.plan();
-  if (user && plan && costCredits !== null && costCredits > 0) {
-    const { maxAwuCredits, maxAwuCreditsTimeframe } = plan.limits.assistant;
-    if (maxAwuCredits !== -1) {
-      // We use rateLimiter infrastructure to enforce the fair use but ignore failure here since
-      // this is run post message execution. The next agent loop will be stopped if we dropped to 0.
-      await rateLimiter({
-        key: makeFairUseAwuCreditsRateLimitKeyForUser(
-          auth.getNonNullableWorkspace(),
-          user.toJSON(),
-          maxAwuCreditsTimeframe
-        ),
-        maxPerTimeframe: maxAwuCredits,
-        timeframeSeconds: getTimeframeSecondsFromLiteral(
-          maxAwuCreditsTimeframe
-        ),
-        incrementBy: costCredits,
-        logger,
-      });
-    }
+  const assistantLimits = plan?.limits.assistant;
+  if (
+    user &&
+    assistantLimits &&
+    costCredits !== null &&
+    costCredits > 0 &&
+    assistantLimits.maxAwuCredits !== -1
+  ) {
+    // We use rateLimiter infrastructure to enforce the fair use but ignore failure here since
+    // this is run post message execution. The next agent loop will be stopped if we dropped to 0.
+    await rateLimiter({
+      key: makeFairUseAwuCreditsRateLimitKeyForUser(
+        auth.getNonNullableWorkspace(),
+        user.toJSON(),
+        assistantLimits.maxAwuCreditsTimeframe
+      ),
+      maxPerTimeframe: assistantLimits.maxAwuCredits,
+      timeframeSeconds: getTimeframeSecondsFromLiteral(
+        assistantLimits.maxAwuCreditsTimeframe
+      ),
+      incrementBy: costCredits,
+      logger,
+    });
   }
 
   return costCredits;

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -1,5 +1,6 @@
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import type { Authenticator } from "@app/lib/auth";
 import {
   intelligenceAwuFromRunUsages,
@@ -10,6 +11,10 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
+import {
+  getTimeframeSecondsFromLiteral,
+  rateLimiter,
+} from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 
@@ -101,6 +106,29 @@ export async function computeAndStoreAgentMessageCredits(
     agentMessageModelId,
     costCredits,
   });
+
+  const user = auth.user();
+  const plan = auth.plan();
+  if (user && plan && costCredits !== null && costCredits > 0) {
+    const { maxAwuCredits, maxAwuCreditsTimeframe } = plan.limits.assistant;
+    if (maxAwuCredits !== -1) {
+      // We use rateLimiter infrastructure to enforce the fair use but ignore failure here since
+      // this is run post message execution. The next agent loop will be stopped if we dropped to 0.
+      await rateLimiter({
+        key: makeFairUseAwuCreditsRateLimitKeyForUser(
+          auth.getNonNullableWorkspace(),
+          user.toJSON(),
+          maxAwuCreditsTimeframe
+        ),
+        maxPerTimeframe: maxAwuCredits,
+        timeframeSeconds: getTimeframeSecondsFromLiteral(
+          maxAwuCreditsTimeframe
+        ),
+        incrementBy: costCredits,
+        logger,
+      });
+    }
+  }
 
   return costCredits;
 }

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -6,8 +6,11 @@ import {
   getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
 } from "@app/lib/utils/rate_limiter";
-import type { MaxMessagesTimeframeType } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
+import type {
+  MaxAwuCreditsTimeframeType,
+  MaxMessagesTimeframeType,
+} from "@app/types/plan";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 
 export type GetTrialMessageUsageResponseType = {
   count: number;
@@ -59,6 +62,14 @@ export const makeAgentMentionsRateLimitKeyForWorkspace = (
   maxMessagesTimeframe: MaxMessagesTimeframeType
 ) => {
   return `workspace:${owner.id}:agent_message_count:${maxMessagesTimeframe}`;
+};
+
+export const makeFairUseAwuCreditsRateLimitKeyForUser = (
+  owner: LightWorkspaceType,
+  user: UserType,
+  maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType
+) => {
+  return `workspace:${owner.id}:user:${user.id}:fair_use_awu_credit_count:${maxAwuCreditsTimeframe}`;
 };
 
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (


### PR DESCRIPTION
## Description

Work for https://github.com/dust-tt/tasks/issues/8257

- Introduce `makeFairUseAwuCreditsRateLimitKeyForUser`
- Track credits (without any action if exhausted) in `computeAndStoreAgentMessageCredits`
- Read the value in `lib/api/assistant/conversation` and error if we reached the limit
- Updated the popup to support language around credits

<img width="508" height="267" alt="Screenshot 2026-06-09 at 16 22 48" src="https://github.com/user-attachments/assets/b30df392-7f24-4a47-a559-31ab319b8eb9" />

TODO later: Update the fair use limit components linked from the popup once we apply the credits-baed limits.

## Tests

Tested locally

## Risk

None, we don't write to redis nor read while value is -1 (true of all plans right now)

## Deploy Plan

- deploy `front`