### PR TITLE
[front] Use Metronome contract transitions for contract switches

### DIFF
--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -476,6 +476,7 @@ export async function switchContract({
     swapAt,
     enableStripeBilling: body.stripeCustomerId !== undefined,
     planCode: body.planCode,
+    fromContractId: currentSubscription?.metronomeContractId ?? undefined,
   });
   if (provisionResult.isErr()) {
     return new Err(

--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -1,5 +1,6 @@
 import {
   adjustSeatCreditBalances,
+  createMetronomeContract,
   createMetronomeCredit,
   findSeatCreditSegmentForPeriod,
 } from "@app/lib/metronome/client";
@@ -26,18 +27,26 @@ function unwrapErr<T>(result: Result<T, Error>): Error {
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockCreate, mockList, mockAddManualBalanceEntry, MockConflictError } =
-  vi.hoisted(() => {
-    class MockConflictError extends Error {
-      status = 409;
-    }
-    return {
-      mockCreate: vi.fn(),
-      mockList: vi.fn(),
-      mockAddManualBalanceEntry: vi.fn(),
-      MockConflictError,
-    };
-  });
+const {
+  mockCreate,
+  mockList,
+  mockAddManualBalanceEntry,
+  mockContractsCreate,
+  mockSetCustomFieldValues,
+  MockConflictError,
+} = vi.hoisted(() => {
+  class MockConflictError extends Error {
+    status = 409;
+  }
+  return {
+    mockCreate: vi.fn(),
+    mockList: vi.fn(),
+    mockAddManualBalanceEntry: vi.fn(),
+    mockContractsCreate: vi.fn(),
+    mockSetCustomFieldValues: vi.fn(),
+    MockConflictError,
+  };
+});
 
 vi.mock("@metronome/sdk", () => {
   // Must use a regular function (not an arrow) so it can be called with `new`.
@@ -47,7 +56,11 @@ vi.mock("@metronome/sdk", () => {
         customers: {
           credits: { create: mockCreate, list: mockList },
         },
-        contracts: { addManualBalanceEntry: mockAddManualBalanceEntry },
+        contracts: {
+          addManualBalanceEntry: mockAddManualBalanceEntry,
+          create: mockContractsCreate,
+        },
+        customFields: { setValues: mockSetCustomFieldValues },
       },
     };
   }
@@ -83,6 +96,11 @@ beforeEach(() => {
   mockList.mockReset();
   mockAddManualBalanceEntry.mockReset();
   mockCreate.mockResolvedValue({ data: { id: "credit-id-1" } });
+
+  mockContractsCreate.mockReset();
+  mockContractsCreate.mockResolvedValue({ data: { id: "contract-id-1" } });
+  mockSetCustomFieldValues.mockReset();
+  mockSetCustomFieldValues.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -303,5 +321,43 @@ describe("adjustSeatCreditBalances", () => {
     });
 
     expect(unwrapErr(result).message).toMatch(/api boom/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMetronomeContract — transition payload
+// ---------------------------------------------------------------------------
+
+describe("createMetronomeContract", () => {
+  const BASE_CONTRACT_PARAMS = {
+    metronomeCustomerId: "cust-1",
+    packageAlias: "legacy-pro-monthly",
+    startingAt: new Date("2026-04-01T00:00:00.000Z"),
+    enableStripeBilling: false,
+    planCode: "PRO_PLAN_SEAT_29",
+  };
+
+  it("omits the transition when no fromContractId is given", async () => {
+    const result = await createMetronomeContract(BASE_CONTRACT_PARAMS);
+
+    expect(result.isOk()).toBe(true);
+    expect(mockContractsCreate).toHaveBeenCalledTimes(1);
+    expect(mockContractsCreate.mock.calls[0][0]).not.toHaveProperty(
+      "transition"
+    );
+  });
+
+  it("sends a RENEWAL transition when fromContractId is given", async () => {
+    const result = await createMetronomeContract({
+      ...BASE_CONTRACT_PARAMS,
+      fromContractId: "prior-contract",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockContractsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transition: { type: "RENEWAL", from_contract_id: "prior-contract" },
+      })
+    );
   });
 });

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -768,6 +768,7 @@ export async function createMetronomeContract({
   enableStripeBilling,
   planCode,
   additionalCustomFields,
+  fromContractId,
 }: {
   metronomeCustomerId: string;
   /** Mutually exclusive with `packageId`. */
@@ -787,6 +788,11 @@ export async function createMetronomeContract({
   // (DUST_PAYMENT_GATE_TYPE) so the contract.start webhook can skip the
   // automatic subscription swap.
   additionalCustomFields?: Record<string, string>;
+  // When set, the contract is created as a RENEWAL transition from this prior
+  // contract: Metronome records the lineage and automatically ends the prior
+  // contract at `startingAt`. Unused commit balance only carries over for
+  // commits that were created with a `rollover_fraction`
+  fromContractId?: string;
 }): Promise<Result<{ contractId: string }, Error>> {
   if (!packageAlias === !packageId) {
     return new Err(
@@ -804,6 +810,11 @@ export async function createMetronomeContract({
   // side, and re-running them is what makes the overall function recoverable.
   let contractId: string;
   let recovered = false;
+
+  const transition = fromContractId
+    ? { type: "RENEWAL" as const, from_contract_id: fromContractId }
+    : undefined;
+
   try {
     const response = await getMetronomeClient().v1.contracts.create({
       customer_id: metronomeCustomerId,
@@ -811,6 +822,7 @@ export async function createMetronomeContract({
       ...(packageId ? { package_id: packageId } : {}),
       starting_at: startingAtISO,
       ...(uniquenessKey ? { uniqueness_key: uniquenessKey } : {}),
+      ...(transition ? { transition } : {}),
     });
     contractId = response.data.id;
   } catch (err) {

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -823,6 +823,47 @@ describe("provisionMetronomeContract — overlap sunset", () => {
     );
   });
 
+  it("forwards fromContractId and skips it in the sunset pass", async () => {
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([
+        // the prior contract the transition renews from — ended by Metronome,
+        // so it must NOT be sunset again here.
+        {
+          id: "prior-contract",
+          starting_at: "2026-03-01T00:00:00.000Z",
+          ending_before: null,
+          archived_at: null,
+        },
+        // an unrelated stray overlap — still sunset.
+        {
+          id: "overlap-1",
+          starting_at: "2026-03-01T00:00:00.000Z",
+          ending_before: null,
+          archived_at: null,
+        },
+      ])
+    );
+
+    const result = await provisionMetronomeContract({
+      metronomeCustomerId: "m-customer",
+      workspace: WORKSPACE,
+      packageAlias: "legacy-pro-monthly",
+      uniquenessKey: "uniq_123",
+      startingAt: new Date(START_DATE),
+      planCode: "PRO_PLAN_SEAT_29",
+      fromContractId: "prior-contract",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockCreateMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ fromContractId: "prior-contract" })
+    );
+    expect(mockScheduleMetronomeContractEnd).toHaveBeenCalledTimes(1);
+    expect(mockScheduleMetronomeContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "overlap-1" })
+    );
+  });
+
   it("returns an error when listing contracts fails", async () => {
     mockListMetronomeContracts.mockResolvedValue(
       new Err(new Error("list failed"))

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -225,6 +225,7 @@ export async function provisionMetronomeContract({
   planCode,
   additionalCustomFields,
   enableSeatSync = true,
+  fromContractId,
 }: {
   metronomeCustomerId: string;
   workspace: LightWorkspaceType;
@@ -236,6 +237,7 @@ export async function provisionMetronomeContract({
   planCode: string;
   additionalCustomFields?: Record<string, string>;
   enableSeatSync?: boolean;
+  fromContractId?: string;
 }): Promise<Result<{ metronomeContractId: string }, Error>> {
   const alignedStart = new Date(
     swapAt === "current-hour"
@@ -263,6 +265,7 @@ export async function provisionMetronomeContract({
     enableStripeBilling,
     planCode,
     additionalCustomFields,
+    fromContractId,
   });
   if (contractResult.isErr()) {
     return new Err(contractResult.error);
@@ -282,6 +285,12 @@ export async function provisionMetronomeContract({
   const newStartMs = alignedStart.getTime();
   for (const existing of contractsResult.value) {
     if (existing.id === metronomeContractId) {
+      continue;
+    }
+    // The RENEWAL transition already ends the prior contract at `alignedStart`;
+    // calling updateEndDate on it again is redundant and Metronome can reject
+    // editing a contract that has been transitioned from.
+    if (existing.id === fromContractId) {
       continue;
     }
     if (existing.archived_at) {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -603,7 +603,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
    * Persist a pending (created_backend_only) subscription for a workspace that
    * is provisioning a new Metronome contract via a future-effective swap. If a
    * prior pending sub exists it is ended (status: "ended") within the same
-   * transaction — the prior contract is sunset on Metronome's side by the
+   * transaction — the prior contract is ended on Metronome's side either by the
+   * RENEWAL transition (when the switch passes `fromContractId`) or by the
    * overlap-sunset pass in `provisionMetronomeContract`.
    *
    * The row flips to "active" when the matching `contract.start` webhook
@@ -1134,6 +1135,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         swapAt: "current-hour",
         enableStripeBilling: isSubscriptionMetronomeBilled(this.toJSON()),
         planCode: PRO_PLAN_SEAT_39_CODE,
+        fromContractId: this.metronomeContractId,
       });
       if (result.isErr() && !this.isMetronomeShadowBilled) {
         return new Err(result.error);


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/8737

Provision contract-to-contract switches as RENEWAL transitions so Metronome records the lineage (from_contract_id -> to_contract_id) and ends the prior contract at the swap moment, instead of relying solely on the manual overlap-sunset pass.

- createMetronomeContract: add `fromContractId`; only send a `transition` when set. Hardcode RENEWAL (SUPERSEDE is feature-flagged off on our account; TODO to revisit).
- provisionMetronomeContract: forward `fromContractId` and skip it in the overlap-sunset pass, since the transition already ends it (and Metronome can reject editing a transitioned-from contract).
- Wire the two direct-swap paths: poke switch_contract and SubscriptionResource.upgradeToBusinessPlan. Free/checkout/shadow and the payment-gated business activation keep create+sunset (no transition).

## Tests

Unit + locally

## Risk

Could break the contract switching logic. Tested on the "switch to business" path.

## Deploy Plan

front