### PR TITLE
Use net balance with pool filter

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -8,7 +8,7 @@ import {
   getMetronomeDefaultUserCapAlertForSeatType,
   getMetronomePerUserCap,
 } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeBalances } from "@app/lib/metronome/client";
+import { getNetBalance } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
@@ -37,7 +37,7 @@ import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 
 /**
  * Resolve the effective pool credit limit for a user.
@@ -806,18 +806,7 @@ export async function syncPoolCreditStateFromBalance({
 export async function getWorkspacePoolAwuBalance(
   metronomeCustomerId: string
 ): Promise<Result<number, Error>> {
-  const balancesResult = await listMetronomeBalances(metronomeCustomerId);
-  if (balancesResult.isErr()) {
-    return new Err(balancesResult.error);
-  }
-
-  const awuCreditTypeId = getCreditTypeAwuId();
-  const awuBalance = balancesResult.value.reduce((sum, entry) => {
-    if (entry.access_schedule?.credit_type?.id !== awuCreditTypeId) {
-      return sum;
-    }
-    return sum + (entry.balance ?? 0);
-  }, 0);
-
-  return new Ok(awuBalance);
+  return getNetBalance(metronomeCustomerId, {
+    creditTypeId: getCreditTypeAwuId(),
+  });
 }

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2054,7 +2054,6 @@ export async function listMetronomeBalances(
       // them via the ContractCreditOrCommit filter).
       if (
         onlyPoolCredits &&
-        entry.type === "CREDIT" &&
         entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
           CONTRACT_CREDIT_TYPE_POOL
       ) {
@@ -2068,6 +2067,60 @@ export async function listMetronomeBalances(
     logger.error(
       { error, metronomeCustomerId },
       "[Metronome] Failed to list balances"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Get the combined net balance a customer can use right now across all
+ * pertinent commits and credits, denominated in `creditTypeId`. Unlike
+ * `listMetronomeBalances`, this delegates the reduction to Metronome and
+ * returns a single number, so it can't surface per-schedule details.
+ *
+ * By default it restricts to pool credits/commits via the
+ * `DUST_CONTRACT_CREDIT_TYPE=pool` custom field — mirroring the
+ * `onlyPoolCredits` filter of `listMetronomeBalances`.
+ */
+export async function getNetBalance(
+  metronomeCustomerId: string,
+  {
+    creditTypeId,
+    onlyPoolCredits = true,
+  }: {
+    creditTypeId?: string;
+    onlyPoolCredits?: boolean;
+  } = {}
+): Promise<Result<number, Error>> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok(0);
+  }
+
+  const client = getMetronomeClient();
+
+  try {
+    const response = await client.v1.contracts.getNetBalance({
+      customer_id: metronomeCustomerId,
+      ...(creditTypeId !== undefined ? { credit_type_id: creditTypeId } : {}),
+      ...(onlyPoolCredits
+        ? {
+            filters: [
+              {
+                custom_fields: {
+                  [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]:
+                    CONTRACT_CREDIT_TYPE_POOL,
+                },
+              },
+            ],
+          }
+        : {}),
+    });
+    return new Ok(response.data.balance);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to get net balance"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/credit_balance.ts
+++ b/front/lib/metronome/credit_balance.ts
@@ -1,4 +1,4 @@
-import { listMetronomeBalances } from "@app/lib/metronome/client";
+import { getNetBalance } from "@app/lib/metronome/client";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import { getCreditTypeAwuId } from "./constants";
@@ -32,7 +32,9 @@ async function fetchPoolCredits(
   workspaceId: string,
   metronomeCustomerId: string
 ): Promise<number> {
-  const result = await listMetronomeBalances(metronomeCustomerId);
+  const result = await getNetBalance(metronomeCustomerId, {
+    creditTypeId: getCreditTypeAwuId(),
+  });
   if (result.isErr()) {
     logger.warn(
       { workspaceId, metronomeCustomerId, error: result.error },
@@ -42,13 +44,7 @@ async function fetchPoolCredits(
     return 1;
   }
 
-  return result.value.reduce((sum, entry) => {
-    const creditTypeId = entry.access_schedule?.credit_type?.id;
-    if (creditTypeId !== getCreditTypeAwuId()) {
-      return sum; // skip non-AWU credits
-    }
-    return sum + (entry.balance ?? 0);
-  }, 0);
+  return result.value;
 }
 
 const getCachedPoolCredits = cacheWithRedis(


### PR DESCRIPTION
## Description

Introduces a `getNetBalance` helper in `front/lib/metronome/client.ts` that delegates the balance reduction to Metronome's `v1.contracts.getNetBalance` endpoint, returning a single net number instead of fetching every balance entry and summing client-side.

By default it restricts to pool credits/commits via the `DUST_CONTRACT_CREDIT_TYPE=pool` custom field filter, mirroring the `onlyPoolCredits` behavior of `listMetronomeBalances`.

Replaces `listMetronomeBalances` with `getNetBalance` at the two call sites that only need the net AWU pool balance (not per-schedule detail):
- `getWorkspacePoolAwuBalance` in `credit_state_dispatcher.ts`
- `fetchPoolCredits` in `credit_balance.ts`

Call sites that still need full balance entries (schedule items, grant amounts, intervals) are intentionally left on `listMetronomeBalances`: `awu_pool_summary.ts` (needs the gross grant `totalActiveCredits` for the consumed/total UI), `metronome_balances.ts` (per-credit display data), and `metronome_usage.ts` (time-bucketed credit overlay).

Also aligns the `onlyPoolCredits` filter in `listMetronomeBalances` to apply the `pool` custom-field check to commits as well as credits (commits are stamped `pool` too), matching how `getNetBalance`'s filter behaves.

## Tests

No new tests. Behavior is preserved: `getNetBalance` with `creditTypeId: AWU` + the `pool` filter returns the same AWU pool balance the previous client-side reduction produced.

## Risk

Low. Pure refactor of how the net pool balance is computed; the value semantics are unchanged. `getNetBalance` fails-open like before (returns `Ok(0)` when no Metronome API key; `fetchPoolCredits` still returns `1` on error to avoid blocking usage). Easy to roll back.

## Deploy Plan

Standard deploy, no migration or coordination required.
