### PR TITLE
[front] feat: add get_top_skills to workspace_analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -704,6 +704,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "workspace_analytics": {
     "get_agent_details": "never_ask",
     "get_top_agents": "never_ask",
+    "get_top_skills": "never_ask",
     "get_top_users": "never_ask",
   },
   "zendesk": {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -40,6 +40,18 @@ const getAgentDetailsSchema = {
     ),
 };
 
+const getTopSkillsSchema = {
+  ...timeWindowSchemaShape,
+  ...usageFilterSchema,
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .optional()
+    .describe("Maximum number of skills to return (default 25, max 100)."),
+};
+
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_top_agents: {
     description:
@@ -81,6 +93,19 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving agent details",
       done: "Retrieved agent details",
+    },
+  },
+  get_top_skills: {
+    description:
+      "Return the workspace's most-used skills over a time window (defaults " +
+      "to the current calendar month), ranked by execution count. Optionally " +
+      "filter by source (context_origin), agent, or user. Use this to answer " +
+      "which skills are used most. Admin-only.",
+    schema: getTopSkillsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top skills",
+      done: "Retrieved top skills",
     },
   },
 });

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -27,6 +27,7 @@ describe("workspace_analytics tools", () => {
     "get_top_agents",
     "get_top_users",
     "get_agent_details",
+    "get_top_skills",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -5,8 +5,10 @@ import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { Err, Ok } from "@app/types/shared/result";
 
 const DEFAULT_LIMIT = 25;
@@ -162,6 +164,63 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
           `- Tools: ${toolNames || "none"}\n\n` +
           "Instructions (full system prompt):\n" +
           `${agent.instructions ?? "(no instructions)"}`,
+      },
+    ]);
+  },
+
+  get_top_skills: async (
+    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const baseQuery = buildAgentAnalyticsBaseQuery({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+    });
+
+    const result = await fetchAvailableSkills(baseQuery);
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to retrieve skill usage: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+    const skills = result.value.slice(0, limit ?? DEFAULT_LIMIT);
+
+    if (skills.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No skill usage recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = skills.map(
+      (skill, index) =>
+        `${index + 1}. ${skill.skillName} — ${skill.totalExecutions} executions`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Most-used skills for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
       },
     ]);
   },


### PR DESCRIPTION
## Description

Add an admin-only get_top_skills tool that ranks the workspace's most-used skills by execution count over a time window, with the shared source/agent/user filters. Reuses the existing observability fetchAvailableSkills over a scoped base query.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
