### PR TITLE
[front] Stamp AWU commits with DUST_CONTRACT_CREDIT_TYPE=pool

### DIFF
--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -7,10 +7,17 @@ import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import * as defaultUserCapAlert from "@app/lib/metronome/alerts/spend_limits";
 import * as perUserAlerts from "@app/lib/metronome/alerts/spend_limits";
 import {
+  getMetronomeCommit,
   getMetronomeContractById,
   listMetronomeContracts,
+  setMetronomeCommitCustomFields,
 } from "@app/lib/metronome/client";
-import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
+import {
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
+  getCreditTypeAwuId,
+  PLAN_CODE_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -35,6 +42,8 @@ vi.mock(import("@app/lib/metronome/client"), async (importOriginal) => {
     ...actual,
     getMetronomeContractById: vi.fn(),
     listMetronomeContracts: vi.fn(),
+    getMetronomeCommit: vi.fn(),
+    setMetronomeCommitCustomFields: vi.fn(),
   };
 });
 
@@ -107,6 +116,7 @@ const OLD_CONTRACT_ID = "contract_old_xxx";
 const NEW_CONTRACT_ID = "contract_new_yyy";
 const ENT_PLAN_CODE = "ENT_TEST_PLAN";
 const USER_ID = "user_test_xxx";
+const COMMIT_ID = "commit_test_xxx";
 
 /** Build a contract event payload that matches the centralized webhook schema. */
 function contractEvent(
@@ -951,5 +961,91 @@ describe("processMetronomeWebhook — workspace-level spend threshold", () => {
     expect(result.isOk()).toBe(true);
     expect(dispatchPaygCapReached).not.toHaveBeenCalled();
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
+  });
+});
+
+describe("processMetronomeWebhook — commit.create DUST_CONTRACT_CREDIT_TYPE stamping", () => {
+  function commitCreateEvent(
+    commitCustomFields: Record<string, string> | null = null
+  ): MetronomeWebhookEvent {
+    return {
+      id: "evt_commit_create_xxx",
+      type: "commit.create",
+      timestamp: new Date().toISOString(),
+      commit_id: COMMIT_ID,
+      commit_custom_fields: commitCustomFields,
+      customer_id: METRONOME_CUSTOMER_ID,
+    } as MetronomeWebhookEvent;
+  }
+
+  function commit(
+    creditTypeId: string,
+    customFields: Record<string, string> | null = null
+  ) {
+    return {
+      id: COMMIT_ID,
+      custom_fields: customFields ?? undefined,
+      access_schedule: { credit_type: { id: creditTypeId } },
+    };
+  }
+
+  beforeEach(() => {
+    vi.mocked(setMetronomeCommitCustomFields).mockResolvedValue(
+      new Ok(undefined)
+    );
+  });
+
+  it("stamps an unstamped AWU commit as pool", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCommit).mockResolvedValue(
+      new Ok(commit(getCreditTypeAwuId()) as never)
+    );
+
+    const result = await processMetronomeWebhook({
+      event: commitCreateEvent(),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(setMetronomeCommitCustomFields).toHaveBeenCalledWith({
+      commitId: COMMIT_ID,
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      },
+    });
+  });
+
+  it("does not stamp a non-AWU commit", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCommit).mockResolvedValue(
+      new Ok(commit("non_awu_credit_type") as never)
+    );
+
+    const result = await processMetronomeWebhook({
+      event: commitCreateEvent(),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(setMetronomeCommitCustomFields).not.toHaveBeenCalled();
+  });
+
+  it("does not re-stamp a commit that already carries the field", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+    vi.mocked(getMetronomeCommit).mockResolvedValue(
+      new Ok(
+        commit(getCreditTypeAwuId(), {
+          [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+        }) as never
+      )
+    );
+
+    const result = await processMetronomeWebhook({
+      event: commitCreateEvent(),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(setMetronomeCommitCustomFields).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -31,7 +31,7 @@ import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
 import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
-import type { ContractV2 } from "@metronome/sdk/resources";
+import type { Commit, ContractV2 } from "@metronome/sdk/resources";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { processMetronomeWebhook } from "./process_webhook";
@@ -975,17 +975,23 @@ describe("processMetronomeWebhook — commit.create DUST_CONTRACT_CREDIT_TYPE st
       commit_id: COMMIT_ID,
       commit_custom_fields: commitCustomFields,
       customer_id: METRONOME_CUSTOMER_ID,
-    } as MetronomeWebhookEvent;
+    };
   }
 
   function commit(
     creditTypeId: string,
     customFields: Record<string, string> | null = null
-  ) {
+  ): Commit {
     return {
       id: COMMIT_ID,
+      created_at: new Date().toISOString(),
+      product: { id: "prod_test", name: "Test Product" },
+      type: "PREPAID",
       custom_fields: customFields ?? undefined,
-      access_schedule: { credit_type: { id: creditTypeId } },
+      access_schedule: {
+        schedule_items: [],
+        credit_type: { id: creditTypeId, name: "AWU" },
+      },
     };
   }
 
@@ -998,7 +1004,7 @@ describe("processMetronomeWebhook — commit.create DUST_CONTRACT_CREDIT_TYPE st
   it("stamps an unstamped AWU commit as pool", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(getMetronomeCommit).mockResolvedValue(
-      new Ok(commit(getCreditTypeAwuId()) as never)
+      new Ok(commit(getCreditTypeAwuId()))
     );
 
     const result = await processMetronomeWebhook({
@@ -1018,7 +1024,7 @@ describe("processMetronomeWebhook — commit.create DUST_CONTRACT_CREDIT_TYPE st
   it("does not stamp a non-AWU commit", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
     vi.mocked(getMetronomeCommit).mockResolvedValue(
-      new Ok(commit("non_awu_credit_type") as never)
+      new Ok(commit("non_awu_credit_type"))
     );
 
     const result = await processMetronomeWebhook({
@@ -1036,7 +1042,7 @@ describe("processMetronomeWebhook — commit.create DUST_CONTRACT_CREDIT_TYPE st
       new Ok(
         commit(getCreditTypeAwuId(), {
           [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
-        }) as never
+        })
       )
     );
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -54,6 +54,7 @@ import {
   getMetronomeContractById,
   getMetronomeCredit,
   listMetronomeContracts,
+  setMetronomeCommitCustomFields,
   setMetronomeContractCreditCustomFields,
   updateMetronomeCreditSegmentAmount,
 } from "@app/lib/metronome/client";
@@ -247,6 +248,56 @@ async function stampContractCreditType({
   logger.info(
     { workspaceId, customerId, contractId, creditId, value, eventType },
     `[Metronome Webhook] ${eventType}: stamped DUST_CONTRACT_CREDIT_TYPE`
+  );
+  return new Ok(undefined);
+}
+
+// Stamp `DUST_CONTRACT_CREDIT_TYPE=pool` on an AWU commit so the pool balance
+// alert's Commit filter counts it alongside pool credits. The key is shared with
+// contract credits — Metronome requires every entity in an alert's
+// custom_field_filters to use the same key/value. Idempotent — bails if already
+// stamped. Commits have no excess or per-seat variants (unlike contract credits),
+// so AWU commits are always "pool"; non-AWU commits (e.g. programmatic USD)
+// belong to other pools and are left unstamped.
+async function stampCommitCreditType({
+  workspaceId,
+  commit,
+  commitCustomFields,
+  eventType,
+}: {
+  workspaceId: string;
+  commit: Commit;
+  commitCustomFields?: Record<string, string> | null;
+  eventType: string;
+}): Promise<Result<void, ProcessMetronomeWebhookError>> {
+  if (
+    commitCustomFields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] ||
+    commit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]
+  ) {
+    return new Ok(undefined);
+  }
+
+  if (commit.access_schedule?.credit_type?.id !== getCreditTypeAwuId()) {
+    return new Ok(undefined);
+  }
+
+  const setResult = await setMetronomeCommitCustomFields({
+    commitId: commit.id,
+    customFields: {
+      [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+    },
+  });
+  if (setResult.isErr()) {
+    return new Err(
+      new ProcessMetronomeWebhookError(
+        "processing_failed",
+        `Error stamping commit custom field: ${setResult.error.message}`
+      )
+    );
+  }
+  logger.info(
+    { workspaceId, commitId: commit.id, eventType },
+    `[Metronome Webhook] ${eventType}: stamped DUST_CONTRACT_CREDIT_TYPE=pool on commit`
   );
   return new Ok(undefined);
 }
@@ -1034,7 +1085,6 @@ export async function processMetronomeWebhook({
     case "alerts.usage_threshold_reached":
     case "alerts.usage_threshold_resolved":
     case "commit.archive":
-    case "commit.create":
     case "commit.segment.end":
     case "contract.archive":
     case "contract.create":
@@ -1061,6 +1111,34 @@ export async function processMetronomeWebhook({
         },
         "[Metronome Webhook] contract.edit: invalidated active-contract cache"
       );
+      break;
+    }
+
+    case "commit.create": {
+      const { customer_id: metronomeCustomerId, commit_id: commitId } = event;
+      const commitResult = await getMetronomeCommit({
+        metronomeCustomerId,
+        commitId,
+      });
+      if (commitResult.isErr()) {
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error fetching commit: ${commitResult.error.message}`
+          )
+        );
+      }
+      if (commitResult.value) {
+        const stampResult = await stampCommitCreditType({
+          workspaceId: workspace.sId,
+          commit: commitResult.value,
+          commitCustomFields: event.commit_custom_fields,
+          eventType: "commit.create",
+        });
+        if (stampResult.isErr()) {
+          return stampResult;
+        }
+      }
       break;
     }
 
@@ -1205,6 +1283,15 @@ export async function processMetronomeWebhook({
           metronomeCustomerId,
           commitOrCredit: commitResult.value,
         });
+        const stampResult = await stampCommitCreditType({
+          workspaceId: workspace.sId,
+          commit: commitResult.value,
+          commitCustomFields: event.commit_custom_fields,
+          eventType: event.type,
+        });
+        if (stampResult.isErr()) {
+          return stampResult;
+        }
       }
       break;
     }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -727,6 +727,26 @@ export async function setMetronomeContractCreditCustomFields({
   }
 }
 
+/** Set custom field values on a Metronome commit. */
+export async function setMetronomeCommitCustomFields({
+  commitId,
+  customFields,
+}: {
+  commitId: string;
+  customFields: Record<string, string>;
+}): Promise<Result<void, Error>> {
+  try {
+    await getMetronomeClient().v1.customFields.setValues({
+      entity: "commit",
+      entity_id: commitId,
+      custom_fields: customFields,
+    });
+    return new Ok(undefined);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Contract management
 // ---------------------------------------------------------------------------
@@ -2026,11 +2046,12 @@ export async function listMetronomeBalances(
         : {}),
       ...(includeArchived ? { include_archived: true } : {}),
     })) {
-      // Mirror the default ContractCredit alert filter: include only
+      // Mirror the pool balance alert filter for credits: include only
       // credits explicitly tagged DUST_CONTRACT_CREDIT_TYPE=pool. Excess
       // credits (tagged "excess") and per-seat / unstamped credits are
       // excluded — they're not part of the workspace pool balance the
-      // alert tracks. Commits are not stamped and pass through unchanged.
+      // alert tracks. Commits always pass through here (the alert counts
+      // them via the ContractCreditOrCommit filter).
       if (
         onlyPoolCredits &&
         entry.type === "CREDIT" &&

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -107,10 +107,15 @@ export const SEAT_TYPE_CUSTOM_FIELD_KEY = "DUST_SEAT_TYPE";
 // for Metronome Product '…'".
 export const STRIPE_PRODUCT_ID_CUSTOM_FIELD_KEY = "STRIPE_PRODUCT_ID";
 
-// Custom field stamped on contract credits / commits to identify whether they
-// belong to the workspace pool ("pool") or are excess-overage accounting
-// credits ("excess"). Default Metronome alerts filter on this field to
-// exclude excess credits from low-balance notifications.
+// Custom field stamped on contract credits AND commits to identify whether they
+// belong to the workspace pool ("pool") or are excess-overage accounting credits
+// ("excess"). The pool balance alert carries per-entity ContractCredit + Commit
+// filters that both match "pool", so pool credits and pool commits count toward
+// the balance while excess credits are excluded. The key must be shared across
+// both entities: Metronome rejects an alert whose custom_field_filters use
+// different key/value pairs per entity type ("must specify the same set of key
+// and value pairs for every entity type"). Commits only ever take "pool" (they
+// have no excess variant).
 export const CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY =
   "DUST_CONTRACT_CREDIT_TYPE";
 export const CONTRACT_CREDIT_TYPE_EXCESS = "excess";

--- a/front/scripts/backfill_commit_credit_type.ts
+++ b/front/scripts/backfill_commit_credit_type.ts
@@ -1,0 +1,118 @@
+/**
+ * Backfill `DUST_CONTRACT_CREDIT_TYPE=pool` on existing Metronome AWU commits.
+ *
+ * New commits get tagged reactively by the `commit.create` /
+ * `commit.segment.start` webhook handlers, but commits created before that
+ * landed have no tag. The pool balance alert carries a Commit filter on
+ * DUST_CONTRACT_CREDIT_TYPE=pool (same key as the ContractCredit filter, as
+ * Metronome requires), so an untagged AWU commit is excluded from the balance —
+ * exactly the early-firing bug the tag fixes. This stamps them so they count.
+ *
+ * Only AWU commits are tagged: commits of other credit types (e.g. programmatic
+ * USD) belong to different pools and are left untouched. Idempotent — commits
+ * already carrying the field are skipped.
+ *
+ * IMPORTANT: run this BEFORE recreating the alerts with the Commit filter
+ * (`recreate_pool_balance_alerts.ts` + `metronome_setup.ts --recreate-pool-defaults`).
+ * Adding the filter first would drop these untagged commits from the balance
+ * until the backfill catches up.
+ *
+ * Run with: npx tsx scripts/backfill_commit_credit_type.ts [--execute] [--workspaceId <sId>]
+ */
+
+import {
+  listMetronomeCustomerCommits,
+  setMetronomeCommitCustomFields,
+} from "@app/lib/metronome/client";
+import {
+  CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
+  CONTRACT_CREDIT_TYPE_POOL,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
+import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types/user";
+
+import { makeScript } from "./helpers";
+import { runOnAllWorkspaces } from "./workspace_helpers";
+
+async function backfillCommitsForWorkspace(
+  workspace: LightWorkspaceType,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return; // Workspace not provisioned in Metronome — skip.
+  }
+
+  const commitsResult = await listMetronomeCustomerCommits({
+    metronomeCustomerId,
+    includeContractCommits: true,
+  });
+  if (commitsResult.isErr()) {
+    logger.error(
+      { workspaceId: workspace.sId, error: commitsResult.error },
+      "[Backfill commit type] Failed to list commits"
+    );
+    return;
+  }
+
+  const awuCreditTypeId = getCreditTypeAwuId();
+  for (const commit of commitsResult.value) {
+    if (commit.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]) {
+      continue;
+    }
+    if (commit.access_schedule?.credit_type?.id !== awuCreditTypeId) {
+      continue;
+    }
+
+    if (!execute) {
+      logger.info(
+        { workspaceId: workspace.sId, commitId: commit.id, name: commit.name },
+        "[Backfill commit type] [DRY RUN] Would stamp DUST_CONTRACT_CREDIT_TYPE=pool"
+      );
+      continue;
+    }
+
+    const setResult = await setMetronomeCommitCustomFields({
+      commitId: commit.id,
+      customFields: {
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: CONTRACT_CREDIT_TYPE_POOL,
+      },
+    });
+    if (setResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          commitId: commit.id,
+          error: setResult.error,
+        },
+        "[Backfill commit type] Failed to stamp commit"
+      );
+      continue;
+    }
+    logger.info(
+      { workspaceId: workspace.sId, commitId: commit.id },
+      "[Backfill commit type] Stamped DUST_CONTRACT_CREDIT_TYPE=pool"
+    );
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string" as const,
+      description:
+        "Optional workspace sId to process (processes all if omitted)",
+      required: false,
+    },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        await backfillCommitsForWorkspace(workspace, execute, logger);
+      },
+      { concurrency: 4, wId: workspaceId }
+    );
+  }
+);


### PR DESCRIPTION
## Description

Tag AWU commits "pool" so the pool balance alert can count them alongside pool credits (the alert is `low_remaining_contract_credit_and_commit_balance_reached`, which sums contract credits + commits). Without a tag, the upcoming per-entity Commit filter would drop commits from the balance and fire the alert as soon as pool credits deplete even when AWU commits remain.

- `setMetronomeCommitCustomFields` (client) sets custom fields on a commit.
- `stampCommitCreditType` (webhook) stamps AWU commits "pool" on `commit.create` and `commit.segment.start` / `commit.edit`. Idempotent; non-AWU commits (e.g. programmatic USD) are left untouched — they belong to other pools.
- `backfill_commit_credit_type.ts` stamps existing AWU commits.

Shared key with contract credits (Metronome requires every entity in an alert's custom_field_filters to use the same key/value). Inert on its own — no alert filters on commits yet, and balance math already counts them — so this is safe to deploy before the filter change.

Requires the `commit` custom-field key registration (previous commit) to be applied in Metronome first.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run `npx tsx scripts/backfill_commit_credit_type.ts --execute`
