### PR TITLE
Pricing: Move onboarding questions after the checkout.

### DIFF
--- a/front-api/routes/user/index.ts
+++ b/front-api/routes/user/index.ts
@@ -19,6 +19,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 import metadata from "./metadata";
+import onboarding from "./onboarding";
 
 const PatchUserBodySchema = z.object({
   firstName: z.string(),
@@ -285,5 +286,6 @@ app.patch(
 );
 
 app.route("/metadata", metadata);
+app.route("/onboarding", onboarding);
 
 export default app;

--- a/front-api/routes/user/onboarding.test.ts
+++ b/front-api/routes/user/onboarding.test.ts
@@ -1,0 +1,42 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ONBOARDING_PROFILE_PENDING_METADATA_KEY } from "@app/types/onboarding";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function completeOnboarding() {
+  return honoApp.request(`/api/user/onboarding/complete`, {
+    method: "POST",
+  });
+}
+
+describe("POST /api/user/onboarding/complete", () => {
+  it("clears the profile onboarding pending marker", async () => {
+    const { user } = await createPrivateApiMockRequest({ method: "POST" });
+
+    await user.setMetadata(ONBOARDING_PROFILE_PENDING_METADATA_KEY, "true");
+
+    const response = await completeOnboarding();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const metadata = await user.getMetadata(
+      ONBOARDING_PROFILE_PENDING_METADATA_KEY
+    );
+    expect(metadata?.value).toBe("false");
+  });
+
+  it("succeeds when no marker was set", async () => {
+    const { user } = await createPrivateApiMockRequest({ method: "POST" });
+
+    const response = await completeOnboarding();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const metadata = await user.getMetadata(
+      ONBOARDING_PROFILE_PENDING_METADATA_KEY
+    );
+    expect(metadata?.value).toBe("false");
+  });
+});

--- a/front-api/routes/user/onboarding.ts
+++ b/front-api/routes/user/onboarding.ts
@@ -1,0 +1,54 @@
+import { getUserFromSession } from "@app/lib/iam/session";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { ONBOARDING_PROFILE_PENDING_METADATA_KEY } from "@app/types/onboarding";
+import { sessionApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+
+export type PostUserOnboardingCompleteResponseBody = {
+  success: boolean;
+};
+
+// Mounted at /api/user/onboarding. sessionAuth is applied by the parent
+// `/api/user` sub-app.
+const app = sessionApp();
+
+// Marks the profile onboarding as completed for the user, by clearing the
+// pending marker from the user metadata. Called when the user submits the
+// profile onboarding form (welcome page or in-app onboarding dialog).
+/** @ignoreswagger */
+app.post(
+  "/complete",
+  async (ctx): HandlerResult<PostUserOnboardingCompleteResponseBody> => {
+    const session = ctx.get("session");
+    const user = await getUserFromSession(session);
+    if (!user) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "user_not_found",
+          message: "The user was not found.",
+        },
+      });
+    }
+
+    // We get the UserResource from the session userId. Temporary, as we'd need
+    // to refactor getUserFromSession to return the UserResource directly.
+    const u = await UserResource.fetchByModelId(user.id);
+    if (!u) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "user_not_found",
+          message: "Could not find the user.",
+        },
+      });
+    }
+
+    await u.setMetadata(ONBOARDING_PROFILE_PENDING_METADATA_KEY, "false");
+
+    return ctx.json({ success: true });
+  }
+);
+
+export default app;

--- a/front-spa/src/app/layouts/WorkspacePage.tsx
+++ b/front-spa/src/app/layouts/WorkspacePage.tsx
@@ -1,4 +1,5 @@
 import { AppAuthContextLayout } from "@dust-tt/front/components/sparkle/AppAuthContextLayout";
+import { computeIsMetronomeCheckout } from "@dust-tt/front/lib/client/subscription";
 import { useKillSwitches } from "@dust-tt/front/lib/swr/kill";
 import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
 import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
@@ -50,18 +51,18 @@ export function WorkspacePage({ children }: WorkspacePageProps) {
 
   const canUseProduct = authContext.subscription.plan.limits.canUseProduct;
 
+  // Not using `useIsMetronomeCheckout` here: the hook reads feature flags from
+  // the auth context provider, which this component is about to mount.
+  const isMetronomeCheckout = computeIsMetronomeCheckout({
+    featureFlags: authContext.featureFlags,
+    killSwitches,
+  });
+
   // Paywall enforcement: redirect when canUseProduct is false
   // and the current route requires canUseProduct (via route handle).
   // Mirrors the Next.js session.ts logic: redirect to the trial / plan
   // selection page if eligible, /subscribe otherwise.
   if (!canUseProduct && isRequireCanUseProduct) {
-    const isMetronomeEnabled =
-      authContext.featureFlags.includes("metronome_billing") ||
-      !killSwitches?.includes("global_disable_metronome_billing");
-    const isMetronomeCheckout =
-      isMetronomeEnabled &&
-      authContext.featureFlags.includes("metronome_cp_checkout");
-
     const target = authContext.isEligibleForTrial
       ? isMetronomeCheckout
         ? "select-subscription"

--- a/front-spa/src/app/layouts/WorkspacePage.tsx
+++ b/front-spa/src/app/layouts/WorkspacePage.tsx
@@ -1,3 +1,4 @@
+import { ProfileOnboardingDialog } from "@dust-tt/front/components/onboarding/ProfileOnboardingDialog";
 import { AppAuthContextLayout } from "@dust-tt/front/components/sparkle/AppAuthContextLayout";
 import { computeIsMetronomeCheckout } from "@dust-tt/front/lib/client/subscription";
 import { useKillSwitches } from "@dust-tt/front/lib/swr/kill";
@@ -73,6 +74,9 @@ export function WorkspacePage({ children }: WorkspacePageProps) {
 
   return (
     <AppAuthContextLayout authContext={authContext}>
+      {isMetronomeCheckout && isRequireCanUseProduct && (
+        <ProfileOnboardingDialog />
+      )}
       {children ?? <Outlet />}
     </AppAuthContextLayout>
   );

--- a/front/components/onboarding/ProfileOnboardingDialog.tsx
+++ b/front/components/onboarding/ProfileOnboardingDialog.tsx
@@ -1,0 +1,107 @@
+import {
+  FavoritePlatformsStep,
+  UserProfileStep,
+} from "@app/components/onboarding/ProfileOnboardingSteps";
+import { useProfileOnboardingForm } from "@app/components/onboarding/useProfileOnboardingForm";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useIsMetronomeCheckout } from "@app/lib/client/subscription";
+import { useAppRouter } from "@app/lib/platform";
+import { useUserMetadata } from "@app/lib/swr/user";
+import { getConversationRoute } from "@app/lib/utils/router";
+import { ONBOARDING_PROFILE_PENDING_METADATA_KEY } from "@app/types/onboarding";
+import { Dialog, DialogContent, DialogTitle, Spinner } from "@dust-tt/sparkle";
+
+/**
+ * Unskippable dialog shown on top of the application until the user has
+ * submitted the profile onboarding form (name and job type, then favorite
+ * platforms for the first admin).
+ *
+ * Only used with the credit-priced checkout flow, where the profile form is
+ * collected in-app instead of on the /welcome page: after checkout or phone
+ * verification for the first admin, on the first visit for other members.
+ * The pending state is stored in the user metadata, set at the user's first
+ * login and cleared when the profile form is submitted.
+ */
+export function ProfileOnboardingDialog() {
+  const isMetronomeCheckout = useIsMetronomeCheckout();
+
+  const { metadata, mutateMetadata } = useUserMetadata(
+    ONBOARDING_PROFILE_PENDING_METADATA_KEY,
+    { disabled: !isMetronomeCheckout }
+  );
+
+  const isProfilePending = isMetronomeCheckout && metadata?.value === "true";
+
+  if (!isProfilePending) {
+    return null;
+  }
+
+  return (
+    <ProfileOnboardingDialogContent
+      onProfileCompleted={async () => {
+        await mutateMetadata();
+      }}
+    />
+  );
+}
+
+interface ProfileOnboardingDialogContentProps {
+  onProfileCompleted: () => Promise<void>;
+}
+
+function ProfileOnboardingDialogContent({
+  onProfileCompleted,
+}: ProfileOnboardingDialogContentProps) {
+  const { workspace, isAdmin } = useAuth();
+  const router = useAppRouter();
+
+  const form = useProfileOnboardingForm({
+    onCompleted: async ({ isFirstAdmin }) => {
+      // The first admin is sent to their personalized welcome conversation;
+      // other members stay where they are.
+      if (isFirstAdmin) {
+        await router.push(
+          getConversationRoute(workspace.sId, "new", "welcome=true")
+        );
+      }
+      await onProfileCompleted();
+    },
+  });
+
+  return (
+    <Dialog open>
+      <DialogContent
+        size="2xl"
+        height="2xl"
+        isAlertDialog
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogTitle className="sr-only">Welcome to Dust</DialogTitle>
+        <div className="flex-1 overflow-y-auto px-12 py-8">
+          {form.isWelcomeDataLoading ? (
+            <div className="flex h-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : form.step === 1 ? (
+            <UserProfileStep
+              owner={workspace}
+              isAdmin={isAdmin}
+              formData={form.formData}
+              setFormData={form.setFormData}
+              formErrors={form.formErrors}
+              showErrors={form.showErrors}
+              onNext={form.handleProfileNext}
+            />
+          ) : (
+            <FavoritePlatformsStep
+              selectedPlatforms={form.selectedPlatforms}
+              onTogglePlatform={form.togglePlatform}
+              onSubmit={form.handlePlatformsSubmit}
+              isSubmitting={form.isSubmitting}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/onboarding/ProfileOnboardingSteps.tsx
+++ b/front/components/onboarding/ProfileOnboardingSteps.tsx
@@ -1,0 +1,259 @@
+import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
+import type { FavoritePlatform } from "@app/types/favorite_platforms";
+import { FAVORITE_PLATFORM_OPTIONS } from "@app/types/favorite_platforms";
+import type { JobType } from "@app/types/job_type";
+import { isJobType, JOB_TYPE_OPTIONS } from "@app/types/job_type";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Card,
+  ConfluenceLogo,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  DustLogoSquare,
+  FrontLogo,
+  GithubLogo,
+  GmailLogo,
+  HubspotLogo,
+  Icon,
+  Input,
+  JiraLogo,
+  MicrosoftOutlookLogo,
+  NotionLogo,
+  Page,
+  SlackLogo,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+import { useMemo } from "react";
+
+const PLATFORM_ICONS: Record<FavoritePlatform, ComponentType> = {
+  gmail: GmailLogo,
+  outlook: MicrosoftOutlookLogo,
+  slack: SlackLogo,
+  notion: NotionLogo,
+  confluence: ConfluenceLogo,
+  github: GithubLogo,
+  hubspot: HubspotLogo,
+  jira: JiraLogo,
+  front: FrontLogo,
+};
+
+export interface ProfileFormData {
+  firstName: string;
+  lastName: string;
+  jobType: JobType | null;
+}
+
+export interface ProfileFormErrors {
+  firstName?: string;
+  lastName?: string;
+  jobType?: string;
+}
+
+export function validateProfileForm(data: ProfileFormData): ProfileFormErrors {
+  const errors: ProfileFormErrors = {};
+  if (!data.firstName.trim()) {
+    errors.firstName = "First name is required";
+  }
+  if (!data.lastName.trim()) {
+    errors.lastName = "Last name is required";
+  }
+  if (!data.jobType) {
+    errors.jobType = "Please select your job type";
+  }
+  return errors;
+}
+
+export function getInitialSelectedPlatforms(
+  emailProvider: EmailProviderType
+): Set<FavoritePlatform> {
+  const platforms = new Set<FavoritePlatform>();
+  if (emailProvider === "google") {
+    platforms.add("gmail");
+  } else if (emailProvider === "microsoft") {
+    platforms.add("outlook");
+  }
+  return platforms;
+}
+
+interface UserProfileStepProps {
+  owner: WorkspaceType;
+  isAdmin: boolean;
+  formData: ProfileFormData;
+  setFormData: React.Dispatch<React.SetStateAction<ProfileFormData>>;
+  formErrors: ProfileFormErrors;
+  showErrors: boolean;
+  onNext: () => void;
+}
+
+export function UserProfileStep({
+  owner,
+  isAdmin,
+  formData,
+  setFormData,
+  formErrors,
+  showErrors,
+  onNext,
+}: UserProfileStepProps) {
+  const selectedJobTypeLabel = useMemo(() => {
+    if (!formData.jobType) {
+      return "Select job type";
+    }
+    const jobType = JOB_TYPE_OPTIONS.find((t) => t.value === formData.jobType);
+    return jobType?.label ?? "Select job type";
+  }, [formData.jobType]);
+
+  return (
+    <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
+      <Page.Header
+        title={`Hello ${formData.firstName || "there"}!`}
+        icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
+      />
+      <p className="text-muted-foreground dark:text-muted-foreground-night">
+        Let's check a few things.
+      </p>
+      {!isAdmin && (
+        <p className="text-muted-foreground dark:text-muted-foreground-night">
+          You'll be joining the workspace:{" "}
+          <span className="font-medium">{owner.name}</span>.
+        </p>
+      )}
+      <div>
+        <p className="pb-2 text-muted-foreground dark:text-muted-foreground-night">
+          Your name is:
+        </p>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <Input
+              name="firstName"
+              placeholder="First Name"
+              value={formData.firstName}
+              onChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  firstName: e.target.value,
+                }))
+              }
+            />
+            {showErrors && formErrors.firstName && (
+              <p className="mt-1 text-sm text-red-500">
+                {formErrors.firstName}
+              </p>
+            )}
+          </div>
+          <div>
+            <Input
+              name="lastName"
+              placeholder="Last Name"
+              value={formData.lastName}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, lastName: e.target.value }))
+              }
+            />
+            {showErrors && formErrors.lastName && (
+              <p className="mt-1 text-sm text-red-500">{formErrors.lastName}</p>
+            )}
+          </div>
+        </div>
+      </div>
+      <div>
+        <p className="pb-2 text-muted-foreground dark:text-muted-foreground-night">
+          Pick your job type to get relevant feature updates:
+        </p>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="justify-between text-muted-foreground dark:text-muted-foreground-night"
+              label={selectedJobTypeLabel}
+              isSelect={true}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+            <DropdownMenuRadioGroup
+              value={formData.jobType ?? ""}
+              onValueChange={(value) => {
+                if (isJobType(value)) {
+                  setFormData((prev) => ({ ...prev, jobType: value }));
+                }
+              }}
+            >
+              {JOB_TYPE_OPTIONS.map((jobTypeOption) => (
+                <DropdownMenuRadioItem
+                  key={jobTypeOption.value}
+                  value={jobTypeOption.value}
+                  label={jobTypeOption.label}
+                />
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        {showErrors && formErrors.jobType && (
+          <p className="mt-1 text-sm text-red-500">{formErrors.jobType}</p>
+        )}
+      </div>
+      <div className="flex justify-end">
+        <Button label="Next" size="md" onClick={onNext} />
+      </div>
+    </div>
+  );
+}
+
+interface FavoritePlatformsStepProps {
+  selectedPlatforms: Set<FavoritePlatform>;
+  onTogglePlatform: (platform: FavoritePlatform) => void;
+  onSubmit: React.MouseEventHandler<HTMLElement>;
+  isSubmitting: boolean;
+}
+
+export function FavoritePlatformsStep({
+  selectedPlatforms,
+  onTogglePlatform,
+  onSubmit,
+  isSubmitting,
+}: FavoritePlatformsStepProps) {
+  return (
+    <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
+      <Page.Header title="What are your favorite platforms?" />
+      <p className="text-muted-foreground dark:text-muted-foreground-night">
+        Dust works at full potential when it can play with your knowledge and
+        help with your tools. Do you recognise some of these?
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {FAVORITE_PLATFORM_OPTIONS.map((platform) => {
+          const PlatformIcon = PLATFORM_ICONS[platform];
+          const isSelected = selectedPlatforms.has(platform);
+          return (
+            <Card
+              key={platform}
+              variant="secondary"
+              size="sm"
+              selected={isSelected}
+              onClick={() => onTogglePlatform(platform)}
+            >
+              <div className="flex items-center gap-3">
+                <Icon visual={PlatformIcon} size="md" />
+                <span className="text-sm font-medium">
+                  {asDisplayName(platform)}
+                </span>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+      <div className="flex justify-end">
+        <Button
+          label="Next"
+          isLoading={isSubmitting}
+          disabled={isSubmitting}
+          size="md"
+          onClick={onSubmit}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/onboarding/useProfileOnboardingForm.ts
+++ b/front/components/onboarding/useProfileOnboardingForm.ts
@@ -1,0 +1,142 @@
+import type {
+  ProfileFormData,
+  ProfileFormErrors,
+} from "@app/components/onboarding/ProfileOnboardingSteps";
+import {
+  getInitialSelectedPlatforms,
+  validateProfileForm,
+} from "@app/components/onboarding/ProfileOnboardingSteps";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { usePatchUser } from "@app/lib/swr/user";
+import { useWelcomeData } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { getStoredUTMParams } from "@app/lib/utils/utm";
+import type { FavoritePlatform } from "@app/types/favorite_platforms";
+import { useEffect, useMemo, useState } from "react";
+
+interface UseProfileOnboardingFormProps {
+  // Called once the profile has been successfully submitted.
+  onCompleted: () => Promise<void> | void;
+}
+
+/**
+ * Form state shared by the two profile onboarding surfaces: the full-page
+ * /welcome page (legacy flow) and the in-app onboarding dialog shown after
+ * checkout in the credit-priced flow.
+ */
+export function useProfileOnboardingForm({
+  onCompleted,
+}: UseProfileOnboardingFormProps) {
+  const { workspace, user } = useAuth();
+  const { patchUser } = usePatchUser();
+
+  const { welcomeData, isFirstAdmin, emailProvider, isWelcomeDataLoading } =
+    useWelcomeData({ workspaceId: workspace.sId });
+
+  const showFavoritePlatformsStep = isFirstAdmin;
+
+  const [step, setStep] = useState<1 | 2>(1);
+  const [formData, setFormData] = useState<ProfileFormData>({
+    firstName: user.firstName,
+    lastName: user.lastName ?? "",
+    jobType: null,
+  });
+  const [selectedPlatforms, setSelectedPlatforms] = useState<
+    Set<FavoritePlatform>
+  >(new Set());
+  const [showErrors, setShowErrors] = useState(false);
+  const [platformsInitialized, setPlatformsInitialized] = useState(false);
+
+  // Initialize selectedPlatforms once emailProvider is loaded.
+  useEffect(() => {
+    if (welcomeData && !platformsInitialized) {
+      setSelectedPlatforms(getInitialSelectedPlatforms(emailProvider));
+      setPlatformsInitialized(true);
+    }
+  }, [welcomeData, platformsInitialized, emailProvider]);
+
+  const formErrors = useMemo((): ProfileFormErrors => {
+    if (!showErrors) {
+      return {};
+    }
+    return validateProfileForm(formData);
+  }, [formData, showErrors]);
+
+  const { submit, isSubmitting } = useSubmitFunction(async () => {
+    await patchUser(
+      formData.firstName.trim(),
+      formData.lastName.trim(),
+      false,
+      formData.jobType ?? undefined,
+      undefined,
+      showFavoritePlatformsStep ? Array.from(selectedPlatforms) : undefined,
+      emailProvider,
+      workspace.sId
+    );
+
+    if (typeof window !== "undefined") {
+      window.dataLayer = window.dataLayer ?? [];
+      const utmParams = getStoredUTMParams();
+      window.dataLayer.push({
+        event: "signup_completed",
+        user_email: user.email,
+        company_name: workspace.name,
+        gclid: utmParams.gclid ?? null,
+        fbclid: utmParams.fbclid ?? null,
+        msclkid: utmParams.msclkid ?? null,
+        li_fat_id: utmParams.li_fat_id ?? null,
+      });
+    }
+
+    await onCompleted();
+  });
+
+  const handleProfileNext = () => {
+    setShowErrors(true);
+    const errors = validateProfileForm(formData);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+    if (showFavoritePlatformsStep) {
+      setStep(2);
+    } else {
+      void submit();
+    }
+  };
+
+  const togglePlatform = (platform: FavoritePlatform) => {
+    setSelectedPlatforms((prev) => {
+      const next = new Set(prev);
+      if (next.has(platform)) {
+        next.delete(platform);
+      } else {
+        next.add(platform);
+      }
+      return next;
+    });
+  };
+
+  const handlePlatformsSubmit = withTracking(
+    TRACKING_AREAS.AUTH,
+    "onboarding_complete",
+    () => {
+      void submit();
+    }
+  );
+
+  return {
+    step,
+    isFirstAdmin,
+    formData,
+    setFormData,
+    formErrors,
+    showErrors,
+    selectedPlatforms,
+    togglePlatform,
+    handleProfileNext,
+    handlePlatformsSubmit,
+    isSubmitting,
+    isWelcomeDataLoading,
+  };
+}

--- a/front/components/onboarding/useProfileOnboardingForm.ts
+++ b/front/components/onboarding/useProfileOnboardingForm.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/components/onboarding/ProfileOnboardingSteps";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
-import { usePatchUser } from "@app/lib/swr/user";
+import { useCompleteUserOnboarding, usePatchUser } from "@app/lib/swr/user";
 import { useWelcomeData } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getStoredUTMParams } from "@app/lib/utils/utm";
@@ -30,6 +30,7 @@ export function useProfileOnboardingForm({
 }: UseProfileOnboardingFormProps) {
   const { workspace, user } = useAuth();
   const { patchUser } = usePatchUser();
+  const { completeUserOnboarding } = useCompleteUserOnboarding();
 
   const { welcomeData, isFirstAdmin, emailProvider, isWelcomeDataLoading } =
     useWelcomeData({ workspaceId: workspace.sId });
@@ -74,6 +75,10 @@ export function useProfileOnboardingForm({
       emailProvider,
       workspace.sId
     );
+
+    // Clear the pending profile onboarding marker from the user metadata
+    // (set at the user's first login).
+    await completeUserOnboarding();
 
     if (typeof window !== "undefined") {
       window.dataLayer = window.dataLayer ?? [];

--- a/front/components/onboarding/useProfileOnboardingForm.ts
+++ b/front/components/onboarding/useProfileOnboardingForm.ts
@@ -17,7 +17,7 @@ import { useEffect, useMemo, useState } from "react";
 
 interface UseProfileOnboardingFormProps {
   // Called once the profile has been successfully submitted.
-  onCompleted: () => Promise<void> | void;
+  onCompleted: (result: { isFirstAdmin: boolean }) => Promise<void> | void;
 }
 
 /**
@@ -94,7 +94,7 @@ export function useProfileOnboardingForm({
       });
     }
 
-    await onCompleted();
+    await onCompleted({ isFirstAdmin });
   });
 
   const handleProfileNext = () => {

--- a/front/components/pages/onboarding/CheckoutPage.tsx
+++ b/front/components/pages/onboarding/CheckoutPage.tsx
@@ -1,6 +1,6 @@
 import { PaymentMethodRow } from "@app/components/checkout/PaymentMethodRow";
 import config from "@app/lib/api/config";
-import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   BUSINESS_PLAN_COST_MONTHLY,
   CP_MAX_SEAT_COST_MONTHLY,
@@ -10,11 +10,11 @@ import {
   getPriceAsString,
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
+  useIsMetronomeCheckout,
   useUserBillingCurrency,
 } from "@app/lib/client/subscription";
 import { isWhitelistedBusinessPlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
-import { useKillSwitches } from "@app/lib/swr/kill";
 import {
   useAuthContext,
   useCheckBusinessActivation,
@@ -101,13 +101,7 @@ export function CheckoutPage() {
   const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
 
   // Determine if CP checkout is enabled.
-  const { hasFeature } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
-  const isMetronomeEnabled =
-    hasFeature("metronome_billing") ||
-    !killSwitches?.includes("global_disable_metronome_billing");
-  const isMetronomeCheckout =
-    isMetronomeEnabled && hasFeature("metronome_cp_checkout") && !!seatType;
+  const isMetronomeCheckout = useIsMetronomeCheckout() && !!seatType;
 
   const [phase, setPhase] = useState<CheckoutPhase>("card_capture");
   const [phaseError, setPhaseError] = useState<PhaseError | null>(null);

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -6,11 +6,11 @@ import {
 import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useIsMetronomeCheckout } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { isFreeTrialPhonePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
-import { useKillSwitches } from "@app/lib/swr/kill";
 import { useUser } from "@app/lib/swr/user";
 import {
   useSubscriptionStatus,
@@ -359,14 +359,7 @@ function LegacySubscribePage() {
 }
 
 export function SubscribePage() {
-  const { hasFeature } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
-
-  const isMetronomeEnabled =
-    hasFeature("metronome_billing") ||
-    !killSwitches?.includes("global_disable_metronome_billing");
-  const isMetronomeCheckout =
-    isMetronomeEnabled && hasFeature("metronome_cp_checkout");
+  const isMetronomeCheckout = useIsMetronomeCheckout();
 
   if (isMetronomeCheckout) {
     return <CPSubscribePage />;

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -1,8 +1,11 @@
 import { PhoneNumberCodeInput } from "@app/components/trial/PhoneNumberCodeInput";
 import { PhoneNumberInput } from "@app/components/trial/PhoneNumberInput";
 import config from "@app/lib/api/config";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { CP_FREE_PLAN_CREDITS } from "@app/lib/client/subscription";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  CP_FREE_PLAN_CREDITS,
+  useIsMetronomeCheckout,
+} from "@app/lib/client/subscription";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   CODE_LENGTH,
@@ -11,7 +14,6 @@ import {
   RESEND_COOLDOWN_SECONDS,
 } from "@app/lib/plans/trial/phone";
 import { useAppRouter } from "@app/lib/platform";
-import { useKillSwitches } from "@app/lib/swr/kill";
 import { useAuthContext, useVerifyData } from "@app/lib/swr/workspaces";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
@@ -32,8 +34,6 @@ type Step = "captcha" | "phone" | "code" | "done";
 export function VerifyPage() {
   const { workspace } = useAuth();
   const router = useAppRouter();
-  const { hasFeature } = useFeatureFlags();
-  const { killSwitches } = useKillSwitches();
   const { mutateAuthContext } = useAuthContext({
     workspaceId: workspace.sId,
   });
@@ -41,11 +41,7 @@ export function VerifyPage() {
   // Same gate as the one that routes to /select-subscription (see
   // `isMetronomeCheckoutEnabled` and SubscribePage): the credit-priced checkout
   // flow gets the new phone verification copy and a welcome screen at the end.
-  const isMetronomeEnabled =
-    hasFeature("metronome_billing") ||
-    !killSwitches?.includes("global_disable_metronome_billing");
-  const isMetronomeCheckout =
-    isMetronomeEnabled && hasFeature("metronome_cp_checkout");
+  const isMetronomeCheckout = useIsMetronomeCheckout();
 
   const {
     verifyData,

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -93,8 +93,15 @@ export function VerifyPage() {
   }, [step]);
 
   const goToWorkspace = useCallback(() => {
-    void router.push(`/w/${workspace.sId}/conversation/new?welcome=true`);
-  }, [router, workspace.sId]);
+    if (isMetronomeCheckout) {
+      // With the credit-priced checkout flow, the profile form is collected
+      // in-app (onboarding dialog), which triggers the welcome conversation
+      // once submitted: enter the workspace directly.
+      void router.push(`/w/${workspace.sId}`);
+    } else {
+      void router.push(`/w/${workspace.sId}/conversation/new?welcome=true`);
+    }
+  }, [router, workspace.sId, isMetronomeCheckout]);
 
   const handleSendCode = async () => {
     setPhoneError(null);

--- a/front/components/pages/onboarding/WelcomePage.tsx
+++ b/front/components/pages/onboarding/WelcomePage.tsx
@@ -1,368 +1,32 @@
+import {
+  FavoritePlatformsStep,
+  UserProfileStep,
+} from "@app/components/onboarding/ProfileOnboardingSteps";
+import { useProfileOnboardingForm } from "@app/components/onboarding/useProfileOnboardingForm";
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { useSubmitFunction } from "@app/lib/client/utils";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
-import { usePatchUser } from "@app/lib/swr/user";
-import { useWelcomeData } from "@app/lib/swr/workspaces";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import { getConversationRoute } from "@app/lib/utils/router";
-import { getStoredUTMParams } from "@app/lib/utils/utm";
-import type { FavoritePlatform } from "@app/types/favorite_platforms";
-import { FAVORITE_PLATFORM_OPTIONS } from "@app/types/favorite_platforms";
-import type { JobType } from "@app/types/job_type";
-import { isJobType, JOB_TYPE_OPTIONS } from "@app/types/job_type";
-import { asDisplayName } from "@app/types/shared/utils/string_utils";
-import type { WorkspaceType } from "@app/types/user";
-import {
-  Button,
-  Card,
-  ConfluenceLogo,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-  DustLogoSquare,
-  FrontLogo,
-  GithubLogo,
-  GmailLogo,
-  HubspotLogo,
-  Icon,
-  Input,
-  JiraLogo,
-  MicrosoftOutlookLogo,
-  NotionLogo,
-  Page,
-  SlackLogo,
-  Spinner,
-} from "@dust-tt/sparkle";
-import type { ComponentType } from "react";
-import { useEffect, useMemo, useState } from "react";
-
-const PLATFORM_ICONS: Record<FavoritePlatform, ComponentType> = {
-  gmail: GmailLogo,
-  outlook: MicrosoftOutlookLogo,
-  slack: SlackLogo,
-  notion: NotionLogo,
-  confluence: ConfluenceLogo,
-  github: GithubLogo,
-  hubspot: HubspotLogo,
-  jira: JiraLogo,
-  front: FrontLogo,
-};
-
-interface UserProfileStepProps {
-  owner: WorkspaceType;
-  isAdmin: boolean;
-  formData: {
-    firstName: string;
-    lastName: string;
-    jobType: JobType | null;
-  };
-  setFormData: React.Dispatch<
-    React.SetStateAction<{
-      firstName: string;
-      lastName: string;
-      jobType: JobType | null;
-    }>
-  >;
-  formErrors: {
-    firstName?: string;
-    lastName?: string;
-    jobType?: string;
-  };
-  showErrors: boolean;
-  onNext: () => void;
-}
-
-function UserProfileStep({
-  owner,
-  isAdmin,
-  formData,
-  setFormData,
-  formErrors,
-  showErrors,
-  onNext,
-}: UserProfileStepProps) {
-  const selectedJobTypeLabel = useMemo(() => {
-    if (!formData.jobType) {
-      return "Select job type";
-    }
-    const jobType = JOB_TYPE_OPTIONS.find((t) => t.value === formData.jobType);
-    return jobType?.label ?? "Select job type";
-  }, [formData.jobType]);
-
-  return (
-    <OnboardingLayout owner={owner}>
-      <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
-        <Page.Header
-          title={`Hello ${formData.firstName || "there"}!`}
-          icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-        />
-        <p className="text-muted-foreground dark:text-muted-foreground-night">
-          Let's check a few things.
-        </p>
-        {!isAdmin && (
-          <p className="text-muted-foreground dark:text-muted-foreground-night">
-            You'll be joining the workspace:{" "}
-            <span className="font-medium">{owner.name}</span>.
-          </p>
-        )}
-        <div>
-          <p className="pb-2 text-muted-foreground dark:text-muted-foreground-night">
-            Your name is:
-          </p>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div>
-              <Input
-                name="firstName"
-                placeholder="First Name"
-                value={formData.firstName}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    firstName: e.target.value,
-                  }))
-                }
-              />
-              {showErrors && formErrors.firstName && (
-                <p className="mt-1 text-sm text-red-500">
-                  {formErrors.firstName}
-                </p>
-              )}
-            </div>
-            <div>
-              <Input
-                name="lastName"
-                placeholder="Last Name"
-                value={formData.lastName}
-                onChange={(e) =>
-                  setFormData((prev) => ({ ...prev, lastName: e.target.value }))
-                }
-              />
-              {showErrors && formErrors.lastName && (
-                <p className="mt-1 text-sm text-red-500">
-                  {formErrors.lastName}
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-        <div>
-          <p className="pb-2 text-muted-foreground dark:text-muted-foreground-night">
-            Pick your job type to get relevant feature updates:
-          </p>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className="justify-between text-muted-foreground dark:text-muted-foreground-night"
-                label={selectedJobTypeLabel}
-                isSelect={true}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
-              <DropdownMenuRadioGroup
-                value={formData.jobType ?? ""}
-                onValueChange={(value) => {
-                  if (isJobType(value)) {
-                    setFormData((prev) => ({ ...prev, jobType: value }));
-                  }
-                }}
-              >
-                {JOB_TYPE_OPTIONS.map((jobTypeOption) => (
-                  <DropdownMenuRadioItem
-                    key={jobTypeOption.value}
-                    value={jobTypeOption.value}
-                    label={jobTypeOption.label}
-                  />
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {showErrors && formErrors.jobType && (
-            <p className="mt-1 text-sm text-red-500">{formErrors.jobType}</p>
-          )}
-        </div>
-        <div className="flex justify-end">
-          <Button label="Next" size="md" onClick={onNext} />
-        </div>
-      </div>
-    </OnboardingLayout>
-  );
-}
-
-interface FavoritePlatformsStepProps {
-  owner: WorkspaceType;
-  selectedPlatforms: Set<FavoritePlatform>;
-  onTogglePlatform: (platform: FavoritePlatform) => void;
-  onSubmit: React.MouseEventHandler<HTMLElement>;
-  isSubmitting: boolean;
-}
-
-function FavoritePlatformsStep({
-  owner,
-  selectedPlatforms,
-  onTogglePlatform,
-  onSubmit,
-  isSubmitting,
-}: FavoritePlatformsStepProps) {
-  return (
-    <OnboardingLayout owner={owner}>
-      <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
-        <Page.Header title="What are your favorite platforms?" />
-        <p className="text-muted-foreground dark:text-muted-foreground-night">
-          Dust works at full potential when it can play with your knowledge and
-          help with your tools. Do you recognise some of these?
-        </p>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          {FAVORITE_PLATFORM_OPTIONS.map((platform) => {
-            const PlatformIcon = PLATFORM_ICONS[platform];
-            const isSelected = selectedPlatforms.has(platform);
-            return (
-              <Card
-                key={platform}
-                variant="secondary"
-                size="sm"
-                selected={isSelected}
-                onClick={() => onTogglePlatform(platform)}
-              >
-                <div className="flex items-center gap-3">
-                  <Icon visual={PlatformIcon} size="md" />
-                  <span className="text-sm font-medium">
-                    {asDisplayName(platform)}
-                  </span>
-                </div>
-              </Card>
-            );
-          })}
-        </div>
-        <div className="flex justify-end">
-          <Button
-            label="Next"
-            isLoading={isSubmitting}
-            disabled={isSubmitting}
-            size="md"
-            onClick={onSubmit}
-          />
-        </div>
-      </div>
-    </OnboardingLayout>
-  );
-}
-
-interface FormData {
-  firstName: string;
-  lastName: string;
-  jobType: JobType | null;
-}
-
-interface FormErrors {
-  firstName?: string;
-  lastName?: string;
-  jobType?: string;
-}
-
-function getInitialSelectedPlatforms(
-  emailProvider: EmailProviderType
-): Set<FavoritePlatform> {
-  const platforms = new Set<FavoritePlatform>();
-  if (emailProvider === "google") {
-    platforms.add("gmail");
-  } else if (emailProvider === "microsoft") {
-    platforms.add("outlook");
-  }
-  return platforms;
-}
+import { Spinner } from "@dust-tt/sparkle";
 
 export function WelcomePage() {
-  const { workspace, user, isAdmin } = useAuth();
+  const { workspace, isAdmin } = useAuth();
   const router = useAppRouter();
-  const { patchUser } = usePatchUser();
   const conversationId = useSearchParam("cId");
 
-  const { welcomeData, isFirstAdmin, emailProvider, isWelcomeDataLoading } =
-    useWelcomeData({ workspaceId: workspace.sId });
-
-  const showFavoritePlatformsStep = isFirstAdmin;
-
-  const [step, setStep] = useState<1 | 2>(1);
-  const [formData, setFormData] = useState<FormData>({
-    firstName: user.firstName,
-    lastName: user.lastName ?? "",
-    jobType: null,
-  });
-  const [selectedPlatforms, setSelectedPlatforms] = useState<
-    Set<FavoritePlatform>
-  >(new Set());
-  const [showErrors, setShowErrors] = useState(false);
-  const [platformsInitialized, setPlatformsInitialized] = useState(false);
-
-  // Initialize selectedPlatforms once emailProvider is loaded.
-  useEffect(() => {
-    if (welcomeData && !platformsInitialized) {
-      setSelectedPlatforms(getInitialSelectedPlatforms(emailProvider));
-      setPlatformsInitialized(true);
-    }
-  }, [welcomeData, platformsInitialized, emailProvider]);
-
-  const validateForm = (data: FormData): FormErrors => {
-    const errors: FormErrors = {};
-    if (!data.firstName.trim()) {
-      errors.firstName = "First name is required";
-    }
-    if (!data.lastName.trim()) {
-      errors.lastName = "Last name is required";
-    }
-    if (!data.jobType) {
-      errors.jobType = "Please select your job type";
-    }
-    return errors;
-  };
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
-  const formErrors = useMemo(() => {
-    if (!showErrors) {
-      return {};
-    }
-    return validateForm(formData);
-  }, [formData, showErrors]);
-
-  const { submit, isSubmitting } = useSubmitFunction(async () => {
-    await patchUser(
-      formData.firstName.trim(),
-      formData.lastName.trim(),
-      false,
-      formData.jobType ?? undefined,
-      undefined,
-      showFavoritePlatformsStep ? Array.from(selectedPlatforms) : undefined,
-      emailProvider,
-      workspace.sId
-    );
-
-    if (typeof window !== "undefined") {
-      window.dataLayer = window.dataLayer ?? [];
-      const utmParams = getStoredUTMParams();
-      window.dataLayer.push({
-        event: "signup_completed",
-        user_email: user.email,
-        company_name: workspace.name,
-        gclid: utmParams.gclid ?? null,
-        fbclid: utmParams.fbclid ?? null,
-        msclkid: utmParams.msclkid ?? null,
-        li_fat_id: utmParams.li_fat_id ?? null,
-      });
-    }
-
-    const queryParams = `welcome=true${
-      conversationId ? `&cId=${conversationId}` : ""
-    }`;
-    await router.push(getConversationRoute(workspace.sId, "new", queryParams));
+  const form = useProfileOnboardingForm({
+    onCompleted: async () => {
+      const queryParams = `welcome=true${
+        conversationId ? `&cId=${conversationId}` : ""
+      }`;
+      await router.push(
+        getConversationRoute(workspace.sId, "new", queryParams)
+      );
+    },
   });
 
   // Show loading while fetching welcome data.
-  if (isWelcomeDataLoading) {
+  if (form.isWelcomeDataLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
         <Spinner />
@@ -370,60 +34,30 @@ export function WelcomePage() {
     );
   }
 
-  const handleStep1Next = () => {
-    setShowErrors(true);
-    const errors = validateForm(formData);
-    if (Object.keys(errors).length > 0) {
-      return;
-    }
-    if (showFavoritePlatformsStep) {
-      setStep(2);
-    } else {
-      void submit();
-    }
-  };
-
-  const togglePlatform = (platform: FavoritePlatform) => {
-    setSelectedPlatforms((prev) => {
-      const next = new Set(prev);
-      if (next.has(platform)) {
-        next.delete(platform);
-      } else {
-        next.add(platform);
-      }
-      return next;
-    });
-  };
-
-  const handleStep2Submit = withTracking(
-    TRACKING_AREAS.AUTH,
-    "onboarding_complete",
-    () => {
-      void submit();
-    }
-  );
-
-  if (step === 1) {
+  if (form.step === 1) {
     return (
-      <UserProfileStep
-        owner={workspace}
-        isAdmin={isAdmin}
-        formData={formData}
-        setFormData={setFormData}
-        formErrors={formErrors}
-        showErrors={showErrors}
-        onNext={handleStep1Next}
-      />
+      <OnboardingLayout owner={workspace}>
+        <UserProfileStep
+          owner={workspace}
+          isAdmin={isAdmin}
+          formData={form.formData}
+          setFormData={form.setFormData}
+          formErrors={form.formErrors}
+          showErrors={form.showErrors}
+          onNext={form.handleProfileNext}
+        />
+      </OnboardingLayout>
     );
   }
 
   return (
-    <FavoritePlatformsStep
-      owner={workspace}
-      selectedPlatforms={selectedPlatforms}
-      onTogglePlatform={togglePlatform}
-      onSubmit={handleStep2Submit}
-      isSubmitting={isSubmitting}
-    />
+    <OnboardingLayout owner={workspace}>
+      <FavoritePlatformsStep
+        selectedPlatforms={form.selectedPlatforms}
+        onTogglePlatform={form.togglePlatform}
+        onSubmit={form.handlePlatformsSubmit}
+        isSubmitting={form.isSubmitting}
+      />
+    </OnboardingLayout>
   );
 }

--- a/front/components/pages/onboarding/WelcomePage.tsx
+++ b/front/components/pages/onboarding/WelcomePage.tsx
@@ -5,6 +5,7 @@ import {
 import { useProfileOnboardingForm } from "@app/components/onboarding/useProfileOnboardingForm";
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { useIsMetronomeCheckout } from "@app/lib/client/subscription";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { Spinner } from "@dust-tt/sparkle";
@@ -13,6 +14,7 @@ export function WelcomePage() {
   const { workspace, isAdmin } = useAuth();
   const router = useAppRouter();
   const conversationId = useSearchParam("cId");
+  const isMetronomeCheckout = useIsMetronomeCheckout();
 
   const form = useProfileOnboardingForm({
     onCompleted: async () => {
@@ -24,6 +26,20 @@ export function WelcomePage() {
       );
     },
   });
+
+  // With the credit-priced checkout flow, the profile form is collected in-app
+  // (onboarding dialog): send the user into the workspace. For the first admin
+  // pre-checkout, the paywall redirects them to the plan selection page first.
+  if (isMetronomeCheckout) {
+    void router.replace(
+      `/w/${workspace.sId}${conversationId ? `?cId=${conversationId}` : ""}`
+    );
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   // Show loading while fetching welcome data.
   if (form.isWelcomeDataLoading) {

--- a/front/lib/api/login.ts
+++ b/front/lib/api/login.ts
@@ -23,6 +23,7 @@ import { readAnonymousIdFromCookies } from "@app/lib/utils/anonymous_id";
 import type { UTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { ONBOARDING_PROFILE_PENDING_METADATA_KEY } from "@app/types/onboarding";
 import type { LightWorkspaceType } from "@app/types/user";
 
 export interface PerformLoginOptions {
@@ -314,10 +315,19 @@ export async function performLogin(
     };
   }
 
+  const isFirstLogin = user.lastLoginAt === null;
+
   const redirectOptions: Parameters<typeof buildPostLoginUrl>[1] = {
-    welcome: user.lastLoginAt === null,
+    welcome: isFirstLogin,
     utmParams: Object.keys(utmParams).length > 0 ? utmParams : undefined,
   };
+
+  if (isFirstLogin) {
+    // Mark the profile onboarding (name, job type, favorite platforms) as
+    // pending. Cleared when the user submits the profile form, either on the
+    // /welcome page or in the in-app onboarding dialog (credit-priced flow).
+    await user.setMetadata(ONBOARDING_PROFILE_PENDING_METADATA_KEY, "true");
+  }
 
   await user.recordLoginActivity();
 

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -1,7 +1,9 @@
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getBillingCurrencyForCountry } from "@app/lib/plans/billing_currency";
+import type { KillSwitchType } from "@app/lib/poke/types";
 import { useGeolocation } from "@app/lib/swr/geo";
 import type { SupportedCurrency } from "@app/types/currency";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { useKillSwitches } from "../swr/kill";
 
 // If mention the price of the PRO plan in a few different places in the code base,
@@ -23,6 +25,34 @@ export const CP_MAX_SEAT_COST_YEARLY = 120;
 // `front/lib/metronome/setup_new_pricing.ts` (that module is server-only and
 // cannot be imported client-side).
 export const CP_FREE_PLAN_CREDITS = 300;
+
+/**
+ * Client-side mirror of the server-side `isMetronomeCheckoutEnabled` gate: the
+ * credit-priced checkout flow is enabled when Metronome billing is on (feature
+ * flag, or kill switch not active) and the workspace has the
+ * `metronome_cp_checkout` feature flag.
+ *
+ * Prefer the `useIsMetronomeCheckout` hook; this helper is for components that
+ * render outside the auth context provider (e.g. the SPA workspace layout).
+ */
+export function computeIsMetronomeCheckout({
+  featureFlags,
+  killSwitches,
+}: {
+  featureFlags: WhitelistableFeature[];
+  killSwitches: KillSwitchType[] | null | undefined;
+}): boolean {
+  const isMetronomeEnabled =
+    featureFlags.includes("metronome_billing") ||
+    !killSwitches?.includes("global_disable_metronome_billing");
+  return isMetronomeEnabled && featureFlags.includes("metronome_cp_checkout");
+}
+
+export function useIsMetronomeCheckout(): boolean {
+  const { featureFlags } = useFeatureFlags();
+  const { killSwitches } = useKillSwitches();
+  return computeIsMetronomeCheckout({ featureFlags, killSwitches });
+}
 
 export function formatPriceWithCurrency(
   price: number,

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -100,6 +100,16 @@ export function useUserApprovals(owner: LightWorkspaceType) {
   };
 }
 
+export function useCompleteUserOnboarding() {
+  const completeUserOnboarding = async () => {
+    return clientFetch("/api/user/onboarding/complete", {
+      method: "POST",
+    });
+  };
+
+  return { completeUserOnboarding };
+}
+
 export function useDeleteMetadata() {
   const deleteMetadata = async (prefix: string) => {
     return clientFetch(`/api/user/metadata/${encodeURIComponent(prefix)}`, {

--- a/front/types/onboarding.ts
+++ b/front/types/onboarding.ts
@@ -1,0 +1,7 @@
+// User metadata key marking that the profile onboarding form (name, job type,
+// favorite platforms) hasn't been completed yet. Set (to "true") at the user's
+// first login and cleared when they submit the profile form — either on the
+// /welcome page or in the in-app onboarding dialog shown in the credit-priced
+// checkout flow.
+export const ONBOARDING_PROFILE_PENDING_METADATA_KEY =
+  "onboarding:profile_pending";


### PR DESCRIPTION
## Description

Can be reviewed commit by commit:
 1. Extract a useIsMetronomeCheckout for cleaning
 2. Splits `front/components/pages/onboarding/WelcomePage.tsx` into several components to be re-used for legacy flow and new flow
 3. Add a new user metadata `onboarding:profile_pending`, which set at the user first login. Add a endpoint to switch it false at the end of onbaording.
 4. Actually add the new flow for metronome checkout. When onboarding:profile_pending is set to true, the user see the pop up to fill additional information (name + job title for normal user, and additionally email service for the first admin)

## Tests

Tested locally, see private video
Not tested: the payed path

## Risk

The logic to alternate between old and new flows is more and more complex, but I have tested both and they seem to work.

## Deploy Plan

deploy front
