### PR TITLE
Keep oversized conversation files attached

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -10711,6 +10711,10 @@
             "nullable": true,
             "description": "Path of this file inside the sandbox conversation mount."
           },
+          "skipDataSourceIndexing": {
+            "type": "boolean",
+            "description": "Whether data source indexing was skipped for this file."
+          },
           "skipFileProcessing": {
             "type": "boolean",
             "description": "Whether upload-time file processing was skipped."
@@ -13202,6 +13206,10 @@
             "nullable": true,
             "description": "Path of this file inside the sandbox conversation mount.",
             "example": "conversation/report.csv"
+          },
+          "skipDataSourceIndexing": {
+            "type": "boolean",
+            "description": "Whether data source indexing was skipped for this file."
           },
           "skipFileProcessing": {
             "type": "boolean",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -606,6 +606,9 @@
  *           type: string
  *           nullable: true
  *           description: Path of this file inside the sandbox conversation mount.
+ *         skipDataSourceIndexing:
+ *           type: boolean
+ *           description: Whether data source indexing was skipped for this file.
  *         skipFileProcessing:
  *           type: boolean
  *           description: Whether upload-time file processing was skipped.

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -407,6 +407,9 @@
  *           nullable: true
  *           description: Path of this file inside the sandbox conversation mount.
  *           example: conversation/report.csv
+ *         skipDataSourceIndexing:
+ *           type: boolean
+ *           description: Whether data source indexing was skipped for this file.
  *         skipFileProcessing:
  *           type: boolean
  *           description: Whether upload-time file processing was skipped.

--- a/front/lib/api/assistant/conversation/attachments.test.ts
+++ b/front/lib/api/assistant/conversation/attachments.test.ts
@@ -63,12 +63,16 @@ describe("makeFileAttachment", () => {
 
 function makeFileContentFragment({
   isInProjectContext = false,
+  skipDataSourceIndexing = false,
   skipFileProcessing = false,
   snippet = "snippet",
+  contentType = "text/csv",
 }: {
   isInProjectContext?: boolean;
+  skipDataSourceIndexing?: boolean;
   skipFileProcessing?: boolean;
   snippet?: string | null;
+  contentType?: "text/csv" | "text/plain";
 }): FileContentFragmentType {
   return {
     type: "content_fragment",
@@ -80,8 +84,8 @@ function makeFileContentFragment({
     rank: 0,
     branchId: null,
     sourceUrl: null,
-    title: "data.csv",
-    contentType: "text/csv",
+    title: contentType === "text/plain" ? "data.txt" : "data.csv",
+    contentType,
     context: {
       username: null,
       fullName: null,
@@ -93,6 +97,7 @@ function makeFileContentFragment({
     expiredReason: null,
     contentFragmentType: "file",
     path: "conversation/data.csv",
+    skipDataSourceIndexing,
     skipFileProcessing,
     fileId: "fil_123",
     snippet,
@@ -171,6 +176,18 @@ describe("renderAttachmentXml", () => {
 });
 
 describe("getAttachmentFromFileContentFragment", () => {
+  it("keeps skipped text files includable without advertising semantic search", () => {
+    const attachment = getAttachmentFromFileContentFragment(
+      makeFileContentFragment({
+        contentType: "text/plain",
+        skipDataSourceIndexing: true,
+      })
+    );
+
+    expect(attachment?.isIncludable).toBe(true);
+    expect(attachment?.isSearchable).toBe(false);
+  });
+
   it("suppresses queryable and includable hints for raw sandbox delimited files", () => {
     const attachment = getAttachmentFromFileContentFragment(
       makeFileContentFragment({ skipFileProcessing: true })

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -227,7 +227,10 @@ export function getAttachmentFromFileContentFragment(
   const isIncludable =
     !shouldSuppressTabularHints &&
     isConversationIncludableFileContentType(cf.contentType);
-  const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
+  const isSearchable =
+    canDoJIT &&
+    isSearchableContentType(cf.contentType) &&
+    cf.skipDataSourceIndexing !== true;
   const creator: AttachmentCreator | null = cf.context.fullName
     ? {
         type: "user",

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -1,14 +1,20 @@
-import { createDataSourceFolder, upsertTable } from "@app/lib/api/data_sources";
+import {
+  createDataSourceFolder,
+  upsertDocument,
+  upsertTable,
+} from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
 import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { TABLE_PREFIX } from "@app/types/files";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -35,6 +41,12 @@ vi.mock(import("../data_sources"), async (importOriginal) => {
           },
         });
       }),
+    upsertDocument: vi.fn().mockImplementation(() => {
+      return new Ok({
+        document: {},
+        data_source: {},
+      });
+    }),
   };
 });
 
@@ -83,6 +95,8 @@ describe("processAndUpsertToDataSource", () => {
 
     // Reset mocks
     vi.clearAllMocks();
+    vi.mocked(getFileContent).mockReset();
+    vi.mocked(upsertDocument).mockReset();
   });
 
   it("should skip all processing for tool_output files with skipDataSourceIndexing", async () => {
@@ -112,6 +126,106 @@ describe("processAndUpsertToDataSource", () => {
     // No Qdrant indexing should have happened.
     expect(upsertTable).not.toHaveBeenCalled();
     expect(createDataSourceFolder).not.toHaveBeenCalled();
+  });
+
+  it("should keep over-quota text conversation files without indexing them", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "large-conversation-file.txt",
+      fileSize: 6 * 1024 * 1024,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: "test-conversation-id",
+      },
+    });
+
+    const space = await SpaceFactory.global(workspace);
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    vi.mocked(getFileContent).mockResolvedValue("large text content");
+    vi.mocked(upsertDocument).mockResolvedValue(
+      new Err(new DustError("data_source_quota_error", "File is too large."))
+    );
+
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      { file }
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    const updatedFile = await FileResource.fetchById(auth, file.sId);
+    expect(updatedFile).not.toBeNull();
+    expect(updatedFile?.useCaseMetadata?.conversationId).toBe(
+      "test-conversation-id"
+    );
+    expect(updatedFile?.useCaseMetadata?.skipDataSourceIndexing).toBe(true);
+    expect(updatedFile?.snippet).toBe("Mocked snippet");
+  });
+
+  it("should keep data source quota errors fatal for non-conversation files", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "large-folder-file.txt",
+      fileSize: 6 * 1024 * 1024,
+      status: "ready",
+      useCase: "folders_document",
+    });
+
+    const space = await SpaceFactory.global(workspace);
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    vi.mocked(getFileContent).mockResolvedValue("large text content");
+    vi.mocked(upsertDocument).mockResolvedValue(
+      new Err(new DustError("data_source_quota_error", "File is too large."))
+    );
+
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      { file }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("data_source_quota_error");
+    }
+  });
+
+  it("should keep unrelated conversation indexing errors fatal", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/plain",
+      fileName: "conversation-file.txt",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: "test-conversation-id",
+      },
+    });
+
+    const space = await SpaceFactory.global(workspace);
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    vi.mocked(getFileContent).mockResolvedValue("text content");
+    vi.mocked(upsertDocument).mockResolvedValue(
+      new Err(
+        new DustError("invalid_request_error", "Missing embedding API key.")
+      )
+    );
+
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      { file }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_request_error");
+    }
   });
 
   it("should call upsertTable with the right parameters for a CSV file", async () => {

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -20,6 +20,8 @@ import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const OVER_QUOTA_FILE_SIZE_BYTES = 6 * 1_024 * 1_024;
+
 // Mock the data_sources module to spy on upsertTable
 vi.mock(import("../data_sources"), async (importOriginal) => {
   const mod = await importOriginal();
@@ -132,7 +134,7 @@ describe("processAndUpsertToDataSource", () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "text/plain",
       fileName: "large-conversation-file.txt",
-      fileSize: 6 * 1024 * 1024,
+      fileSize: OVER_QUOTA_FILE_SIZE_BYTES,
       status: "ready",
       useCase: "conversation",
       useCaseMetadata: {
@@ -169,7 +171,7 @@ describe("processAndUpsertToDataSource", () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "text/plain",
       fileName: "large-folder-file.txt",
-      fileSize: 6 * 1024 * 1024,
+      fileSize: OVER_QUOTA_FILE_SIZE_BYTES,
       status: "ready",
       useCase: "folders_document",
     });

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -9,6 +9,7 @@ import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -19,8 +20,6 @@ import { slugify } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const OVER_QUOTA_FILE_SIZE_BYTES = 6 * 1_024 * 1_024;
 
 // Mock the data_sources module to spy on upsertTable
 vi.mock(import("../data_sources"), async (importOriginal) => {
@@ -84,10 +83,23 @@ vi.mock(import("../files/processing"), async (importOriginal) => {
 describe("processAndUpsertToDataSource", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
+  let overQuotaFileSizeBytes: number;
 
   beforeEach(async () => {
     // Create a workspace using WorkspaceFactory
     workspace = await WorkspaceFactory.basic();
+
+    // Derive the over-quota size from the workspace plan so the tests follow
+    // along if the document size limit is tweaked.
+    const subscription =
+      await SubscriptionResource.fetchLastByWorkspace(workspace);
+    if (!subscription) {
+      throw new Error("Expected the test workspace to have a subscription.");
+    }
+    overQuotaFileSizeBytes =
+      (subscription.getPlan().limits.dataSources.documents.sizeMb + 1) *
+      1024 *
+      1024;
 
     // Mock auth
     auth = {
@@ -134,7 +146,7 @@ describe("processAndUpsertToDataSource", () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "text/plain",
       fileName: "large-conversation-file.txt",
-      fileSize: OVER_QUOTA_FILE_SIZE_BYTES,
+      fileSize: overQuotaFileSizeBytes,
       status: "ready",
       useCase: "conversation",
       useCaseMetadata: {
@@ -171,7 +183,7 @@ describe("processAndUpsertToDataSource", () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "text/plain",
       fileName: "large-folder-file.txt",
-      fileSize: OVER_QUOTA_FILE_SIZE_BYTES,
+      fileSize: overQuotaFileSizeBytes,
       status: "ready",
       useCase: "folders_document",
     });

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -562,8 +562,9 @@ const maybeApplyProcessing: ProcessingFunction = async (
             workspaceId: auth.workspace()?.sId,
             fileId: file.sId,
             contentType: file.contentType,
-            fileSize: file.fileSize,
-            error: res.error,
+            fileSizeBytes: file.fileSize,
+            errorCode: res.error.code,
+            err: res.error,
           },
           "Conversation file exceeds data source indexing quota; skipping indexing and keeping the attachment available."
         );

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -553,6 +553,29 @@ const maybeApplyProcessing: ProcessingFunction = async (
       upsertArgs,
     });
     if (res.isErr()) {
+      if (
+        file.useCase === "conversation" &&
+        res.error.code === "data_source_quota_error"
+      ) {
+        logger.warn(
+          {
+            workspaceId: auth.workspace()?.sId,
+            fileId: file.sId,
+            contentType: file.contentType,
+            fileSize: file.fileSize,
+            error: res.error,
+          },
+          "Conversation file exceeds data source indexing quota; skipping indexing and keeping the attachment available."
+        );
+
+        await file.setUseCaseMetadata(auth, {
+          ...(file.useCaseMetadata ?? {}),
+          skipDataSourceIndexing: true,
+        });
+
+        return new Ok(undefined);
+      }
+
       return res;
     }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -806,6 +806,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           contentFragmentType: "file",
           expiredReason: fr.expiredReason,
           path: null,
+          skipDataSourceIndexing: false,
           skipFileProcessing: false,
           fileId: null,
           snippet: null,
@@ -864,6 +865,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       let isInProjectContext = false;
       let hidden = true;
       let path: string | null = null;
+      let skipDataSourceIndexing = false;
       let skipFileProcessing = false;
 
       if (fileResource) {
@@ -875,6 +877,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         sourceIcon = fileResource.useCaseMetadata?.sourceIcon ?? null;
         isInProjectContext = !!fileResource.useCaseMetadata?.spaceId;
         hidden = !!fileResource.useCaseMetadata?.hideFromUser;
+        skipDataSourceIndexing =
+          fileResource.useCaseMetadata?.skipDataSourceIndexing === true;
         skipFileProcessing =
           fileResource.useCaseMetadata?.skipFileProcessing === true;
         path = getConversationFilePath({
@@ -897,6 +901,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
         contentFragmentType: "file",
         expiredReason: null,
         path,
+        skipDataSourceIndexing,
         skipFileProcessing,
         fileId: fileStringId,
         snippet,

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -80,6 +80,7 @@ export type ContentNodeContentFragmentType = BaseContentFragmentType & {
 export type FileContentFragmentType = BaseContentFragmentType & {
   contentFragmentType: "file";
   path?: string | null;
+  skipDataSourceIndexing?: boolean;
   skipFileProcessing?: boolean;
 } & (
     | {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8560.

Conversation attachments that exceed the data source indexing quota now stay uploaded. The file is kept readable from GCS, indexing is skipped for that quota error only, and other indexing errors still fail.

Root cause: `processAndUpsertToDataSource` treated the data source document-size quota error as fatal, so an already-uploaded conversation file failed post-processing instead of remaining available through file reads.

## Tests

Added regression coverage for the quota case, non-conversation files, unrelated indexing errors, and skipped attachment searchability. Ran `NODE_ENV=test npm test -- upsert attachments.test.ts` locally.

## Risk

Low. The fallback only applies to conversation files with `data_source_quota_error`; folder and data source uploads stay strict. Safe to rollback.

## Deploy Plan

Standard deploy.