### PR TITLE
feat: business admin navbar

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -136,6 +136,7 @@ export const NavigationSidebar = React.forwardRef<
                             <NavigationListItem
                               key={menu.id}
                               selected={menu.current}
+                              disabled={menu.disabled}
                               label={menu.label}
                               icon={menu.icon}
                               href={menu.href}

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -252,6 +252,11 @@ export const subNavigationAdmin = ({
   const isCurrent = (id: SubNavigationAdminId): boolean =>
     matchesRoutePattern(currentRoute, ADMIN_ROUTE_PATTERNS[id]);
 
+  const hasWorkspaceAdminPermission = hasPermission(
+    owner.role,
+    "workspace:admin"
+  );
+
   nav.push({
     id: "workspace",
     label: "Workspace",
@@ -270,7 +275,7 @@ export const subNavigationAdmin = ({
         icon: Fingerprint04,
         href: `/w/${owner.sId}/identity-and-provisioning`,
         current: isCurrent("identity_and_provisioning"),
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       {
         id: "workspace",
@@ -278,7 +283,7 @@ export const subNavigationAdmin = ({
         icon: Building04,
         href: `/w/${owner.sId}/workspace`,
         current: isCurrent("workspace"),
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       ...(isCreditPricedPlan(subscription.plan)
         ? [
@@ -288,7 +293,7 @@ export const subNavigationAdmin = ({
               icon: PieChart01,
               href: `/w/${owner.sId}/usage`,
               current: isCurrent("usage"),
-              disabled: !hasPermission(owner.role, "workspace:admin"),
+              disabled: !hasWorkspaceAdminPermission,
             },
           ]
         : []),
@@ -298,7 +303,7 @@ export const subNavigationAdmin = ({
         icon: Brain,
         href: `/w/${owner.sId}/model-providers`,
         current: isCurrent("model_providers"),
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       {
         id: "analytics",
@@ -306,7 +311,7 @@ export const subNavigationAdmin = ({
         icon: BarChart01,
         href: `/w/${owner.sId}/analytics`,
         current: isCurrent("analytics"),
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       isCreditPricedPlan(subscription.plan)
         ? {
@@ -315,7 +320,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/billing`,
             current: isCurrent("billing"),
-            disabled: !hasPermission(owner.role, "workspace:admin"),
+            disabled: !hasWorkspaceAdminPermission,
           }
         : {
             id: "subscription",
@@ -323,7 +328,7 @@ export const subNavigationAdmin = ({
             icon: CreditCard01,
             href: `/w/${owner.sId}/subscription`,
             current: isCurrent("subscription"),
-            disabled: !hasPermission(owner.role, "workspace:admin"),
+            disabled: !hasWorkspaceAdminPermission,
           },
     ],
   });
@@ -338,7 +343,7 @@ export const subNavigationAdmin = ({
         icon: Lock01,
         href: `/w/${owner.sId}/developers/api-keys`,
         current: isCurrent("api_keys"),
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       ...(isCreditPricedPlan(subscription.plan)
         ? []
@@ -349,7 +354,7 @@ export const subNavigationAdmin = ({
               icon: Zap,
               href: `/w/${owner.sId}/developers/credits-usage`,
               current: isCurrent("credits_usage"),
-              disabled: !hasPermission(owner.role, "workspace:admin"),
+              disabled: !hasWorkspaceAdminPermission,
             },
           ]),
     ],
@@ -366,7 +371,7 @@ export const subNavigationAdmin = ({
         href: `/w/${owner.sId}/developers/providers`,
         current: isCurrent("providers"),
         featureFlag: "legacy_dust_apps",
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       {
         id: "dev_secrets",
@@ -374,7 +379,7 @@ export const subNavigationAdmin = ({
         icon: Brackets,
         href: `/w/${owner.sId}/developers/dev-secrets`,
         current: isCurrent("dev_secrets"),
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       {
         id: "sandbox",
@@ -383,7 +388,7 @@ export const subNavigationAdmin = ({
         href: `/w/${owner.sId}/developers/sandbox`,
         current: isCurrent("sandbox"),
         featureFlag: "sandbox_workspace_admin",
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
       {
         id: "self_improving_skills",
@@ -392,7 +397,7 @@ export const subNavigationAdmin = ({
         href: `/w/${owner.sId}/developers/self-improving-skills`,
         current: isCurrent("self_improving_skills"),
         featureFlag: "reinforcement_ui",
-        disabled: !hasPermission(owner.role, "workspace:admin"),
+        disabled: !hasWorkspaceAdminPermission,
       },
     ],
   });

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -1,9 +1,10 @@
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { AppType } from "@app/types/app";
+import { hasPermission } from "@app/types/permissions";
 import { isCreditPricedPlan, type SubscriptionType } from "@app/types/plan";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { WorkspaceType } from "@app/types/user";
-import { isAdmin, isBuilder } from "@app/types/user";
+import { isAdmin, isBuilder, isOnlyBusinessAdmin } from "@app/types/user";
 import {
   BarChart01,
   Brackets,
@@ -132,6 +133,9 @@ export type AppLayoutNavigation = {
   hasSeparator?: boolean;
   current: boolean;
   featureFlag?: WhitelistableFeature;
+  // When true, the item is shown but greyed out and not navigable (the current
+  // role lacks the permission to access it).
+  disabled?: boolean;
 };
 
 export type TabAppLayoutNavigation = {
@@ -195,7 +199,7 @@ export const getTopNavigationTabs = (
     ref: spaceMenuButtonRef,
   });
 
-  if (isAdmin(owner)) {
+  if (isAdmin(owner) || isOnlyBusinessAdmin(owner)) {
     nav.push({
       id: "settings",
       label: "Admin",
@@ -239,145 +243,159 @@ export const subNavigationAdmin = ({
 }): SidebarNavigation[] => {
   const nav: SidebarNavigation[] = [];
 
-  if (!isBuilder(owner)) {
+  // Admins and business admins see the admin sidebar; builders and members do
+  // not. Each item is then individually enabled/disabled based on permission.
+  if (!isAdmin(owner) && !isOnlyBusinessAdmin(owner)) {
     return nav;
   }
 
   const isCurrent = (id: SubNavigationAdminId): boolean =>
     matchesRoutePattern(currentRoute, ADMIN_ROUTE_PATTERNS[id]);
 
-  if (isAdmin(owner)) {
-    nav.push({
-      id: "workspace",
-      label: "Workspace",
-      menus: [
-        {
-          id: "members",
-          label: "People",
-          icon: Users01,
-          href: `/w/${owner.sId}/members`,
-          current: isCurrent("members"),
-        },
-        {
-          id: "identity_and_provisioning",
-          label: "Identity & Provisioning",
-          icon: Fingerprint04,
-          href: `/w/${owner.sId}/identity-and-provisioning`,
-          current: isCurrent("identity_and_provisioning"),
-        },
-        {
-          id: "workspace",
-          label: "Workspace Settings",
-          icon: Building04,
-          href: `/w/${owner.sId}/workspace`,
-          current: isCurrent("workspace"),
-        },
-        ...(isCreditPricedPlan(subscription.plan)
-          ? [
-              {
-                id: "usage" as const,
-                label: "Usage",
-                icon: PieChart01,
-                href: `/w/${owner.sId}/usage`,
-                current: isCurrent("usage"),
-              },
-            ]
-          : []),
-        {
-          id: "model_providers",
-          label: "Model Providers",
-          icon: Brain,
-          href: `/w/${owner.sId}/model-providers`,
-          current: isCurrent("model_providers"),
-        },
-        {
-          id: "analytics",
-          label: "Analytics",
-          icon: BarChart01,
-          href: `/w/${owner.sId}/analytics`,
-          current: isCurrent("analytics"),
-        },
-        isCreditPricedPlan(subscription.plan)
-          ? {
-              id: "billing",
-              label: "Billing",
-              icon: CreditCard01,
-              href: `/w/${owner.sId}/billing`,
-              current: isCurrent("billing"),
-            }
-          : {
-              id: "subscription",
-              label: "Subscription",
-              icon: CreditCard01,
-              href: `/w/${owner.sId}/subscription`,
-              current: isCurrent("subscription"),
+  nav.push({
+    id: "workspace",
+    label: "Workspace",
+    menus: [
+      {
+        id: "members",
+        label: "People",
+        icon: Users01,
+        href: `/w/${owner.sId}/members`,
+        current: isCurrent("members"),
+        disabled: !hasPermission(owner.role, "workspace:manage_members"),
+      },
+      {
+        id: "identity_and_provisioning",
+        label: "Identity & Provisioning",
+        icon: Fingerprint04,
+        href: `/w/${owner.sId}/identity-and-provisioning`,
+        current: isCurrent("identity_and_provisioning"),
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      {
+        id: "workspace",
+        label: "Workspace Settings",
+        icon: Building04,
+        href: `/w/${owner.sId}/workspace`,
+        current: isCurrent("workspace"),
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      ...(isCreditPricedPlan(subscription.plan)
+        ? [
+            {
+              id: "usage" as const,
+              label: "Usage",
+              icon: PieChart01,
+              href: `/w/${owner.sId}/usage`,
+              current: isCurrent("usage"),
+              disabled: !hasPermission(owner.role, "workspace:admin"),
             },
-      ],
-    });
+          ]
+        : []),
+      {
+        id: "model_providers",
+        label: "Model Providers",
+        icon: Brain,
+        href: `/w/${owner.sId}/model-providers`,
+        current: isCurrent("model_providers"),
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      {
+        id: "analytics",
+        label: "Analytics",
+        icon: BarChart01,
+        href: `/w/${owner.sId}/analytics`,
+        current: isCurrent("analytics"),
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      isCreditPricedPlan(subscription.plan)
+        ? {
+            id: "billing",
+            label: "Billing",
+            icon: CreditCard01,
+            href: `/w/${owner.sId}/billing`,
+            current: isCurrent("billing"),
+            disabled: !hasPermission(owner.role, "workspace:admin"),
+          }
+        : {
+            id: "subscription",
+            label: "Subscription",
+            icon: CreditCard01,
+            href: `/w/${owner.sId}/subscription`,
+            current: isCurrent("subscription"),
+            disabled: !hasPermission(owner.role, "workspace:admin"),
+          },
+    ],
+  });
 
-    nav.push({
-      id: "api",
-      label: "API & Programmatic",
-      menus: [
-        {
-          id: "api_keys",
-          label: "API Keys",
-          icon: Lock01,
-          href: `/w/${owner.sId}/developers/api-keys`,
-          current: isCurrent("api_keys"),
-        },
-        ...(isCreditPricedPlan(subscription.plan)
-          ? []
-          : [
-              {
-                id: "credits_usage" as const,
-                label: "Programmatic Usage",
-                icon: Zap,
-                href: `/w/${owner.sId}/developers/credits-usage`,
-                current: isCurrent("credits_usage"),
-              },
-            ]),
-      ],
-    });
+  nav.push({
+    id: "api",
+    label: "API & Programmatic",
+    menus: [
+      {
+        id: "api_keys",
+        label: "API Keys",
+        icon: Lock01,
+        href: `/w/${owner.sId}/developers/api-keys`,
+        current: isCurrent("api_keys"),
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      ...(isCreditPricedPlan(subscription.plan)
+        ? []
+        : [
+            {
+              id: "credits_usage" as const,
+              label: "Programmatic Usage",
+              icon: Zap,
+              href: `/w/${owner.sId}/developers/credits-usage`,
+              current: isCurrent("credits_usage"),
+              disabled: !hasPermission(owner.role, "workspace:admin"),
+            },
+          ]),
+    ],
+  });
 
-    nav.push({
-      id: "developers",
-      label: "Builder Tools",
-      menus: [
-        {
-          id: "providers",
-          label: "App Credentials",
-          icon: Shapes,
-          href: `/w/${owner.sId}/developers/providers`,
-          current: isCurrent("providers"),
-          featureFlag: "legacy_dust_apps",
-        },
-        {
-          id: "dev_secrets",
-          label: "Secrets",
-          icon: Brackets,
-          href: `/w/${owner.sId}/developers/dev-secrets`,
-          current: isCurrent("dev_secrets"),
-        },
-        {
-          id: "sandbox",
-          label: "Computer",
-          icon: Globe01,
-          href: `/w/${owner.sId}/developers/sandbox`,
-          current: isCurrent("sandbox"),
-          featureFlag: "sandbox_workspace_admin",
-        },
-        {
-          id: "self_improving_skills",
-          label: "Self-Improving Skills",
-          icon: Stars02,
-          href: `/w/${owner.sId}/developers/self-improving-skills`,
-          current: isCurrent("self_improving_skills"),
-          featureFlag: "reinforcement_ui",
-        },
-      ],
-    });
-  }
+  nav.push({
+    id: "developers",
+    label: "Builder Tools",
+    menus: [
+      {
+        id: "providers",
+        label: "App Credentials",
+        icon: Shapes,
+        href: `/w/${owner.sId}/developers/providers`,
+        current: isCurrent("providers"),
+        featureFlag: "legacy_dust_apps",
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      {
+        id: "dev_secrets",
+        label: "Secrets",
+        icon: Brackets,
+        href: `/w/${owner.sId}/developers/dev-secrets`,
+        current: isCurrent("dev_secrets"),
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      {
+        id: "sandbox",
+        label: "Computer",
+        icon: Globe01,
+        href: `/w/${owner.sId}/developers/sandbox`,
+        current: isCurrent("sandbox"),
+        featureFlag: "sandbox_workspace_admin",
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+      {
+        id: "self_improving_skills",
+        label: "Self-Improving Skills",
+        icon: Stars02,
+        href: `/w/${owner.sId}/developers/self-improving-skills`,
+        current: isCurrent("self_improving_skills"),
+        featureFlag: "reinforcement_ui",
+        disabled: !hasPermission(owner.role, "workspace:admin"),
+      },
+    ],
+  });
 
   return nav;
 };

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -52,6 +52,7 @@ interface NavigationListItemProps
   extends React.HTMLAttributes<HTMLDivElement>,
     Omit<LinkWrapperProps, "children" | "className"> {
   selected?: boolean;
+  disabled?: boolean;
   label?: string;
   labelAnimation?: "none" | "typing" | "streaming";
   onTypingAnimationComplete?: () => void;
@@ -72,6 +73,7 @@ const NavigationListItem = React.forwardRef<
     {
       className,
       selected,
+      disabled,
       label,
       labelAnimation = "none",
       onTypingAnimationComplete,
@@ -114,16 +116,18 @@ const NavigationListItem = React.forwardRef<
         ref={ref}
         data-nav="menu-button"
         data-selected={selected}
+        data-disabled={disabled}
         {...props}
       >
         <LinkWrapper
-          href={href}
+          href={disabled ? undefined : href}
           target={target}
           rel={rel}
           replace={replace}
           shallow={shallow}
         >
           <div
+            aria-disabled={disabled}
             className={cn(
               "s-peer/menu-button",
               "s-text-primary dark:s-text-primary-night s-font-medium",
@@ -131,7 +135,8 @@ const NavigationListItem = React.forwardRef<
               "s-items-center s-outline-none s-rounded-lg s-text-sm s-p-2 s-transition-colors",
               "data-[disabled]:s-pointer-events-none",
               "hover:s-bg-stone-100 dark:hover:s-bg-primary-200-night",
-              selected && "s-bg-stone-100 dark:s-bg-primary-200-night"
+              selected && "s-bg-stone-100 dark:s-bg-primary-200-night",
+              disabled && "s-pointer-events-none s-cursor-default s-opacity-50"
             )}
           >
             {icon && (


### PR DESCRIPTION
## Description

This PR adds the admin navbar and sidebar to business admins, with items requiring full admin permissions shown as disabled (greyed out and non-navigable). A popup explaining why they cannot access the page will be added in a follow up.

- Extends `getTopNavigationTabs` and `subNavigationAdmin` to include `isOnlyBusinessAdmin` users, previously restricted to admins only.
- Admin sidebar items now use `hasPermission(owner.role, "workspace:admin")` to conditionally set `disabled`, so business admins see the full sidebar but can only navigate to items within their permissions.
- Adds `disabled` prop to `NavigationListItem` in the sparkle component, which removes the `href` and applies reduced-opacity styling when disabled.

<img width="308" height="686" alt="Capture d’écran 2026-06-10 à 10 57 40" src="https://github.com/user-attachments/assets/301d414f-171d-49e2-b403-7eda52138346" />


## Tests

Manually.

## Risks

## Deploy Plan
