### PR TITLE
Fix next invoice preview

### DIFF
--- a/front-api/routes/w/[wId]/metronome/invoice.ts
+++ b/front-api/routes/w/[wId]/metronome/invoice.ts
@@ -229,12 +229,8 @@ app.get(
         const itemCurrency = creditTypeIdToCurrency(item.credit_type.id);
         return !!currency && !!itemCurrency && itemCurrency === currency;
       })
-      .filter((item) => item.total >= 0)
-      .filter(
-        (item) =>
-          !item.applied_commit_or_credit ||
-          item.applied_commit_or_credit?.type !== "CREDIT"
-      )
+      .filter((item) => item.total >= 0.01)
+      .filter((item) => !item.applied_commit_or_credit)
       .map((item) => {
         const itemCurrency = creditTypeIdToCurrency(item.credit_type.id);
         return {


### PR DESCRIPTION
## Description

Tightens the line-item filtering logic used to compute the **next invoice preview** in the Metronome invoice endpoint (`front-api/routes/w/[wId]/metronome/invoice.ts`):

1. The `total >= 0` threshold is raised to `total >= 0.01` to exclude $0.00 line items (i.e., items fully absorbed by credits/commits that would otherwise appear as zero-cost entries).
2. The second filter is simplified from `!applied_commit_or_credit || applied_commit_or_credit.type !== "CREDIT"` to `!applied_commit_or_credit`, so that **any** line item covered by a commit **or** a credit is excluded — not only those with an explicit `"CREDIT"` type.

Together, these changes ensure the invoice preview only shows line items the customer will actually be charged for.

## Tests

Tested manually by inspecting the next-invoice preview for workspaces with active commits/credits.

## Risk

Low — filtering-only change with no schema or API contract impact. In the worst case the preview could display slightly different line items; it does not affect the actual Metronome invoicing.

## Deploy Plan

Deploy `front-api`.