### PR TITLE
Oauth support for force refresh and more details in logs for jira.

### DIFF
--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     middleware::from_fn,
     response::Json,
     routing::{delete, get, patch, post},
@@ -208,6 +208,12 @@ async fn connections_finalize(
     }
 }
 
+#[derive(Deserialize, Default)]
+struct ConnectionAccessTokenQuery {
+    #[serde(default)]
+    force_refresh: bool,
+}
+
 #[derive(Deserialize)]
 #[allow(dead_code)]
 struct ConnectionAccessTokenPayload {
@@ -241,12 +247,18 @@ async fn deprecated_connections_access_token(
     Path(connection_id): Path<String>,
     Json(_payload): Json<ConnectionAccessTokenPayload>,
 ) -> (StatusCode, Json<APIResponse>) {
-    connections_access_token(State(state), Path(connection_id)).await
+    connections_access_token(
+        State(state),
+        Path(connection_id),
+        Query(ConnectionAccessTokenQuery::default()),
+    )
+    .await
 }
 
 async fn connections_access_token(
     State(state): State<Arc<OAuthState>>,
     Path(connection_id): Path<String>,
+    Query(query): Query<ConnectionAccessTokenQuery>,
 ) -> (StatusCode, Json<APIResponse>) {
     match state.store.retrieve_connection(&connection_id).await {
         Err(e) => error_response(
@@ -261,39 +273,46 @@ async fn connections_access_token(
             "Requested connection was not found",
             None,
         ),
-        Ok(Some(mut c)) => match c.access_token(state.clone().store.clone()).await {
-            Err(e) => error_response(
-                match e.code {
-                    connection::ConnectionErrorCode::TokenRevokedError => StatusCode::UNAUTHORIZED,
-                    connection::ConnectionErrorCode::ConnectionNotFinalizedError
-                    | connection::ConnectionErrorCode::InvalidMetadataError => {
-                        StatusCode::BAD_REQUEST
-                    }
-                    _ => StatusCode::INTERNAL_SERVER_ERROR,
-                },
-                &e.code.to_string(),
-                &e.message,
-                None,
-            ),
-            Ok((access_token, scrubbed_raw_json)) => (
-                StatusCode::OK,
-                Json(APIResponse {
-                    error: None,
-                    response: Some(json!(ConnectionAccessTokenResponse {
-                        connection: ConnectionInfo {
-                            connection_id: c.connection_id(),
-                            created: c.created(),
-                            provider: c.provider(),
-                            status: c.status(),
-                            metadata: c.metadata().clone(),
-                        },
-                        access_token,
-                        access_token_expiry: c.access_token_expiry(),
-                        scrubbed_raw_json: scrubbed_raw_json.unwrap_or_default(),
-                    })),
-                }),
-            ),
-        },
+        Ok(Some(mut c)) => {
+            match c
+                .access_token(state.clone().store.clone(), query.force_refresh)
+                .await
+            {
+                Err(e) => error_response(
+                    match e.code {
+                        connection::ConnectionErrorCode::TokenRevokedError => {
+                            StatusCode::UNAUTHORIZED
+                        }
+                        connection::ConnectionErrorCode::ConnectionNotFinalizedError
+                        | connection::ConnectionErrorCode::InvalidMetadataError => {
+                            StatusCode::BAD_REQUEST
+                        }
+                        _ => StatusCode::INTERNAL_SERVER_ERROR,
+                    },
+                    &e.code.to_string(),
+                    &e.message,
+                    None,
+                ),
+                Ok((access_token, scrubbed_raw_json)) => (
+                    StatusCode::OK,
+                    Json(APIResponse {
+                        error: None,
+                        response: Some(json!(ConnectionAccessTokenResponse {
+                            connection: ConnectionInfo {
+                                connection_id: c.connection_id(),
+                                created: c.created(),
+                                provider: c.provider(),
+                                status: c.status(),
+                                metadata: c.metadata().clone(),
+                            },
+                            access_token,
+                            access_token_expiry: c.access_token_expiry(),
+                            scrubbed_raw_json: scrubbed_raw_json.unwrap_or_default(),
+                        })),
+                    }),
+                ),
+            }
+        }
     }
 }
 async fn connections_metadata(

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -879,6 +879,7 @@ impl Connection {
     pub async fn access_token(
         &mut self,
         store: Box<dyn OAuthStore + Sync + Send>,
+        force_refresh: bool,
     ) -> Result<(String, Option<serde_json::Value>), ConnectionError> {
         if self.status != ConnectionStatus::Finalized {
             return Err(ConnectionError {
@@ -886,23 +887,26 @@ impl Connection {
                 message: "Connection is not finalized".to_string(),
             });
         }
-        if let Some(access_token) = self.valid_access_token()? {
-            return Ok((
-                access_token,
-                self.scrubbed_raw_json().map_err(|e| {
-                    error!(error = ?e, "Failed to retrieve and scrub raw_json");
-                    ConnectionError {
-                        code: ConnectionErrorCode::InternalError,
-                        message: "Failed to retrieve and scrub raw_json".to_string(),
-                    }
-                })?,
-            ));
+        if !force_refresh {
+            if let Some(access_token) = self.valid_access_token()? {
+                return Ok((
+                    access_token,
+                    self.scrubbed_raw_json().map_err(|e| {
+                        error!(error = ?e, "Failed to retrieve and scrub raw_json");
+                        ConnectionError {
+                            code: ConnectionErrorCode::InternalError,
+                            message: "Failed to retrieve and scrub raw_json".to_string(),
+                        }
+                    })?,
+                ));
+            }
         }
 
         info!(
             connection_id = self.connection_id(),
             provider = self.provider.to_string(),
             access_token_expiry = self.access_token_expiry,
+            force_refresh,
             "Refreshing access token",
         );
 

--- a/core/src/oauth/providers/jira.rs
+++ b/core/src/oauth/providers/jira.rs
@@ -36,14 +36,18 @@ impl JiraConnectionProvider {
         JiraConnectionProvider {}
     }
 
-    fn handle_refresh_request_error(&self, error: ProviderHttpRequestError) -> ProviderError {
+    fn handle_refresh_request_error(
+        &self,
+        connection: &Connection,
+        error: ProviderHttpRequestError,
+    ) -> ProviderError {
+        log_jira_refresh_error(connection, &error);
+
         match &error {
             ProviderHttpRequestError::RequestFailed {
                 status, message, ..
             } => {
-                let is_revoked = is_jira_refresh_token_revoked(*status, message);
-                info!(message, is_revoked, status, "JIRA refresh OAuth error");
-                if is_revoked {
+                if is_jira_refresh_token_revoked(*status, message) {
                     ProviderError::TokenRevokedError
                 } else {
                     self.default_handle_provider_request_error(error)
@@ -65,6 +69,27 @@ fn is_jira_refresh_token_revoked(status: u16, message: &str) -> bool {
         || message.contains(JIRA_INVALID_REFRESH_TOKEN_WITH_SPACES_FRAGMENT)
         || message.contains(JIRA_INVALID_REFRESH_TOKEN_GENERIC_FRAGMENT)
         || message.contains(JIRA_GLOBAL_REVOCATION_FRAGMENT)
+}
+
+fn log_jira_refresh_error(connection: &Connection, error: &ProviderHttpRequestError) {
+    match error {
+        ProviderHttpRequestError::RequestFailed {
+            status, message, ..
+        } => {
+            let is_revoked = is_jira_refresh_token_revoked(*status, message);
+            info!(
+                connection_id = connection.connection_id(),
+                status, message, is_revoked, "JIRA refresh OAuth error"
+            );
+        }
+        _ => {
+            info!(
+                connection_id = connection.connection_id(),
+                error = %error,
+                "JIRA refresh OAuth error"
+            );
+        }
+    }
 }
 
 /// JIRA documentation: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
@@ -159,7 +184,7 @@ impl Provider for JiraConnectionProvider {
 
         let raw_json = execute_request(ConnectionProvider::Jira, req)
             .await
-            .map_err(|e| self.handle_refresh_request_error(e))?;
+            .map_err(|e| self.handle_refresh_request_error(connection, e))?;
 
         let access_token = match raw_json["access_token"].as_str() {
             Some(token) => token,
@@ -216,9 +241,27 @@ impl Provider for JiraConnectionProvider {
 mod tests {
     use super::{is_jira_refresh_token_revoked, JiraConnectionProvider};
     use crate::oauth::{
-        connection::{ConnectionProvider, Provider, ProviderError},
+        connection::{Connection, ConnectionProvider, ConnectionStatus, Provider, ProviderError},
         providers::utils::ProviderHttpRequestError,
     };
+    use serde_json::json;
+
+    fn test_jira_connection(metadata: serde_json::Value) -> Connection {
+        Connection::new(
+            "con_test".to_string(),
+            0,
+            ConnectionProvider::Jira,
+            ConnectionStatus::Finalized,
+            metadata,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
 
     #[test]
     fn detects_jira_revoked_refresh_token_errors() {
@@ -243,12 +286,19 @@ mod tests {
     #[test]
     fn maps_revoked_refresh_failures_to_token_revoked_error() {
         let provider = JiraConnectionProvider::new();
-        let error =
-            provider.handle_refresh_request_error(ProviderHttpRequestError::RequestFailed {
+        let connection = test_jira_connection(json!({
+            "workspace_id": "jGdvDdLddV",
+            "user_id": "cj7cEVNGfx",
+            "use_case": "platform_actions",
+        }));
+        let error = provider.handle_refresh_request_error(
+            &connection,
+            ProviderHttpRequestError::RequestFailed {
                 provider: ConnectionProvider::Jira,
                 status: 400,
                 message: "invalid_grant".to_string(),
-            });
+            },
+        );
 
         assert!(matches!(error, ProviderError::TokenRevokedError));
     }


### PR DESCRIPTION
## Description

Two improvements to the OAuth core layer:

- `Connection::access_token()` gains a `force_refresh: bool` parameter. When `true`, it bypasses the cached `valid_access_token()` check and always triggers a provider refresh. Exposed via `?force_refresh=true` on the `GET /connections/:id/access_token` endpoint. The deprecated POST variant defaults to `force_refresh: false`, preserving backward compatibility.
- `JiraConnectionProvider::handle_refresh_request_error` now takes a `&Connection` reference. Logging is extracted into `log_jira_refresh_error`, which emits `connection_id` as a structured field and covers non-`RequestFailed` error variants that were previously silent.

## Tests

- Existing unit tests in `jira.rs` updated to pass a `Connection` to `handle_refresh_request_error` via a `test_jira_connection` helper. All assertions unchanged.
- Tested locally against a Jira connection to verify force-refresh triggers a real token exchange.

## Risk

Low. The `force_refresh` flag is additive — all existing callers default to `false` (cache-first behavior unchanged). The Jira log refactor is purely observability. No schema or API contract changes.

## Deploy Plan

Deploy core.
