### PR TITLE
 opt(cache): cache the equipped skills list for cross-conversation reuse

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -51,15 +51,23 @@ const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
  *
- * Each non-empty tier becomes a separate text block. Cache breakpoints are placed
+ * Anthropic allows at most 4 cache breakpoints per request (system + messages combined).
+ * Automatic caching (top-level cache_control on the request) consumes one slot.
+ * The full 4-slot budget across the request is:
+ *
+ *  Slot 1 – system: instructions block    (1h TTL, stable per agent config), only targets some global agents
+ *  Slot 2 – system: shared context block  (5min TTL, shared across callers)
+ *  Slot 3 – messages[0]: equipped skills  (5min TTL, stable per agent within a workspace;
+ *                                          set in conversation_to_anthropic.ts when name="system")
+ *  Slot 4 – automatic cache_control       (5min TTL, auto-placed at last cacheable message block;
+ *                                          added as top-level field in buildStreamRequestPayload)
+ *
+ * Each non-empty system tier becomes a separate text block. Breakpoints are placed
  * between tiers so that stable prefixes can be reused even when later tiers change:
  *  1. Instructions      – long TTL (1h), stable per agent config.
  *  2. Shared context    – default ephemeral (5min), shared across callers.
- *  3. Ephemeral context – no breakpoint needed (last block).
+ *  3. Ephemeral context – no breakpoint (covered by automatic caching as last block).
  *
- * IMPORTANT: Anthropic allows at most 4 cache breakpoints per request (system + messages combined).
- * This function uses up to 2 (instructions + shared context).
- * The remaining budget is for the global + conversation message breakpoints.
  * /!\ Do not add breakpoints here without auditing total usage across the request.
  */
 function buildSystemBlocks(
@@ -147,7 +155,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       conversation.messages,
       (msg, index) =>
         toMessage(msg, {
-          isLast: index === conversation.messages.length - 1,
+          isFirst: index === 0,
           omittedThinking: this.omittedThinking,
           convertToBase64: this.useVertex,
         }),

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -59,8 +59,11 @@ const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
  *  Slot 2 – system: shared context block  (5min TTL, shared across callers)
  *  Slot 3 – messages[0]: equipped skills  (5min TTL, stable per agent within a workspace;
  *                                          set in conversation_to_anthropic.ts when name="system")
- *  Slot 4 – automatic cache_control       (5min TTL, auto-placed at last cacheable message block;
+ *  Slot 4 – Anthropic API: automatic cache_control (5min TTL, auto-placed at last cacheable block;
  *                                          added as top-level field in buildStreamRequestPayload)
+ *         – Vertex AI:     explicit last-message breakpoint (5min TTL; Vertex does not support
+ *                                          automatic caching, so the last message is marked
+ *                                          explicitly via isLast in buildBaseRequestPayload)
  *
  * Each non-empty system tier becomes a separate text block. Breakpoints are placed
  * between tiers so that stable prefixes can be reused even when later tiers change:
@@ -156,6 +159,9 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       (msg, index) =>
         toMessage(msg, {
           isFirst: index === 0,
+          // Vertex AI does not support automatic caching, so we need an explicit breakpoint on the
+          // last message. On the Anthropic API the top-level cache_control handles this.
+          isLast: this.useVertex && index === conversation.messages.length - 1,
           omittedThinking: this.omittedThinking,
           convertToBase64: this.useVertex,
         }),

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -169,7 +169,11 @@ async function functionMessage(
 
 async function userMessage(
   message: UserMessageTypeModel,
-  { isFirst, convertToBase64 }: { isFirst: boolean; convertToBase64: boolean }
+  {
+    isFirst,
+    isLast,
+    convertToBase64,
+  }: { isFirst: boolean; isLast: boolean; convertToBase64: boolean }
 ): Promise<MessageParam> {
   const content = await concurrentExecutor(
     message.content,
@@ -177,10 +181,17 @@ async function userMessage(
     { concurrency: 10 }
   );
 
-  // Cache the equipped skills list (messages[0], name="system") for cross-conversation reuse.
-  // The last message's cache is handled by the top-level automatic cache_control on the request.
-  if (isFirst && message.name === "system" && content.length > 0) {
-    content[content.length - 1].cache_control = { type: "ephemeral" };
+  if (content.length > 0) {
+    // Cache the equipped skills list (messages[0], name="system") for cross-conversation reuse.
+    // The last message's cache is handled by the top-level automatic cache_control on the request.
+    if (isFirst && message.name === "system") {
+      content[content.length - 1].cache_control = { type: "ephemeral" };
+    }
+    // On Vertex AI, automatic caching is not supported, so we need an explicit breakpoint on the
+    // last message. On the Anthropic API this is handled by the top-level automatic cache_control.
+    if (isLast) {
+      content[content.length - 1].cache_control = { type: "ephemeral" };
+    }
   }
 
   return {
@@ -211,10 +222,12 @@ export async function toMessage(
   message: ModelMessageTypeMultiActionsWithoutContentFragment,
   {
     isFirst,
+    isLast = false,
     omittedThinking,
     convertToBase64,
   }: {
     isFirst: boolean;
+    isLast?: boolean;
     omittedThinking: boolean;
     convertToBase64?: boolean;
   } = {
@@ -227,6 +240,7 @@ export async function toMessage(
     case "user":
       return userMessage(message, {
         isFirst,
+        isLast,
         convertToBase64: convertToBase64 ?? false,
       });
     case "function":

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -169,7 +169,7 @@ async function functionMessage(
 
 async function userMessage(
   message: UserMessageTypeModel,
-  { isLast, convertToBase64 }: { isLast: boolean; convertToBase64: boolean }
+  { isFirst, convertToBase64 }: { isFirst: boolean; convertToBase64: boolean }
 ): Promise<MessageParam> {
   const content = await concurrentExecutor(
     message.content,
@@ -177,8 +177,9 @@ async function userMessage(
     { concurrency: 10 }
   );
 
-  // Add cache_control to the last content block if this is the last message.
-  if (isLast && content.length > 0) {
+  // Cache the equipped skills list (messages[0], name="system") for cross-conversation reuse.
+  // The last message's cache is handled by the top-level automatic cache_control on the request.
+  if (isFirst && message.name === "system" && content.length > 0) {
     content[content.length - 1].cache_control = { type: "ephemeral" };
   }
 
@@ -209,15 +210,15 @@ function assistantMessage(
 export async function toMessage(
   message: ModelMessageTypeMultiActionsWithoutContentFragment,
   {
-    isLast,
+    isFirst,
     omittedThinking,
     convertToBase64,
   }: {
-    isLast: boolean;
+    isFirst: boolean;
     omittedThinking: boolean;
     convertToBase64?: boolean;
   } = {
-    isLast: false,
+    isFirst: false,
     omittedThinking: false,
     convertToBase64: false,
   }
@@ -225,7 +226,7 @@ export async function toMessage(
   switch (message.role) {
     case "user":
       return userMessage(message, {
-        isLast,
+        isFirst,
         convertToBase64: convertToBase64 ?? false,
       });
     case "function":

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -28,7 +28,7 @@ describe("toMessage", () => {
   });
 
   describe("cache_control", () => {
-    it("should not add cache_control when isLast is false", async () => {
+    it("should not add cache_control to a regular user message even when isFirst", async () => {
       const userMessage = conversationMessages.find(
         (msg) => msg.role === "user"
       );
@@ -37,11 +37,12 @@ describe("toMessage", () => {
       }
 
       const result = await toMessage(userMessage, {
-        isLast: false,
+        isFirst: true,
         omittedThinking: false,
       });
 
-      // Verify no cache_control is present
+      // Regular user messages (name !== "system") never get cache_control. Covered by automatic
+      // caching.
       if (Array.isArray(result.content)) {
         result.content.forEach((block) => {
           expect(block).not.toHaveProperty("cache_control");
@@ -49,26 +50,43 @@ describe("toMessage", () => {
       }
     });
 
-    it("should add cache_control to last content block when isLast is true", async () => {
-      const userMessage = conversationMessages.find(
-        (msg) => msg.role === "user"
-      );
-      if (!userMessage) {
-        throw new Error("No user message found in test fixtures");
-      }
+    it("should add cache_control to the equipped skills message when isFirst", async () => {
+      const skillsMessage = {
+        role: "user" as const,
+        name: "system",
+        content: [{ type: "text" as const, text: "Available skills: ..." }],
+      };
 
-      const result = await toMessage(userMessage, {
-        isLast: true,
+      const result = await toMessage(skillsMessage, {
+        isFirst: true,
         omittedThinking: false,
       });
 
-      // Verify cache_control is added to the last content block
       if (Array.isArray(result.content) && result.content.length > 0) {
         const lastBlock = result.content[result.content.length - 1];
         expect(lastBlock).toHaveProperty("cache_control");
         expect(lastBlock).toHaveProperty("cache_control.type", "ephemeral");
       } else {
         throw new Error("Expected content array with at least one element");
+      }
+    });
+
+    it("should not add cache_control to the skills message when not isFirst", async () => {
+      const skillsMessage = {
+        role: "user" as const,
+        name: "system",
+        content: [{ type: "text" as const, text: "Available skills: ..." }],
+      };
+
+      const result = await toMessage(skillsMessage, {
+        isFirst: false,
+        omittedThinking: false,
+      });
+
+      if (Array.isArray(result.content)) {
+        result.content.forEach((block) => {
+          expect(block).not.toHaveProperty("cache_control");
+        });
       }
     });
 
@@ -81,11 +99,10 @@ describe("toMessage", () => {
       }
 
       const result = await toMessage(assistantMessage, {
-        isLast: true,
+        isFirst: true,
         omittedThinking: false,
       });
 
-      // Assistant messages should not have cache_control even if isLast is true
       if (Array.isArray(result.content)) {
         result.content.forEach((block) => {
           expect(block).not.toHaveProperty("cache_control");
@@ -112,7 +129,7 @@ describe("toMessage", () => {
             },
           ],
         },
-        { isLast: false, omittedThinking: false, convertToBase64: true }
+        { isFirst: false, omittedThinking: false, convertToBase64: true }
       );
 
       expect(result).toEqual({
@@ -147,7 +164,7 @@ describe("toMessage", () => {
             },
           ],
         },
-        { isLast: false, omittedThinking: false, convertToBase64: true }
+        { isFirst: false, omittedThinking: false, convertToBase64: true }
       );
 
       expect(result).toEqual({

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -90,6 +90,29 @@ describe("toMessage", () => {
       }
     });
 
+    it("should add cache_control to last user message when isLast (Vertex path)", async () => {
+      const userMessage = conversationMessages.find(
+        (msg) => msg.role === "user"
+      );
+      if (!userMessage) {
+        throw new Error("No user message found in test fixtures");
+      }
+
+      const result = await toMessage(userMessage, {
+        isFirst: false,
+        isLast: true,
+        omittedThinking: false,
+      });
+
+      if (Array.isArray(result.content) && result.content.length > 0) {
+        const lastBlock = result.content[result.content.length - 1];
+        expect(lastBlock).toHaveProperty("cache_control");
+        expect(lastBlock).toHaveProperty("cache_control.type", "ephemeral");
+      } else {
+        throw new Error("Expected content array with at least one element");
+      }
+    });
+
     it("should not add cache_control to non-user messages", async () => {
       const assistantMessage = conversationMessages.find(
         (msg) => msg.role === "assistant"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When an agent has equipped skills, the list of available skills is rendered as the first message in every conversation as a stable block whose content is identical across all conversations using the same agent configuration. Until now, the only explicit cache breakpoint placed in the messages array was on the last user message of each turn. This meant the skills list, despite not changing too often between conversations, fell in the uncached portion of every new conversation start and was re-written to Anthropic's cache each time.

This change repurposes that explicit breakpoint by moving it from the last message to the equipped skills message. The last message is already handled automatically: every Anthropic request we send carries a top-level automatic caching instruction that Anthropic places on the last cacheable block of each turn, making an additional explicit marker there redundant. Since automatic caching covers the last-message case, the freed explicit slot can instead be used to mark the skills list as a stable cache prefix shared across conversations.

Any new conversation started within the 5-minute cache window and using the same agent will now read the skills list from cache rather than re-creating it, reducing cache creation costs at the start of each conversation.

There is no regression risk on subsequent turns within a single conversation. Automatic caching advances its breakpoint as the conversation grows, so the first user message (including any large pasted content) remains cached and is served from cache on the second turn exactly as before.

Anthropic supports a maximum of 4 cache breakpoints per request, combining explicit markers and the one slot consumed by automatic caching. This change keeps the total at 4 by performing a direct swap: the explicit last-message breakpoint is removed and the explicit skills-message breakpoint is added in its place. The 4-slot budget and the full caching strategy across a request are now documented in a single comment in the Anthropic client.

This optimization is only meaningful because the skills-as-first-message rendering became the default for all agents in PR #25713, which removed the `skills_as_user_messages` feature flag and made the behavior fully GA. With that guaranteed, the skills list position in the messages array is stable enough to serve as a reliable cache anchor.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
