### PR TITLE
feat: hide admin role actions when no permission

### DIFF
--- a/front/components/members/RolesDropDown.tsx
+++ b/front/components/members/RolesDropDown.tsx
@@ -1,5 +1,6 @@
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import { hasPermission } from "@app/types/permissions";
 import type { ActiveRoleType } from "@app/types/user";
 import { ACTIVE_ROLES } from "@app/types/user";
 import {
@@ -24,14 +25,32 @@ export function RoleDropDown({
   disabled = false,
 }: RoleDropDownProps) {
   const { hasFeature } = useFeatureFlags();
+  const workspace = useWorkspace();
+  const canManageAdminRole = hasPermission(
+    workspace.role,
+    "workspace:manage_admin_role"
+  );
 
-  // `business_admin` can only be assigned when the
-  // workspace has the `admin_governance` feature flag.
-  const availableRoles = hasFeature("admin_governance")
-    ? ACTIVE_ROLES
-    : ACTIVE_ROLES.filter((role) => role !== "business_admin");
+  const availableRoles = ACTIVE_ROLES.filter((role) => {
+    // `business_admin` can only be assigned when the workspace has the
+    // `admin_governance` feature flag.
+    if (role === "business_admin" && !hasFeature("admin_governance")) {
+      return false;
+    }
+    // `admin` can only be assigned by those allowed to manage the admin role
+    // (matches the server-side escalation guard).
+    if (role === "admin" && !canManageAdminRole) {
+      return false;
+    }
+    return true;
+  });
 
-  if (disabled) {
+  // Lock the selector entirely when the target is an admin and the caller
+  // cannot manage the admin role (they may neither demote nor revoke admins).
+  const isLocked =
+    disabled || (selectedRole === "admin" && !canManageAdminRole);
+
+  if (isLocked) {
     return (
       <Chip
         color={ROLES_DATA[selectedRole]["color"]}

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -4,6 +4,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { SearchMembersAdminResponseBody } from "@app/lib/api/workspace";
 import { handleMembersRoleChange } from "@app/lib/client/members";
 import { useProvisioningStatus } from "@app/lib/swr/workos";
+import { hasPermission } from "@app/types/permissions";
 import type {
   ActiveRoleType,
   LightWorkspaceType,
@@ -61,6 +62,11 @@ export function ChangeMemberModal({
       roleProvisioningStatus.hasBuilderGroup
     );
   };
+
+  // Revoking an admin requires the manage_admin_role permission
+  const canRevokeMember =
+    role !== "admin" ||
+    hasPermission(workspace.role, "workspace:manage_admin_role");
 
   const handleSave = async () => {
     if (!selectedRole) {
@@ -134,73 +140,75 @@ export function ChangeMemberModal({
                   </Page.P>
                 </div>
 
-                <div className="flex flex-none flex-col gap-2">
-                  <div className="flex-none">
-                    <Dialog>
-                      <DialogTrigger asChild>
-                        <Button
-                          variant="warning"
-                          label="Revoke member access"
-                          size="sm"
-                          disabled={member.origin === "provisioned"}
-                          tooltip={
-                            member.origin === "provisioned"
-                              ? "This user is managed by your identity provider."
-                              : undefined
-                          }
-                        />
-                      </DialogTrigger>
-                      <DialogContent>
-                        <DialogHeader>
-                          <DialogTitle>Confirm deletion</DialogTitle>
-                        </DialogHeader>
-                        {isSaving ? (
-                          <div className="flex justify-center py-8">
-                            <Spinner variant="dark" size="md" />
-                          </div>
-                        ) : (
-                          <>
-                            <DialogContainer>
-                              <div>
-                                Revoke access for user{" "}
-                                <span className="font-bold">
-                                  {member.fullName}
-                                </span>
-                                ?
-                              </div>
-                            </DialogContainer>
-                            <DialogFooter
-                              leftButtonProps={{
-                                label: "Cancel",
-                                variant: "outline",
-                              }}
-                              rightButtonProps={{
-                                label: "Yes, revoke",
-                                variant: "warning",
-                                onClick: async () => {
-                                  await handleMembersRoleChange({
-                                    members: [member],
-                                    role: "none",
-                                    sendNotification,
-                                  });
-                                  await mutateMembers();
-                                  onClose();
-                                },
-                              }}
-                            />
-                          </>
-                        )}
-                      </DialogContent>
-                    </Dialog>
+                {canRevokeMember && (
+                  <div className="flex flex-none flex-col gap-2">
+                    <div className="flex-none">
+                      <Dialog>
+                        <DialogTrigger asChild>
+                          <Button
+                            variant="warning"
+                            label="Revoke member access"
+                            size="sm"
+                            disabled={member.origin === "provisioned"}
+                            tooltip={
+                              member.origin === "provisioned"
+                                ? "This user is managed by your identity provider."
+                                : undefined
+                            }
+                          />
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>Confirm deletion</DialogTitle>
+                          </DialogHeader>
+                          {isSaving ? (
+                            <div className="flex justify-center py-8">
+                              <Spinner variant="dark" size="md" />
+                            </div>
+                          ) : (
+                            <>
+                              <DialogContainer>
+                                <div>
+                                  Revoke access for user{" "}
+                                  <span className="font-bold">
+                                    {member.fullName}
+                                  </span>
+                                  ?
+                                </div>
+                              </DialogContainer>
+                              <DialogFooter
+                                leftButtonProps={{
+                                  label: "Cancel",
+                                  variant: "outline",
+                                }}
+                                rightButtonProps={{
+                                  label: "Yes, revoke",
+                                  variant: "warning",
+                                  onClick: async () => {
+                                    await handleMembersRoleChange({
+                                      members: [member],
+                                      role: "none",
+                                      sendNotification,
+                                    });
+                                    await mutateMembers();
+                                    onClose();
+                                  },
+                                }}
+                              />
+                            </>
+                          )}
+                        </DialogContent>
+                      </Dialog>
+                    </div>
+                    {member.origin !== "provisioned" && (
+                      <Page.P>
+                        Deleting a member will remove them from the workspace.
+                        They will be able to rejoin if they have an invitation
+                        link.
+                      </Page.P>
+                    )}
                   </div>
-                  {member.origin !== "provisioned" && (
-                    <Page.P>
-                      Deleting a member will remove them from the workspace.
-                      They will be able to rejoin if they have an invitation
-                      link.
-                    </Page.P>
-                  )}
-                </div>
+                )}
               </div>
             </SheetContainer>
             <SheetFooter


### PR DESCRIPTION
## Description

This PR hides admin role management actions in the members UI when the current user lacks the `workspace:manage_admin_role` permission, matching the existing server-side guard.

- In `RolesDropDown`, filters out the `admin` role from available options when the user cannot manage it, and locks the dropdown entirely if the selected member is already an admin.
- In `ChangeMemberModal`, hides the "Revoke member access" button when the member has the admin role and the caller lacks the permission.

<img width="453" height="646" alt="Capture d’écran 2026-06-09 à 16 27 18" src="https://github.com/user-attachments/assets/5a9bf64b-7b19-460d-9be5-fc4ae47e0ccd" />
<img width="453" height="646" alt="Capture d’écran 2026-06-09 à 16 27 31" src="https://github.com/user-attachments/assets/07d8f0f9-dff3-42b4-9b6f-c3232c6f13d3" />
<img width="453" height="646" alt="Capture d’écran 2026-06-09 à 16 27 35" src="https://github.com/user-attachments/assets/ceb8a936-2c3c-4b6c-96a1-fe0a7190d14c" />


## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.
