### PR TITLE
[front] fix: use compact notation for usage chart y-axis ticks

### DIFF
--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -17,7 +17,7 @@ import type {
   AwuUsageGroupByType,
   GetAwuUsageResponse,
 } from "@app/lib/api/analytics/awu_usage";
-import { formatCredits } from "@app/lib/client/credits";
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { useAwuUsage } from "@app/lib/swr/workspaces";
 import {
@@ -651,7 +651,7 @@ export function BaseAwuUsageChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          tickFormatter={(value) => formatCredits(value)}
+          tickFormatter={(value) => formatCreditsCompact(value)}
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) =>

--- a/front/components/workspace/MetronomeUsageChart.tsx
+++ b/front/components/workspace/MetronomeUsageChart.tsx
@@ -17,6 +17,7 @@ import type {
   GetMetronomeUsageResponse,
   MetronomeUsageGroupByType,
 } from "@app/lib/api/analytics/metronome_usage";
+import { formatMicroUsdCompact } from "@app/lib/client/credits";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { useMetronomeUsage } from "@app/lib/swr/workspaces";
 import {
@@ -604,7 +605,7 @@ export function BaseMetronomeUsageChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          tickFormatter={(value) => `$${(value / 1_000_000).toFixed(0)}`}
+          tickFormatter={(value) => formatMicroUsdCompact(value)}
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) =>

--- a/front/components/workspace/ProgrammaticCostChart.tsx
+++ b/front/components/workspace/ProgrammaticCostChart.tsx
@@ -17,6 +17,7 @@ import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
+import { formatMicroUsdCompact } from "@app/lib/client/credits";
 import { getBillingCycleFromDay } from "@app/lib/client/subscription";
 import { clientFetch } from "@app/lib/egress/client";
 import { useWorkspaceProgrammaticCost } from "@app/lib/swr/workspaces";
@@ -760,7 +761,7 @@ export function BaseProgrammaticCostChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          tickFormatter={(value) => `$${(value / 1_000_000).toFixed(0)}`}
+          tickFormatter={(value) => formatMicroUsdCompact(value)}
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) =>

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -4,3 +4,18 @@
 export function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
 }
+
+export function formatCreditsCompact(credits: number): string {
+  return credits.toLocaleString("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
+}
+
+export function formatMicroUsdCompact(microUsd: number): string {
+  const dollars = microUsd / 1_000_000;
+  return `$${dollars.toLocaleString("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  })}`;
+}


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/8766

Y-axis labels like "2,400,000" overflowed the chart's left edge. Render them compactly ("2.4M", "600K", "$1.2M") via two new helpers in credits.ts, applied to AwuUsageChart, MetronomeUsageChart, and ProgrammaticCostChart. Tooltips keep full-precision values.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
