### PR TITLE
[Seats] Add maxSeats hard cap per seat type (#8448 PR5)

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -91,6 +91,15 @@ app.patch(
                 "The free seat is reserved for first-time members and cannot be assigned again.",
             },
           });
+        case "seat_limit_reached":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "The seat type has reached its maximum capacity for this workspace.",
+            },
+          });
         case "metronome_error":
           return apiError(ctx, {
             status_code: 502,

--- a/front/lib/api/credits/seat_plan.ts
+++ b/front/lib/api/credits/seat_plan.ts
@@ -11,6 +11,8 @@ import {
   isMauContract,
   type SeatAwuCreditsPeriod,
 } from "@app/lib/metronome/seat_types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -35,6 +37,10 @@ export interface SeatTypeInfo {
   // `priceCents` is the amount billed per `billingFrequency` (per month for
   // monthly, per year for annual).
   billingFrequency: SeatBillingFrequency;
+  // Hard cap on assignments; null means no cap.
+  maxSeats: number | null;
+  // Number of workspace members currently assigned to this seat type.
+  assignedCount: number;
 }
 
 // Dynamic seat-type → info map. The list of seat types is driven by the
@@ -105,7 +111,11 @@ export async function getSeatPlan(
 
   // Build `productId → seatType` from contract subscriptions so we can resolve
   // rate-schedule entries without comparing product names or IDs.
-  const productSeatTypes = await getProductSeatTypes();
+  const [productSeatTypes, seatLimits, seatCounts] = await Promise.all([
+    getProductSeatTypes(),
+    WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
+    MembershipResource.getActiveSeatTypeCountsForWorkspace({ workspace }),
+  ]);
   const seatTypesByProductId = getSeatTypesByProductIdFromContract(
     contract,
     productSeatTypes
@@ -191,6 +201,7 @@ export async function getSeatPlan(
       seatType,
       productSeatTypes
     );
+    const limit = seatLimits.get(seatType);
     response[seatType] = {
       name,
       awuCredits: awuAllocation.credits,
@@ -198,6 +209,8 @@ export async function getSeatPlan(
       priceCents,
       currency,
       billingFrequency: billingFrequencyBySeatType.get(seatType) ?? "monthly",
+      maxSeats: limit?.maxSeats ?? null,
+      assignedCount: seatCounts[seatType] ?? 0,
     };
   }
   return new Ok(response);

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -26,6 +26,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -97,14 +98,27 @@ async function resolveSeatTypeForNewMembership(
   // otherwise.
   const limitsActive =
     planLimits.maxFreeUsers !== -1 || planLimits.maxLifetimeFreeUsers !== -1;
-  const [productSeatTypes, isReturningMember, freeSeatCounts] =
+  const [productSeatTypes, isReturningMember, freeSeatCounts, seatLimits] =
     await Promise.all([
       getProductSeatTypes(),
       MembershipResource.hasAnyMembershipOfUserInWorkspace({ user, workspace }),
       limitsActive
         ? MembershipResource.getFreeSeatCounts({ workspace })
         : Promise.resolve(undefined),
+      WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
     ]);
+
+  // Only fetch per-seat-type counts when at least one tier has a maxSeats cap
+  // configured
+  const hasAnyCap = [...seatLimits.values()].some(
+    (l) => l.maxSeats !== null && l.maxSeats !== undefined
+  );
+  const seatCounts = hasAnyCap
+    ? await MembershipResource.getActiveSeatTypeCountsForWorkspace({
+        workspace,
+      })
+    : undefined;
+
   const defaultSeatType = getDefaultSeatTypeForContract(
     contract,
     productSeatTypes,
@@ -116,6 +130,8 @@ async function resolveSeatTypeForNewMembership(
         maxActiveFreeUsers: planLimits.maxFreeUsers,
         maxLifetimeFreeUsers: planLimits.maxLifetimeFreeUsers,
       },
+      seatLimits,
+      seatCounts,
     }
   );
   if (!defaultSeatType) {
@@ -555,7 +571,13 @@ export async function updateMembershipSeatAndTrack({
       newSeatType: MembershipSeatType;
       scheduledSeatChangeAt: Date | undefined;
     },
-    { type: "not_found" | "metronome_error" | "free_seat_not_allowed" }
+    {
+      type:
+        | "not_found"
+        | "metronome_error"
+        | "free_seat_not_allowed"
+        | "seat_limit_reached";
+    }
   >
 > {
   const membership =
@@ -575,6 +597,25 @@ export async function updateMembershipSeatAndTrack({
   // (no twice-free). A free→free noop is unaffected: nothing is written.
   if (newSeatType === "free" && previousSeatType !== "free") {
     return new Err({ type: "free_seat_not_allowed" });
+  }
+
+  // Enforce the per-seat-type hard cap. Assigning to `none` (removing a seat)
+  // is always allowed. Same-type noops are also allowed (no net change).
+  if (newSeatType !== "none" && newSeatType !== previousSeatType) {
+    const seatLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    const limit = seatLimits.get(newSeatType);
+    if (limit?.maxSeats !== null && limit?.maxSeats !== undefined) {
+      const seatCounts =
+        await MembershipResource.getActiveSeatTypeCountsForWorkspace({
+          workspace,
+        });
+      const currentCount = seatCounts[newSeatType] ?? 0;
+      if (currentCount >= limit.maxSeats) {
+        return new Err({ type: "seat_limit_reached" });
+      }
+    }
   }
 
   const scheduledRow =

--- a/front/lib/api/poke/plugins/workspaces/manage_seat_limits.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_seat_limits.ts
@@ -16,6 +16,11 @@ const SeatLimitArgsSchema = z.object({
     .number()
     .int("Min seats must be an integer")
     .min(0, "Min seats must be at least 0"),
+  maxSeats: z
+    .number()
+    .int("Max seats must be an integer")
+    .min(1, "Max seats must be at least 1")
+    .optional(),
 });
 
 export const manageSeatLimitsPlugin = createPlugin({
@@ -23,10 +28,11 @@ export const manageSeatLimitsPlugin = createPlugin({
     id: "manage-seat-limits",
     name: "Manage Seat Limits",
     description:
-      "Configure the per-seat-type minimum seat count for this workspace. " +
+      "Configure the per-seat-type minimum and maximum seat counts for this workspace. " +
       "The minimum is the billing floor sent to Metronome even when fewer " +
       "members hold that seat (the shortfall is billed as unassigned seats). " +
-      "Disabling removes the floor for the selected seat type.",
+      "The maximum is a hard cap — assignments into an at-cap tier are rejected. " +
+      "Disabling removes the floor and cap for the selected seat type.",
     resourceTypes: ["workspaces"],
     args: {
       seatType: {
@@ -42,15 +48,23 @@ export const manageSeatLimitsPlugin = createPlugin({
       enabled: {
         type: "boolean",
         variant: "toggle",
-        label: "Enable floor",
+        label: "Enable limits",
         description:
-          "When off, removes any configured minimum for the selected seat type.",
+          "When off, removes any configured minimum and maximum for the selected seat type.",
       },
       minSeats: {
         type: "number",
         variant: "text",
         label: "Min seats",
         description: "Billing floor — minimum seats billed for this type.",
+        dependsOn: { field: "enabled", value: true },
+      },
+      maxSeats: {
+        type: "number",
+        variant: "text",
+        label: "Max seats",
+        description:
+          "Hard cap — maximum seats assignable for this type. Leave blank for no cap.",
         dependsOn: { field: "enabled", value: true },
       },
     },
@@ -73,30 +87,35 @@ export const manageSeatLimitsPlugin = createPlugin({
 
     let message: string;
     if (!args.enabled) {
-      // Disable: drop any configured floor for this seat type.
+      // Disable: drop any configured floor/cap for this seat type.
       const removed = await WorkspaceSeatLimitResource.remove({
         workspace,
         seatType,
       });
       message = removed
-        ? `Removed seat floor for '${seatType}'.`
-        : `No seat floor was configured for '${seatType}'.`;
+        ? `Removed seat limits for '${seatType}'.`
+        : `No seat limits were configured for '${seatType}'.`;
     } else {
       const parseResult = SeatLimitArgsSchema.safeParse(args);
       if (!parseResult.success) {
         return new Err(new Error(fromError(parseResult.error).toString()));
       }
 
-      const { minSeats } = parseResult.data;
-      await WorkspaceSeatLimitResource.upsert({
+      const { minSeats, maxSeats } = parseResult.data;
+      const upsertResult = await WorkspaceSeatLimitResource.upsert({
         workspace,
         seatType,
         minSeats,
+        maxSeats: maxSeats ?? null,
       });
-      message = `Seat floor for '${seatType}' saved: min ${minSeats}.`;
+      if (upsertResult.isErr()) {
+        return new Err(upsertResult.error);
+      }
+      const maxDesc = maxSeats !== undefined ? `, max ${maxSeats}` : ", no cap";
+      message = `Seat limits for '${seatType}' saved: min ${minSeats}${maxDesc}.`;
     }
 
-    // Re-sync seats to Metronome so the new floor is reflected immediately.
+    // Re-sync seats to Metronome so the new limits are reflected immediately.
     const syncResult = await launchMetronomeSeatCountSyncWorkflow({
       workspaceId: workspace.sId,
     });

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -452,11 +452,14 @@ export async function switchContract({
     }
     // A deselected seat carries no billing floor — clear any existing one.
     if (seat.selected && seat.minSeats > 0) {
-      await WorkspaceSeatLimitResource.upsert({
+      const upsertResult = await WorkspaceSeatLimitResource.upsert({
         workspace: owner,
         seatType: seat.seatType,
         minSeats: seat.minSeats,
       });
+      if (upsertResult.isErr()) {
+        throw upsertResult.error;
+      }
     } else {
       await WorkspaceSeatLimitResource.remove({
         workspace: owner,

--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -3,6 +3,7 @@ import {
   getDefaultSeatTypeForContract,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
+import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { describe, expect, it } from "vitest";
 
@@ -45,6 +46,104 @@ describe("getDefaultSeatTypeForContract — entitlement", () => {
     expect(getDefaultSeatTypeForContract(contract, productSeatTypes)).toBe(
       "workspace_yearly"
     );
+  });
+});
+
+// maxSeats cap: skips tiers at capacity; returns "none" when all capped.
+describe("getDefaultSeatTypeForContract — maxSeats cap", () => {
+  const productSeatTypes = new Map<string, MembershipSeatType>([
+    ["pro-product", "pro"],
+    ["max-product", "max"],
+  ]);
+
+  // Contract with two entitled seat types: pro (lower AWU) and max.
+  const contract = {
+    subscriptions: [
+      {
+        id: "sub_pro",
+        subscription_rate: { product: { id: "pro-product", name: "Pro" } },
+      },
+      {
+        id: "sub_max",
+        subscription_rate: { product: { id: "max-product", name: "Max" } },
+      },
+    ],
+    recurring_credits: [],
+    overrides: [
+      { entitled: true, product: { id: "pro-product" } },
+      { entitled: true, product: { id: "max-product" } },
+    ],
+  } as unknown as CachedContract;
+
+  it("skips a capped tier and falls through to the next", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 0, maxSeats: 2 }],
+    ]);
+    // Pro is at cap (2 assigned, maxSeats=2); should fall through to max.
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
+      pro: 2,
+    };
+    expect(
+      getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("max");
+  });
+
+  it("returns none when all tiers are at their maxSeats cap", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 0, maxSeats: 2 }],
+      ["max", { minSeats: 0, maxSeats: 1 }],
+    ]);
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
+      pro: 2,
+      max: 1,
+    };
+    expect(
+      getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("none");
+  });
+
+  it("assigns normally when no tiers are at cap", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 0, maxSeats: 10 }],
+    ]);
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
+      pro: 5,
+    };
+    // Both tiers have 0 AWU; tie-break is alphabetical, so "max" < "pro".
+    // Neither is capped, so the first sorted tier ("max") is assigned.
+    expect(
+      getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("max");
+  });
+
+  it("legacy: no-seat-subscription contract returns workspace regardless of caps", () => {
+    const legacyContract = {
+      subscriptions: [],
+      recurring_credits: [],
+      overrides: [],
+    } as unknown as CachedContract;
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["workspace", { minSeats: 0, maxSeats: 0 }],
+    ]);
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
+      workspace: 99,
+    };
+    // The early-return for no subscriptions runs before cap logic.
+    expect(
+      getDefaultSeatTypeForContract(legacyContract, productSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("workspace");
   });
 });
 

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -2,6 +2,7 @@ import { listMetronomeProducts } from "@app/lib/metronome/client";
 import { SEAT_TYPE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
+import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import type {
   MembershipSeatType,
@@ -164,11 +165,15 @@ export function getDefaultSeatTypeForContract(
     useFreeSeat = true,
     freeSeatCounts,
     freeSeatLimits,
+    seatLimits,
+    seatCounts,
   }: {
     isReturningMember?: boolean;
     useFreeSeat?: boolean;
     freeSeatCounts?: FreeSeatCounts;
     freeSeatLimits?: FreeSeatLimits;
+    seatLimits?: Map<MembershipSeatType, SeatLimit>;
+    seatCounts?: Partial<Record<MembershipSeatType, number>>;
   } = {}
 ): MembershipSeatType | undefined {
   const seatTypesOnContract = [
@@ -186,6 +191,13 @@ export function getDefaultSeatTypeForContract(
     // deterministic when two tiers share an allowance (e.g. workspace = 0
     // and free = 0 on a hybrid contract).
     .sort((a, b) => a.awu - b.awu || a.seatType.localeCompare(b.seatType));
+
+  // Track whether any tier was skipped because it hit its maxSeats cap.
+  // If every tier is capped (and none was skippable for another reason), we
+  // return "none" instead of undefined so callers assign the member to the
+  // "no seat" tier rather than throwing.
+  let anyTierAtMaxCap = false;
+
   for (const { seatType } of ordered) {
     if (seatType === "free") {
       if (isReturningMember || !useFreeSeat) {
@@ -208,9 +220,25 @@ export function getDefaultSeatTypeForContract(
         continue;
       }
     }
+
+    // Skip this tier if it has a maxSeats cap and is at capacity.
+    const limit = seatLimits?.get(seatType);
+    if (limit?.maxSeats !== null && limit?.maxSeats !== undefined) {
+      const assignedCount = seatCounts?.[seatType] ?? 0;
+      if (assignedCount >= limit.maxSeats) {
+        anyTierAtMaxCap = true;
+        continue;
+      }
+    }
+
     return seatType;
   }
-  return undefined;
+
+  // All tiers were skipped: if at least one was capped by maxSeats, signal
+  // "no seat" so the caller assigns the member to the none tier. Otherwise
+  // (e.g. only the free tier exists and it is exhausted) return undefined so
+  // the caller can surface the appropriate error.
+  return anyTierAtMaxCap ? "none" : undefined;
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -635,7 +635,9 @@ export async function syncSeatCount({
         // (free / unlimited tiers) and Metronome doesn't bill them per-seat.
         const actualQuantity = desiredSIdsAt(seatType, Date.now()).length;
         // Clamp up to the configured billing floor: below `minSeats` we still
-        // bill the floor.
+        // bill the floor. `maxSeats` is deliberately NOT applied here — it is
+        // an assignment-time cap, and billing must always reflect the actual
+        // assigned count so members holding a seat are never unbilled.
         const quantity = clampSeatCountToMin(actualQuantity, seatLimit);
         logger.info(
           {
@@ -679,6 +681,8 @@ export async function syncSeatCount({
 /**
  * Clamp a seat count up to the configured `minSeats` billing floor. Counts at
  * or above the floor (or with no limit configured) are returned unchanged.
+ * `maxSeats` is intentionally not applied: it caps new assignments, never the
+ * billed quantity — billing must reflect the seats actually held.
  */
 function clampSeatCountToMin(
   count: number,
@@ -730,6 +734,10 @@ async function reconcileSeatBasedSegment({
   const { assignedSeatIds, unassignedSeats: currentUnassigned } =
     currentResult.value;
 
+  // `maxSeats` is deliberately not enforced here: it caps new assignments
+  // (`seat_limit_reached` upstream), never the synced state. Every member who
+  // actually holds a seat must stay assigned and billed in Metronome — e.g.
+  // when an admin lowers the cap below the current headcount.
   const desired = new Set(desiredSIds);
   const current = new Set(assignedSeatIds);
   const addSeatIds = desiredSIds.filter((id) => !current.has(id));

--- a/front/lib/resources/storage/models/workspace_seat_limit.ts
+++ b/front/lib/resources/storage/models/workspace_seat_limit.ts
@@ -9,8 +9,7 @@ import type { CreationOptional } from "sequelize";
  *
  * - `minSeats`: billing floor for that seat type — the minimum count billed to
  *   Metronome even when the actual headcount on the seat type is lower.
- *
- * (`maxSeats` — a hard cap on assignments — will be added later.)
+ * - `maxSeats`: hard assignment cap — null means no cap.
  */
 export class WorkspaceSeatLimitModel extends WorkspaceAwareModel<WorkspaceSeatLimitModel> {
   declare createdAt: CreationOptional<Date>;
@@ -18,6 +17,7 @@ export class WorkspaceSeatLimitModel extends WorkspaceAwareModel<WorkspaceSeatLi
 
   declare seatType: MembershipSeatType;
   declare minSeats: CreationOptional<number>;
+  declare maxSeats: CreationOptional<number | null>;
 }
 
 WorkspaceSeatLimitModel.init(
@@ -40,6 +40,10 @@ WorkspaceSeatLimitModel.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+    },
+    maxSeats: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/workspace_seat_limit_resource.test.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.test.ts
@@ -11,36 +11,88 @@ describe("WorkspaceSeatLimitResource", () => {
     workspace = await WorkspaceFactory.basic();
   });
 
-  it("upserts and fetches a seat limit", async () => {
-    await WorkspaceSeatLimitResource.upsert({
+  it("upserts and fetches a seat limit (minSeats only)", async () => {
+    const result = await WorkspaceSeatLimitResource.upsert({
       workspace,
       seatType: "pro",
       minSeats: 5,
     });
+    expect(result.isOk()).toBe(true);
 
     const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
       workspace,
     });
-    expect(limits.get("pro")).toEqual({ minSeats: 5 });
+    expect(limits.get("pro")).toEqual({ minSeats: 5, maxSeats: null });
   });
 
-  it("updates minSeats on a second upsert for the same seat type", async () => {
+  it("upserts and fetches a seat limit with maxSeats", async () => {
+    const result = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+      maxSeats: 20,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.get("pro")).toEqual({ minSeats: 5, maxSeats: 20 });
+  });
+
+  it("rejects upsert when maxSeats < minSeats", async () => {
+    const result = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 10,
+      maxSeats: 5,
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toMatch(/maxSeats.*minSeats/);
+    }
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.has("pro")).toBe(false);
+  });
+
+  it("allows maxSeats equal to minSeats", async () => {
+    const result = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 5,
+      maxSeats: 5,
+    });
+    expect(result.isOk()).toBe(true);
+
+    const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
+      workspace,
+    });
+    expect(limits.get("pro")).toEqual({ minSeats: 5, maxSeats: 5 });
+  });
+
+  it("updates minSeats and maxSeats on a second upsert for the same seat type", async () => {
     await WorkspaceSeatLimitResource.upsert({
       workspace,
       seatType: "pro",
       minSeats: 5,
+      maxSeats: 10,
     });
-    await WorkspaceSeatLimitResource.upsert({
+    const result = await WorkspaceSeatLimitResource.upsert({
       workspace,
       seatType: "pro",
       minSeats: 8,
+      maxSeats: 15,
     });
+    expect(result.isOk()).toBe(true);
 
     const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
       workspace,
     });
     expect(limits.size).toBe(1);
-    expect(limits.get("pro")).toEqual({ minSeats: 8 });
+    expect(limits.get("pro")).toEqual({ minSeats: 8, maxSeats: 15 });
   });
 
   it("keeps limits for distinct seat types independent", async () => {
@@ -48,6 +100,7 @@ describe("WorkspaceSeatLimitResource", () => {
       workspace,
       seatType: "pro",
       minSeats: 3,
+      maxSeats: 10,
     });
     await WorkspaceSeatLimitResource.upsert({
       workspace,
@@ -58,8 +111,8 @@ describe("WorkspaceSeatLimitResource", () => {
     const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
       workspace,
     });
-    expect(limits.get("pro")).toEqual({ minSeats: 3 });
-    expect(limits.get("max")).toEqual({ minSeats: 1 });
+    expect(limits.get("pro")).toEqual({ minSeats: 3, maxSeats: 10 });
+    expect(limits.get("max")).toEqual({ minSeats: 1, maxSeats: null });
   });
 
   it("removes a configured limit", async () => {
@@ -67,6 +120,7 @@ describe("WorkspaceSeatLimitResource", () => {
       workspace,
       seatType: "pro",
       minSeats: 5,
+      maxSeats: 20,
     });
 
     const removed = await WorkspaceSeatLimitResource.remove({

--- a/front/lib/resources/workspace_seat_limit_resource.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.ts
@@ -14,10 +14,12 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 /**
  * The seat configuration for a single seat type.
  *
- * (`maxSeats` — a hard cap — will be added later.)
+ * - `minSeats`: billing floor (count billed to Metronome when actual headcount is lower).
+ * - `maxSeats`: hard assignment cap; null means no cap.
  */
 export type SeatLimit = {
   minSeats: number;
+  maxSeats: number | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -38,7 +40,7 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
   /**
    * Returns the configured per-seat-type limits for a workspace, keyed by seat
    * type. Seat types without a row are simply absent from the map (callers
-   * treat that as "no floor").
+   * treat that as "no floor / no cap").
    */
   static async fetchByWorkspace({
     workspace,
@@ -51,7 +53,10 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
     const result = new Map<MembershipSeatType, SeatLimit>();
     for (const row of rows) {
       if (isMembershipSeatType(row.seatType)) {
-        result.set(row.seatType, { minSeats: row.minSeats });
+        result.set(row.seatType, {
+          minSeats: row.minSeats,
+          maxSeats: row.maxSeats ?? null,
+        });
       }
     }
     return result;
@@ -59,30 +64,48 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
 
   /**
    * Create or update the configured limit for a (workspace, seat type).
+   * Rejects when `maxSeats` is set and less than `minSeats`.
    */
   static async upsert({
     workspace,
     seatType,
     minSeats,
+    maxSeats,
     transaction,
   }: {
     workspace: LightWorkspaceType;
     seatType: MembershipSeatType;
     minSeats: number;
+    maxSeats?: number | null;
     transaction?: Transaction;
-  }): Promise<void> {
+  }): Promise<Result<void, Error>> {
+    if (maxSeats !== null && maxSeats !== undefined && maxSeats < minSeats) {
+      return new Err(
+        new Error(
+          `maxSeats (${maxSeats}) must be greater than or equal to minSeats (${minSeats}).`
+        )
+      );
+    }
+    const fields: {
+      minSeats: number;
+      maxSeats?: number | null;
+    } = { minSeats };
+    if (maxSeats !== undefined) {
+      fields.maxSeats = maxSeats;
+    }
     const existing = await this.model.findOne({
       where: { workspaceId: workspace.id, seatType },
       transaction,
     });
     if (existing) {
-      await existing.update({ minSeats }, { transaction });
-      return;
+      await existing.update(fields, { transaction });
+      return new Ok(undefined);
     }
     await this.model.create(
-      { workspaceId: workspace.id, seatType, minSeats },
+      { workspaceId: workspace.id, seatType, ...fields },
       { transaction }
     );
+    return new Ok(undefined);
   }
 
   /**

--- a/front/migrations/db/migration_673.sql
+++ b/front/migrations/db/migration_673.sql
@@ -1,6 +1,0 @@
--- Migration created on Jun 09, 2026
-CREATE TABLE IF NOT EXISTS "membership_upgrade_requests" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "status" VARCHAR(16) NOT NULL DEFAULT 'pending', "resolvedAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , "userId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "resolvedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE, PRIMARY KEY ("id"));
-CREATE INDEX "membership_upgrade_requests_workspace_status_idx" ON "membership_upgrade_requests" ("workspaceId", "status");
-CREATE UNIQUE INDEX "membership_upgrade_requests_workspace_user_pending_idx" ON "membership_upgrade_requests" ("workspaceId", "userId") WHERE "status" = 'pending';
-CREATE INDEX "membership_upgrade_requests_user_idx" ON "membership_upgrade_requests" ("userId");
-CREATE INDEX "membership_upgrade_requests_resolved_by_user_idx" ON "membership_upgrade_requests" ("resolvedByUserId");

--- a/front/migrations/db/migration_673.sql
+++ b/front/migrations/db/migration_673.sql
@@ -1,0 +1,6 @@
+-- Migration created on Jun 09, 2026
+CREATE TABLE IF NOT EXISTS "membership_upgrade_requests" ("createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "status" VARCHAR(16) NOT NULL DEFAULT 'pending', "resolvedAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL, "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "id"  BIGSERIAL , "userId" BIGINT NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE, "resolvedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE, PRIMARY KEY ("id"));
+CREATE INDEX "membership_upgrade_requests_workspace_status_idx" ON "membership_upgrade_requests" ("workspaceId", "status");
+CREATE UNIQUE INDEX "membership_upgrade_requests_workspace_user_pending_idx" ON "membership_upgrade_requests" ("workspaceId", "userId") WHERE "status" = 'pending';
+CREATE INDEX "membership_upgrade_requests_user_idx" ON "membership_upgrade_requests" ("userId");
+CREATE INDEX "membership_upgrade_requests_resolved_by_user_idx" ON "membership_upgrade_requests" ("resolvedByUserId");

--- a/front/migrations/db/migration_675.sql
+++ b/front/migrations/db/migration_675.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 09, 2026
+ALTER TABLE "workspace_seat_limits" ADD COLUMN "maxSeats" INTEGER NULL;


### PR DESCRIPTION

## Description

* https://github.com/dust-tt/tasks/issues/8448
* Adds a per-seat-type assignment cap to workspace_seat_limits. New members auto-fall to `none` when all entitled tiers are at cap; manual assignments are rejected with `seat_limit_reached`. Billing always reflects actual assigned seats — maxSeats is never applied in the Metronome sync path.
* Can edit the cap via poke
* Technically not atomic, so acts as a soft limit

## Tests

<img width="372" height="336" alt="Screenshot 2026-06-09 at 5 19 38 PM" src="https://github.com/user-attachments/assets/b67846b4-9681-44e1-99f2-b9e670e513df" />

## Risk

* Low

## Deploy Plan

* Deploy front