### PR TITLE
[front] CheckoutPage: checkout_success screen + invoice retrieval

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -1,5 +1,6 @@
 import {
   type BusinessActivationRequestError,
+  fetchStripeHostedInvoiceUrl,
   type GetBusinessActivationResponseBody,
   type PostBusinessActivationResponseBody,
   processBusinessActivation,
@@ -34,12 +35,26 @@ app.get(
       });
     }
 
+    const workspace = auth.getNonNullableWorkspace();
     const checkoutPayment = await getCheckoutPaymentStatus({
-      workspaceId: auth.getNonNullableWorkspace().sId,
+      workspaceId: workspace.sId,
       contractId,
     });
 
-    return ctx.json({ checkoutPayment });
+    let invoiceUrl: string | undefined;
+    if (
+      checkoutPayment?.status === "succeeded" &&
+      checkoutPayment.invoiceId &&
+      workspace.metronomeCustomerId
+    ) {
+      invoiceUrl =
+        (await fetchStripeHostedInvoiceUrl({
+          metronomeCustomerId: workspace.metronomeCustomerId,
+          metronomeInvoiceId: checkoutPayment.invoiceId,
+        })) ?? undefined;
+    }
+
+    return ctx.json({ checkoutPayment, invoiceUrl });
   }
 );
 

--- a/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout/business-activation.ts
@@ -1,12 +1,11 @@
 import {
   type BusinessActivationRequestError,
-  fetchStripeHostedInvoiceUrl,
   type GetBusinessActivationResponseBody,
+  getBusinessActivationStatus,
   type PostBusinessActivationResponseBody,
   processBusinessActivation,
 } from "@app/lib/api/checkout/business_activation";
 import { PostCheckoutPaymentBodySchema } from "@app/lib/api/checkout/payment";
-import { getCheckoutPaymentStatus } from "@app/lib/credits/checkout_payment_status";
 import { wakeLock } from "@app/lib/wake_lock";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -36,25 +35,7 @@ app.get(
     }
 
     const workspace = auth.getNonNullableWorkspace();
-    const checkoutPayment = await getCheckoutPaymentStatus({
-      workspaceId: workspace.sId,
-      contractId,
-    });
-
-    let invoiceUrl: string | undefined;
-    if (
-      checkoutPayment?.status === "succeeded" &&
-      checkoutPayment.invoiceId &&
-      workspace.metronomeCustomerId
-    ) {
-      invoiceUrl =
-        (await fetchStripeHostedInvoiceUrl({
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          metronomeInvoiceId: checkoutPayment.invoiceId,
-        })) ?? undefined;
-    }
-
-    return ctx.json({ checkoutPayment, invoiceUrl });
+    return ctx.json(await getBusinessActivationStatus(workspace, contractId));
   }
 );
 

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -28,6 +28,7 @@ import {
 import type { CouponType } from "@app/types/coupon";
 import type { BillingPeriod } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   CheckCircle,
@@ -484,40 +485,11 @@ export function CheckoutPage() {
 
   if (phase === "checkout_success") {
     return (
-      <main className="flex h-screen flex-col items-center justify-center gap-4 px-6 pb-24 pt-6">
-        <Icon visual={CheckCircle} size="2xl" className="text-success-500" />
-        <div className="flex flex-col items-center gap-4 text-center">
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            You&apos;re all set!
-          </h1>
-          <p className="text-base text-muted-foreground">
-            Your{" "}
-            <span className="font-semibold">
-              {seatType === "max" ? "Max" : "Pro"}
-            </span>{" "}
-            seat is ready with{" "}
-            <span className="font-semibold">
-              {seatType === "max" ? "40,000" : "8,000"}
-            </span>{" "}
-            credits a month. Let&apos;s build something.
-          </p>
-        </div>
-        <div className="flex gap-4">
-          {receiptUrl && (
-            <Button
-              label="View receipt"
-              variant="outline"
-              size="md"
-              onClick={() => window.open(receiptUrl, "_blank")}
-            />
-          )}
-          <Button
-            label="Start building"
-            size="md"
-            onClick={() => void router.replace(`/w/${owner.sId}`)}
-          />
-        </div>
-      </main>
+      <CheckoutSuccessPage
+        seatType={seatType}
+        receiptUrl={receiptUrl}
+        owner={owner}
+      />
     );
   }
 
@@ -720,6 +692,57 @@ export function CheckoutPage() {
           onRestart={handleRestart}
           onConfirmPayment={handleConfirmPayment}
           onCardCaptureComplete={handleCardCaptureComplete}
+        />
+      </div>
+    </main>
+  );
+}
+
+interface CheckoutSuccessPageProps {
+  seatType: "pro" | "max" | null;
+  receiptUrl: string | null;
+  owner: LightWorkspaceType;
+}
+
+function CheckoutSuccessPage({
+  seatType,
+  receiptUrl,
+  owner,
+}: CheckoutSuccessPageProps) {
+  const router = useAppRouter();
+
+  return (
+    <main className="flex h-screen flex-col items-center justify-center gap-4 bg-white px-6 pb-24 pt-6">
+      <Icon visual={CheckCircle} size="2xl" className="text-success-500" />
+      <div className="flex flex-col items-center gap-4 text-center">
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+          You&apos;re all set!
+        </h1>
+        <p className="text-base text-muted-foreground">
+          Your{" "}
+          <span className="font-semibold">
+            {seatType === "max" ? "Max" : "Pro"}
+          </span>{" "}
+          seat is ready with{" "}
+          <span className="font-semibold">
+            {seatType === "max" ? "40,000" : "8,000"}
+          </span>{" "}
+          credits a month. Let&apos;s build something.
+        </p>
+      </div>
+      <div className="flex gap-4">
+        {receiptUrl && (
+          <Button
+            label="View receipt"
+            variant="outline"
+            size="md"
+            onClick={() => window.open(receiptUrl, "_blank")}
+          />
+        )}
+        <Button
+          label="Start building"
+          size="md"
+          onClick={() => void router.replace(`/w/${owner.sId}`)}
         />
       </div>
     </main>

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -70,7 +70,7 @@ type CheckoutPhase =
   | "payment_review" // Phase 2 — tax breakdown + confirm button
   | "confirming" // Phase 3 — POST /payment in progress
   | "waiting_for_payment" // Phase 4 — polling Redis for Metronome webhook result
-  | "activating" // Phase 5 — mutating auth context, redirecting
+  | "checkout_success" // Phase 5 — success screen, user continues manually
   | "error"; // Terminal error
 
 type PhaseError =
@@ -116,6 +116,7 @@ export function CheckoutPage() {
   const [pendingContractId, setPendingContractId] = useState<string | null>(
     null
   );
+  const [receiptUrl, setReceiptUrl] = useState<string | null>(null);
   // Prevents initSession from firing before URL params have been read on mount.
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -178,7 +179,7 @@ export function CheckoutPage() {
   }, [livePreparePayment]);
 
   // Poll checkout payment status while in waiting_for_payment phase.
-  const { checkoutPayment } = useCheckBusinessActivation({
+  const { checkoutPayment, invoiceUrl } = useCheckBusinessActivation({
     workspaceId: owner.sId,
     contractId: pendingContractId,
     disabled: phase !== "waiting_for_payment",
@@ -191,20 +192,15 @@ export function CheckoutPage() {
       return;
     }
     if (checkoutPayment.status === "succeeded") {
-      setPhase("activating");
-      void (async () => {
-        await Promise.all([
-          mutateAuthContext(),
-          new Promise<void>((resolve) => setTimeout(resolve, 2000)),
-        ]);
-        void router.replace(`/w/${owner.sId}`);
-      })();
+      setReceiptUrl(invoiceUrl);
+      setPhase("checkout_success");
+      void mutateAuthContext();
     } else if (checkoutPayment.status === "failed") {
       setPhaseError({ kind: "activation_failed" });
       setPhase("error");
     }
     // pending: keep polling
-  }, [phase, checkoutPayment, mutateAuthContext, router, owner.sId]);
+  }, [phase, checkoutPayment, invoiceUrl, mutateAuthContext]);
 
   const {
     register: registerCoupon,
@@ -374,21 +370,14 @@ export function CheckoutPage() {
       return;
     }
 
-    // Payment and provisioning succeeded — show success state for 2s, then redirect.
-    setPhase("activating");
-    await Promise.all([
-      mutateAuthContext(),
-      new Promise<void>((resolve) => setTimeout(resolve, 2000)),
-    ]);
-    void router.replace(`/w/${owner.sId}`);
+    setPhase("checkout_success");
+    void mutateAuthContext();
   }, [
     setupSessionId,
     isMetronomeCheckout,
     initiateBusinessActivation,
     confirmPayment,
     mutateAuthContext,
-    router,
-    owner.sId,
   ]);
 
   const handleCardCaptureComplete = useCallback(() => {
@@ -489,6 +478,45 @@ export function CheckoutPage() {
     return (
       <main className="flex min-h-screen items-center justify-center">
         <Spinner size="xl" />
+      </main>
+    );
+  }
+
+  if (phase === "checkout_success") {
+    return (
+      <main className="flex h-screen flex-col items-center justify-center gap-4 px-6 pb-24 pt-6">
+        <Icon visual={CheckCircle} size="2xl" className="text-success-500" />
+        <div className="flex flex-col items-center gap-4 text-center">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
+            You&apos;re all set!
+          </h1>
+          <p className="text-base text-muted-foreground">
+            Your{" "}
+            <span className="font-semibold">
+              {seatType === "max" ? "Max" : "Pro"}
+            </span>{" "}
+            seat is ready with{" "}
+            <span className="font-semibold">
+              {seatType === "max" ? "40,000" : "8,000"}
+            </span>{" "}
+            credits a month. Let&apos;s build something.
+          </p>
+        </div>
+        <div className="flex gap-4">
+          {receiptUrl && (
+            <Button
+              label="View receipt"
+              variant="outline"
+              size="md"
+              onClick={() => window.open(receiptUrl, "_blank")}
+            />
+          )}
+          <Button
+            label="Start building"
+            size="md"
+            onClick={() => void router.replace(`/w/${owner.sId}`)}
+          />
+        </div>
       </main>
     );
   }
@@ -834,15 +862,8 @@ function RightPane({
         </div>
       );
 
-    case "activating":
-      return (
-        <div className="flex flex-col items-center gap-6 text-center">
-          <Icon visual={CheckCircle} size="2xl" className="text-success-500" />
-          <h2 className="text-2xl font-semibold text-foreground">
-            Thanks for subscribing
-          </h2>
-        </div>
-      );
+    case "checkout_success":
+      return null;
 
     case "error": {
       if (phaseError?.kind === "metronome_error") {

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -16,6 +16,7 @@ import { metronomeAmount } from "@app/lib/metronome/amounts";
 import {
   addPaymentGatedCommitToContract,
   floorToHourISO,
+  getMetronomeClient,
 } from "@app/lib/metronome/client";
 import {
   CURRENCY_TO_CREDIT_TYPE_ID,
@@ -618,6 +619,57 @@ export async function handleSubscriptionActivationFailure({
 export { checkoutToMembershipSeatType };
 
 // ---------------------------------------------------------------------------
+// Invoice URL retrieval — called from the GET /checkout/business-activation
+// handler when status is "succeeded".
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a Metronome invoice ID, retrieves the Stripe hosted_invoice_url via:
+ *   Metronome invoices.retrieve → external_invoice.invoice_id (Stripe ID)
+ *   → Stripe invoices.retrieve → hosted_invoice_url
+ *
+ * Returns null on any failure so callers can treat the URL as optional.
+ */
+export async function fetchStripeHostedInvoiceUrl({
+  metronomeCustomerId,
+  metronomeInvoiceId,
+}: {
+  metronomeCustomerId: string;
+  metronomeInvoiceId: string;
+}): Promise<string | null> {
+  try {
+    const { data: invoice } =
+      await getMetronomeClient().v1.customers.invoices.retrieve({
+        customer_id: metronomeCustomerId,
+        invoice_id: metronomeInvoiceId,
+      });
+
+    const stripeInvoiceId =
+      invoice.external_invoice?.billing_provider_type === "stripe"
+        ? invoice.external_invoice.invoice_id
+        : undefined;
+
+    if (!stripeInvoiceId) {
+      logger.warn(
+        { metronomeCustomerId, metronomeInvoiceId },
+        "[Business Activation] No Stripe invoice ID found on Metronome invoice"
+      );
+      return null;
+    }
+
+    const stripe = getStripeClient();
+    const stripeInvoice = await stripe.invoices.retrieve(stripeInvoiceId);
+    return stripeInvoice.hosted_invoice_url ?? null;
+  } catch (err) {
+    logger.warn(
+      { metronomeCustomerId, metronomeInvoiceId, err },
+      "[Business Activation] Failed to fetch Stripe hosted invoice URL"
+    );
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // HTTP-layer entry point — called from the POST /checkout/business-activation
 // route handler.
 // ---------------------------------------------------------------------------
@@ -650,6 +702,7 @@ export type PostBusinessActivationResponseBody =
 
 export type GetBusinessActivationResponseBody = {
   checkoutPayment: CheckoutPayment | null;
+  invoiceUrl?: string;
 };
 
 /**

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -65,6 +65,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   type CheckoutBillingPeriod,
   CheckoutBillingPeriodSchema,
@@ -704,6 +705,36 @@ export type GetBusinessActivationResponseBody = {
   checkoutPayment: CheckoutPayment | null;
   invoiceUrl?: string;
 };
+
+/**
+ * Returns the checkout payment status and, when payment has succeeded, the
+ * Stripe hosted invoice URL. Coordinates the two sequential external-service
+ * calls so the GET handler stays thin.
+ */
+export async function getBusinessActivationStatus(
+  workspace: LightWorkspaceType,
+  contractId: string
+): Promise<GetBusinessActivationResponseBody> {
+  const checkoutPayment = await getCheckoutPaymentStatus({
+    workspaceId: workspace.sId,
+    contractId,
+  });
+
+  let invoiceUrl: string | undefined;
+  if (
+    checkoutPayment?.status === "succeeded" &&
+    checkoutPayment.invoiceId &&
+    workspace.metronomeCustomerId
+  ) {
+    invoiceUrl =
+      (await fetchStripeHostedInvoiceUrl({
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        metronomeInvoiceId: checkoutPayment.invoiceId,
+      })) ?? undefined;
+  }
+
+  return { checkoutPayment, invoiceUrl };
+}
 
 /**
  * Validate the completed Stripe setup session and kick off a payment-gated

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -1307,6 +1307,7 @@ export function useCheckBusinessActivation({
 
   return {
     checkoutPayment: data?.checkoutPayment ?? null,
+    invoiceUrl: data?.invoiceUrl ?? null,
     isCheckoutPaymentLoading: !error && !data && !disabled && !!contractId,
     isCheckoutPaymentError: !!error,
   };


### PR DESCRIPTION
## Description

Goal
* Retrieve stripe invoice url for the payment gated commit
* Update checkout_success screen (last one in the checkout flow) to fit with design on Figma with 
  * full screen (not only on right pane)
  * success message based on seat and credits
  * "View receipt" and "Start building" buttons
  * no automatic redirection

Changes
* lib/api/checkout/business_activation.ts — new fetchStripeHostedInvoiceUrl helper; GetBusinessActivationResponseBody gains invoiceUrl?: string
* front-api/routes/.../checkout/business-activation.ts — GET handler enriches the response with invoiceUrl when status is succeeded and both invoiceId and metronomeCustomerId are present
* lib/swr/workspaces.ts — useCheckBusinessActivation exposes invoiceUrl
* CheckoutPage.tsx — receiptUrl state captures the URL on activation success; "View receipt" button wired; success copy is seat-type-aware

## Tests

Tested locally => checkout_success properly displayed + "View receipt" button links to stripe receipt

## Risk

Low, UI only behind a feature flag

## Deploy Plan

Deploy front