### PR TITLE
pricing: revamp the /subscription page

### DIFF
--- a/front/components/pages/onboarding/SelectSubscriptionPage.tsx
+++ b/front/components/pages/onboarding/SelectSubscriptionPage.tsx
@@ -1,124 +1,17 @@
+import {
+  BillingPeriodSwitch,
+  FreePlanCard,
+  PaidPlanCards,
+  type PaidPlanTier,
+} from "@app/components/pages/onboarding/SubscriptionPlans";
 import { UserMenu } from "@app/components/UserMenu";
-import {
-  getSeatBarClasses,
-  getSeatIconColorClass,
-} from "@app/components/workspace/seat_styles";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import {
-  CP_FREE_PLAN_CREDITS,
-  CP_MAX_SEAT_COST_MONTHLY,
-  CP_MAX_SEAT_COST_YEARLY,
-  CP_PRO_SEAT_COST_MONTHLY,
-  CP_PRO_SEAT_COST_YEARLY,
-} from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAppRouter } from "@app/lib/platform";
 import { useUser } from "@app/lib/swr/user";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { MembershipSeatType } from "@app/types/memberships";
 import type { BillingPeriod } from "@app/types/plan";
-import {
-  BarHeader,
-  Button,
-  ButtonsSwitch,
-  ButtonsSwitchList,
-  Check,
-  Chip,
-  cn,
-  Icon,
-  LayerSingle,
-  LayersThree01,
-  LayersTwo01,
-} from "@dust-tt/sparkle";
+import { BarHeader } from "@dust-tt/sparkle";
 import React from "react";
-
-type PlanTier = "free" | "pro" | "max";
-
-interface PlanCardProps {
-  icon: React.ComponentType<{ className?: string }>;
-  seatType: Extract<MembershipSeatType, "free" | "pro" | "max">;
-  name: string;
-  credits: string;
-  creditsLabel: string;
-  priceLabel: string;
-  features: string[];
-  action: React.ReactNode;
-  footnote?: string;
-}
-
-function PlanCard({
-  icon,
-  seatType,
-  name,
-  credits,
-  creditsLabel,
-  priceLabel,
-  features,
-  action,
-  footnote,
-}: PlanCardProps) {
-  // The "free" seat maps to the muted bar track, which matches the card
-  // background (invisible in dark mode), so use a contrasting neutral instead.
-  const iconBackgroundClass =
-    seatType === "free"
-      ? "bg-muted dark:bg-muted-night"
-      : getSeatBarClasses(seatType).track;
-  const iconColorClass = getSeatIconColorClass(seatType);
-
-  return (
-    <div className="flex w-full flex-col rounded-2xl border border-border bg-background p-6 dark:border-border-night dark:bg-muted-background-night">
-      <div className="flex items-center gap-2">
-        <div
-          className={cn(
-            "flex h-7 w-7 items-center justify-center rounded-lg",
-            iconBackgroundClass
-          )}
-        >
-          <Icon visual={icon} size="sm" className={iconColorClass} />
-        </div>
-        <span className="text-lg font-semibold text-foreground dark:text-foreground-night">
-          {name}
-        </span>
-      </div>
-
-      <div className="mt-6 flex items-baseline gap-2">
-        <span className="text-4xl font-bold text-foreground dark:text-foreground-night">
-          {credits}
-        </span>
-        <span className="whitespace-nowrap text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {creditsLabel}
-        </span>
-      </div>
-      <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-        {priceLabel}
-      </p>
-
-      <ul className="mt-6 flex flex-col gap-3">
-        {features.map((feature) => (
-          <li key={feature} className="flex items-start gap-2">
-            <Icon
-              visual={Check}
-              size="sm"
-              className="mt-0.5 text-primary-500"
-            />
-            <span className="text-sm text-foreground dark:text-foreground-night">
-              {feature}
-            </span>
-          </li>
-        ))}
-      </ul>
-
-      <div className="mt-auto flex flex-col items-center gap-2 pt-12">
-        {action}
-        {footnote && (
-          <p className="text-center text-xs text-muted-foreground dark:text-muted-foreground-night">
-            {footnote}
-          </p>
-        )}
-      </div>
-    </div>
-  );
-}
 
 export function SelectSubscriptionPage() {
   const { workspace, user: authUser } = useAuth();
@@ -133,7 +26,7 @@ export function SelectSubscriptionPage() {
   });
 
   const { submit: handleSubscribe } = useSubmitFunction(
-    async (seatType: Exclude<PlanTier, "free">) => {
+    async (seatType: PaidPlanTier) => {
       const query = new URLSearchParams({
         seatType,
         billingPeriod,
@@ -144,15 +37,6 @@ export function SelectSubscriptionPage() {
       );
     }
   );
-
-  const isYearly = billingPeriod === "yearly";
-  const period = isYearly ? "yearly" : "monthly";
-  const proSeatCostDollars = isYearly
-    ? CP_PRO_SEAT_COST_YEARLY
-    : CP_PRO_SEAT_COST_MONTHLY;
-  const maxSeatCostDollars = isYearly
-    ? CP_MAX_SEAT_COST_YEARLY
-    : CP_MAX_SEAT_COST_MONTHLY;
 
   return (
     <>
@@ -173,105 +57,19 @@ export function SelectSubscriptionPage() {
           </p>
         </div>
 
-        <ButtonsSwitchList
-          defaultValue="monthly"
-          onValueChange={(value) =>
-            setBillingPeriod(value === "yearly" ? "yearly" : "monthly")
-          }
-        >
-          <ButtonsSwitch value="monthly" label="Monthly" />
-          <div className="flex items-center gap-1.5">
-            <ButtonsSwitch value="yearly" label="Yearly" />
-            <Chip size="xs" color="blue" label="Save 20%" />
-          </div>
-        </ButtonsSwitchList>
+        <BillingPeriodSwitch onValueChange={setBillingPeriod} />
 
         <div className="flex w-full max-w-4xl flex-col items-stretch gap-4 md:flex-row">
           <div className="flex flex-1">
-            <PlanCard
-              icon={LayerSingle}
-              seatType="free"
-              name="Free"
-              credits={CP_FREE_PLAN_CREDITS.toLocaleString()}
-              creditsLabel="credits"
-              priceLabel="One-time · never expires"
-              features={[
-                "Credits never reset",
-                "Full access to every Dust feature",
-              ]}
-              footnote="One-time phone verification required"
-              action={
-                <Button
-                  className="w-full"
-                  variant="outline"
-                  label="Start Free"
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "cp_free_start",
-                    () => {
-                      void startFreePlan();
-                    }
-                  )}
-                />
-              }
-            />
+            <FreePlanCard onStartFree={() => void startFreePlan()} />
           </div>
 
-          {/* Paid plans share a subtle wrapper to group them visually. */}
+          {/* Paid plans share a subtle wrapper to group them visually next to
+              the Free plan. */}
           <div className="flex flex-[2] flex-col gap-3 rounded-3xl border border-border bg-muted-background p-3 dark:border-border-night dark:bg-muted-background-night sm:flex-row">
-            <PlanCard
-              icon={LayersTwo01}
-              seatType="pro"
-              name="Pro"
-              credits="8,000"
-              creditsLabel="credits/mo"
-              priceLabel={`$${proSeatCostDollars}/seat/mo · billed ${period}`}
-              features={[
-                "Refills every month",
-                "Full access to every Dust feature",
-              ]}
-              action={
-                <Button
-                  className="w-full"
-                  variant="highlight"
-                  label="Subscribe to Pro"
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "cp_subscription_start",
-                    () => {
-                      void handleSubscribe("pro");
-                    },
-                    { seat_type: "pro", billing_period: billingPeriod }
-                  )}
-                />
-              }
-            />
-            <PlanCard
-              icon={LayersThree01}
-              seatType="max"
-              name="Max"
-              credits="40,000"
-              creditsLabel="credits/mo"
-              priceLabel={`$${maxSeatCostDollars}/seat/mo · billed ${period}`}
-              features={[
-                "Refills every month",
-                "Full access to every Dust feature",
-              ]}
-              action={
-                <Button
-                  className="w-full"
-                  variant="outline"
-                  label="Subscribe to Max"
-                  onClick={withTracking(
-                    TRACKING_AREAS.AUTH,
-                    "cp_subscription_start",
-                    () => {
-                      void handleSubscribe("max");
-                    },
-                    { seat_type: "max", billing_period: billingPeriod }
-                  )}
-                />
-              }
+            <PaidPlanCards
+              billingPeriod={billingPeriod}
+              onSubscribe={(seatType) => void handleSubscribe(seatType)}
             />
           </div>
         </div>

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -1,13 +1,12 @@
+import {
+  BillingPeriodSwitch,
+  PaidPlanCards,
+  type PaidPlanTier,
+} from "@app/components/pages/onboarding/SubscriptionPlans";
 import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import {
-  CP_MAX_SEAT_COST_MONTHLY,
-  CP_MAX_SEAT_COST_YEARLY,
-  CP_PRO_SEAT_COST_MONTHLY,
-  CP_PRO_SEAT_COST_YEARLY,
-} from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isFreeTrialPhonePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
@@ -20,15 +19,7 @@ import {
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { BillingPeriod } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
-import {
-  BarHeader,
-  Button,
-  ButtonGroup,
-  Chip,
-  Lock01,
-  Page,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { BarHeader, Button, Lock01, Page, Spinner } from "@dust-tt/sparkle";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import React, { useEffect } from "react";
 
@@ -41,16 +32,12 @@ function CPSubscribePage() {
 
   const [billingPeriod, setBillingPeriod] =
     React.useState<BillingPeriod>("monthly");
-  const [seatType, setSeatType] = React.useState<"pro" | "max">("pro");
 
   const { submit: handleSubscribe } = useSubmitFunction(
-    async (params: {
-      seatType: "pro" | "max";
-      billingPeriod: BillingPeriod;
-    }) => {
+    async (seatType: PaidPlanTier) => {
       const query = new URLSearchParams({
-        seatType: params.seatType,
-        billingPeriod: params.billingPeriod,
+        seatType,
+        billingPeriod,
         targetUserId: authUser.sId,
       });
       await router.push(
@@ -110,7 +97,7 @@ function CPSubscribePage() {
   return (
     <>
       <BarHeader
-        title="Subscribe to Business"
+        title="Choose your plan"
         className="ml-10 lg:ml-0"
         rightActions={
           <div className="flex flex-row items-center">
@@ -120,132 +107,25 @@ function CPSubscribePage() {
           </div>
         }
       />
-      <Page>
-        <div className="flex h-full flex-col items-center justify-center gap-8">
-          {/* Placeholder banner */}
-          <div className="w-full max-w-xl rounded-xl border border-warning-200 bg-warning-100 p-4 text-center dark:border-warning-200-night dark:bg-warning-100-night">
-            <p className="text-lg font-bold text-foreground dark:text-foreground-night">
-              Placeholder — Page to be designed
-            </p>
-            <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-              This page has not been designed yet.
-            </p>
-          </div>
-          <div className="flex flex-col items-center gap-2 text-center">
-            <Page.Header
-              icon={CreditCardIcon}
-              title="Choose your Business plan"
-            />
-            <Page.P>
-              Select a seat type and billing period to get started.
-            </Page.P>
-          </div>
+      <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-4 py-16">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-4xl font-bold text-foreground dark:text-foreground-night">
+            Choose your plan to continue
+          </h1>
+          <p className="text-lg text-muted-foreground dark:text-muted-foreground-night">
+            You can change it anytime from the admin page.
+          </p>
+        </div>
 
-          {/* Billing period toggle */}
-          <div className="flex items-center gap-3">
-            <ButtonGroup>
-              <Button
-                size="sm"
-                variant={billingPeriod === "monthly" ? "primary" : "outline"}
-                label="Monthly"
-                onClick={() => setBillingPeriod("monthly")}
-              />
-              <Button
-                size="sm"
-                variant={billingPeriod === "yearly" ? "primary" : "outline"}
-                label="Yearly"
-                onClick={() => setBillingPeriod("yearly")}
-              />
-            </ButtonGroup>
-            {billingPeriod === "yearly" && (
-              <Chip size="xs" color="green" label="Save 20%" />
-            )}
-          </div>
+        <BillingPeriodSwitch onValueChange={setBillingPeriod} />
 
-          {/* Seat type cards */}
-          <div className="flex w-full max-w-xl flex-col gap-4">
-            {(
-              [
-                {
-                  type: "pro" as const,
-                  name: "Pro",
-                  monthlyPrice: `$${CP_PRO_SEAT_COST_MONTHLY}/mo`,
-                  yearlyPrice: `$${CP_PRO_SEAT_COST_YEARLY}/mo`,
-                  yearlyTotal: `$${CP_PRO_SEAT_COST_YEARLY * 12} billed yearly`,
-                  creditsLabel: "8,000 credits/month",
-                },
-                {
-                  type: "max" as const,
-                  name: "Max",
-                  monthlyPrice: `$${CP_MAX_SEAT_COST_MONTHLY}/mo`,
-                  yearlyPrice: `$${CP_MAX_SEAT_COST_YEARLY}/mo`,
-                  yearlyTotal: `$${CP_MAX_SEAT_COST_YEARLY * 12} billed yearly`,
-                  creditsLabel: "40,000 credits/month",
-                },
-              ] satisfies Array<{
-                type: "pro" | "max";
-                name: string;
-                monthlyPrice: string;
-                yearlyPrice: string;
-                yearlyTotal: string;
-                creditsLabel: string;
-              }>
-            ).map((seat) => (
-              <button
-                key={seat.type}
-                type="button"
-                onClick={() => setSeatType(seat.type)}
-                className={`flex w-full flex-col gap-2 rounded-xl border-2 p-5 text-left transition-colors ${
-                  seatType === seat.type
-                    ? "border-highlight-500 bg-highlight-500/10"
-                    : "border-separator dark:border-separator-night hover:border-muted-foreground/40"
-                }`}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex flex-col gap-1">
-                    <span className="text-lg font-semibold text-foreground dark:text-foreground-night">
-                      {seat.name}
-                    </span>
-                    <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                      {seat.creditsLabel}
-                    </span>
-                  </div>
-                  <div className="flex flex-col items-end gap-0.5">
-                    <span className="text-xl font-bold text-foreground dark:text-foreground-night">
-                      {billingPeriod === "monthly"
-                        ? seat.monthlyPrice
-                        : seat.yearlyPrice}
-                    </span>
-                    {billingPeriod === "yearly" && (
-                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                        {seat.yearlyTotal}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-
-          <Button
-            variant="primary"
-            label="Continue to checkout"
-            icon={CreditCardIcon}
-            size="sm"
-            onClick={withTracking(
-              TRACKING_AREAS.AUTH,
-              "cp_subscription_start",
-              () => {
-                void handleSubscribe({ seatType, billingPeriod });
-              },
-              {
-                seat_type: seatType,
-                billing_period: billingPeriod,
-              }
-            )}
+        <div className="flex w-full max-w-2xl flex-col gap-4 sm:flex-row">
+          <PaidPlanCards
+            billingPeriod={billingPeriod}
+            onSubscribe={(seatType) => void handleSubscribe(seatType)}
           />
         </div>
-      </Page>
+      </div>
     </>
   );
 }

--- a/front/components/pages/onboarding/SubscriptionPlans.tsx
+++ b/front/components/pages/onboarding/SubscriptionPlans.tsx
@@ -1,0 +1,246 @@
+import {
+  getSeatBarClasses,
+  getSeatIconColorClass,
+} from "@app/components/workspace/seat_styles";
+import {
+  CP_FREE_PLAN_CREDITS,
+  CP_MAX_SEAT_COST_MONTHLY,
+  CP_MAX_SEAT_COST_YEARLY,
+  CP_PRO_SEAT_COST_MONTHLY,
+  CP_PRO_SEAT_COST_YEARLY,
+} from "@app/lib/client/subscription";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import type { MembershipSeatType } from "@app/types/memberships";
+import type { BillingPeriod } from "@app/types/plan";
+import {
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  Check,
+  Chip,
+  cn,
+  Icon,
+  LayerSingle,
+  LayersThree01,
+  LayersTwo01,
+} from "@dust-tt/sparkle";
+import type React from "react";
+
+// Shared building blocks for the plan-selection pages (SelectSubscriptionPage
+// and the credit-priced SubscribePage). Page-specific chrome (titles, headers,
+// admin/loading logic) lives in each page.
+
+export type PaidPlanTier = "pro" | "max";
+
+interface PlanCardProps {
+  icon: React.ComponentType<{ className?: string }>;
+  seatType: Extract<MembershipSeatType, "free" | "pro" | "max">;
+  name: string;
+  credits: string;
+  creditsLabel: string;
+  priceLabel: string;
+  features: string[];
+  action: React.ReactNode;
+  footnote?: string;
+}
+
+export function PlanCard({
+  icon,
+  seatType,
+  name,
+  credits,
+  creditsLabel,
+  priceLabel,
+  features,
+  action,
+  footnote,
+}: PlanCardProps) {
+  // The "free" seat maps to the muted bar track, which matches the card
+  // background (invisible in dark mode), so use a contrasting neutral instead.
+  const iconBackgroundClass =
+    seatType === "free"
+      ? "bg-muted dark:bg-muted-night"
+      : getSeatBarClasses(seatType).track;
+  const iconColorClass = getSeatIconColorClass(seatType);
+
+  return (
+    <div className="flex w-full flex-col rounded-2xl border border-border bg-background p-6 dark:border-border-night dark:bg-muted-background-night">
+      <div className="flex items-center gap-2">
+        <div
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-lg",
+            iconBackgroundClass
+          )}
+        >
+          <Icon visual={icon} size="sm" className={iconColorClass} />
+        </div>
+        <span className="text-lg font-semibold text-foreground dark:text-foreground-night">
+          {name}
+        </span>
+      </div>
+
+      <div className="mt-6 flex items-baseline gap-2">
+        <span className="text-4xl font-bold text-foreground dark:text-foreground-night">
+          {credits}
+        </span>
+        <span className="whitespace-nowrap text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {creditsLabel}
+        </span>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {priceLabel}
+      </p>
+
+      <ul className="mt-6 flex flex-col gap-3">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <Icon
+              visual={Check}
+              size="sm"
+              className="mt-0.5 text-primary-500"
+            />
+            <span className="text-sm text-foreground dark:text-foreground-night">
+              {feature}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto flex flex-col items-center gap-2 pt-12">
+        {action}
+        {footnote && (
+          <p className="text-center text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {footnote}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface BillingPeriodSwitchProps {
+  onValueChange: (period: BillingPeriod) => void;
+}
+
+export function BillingPeriodSwitch({
+  onValueChange,
+}: BillingPeriodSwitchProps) {
+  return (
+    <ButtonsSwitchList
+      defaultValue="monthly"
+      onValueChange={(value) =>
+        onValueChange(value === "yearly" ? "yearly" : "monthly")
+      }
+    >
+      <ButtonsSwitch value="monthly" label="Monthly" />
+      <div className="flex items-center gap-1.5">
+        <ButtonsSwitch value="yearly" label="Yearly" />
+        <Chip size="xs" color="blue" label="Save 20%" />
+      </div>
+    </ButtonsSwitchList>
+  );
+}
+
+interface FreePlanCardProps {
+  onStartFree: () => void;
+}
+
+export function FreePlanCard({ onStartFree }: FreePlanCardProps) {
+  return (
+    <PlanCard
+      icon={LayerSingle}
+      seatType="free"
+      name="Free"
+      credits={CP_FREE_PLAN_CREDITS.toLocaleString()}
+      creditsLabel="credits"
+      priceLabel="One-time · never expires"
+      features={["Credits never reset", "Full access to every Dust feature"]}
+      footnote="One-time phone verification required"
+      action={
+        <Button
+          className="w-full"
+          variant="outline"
+          label="Start Free"
+          onClick={withTracking(TRACKING_AREAS.AUTH, "cp_free_start", () => {
+            onStartFree();
+          })}
+        />
+      }
+    />
+  );
+}
+
+interface PaidPlanCardsProps {
+  billingPeriod: BillingPeriod;
+  onSubscribe: (seatType: PaidPlanTier) => void;
+}
+
+export function PaidPlanCards({
+  billingPeriod,
+  onSubscribe,
+}: PaidPlanCardsProps) {
+  const isYearly = billingPeriod === "yearly";
+  const period = isYearly ? "yearly" : "monthly";
+  const proSeatCostDollars = isYearly
+    ? CP_PRO_SEAT_COST_YEARLY
+    : CP_PRO_SEAT_COST_MONTHLY;
+  const maxSeatCostDollars = isYearly
+    ? CP_MAX_SEAT_COST_YEARLY
+    : CP_MAX_SEAT_COST_MONTHLY;
+
+  // The cards are returned without a layout/grouping container so each page
+  // can decide its own wrapper (e.g. the subtle grouped wrapper only used
+  // alongside the Free plan on SelectSubscriptionPage).
+  return (
+    <>
+      <PlanCard
+        icon={LayersTwo01}
+        seatType="pro"
+        name="Pro"
+        credits="8,000"
+        creditsLabel="credits/mo"
+        priceLabel={`$${proSeatCostDollars}/seat/mo · billed ${period}`}
+        features={["Refills every month", "Full access to every Dust feature"]}
+        action={
+          <Button
+            className="w-full"
+            variant="highlight"
+            label="Subscribe to Pro"
+            onClick={withTracking(
+              TRACKING_AREAS.AUTH,
+              "cp_subscription_start",
+              () => {
+                onSubscribe("pro");
+              },
+              { seat_type: "pro", billing_period: billingPeriod }
+            )}
+          />
+        }
+      />
+      <PlanCard
+        icon={LayersThree01}
+        seatType="max"
+        name="Max"
+        credits="40,000"
+        creditsLabel="credits/mo"
+        priceLabel={`$${maxSeatCostDollars}/seat/mo · billed ${period}`}
+        features={["Refills every month", "Full access to every Dust feature"]}
+        action={
+          <Button
+            className="w-full"
+            variant="outline"
+            label="Subscribe to Max"
+            onClick={withTracking(
+              TRACKING_AREAS.AUTH,
+              "cp_subscription_start",
+              () => {
+                onSubscribe("max");
+              },
+              { seat_type: "max", billing_period: billingPeriod }
+            )}
+          />
+        }
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Description

Use the same cards as the /select-subscription page but without the free path.
Only impact the new CP path, not the legacy one.

<img width="1918" height="903" alt="Screenshot 2026-06-09 at 18 09 20" src="https://github.com/user-attachments/assets/9528bd47-dd5b-42dc-8026-73f2cdfa1291" />

<img width="1917" height="901" alt="Screenshot 2026-06-09 at 18 09 32" src="https://github.com/user-attachments/assets/b504f013-5aba-4cf7-a951-29961a9f8eb8" />

Most of the PR is moving code into a reusable module


## Tests

tested locally

## Risk

low (only UI, easy to revert)

## Deploy Plan

deploy front
