### PR TITLE
[front] Auto-enable Computer skill for all agents when sandbox_tools is on

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -170,7 +170,7 @@ For complex requests that require a lot of research, you should default to produ
 
 function getSubAgentGuidelines({ hasSandbox }: { hasSandbox?: boolean }) {
   const sandboxNote = hasSandbox
-    ? `\nIMPORTANT: Sub-agents do NOT have access to the Sandbox environment. Any task requiring code execution, running scripts, or shell commands in the sandbox must be performed by you directly — do not delegate it to a sub-agent.\n`
+    ? `\nIMPORTANT: Each sub-agent runs in its OWN Computer, isolated from yours. Files in your Computer are not visible to sub-agents, and files a sub-agent creates in its Computer do not come back to you (only its text output does). So any code execution, scripts, or shell commands whose inputs or outputs live in your Computer must be run by you directly, not delegated to a sub-agent.\n`
     : "";
 
   return `<sub_agent_guidelines>
@@ -421,6 +421,7 @@ export function _getDeepDiveGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
+    hasSandbox,
     excludeProviders,
   }: {
     settings: GlobalAgentSettingsModel | null;
@@ -430,9 +431,6 @@ export function _getDeepDiveGlobalAgent(
     excludeProviders: ReadonlySet<ModelProviderIdType>;
   }
 ): AgentConfigurationType | null {
-  // TODO(2026-04-15 sandbox): re-enable sandbox for deep-dive once fully ready.
-  const hasSandbox = false;
-
   const {
     run_agent: runAgentMCPServerView,
     ask_user_question: askUserQuestionMCPServerView,
@@ -603,9 +601,10 @@ export function _getDeepDiveGlobalAgent(
     ...deepAgent,
     status,
     actions,
-    skills: hasSandbox
-      ? ["frames", "discover_skills", "skill-authoring", "sandbox"]
-      : ["frames", "discover_skills", "skill-authoring"],
+    // The "sandbox" (Computer) skill is auto-enabled for all agents when the
+    // `sandbox_tools` feature flag is on (see SkillResource.listForAgentLoop),
+    // so it no longer needs to be listed here.
+    skills: ["frames", "discover_skills", "skill-authoring"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -470,7 +470,6 @@ function _getDustLikeGlobalAgent(
       "skill-authoring",
       "go-deep",
       "mention_users",
-      "sandbox",
       "projects",
       "plan_mode",
       "support",

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -12,6 +12,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -259,6 +260,44 @@ describe("getJITServers", () => {
       });
 
       expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
+    });
+  });
+
+  describe("sandbox (Computer) auto-enable", () => {
+    it("auto-enables the sandbox system skill for any agent when sandbox_tools is on", async () => {
+      await FeatureFlagFactory.basic(auth, "sandbox_tools");
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+      // The test agent does not list the sandbox skill in its configuration.
+      const { systemSkills } = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(true);
+    });
+
+    it("does not enable the sandbox skill when sandbox_tools is off", async () => {
+      const { systemSkills } = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+      });
+
+      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(false);
+    });
+
+    it("keeps the sandbox skill enabled for nested sub-agent conversations", async () => {
+      await FeatureFlagFactory.basic(auth, "sandbox_tools");
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+      // run_agent sub-agents run in a child conversation (depth > 0); they get
+      // their own Computer too.
+      const { systemSkills } = await SkillResource.listForAgentLoop(auth, {
+        agentConfiguration: agentConfig,
+        conversation: { ...conversation, depth: 1 },
+      });
+
+      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(true);
     });
   });
 

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -60,7 +60,9 @@ When you need to find information, use this order (skip steps if the relevant to
   version: 3,
   icon: "ActionFolderIcon",
   isRestricted: undefined,
-  // Note: we auto enabled in listForAgentLoop for project conversations.
+  // Auto-enabled whenever the conversation belongs to a Pod.
+  isAutoEnabledForAgentLoop: ({ conversation }) =>
+    isPodConversation(conversation),
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -378,6 +378,9 @@ export const sandboxSkill = {
   mcpServers: [{ name: "sandbox" }],
   version: 1,
   icon: "CommandLineIcon",
+  // Auto-enabled for every agent when the `sandbox_tools` flag is on (the flag gate lives in
+  // isRestricted), so agents do not need to opt in.
+  isAutoEnabledForAgentLoop: () => true,
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -3,7 +3,9 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 export type MCPServerDefinition = {
@@ -22,6 +24,14 @@ interface BaseSkillDefinition {
   readonly mcpServers?: MCPServerDefinition[];
   readonly inheritAgentConfigurationDataSources?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
+  // Optional callback to auto-enable a code-defined skill for an agent loop (subject to
+  // isRestricted), without it being added to the agent configuration. Return true to enable.
+  // Used for skills that are on by default, either always (e.g. the Computer) or for a given
+  // context (e.g. Pods in a Pod conversation).
+  readonly isAutoEnabledForAgentLoop?: (params: {
+    agentConfiguration: AgentConfigurationType;
+    conversation: ConversationWithoutContentType;
+  }) => boolean;
   // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -65,10 +65,9 @@ import type {
 } from "@app/types/assistant/agent";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
-import {
-  type ConversationType,
-  type ConversationWithoutContentType,
-  isPodConversation,
+import type {
+  ConversationType,
+  ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
 import type {
   SkillReinforcementMode,
@@ -1436,30 +1435,52 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       discoverableSkills = await this.listDiscoverable(auth);
     }
 
-    // System skills are always treated as enabled when present in the agent configuration.
-    const systemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
-
     const sortByName = (a: SkillResource, b: SkillResource) =>
       a.name.localeCompare(b.name);
 
-    // Project skill is always enabled for project conversations, enable it if it's not enabled already.
-    const projectSkill =
-      conversation &&
-      isPodConversation(conversation) &&
-      !systemSkills.some((s) => s.globalSId === "projects") &&
-      !conversationEnabledSkills.some((s) => s.globalSId === "projects")
-        ? await SkillResource.fetchBySkillReferences(
-            auth,
-            [{ globalSkillId: "projects", customSkillId: null }],
-            { agentLoopData }
-          )
-        : [];
+    // System skills are always treated as enabled when present in the agent configuration.
+    const configSystemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
 
-    // Compute the enabled skills: conversation-enabled skills + project skill.
-    const enabledSkills = [
-      ...conversationEnabledSkills.sort(sortByName),
-      ...projectSkill,
+    // Code-defined skills can opt into being auto-enabled for the agent loop without being
+    // added to the agent configuration, either always (e.g. the Computer) or for a given
+    // context (e.g. Pods in a Pod conversation). `findAll` already drops restricted skills, so
+    // a flag-gated skill only shows up once its feature flag is on.
+    const enabledGlobalSkillIds = new Set(
+      removeNulls([
+        ...configSystemSkills.map((s) => s.globalSId),
+        ...conversationEnabledSkills.map((s) => s.globalSId),
+      ])
+    );
+    const codeDefinedDefs = [
+      ...(await SystemSkillsRegistry.findAll(auth)),
+      ...(await GlobalSkillsRegistry.findAll(auth)),
     ];
+    const autoEnabledRefs = codeDefinedDefs
+      .filter(
+        (def) =>
+          def.isAutoEnabledForAgentLoop?.({
+            agentConfiguration,
+            conversation,
+          }) && !enabledGlobalSkillIds.has(def.sId)
+      )
+      .map((def) => ({ globalSkillId: def.sId, customSkillId: null }));
+    const autoEnabledSkills = autoEnabledRefs.length
+      ? await this.fetchBySkillReferences(auth, autoEnabledRefs, {
+          agentLoopData,
+        })
+      : [];
+
+    // System skills land in `systemSkills` (always enabled); auto-enabled global skills join
+    // the conversation-enabled skills.
+    const systemSkills = [
+      ...configSystemSkills,
+      ...autoEnabledSkills.filter((s) => s.isSystemSkill),
+    ];
+
+    const enabledSkills = [
+      ...conversationEnabledSkills,
+      ...autoEnabledSkills.filter((s) => !s.isSystemSkill),
+    ].sort(sortByName);
 
     const augmentedEnabledSkills = await this.augmentSkillsWithExtendedSkills(
       auth,


### PR DESCRIPTION
## Description

The sandbox (Computer) system skill used to be opt-in: an agent only got it if "sandbox" was listed in its config. Now it is auto-enabled for every agent when the `sandbox_tools` feature flag is on.

- `SkillResource.listForAgentLoop` injects the sandbox skill into `systemSkills` when the flag is on and it is not already present (same auto-enable pattern as the `projects` skill).
- Removed the redundant explicit "sandbox" entries from the Dust and deep-dive global agents.
- deep-dive: removed the hardcoded `hasSandbox = false` + `TODO(2026-04-15 sandbox)` hold and wired `hasSandbox` from the param.

> [!NOTE]
> Dropping the deep-dive `hasSandbox = false` override does two things: the Computer skill is now auto-injected for deep-dive like every other agent, and `hasSandbox` again flows into the deep-dive sub-agent prompt note ("sub-agents do not have the sandbox, do not delegate code execution"). This lifts the explicit `2026-04-15` hold. Deep-dive sandbox is considered ready.

## Tests

Typechecked locally. Existing global-agent and skill-loop tests cover the resolution path; no test asserted the old opt-in behavior.

## Risk

Low. Behavior only changes for workspaces with `sandbox_tools` enabled (dust_only), where the Computer now appears on agents that did not list it. The dedup guard keeps existing explicit attachments a no-op. Safe to rollback.

## Deploy Plan

Standard deploy.