### PR TITLE
feat(logging): attach request context to unhandled rejection logs

### DIFF
--- a/connectors/src/types/shared/utils/global_error_handler.ts
+++ b/connectors/src/types/shared/utils/global_error_handler.ts
@@ -30,7 +30,16 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
     promise.catch((error) => {
       // We'll get the call stack from error only if the promise was rejected with an error object.
       // Example: new Promise((_, reject) => reject(new Error("Some error")))
-      logger.error({ error, panic: true, uuid, reason }, "Unhandled Rejection");
+      logger.error(
+        {
+          error,
+          panic: true,
+          uuid,
+          reason: reason instanceof Error ? reason.stack : String(reason),
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+        "Unhandled Rejection"
+      );
     });
   });
 
@@ -45,7 +54,7 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
     }
 
     logger.error(
-      { error, message: error.message, panic: true },
+      { error, message: error.message, stack: error.stack, panic: true },
       "Uncaught Exception"
     );
   });

--- a/front-api/middlewares/request_logger.ts
+++ b/front-api/middlewares/request_logger.ts
@@ -3,8 +3,11 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
+import type { RequestContext } from "@app/types/shared/utils/request_context";
+import { runWithRequestContext } from "@app/types/shared/utils/request_context";
 import { getClientIpFromContext } from "@front-api/lib/request";
 import { createMiddleware } from "hono/factory";
+import { routePath } from "hono/route";
 
 type RequestLoggerEnv = {
   Variables: {
@@ -28,27 +31,42 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
       return next();
     }
 
+    // Mutable: `route` starts as the raw URL path and is updated to the matched
+    // route pattern in the finally block (routePath is only set after routing).
+    // Any unhandled rejection fired from the handler will see the updated value
+    // because routing completes before the handler (and any fire-and-forget
+    // promises it spawns) run.
+    const reqCtx: RequestContext = {
+      method: c.req.method,
+      route: c.req.path,
+      url: c.req.path,
+    };
+
     const startMs = performance.now();
-    try {
-      await next();
-    } finally {
-      const routePath = c.req.routePath;
-      if (routePath) {
-        // dd-trace's Hono auto-instrumentation can land on a wildcard
-        // middleware path (e.g. `/api/w/:wId/*` from
-        // `app.use("*", workspaceAuth())`) instead of the matched handler
-        // route. Override with Hono's own routePath, which always points at
-        // the handler that ran.
-        const span = tracer.scope().active();
-        if (span) {
-          span.setTag("resource.name", `${c.req.method} ${routePath}`);
+    await runWithRequestContext(reqCtx, async () => {
+      try {
+        await next();
+      } finally {
+        const _routePath = routePath(c);
+        if (_routePath) {
+          // dd-trace's Hono auto-instrumentation can land on a wildcard
+          // middleware path (e.g. `/api/w/:wId/*` from
+          // `app.use("*", workspaceAuth())`) instead of the matched handler
+          // route. Override with Hono's own routePath, which always points at
+          // the handler that ran.
+          const span = tracer.scope().active();
+          if (span) {
+            span.setTag("resource.name", `${c.req.method} ${_routePath}`);
+          }
+          reqCtx.route = _routePath;
         }
       }
-    }
+    });
+
     const durationMs = Math.round(performance.now() - startMs);
 
     const statusCode = c.res.status;
-    const route = c.req.routePath ?? c.req.path;
+    const route = routePath(c) ?? c.req.path;
 
     const clientIp = getClientIpFromContext(c);
 

--- a/front/types/shared/utils/global_error_handler.ts
+++ b/front/types/shared/utils/global_error_handler.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
 import type { LoggerInterface } from "../logger";
+import { getRequestContext } from "./request_context";
 
 const TEENY_REQUEST_STREAM_PIPE_ERROR_CODE = "ERR_STREAM_UNABLE_TO_PIPE";
 const TEENY_REQUEST_STREAM_PIPE_ERROR_MESSAGE =
@@ -50,14 +51,39 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
     // console.log here is important because the promise.catch() below could fail.
     console.error("unhandledRejection", promise, reason, uuid);
 
+    // Capture request context here (before promise.catch) while the async
+    // context from the originating Hono handler is still active.
+    const reqCtx = getRequestContext();
+
     promise.catch((error) => {
       // We'll get the call stack from error only if the promise was rejected with an error object.
       // Example: new Promise((_, reject) => reject(new Error("Some error")))
-      logger.error({ error, panic: true, uuid, reason }, "Unhandled Rejection");
+      logger.error(
+        {
+          error,
+          panic: true,
+          uuid,
+          // reason may be a non-Error (string, number, plain object); serialize it explicitly
+          // so its stack/message is visible when it is an Error, or readable when it is not.
+          reason: reason instanceof Error ? reason.stack : String(reason),
+          errorMessage: error instanceof Error ? error.message : String(error),
+          ...(reqCtx
+            ? {
+                honoRoute: reqCtx.route,
+                method: reqCtx.method,
+                url: reqCtx.url,
+              }
+            : {}),
+        },
+        "Unhandled Rejection"
+      );
     });
   });
 
   process.on("uncaughtException", (error) => {
-    logger.error({ error, panic: true }, "Uncaught Exception");
+    logger.error(
+      { error, message: error.message, stack: error.stack, panic: true },
+      "Uncaught Exception"
+    );
   });
 }

--- a/front/types/shared/utils/request_context.ts
+++ b/front/types/shared/utils/request_context.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RequestContext = {
+  method: string;
+  route: string;
+  url: string;
+};
+
+const requestContext = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(ctx: RequestContext, fn: () => T): T {
+  return requestContext.run(ctx, fn);
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return requestContext.getStore();
+}


### PR DESCRIPTION
## Description

Adds an `AsyncLocalStorage`-based request context that propagates HTTP request metadata (`method`, `route`, `url`) through async call chains in Hono handlers. The request logger middleware sets this context via `runWithRequestContext`, making it available to any code running within that handler — including fire-and-forget promises.

The `unhandledRejection` handler in `global_error_handler.ts` now reads the context at rejection time and includes `honoRoute`, `method`, and `url` in the log entry, making it straightforward to trace which endpoint originated the unhandled rejection.

Also improves serialization for both `unhandledRejection` and `uncaughtException`:
- `reason` is serialized as stack (if Error) or `String()` (if not) instead of being passed raw
- `errorMessage` is extracted explicitly for readability
- `uncaughtException` now logs `stack` alongside `message`

Applied the same error-logging improvements to `connectors` as well.

## Tests

Verified locally that unhandled rejections from Hono route handlers now include `honoRoute`/`method`/`url` in the log output.

Example
```
[...]
"errorMessage":"intentional unhandled rejection for testing",
"honoRoute":"/api/debug/unhandled-rejection",
"method":"GET",
"url":"/api/debug/unhandled-rejection"
```