### PR TITLE
[front] feat: add get_agent_details to workspace_analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -702,6 +702,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "websearch": "never_ask",
   },
   "workspace_analytics": {
+    "get_agent_details": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_users": "never_ask",
   },

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -32,6 +32,14 @@ const getTopUsersSchema = {
     .describe("Maximum number of users to return (default 25, max 100)."),
 };
 
+const getAgentDetailsSchema = {
+  agentId: z
+    .string()
+    .describe(
+      "The agent's id (sId), as returned by get_top_agents or other tools."
+    ),
+};
+
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_top_agents: {
     description:
@@ -59,6 +67,20 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving top users",
       done: "Retrieved top users",
+    },
+  },
+  get_agent_details: {
+    description:
+      "Return an agent's full configuration: name, description, scope, model, " +
+      "equipped skills and tools, and its complete instructions (system " +
+      "prompt). Use this after a usage tool to explain what a heavily-used " +
+      "agent actually does. Takes the agent id returned by other tools. " +
+      "Admin-only.",
+    schema: getAgentDetailsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving agent details",
+      done: "Retrieved agent details",
     },
   },
 });

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -26,6 +26,7 @@ describe("workspace_analytics tools", () => {
   it.each([
     "get_top_agents",
     "get_top_users",
+    "get_agent_details",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -4,6 +4,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { Err, Ok } from "@app/types/shared/result";
@@ -119,6 +120,48 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         text:
           `Top users for ${label} (${tz}), most active first:\n` +
           lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_agent_details: async ({ agentId }, { auth }) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const agents = await getAgentConfigurations(auth, {
+      agentIds: [agentId],
+      variant: "full",
+    });
+    const agent = agents[0];
+
+    if (!agent) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `No agent found with id ${agentId} (it may be archived or not ` +
+            "accessible).",
+        },
+      ]);
+    }
+
+    const toolNames = agent.actions.map((action) => action.name).join(", ");
+    const skillNames = (agent.skills ?? []).join(", ");
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Agent ${agent.name} [${agent.sId}]\n` +
+          `- Description: ${agent.description}\n` +
+          `- Scope: ${agent.scope}\n` +
+          `- Model: ${agent.model.providerId}/${agent.model.modelId}\n` +
+          `- Skills: ${skillNames || "none"}\n` +
+          `- Tools: ${toolNames || "none"}\n\n` +
+          "Instructions (full system prompt):\n" +
+          `${agent.instructions ?? "(no instructions)"}`,
       },
     ]);
   },


### PR DESCRIPTION
## Description

Add an admin-only get_agent_details tool that returns an agent's full configuration: name, description, scope, model, equipped skills/tools, and its complete instructions, via getAgentConfigurations (full variant, so standard access checks apply). Pairs with the agent ids returned by the usage tools so admins can see what a heavily-used agent actually does. No new query, pure reuse.

## Tests

Unit

## Risk

Low
## Deploy Plan

Front