### PR TITLE
Cleanup stripe invoices

### DIFF
--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -44,6 +44,7 @@ import {
   isAwuPurchaseInvoice,
   isCreditPurchaseInvoice,
   isEnterpriseSubscription,
+  isMetronomePushedInvoice,
   isSubscriptionActivationInvoice,
 } from "@app/lib/plans/stripe";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -56,6 +57,7 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import { launchCleanMetronomeInvoiceWorkflow } from "@app/temporal/metronome_events_queue/client";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
@@ -831,6 +833,49 @@ export async function processStripeWebhookEvent({
         // pending-purchase eligibility check works.
       } else {
         await ctx.subscription.clearPaymentFailingStatus();
+      }
+      break;
+    }
+
+    case "invoice.created": {
+      const invoice = event.data.object as Stripe.Invoice;
+
+      // Only Metronome-pushed draft invoices are eligible for line cleaning.
+      if (!isMetronomePushedInvoice(invoice) || invoice.status !== "draft") {
+        break;
+      }
+
+      const metronomeCustomerId = invoice.metadata?.metronome_customer_id;
+      const workspace = metronomeCustomerId
+        ? await WorkspaceResource.fetchByMetronomeCustomerId(
+            metronomeCustomerId
+          )
+        : null;
+      if (!workspace) {
+        logger.warn(
+          { invoiceId: invoice.id, metronomeCustomerId },
+          "[Stripe Webhook] invoice.created: workspace not found for Metronome invoice, skipping clean"
+        );
+        break;
+      }
+
+      // Defer cleaning so Metronome finishes writing all line items before we
+      // touch the draft; the workflow re-fetches and self-gates (draft +
+      // not-yet-cleaned) and finalizes explicitly.
+      const launchResult = await launchCleanMetronomeInvoiceWorkflow({
+        invoiceId: invoice.id,
+        workspaceId: workspace.sId,
+      });
+      if (launchResult.isErr()) {
+        logger.error(
+          {
+            invoiceId: invoice.id,
+            workspaceId: workspace.sId,
+            error: launchResult.error,
+            stripeError: true,
+          },
+          "[Stripe Webhook] Failed to launch invoice clean workflow"
+        );
       }
       break;
     }

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -918,6 +918,15 @@ export function isAwuPurchaseInvoice(invoice: Stripe.Invoice): boolean {
 }
 
 /**
+ * Any invoice Metronome generated and pushed to Stripe — identified by the
+ * `metronome_customer_id` metadata Metronome stamps on every invoice it pushes.
+ * Scopes the line-cleaning flow to Metronome invoices only.
+ */
+export function isMetronomePushedInvoice(invoice: Stripe.Invoice): boolean {
+  return invoice.metadata?.metronome_customer_id != null;
+}
+
+/**
  * Extracts the credit amount in cents from a credit purchase invoice.
  * Returns null if the invoice is not a credit purchase or if the amount is invalid.
  */
@@ -1347,6 +1356,136 @@ export async function finalizeInvoice(
     );
     return new Err({
       error_message: `Failed to finalize invoice: ${normalizeError(error).message}`,
+    });
+  }
+}
+
+/**
+ * Metadata flag stamped on a Metronome draft invoice once we have normalized its
+ * line items, so redeliveries / Temporal retries don't clean it twice.
+ */
+const METRONOME_INVOICE_LINES_CLEANED_FLAG = "lines_cleaned";
+
+/**
+ * Normalizes the line items of a Metronome-pushed draft invoice in place (via the
+ * Stripe API) before finalization — e.g. dropping zero-amount noise, merging
+ * granular usage lines into summary lines, or relabeling descriptions.
+ *
+ * INVARIANT: the transform MUST preserve the invoice's pre-tax total. Metronome
+ * remains the source of truth for what was billed (credit drawdown, revenue
+ * reporting, the `payment_gate.*` reconciliation all key off Metronome's figure);
+ * changing the amount here would silently desync Stripe from Metronome. Cleaning
+ * is presentation-only.
+ *
+ * TODO(billing): implement the actual line transform once the target invoice
+ * shape is pinned down. Use `stripe.invoices.updateLines` / `addLines` /
+ * `removeLines` (or `stripe.invoiceItems.*` for invoice-item-backed lines).
+ * For now this only reads and logs every line item (auto-paginated) so we can
+ * inspect the exact shape Metronome pushes before deciding the transform.
+ */
+async function cleanMetronomeInvoiceLines(
+  stripe: Stripe,
+  invoice: Stripe.Invoice
+): Promise<void> {
+  // `invoice.lines` only holds the first page; iterate the list endpoint so we
+  // see every line. The Stripe SDK list result auto-paginates when iterated.
+  for await (const line of stripe.invoices.listLineItems(invoice.id, {
+    limit: 100,
+  })) {
+    logger.info(
+      { stripeInvoiceId: invoice.id, line },
+      "[Stripe] Metronome invoice line item"
+    );
+  }
+}
+
+/**
+ * Re-fetches a Metronome-pushed draft invoice, normalizes its line items, then
+ * finalizes it. Invoked ~1 minute after Stripe's `invoice.created` (via Temporal)
+ * so Metronome has finished writing all line items before we touch the draft.
+ *
+ * Idempotent and self-gating: re-asserts the invoice is still a Metronome draft
+ * we have not cleaned yet, so Stripe redeliveries and Temporal retries collapse to
+ * a single effective run. `auto_advance` is disabled up-front so Stripe cannot
+ * finalize the draft out from under us while we edit; we finalize explicitly at
+ * the end.
+ */
+export async function cleanAndFinalizeMetronomeDraftInvoice({
+  invoiceId,
+  workspaceId,
+}: {
+  invoiceId: string;
+  workspaceId: string;
+}): Promise<
+  Result<{ outcome: "cleaned" | "skipped" }, { error_message: string }>
+> {
+  const stripe = getStripeClient();
+
+  try {
+    const invoice = await stripe.invoices.retrieve(invoiceId);
+
+    if (!isMetronomePushedInvoice(invoice)) {
+      logger.info(
+        { stripeInvoiceId: invoiceId, workspaceId },
+        "[Stripe] Skipping invoice clean: not a Metronome-pushed invoice"
+      );
+      return new Ok({ outcome: "skipped" });
+    }
+
+    if (invoice.status !== "draft") {
+      logger.info(
+        { stripeInvoiceId: invoiceId, workspaceId, status: invoice.status },
+        "[Stripe] Skipping invoice clean: invoice is no longer a draft"
+      );
+      return new Ok({ outcome: "skipped" });
+    }
+
+    if (invoice.metadata?.[METRONOME_INVOICE_LINES_CLEANED_FLAG] === "true") {
+      logger.info(
+        { stripeInvoiceId: invoiceId, workspaceId },
+        "[Stripe] Skipping invoice clean: already cleaned"
+      );
+      return new Ok({ outcome: "skipped" });
+    }
+
+    // Freeze the draft so Stripe's auto-advance can't finalize it while we edit.
+    await stripe.invoices.update(invoiceId, { auto_advance: false });
+
+    await cleanMetronomeInvoiceLines(stripe, invoice);
+
+    await stripe.invoices.update(invoiceId, {
+      metadata: {
+        ...invoice.metadata,
+        [METRONOME_INVOICE_LINES_CLEANED_FLAG]: "true",
+      },
+    });
+
+    // Finalization is intentionally disabled for now: while we are still
+    // inspecting line shapes and designing the transform, leave the invoice as a
+    // draft so it can be reviewed manually rather than charged. Re-enable once
+    // the line transform is in place.
+    // const finalizeResult = await finalizeInvoice(invoice);
+    // if (finalizeResult.isErr()) {
+    //   return finalizeResult;
+    // }
+
+    logger.info(
+      { stripeInvoiceId: invoiceId, workspaceId },
+      "[Stripe] Cleaned Metronome draft invoice (finalization disabled)"
+    );
+    return new Ok({ outcome: "cleaned" });
+  } catch (error) {
+    logger.error(
+      {
+        stripeInvoiceId: invoiceId,
+        workspaceId,
+        stripeError: true,
+        error: normalizeError(error).message,
+      },
+      "[Stripe] Failed to clean and finalize Metronome draft invoice"
+    );
+    return new Err({
+      error_message: `Failed to clean and finalize invoice: ${normalizeError(error).message}`,
     });
   }
 }

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1501,10 +1501,10 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
     // inspecting line shapes and designing the transform, leave the invoice as a
     // draft so it can be reviewed manually rather than charged. Re-enable once
     // the line transform is in place.
-    // const finalizeResult = await finalizeInvoice(invoice);
-    // if (finalizeResult.isErr()) {
-    //   return finalizeResult;
-    // }
+    const finalizeResult = await finalizeInvoice(invoice);
+    if (finalizeResult.isErr()) {
+      return finalizeResult;
+    }
 
     logger.info(
       { stripeInvoiceId: invoiceId, workspaceId },

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -1367,35 +1367,72 @@ export async function finalizeInvoice(
 const METRONOME_INVOICE_LINES_CLEANED_FLAG = "lines_cleaned";
 
 /**
- * Normalizes the line items of a Metronome-pushed draft invoice in place (via the
- * Stripe API) before finalization — e.g. dropping zero-amount noise, merging
- * granular usage lines into summary lines, or relabeling descriptions.
+ * Removes from a Metronome-pushed Stripe draft invoice the line items that
+ * should not appear on the customer-facing invoice, mirroring the filters
+ * applied by the /invoice/lines API endpoint:
  *
- * INVARIANT: the transform MUST preserve the invoice's pre-tax total. Metronome
- * remains the source of truth for what was billed (credit drawdown, revenue
- * reporting, the `payment_gate.*` reconciliation all key off Metronome's figure);
- * changing the amount here would silently desync Stripe from Metronome. Cleaning
- * is presentation-only.
+ * 1. Negative lines
+ * 2. Lines with an applied commit or credit — usage/subscription lines whose
+ *    cost is covered by a commit/credit (identified by `metronome_commit_id`
+ *    in the Stripe line item metadata).
+ * 3. Wrong-currency lines — non-fiat lines (e.g. AWU-priced) that Metronome may
+ *    not transfer to Stripe; guard retained for safety.
  *
- * TODO(billing): implement the actual line transform once the target invoice
- * shape is pinned down. Use `stripe.invoices.updateLines` / `addLines` /
- * `removeLines` (or `stripe.invoiceItems.*` for invoice-item-backed lines).
- * For now this only reads and logs every line item (auto-paginated) so we can
- * inspect the exact shape Metronome pushes before deciding the transform.
+ * Filters 1 and 2 cancel each other out: every negative credit line is paired
+ * with a positive usage line of the same absolute amount, so removing both
+ * leaves the invoice total unchanged.
  */
 async function cleanMetronomeInvoiceLines(
   stripe: Stripe,
   invoice: Stripe.Invoice
 ): Promise<void> {
+  const invoiceCurrency = invoice.currency;
+
   // `invoice.lines` only holds the first page; iterate the list endpoint so we
   // see every line. The Stripe SDK list result auto-paginates when iterated.
   for await (const line of stripe.invoices.listLineItems(invoice.id, {
     limit: 100,
   })) {
+    const isNegative = line.amount < 1;
+    const hasAppliedCommitOrCredit = !!line.metadata?.metronome_commit_id;
+    const isWrongCurrency = line.currency !== invoiceCurrency;
+    const shouldRemove =
+      isNegative || hasAppliedCommitOrCredit || isWrongCurrency;
+
     logger.info(
-      { stripeInvoiceId: invoice.id, line },
+      {
+        stripeInvoiceId: invoice.id,
+        lineId: line.id,
+        amount: line.amount,
+        currency: line.currency,
+        metadata: line.metadata,
+        isNegative,
+        hasAppliedCommitOrCredit,
+        isWrongCurrency,
+        shouldRemove,
+        line,
+      },
       "[Stripe] Metronome invoice line item"
     );
+
+    if (!shouldRemove) {
+      continue;
+    }
+
+    const invoiceItemId =
+      typeof line.invoice_item === "string"
+        ? line.invoice_item
+        : line.invoice_item?.id;
+
+    if (!invoiceItemId) {
+      logger.warn(
+        { stripeInvoiceId: invoice.id, lineId: line.id },
+        "[Stripe] Cannot remove line item: not backed by an invoice item"
+      );
+      continue;
+    }
+
+    await stripe.invoiceItems.del(invoiceItemId);
   }
 }
 

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -1,5 +1,6 @@
 import { processMetronomeWebhook } from "@app/lib/api/metronome/process_webhook";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
+import { cleanAndFinalizeMetronomeDraftInvoice } from "@app/lib/plans/stripe";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 
 /**
@@ -28,5 +29,28 @@ export async function processMetronomeWebhookActivity({
   const result = await processMetronomeWebhook({ event, workspace });
   if (result.isErr()) {
     throw result.error;
+  }
+}
+
+/**
+ * Cleans and finalizes a Metronome-pushed Stripe draft invoice. Scheduled with a
+ * start delay (see the launcher) so Metronome has finished writing all line items
+ * before we touch the draft. The underlying lib call is idempotent and re-asserts
+ * draft + not-yet-cleaned, so Temporal retries are safe. Throws on Result.Err so
+ * transient Stripe failures retry with backoff.
+ */
+export async function cleanMetronomeInvoiceActivity({
+  invoiceId,
+  workspaceId,
+}: {
+  invoiceId: string;
+  workspaceId: string;
+}): Promise<void> {
+  const result = await cleanAndFinalizeMetronomeDraftInvoice({
+    invoiceId,
+    workspaceId,
+  });
+  if (result.isErr()) {
+    throw new Error(result.error.error_message);
   }
 }

--- a/front/temporal/metronome_events_queue/client.ts
+++ b/front/temporal/metronome_events_queue/client.ts
@@ -2,7 +2,10 @@ import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/metronome_events_queue/config";
-import { metronomeEventsWorkflow } from "@app/temporal/metronome_events_queue/workflows";
+import {
+  cleanMetronomeInvoiceWorkflow,
+  metronomeEventsWorkflow,
+} from "@app/temporal/metronome_events_queue/workflows";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -62,6 +65,55 @@ export async function launchMetronomeEventsWorkflow({
       logger.info(
         { workflowId, eventId: event.id, eventType: event.type, workspaceId },
         "[Metronome Events] Workflow already started (duplicate delivery), skipping"
+      );
+      return new Ok("already_started");
+    }
+    return new Err(normalizeError(err));
+  }
+}
+
+// Defer the clean workflow so Metronome has finished writing all line items on
+// the freshly created Stripe draft before we fetch and edit it.
+const CLEAN_INVOICE_START_DELAY_MS = 60 * 1_000;
+
+/**
+ * Schedules cleaning + finalization of a Metronome-pushed Stripe draft invoice,
+ * deferred by `CLEAN_INVOICE_START_DELAY_MS` (via Temporal `startDelay`, not a
+ * `sleep`). The workflow id is derived from the invoice id so Stripe's
+ * at-least-once `invoice.created` redeliveries dedup to a single workflow;
+ * `ALLOW_DUPLICATE_FAILED_ONLY` lets a redelivery restart it if a prior attempt
+ * ultimately failed.
+ */
+export async function launchCleanMetronomeInvoiceWorkflow({
+  invoiceId,
+  workspaceId,
+}: {
+  invoiceId: string;
+  workspaceId: string;
+}): Promise<Result<LaunchMetronomeEventsWorkflowOutcome, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = `clean-metronome-invoice-${invoiceId}`;
+
+  try {
+    await client.workflow.start(cleanMetronomeInvoiceWorkflow, {
+      args: [{ invoiceId, workspaceId }],
+      memo: { invoiceId, workspaceId },
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      workflowIdReusePolicy: WorkflowIdReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY,
+      startDelay: CLEAN_INVOICE_START_DELAY_MS,
+    });
+
+    logger.info(
+      { workflowId, invoiceId, workspaceId },
+      "[Metronome Events] Started invoice clean workflow"
+    );
+    return new Ok("started");
+  } catch (err) {
+    if (err instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId, invoiceId, workspaceId },
+        "[Metronome Events] Invoice clean workflow already started (duplicate delivery), skipping"
       );
       return new Ok("already_started");
     }

--- a/front/temporal/metronome_events_queue/workflows.ts
+++ b/front/temporal/metronome_events_queue/workflows.ts
@@ -2,9 +2,10 @@ import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import type * as activities from "@app/temporal/metronome_events_queue/activities";
 import { proxyActivities } from "@temporalio/workflow";
 
-const { processMetronomeWebhookActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "5 minutes",
-});
+const { processMetronomeWebhookActivity, cleanMetronomeInvoiceActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "5 minutes",
+  });
 
 export async function metronomeEventsWorkflow({
   event,
@@ -14,4 +15,19 @@ export async function metronomeEventsWorkflow({
   workspaceId: string;
 }): Promise<void> {
   await processMetronomeWebhookActivity({ event, workspaceId });
+}
+
+/**
+ * Cleans and finalizes a Metronome-pushed Stripe draft invoice. The launcher
+ * defers the workflow start (via `startDelay`) so by the time this runs Metronome
+ * has finished writing all line items — there is no `sleep` here on purpose.
+ */
+export async function cleanMetronomeInvoiceWorkflow({
+  invoiceId,
+  workspaceId,
+}: {
+  invoiceId: string;
+  workspaceId: string;
+}): Promise<void> {
+  await cleanMetronomeInvoiceActivity({ invoiceId, workspaceId });
 }


### PR DESCRIPTION
## Description

Metronome-pushed Stripe invoices contain noisy line items (negative credit offsets, zero-amount commit-covered lines, wrong-currency entries) that should not appear on the customer-facing invoice. This PR intercepts those draft invoices and normalises them before finalisation.

Three changes work together:
1. **`isMetronomePushedInvoice()`** — new helper in `stripe.ts` that identifies Metronome-originated invoices by the `metronome_customer_id` metadata field Metronome stamps on every invoice it pushes.
2. **`cleanMetronomeInvoiceLines()` / `cleanAndFinalizeMetronomeDraftInvoice()`** — new functions in `stripe.ts` that paginate through all line items, delete those that are negative, covered by a commit/credit (`metronome_commit_id` in metadata), or in the wrong currency, then finalise the invoice explicitly. The function is idempotent via a `lines_cleaned` metadata flag and disables `auto_advance` before editing to prevent Stripe from finalising the draft concurrently.
3. **`invoice.created` webhook handler** — on receiving a Metronome draft invoice creation event, the webhook resolves the workspace via `metronome_customer_id` and launches a Temporal workflow (deferred ~1 minute) so Metronome has finished writing all line items before we touch the draft.

The filters applied to Stripe line items mirror those already applied in the Metronome invoice preview endpoint (`front-api/routes/w/[wId]/metronome/invoice.ts`).

## Tests

Manually tested by inspecting Metronome draft invoices in Stripe before and after the clean step; verified idempotency by triggering the workflow twice on the same invoice.

## Risk

Low — the function is self-gating (skips non-draft, non-Metronome, or already-cleaned invoices) and only touches invoices Metronome pushes. A bug in line-item filtering could result in removing or keeping the wrong line items on a customer invoice; the `lines_cleaned` flag prevents double-runs. No DB schema changes.

## Deploy Plan

Deploy `front`.