### PR TITLE
Handle terminal runModel LLM timeout failures

### DIFF
--- a/front/temporal/agent_loop/lib/workflow_failures.test.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import { makeRunModelLLMError } from "./run_model_errors";
 import {
   isRunModelLLMUnresponsiveError,
+  isTerminalRunModelLLMUnresponsiveFailure,
   isTerminalRunModelTimeout,
   RUN_MODEL_ACTIVITY_NAME,
 } from "./workflow_failures";
@@ -62,10 +63,32 @@ function makeActivityFailure({
   );
 }
 
-function shouldSwallowWorkflowFailure(error: unknown): boolean {
-  return (
-    isTerminalRunModelTimeout(error) && isRunModelLLMUnresponsiveError(error)
+function makeApplicationActivityFailure({
+  activityType = RUN_MODEL_ACTIVITY_NAME,
+  llmErrorType = "llm_timeout_error",
+  llmErrorMessage = LLM_TIMEOUT_MESSAGE,
+  retryState = RetryState.MAXIMUM_ATTEMPTS_REACHED,
+}: {
+  activityType?: string;
+  llmErrorType?: LLMErrorType;
+  llmErrorMessage?: string;
+  retryState?: RetryState;
+} = {}) {
+  return new ActivityFailure(
+    "Activity task failed",
+    activityType,
+    "activity-id",
+    retryState,
+    "worker-id",
+    makeRunModelLLMError({
+      type: llmErrorType,
+      message: llmErrorMessage,
+    })
   );
+}
+
+function shouldSwallowWorkflowFailure(error: unknown): boolean {
+  return isTerminalRunModelLLMUnresponsiveFailure(error);
 }
 
 describe("workflow failure predicates", () => {
@@ -75,6 +98,36 @@ describe("workflow failure predicates", () => {
     expect(isTerminalRunModelTimeout(failure)).toBe(true);
     expect(isRunModelLLMUnresponsiveError(failure)).toBe(true);
     expect(shouldSwallowWorkflowFailure(failure)).toBe(true);
+  });
+
+  it("matches terminal runModel LLM application failures", () => {
+    const failure = makeApplicationActivityFailure();
+
+    expect(isTerminalRunModelTimeout(failure)).toBe(false);
+    expect(isRunModelLLMUnresponsiveError(failure)).toBe(true);
+    expect(isTerminalRunModelLLMUnresponsiveFailure(failure)).toBe(true);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(true);
+  });
+
+  it("ignores non-terminal runModel LLM application failures", () => {
+    const failure = makeApplicationActivityFailure({
+      retryState: RetryState.IN_PROGRESS,
+    });
+
+    expect(isRunModelLLMUnresponsiveError(failure)).toBe(true);
+    expect(isTerminalRunModelLLMUnresponsiveFailure(failure)).toBe(false);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(false);
+  });
+
+  it("ignores terminal runModel non-timeout application failures", () => {
+    const failure = makeApplicationActivityFailure({
+      llmErrorType: "rate_limit_error",
+      llmErrorMessage: "Too many requests.",
+    });
+
+    expect(isRunModelLLMUnresponsiveError(failure)).toBe(false);
+    expect(isTerminalRunModelLLMUnresponsiveFailure(failure)).toBe(false);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(false);
   });
 
   it("matches terminal StartToClose timeouts with an LLM request timeout cause", () => {

--- a/front/temporal/agent_loop/lib/workflow_failures.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.ts
@@ -48,6 +48,20 @@ export function isTerminalRunModelTimeout(
   );
 }
 
+export function isTerminalRunModelLLMUnresponsiveFailure(
+  error: unknown
+): error is ActivityFailure {
+  if (!isRunModelActivityFailure(error)) {
+    return false;
+  }
+
+  if (!isTerminalRetryState(error.retryState)) {
+    return false;
+  }
+
+  return isRunModelLLMUnresponsiveError(error);
+}
+
 export function isRunModelLLMUnresponsiveError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -16,8 +16,7 @@ import {
   TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
 } from "@app/temporal/agent_loop/config";
 import {
-  isRunModelLLMUnresponsiveError,
-  isTerminalRunModelTimeout,
+  isTerminalRunModelLLMUnresponsiveFailure,
 } from "@app/temporal/agent_loop/lib/workflow_failures";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
@@ -336,10 +335,10 @@ export async function agentLoopWorkflow({
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
     // The activity publishes user-facing model errors when our code regains control. We swallow
-    // only terminal Temporal timeouts whose failure chain proves the blocked work was an LLM
-    // provider timeout, so unrelated infrastructure timeouts still surface as workflow failures.
+    // terminal runModel failures whose failure chain proves the blocked work was an LLM
+    // provider timeout, so unrelated infrastructure failures still surface as workflow failures.
     const shouldSwallowWorkflowFailure =
-      isTerminalRunModelTimeout(err) && isRunModelLLMUnresponsiveError(err);
+      isTerminalRunModelLLMUnresponsiveFailure(err);
 
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     // Pass this execution's runIds and startStep to finalize so tracking


### PR DESCRIPTION
## Description

Handle terminal `runModelAndCreateActionsActivity` LLM timeout application failures as expected agent errors instead of failed Temporal workflows.

The existing workflow catch path only swallowed terminal Temporal timeout failures whose cause was an unresponsive LLM. In the observed production case, the terminal failure was a retry-exhausted `ApplicationFailure` from `makeRunModelLLMError` with `llm_timeout_error` (`Anthropic is taking longer than expected`). The agent message was finalized with the right user-facing error, but the workflow was still rethrown and counted by the failed-workflow monitor.

This PR adds a stricter classifier for terminal runModel LLM-unresponsive failures and uses it in the agent loop catch path, so unrelated runTool, non-terminal, and non-timeout LLM failures still surface as workflow failures.

## Tests

- Added unit coverage for terminal retry-exhausted runModel LLM application failures, non-terminal failures, and non-timeout LLM failures.
- Ran `git diff --check` successfully.
- Tried to run `npm -w front run test -- ./temporal/agent_loop/lib/workflow_failures.test.ts`, but the Computer image does not have `npm` installed, so local test execution was not possible here. Final validation should run in PR CI.

## Risk

Low to medium. The change is limited to agent loop failure classification. It only swallows failures for the `runModelAndCreateActionsActivity` activity when the activity is in a terminal retry state and the failure chain is an LLM-unresponsive timeout class. Other activity failures continue to be rethrown and monitored.

## Deploy Plan

Deploy front workers.
