### PR TITLE
feat(credits): add admin upgrade-requests tab and resolution wiring

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -7,6 +7,7 @@ import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDial
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
+import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
@@ -26,10 +27,17 @@ import {
   useUpdateMemberSeatType,
 } from "@app/lib/swr/memberships";
 import {
+  useResolveUpgradeRequest,
+  useUpgradeRequests,
+} from "@app/lib/swr/upgrade_requests";
+import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
-import type { MembershipSeatType } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  MembershipUpgradeRequestType,
+} from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { isAdmin } from "@app/types/user";
 import {
@@ -46,9 +54,41 @@ import {
   PieChart01,
   SearchInput,
   Spinner,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+
+// Build a minimal member from an upgrade request to feed the reused seat / spend
+// limit modals.
+function memberFromUpgradeRequest(
+  request: MembershipUpgradeRequestType
+): MemberUsageType {
+  return {
+    sId: request.requester.sId,
+    name: request.requester.name,
+    email: request.requester.email,
+    image: request.requester.image,
+    seatType: null,
+    memberUsageLimit: null,
+    seatBalanceAwu: null,
+    consumedAwuCredits: 0,
+    consumedFromAllowanceAwuCredits: 0,
+    consumedFromPoolAwuCredits: 0,
+    billingFrequency: null,
+    scheduledSeatType: null,
+    scheduledSeatChangeAt: null,
+    spendLimitAwuCredits: null,
+    spendLimitSource: "none",
+    spendLimitAlertId: null,
+    spendLimitWarningAlertId: null,
+    creditState: "capped",
+  };
+}
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -141,6 +181,122 @@ export function UsagePage() {
       }),
     []
   );
+  // Admin-only Requests tab: pending member-initiated upgrade requests, resolved
+  // by approving (via the seat / spend-limit modals) or denying.
+  const isWorkspaceAdmin = isAdmin(owner);
+  const [membersTab, setMembersTab] = useState<"members" | "requests">(
+    "members"
+  );
+  const { upgradeRequests, isUpgradeRequestsLoading } = useUpgradeRequests({
+    workspaceId: owner.sId,
+    disabled: !isWorkspaceAdmin,
+  });
+
+  const filteredUpgradeRequests = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    return upgradeRequests.filter((request) => {
+      if (request.status !== "pending") {
+        return false;
+      }
+      if (!normalizedSearch) {
+        return true;
+      }
+      const { name, email } = request.requester;
+      return (
+        name.toLowerCase().includes(normalizedSearch) ||
+        (email?.toLowerCase().includes(normalizedSearch) ?? false)
+      );
+    });
+  }, [upgradeRequests, searchTerm]);
+  const { doResolveUpgradeRequest } = useResolveUpgradeRequest({
+    workspaceId: owner.sId,
+  });
+  const [resolvingRequestIds, setResolvingRequestIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const setRequestResolving = useCallback(
+    (requestId: string, isResolving: boolean) =>
+      setResolvingRequestIds((prev) => {
+        const next = new Set(prev);
+        next[isResolving ? "add" : "delete"](requestId);
+        return next;
+      }),
+    []
+  );
+  // When a seat / spend-limit modal was opened to resolve a request, this holds
+  // the request to mark approved once the modal saves. Null when the modal was
+  // opened from the members table.
+  const [pendingApproveRequestId, setPendingApproveRequestId] = useState<
+    string | null
+  >(null);
+  const handleChangeSeatFromTable = useCallback((member: MemberUsageType) => {
+    setPendingApproveRequestId(null);
+    setChangeSeatMember(member);
+  }, []);
+  const handleEditSpendLimitFromTable = useCallback(
+    (member: MemberUsageType) => {
+      setPendingApproveRequestId(null);
+      setEditSpendLimitMember(member);
+    },
+    []
+  );
+  const handleUpgradePlanRequest = useCallback(
+    (request: MembershipUpgradeRequestType) => {
+      setPendingApproveRequestId(request.sId);
+      setChangeSeatMember(memberFromUpgradeRequest(request));
+    },
+    []
+  );
+  const handleEditLimitRequest = useCallback(
+    (request: MembershipUpgradeRequestType) => {
+      setPendingApproveRequestId(request.sId);
+      setEditSpendLimitMember(memberFromUpgradeRequest(request));
+    },
+    []
+  );
+  const handleApproveOnModalSaved = useCallback(() => {
+    if (!pendingApproveRequestId) {
+      return;
+    }
+    const requestId = pendingApproveRequestId;
+    const request = upgradeRequests.find((r) => r.sId === requestId);
+    setRequestResolving(requestId, true);
+    void doResolveUpgradeRequest({
+      requestId,
+      requesterName: request?.requester.name ?? "Member",
+      status: "approved",
+    }).finally(() => setRequestResolving(requestId, false));
+  }, [
+    pendingApproveRequestId,
+    upgradeRequests,
+    doResolveUpgradeRequest,
+    setRequestResolving,
+  ]);
+  const handleDenyRequest = useCallback(
+    async (request: MembershipUpgradeRequestType) => {
+      const confirmed = await confirm({
+        title: "Deny upgrade request",
+        message: `Deny ${request.requester.name}'s request to increase their spend limit?`,
+        validateLabel: "Deny",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      setRequestResolving(request.sId, true);
+      try {
+        await doResolveUpgradeRequest({
+          requestId: request.sId,
+          requesterName: request.requester.name,
+          status: "denied",
+        });
+      } finally {
+        setRequestResolving(request.sId, false);
+      }
+    },
+    [confirm, doResolveUpgradeRequest, setRequestResolving]
+  );
+
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
   useEffect(() => {
@@ -224,6 +380,87 @@ export function UsagePage() {
   if (!isCreditPriced) {
     return null;
   }
+
+  const searchAndInviteRow = (
+    <div className="flex flex-row gap-2">
+      <SearchInput
+        placeholder="Search members"
+        value={searchTerm}
+        name="search"
+        onChange={setSearchTerm}
+        className="w-full"
+      />
+      {isManualInvitationsEnabled && (
+        <InviteEmailButtonWithModal
+          owner={owner}
+          prefillText=""
+          perSeatPricing={perSeatPricing}
+          onInviteClick={onInviteClick}
+        />
+      )}
+    </div>
+  );
+
+  const seatFilterDropdown = isSeatBased ? (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={
+            seatTypeFilter === "none"
+              ? "No seat"
+              : seatTypeFilter
+                ? seatTypeFilter.charAt(0).toUpperCase() +
+                  seatTypeFilter.slice(1)
+                : "All seats"
+          }
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          label="All seats"
+          onClick={() => setSeatTypeFilter(null)}
+        />
+        <DropdownMenuItem
+          label="No seat"
+          onClick={() => setSeatTypeFilter("none")}
+        />
+        <DropdownMenuItem
+          label="Free"
+          onClick={() => setSeatTypeFilter("free")}
+        />
+        <DropdownMenuItem
+          label="Pro"
+          onClick={() => setSeatTypeFilter("pro")}
+        />
+        <DropdownMenuItem
+          label="Max"
+          onClick={() => setSeatTypeFilter("max")}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ) : null;
+
+  const membersTable = (
+    <MembersUsageTable
+      members={membersUsage}
+      isLoading={isMembersUsageLoading}
+      totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
+      seatChangePendingMemberIds={seatChangePendingMemberIds}
+      seatTypeFilter={seatTypeFilter}
+      isSeatBased={isSeatBased}
+      onChangeSeat={handleChangeSeatFromTable}
+      onRemoveSeat={onRemoveSeat}
+      onEditSpendLimit={handleEditSpendLimitFromTable}
+      pagination={pagination}
+      setPagination={setPagination}
+      totalRowCount={totalMembersUsage}
+      sorting={sorting}
+      setSorting={handleSetSorting}
+    />
+  );
 
   return (
     <>
@@ -321,84 +558,57 @@ export function UsagePage() {
           <span className="heading-2xl text-foreground dark:text-foreground-night">
             Members
           </span>
-          <div className="flex flex-row gap-2">
-            <SearchInput
-              placeholder="Search members"
-              value={searchTerm}
-              name="search"
-              onChange={setSearchTerm}
-              className="w-full"
-            />
-            {isManualInvitationsEnabled && (
-              <InviteEmailButtonWithModal
-                owner={owner}
-                prefillText=""
-                perSeatPricing={perSeatPricing}
-                onInviteClick={onInviteClick}
-              />
-            )}
-          </div>
-          {isSeatBased && (
-            <div className="flex flex-row justify-end">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    label={
-                      seatTypeFilter === "none"
-                        ? "No seat"
-                        : seatTypeFilter
-                          ? seatTypeFilter.charAt(0).toUpperCase() +
-                            seatTypeFilter.slice(1)
-                          : "All seats"
+          {searchAndInviteRow}
+          {isWorkspaceAdmin ? (
+            <Tabs
+              value={membersTab}
+              onValueChange={(value) =>
+                setMembersTab(value === "requests" ? "requests" : "members")
+              }
+            >
+              <div className="flex flex-row items-center justify-between gap-2">
+                <TabsList border={false} className="w-auto">
+                  <TabsTrigger value="members" label="Members" />
+                  <TabsTrigger
+                    value="requests"
+                    label="Requests"
+                    isCounter
+                    counterValue={
+                      filteredUpgradeRequests.length > 0
+                        ? String(filteredUpgradeRequests.length)
+                        : undefined
                     }
-                    size="sm"
-                    isSelect
                   />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    label="All seats"
-                    onClick={() => setSeatTypeFilter(null)}
+                </TabsList>
+                {membersTab === "members" && seatFilterDropdown}
+              </div>
+              <TabsContent value="members">
+                <div className="pt-2">{membersTable}</div>
+              </TabsContent>
+              <TabsContent value="requests">
+                <div className="pt-2">
+                  <UpgradeRequestsTable
+                    requests={filteredUpgradeRequests}
+                    isLoading={isUpgradeRequestsLoading}
+                    isSeatBased={isSeatBased}
+                    pendingRequestIds={resolvingRequestIds}
+                    onUpgradePlan={handleUpgradePlanRequest}
+                    onEditLimit={handleEditLimitRequest}
+                    onDeny={handleDenyRequest}
                   />
-                  <DropdownMenuItem
-                    label="No seat"
-                    onClick={() => setSeatTypeFilter("none")}
-                  />
-                  <DropdownMenuItem
-                    label="Free"
-                    onClick={() => setSeatTypeFilter("free")}
-                  />
-                  <DropdownMenuItem
-                    label="Pro"
-                    onClick={() => setSeatTypeFilter("pro")}
-                  />
-                  <DropdownMenuItem
-                    label="Max"
-                    onClick={() => setSeatTypeFilter("max")}
-                  />
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
+                </div>
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <>
+              {seatFilterDropdown && (
+                <div className="flex flex-row justify-end">
+                  {seatFilterDropdown}
+                </div>
+              )}
+              {membersTable}
+            </>
           )}
-          <MembersUsageTable
-            members={membersUsage}
-            isLoading={isMembersUsageLoading}
-            totalAllowedUsagePendingMemberIds={
-              totalAllowedUsagePendingMemberIds
-            }
-            seatChangePendingMemberIds={seatChangePendingMemberIds}
-            seatTypeFilter={seatTypeFilter}
-            isSeatBased={isSeatBased}
-            onChangeSeat={setChangeSeatMember}
-            onRemoveSeat={onRemoveSeat}
-            onEditSpendLimit={setEditSpendLimitMember}
-            pagination={pagination}
-            setPagination={setPagination}
-            totalRowCount={totalMembersUsage}
-            sorting={sorting}
-            setSorting={handleSetSorting}
-          />
         </Page.Vertical>
 
         {inviteBlockedPopupReason && (
@@ -414,19 +624,27 @@ export function UsagePage() {
 
         <ChangeSeatModal
           isOpen={changeSeatMember !== null}
-          onClose={() => setChangeSeatMember(null)}
+          onClose={() => {
+            setChangeSeatMember(null);
+            setPendingApproveRequestId(null);
+          }}
           member={changeSeatMember}
           owner={owner}
           seatPlans={seatPlans}
           onSavingChange={handleSeatChangePendingChange}
+          onSaved={handleApproveOnModalSaved}
         />
 
         <EditSpendLimitModal
           isOpen={editSpendLimitMember !== null}
-          onClose={() => setEditSpendLimitMember(null)}
+          onClose={() => {
+            setEditSpendLimitMember(null);
+            setPendingApproveRequestId(null);
+          }}
           member={editSpendLimitMember}
           owner={owner}
           onSavingChange={handleUsagePendingChange}
+          onSaved={handleApproveOnModalSaved}
         />
       </div>
     </>

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -38,6 +38,7 @@ import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
+import { SEAT_TYPE_ORDER } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { isAdmin } from "@app/types/user";
 import {
@@ -61,7 +62,6 @@ import {
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-
 
 // Build a minimal member from an upgrade request to feed the reused seat / spend
 // limit modals.
@@ -352,6 +352,19 @@ export function UsagePage() {
 
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);
+
+  // Tier order of the most premium seat plan offered to the workspace. A
+  // requester whose current seat is already at (or above) this tier has no
+  // higher plan to upgrade to, so the "Upgrade plan" action is hidden for them.
+  const highestSeatTypeOrder = useMemo(() => {
+    let highest: number | null = null;
+    for (const [seatType, order] of Object.entries(SEAT_TYPE_ORDER)) {
+      if (seatType in seatPlans && (highest === null || order > highest)) {
+        highest = order;
+      }
+    }
+    return highest;
+  }, [seatPlans]);
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
 
@@ -591,6 +604,8 @@ export function UsagePage() {
                     requests={filteredUpgradeRequests}
                     isLoading={isUpgradeRequestsLoading}
                     isSeatBased={isSeatBased}
+                    isTopWorkspacePlan={isEnterprise}
+                    highestSeatTypeOrder={highestSeatTypeOrder}
                     pendingRequestIds={resolvingRequestIds}
                     onUpgradePlan={handleUpgradePlanRequest}
                     onEditLimit={handleEditLimitRequest}

--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -201,6 +201,9 @@ interface ChangeSeatModalProps {
   owner: WorkspaceType;
   seatPlans: SeatPlanResponseBody;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
+  // Fired once the seat change has been persisted successfully (not on cancel
+  // or a no-op close). Used to resolve a linked upgrade request as approved.
+  onSaved?: () => void;
 }
 
 export function ChangeSeatModal({
@@ -210,6 +213,7 @@ export function ChangeSeatModal({
   owner,
   seatPlans,
   onSavingChange,
+  onSaved,
 }: ChangeSeatModalProps) {
   const { subscription } = useAuth();
   const router = useAppRouter();
@@ -403,6 +407,7 @@ export function ChangeSeatModal({
         hasSeatPool: (seatPlans[selectedSeat]?.awuCredits ?? 0) > 0,
       });
       if (ok) {
+        onSaved?.();
         onClose();
       }
     } finally {

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -37,6 +37,9 @@ interface EditSpendLimitModalProps {
   member: MemberUsageType | null;
   owner: WorkspaceType;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
+  // Fired once the spend limit has been persisted successfully (not on cancel
+  // or a load error). Used to resolve a linked upgrade request as approved.
+  onSaved?: () => void;
 }
 
 export function EditSpendLimitModal({
@@ -45,6 +48,7 @@ export function EditSpendLimitModal({
   member,
   owner,
   onSavingChange,
+  onSaved,
 }: EditSpendLimitModalProps) {
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
@@ -170,6 +174,7 @@ export function EditSpendLimitModal({
         limit,
       });
       if (body) {
+        onSaved?.();
         onClose();
       }
     } finally {

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -1,0 +1,207 @@
+import { timeAgoFrom } from "@app/lib/utils";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
+import {
+  Button,
+  Check,
+  DataTable,
+  LoadingBlock,
+  Spinner,
+  X,
+} from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+type RowData = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  createdAt: number;
+  request: MembershipUpgradeRequestType;
+  isPending: boolean;
+  // Rows are not clickable (actions live in explicit buttons), but DataTable's
+  // row type requires at least one of its optional fields to be present.
+  onClick?: () => void;
+};
+
+type Info = CellContext<RowData, string>;
+
+const nameColumn: ColumnDef<RowData, string> = {
+  id: "name" as const,
+  header: "Name",
+  enableSorting: true,
+  accessorFn: (row) => row.name,
+  cell: (info: Info) => (
+    <DataTable.CellContent
+      avatarUrl={info.row.original.image ?? ANONYMOUS_USER_IMAGE_URL}
+      roundedAvatar
+    >
+      <div>
+        <div>{info.row.original.name}</div>
+        {info.row.original.email &&
+          info.row.original.email !== info.row.original.name && (
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {info.row.original.email}
+            </div>
+          )}
+      </div>
+    </DataTable.CellContent>
+  ),
+};
+
+const reasonColumn: ColumnDef<RowData, string> = {
+  id: "reason" as const,
+  header: "",
+  enableSorting: false,
+  accessorFn: () => "Reached credit limit",
+  cell: () => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Reached credit limit
+      </span>
+    </DataTable.CellContent>
+  ),
+};
+
+const requestedColumn: ColumnDef<RowData, string> = {
+  id: "requested" as const,
+  header: "",
+  accessorFn: (row) => row.createdAt.toString(),
+  cell: (info: Info) => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {timeAgoFrom(info.row.original.createdAt, { useLongFormat: true })} ago
+      </span>
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "w-32",
+  },
+};
+
+function buildActionsColumn({
+  isSeatBased,
+  onUpgradePlan,
+  onEditLimit,
+  onDeny,
+}: {
+  isSeatBased: boolean;
+  onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
+  onEditLimit: (request: MembershipUpgradeRequestType) => void;
+  onDeny: (request: MembershipUpgradeRequestType) => void;
+}): ColumnDef<RowData, string> {
+  return {
+    id: "actions" as const,
+    header: "",
+    enableSorting: false,
+    accessorKey: "actions",
+    cell: (info: Info) => {
+      const { request, isPending } = info.row.original;
+      if (isPending) {
+        return (
+          <div className="flex w-full justify-end pr-2">
+            <Spinner size="xs" />
+          </div>
+        );
+      }
+      return (
+        <div className="flex w-full items-center justify-end gap-2">
+          <Button
+            size="sm"
+            variant="warning-secondary"
+            icon={X}
+            label="Deny"
+            onClick={() => onDeny(request)}
+          />
+          {isSeatBased && (
+            <Button
+              size="sm"
+              variant="highlight-secondary"
+              icon={Check}
+              label="Upgrade plan"
+              onClick={() => onUpgradePlan(request)}
+            />
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            label="Edit limit"
+            onClick={() => onEditLimit(request)}
+          />
+        </div>
+      );
+    },
+    meta: {
+      className: "w-96",
+    },
+  };
+}
+
+interface UpgradeRequestsTableProps {
+  requests: MembershipUpgradeRequestType[];
+  isLoading: boolean;
+  isSeatBased: boolean;
+  pendingRequestIds: ReadonlySet<string>;
+  onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
+  onEditLimit: (request: MembershipUpgradeRequestType) => void;
+  onDeny: (request: MembershipUpgradeRequestType) => void;
+}
+
+export function UpgradeRequestsTable({
+  requests,
+  isLoading,
+  isSeatBased,
+  pendingRequestIds,
+  onUpgradePlan,
+  onEditLimit,
+  onDeny,
+}: UpgradeRequestsTableProps) {
+  const rows: RowData[] = useMemo(
+    () =>
+      requests
+        .filter((request) => request.status === "pending")
+        .map((request) => ({
+          sId: request.sId,
+          name: request.requester.name,
+          email: request.requester.email,
+          image: request.requester.image,
+          createdAt: request.createdAt,
+          request,
+          isPending: pendingRequestIds.has(request.sId),
+        })),
+    [requests, pendingRequestIds]
+  );
+
+  const columns = useMemo(
+    () => [
+      nameColumn,
+      reasonColumn,
+      requestedColumn,
+      buildActionsColumn({ isSeatBased, onUpgradePlan, onEditLimit, onDeny }),
+    ],
+    [isSeatBased, onUpgradePlan, onEditLimit, onDeny]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col space-y-2">
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex w-full justify-center py-8">
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No pending upgrade requests.
+        </span>
+      </div>
+    );
+  }
+
+  return <DataTable<RowData> data={rows} columns={columns} />;
+}

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -1,5 +1,6 @@
 import { timeAgoFrom } from "@app/lib/utils";
 import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import { SEAT_TYPE_ORDER } from "@app/types/memberships";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   Button,
@@ -82,11 +83,15 @@ const requestedColumn: ColumnDef<RowData, string> = {
 
 function buildActionsColumn({
   isSeatBased,
+  isTopWorkspacePlan,
+  highestSeatTypeOrder,
   onUpgradePlan,
   onEditLimit,
   onDeny,
 }: {
   isSeatBased: boolean;
+  isTopWorkspacePlan: boolean;
+  highestSeatTypeOrder: number | null;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
   onEditLimit: (request: MembershipUpgradeRequestType) => void;
   onDeny: (request: MembershipUpgradeRequestType) => void;
@@ -105,6 +110,16 @@ function buildActionsColumn({
           </div>
         );
       }
+      // Hide "Upgrade plan" when there is no higher seat tier to move the
+      // requester to: the workspace is already on its top plan, or the
+      // requester's current seat is at/above the highest offered seat tier.
+      const requesterSeatOrder =
+        SEAT_TYPE_ORDER[request.requester.seatType ?? "none"];
+      const canUpgradePlan =
+        isSeatBased &&
+        !isTopWorkspacePlan &&
+        highestSeatTypeOrder !== null &&
+        requesterSeatOrder < highestSeatTypeOrder;
       return (
         <div className="flex w-full items-center justify-end gap-2">
           <Button
@@ -114,7 +129,7 @@ function buildActionsColumn({
             label="Deny"
             onClick={() => onDeny(request)}
           />
-          {isSeatBased && (
+          {canUpgradePlan && (
             <Button
               size="sm"
               variant="highlight-secondary"
@@ -142,6 +157,8 @@ interface UpgradeRequestsTableProps {
   requests: MembershipUpgradeRequestType[];
   isLoading: boolean;
   isSeatBased: boolean;
+  isTopWorkspacePlan: boolean;
+  highestSeatTypeOrder: number | null;
   pendingRequestIds: ReadonlySet<string>;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
   onEditLimit: (request: MembershipUpgradeRequestType) => void;
@@ -152,6 +169,8 @@ export function UpgradeRequestsTable({
   requests,
   isLoading,
   isSeatBased,
+  isTopWorkspacePlan,
+  highestSeatTypeOrder,
   pendingRequestIds,
   onUpgradePlan,
   onEditLimit,
@@ -178,9 +197,23 @@ export function UpgradeRequestsTable({
       nameColumn,
       reasonColumn,
       requestedColumn,
-      buildActionsColumn({ isSeatBased, onUpgradePlan, onEditLimit, onDeny }),
+      buildActionsColumn({
+        isSeatBased,
+        isTopWorkspacePlan,
+        highestSeatTypeOrder,
+        onUpgradePlan,
+        onEditLimit,
+        onDeny,
+      }),
     ],
-    [isSeatBased, onUpgradePlan, onEditLimit, onDeny]
+    [
+      isSeatBased,
+      isTopWorkspacePlan,
+      highestSeatTypeOrder,
+      onUpgradePlan,
+      onEditLimit,
+      onDeny,
+    ]
   );
 
   if (isLoading) {

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestModel } from "@app/lib/resources/storage/models/membership_upgrade_requests";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -8,6 +9,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
+  MembershipSeatType,
   MembershipUpgradeRequestStatus,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
@@ -26,14 +28,22 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     MembershipUpgradeRequestModel;
 
   readonly requester: UserResource;
+  readonly requesterSeatType: MembershipSeatType | null;
 
   constructor(
     _: ModelStatic<MembershipUpgradeRequestModel>,
     blob: Attributes<MembershipUpgradeRequestModel>,
-    { requester }: { requester: UserResource }
+    {
+      requester,
+      requesterSeatType,
+    }: {
+      requester: UserResource;
+      requesterSeatType: MembershipSeatType | null;
+    }
   ) {
     super(MembershipUpgradeRequestModel, blob);
     this.requester = requester;
+    this.requesterSeatType = requesterSeatType;
   }
 
   get sId(): string {
@@ -83,7 +93,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         { transaction }
       );
     });
-    return new Ok(new this(this.model, row.get(), { requester: user }));
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    return new Ok(
+      new this(this.model, row.get(), {
+        requester: user,
+        requesterSeatType: membership?.seatType ?? null,
+      })
+    );
   }
 
   private static async baseFetch(
@@ -108,12 +128,25 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     );
     const requesterByModelId = new Map(requesters.map((u) => [u.id, u]));
 
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      users: requesters,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    const seatTypeByUserModelId = new Map(
+      memberships.map((m) => [m.userId, m.seatType])
+    );
+
     return rows.flatMap((r) => {
       const requester = requesterByModelId.get(r.userId);
       if (!requester) {
         return [];
       }
-      return [new this(this.model, r.get(), { requester })];
+      return [
+        new this(this.model, r.get(), {
+          requester,
+          requesterSeatType: seatTypeByUserModelId.get(r.userId) ?? null,
+        }),
+      ];
     });
   }
 
@@ -221,6 +254,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         name: this.requester.fullName() || this.requester.name,
         email: this.requester.email ?? null,
         image: this.requester.imageUrl ?? null,
+        seatType: this.requesterSeatType,
       },
     };
   }

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -1,0 +1,108 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetUpgradeRequestsResponseBody } from "@app/lib/api/credits/upgrade_requests";
+import { clientFetch } from "@app/lib/egress/client";
+import { invalidateMembersUsage } from "@app/lib/swr/memberships";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
+import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+function upgradeRequestsUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/credits/upgrade-requests`;
+}
+
+// Admin-only: pending upgrade requests for the workspace. Fetched on the Usage
+// page both to render the Requests tab and to back its count badge, so it is
+// not gated behind tab visibility.
+export function useUpgradeRequests({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const upgradeRequestsFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    upgradeRequestsUrl(workspaceId),
+    upgradeRequestsFetcher,
+    { disabled }
+  );
+
+  const requests = data?.requests ?? emptyArray();
+
+  return {
+    upgradeRequests: requests,
+    isUpgradeRequestsLoading: !error && !data && !disabled,
+    isUpgradeRequestsError: !!error,
+    mutateUpgradeRequests: mutate,
+  };
+}
+
+export function useResolveUpgradeRequest({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRWithDefaults(upgradeRequestsUrl(workspaceId), null);
+
+  const doResolveUpgradeRequest = useCallback(
+    async ({
+      requestId,
+      requesterName,
+      status,
+    }: {
+      requestId: string;
+      requesterName: string;
+      status: Exclude<MembershipUpgradeRequestStatus, "pending">;
+    }): Promise<boolean> => {
+      const res = await clientFetch(
+        `${upgradeRequestsUrl(workspaceId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to resolve upgrade request",
+          description: errorData.message,
+        });
+        return false;
+      }
+
+      // Resolving removes the request from the pending list and may change the
+      // member's seat / limit, so refresh both surfaces.
+      await mutate();
+      await invalidateMembersUsage(workspaceId);
+
+      sendNotification({
+        type: "success",
+        title:
+          status === "approved"
+            ? "Upgrade request approved"
+            : "Upgrade request denied",
+        description:
+          status === "approved"
+            ? `${requesterName}'s upgrade request has been approved.`
+            : `${requesterName}'s upgrade request has been denied.`,
+      });
+      return true;
+    },
+    [workspaceId, sendNotification, mutate]
+  );
+
+  return { doResolveUpgradeRequest };
+}

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -238,6 +238,7 @@ export interface MembershipUpgradeRequestType {
     name: string;
     email: string | null;
     image: string | null;
+    seatType: MembershipSeatType | null;
   };
 }
 


### PR DESCRIPTION
## Description

Adds the admin **Requests** surface to the credit Usage page (stacked on top of the upgrade-request data model, API, and settings toggles from the rest of this stack).

The Members section becomes a **Members / Requests** tab toggle (admin only) with a pending-count badge on Requests. The Requests tab lists member-initiated upgrade requests (requester, reason, relative time) and lets an admin resolve each one:

- **Upgrade plan** reuses the existing `ChangeSeatModal`, **Edit limit** reuses `EditSpendLimitModal`; a successful save marks the linked request `approved`.
- **Deny** marks the request `denied` (behind a confirmation).

New SWR hooks `useUpgradeRequests` / `useResolveUpgradeRequest` back the list and the PATCH; resolving refreshes the requests list and the members-usage table. The two reused modals gained an optional `onSaved` callback fired only on a successful save (not on cancel/no-op) so a request is resolved on approval rather than on close.

Note: the seat modal isn't pre-populated with the member's current seat — the GET endpoint only returns requester identity, so a minimal member is passed; the spend-limit modal fetches the live limit itself.

## Tests

Frontend-only change; the upgrade-request endpoints are covered by functional tests in the API branch of this stack. Verified locally: `npx tsgo --noEmit` and `npm run format:changed` pass. Manual check: as an admin on a credit-priced workspace, the Requests tab shows pending requests with a count badge, Deny/Upgrade plan/Edit limit resolve the row and update the badge.

## Risk

Low. UI-only, admin-gated, additive. The list hook is disabled for non-admins and the Requests tab is not rendered for them.
