### PR TITLE
Simplify POKE regarding MCP management.

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp/views/index.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 const QuerySchema = z.object({
   globalSpaceOnly: z.enum(["true", "false"]).optional(),
+  systemSpaceOnly: z.enum(["true", "false"]).optional(),
 });
 
 // Mounted at /api/poke/workspaces/:wId/mcp/views.
@@ -19,10 +20,12 @@ app.get(
   validate("query", QuerySchema),
   async (ctx): HandlerResult<PokeListMCPServerViews> => {
     const auth = ctx.get("auth");
-    const { globalSpaceOnly } = ctx.req.valid("query");
+    const { globalSpaceOnly, systemSpaceOnly } = ctx.req.valid("query");
 
     let mcpServerViews: MCPServerViewResource[];
-    if (globalSpaceOnly === "true") {
+    if (systemSpaceOnly === "true") {
+      mcpServerViews = await MCPServerViewResource.listForSystemSpace(auth);
+    } else if (globalSpaceOnly === "true") {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
       mcpServerViews = await MCPServerViewResource.listBySpace(
         auth,

--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -37,7 +37,29 @@ app.get(
       auth
     );
 
-    return ctx.json({ mcpServerView: mcpServerViewJSON });
+    const allViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      mcpServerView.mcpServerId
+    );
+    const spaceViews = allViews
+      .filter((view) => view.space.kind !== "system")
+      .map((view) => {
+        const json = view.toJSON();
+        return {
+          sId: view.sId,
+          spaceId: view.space.sId,
+          space: {
+            sId: view.space.sId,
+            name: view.space.name,
+            kind: view.space.kind,
+          },
+          createdAt: json.createdAt,
+          editedBy: json.editedByUser?.fullName ?? null,
+          editedAt: json.editedByUser?.editedAt ?? null,
+        };
+      });
+
+    return ctx.json({ mcpServerView: mcpServerViewJSON, spaceViews });
   }
 );
 

--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -11,43 +11,12 @@ interface MCPServerView extends PokeMCPServerViewListItemType {
   spaceLink: string;
 }
 
-export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
-  return [
-    {
-      accessorKey: "sId",
-      cell: ({ row }) => {
-        const { mcpServerViewLink, sId } = row.original;
-
-        return <LinkWrapper href={mcpServerViewLink}>{sId}</LinkWrapper>;
-      },
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="sId" />
-      ),
-    },
-    {
-      accessorKey: "name",
-      cell: ({ row }) => {
-        const { mcpServerViewLink, name } = row.original;
-
-        return <LinkWrapper href={mcpServerViewLink}>{name ?? ""}</LinkWrapper>;
-      },
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Custom name" />
-      ),
-    },
-    {
-      accessorKey: "server.name",
-      cell: ({ row }) => {
-        const { mcpServerViewLink, server } = row.original;
-
-        return (
-          <LinkWrapper href={mcpServerViewLink}>{server.name}</LinkWrapper>
-        );
-      },
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Server name" />
-      ),
-    },
+export function makeColumnsForMCPServerViews({
+  hideSpaceColumn = false,
+}: {
+  hideSpaceColumn?: boolean;
+} = {}): ColumnDef<MCPServerView>[] {
+  const columns: ColumnDef<MCPServerView>[] = [
     {
       accessorKey: "server.sId",
       cell: ({ row }) => {
@@ -56,25 +25,39 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
         return `${server.sId}`;
       },
       header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Server ID" />
+        <PokeColumnSortableHeader column={column} label="sId" />
       ),
     },
     {
+      accessorKey: "server.name",
+      cell: ({ row }) => {
+        const { name, server } = row.original;
+        return name ? `${server.name} (${name})` : server.name;
+      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
+    },
+  ];
+
+  if (!hideSpaceColumn) {
+    columns.push({
       accessorKey: "space.name",
       cell: ({ row }) => {
         const { spaceLink, space } = row.original;
-        return <LinkWrapper href={spaceLink}>{space.name}</LinkWrapper>;
+        return (
+          <span onClick={(e) => e.stopPropagation()}>
+            <LinkWrapper href={spaceLink}>{space.name}</LinkWrapper>
+          </span>
+        );
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Space" />
       ),
-    },
-    {
-      accessorKey: "editedBy",
-      header: ({ column }) => (
-        <PokeColumnSortableHeader column={column} label="Last edited by" />
-      ),
-    },
+    });
+  }
+
+  columns.push(
     {
       accessorKey: "createdAt",
       cell: ({ row }) => {
@@ -82,6 +65,12 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
       },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
+    },
+    {
+      accessorKey: "editedBy",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited by" />
       ),
     },
     {
@@ -94,6 +83,8 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Last edited at" />
       ),
-    },
-  ];
+    }
+  );
+
+  return columns;
 }

--- a/front/components/poke/mcp_server_views/space_availability.tsx
+++ b/front/components/poke/mcp_server_views/space_availability.tsx
@@ -1,0 +1,62 @@
+import {
+  PokeTable,
+  PokeTableBody,
+  PokeTableCell,
+  PokeTableCellWithLink,
+  PokeTableHead,
+  PokeTableHeader,
+  PokeTableRow,
+} from "@app/components/poke/shadcn/ui/table";
+import type { PokeMCPServerViewSpaceAvailabilityType } from "@app/lib/api/poke/mcp_server_views";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { LightWorkspaceType } from "@app/types/user";
+
+interface MCPServerSpaceAvailabilityTableProps {
+  owner: LightWorkspaceType;
+  spaceViews: PokeMCPServerViewSpaceAvailabilityType[];
+}
+
+export function MCPServerSpaceAvailabilityTable({
+  owner,
+  spaceViews,
+}: MCPServerSpaceAvailabilityTableProps) {
+  return (
+    <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+      <h2 className="text-md pb-4 font-bold">Available in spaces</h2>
+      {spaceViews.length === 0 ? (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          This server is only installed in the system space and not shared to
+          any other space yet.
+        </p>
+      ) : (
+        <PokeTable>
+          <PokeTableHeader>
+            <PokeTableRow>
+              <PokeTableHead>Space</PokeTableHead>
+              <PokeTableHead>Kind</PokeTableHead>
+              <PokeTableHead>Added by</PokeTableHead>
+              <PokeTableHead>Added at</PokeTableHead>
+            </PokeTableRow>
+          </PokeTableHeader>
+          <PokeTableBody>
+            {spaceViews.map((view) => (
+              <PokeTableRow key={view.sId}>
+                <PokeTableCellWithLink
+                  href={`/poke/${owner.sId}/spaces/${view.spaceId}/mcp_server_views/${view.sId}`}
+                  content={view.space.name}
+                />
+                <PokeTableCell>{view.space.kind}</PokeTableCell>
+                <PokeTableCell>{view.editedBy ?? ""}</PokeTableCell>
+                <PokeTableCell>
+                  {view.editedAt
+                    ? formatTimestampToFriendlyDate(view.editedAt)
+                    : formatTimestampToFriendlyDate(view.createdAt)}
+                </PokeTableCell>
+              </PokeTableRow>
+            ))}
+          </PokeTableBody>
+        </PokeTable>
+      )}
+    </div>
+  );
+}

--- a/front/components/poke/mcp_server_views/table.tsx
+++ b/front/components/poke/mcp_server_views/table.tsx
@@ -2,13 +2,18 @@ import { makeColumnsForMCPServerViews } from "@app/components/poke/mcp_server_vi
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { PokeMCPServerViewListItemType } from "@app/lib/api/poke/mcp_server_views";
-import { usePokeMCPServerViews } from "@app/poke/swr/mcp_server_views";
+import { useAppRouter } from "@app/lib/platform";
+import {
+  usePokeMCPServerViews,
+  usePokeSystemSpaceMCPServerViews,
+} from "@app/poke/swr/mcp_server_views";
 import type { LightWorkspaceType } from "@app/types/user";
 
 interface MCPServerViewsDataTableProps {
   owner: LightWorkspaceType;
   spaceId?: string;
   loadOnInit?: boolean;
+  systemSpaceOnly?: boolean;
 }
 
 function prepareMCPServerViewsForDisplay(
@@ -37,18 +42,28 @@ export function MCPServerViewsDataTable({
   owner,
   spaceId,
   loadOnInit,
+  systemSpaceOnly = false,
 }: MCPServerViewsDataTableProps) {
+  const router = useAppRouter();
+
   return (
     <PokeDataTableConditionalFetch
-      header="MCP Server Views"
+      header={systemSpaceOnly ? "MCP Servers" : "MCP Server Views"}
       owner={owner}
       loadOnInit={loadOnInit}
-      useSWRHook={usePokeMCPServerViews}
+      useSWRHook={
+        systemSpaceOnly
+          ? usePokeSystemSpaceMCPServerViews
+          : usePokeMCPServerViews
+      }
     >
       {(data) => (
         <PokeDataTable
-          columns={makeColumnsForMCPServerViews()}
+          columns={makeColumnsForMCPServerViews({
+            hideSpaceColumn: systemSpaceOnly,
+          })}
           data={prepareMCPServerViewsForDisplay(owner, data, spaceId)}
+          onRowClick={(row) => void router.push(row.mcpServerViewLink)}
         />
       )}
     </PokeDataTableConditionalFetch>

--- a/front/components/poke/pages/MCPServerViewPage.tsx
+++ b/front/components/poke/pages/MCPServerViewPage.tsx
@@ -1,3 +1,4 @@
+import { MCPServerSpaceAvailabilityTable } from "@app/components/poke/mcp_server_views/space_availability";
 import { ToolsConfigTable } from "@app/components/poke/mcp_server_views/tools_config";
 import { ViewMCPServerViewTable } from "@app/components/poke/mcp_server_views/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
@@ -46,18 +47,24 @@ export function MCPServerViewPage() {
     );
   }
 
-  const { mcpServerView } = mcpServerViewDetails;
+  const { mcpServerView, spaceViews } = mcpServerViewDetails;
 
   return (
     <>
       <h3 className="text-xl font-bold">
-        MCP Server View {getMcpServerViewDisplayName(mcpServerView)} in space{" "}
-        <LinkWrapper
-          href={`/poke/${owner.sId}/spaces/${mcpServerView.spaceId}`}
-          className="text-highlight-500"
-        >
-          {mcpServerView.space?.name || mcpServerView.spaceId}
-        </LinkWrapper>{" "}
+        MCP Server {getMcpServerViewDisplayName(mcpServerView)}
+        {mcpServerView.space?.kind !== "system" && (
+          <>
+            {" "}
+            in space{" "}
+            <LinkWrapper
+              href={`/poke/${owner.sId}/spaces/${mcpServerView.spaceId}`}
+              className="text-highlight-500"
+            >
+              {mcpServerView.space?.name || mcpServerView.spaceId}
+            </LinkWrapper>
+          </>
+        )}{" "}
         within workspace{" "}
         <LinkWrapper href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
@@ -66,6 +73,10 @@ export function MCPServerViewPage() {
       <div className="flex flex-row gap-x-6">
         <div className="flex flex-col">
           <ViewMCPServerViewTable mcpServerView={mcpServerView} owner={owner} />
+          <MCPServerSpaceAvailabilityTable
+            owner={owner}
+            spaceViews={spaceViews}
+          />
           <ToolsConfigTable mcpServerView={mcpServerView} />
         </div>
         <div className="mt-4 flex grow flex-col gap-y-4">

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -277,7 +277,7 @@ export function WorkspacePage() {
               <TabsTrigger value="datasourceviews" label="Data Source Views" />
               <TabsTrigger value="featureflags" label="Feature Flags" />
               <TabsTrigger value="groups" label="Groups" />
-              <TabsTrigger value="mcpviews" label="MCP Server Views" />
+              <TabsTrigger value="mcpviews" label="MCP" />
               <TabsTrigger value="pods" label="Pods" />
               <TabsTrigger value="skills" label="Skills" />
               <TabsTrigger value="spaces" label="Spaces" />
@@ -296,7 +296,11 @@ export function WorkspacePage() {
               <DataSourceViewsDataTable owner={owner} loadOnInit />
             </TabsContent>
             <TabsContent value="mcpviews">
-              <MCPServerViewsDataTable owner={owner} loadOnInit />
+              <MCPServerViewsDataTable
+                owner={owner}
+                loadOnInit
+                systemSpaceOnly
+              />
             </TabsContent>
             <TabsContent value="pods">
               <ProjectsDataTable owner={owner} loadOnInit />

--- a/front/components/poke/shadcn/ui/data_table.tsx
+++ b/front/components/poke/shadcn/ui/data_table.tsx
@@ -58,6 +58,7 @@ interface DataTableProps<TData, TValue> {
   // caller) instead of the built-in client-side global filter.
   search?: string;
   onSearchChange?: (search: string) => void;
+  onRowClick?: (row: TData) => void;
 }
 
 export function PokeDataTable<TData, TValue>({
@@ -74,6 +75,7 @@ export function PokeDataTable<TData, TValue>({
   onSortingChange,
   search,
   onSearchChange,
+  onRowClick,
 }: DataTableProps<TData, TValue>) {
   const isServerSide = serverSideRowCount !== undefined;
   const isServerSearch = onSearchChange !== undefined;
@@ -199,6 +201,10 @@ export function PokeDataTable<TData, TValue>({
                 <PokeTableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
+                  className={onRowClick ? "cursor-pointer" : undefined}
+                  onClick={
+                    onRowClick ? () => onRowClick(row.original) : undefined
+                  }
                 >
                   {row.getVisibleCells().map((cell) => (
                     <PokeTableCell key={cell.id}>

--- a/front/lib/api/poke/mcp_server_views.ts
+++ b/front/lib/api/poke/mcp_server_views.ts
@@ -10,6 +10,16 @@ export type PokeListMCPServerViews = {
   serverViews: PokeMCPServerViewListItemType[];
 };
 
+export type PokeMCPServerViewSpaceAvailabilityType = {
+  sId: string;
+  spaceId: string;
+  space: Pick<SpaceType, "sId" | "name" | "kind">;
+  createdAt: number;
+  editedBy: string | null;
+  editedAt: number | null;
+};
+
 export type PokeGetMCPServerViewDetails = {
   mcpServerView: PokeMCPServerViewType;
+  spaceViews: PokeMCPServerViewSpaceAvailabilityType[];
 };

--- a/front/poke/swr/mcp_server_views.ts
+++ b/front/poke/swr/mcp_server_views.ts
@@ -5,6 +5,7 @@ import type { Fetcher } from "swr";
 
 interface UsePokeMCPServerViewsProps extends PokeConditionalFetchProps {
   globalSpaceOnly?: boolean;
+  systemSpaceOnly?: boolean;
 }
 
 /*
@@ -14,6 +15,7 @@ export function usePokeMCPServerViews({
   disabled,
   owner,
   globalSpaceOnly,
+  systemSpaceOnly,
 }: UsePokeMCPServerViewsProps) {
   const { fetcher } = useFetcher();
   const mcpServerViewsFetcher: Fetcher<PokeListMCPServerViews> = fetcher;
@@ -21,6 +23,9 @@ export function usePokeMCPServerViews({
   const params = new URLSearchParams();
   if (globalSpaceOnly) {
     params.set("globalSpaceOnly", "true");
+  }
+  if (systemSpaceOnly) {
+    params.set("systemSpaceOnly", "true");
   }
 
   const { data, error, mutate } = useSWRWithDefaults(
@@ -35,4 +40,10 @@ export function usePokeMCPServerViews({
     isError: error,
     mutate,
   };
+}
+
+export function usePokeSystemSpaceMCPServerViews(
+  props: PokeConditionalFetchProps
+) {
+  return usePokeMCPServerViews({ ...props, systemSpaceOnly: true });
 }


### PR DESCRIPTION
## Description

Reworks the Poke MCP management experience to surface servers in a more intuitive way:

- The workspace "MCP" tab now lists only system-space servers (via new `systemSpaceOnly` query param on `MCPServerViewResource.listForSystemSpace`), hiding the space column and enabling row-click navigation to the detail page.
- The `MCPServerViewPage` detail page drops "View" from its title for system-space entries, and adds a new `MCPServerSpaceAvailabilityTable` showing which non-system spaces the server has been shared into (fetched via `MCPServerViewResource.listByMCPServer` + `spaceViews` added to the details endpoint response).
- `makeColumnsForMCPServerViews` gains a `hideSpaceColumn` option; server name column merges custom name as `"Server (custom name)"`.
- `PokeDataTable` gains an `onRowClick` prop with `cursor-pointer` styling.

## Tests

Tested manually in Poke.

## Risk

Low — Poke-only UI changes, no data model changes, no migrations. The new `systemSpaceOnly` filter is additive; `globalSpaceOnly` path is unchanged.

## Deploy Plan

Deploy front.
