### PR TITLE
refactor(credits): consolidate formatCredits into shared utility

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -140,7 +140,6 @@ function UsageSection({ owner }: { owner: WorkspaceType }) {
     totalRemainingCredits,
     totalActiveCredits,
     overageCredits,
-    resetDate,
     isAwuPoolSummaryLoading,
     isAwuPoolSummaryError,
   } = useAwuPoolSummary({ workspaceId: owner.sId });
@@ -217,15 +216,6 @@ function UsageSection({ owner }: { owner: WorkspaceType }) {
                 <span>{formatCredits(overageCredits)} overage credits</span>
               ) : (
                 <span />
-              )}
-              {resetDate && (
-                <span>
-                  Resets{" "}
-                  {new Date(resetDate).toLocaleDateString(undefined, {
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
               )}
             </div>
             {myUsage && myUsage.memberUsageLimit !== null && (

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { formatCredits } from "@app/lib/client/credits";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import {
   useAwuPoolSummary,
@@ -111,10 +112,6 @@ function SectionContent({
 }
 
 // ─── Usage ────────────────────────────────────────────────────────────────────
-
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString("en-US");
-}
 
 function ordinalDay(day: number): string {
   const suffix =

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -12,6 +12,7 @@ import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/Usag
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { formatCredits } from "@app/lib/client/credits";
 import { isEnterprisePlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
@@ -48,10 +49,6 @@ import {
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useCallback, useContext, useEffect, useState } from "react";
-
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString("en-US");
-}
 
 const DEFAULT_PAGE_SIZE = 25;
 

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -2,6 +2,7 @@ import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLog
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import { formatCredits } from "@app/lib/client/credits";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
 import { usePokeMembersUsage } from "@app/poke/swr/credits";
 import type { UserCreditState } from "@app/types/memberships";
@@ -42,10 +43,6 @@ function MemberSortHeader({ direction, onToggle }: MemberSortHeaderProps) {
 }
 
 const DEFAULT_PAGE_SIZE = 25;
-
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString("en-US");
-}
 
 const USER_CREDIT_STATE_CHIP_COLOR: Record<
   UserCreditState,

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -7,6 +7,7 @@ import type {
   PokeProgrammaticAlerts,
   PokeStripeSubscriptionWire,
 } from "@app/lib/api/poke/workspace_info";
+import { formatCredits } from "@app/lib/client/credits";
 import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_alerts";
 import type {
   MetronomeAlertRef,
@@ -40,10 +41,6 @@ interface PokeUsageTabProps {
   programmaticAlerts: PokeProgrammaticAlerts;
   usageCapAlert: MetronomeAlertRef | null;
   defaultAlerts: DefaultMetronomeAlerts;
-}
-
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString("en-US");
 }
 
 // Maps a Metronome alert's evaluation status to a Chip color and readable

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -304,12 +304,8 @@ function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
     );
   }
 
-  const {
-    totalActiveCredits,
-    totalRemainingCredits,
-    resetDate,
-    overageCredits,
-  } = awuPoolSummary;
+  const { totalActiveCredits, totalRemainingCredits, overageCredits } =
+    awuPoolSummary;
   const consumed = Math.max(0, totalActiveCredits - totalRemainingCredits);
   const consumedPct =
     totalActiveCredits > 0
@@ -337,17 +333,6 @@ function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
         <span>{formatCredits(totalRemainingCredits)} credits remaining</span>
         {overageCredits !== null && overageCredits > 0 && (
           <span>{formatCredits(overageCredits)} overage credits</span>
-        )}
-        {resetDate && (
-          <span>
-            Resets{" "}
-            {new Date(resetDate).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-              timeZone: "UTC",
-            })}
-          </span>
         )}
       </div>
     </div>

--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -17,6 +17,7 @@ import type {
   AwuUsageGroupByType,
   GetAwuUsageResponse,
 } from "@app/lib/api/analytics/awu_usage";
+import { formatCredits } from "@app/lib/client/credits";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { useAwuUsage } from "@app/lib/swr/workspaces";
 import {
@@ -55,11 +56,6 @@ type ChartDataPoint = {
   timestamp: number;
   [key: string]: string | number | undefined;
 };
-
-// All values are AWU credits — never USD/microUsd.
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString("en-US");
-}
 
 const GROUP_BY_OPTIONS: {
   value: AwuUsageGroupByType;

--- a/front/components/workspace/BuyAwuCreditsDialog.tsx
+++ b/front/components/workspace/BuyAwuCreditsDialog.tsx
@@ -4,6 +4,7 @@ import {
 } from "@app/components/checkout/PaymentMethodRow";
 import { useAwuPurchase } from "@app/hooks/useAwuPurchase";
 import config from "@app/lib/api/config";
+import { formatCredits } from "@app/lib/client/credits";
 import type { AwuPurchaseInfo } from "@app/lib/credits/awu_purchase";
 import {
   MAX_AWU_PURCHASE_CREDITS_PER_CYCLE,
@@ -43,10 +44,6 @@ type TopUpTab = "one-time" | "automatic";
 const QUICK_SELECT_AMOUNTS = [10, 50, 100] as const;
 
 const supportEmail = config.getSupportEmailAddress().email;
-
-function formatCredits(credits: number): string {
-  return Math.round(credits).toLocaleString("en-US");
-}
 
 function formatPaymentMethodLabel(
   pm:

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -1,7 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { amountCents } from "@app/lib/metronome/amounts";
 import {
-  ceilToMidnightUTC,
   listMetronomeBalances,
   listMetronomeDraftInvoices,
 } from "@app/lib/metronome/client";
@@ -35,7 +34,6 @@ function creditTypeIdToCurrency(
 export type AwuPoolSummaryResponseBody = {
   totalRemainingCredits: number;
   totalActiveCredits: number;
-  resetDate: string;
   /**
    * PAYG overage consumed so far this billing period — credits charged on
    * top of the workspace pool. `null` when the workspace is not on PAYG or
@@ -106,16 +104,11 @@ export async function getAwuPoolSummary(
     return new Ok({
       totalRemainingCredits: 0,
       totalActiveCredits: 0,
-      resetDate: "",
       overageCredits: null,
       overageAmountCents: null,
       overageCurrency: null,
     });
   }
-
-  const resetDate = ceilToMidnightUTC(
-    new Date(currentInvoice.end_timestamp)
-  ).toISOString();
 
   // PAYG overage on credit-priced contracts shows up as a `cpu_conversion`
   // line item (Metronome converts AWU spend that exceeds the prepaid AWU
@@ -183,7 +176,6 @@ export async function getAwuPoolSummary(
   return new Ok({
     totalRemainingCredits,
     totalActiveCredits,
-    resetDate,
     overageCredits,
     overageAmountCents,
     overageCurrency: overageCredits !== null ? overageCurrency : null,

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -256,7 +256,6 @@ export function useAwuPoolSummary({
   return {
     totalRemainingCredits: data?.totalRemainingCredits ?? 0,
     totalActiveCredits: data?.totalActiveCredits ?? 0,
-    resetDate: data?.resetDate ?? "",
     overageCredits: data?.overageCredits ?? null,
     overageAmountCents: data?.overageAmountCents ?? null,
     overageCurrency: data?.overageCurrency ?? null,


### PR DESCRIPTION
## Description

This PR removes those duplicates and imports the shared `formatCredits` from `front/lib/client/credits.ts` instead.

Affected components: `UserSettingsPopover`, `UsagePage`, `AwuUsageChart`, `BuyAwuCreditsDialog`, `PokeMembersUsageTable`, `PokeUsageTab`.

## Tests

No behaviour change — pure deduplication.

## Risk

## Deploy Plan
