### PR TITLE
feat(google_drive): add create_folder tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -227,6 +227,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "copy_file": "low",
     "create_comment": "low",
     "create_document": "low",
+    "create_folder": "low",
     "create_presentation": "low",
     "create_reply": "low",
     "create_spreadsheet": "low",

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -590,6 +590,13 @@ function getDynamicToolDisplayLabels({
           done: `Create “${t}”`,
         };
       }
+      if (toolName === "create_folder" && isString(inputs.name)) {
+        const t = truncateQuery(inputs.name);
+        return {
+          running: `Creating folder “${t}”`,
+          done: `Create folder “${t}”`,
+        };
+      }
       if (toolName === "get_worksheet" && isString(inputs.range)) {
         const range = truncateQuery(inputs.range);
         return {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -333,6 +333,24 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       done: "Create Google presentation",
     },
   },
+  create_folder: {
+    description:
+      "Create a new Google Drive folder. Optionally specify a parent folder to create it in.",
+    schema: {
+      name: z.string().describe("The name of the new folder."),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the parent folder to create the folder in. If not provided, creates in the user's root Drive. Use the search_files tool with `mimeType = 'application/vnd.google-apps.folder'` to find folder IDs."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Creating Google Drive folder",
+      done: "Create Google Drive folder",
+    },
+  },
   copy_file: {
     description:
       "Copy an existing Google Drive file (Doc, Sheet, or Presentation). " +

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -841,6 +841,40 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
   },
 
+  create_folder: async ({ name, parentId }, { authInfo }) => {
+    const drive = await getDriveClient(authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+    try {
+      const res = await drive.files.create({
+        requestBody: {
+          name,
+          mimeType: "application/vnd.google-apps.folder",
+          ...(parentId ? { parents: [parentId] } : {}),
+        },
+        fields: "id, name, webViewLink",
+        supportsAllDrives: true,
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              folderId: res.data.id,
+              name: res.data.name,
+              url: res.data.webViewLink,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      return handleDriveAccessError(err, authInfo);
+    }
+  },
+
   copy_file: async (
     { fileId, name, parentId, capabilities },
     { authInfo, agentLoopContext }


### PR DESCRIPTION
## Description

Adds a `create_folder` tool to the Google Drive MCP server so agents can create new Google Drive folders (optionally inside a parent folder). This fills the obvious gap in the existing `create_*` surface (Docs/Sheets/Slides can be created, but not folders) and unblocks requests from users who need to create folders from an agent.

Scope decision: this PR intentionally adds **only** folder *creation*. It does not add a dedicated recursive `copy_folder` tool. Folder-tree copying is a cost-heavy operation we don't want to actively push; if a builder genuinely needs to replicate a template structure, they can compose it from `search_files` + `create_folder` + `copy_file`, and own that cost. The `create_folder` description is kept minimal and non-suggestive so it doesn't advertise the recursive pattern.

Relates to dust-tt/tasks#8626.

### Changes
- `metadata.ts`: new `create_folder` entry in `GOOGLE_DRIVE_WRITE_TOOLS_METADATA` (`name` + optional `parentId`, `stake: "low"`, static display labels).
- `tools/index.ts`: new `create_folder` handler mirroring `create_document` (`drive.files.create` with `mimeType: "application/vnd.google-apps.folder"`, `supportsAllDrives: true`).
- `tool_display_labels.ts`: dynamic display label for `create_folder` based on the folder `name`.
- `mcp_servers_metadata.test.ts.snap`: snapshot updated with the new tool stake.

## Tests

Local validation was not run in the Computer (the repo's full validation runs in CI). Changes were made on a local clone and the diff was inspected with `git diff` / `git diff --check` (no whitespace errors). The new tool mirrors the existing, tested `create_document`/`create_spreadsheet`/`create_presentation` handlers exactly (same `files.create` shape and error handling via `handleDriveAccessError`), and the metadata snapshot test was updated to include `create_folder`. Validation is delegated to PR CI.

## Risk

Low. Additive change: one new low-stake write tool that wraps a single `drive.files.create` call, following the existing create-tool pattern and error handling. No changes to existing tools or behavior. Safe to roll back by reverting the PR.

## Deploy Plan

Standard deploy. No migrations, env, or config changes required. The new tool becomes available on the Google Drive MCP server once shipped.