### PR TITLE
do not send top-level cache_control on Vertex AI

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -60,7 +60,8 @@ const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
  *  Slot 3 – messages[0]: equipped skills  (5min TTL, stable per agent within a workspace;
  *                                          set in conversation_to_anthropic.ts when name="system")
  *  Slot 4 – Anthropic API: automatic cache_control (5min TTL, auto-placed at last cacheable block;
- *                                          added as top-level field in buildStreamRequestPayload)
+ *                                          added as top-level field in buildStreamRequestPayload;
+ *                                          NOT added on Vertex AI to stay within the 4-slot limit)
  *         – Vertex AI:     explicit last-message breakpoint (5min TTL; Vertex does not support
  *                                          automatic caching, so the last message is marked
  *                                          explicitly via isLast in buildBaseRequestPayload)
@@ -212,7 +213,9 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       output_config: outputFormat
         ? { ...basePayload.output_config, format: outputFormat }
         : basePayload.output_config,
-      cache_control: { type: "ephemeral" },
+      // Automatic caching is not supported on Vertex AI; the explicit breakpoints in
+      // buildBaseRequestPayload (isFirst and isLast) cover Vertex instead.
+      ...(!this.useVertex ? { cache_control: { type: "ephemeral" } } : {}),
       model: getModel(this.useVertex, { modelId: this.modelId }),
     };
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In https://github.com/dust-tt/dust/pull/27093 I oversaw the Vertex AI subtlety. 

Vertex AI does not support automatic caching. The previous code always emitted `cache_control: { type: "ephemeral" }` at the request level regardless of provider, which would push the total number of cache breakpoints to 5 on Vertex. Decompose as 2 system blocks, the equipped skills marker on messages[0], the explicit last-message marker for Vertex, and the now-redundant automatic top-level one, exceeding Anthropic's 4-slot limit.

The top-level `cache_control` is now gated to Anthropic API only.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
