### PR TITLE
[Skills] Fix Dust skill avatar size in dropdowns

### DIFF
--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -93,11 +93,12 @@ export function getSkillAvatarIcon(
 
   return ({ className, size, ...props }) => {
     const avatarSize = size ?? "sm";
-    const badgeSize = size ?? "sm";
+    // Size is relative to avatar, not equal to avatar size.
+    const relativeBadgeSize = size ?? "sm";
 
     return React.createElement(ResourceAvatarWithBadge, {
       badgeIcon: DustLogoSquare,
-      badgeSize,
+      badgeSize: relativeBadgeSize,
       className: size ? className : undefined,
       icon: skillIcon,
       size: avatarSize,

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -92,13 +92,13 @@ export function getSkillAvatarIcon(
   }
 
   return ({ className, size, ...props }) => {
-    const avatarSize = size ?? (className ? "xxs" : "sm");
-    const badgeSize = size ?? (className ? "xxs" : "sm");
+    const avatarSize = size ?? "sm";
+    const badgeSize = size ?? "sm";
 
     return React.createElement(ResourceAvatarWithBadge, {
       badgeIcon: DustLogoSquare,
       badgeSize,
-      className,
+      className: size ? className : undefined,
       icon: skillIcon,
       size: avatarSize,
       backgroundColor: SKILL_AVATAR_BACKGROUND_COLOR,


### PR DESCRIPTION
## Description
Fixes a regression from https://github.com/dust-tt/dust/pull/27073.

Dust-provided skill avatars rendered smaller than other skill avatars in slash capability dropdowns, which also shifted the text left. The dropdown icon renderer passes SVG sizing through `className`; the badged avatar path was interpreting that as an avatar size signal and rendering the avatar as `xxs`.

This keeps Dust-provided skill avatars at the same default `sm` avatar size as regular skill avatars when no explicit `size` prop is provided, while still preserving explicit sizes in other surfaces.

### After:
<img width="642" height="576" alt="image" src="https://github.com/user-attachments/assets/7f4bca9a-5f8b-4521-9a6c-d5c9501c1cbe" />

### Before:
<img width="642" height="576" alt="image" src="https://github.com/user-attachments/assets/7f00ce96-7442-4c6e-8c17-fb7be348ac73" />

## Risks
Blast radius: Dust-provided skill avatar rendering in front surfaces.
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- [x] `NODE_ENV=test npm test components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts components/editor/extensions/skill_builder/SlashCommandExtension.test.ts`