### PR TITLE
More logs to debug JIRA.

### DIFF
--- a/core/src/oauth/providers/jira.rs
+++ b/core/src/oauth/providers/jira.rs
@@ -14,9 +14,9 @@ use async_trait::async_trait;
 use lazy_static::lazy_static;
 use serde_json::json;
 use std::env;
-use tracing::info;
+use tracing::{error, info};
 
-use super::utils::ProviderHttpRequestError;
+use super::utils::{error_source_chain, network_error_kind, ProviderHttpRequestError};
 
 lazy_static! {
     static ref OAUTH_JIRA_CLIENT_ID: String = env::var("OAUTH_JIRA_CLIENT_ID").unwrap();
@@ -77,15 +77,36 @@ fn log_jira_refresh_error(connection: &Connection, error: &ProviderHttpRequestEr
             status, message, ..
         } => {
             let is_revoked = is_jira_refresh_token_revoked(*status, message);
-            info!(
+            error!(
                 connection_id = connection.connection_id(),
                 status, message, is_revoked, "JIRA refresh OAuth error"
             );
         }
-        _ => {
-            info!(
+        ProviderHttpRequestError::NetworkError(e) => {
+            error!(
                 connection_id = connection.connection_id(),
-                error = %error,
+                error_kind = network_error_kind(e),
+                error_message = %e,
+                error_chain = %error_source_chain(e),
+                url = ?e.url().map(|u| u.as_str()),
+                http_status = ?e.status().map(|s| s.as_u16()),
+                is_connect = e.is_connect(),
+                is_timeout = e.is_timeout(),
+                "JIRA refresh OAuth error"
+            );
+        }
+        ProviderHttpRequestError::Timeout => {
+            error!(
+                connection_id = connection.connection_id(),
+                error_kind = "timeout",
+                "JIRA refresh OAuth error"
+            );
+        }
+        ProviderHttpRequestError::InvalidResponse(e) => {
+            error!(
+                connection_id = connection.connection_id(),
+                error = %e,
+                error_chain = %error_source_chain(e.as_ref()),
                 "JIRA refresh OAuth error"
             );
         }

--- a/core/src/oauth/providers/utils.rs
+++ b/core/src/oauth/providers/utils.rs
@@ -10,6 +10,34 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tracing::{error, info};
 
+pub fn network_error_kind(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connect"
+    } else if error.is_request() {
+        "request"
+    } else if error.is_body() {
+        "body"
+    } else if error.is_decode() {
+        "decode"
+    } else if error.is_status() {
+        "status"
+    } else {
+        "unknown"
+    }
+}
+
+pub fn error_source_chain(error: &(dyn std::error::Error + '_)) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut current = error.source();
+    while let Some(source) = current {
+        parts.push(source.to_string());
+        current = source.source();
+    }
+    parts.join(" | ")
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderHttpRequestError {
     #[error("Network error: {0}")]


### PR DESCRIPTION
## Description

Improves structured logging in `log_jira_refresh_error` to help diagnose JIRA OAuth token refresh failures. Switches from `info!` to `error!` and expands the catch-all error arm into three explicit `ProviderHttpRequestError` variants (`NetworkError`, `Timeout`, `InvalidResponse`), each emitting structured fields (error kind, message, source chain, URL, HTTP status, connect/timeout flags). Adds two helpers in `utils.rs`: `network_error_kind` and `error_source_chain`.

## Tests

Observability-only change — tested by deploying and monitoring logs during JIRA OAuth refresh flows.

## Risk

Low. Pure logging change — no behavior or auth logic modified. Safe to rollback at any time.

## Deploy Plan

Deploy `core`.
