### PR TITLE
pricing: Revamp the phone verif pages for new design

### DIFF
--- a/front/components/pages/onboarding/SelectSubscriptionPage.tsx
+++ b/front/components/pages/onboarding/SelectSubscriptionPage.tsx
@@ -5,6 +5,7 @@ import {
 } from "@app/components/workspace/seat_styles";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import {
+  CP_FREE_PLAN_CREDITS,
   CP_MAX_SEAT_COST_MONTHLY,
   CP_MAX_SEAT_COST_YEARLY,
   CP_PRO_SEAT_COST_MONTHLY,
@@ -191,7 +192,7 @@ export function SelectSubscriptionPage() {
               icon={LayerSingle}
               seatType="free"
               name="Free"
-              credits="300"
+              credits={CP_FREE_PLAN_CREDITS.toLocaleString()}
               creditsLabel="credits"
               priceLabel="One-time · never expires"
               features={[

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import { useKillSwitches } from "@app/lib/swr/kill";
 import { useAuthContext, useVerifyData } from "@app/lib/swr/workspaces";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   ActionSparklesIcon,
   Button,
@@ -313,70 +314,70 @@ export function VerifyPage() {
     );
   }
 
-  if (step === "done") {
-    return (
-      <WelcomeStep
-        credits={CP_FREE_PLAN_CREDITS}
-        onStartBuilding={goToWorkspace}
-      />
-    );
+  switch (step) {
+    case "done":
+      return (
+        <WelcomeStep
+          credits={CP_FREE_PLAN_CREDITS}
+          onStartBuilding={goToWorkspace}
+        />
+      );
+    case "captcha":
+      return (
+        <CaptchaStep
+          captchaKey={captchaKey}
+          siteKey={config.getTurnstileSiteKey()}
+          error={phoneError}
+          onSuccess={(token) => {
+            setCaptchaToken(token);
+            setPhoneError(null);
+            setStep("phone");
+          }}
+          onExpire={() => {
+            setCaptchaToken(null);
+          }}
+          onError={() => {
+            setCaptchaToken(null);
+            setPhoneError(
+              "Captcha could not load. Please refresh and try again."
+            );
+          }}
+        />
+      );
+    case "code":
+      return (
+        <CodeVerificationStep
+          maskedPhone={maskPhoneNumber(phoneNumber)}
+          code={code}
+          error={phoneError}
+          resendCooldown={resendCooldown}
+          inputRefs={inputRefs}
+          isLoading={isLoading}
+          onCodeChange={handleCodeChange}
+          onCodeKeyDown={handleCodeKeyDown}
+          onCodePaste={handleCodePaste}
+          onBack={handleBack}
+          onResend={handleSendCode}
+          onVerify={handleVerifyCode}
+        />
+      );
+    case "phone":
+      return (
+        <PhoneInputStep
+          isMetronome={isMetronomeCheckout}
+          phoneNumber={phoneNumber}
+          countryCode={countryCode}
+          error={phoneError}
+          isLoading={isLoading}
+          onPhoneNumberChange={handlePhoneNumberChange}
+          onCountryCodeChange={handleCountryCodeChange}
+          onSubmit={handleSendCode}
+        />
+      );
+    default:
+      assertNeverAndIgnore(step);
+      return null;
   }
-
-  if (step === "captcha") {
-    return (
-      <CaptchaStep
-        captchaKey={captchaKey}
-        siteKey={config.getTurnstileSiteKey()}
-        error={phoneError}
-        onSuccess={(token) => {
-          setCaptchaToken(token);
-          setPhoneError(null);
-          setStep("phone");
-        }}
-        onExpire={() => {
-          setCaptchaToken(null);
-        }}
-        onError={() => {
-          setCaptchaToken(null);
-          setPhoneError(
-            "Captcha could not load. Please refresh and try again."
-          );
-        }}
-      />
-    );
-  }
-
-  if (step === "code") {
-    return (
-      <CodeVerificationStep
-        maskedPhone={maskPhoneNumber(phoneNumber)}
-        code={code}
-        error={phoneError}
-        resendCooldown={resendCooldown}
-        inputRefs={inputRefs}
-        isLoading={isLoading}
-        onCodeChange={handleCodeChange}
-        onCodeKeyDown={handleCodeKeyDown}
-        onCodePaste={handleCodePaste}
-        onBack={handleBack}
-        onResend={handleSendCode}
-        onVerify={handleVerifyCode}
-      />
-    );
-  }
-
-  return (
-    <PhoneInputStep
-      isMetronome={isMetronomeCheckout}
-      phoneNumber={phoneNumber}
-      countryCode={countryCode}
-      error={phoneError}
-      isLoading={isLoading}
-      onPhoneNumberChange={handlePhoneNumberChange}
-      onCountryCodeChange={handleCountryCodeChange}
-      onSubmit={handleSendCode}
-    />
-  );
 }
 
 interface PhoneInputStepProps {

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -1,7 +1,8 @@
 import { PhoneNumberCodeInput } from "@app/components/trial/PhoneNumberCodeInput";
 import { PhoneNumberInput } from "@app/components/trial/PhoneNumberInput";
 import config from "@app/lib/api/config";
-import { useAuth } from "@app/lib/auth/AuthContext";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { CP_FREE_PLAN_CREDITS } from "@app/lib/client/subscription";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   CODE_LENGTH,
@@ -10,21 +11,40 @@ import {
   RESEND_COOLDOWN_SECONDS,
 } from "@app/lib/plans/trial/phone";
 import { useAppRouter } from "@app/lib/platform";
+import { useKillSwitches } from "@app/lib/swr/kill";
 import { useAuthContext, useVerifyData } from "@app/lib/swr/workspaces";
-import { Button, DustLogoSquare, Page, Spinner } from "@dust-tt/sparkle";
+import {
+  ActionSparklesIcon,
+  Button,
+  DustLogoSquare,
+  Icon,
+  Page,
+  Spinner,
+} from "@dust-tt/sparkle";
 import { Turnstile } from "@marsidev/react-turnstile";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Country } from "react-phone-number-input";
 
-type Step = "captcha" | "phone" | "code";
+type Step = "captcha" | "phone" | "code" | "done";
 
 export function VerifyPage() {
   const { workspace } = useAuth();
   const router = useAppRouter();
+  const { hasFeature } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
   const { mutateAuthContext } = useAuthContext({
     workspaceId: workspace.sId,
   });
+
+  // Same gate as the one that routes to /select-subscription (see
+  // `isMetronomeCheckoutEnabled` and SubscribePage): the credit-priced checkout
+  // flow gets the new phone verification copy and a welcome screen at the end.
+  const isMetronomeEnabled =
+    hasFeature("metronome_billing") ||
+    !killSwitches?.includes("global_disable_metronome_billing");
+  const isMetronomeCheckout =
+    isMetronomeEnabled && hasFeature("metronome_cp_checkout");
 
   const {
     verifyData,
@@ -74,6 +94,10 @@ export function VerifyPage() {
       inputRefs.current[0]?.focus();
     }
   }, [step]);
+
+  const goToWorkspace = useCallback(() => {
+    void router.push(`/w/${workspace.sId}/conversation/new?welcome=true`);
+  }, [router, workspace.sId]);
 
   const handleSendCode = async () => {
     setPhoneError(null);
@@ -191,7 +215,13 @@ export function VerifyPage() {
       // (canUseProduct is now true) and doesn't redirect back to /trial.
       await mutateAuthContext();
 
-      void router.push(`/w/${workspace.sId}/conversation/new?welcome=true`);
+      // With the credit-priced checkout flow we show a welcome screen before
+      // entering the workspace instead of redirecting there directly.
+      if (isMetronomeCheckout) {
+        setStep("done");
+      } else {
+        goToWorkspace();
+      }
     } catch {
       setPhoneError("Network error. Please try again.");
     } finally {
@@ -283,6 +313,15 @@ export function VerifyPage() {
     );
   }
 
+  if (step === "done") {
+    return (
+      <WelcomeStep
+        credits={CP_FREE_PLAN_CREDITS}
+        onStartBuilding={goToWorkspace}
+      />
+    );
+  }
+
   if (step === "captcha") {
     return (
       <CaptchaStep
@@ -328,6 +367,7 @@ export function VerifyPage() {
 
   return (
     <PhoneInputStep
+      isMetronome={isMetronomeCheckout}
       phoneNumber={phoneNumber}
       countryCode={countryCode}
       error={phoneError}
@@ -340,6 +380,7 @@ export function VerifyPage() {
 }
 
 interface PhoneInputStepProps {
+  isMetronome: boolean;
   phoneNumber: string;
   countryCode: Country;
   error: string | null;
@@ -350,6 +391,7 @@ interface PhoneInputStepProps {
 }
 
 function PhoneInputStep({
+  isMetronome,
   phoneNumber,
   countryCode,
   error,
@@ -363,15 +405,29 @@ function PhoneInputStep({
       <div className="flex h-full flex-col justify-center">
         <Page.Horizontal>
           <Page.Vertical sizing="grow" gap="lg">
-            <Page.Header
-              title="Phone number"
-              icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-            />
-            <p className="-mt-4 text-muted-foreground dark:text-muted-foreground-night">
-              To start your free trial, we need to verify your account with an
-              SMS code. <br />
-              Your number will only be used for this verification.
-            </p>
+            {isMetronome ? (
+              <div className="flex flex-col gap-2">
+                <h1 className="text-2xl font-bold text-foreground dark:text-foreground-night">
+                  Verify your phone
+                </h1>
+                <p className="text-muted-foreground dark:text-muted-foreground-night">
+                  We verify your number once to keep free credits fair. We won't
+                  text you otherwise.
+                </p>
+              </div>
+            ) : (
+              <>
+                <Page.Header
+                  title="Phone number"
+                  icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
+                />
+                <p className="-mt-4 text-muted-foreground dark:text-muted-foreground-night">
+                  To start your free trial, we need to verify your account with
+                  an SMS code. <br />
+                  Your number will only be used for this verification.
+                </p>
+              </>
+            )}
 
             <div className="flex w-full max-w-xl flex-col gap-4">
               <div className="flex w-full flex-col gap-2">
@@ -538,6 +594,44 @@ function CaptchaStep({
             </div>
           </Page.Vertical>
         </Page.Horizontal>
+      </div>
+    </Page>
+  );
+}
+
+interface WelcomeStepProps {
+  credits: number;
+  onStartBuilding: () => void;
+}
+
+function WelcomeStep({ credits, onStartBuilding }: WelcomeStepProps) {
+  return (
+    <Page>
+      <div className="flex h-full flex-col items-center justify-center">
+        <div className="flex max-w-xl flex-col items-center gap-6 text-center">
+          <Icon
+            visual={ActionSparklesIcon}
+            size="lg"
+            className="text-highlight-500"
+          />
+          <h1 className="text-4xl font-bold text-foreground dark:text-foreground-night">
+            You're in. Welcome to Dust.
+          </h1>
+          <p className="text-lg text-muted-foreground dark:text-muted-foreground-night">
+            You've got{" "}
+            <span className="font-bold text-foreground dark:text-foreground-night">
+              {credits.toLocaleString()} credits
+            </span>{" "}
+            to explore, they never expire, so take your time. Let's put them to
+            work.
+          </p>
+          <Button
+            variant="highlight"
+            size="md"
+            label="Start building"
+            onClick={onStartBuilding}
+          />
+        </div>
       </div>
     </Page>
   );

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -18,6 +18,12 @@ export const CP_PRO_SEAT_COST_YEARLY = 24;
 export const CP_MAX_SEAT_COST_MONTHLY = 150;
 export const CP_MAX_SEAT_COST_YEARLY = 120;
 
+// Lifetime AWU credits granted once per seat on the credit-priced Free plan.
+// Mirrors the server-side source of truth `FREE_SEAT_LIFETIME_AWU_CREDITS` in
+// `front/lib/metronome/setup_new_pricing.ts` (that module is server-only and
+// cannot be imported client-side).
+export const CP_FREE_PLAN_CREDITS = 300;
+
 export function formatPriceWithCurrency(
   price: number,
   currency: SupportedCurrency


### PR DESCRIPTION
## Description

- First page is split between old and new design. I chose not to create a separate component as it was moving and duplicating lot of code and in the end the switches between metronome and legacy are pretty targetted

<img width="1197" height="684" alt="Screenshot 2026-06-09 at 17 46 53" src="https://github.com/user-attachments/assets/a4880e9f-1893-4892-8818-13db5909e852" />


- Seconda page is the code, same for new and legacy path

<img width="1348" height="675" alt="Screenshot 2026-06-09 at 17 49 57" src="https://github.com/user-attachments/assets/5f944a6a-c239-4d94-9316-ba6faf646145" />

- New third page to welcom you in.

<img width="1263" height="768" alt="Screenshot 2026-06-09 at 17 50 15" src="https://github.com/user-attachments/assets/1289cac3-9164-4c6b-8709-ec789222b2fd" />

And them normal access to the workspace.

## Tests

tested locally

## Risk

low, only ui and easy to revert

## Deploy Plan

deploy front
