### PR TITLE
Fix title field type from search codec

### DIFF
--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -271,7 +271,7 @@ export const confluence = async ({
         hasChildren,
         hasReadRestrictions: hasReadRestrictions ?? true,
         status: page.status,
-        title: page.title,
+        title: page.title ?? "Untitled",
       };
     }
 

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -70,7 +70,6 @@ const ConfluencePageCodec = t.intersection([
 const SearchBaseContentCodec = t.type({
   id: t.string,
   status: t.string,
-  title: t.string,
 
   // Version info.
   version: t.type({

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -67,38 +67,43 @@ const ConfluencePageCodec = t.intersection([
   CatchAllCodec,
 ]);
 
-const SearchBaseContentCodec = t.type({
-  id: t.string,
-  status: t.string,
+const SearchBaseContentCodec = t.intersection([
+  t.type({
+    id: t.string,
+    status: t.string,
 
-  // Version info.
-  version: t.type({
-    number: t.number,
-  }),
+    // Version info.
+    version: t.type({
+      number: t.number,
+    }),
 
-  // Restrictions.
-  restrictions: t.type({
-    read: t.type({
-      restrictions: t.type({
-        user: t.type({
-          results: t.array(t.unknown),
-        }),
-        group: t.type({
-          results: t.array(t.unknown),
+    // Restrictions.
+    restrictions: t.type({
+      read: t.type({
+        restrictions: t.type({
+          user: t.type({
+            results: t.array(t.unknown),
+          }),
+          group: t.type({
+            results: t.array(t.unknown),
+          }),
         }),
       }),
     }),
+
+    // Ancestors (parent chain).
+    ancestors: t.array(
+      t.type({
+        id: t.string,
+        type: t.string,
+        title: t.union([t.undefined, t.string]),
+      })
+    ),
   }),
 
-  // Ancestors (parent chain).
-  ancestors: t.array(
-    t.type({
-      id: t.string,
-      type: t.string,
-      title: t.union([t.undefined, t.string]),
-    })
-  ),
-});
+  // title is absent for some space overview pages in the legacy search API. Only used by the CLI.
+  t.partial({ title: t.string }),
+]);
 
 const SearchConfluencePageCodec = t.intersection([
   SearchBaseContentCodec,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The legacy Confluence search API omits the `title` field entirely for _some_ space overview pages, causing codec validation to fail in `bulkFetchConfluencePageRefs`. ~The field was never used downstream, we only reads `id`, `version`, `ancestors`, `type`, `restrictions`, and `childTypes`. Removing it entirely.~ Field is used in the CLI, so made it optional. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
