### PR TITLE
GA the defered conversation flow.

### DIFF
--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,7 +1,6 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { PostConversationsResponseBody } from "@app/lib/api/assistant/conversation/types";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher } from "@app/lib/swr/swr";
@@ -40,7 +39,6 @@ export function useCreateConversationWithMessage({
 }) {
   const { fetcher } = useFetcher();
   const contextOrigin = useClientType();
-  const { hasFeature } = useFeatureFlags();
   const sendNotification = useSendNotification();
   const { setPendingFirstMessage, clearPendingFirstMessage } =
     useContext(InputBarContext);
@@ -96,15 +94,7 @@ export function useCreateConversationWithMessage({
       } = messageData;
       const origin = messageOrigin ?? contextOrigin;
 
-      // `selectedMCPServerViewIds` (conversation-level tools) are only wired up by
-      // the conversations endpoint when an initial message is posted (it calls
-      // `upsertMCPServerViews` inside `if (message)`), and the messages endpoint drops
-      // them. Until that's wired through, deferring with tools would silently lose
-      // them, so we keep the combined call in that case.
-      const canDefer =
-        deferMessage && hasFeature("deferred_conversation_creation");
-
-      if (canDefer) {
+      if (deferMessage) {
         const createBody: z.infer<
           typeof InternalPostConversationsRequestBodySchema
         > = {
@@ -239,7 +229,6 @@ export function useCreateConversationWithMessage({
       user,
       fetcher,
       contextOrigin,
-      hasFeature,
       sendNotification,
       setPendingFirstMessage,
       clearPendingFirstMessage,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -282,11 +282,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",
     stage: "on_demand",
   },
-  deferred_conversation_creation: {
-    description:
-      "Create conversations in two steps (conversation first, first message in background) for faster navigation to the conversation page",
-    stage: "dust_only",
-  },
   conversation_search_indexing: {
     description: "Enable ES indexing of conversations on mutation (write path)",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -759,7 +759,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "sensitivity_labels"
   | "conversation_search_indexing"
   | "conversation_search_read"
-  | "deferred_conversation_creation"
   | "new_file_explorer"
   | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"


### PR DESCRIPTION
## Description

GA the deferred conversation creation flow by removing the `deferred_conversation_creation` feature flag. `useCreateConversationWithMessage` now executes the two-step path (`deferMessage`) unconditionally for all workspaces: the conversation is created immediately and the first message is posted in the background, allowing faster navigation to the conversation page. Drops the FF from `WHITELISTABLE_FEATURES_CONFIG`, `WhitelistableFeaturesSchema`, and the `canDefer` guard.

## Tests

Tested manually. The deferred flow was already live for all `dust_only` workspaces under the FF; no behavioral change is expected beyond enabling it globally.

## Risk

Medium — activates globally for all workspaces. Known risk: if the background POST for the first message silently fails, the user lands on an empty conversation with no error feedback. This path has been exercised at scale on Dust workspaces, so broader rollout risk is low. Rollback: re-introduce the FF gate and `canDefer` check.

## Deploy Plan

Deploy front.
