### PR TITLE
Fix: send sse comments to flush http headers early

### DIFF
--- a/front-api/lib/api/sse/stream_events.ts
+++ b/front-api/lib/api/sse/stream_events.ts
@@ -3,6 +3,11 @@ import type { Context } from "hono";
 import { stream } from "hono/streaming";
 import { z } from "zod";
 
+// Written before consuming the event iterator so response bytes hit the wire
+// before any Redis subscribe / history fetch in the iterator. SSE comments are
+// ignored by clients per spec.
+const SSE_OPEN_COMMENT = ": connected\n\n";
+
 // Standard SSE resume parameter shared by every streaming route. An absent or
 // empty `lastEventId` (clients reconnecting without a prior event send `?lastEventId=`)
 // normalizes to null rather than failing validation.
@@ -31,6 +36,8 @@ export function streamEvents<TIn>(params: StreamEventsParams<TIn>) {
   return stream(params.ctx, async (s) => {
     const controller = new AbortController();
     s.onAbort(() => controller.abort());
+
+    await s.write(SSE_OPEN_COMMENT);
 
     for await (const event of params.iterator(controller.signal)) {
       const out: unknown = params.transform

--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
@@ -183,16 +183,30 @@ describe("GET /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events", () => {
   it("propagates the client disconnect to the event source and stops", async () => {
     const { workspace, key, conversation } = await setupConversation();
     const abortObserved = vi.fn();
+    let resolveWaitingForAbort: (() => void) | undefined;
+    const waitingForAbort = new Promise<void>((resolve) => {
+      resolveWaitingForAbort = resolve;
+    });
 
     vi.mocked(getConversationEvents).mockImplementation(async function* ({
       signal,
     }) {
       yield titleEvent("first");
+      resolveWaitingForAbort?.();
       await new Promise<void>((resolve) => {
-        signal.addEventListener("abort", () => {
+        if (signal.aborted) {
           abortObserved();
           resolve();
-        });
+          return;
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            abortObserved();
+            resolve();
+          },
+          { once: true }
+        );
       });
       yield titleEvent("never-sent");
     });
@@ -207,8 +221,20 @@ describe("GET /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events", () => {
     }
 
     const reader = response.body.getReader();
-    const first = await reader.read();
-    expect(new TextDecoder().decode(first.value)).toContain("first");
+    const decoder = new TextDecoder();
+    let received = "";
+    while (!received.includes("first")) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      received += decoder.decode(chunk.value);
+    }
+    expect(received).toContain("first");
+
+    // Wait until the event source is blocked on the abort signal before
+    // simulating a client disconnect.
+    await waitingForAbort;
 
     // Cancelling the reader simulates a client disconnect, which Hono surfaces
     // through `s.onAbort` -> the AbortController passed to the event source.

--- a/front-api/routes/v1/w/[wId]/mcp/requests.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/requests.ts
@@ -1,11 +1,8 @@
-import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
-import { getMCPEventsForServer } from "@app/lib/api/assistant/mcp_events";
 import { PostMCPRequestsRequestQuerySchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
-import { setSSEHeaders, streamingTag } from "@front-api/middlewares/streaming";
-import { apiError } from "@front-api/middlewares/utils";
+import { streamingTag } from "@front-api/middlewares/streaming";
 import { validate } from "@front-api/middlewares/validator";
-import { stream } from "hono/streaming";
+import { streamMcpRequests } from "@front-api/routes/sse/v1/w/[wId]/mcp/requests";
 
 // Mounted at /api/v1/w/:wId/mcp/requests.
 const app = publicApiApp();
@@ -70,58 +67,8 @@ app.use("*", streamingTag);
  *       500:
  *         description: Internal Server Error.
  */
-app.get(
-  "/",
-  validate("query", PostMCPRequestsRequestQuerySchema),
-  async (ctx) => {
-    const auth = ctx.get("auth");
-    const { serverId, lastEventId } = ctx.req.valid("query");
-
-    const isValidAccess = await validateMCPServerAccess(auth, {
-      serverId,
-    });
-    if (!isValidAccess) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "mcp_auth_error",
-          message:
-            "You don't have access to this MCP server or it has expired.",
-        },
-      });
-    }
-
-    setSSEHeaders(ctx);
-
-    return stream(ctx, async (s) => {
-      const controller = new AbortController();
-      const { signal } = controller;
-
-      // Handle client disconnection.
-      s.onAbort(() => {
-        controller.abort();
-      });
-
-      const mcpEvents = getMCPEventsForServer(
-        auth,
-        {
-          lastEventId,
-          mcpServerId: serverId,
-        },
-        signal
-      );
-
-      for await (const event of mcpEvents) {
-        await s.write(`data: ${JSON.stringify(event)}\n\n`);
-
-        if (s.aborted || signal.aborted) {
-          break;
-        }
-      }
-
-      await s.write("data: done\n\n");
-    });
-  }
+app.get("/", validate("query", PostMCPRequestsRequestQuerySchema), (ctx) =>
+  streamMcpRequests(ctx, ctx.var.auth, ctx.req.valid("query"))
 );
 
 export default app;


### PR DESCRIPTION
## Description

Figured it out while debugging why the Dust Desktop app would "connect timeout" if there was no events to receive.

Two related fixes to SSE streaming in `front-api`:

- Write a spec-compliant SSE comment (`": connected\n\n"`) at the top of `streamEvents` before the iterator is consumed. This forces HTTP response headers to flush to the client immediately, ahead of any blocking work (Redis subscribe, event history fetch) inside the iterator — preventing clients from stalling on an empty response while the server is still initializing.
- Remove the duplicate inline SSE handler from the public API `mcp/requests` route, replacing it with a call to the existing `streamMcpRequests` helper.

## Tests

Tested manually: verified SSE connections receive the initial comment and that MCP request streaming still functions correctly end-to-end.

## Risk

Low. SSE comments are spec-compliant and silently ignored by all conformant clients. The `mcp/requests` change is a pure refactor — same logic, shared implementation.

## Deploy Plan

Deploy front-api.
