### PR TITLE
New subscription cancellation modal

### DIFF
--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -5,6 +5,7 @@ import { BillingUpgrade } from "@app/components/workspace/billing/BillingUpgrade
 import { NextInvoiceOverview } from "@app/components/workspace/billing/NextInvoiceOverview";
 import { NextInvoicePreview } from "@app/components/workspace/billing/NextInvoicePreview";
 import { RecentInvoices } from "@app/components/workspace/billing/RecentInvoices";
+import { SubscriptionProvider } from "@app/components/workspace/billing/SubscriptionContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import {
   CreditCard01,
@@ -25,32 +26,34 @@ export function BillingPage() {
         icon={CreditCard01}
         description="Change your subscription and edit your billing information."
       />
-      <Tabs defaultValue="billing-information">
-        <TabsList>
-          <TabsTrigger
-            value="billing-information"
-            label="Billing information"
-          />
-          <TabsTrigger value="invoices" label="Invoices" />
-        </TabsList>
-        <TabsContent value="billing-information">
-          <div className="flex flex-col mt-8 gap-8">
-            <div className="flex flex-col gap-4">
-              <BillingOverview owner={owner} subscription={subscription} />
-              <BillingSeatsOverview owner={owner} />
+      <SubscriptionProvider owner={owner} subscription={subscription}>
+        <Tabs defaultValue="billing-information">
+          <TabsList>
+            <TabsTrigger
+              value="billing-information"
+              label="Billing information"
+            />
+            <TabsTrigger value="invoices" label="Invoices" />
+          </TabsList>
+          <TabsContent value="billing-information">
+            <div className="flex flex-col mt-8 gap-8">
+              <div className="flex flex-col gap-4">
+                <BillingOverview />
+                <BillingSeatsOverview owner={owner} />
+              </div>
+              <BillingUpgrade owner={owner} subscription={subscription} />
+              <BillingInformation owner={owner} />
             </div>
-            <BillingUpgrade owner={owner} subscription={subscription} />
-            <BillingInformation owner={owner} />
-          </div>
-        </TabsContent>
-        <TabsContent value="invoices">
-          <div className="flex flex-col mt-8 gap-8">
-            <NextInvoiceOverview owner={owner} subscription={subscription} />
-            <NextInvoicePreview owner={owner} subscription={subscription} />
-            <RecentInvoices owner={owner} />
-          </div>
-        </TabsContent>
-      </Tabs>
+          </TabsContent>
+          <TabsContent value="invoices">
+            <div className="flex flex-col mt-8 gap-8">
+              <NextInvoiceOverview />
+              <NextInvoicePreview owner={owner} subscription={subscription} />
+              <RecentInvoices owner={owner} />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </SubscriptionProvider>
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -41,15 +41,15 @@ export function BillingPage() {
                 <BillingOverview />
                 <BillingSeatsOverview owner={owner} />
               </div>
-              <BillingUpgrade owner={owner} subscription={subscription} />
-              <BillingInformation owner={owner} />
+              <BillingUpgrade />
+              <BillingInformation />
             </div>
           </TabsContent>
           <TabsContent value="invoices">
             <div className="flex flex-col mt-8 gap-8">
               <NextInvoiceOverview />
-              <NextInvoicePreview owner={owner} subscription={subscription} />
-              <RecentInvoices owner={owner} />
+              <NextInvoicePreview />
+              <RecentInvoices />
             </div>
           </TabsContent>
         </Tabs>

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -142,7 +142,7 @@ export function CancelMetronomeSubscriptionDialog({
                     </div>
                     <div className="text-sm text-muted-foreground ark:text-muted-foreground-night">
                       Agents, conversations, and connected data sources are
-                      preserved for 90 days. Reactivate any time during that
+                      preserved for 30 days. Reactivate any time during that
                       window.
                     </div>
                   </div>

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -30,6 +30,7 @@ import {
   ButtonsSwitch,
   ButtonsSwitchList,
   Chip,
+  ContentMessage,
   CreditCard01,
   Dialog,
   DialogContainer,
@@ -69,6 +70,9 @@ export function CancelMetronomeSubscriptionDialog({
   isSaving,
   periodEndLabel,
 }: CancelMetronomeSubscriptionDialogProps) {
+  // "July 12, 2026" → "July 12"
+  const shortDate = periodEndLabel ? periodEndLabel.split(",")[0] : null;
+
   return (
     <Dialog
       open={show}
@@ -80,11 +84,16 @@ export function CancelMetronomeSubscriptionDialog({
     >
       <DialogContent size="md">
         <DialogHeader>
-          <DialogTitle>Cancel subscription</DialogTitle>
+          <DialogTitle>Cancel your subscription</DialogTitle>
           <DialogDescription>
-            {periodEndLabel
-              ? `Your subscription will end on ${periodEndLabel}. Until then you keep full access.`
-              : "Your subscription will end at the end of the current billing period. Until then you keep full access."}
+            {periodEndLabel ? (
+              <>
+                Your plan will remain active until{" "}
+                <span className="font-bold">{periodEndLabel}</span>.
+              </>
+            ) : (
+              "Your plan will remain active until the end of the current billing period."
+            )}
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
@@ -93,16 +102,71 @@ export function CancelMetronomeSubscriptionDialog({
               <Spinner variant="dark" size="md" />
             </div>
           ) : (
-            <div className="font-bold">Are you sure you want to proceed?</div>
+            <div className="flex flex-col gap-4">
+              {periodEndLabel && (
+                <ContentMessage size="sm" variant="highlight">
+                  You can resume your subscription any time before{" "}
+                  {periodEndLabel} with no interruption to your plan.
+                </ContentMessage>
+              )}
+              <div className="flex flex-col gap-3">
+                <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                  What happens next
+                </div>
+                <div className="flex flex-col gap-3">
+                  <div>
+                    <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                      {shortDate
+                        ? `Until ${shortDate}`
+                        : "Until your plan ends"}
+                    </div>
+                    <div className="text-sm text-muted-foreground ark:text-muted-foreground-night">
+                      Everything works exactly as it does today. You keep full
+                      access to your workspace.
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                      {shortDate
+                        ? `After ${shortDate}`
+                        : "After your plan ends"}
+                    </div>
+                    <div className="text-sm text-muted-foreground ark:text-muted-foreground-night">
+                      Your workspace becomes read-only. Members keep their
+                      accounts and can still sign in to view content.
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                      Your data
+                    </div>
+                    <div className="text-sm text-muted-foreground ark:text-muted-foreground-night">
+                      Agents, conversations, and connected data sources are
+                      preserved for 90 days. Reactivate any time during that
+                      window.
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                      Invoices
+                    </div>
+                    <div className="text-sm text-muted-foreground ark:text-muted-foreground-night">
+                      Past invoices remain available indefinitely from this
+                      page.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           )}
         </DialogContainer>
         <DialogFooter
           leftButtonProps={{
-            label: "Keep subscription",
+            label: "Keep my subscription",
             variant: "outline",
           }}
           rightButtonProps={{
-            label: "Cancel subscription",
+            label: "Cancel Subscription",
             variant: "warning",
             onClick: onValidate,
           }}

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -1,8 +1,5 @@
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
-import {
-  useCancelMetronomeContract,
-  useReactivateMetronomeContract,
-} from "@app/hooks/useMetronomeContractLifecycleAction";
+import { useSubscriptionContext } from "@app/components/workspace/billing/SubscriptionContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import type { PatchSubscriptionRequestBody } from "@app/lib/api/subscription";
@@ -18,13 +15,12 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import {
   useMetronomeContract,
-  useMetronomeInvoice,
+  type useMetronomeInvoice,
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { BillingPeriod, SubscriptionType } from "@app/types/plan";
+import type { BillingPeriod } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   ButtonsSwitch,
@@ -55,30 +51,23 @@ function formatDate(msEpoch: number): string {
   });
 }
 
-interface CancelMetronomeSubscriptionDialogProps {
-  show: boolean;
-  onClose: () => void;
-  onValidate: () => Promise<void>;
-  isSaving: boolean;
-  periodEndLabel: string | null;
-}
-
-export function CancelMetronomeSubscriptionDialog({
-  show,
-  onClose,
-  onValidate,
-  isSaving,
-  periodEndLabel,
-}: CancelMetronomeSubscriptionDialogProps) {
+export function CancelMetronomeSubscriptionDialog() {
+  const {
+    periodEndLabel,
+    isCancellingSubscription,
+    cancelSubscription,
+    showCancelDialog,
+    setShowCancelDialog,
+  } = useSubscriptionContext();
   // "July 12, 2026" → "July 12"
   const shortDate = periodEndLabel ? periodEndLabel.split(",")[0] : null;
 
   return (
     <Dialog
-      open={show}
+      open={showCancelDialog}
       onOpenChange={(open) => {
         if (!open) {
-          onClose();
+          setShowCancelDialog(false);
         }
       }}
     >
@@ -97,7 +86,7 @@ export function CancelMetronomeSubscriptionDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>
-          {isSaving ? (
+          {isCancellingSubscription ? (
             <div className="flex justify-center py-8">
               <Spinner variant="dark" size="md" />
             </div>
@@ -168,7 +157,67 @@ export function CancelMetronomeSubscriptionDialog({
           rightButtonProps={{
             label: "Cancel Subscription",
             variant: "warning",
-            onClick: onValidate,
+            onClick: cancelSubscription,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ReactivateMetronomeSubscriptionDialog() {
+  const {
+    subscriptionEndLabel,
+    isReactivatingSubscription,
+    reactivateSubscription,
+    showReactivateDialog,
+    setShowReactivateDialog,
+  } = useSubscriptionContext();
+  return (
+    <Dialog
+      open={showReactivateDialog}
+      onOpenChange={(open) => {
+        if (!open) {
+          setShowReactivateDialog(false);
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Resume your subscription</DialogTitle>
+          <DialogDescription>
+            {subscriptionEndLabel ? (
+              <>
+                Your plan is scheduled to end on{" "}
+                <span className="font-bold">{subscriptionEndLabel}</span>.
+                Resuming now keeps everything active without interruption.
+              </>
+            ) : (
+              "Resuming your subscription will keep everything active without interruption."
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          {isReactivatingSubscription ? (
+            <div className="flex justify-center py-8">
+              <Spinner variant="dark" size="md" />
+            </div>
+          ) : (
+            <ContentMessage size="sm" variant="highlight">
+              Your billing cycle will continue as normal and you will not be
+              charged again until the next billing date.
+            </ContentMessage>
+          )}
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+          rightButtonProps={{
+            label: "Resume subscription",
+            variant: "highlight",
+            onClick: reactivateSubscription,
           }}
         />
       </DialogContent>
@@ -232,23 +281,25 @@ function UpgradeToBusinessDialog({
   );
 }
 
-interface MetronomeSubscriptionPanelProps {
-  owner: LightWorkspaceType;
-  subscription: SubscriptionType;
-}
-
-export function MetronomeSubscriptionPanel({
-  owner,
-  subscription,
-}: MetronomeSubscriptionPanelProps) {
+export function MetronomeSubscriptionPanel() {
   const router = useAppRouter();
   const sendNotification = useSendNotification();
+
+  const {
+    subscription,
+    owner,
+    setShowCancelDialog,
+    invoice,
+    isMetronomeInvoiceLoading,
+    isCancellingSubscription,
+    isReactivatingSubscription,
+    reactivateSubscription,
+  } = useSubscriptionContext();
 
   const isMetronomeBilled = isSubscriptionMetronomeBilled(subscription);
   const isEnterprise = isEnterprisePlanPrefix(subscription.plan.code);
 
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
-  const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
 
   const { seatsCount, isSeatsCountLoading } = useWorkspaceSeatsCount({
@@ -259,18 +310,6 @@ export function MetronomeSubscriptionPanel({
     workspaceId: owner.sId,
     disabled: !isMetronomeBilled,
   });
-  const { invoice, isMetronomeInvoiceLoading } = useMetronomeInvoice({
-    workspaceId: owner.sId,
-    disabled: !isMetronomeBilled,
-  });
-  const { cancelMetronomeContract, isCancellingMetronomeContract } =
-    useCancelMetronomeContract({
-      workspaceId: owner.sId,
-    });
-  const { reactivateMetronomeContract, isReactivatingMetronomeContract } =
-    useReactivateMetronomeContract({
-      workspaceId: owner.sId,
-    });
 
   const { submit: handleSubscribePlan, isSubmitting: isSubscribingPlan } =
     useSubmitFunction(async () => {
@@ -278,31 +317,6 @@ export function MetronomeSubscriptionPanel({
         `/w/${owner.sId}/subscription/checkout?billingPeriod=${billingPeriod}`
       );
     });
-
-  const { submit: cancelSubscription, isSubmitting: isCancelling } =
-    useSubmitFunction(async () => {
-      try {
-        const success = await cancelMetronomeContract();
-        if (success) {
-          router.reload();
-        }
-      } finally {
-        setShowCancelDialog(false);
-      }
-    });
-
-  const { submit: reactivateSubscription, isSubmitting: isReactivating } =
-    useSubmitFunction(async () => {
-      const success = await reactivateMetronomeContract();
-      if (success) {
-        router.reload();
-      }
-    });
-
-  const isCancellingSubscription =
-    isCancelling || isCancellingMetronomeContract;
-  const isReactivatingSubscription =
-    isReactivating || isReactivatingMetronomeContract;
 
   const {
     submit: handleUpgradeToBusiness,
@@ -391,13 +405,7 @@ export function MetronomeSubscriptionPanel({
 
   return (
     <>
-      <CancelMetronomeSubscriptionDialog
-        show={showCancelDialog}
-        onClose={() => setShowCancelDialog(false)}
-        onValidate={cancelSubscription}
-        isSaving={isCancellingSubscription}
-        periodEndLabel={periodEndLabel}
-      />
+      <CancelMetronomeSubscriptionDialog />
       <UpgradeToBusinessDialog
         show={showUpgradeDialog}
         onClose={() => setShowUpgradeDialog(false)}

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -1,5 +1,6 @@
 import { MetronomeSubscriptionPanel } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
+import { SubscriptionProvider } from "@app/components/workspace/billing/SubscriptionContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { PatchSubscriptionRequestBody } from "@app/lib/api/subscription";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -445,10 +446,9 @@ export function SubscriptionPage() {
             </ContentMessage>
           )}
           {useMetronomePanel ? (
-            <MetronomeSubscriptionPanel
-              owner={owner}
-              subscription={subscription}
-            />
+            <SubscriptionProvider owner={owner} subscription={subscription}>
+              <MetronomeSubscriptionPanel />
+            </SubscriptionProvider>
           ) : (
             <>
               <div>

--- a/front/components/workspace/billing/BillingInformation.tsx
+++ b/front/components/workspace/billing/BillingInformation.tsx
@@ -7,7 +7,6 @@ import type {
   BillingPaymentMethod,
 } from "@app/lib/api/billing/info";
 import { useBillingInfo } from "@app/lib/swr/workspaces";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   Hash01,
@@ -17,10 +16,7 @@ import {
   Spinner,
   User01,
 } from "@dust-tt/sparkle";
-
-interface BillingInformationProps {
-  owner: LightWorkspaceType;
-}
+import { useSubscriptionContext } from "./SubscriptionContext";
 
 function formatAddress(address: BillingAddress | null): string | null {
   if (!address) {
@@ -65,7 +61,8 @@ function formatPaymentMethod(
     : "Payment method";
 }
 
-export function BillingInformation({ owner }: BillingInformationProps) {
+export function BillingInformation() {
+  const { owner } = useSubscriptionContext();
   const { billingInfo, isBillingInfoLoading } = useBillingInfo({
     workspaceId: owner.sId,
   });

--- a/front/components/workspace/billing/BillingOverview.tsx
+++ b/front/components/workspace/billing/BillingOverview.tsx
@@ -1,18 +1,10 @@
-import { CancelMetronomeSubscriptionDialog } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import {
-  useCancelMetronomeContract,
-  useReactivateMetronomeContract,
-} from "@app/hooks/useMetronomeContractLifecycleAction";
+  CancelMetronomeSubscriptionDialog,
+  ReactivateMetronomeSubscriptionDialog,
+} from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { getPriceAsString } from "@app/lib/client/subscription";
-import { useSubmitFunction } from "@app/lib/client/utils";
-import { isBusinessPlanPrefix } from "@app/lib/plans/plan_codes";
-import { useAppRouter } from "@app/lib/platform";
-import { useMetronomeInvoice } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { SubscriptionType } from "@app/types/plan";
-import { isSubscriptionMetronomeBilled } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   Calendar,
@@ -21,76 +13,27 @@ import {
   Spinner,
   Upload01,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
-
-interface BillingOverviewProps {
-  owner: LightWorkspaceType;
-  subscription: SubscriptionType;
-}
+import { useSubscriptionContext } from "./SubscriptionContext";
+import { SubscriptionStatusChip } from "./SubscriptionStatusChip";
 
 function formatBillingPeriod(period: string): string {
   return period.charAt(0).toUpperCase() + period.slice(1);
 }
 
-export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
-  const router = useAppRouter();
-  const [showCancelDialog, setShowCancelDialog] = useState(false);
-
-  const { invoice, isMetronomeInvoiceLoading } = useMetronomeInvoice({
-    workspaceId: owner.sId,
-    disabled: !subscription.metronomeContractId,
-  });
-  const { cancelMetronomeContract, isCancellingMetronomeContract } =
-    useCancelMetronomeContract({
-      workspaceId: owner.sId,
-    });
-  const { reactivateMetronomeContract, isReactivatingMetronomeContract } =
-    useReactivateMetronomeContract({
-      workspaceId: owner.sId,
-    });
-  const { submit: cancelSubscription, isSubmitting: isCancelling } =
-    useSubmitFunction(async () => {
-      try {
-        const success = await cancelMetronomeContract();
-        if (success) {
-          router.reload();
-        }
-      } finally {
-        setShowCancelDialog(false);
-      }
-    });
-  const { submit: reactivateSubscription, isSubmitting: isReactivating } =
-    useSubmitFunction(async () => {
-      const success = await reactivateMetronomeContract();
-      if (success) {
-        router.reload();
-      }
-    });
-
-  const isCancellablePlan =
-    isSubscriptionMetronomeBilled(subscription) &&
-    isBusinessPlanPrefix(subscription.plan.code);
-  const isCancellationScheduled =
-    subscription.endDate !== null || subscription.requestCancelAt !== null;
-  const subscriptionEndsAtMs =
-    subscription.endDate ??
-    (isCancellationScheduled ? (invoice?.currentPeriodEndMs ?? null) : null);
-  const canCancelSubscription = isCancellablePlan && !isCancellationScheduled;
-  const canReactivateSubscription =
-    isCancellablePlan &&
-    isCancellationScheduled &&
-    subscriptionEndsAtMs !== null &&
-    subscriptionEndsAtMs > Date.now();
-  const isCancellingSubscription =
-    isCancelling || isCancellingMetronomeContract;
-  const isReactivatingSubscription =
-    isReactivating || isReactivatingMetronomeContract;
-  const periodEndLabel = invoice
-    ? formatTimestampToFriendlyDate(invoice.currentPeriodEndMs, "short")
-    : null;
-  const subscriptionEndLabel = subscriptionEndsAtMs
-    ? formatTimestampToFriendlyDate(subscriptionEndsAtMs, "short")
-    : null;
+export function BillingOverview() {
+  const {
+    subscription,
+    invoice,
+    isMetronomeInvoiceLoading,
+    isCancellationScheduled,
+    canCancelSubscription,
+    canReactivateSubscription,
+    isCancellingSubscription,
+    isReactivatingSubscription,
+    subscriptionEndLabel,
+    setShowCancelDialog,
+    setShowReactivateDialog,
+  } = useSubscriptionContext();
 
   if (isMetronomeInvoiceLoading) {
     return (
@@ -102,13 +45,8 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
 
   return (
     <>
-      <CancelMetronomeSubscriptionDialog
-        show={showCancelDialog}
-        onClose={() => setShowCancelDialog(false)}
-        onValidate={cancelSubscription}
-        isSaving={isCancellingSubscription}
-        periodEndLabel={periodEndLabel}
-      />
+      <CancelMetronomeSubscriptionDialog />
+      <ReactivateMetronomeSubscriptionDialog />
 
       <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
         <div className="flex items-center justify-between gap-4">
@@ -116,15 +54,7 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
             <div className="truncate text-base font-semibold text-foreground dark:text-foreground-night">
               {subscription.plan.name}
             </div>
-            <div
-              className={
-                isCancellationScheduled
-                  ? "rounded-md bg-warning-100 px-2 py-1 text-xs text-warning-900 dark:bg-warning-100-night dark:text-warning-900-night"
-                  : "rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-900 dark:bg-gray-100-night dark:text-gray-900-night"
-              }
-            >
-              {isCancellationScheduled ? "Cancelled" : "Current"}
-            </div>
+            <SubscriptionStatusChip />
           </div>
           {canReactivateSubscription ? (
             <Button
@@ -136,7 +66,7 @@ export function BillingOverview({ owner, subscription }: BillingOverviewProps) {
                 TRACKING_AREAS.AUTH,
                 "subscription_reactivate",
                 () => {
-                  void reactivateSubscription();
+                  setShowReactivateDialog(true);
                 }
               )}
             />

--- a/front/components/workspace/billing/BillingOverview.tsx
+++ b/front/components/workspace/billing/BillingOverview.tsx
@@ -1,18 +1,13 @@
-import {
-  CancelMetronomeSubscriptionDialog,
-  ReactivateMetronomeSubscriptionDialog,
-} from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { getPriceAsString } from "@app/lib/client/subscription";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import {
-  Button,
   Calendar,
   ClockRewind,
   Icon,
   Spinner,
   Upload01,
 } from "@dust-tt/sparkle";
+import { SubscriptionActionButtons } from "./SubscriptionActionButtons";
 import { useSubscriptionContext } from "./SubscriptionContext";
 import { SubscriptionStatusChip } from "./SubscriptionStatusChip";
 
@@ -26,13 +21,7 @@ export function BillingOverview() {
     invoice,
     isMetronomeInvoiceLoading,
     isCancellationScheduled,
-    canCancelSubscription,
-    canReactivateSubscription,
-    isCancellingSubscription,
-    isReactivatingSubscription,
     subscriptionEndLabel,
-    setShowCancelDialog,
-    setShowReactivateDialog,
   } = useSubscriptionContext();
 
   if (isMetronomeInvoiceLoading) {
@@ -44,92 +33,57 @@ export function BillingOverview() {
   }
 
   return (
-    <>
-      <CancelMetronomeSubscriptionDialog />
-      <ReactivateMetronomeSubscriptionDialog />
-
-      <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex min-w-0 items-center gap-2">
-            <div className="truncate text-base font-semibold text-foreground dark:text-foreground-night">
-              {subscription.plan.name}
-            </div>
-            <SubscriptionStatusChip />
+    <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="truncate text-base font-semibold text-foreground dark:text-foreground-night">
+            {subscription.plan.name}
           </div>
-          {canReactivateSubscription ? (
-            <Button
-              label="Resume subscription"
-              size="sm"
-              variant="highlight"
-              disabled={isReactivatingSubscription}
-              onClick={withTracking(
-                TRACKING_AREAS.AUTH,
-                "subscription_reactivate",
-                () => {
-                  setShowReactivateDialog(true);
-                }
-              )}
-            />
-          ) : canCancelSubscription ? (
-            <Button
-              label="Cancel subscription"
-              size="sm"
-              variant="outline"
-              disabled={isCancellingSubscription}
-              onClick={withTracking(
-                TRACKING_AREAS.AUTH,
-                "subscription_cancel",
-                () => {
-                  setShowCancelDialog(true);
-                }
-              )}
-            />
-          ) : null}
+          <SubscriptionStatusChip />
         </div>
-
-        {invoice ? (
-          <div className="flex flex-col gap-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
-            {subscriptionEndLabel && (
-              <div className="flex items-center gap-2 font-semibold text-foreground dark:text-foreground-night">
-                <Icon visual={Calendar} size="xs" />
-                <span>Subscription end: {subscriptionEndLabel}</span>
-              </div>
-            )}
-            <div className="flex items-center gap-2">
-              <Icon visual={ClockRewind} size="xs" />
-              <span>
-                Frequency: {formatBillingPeriod(invoice.billingPeriod)}
-              </span>
-            </div>
-            {!isCancellationScheduled && (
-              <div className="flex items-center gap-2">
-                <Icon visual={Calendar} size="xs" />
-                <span>
-                  Next billing date:{" "}
-                  {formatTimestampToFriendlyDate(
-                    invoice.currentPeriodEndMs,
-                    "short"
-                  )}
-                </span>
-              </div>
-            )}
-            <div className="flex items-center gap-2">
-              <Icon visual={Upload01} size="xs" />
-              <span>
-                Amount:{" "}
-                {getPriceAsString({
-                  currency: invoice.currency,
-                  priceInCents: invoice.estimatedAmountCents,
-                })}
-              </span>
-            </div>
-          </div>
-        ) : (
-          <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            No billing information available for this period yet.
-          </div>
-        )}
+        <SubscriptionActionButtons />
       </div>
-    </>
+
+      {invoice ? (
+        <div className="flex flex-col gap-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+          {subscriptionEndLabel && (
+            <div className="flex items-center gap-2 font-semibold text-foreground dark:text-foreground-night">
+              <Icon visual={Calendar} size="xs" />
+              <span>Subscription end: {subscriptionEndLabel}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Icon visual={ClockRewind} size="xs" />
+            <span>Frequency: {formatBillingPeriod(invoice.billingPeriod)}</span>
+          </div>{" "}
+          {!isCancellationScheduled && (
+            <div className="flex items-center gap-2">
+              <Icon visual={Calendar} size="xs" />
+              <span>
+                Next billing date:{" "}
+                {formatTimestampToFriendlyDate(
+                  invoice.currentPeriodEndMs,
+                  "short"
+                )}
+              </span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Icon visual={Upload01} size="xs" />
+            <span>
+              Amount:{" "}
+              {getPriceAsString({
+                currency: invoice.currency,
+                priceInCents: invoice.estimatedAmountCents,
+              })}
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+          No billing information available for this period yet.
+        </div>
+      )}
+    </div>
   );
 }

--- a/front/components/workspace/billing/BillingUpgrade.tsx
+++ b/front/components/workspace/billing/BillingUpgrade.tsx
@@ -4,16 +4,11 @@ import {
   CREDIT_PRICED_FREE_PLAN_CODE,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
-import type { SubscriptionType } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
 import { Button } from "@dust-tt/sparkle";
+import { useSubscriptionContext } from "./SubscriptionContext";
 
-interface BillingUpgradeProps {
-  owner: LightWorkspaceType;
-  subscription: SubscriptionType;
-}
-
-export function BillingUpgrade({ owner, subscription }: BillingUpgradeProps) {
+export function BillingUpgrade() {
+  const { owner, subscription } = useSubscriptionContext();
   const { code } = subscription.plan;
 
   if (subscription.endDate !== null || isEnterprisePlanPrefix(code)) {

--- a/front/components/workspace/billing/NextInvoiceOverview.tsx
+++ b/front/components/workspace/billing/NextInvoiceOverview.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from "@dust-tt/sparkle";
+import { SubscriptionActionButtons } from "./SubscriptionActionButtons";
 import { useSubscriptionContext } from "./SubscriptionContext";
 import type { SubscriptionStatus } from "./SubscriptionStatusChip";
 import { SubscriptionStatusChip } from "./SubscriptionStatusChip";
@@ -52,6 +53,7 @@ export function NextInvoiceOverview() {
             usage.
           </div>
         </div>
+        <SubscriptionActionButtons />
       </div>
 
       {invoice ? (

--- a/front/components/workspace/billing/NextInvoiceOverview.tsx
+++ b/front/components/workspace/billing/NextInvoiceOverview.tsx
@@ -1,72 +1,21 @@
-import { useMetronomeInvoice } from "@app/lib/swr/workspaces";
-import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { SubscriptionType } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
 import { Spinner } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useSubscriptionContext } from "./SubscriptionContext";
+import type { SubscriptionStatus } from "./SubscriptionStatusChip";
+import { SubscriptionStatusChip } from "./SubscriptionStatusChip";
 import { formatAmount } from "./seatTypeUtils";
-
-type SubscriptionStatus = "active" | "cancelled" | "ended";
-
-const STATUS_BADGE: Record<
-  SubscriptionStatus,
-  { badgeLabel: string; badgeClassName: string }
-> = {
-  active: {
-    badgeLabel: "ACTIVE",
-    badgeClassName:
-      "rounded-md bg-blue-100 px-1.5 py-1 text-xs font-semibold text-blue-900 dark:bg-blue-100-night dark:text-blue-900-night",
-  },
-  cancelled: {
-    badgeLabel: "CANCELLED",
-    badgeClassName:
-      "rounded-md bg-warning-100 px-1.5 py-1 text-xs font-semibold text-warning-900 dark:bg-warning-100-night dark:text-warning-900-night",
-  },
-  ended: {
-    badgeLabel: "ENDED",
-    badgeClassName:
-      "rounded-md bg-red-100 px-1.5 py-1 text-xs font-semibold text-red-900 dark:bg-red-100-night dark:text-red-900-night",
-  },
-};
-
-interface NextInvoiceOverviewProps {
-  owner: LightWorkspaceType;
-  subscription: SubscriptionType;
-}
 
 function formatBillingPeriod(period: string): string {
   return period.charAt(0).toUpperCase() + period.slice(1);
 }
 
-export function NextInvoiceOverview({
-  owner,
-  subscription,
-}: NextInvoiceOverviewProps) {
-  const { invoice, isMetronomeInvoiceLoading } = useMetronomeInvoice({
-    workspaceId: owner.sId,
-    disabled: !subscription.metronomeContractId,
-  });
-
-  const isCancellationScheduled =
-    subscription.endDate !== null || subscription.requestCancelAt !== null;
-  const subscriptionEndsAtMs =
-    subscription.endDate ??
-    (isCancellationScheduled ? (invoice?.currentPeriodEndMs ?? null) : null);
-
-  const periodEndLabel = invoice
-    ? formatTimestampToFriendlyDate(invoice.currentPeriodEndMs, "short")
-    : null;
-  const subscriptionEndLabel = subscriptionEndsAtMs
-    ? formatTimestampToFriendlyDate(subscriptionEndsAtMs, "short")
-    : null;
-
-  const [subscriptionStatus] = useState<SubscriptionStatus>(() =>
-    isCancellationScheduled && subscriptionEndsAtMs !== null
-      ? subscriptionEndsAtMs <= Date.now()
-        ? "ended"
-        : "cancelled"
-      : "active"
-  );
+export function NextInvoiceOverview() {
+  const {
+    invoice,
+    isMetronomeInvoiceLoading,
+    subscriptionStatus,
+    periodEndLabel,
+    subscriptionEndLabel,
+  } = useSubscriptionContext();
 
   const periodLabel: Record<SubscriptionStatus, string | null> = {
     active: invoice
@@ -96,9 +45,7 @@ export function NextInvoiceOverview({
             <span className="text-lg font-semibold text-foreground dark:text-foreground-night">
               Next Bill preview
             </span>
-            <span className={STATUS_BADGE[subscriptionStatus].badgeClassName}>
-              {STATUS_BADGE[subscriptionStatus].badgeLabel}
-            </span>
+            <SubscriptionStatusChip />
           </div>
           <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             A preview of what your invoice will look like based on your recent

--- a/front/components/workspace/billing/NextInvoicePreview.tsx
+++ b/front/components/workspace/billing/NextInvoicePreview.tsx
@@ -12,8 +12,6 @@ import {
   WORKSPACE_SEAT_PRODUCT_NAME,
 } from "@app/lib/metronome/setup_common";
 import { useMetronomeInvoiceLines } from "@app/lib/swr/workspaces";
-import type { SubscriptionType } from "@app/types/plan";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   ChevronDown,
@@ -25,11 +23,7 @@ import {
 import type { ColumnDef } from "@tanstack/react-table";
 import type { ComponentType } from "react";
 import { useState } from "react";
-
-interface InvoiceSeatsPreviewProps {
-  owner: LightWorkspaceType;
-  subscription: SubscriptionType;
-}
+import { useSubscriptionContext } from "./SubscriptionContext";
 
 interface InvoiceRow {
   name: string;
@@ -172,10 +166,8 @@ function buildColumns(currency: string): ColumnDef<InvoiceRow>[] {
   ];
 }
 
-export function NextInvoicePreview({
-  owner,
-  subscription,
-}: InvoiceSeatsPreviewProps) {
+export function NextInvoicePreview() {
+  const { owner, subscription } = useSubscriptionContext();
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   const { invoiceLines, isMetronomeInvoiceLinesLoading } =

--- a/front/components/workspace/billing/RecentInvoices.tsx
+++ b/front/components/workspace/billing/RecentInvoices.tsx
@@ -2,12 +2,8 @@ import type { BillingInvoice } from "@app/lib/api/billing/invoices";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useRecentBillingInvoices } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { LightWorkspaceType } from "@app/types/user";
 import { Button, Spinner } from "@dust-tt/sparkle";
-
-interface RecentInvoicesProps {
-  owner: LightWorkspaceType;
-}
+import { useSubscriptionContext } from "./SubscriptionContext";
 
 function getInvoiceLabel(invoice: BillingInvoice): string {
   return invoice.description ?? invoice.number ?? "Invoice";
@@ -17,7 +13,8 @@ function getInvoiceUrl(invoice: BillingInvoice): string | null {
   return invoice.hostedInvoiceUrl ?? invoice.invoicePdf;
 }
 
-export function RecentInvoices({ owner }: RecentInvoicesProps) {
+export function RecentInvoices() {
+  const { owner } = useSubscriptionContext();
   const { billingInvoices, isBillingInvoicesLoading } =
     useRecentBillingInvoices({
       workspaceId: owner.sId,

--- a/front/components/workspace/billing/SubscriptionActionButtons.tsx
+++ b/front/components/workspace/billing/SubscriptionActionButtons.tsx
@@ -1,0 +1,54 @@
+import {
+  CancelMetronomeSubscriptionDialog,
+  ReactivateMetronomeSubscriptionDialog,
+} from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { Button } from "@dust-tt/sparkle";
+import { useSubscriptionContext } from "./SubscriptionContext";
+
+export function SubscriptionActionButtons() {
+  const {
+    canCancelSubscription,
+    canReactivateSubscription,
+    isCancellingSubscription,
+    isReactivatingSubscription,
+    setShowCancelDialog,
+    setShowReactivateDialog,
+  } = useSubscriptionContext();
+
+  return (
+    <>
+      <CancelMetronomeSubscriptionDialog />
+      <ReactivateMetronomeSubscriptionDialog />
+      {canReactivateSubscription ? (
+        <Button
+          label="Resume subscription"
+          size="sm"
+          variant="highlight"
+          disabled={isReactivatingSubscription}
+          onClick={withTracking(
+            TRACKING_AREAS.AUTH,
+            "subscription_reactivate",
+            () => {
+              setShowReactivateDialog(true);
+            }
+          )}
+        />
+      ) : canCancelSubscription ? (
+        <Button
+          label="Cancel subscription"
+          size="sm"
+          variant="outline"
+          disabled={isCancellingSubscription}
+          onClick={withTracking(
+            TRACKING_AREAS.AUTH,
+            "subscription_cancel",
+            () => {
+              setShowCancelDialog(true);
+            }
+          )}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/front/components/workspace/billing/SubscriptionContext.tsx
+++ b/front/components/workspace/billing/SubscriptionContext.tsx
@@ -1,0 +1,162 @@
+import {
+  useCancelMetronomeContract,
+  useReactivateMetronomeContract,
+} from "@app/hooks/useMetronomeContractLifecycleAction";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import type { MetronomeInvoiceSummary } from "@app/lib/metronome/invoice";
+import { isBusinessPlanPrefix } from "@app/lib/plans/plan_codes";
+import { useAppRouter } from "@app/lib/platform";
+import { useMetronomeInvoice } from "@app/lib/swr/workspaces";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { SubscriptionType } from "@app/types/plan";
+import { isSubscriptionMetronomeBilled } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
+import type { ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
+import type { SubscriptionStatus } from "./SubscriptionStatusChip";
+
+interface SubscriptionContextType {
+  owner: LightWorkspaceType;
+  subscription: SubscriptionType;
+  invoice: MetronomeInvoiceSummary | null;
+  isMetronomeInvoiceLoading: boolean;
+  isCancellablePlan: boolean;
+  isCancellationScheduled: boolean;
+  subscriptionEndsAtMs: number | null;
+  subscriptionStatus: SubscriptionStatus;
+  canCancelSubscription: boolean;
+  canReactivateSubscription: boolean;
+  isCancellingSubscription: boolean;
+  isReactivatingSubscription: boolean;
+  periodEndLabel: string | null;
+  subscriptionEndLabel: string | null;
+  showCancelDialog: boolean;
+  setShowCancelDialog: (show: boolean) => void;
+  showReactivateDialog: boolean;
+  setShowReactivateDialog: (show: boolean) => void;
+  cancelSubscription: () => Promise<void>;
+  reactivateSubscription: () => Promise<void>;
+}
+
+const SubscriptionContext = createContext<SubscriptionContextType | null>(null);
+
+export function useSubscriptionContext(): SubscriptionContextType {
+  const ctx = useContext(SubscriptionContext);
+  if (!ctx) {
+    throw new Error(
+      "useSubscriptionContext must be used within SubscriptionProvider"
+    );
+  }
+  return ctx;
+}
+
+interface SubscriptionProviderProps {
+  owner: LightWorkspaceType;
+  subscription: SubscriptionType;
+  children: ReactNode;
+}
+
+export function SubscriptionProvider({
+  owner,
+  subscription,
+  children,
+}: SubscriptionProviderProps) {
+  const router = useAppRouter();
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showReactivateDialog, setShowReactivateDialog] = useState(false);
+
+  const { invoice, isMetronomeInvoiceLoading } = useMetronomeInvoice({
+    workspaceId: owner.sId,
+    disabled: !subscription.metronomeContractId,
+  });
+  const { cancelMetronomeContract, isCancellingMetronomeContract } =
+    useCancelMetronomeContract({ workspaceId: owner.sId });
+  const { reactivateMetronomeContract, isReactivatingMetronomeContract } =
+    useReactivateMetronomeContract({ workspaceId: owner.sId });
+
+  const { submit: cancelSubscription, isSubmitting: isCancellingViaSubmit } =
+    useSubmitFunction(async () => {
+      try {
+        const success = await cancelMetronomeContract();
+        if (success) {
+          router.reload();
+        }
+      } finally {
+        setShowCancelDialog(false);
+      }
+    });
+
+  const {
+    submit: reactivateSubscription,
+    isSubmitting: isReactivatingViaSubmit,
+  } = useSubmitFunction(async () => {
+    try {
+      const success = await reactivateMetronomeContract();
+      if (success) {
+        router.reload();
+      }
+    } finally {
+      setShowReactivateDialog(false);
+    }
+  });
+
+  const isCancellablePlan =
+    isSubscriptionMetronomeBilled(subscription) &&
+    isBusinessPlanPrefix(subscription.plan.code);
+  const isCancellationScheduled =
+    subscription.endDate !== null || subscription.requestCancelAt !== null;
+  const subscriptionEndsAtMs =
+    subscription.endDate ??
+    (isCancellationScheduled ? (invoice?.currentPeriodEndMs ?? null) : null);
+  const subscriptionStatus: SubscriptionStatus =
+    isCancellationScheduled && subscriptionEndsAtMs !== null
+      ? subscriptionEndsAtMs <= Date.now()
+        ? "ended"
+        : "cancelled"
+      : "active";
+  const canCancelSubscription = isCancellablePlan && !isCancellationScheduled;
+  const canReactivateSubscription =
+    isCancellablePlan &&
+    isCancellationScheduled &&
+    subscriptionEndsAtMs !== null &&
+    subscriptionEndsAtMs > Date.now();
+  const isCancellingSubscription =
+    isCancellingViaSubmit || isCancellingMetronomeContract;
+  const isReactivatingSubscription =
+    isReactivatingViaSubmit || isReactivatingMetronomeContract;
+  const periodEndLabel = invoice
+    ? formatTimestampToFriendlyDate(invoice.currentPeriodEndMs, "short")
+    : null;
+  const subscriptionEndLabel = subscriptionEndsAtMs
+    ? formatTimestampToFriendlyDate(subscriptionEndsAtMs, "short")
+    : null;
+
+  return (
+    <SubscriptionContext.Provider
+      value={{
+        owner,
+        subscription,
+        invoice,
+        isMetronomeInvoiceLoading,
+        isCancellablePlan,
+        isCancellationScheduled,
+        subscriptionEndsAtMs,
+        subscriptionStatus,
+        canCancelSubscription,
+        canReactivateSubscription,
+        isCancellingSubscription,
+        isReactivatingSubscription,
+        periodEndLabel,
+        subscriptionEndLabel,
+        showCancelDialog,
+        setShowCancelDialog,
+        showReactivateDialog,
+        setShowReactivateDialog,
+        cancelSubscription,
+        reactivateSubscription,
+      }}
+    >
+      {children}
+    </SubscriptionContext.Provider>
+  );
+}

--- a/front/components/workspace/billing/SubscriptionStatusChip.tsx
+++ b/front/components/workspace/billing/SubscriptionStatusChip.tsx
@@ -1,0 +1,24 @@
+import { Chip } from "@dust-tt/sparkle";
+import { useSubscriptionContext } from "./SubscriptionContext";
+
+export type SubscriptionStatus = "active" | "cancelled" | "ended";
+
+const STATUS_CHIP: Record<
+  SubscriptionStatus,
+  { label: string; color: "blue" | "golden" | "rose" }
+> = {
+  active: { label: "Active", color: "blue" },
+  cancelled: { label: "Cancelled", color: "golden" },
+  ended: { label: "Ended", color: "rose" },
+};
+
+export function SubscriptionStatusChip() {
+  const { subscriptionStatus } = useSubscriptionContext();
+  return (
+    <Chip
+      size="mini"
+      color={STATUS_CHIP[subscriptionStatus].color}
+      label={STATUS_CHIP[subscriptionStatus].label}
+    />
+  );
+}


### PR DESCRIPTION
## Description

This PR does two things:

1. **Introduces `SubscriptionContext`** (`SubscriptionContext.tsx`): a new React context (`SubscriptionProvider` / `useSubscriptionContext`) that centralizes all subscription state — invoice data, cancellation/reactivation logic, dialog visibility, and derived labels (`periodEndLabel`, `subscriptionEndLabel`, `subscriptionStatus`, etc.). This eliminates prop-drilling of `owner` and `subscription` across `BillingOverview`, `BillingUpgrade`, `BillingInformation`, `NextInvoiceOverview`, `NextInvoicePreview`, `RecentInvoices`, and `MetronomeSubscriptionPanel`. The provider is mounted in both `BillingPage` and `SubscriptionPage`.

2. **Reworks the cancellation (and reactivation) dialogs**: The `CancelMetronomeSubscriptionDialog` replaces the plain "Are you sure?" message with a structured "What happens next" section (continued access, read-only mode, 30-day data retention, invoice availability). A new `ReactivateMetronomeSubscriptionDialog` is added with a `ContentMessage` banner. Both dialogs now read their state directly from context instead of accepting props. Two new small components are also extracted: `SubscriptionActionButtons` (cancel/resume buttons with tracking) and `SubscriptionStatusChip` (active/cancelled/ended badge).
<img width="865" height="730" alt="image" src="https://github.com/user-attachments/assets/95322c66-6b0e-40cb-bb53-ac1901862582" />
<img width="1276" height="831" alt="image" src="https://github.com/user-attachments/assets/9b1399b1-7f7d-4afc-9283-3b903e5fe973" />


## Tests

Tested manually via the existing cancellation flow on the billing/subscription page.

## Risk

Low — UI-only change, no backend or data model impact. The context wrapping could mask missing-provider errors at runtime if a consumer is ever rendered outside a `SubscriptionProvider`, but the hook throws an explicit error in that case.

## Deploy Plan

Deploy `front`.