### PR TITLE
[front] feat: add get_top_tools to workspace_analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -705,6 +705,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_agent_details": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_skills": "never_ask",
+    "get_top_tools": "never_ask",
     "get_top_users": "never_ask",
   },
   "zendesk": {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -1,6 +1,8 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  DEFAULT_RESULTS,
+  MAX_RESULTS,
   timeWindowSchemaShape,
   usageFilterSchema,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
@@ -8,29 +10,25 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const getTopAgentsSchema = {
+const topListSchema = (entityPlural: string) => ({
   ...timeWindowSchemaShape,
   ...usageFilterSchema,
   limit: z
     .number()
     .int()
     .positive()
-    .max(100)
+    .max(MAX_RESULTS)
     .optional()
-    .describe("Maximum number of agents to return (default 25, max 100)."),
-};
+    .describe(
+      `Maximum number of ${entityPlural} to return ` +
+        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
+    ),
+});
 
-const getTopUsersSchema = {
-  ...timeWindowSchemaShape,
-  ...usageFilterSchema,
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(100)
-    .optional()
-    .describe("Maximum number of users to return (default 25, max 100)."),
-};
+const getTopAgentsSchema = topListSchema("agents");
+const getTopUsersSchema = topListSchema("users");
+const getTopSkillsSchema = topListSchema("skills");
+const getTopToolsSchema = topListSchema("tools");
 
 const getAgentDetailsSchema = {
   agentId: z
@@ -38,18 +36,6 @@ const getAgentDetailsSchema = {
     .describe(
       "The agent's id (sId), as returned by get_top_agents or other tools."
     ),
-};
-
-const getTopSkillsSchema = {
-  ...timeWindowSchemaShape,
-  ...usageFilterSchema,
-  limit: z
-    .number()
-    .int()
-    .positive()
-    .max(100)
-    .optional()
-    .describe("Maximum number of skills to return (default 25, max 100)."),
 };
 
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
@@ -106,6 +92,19 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving top skills",
       done: "Retrieved top skills",
+    },
+  },
+  get_top_tools: {
+    description:
+      "Return the workspace's most-used tools (by MCP server) over a time " +
+      "window (defaults to the current calendar month), ranked by execution " +
+      "count. Optionally filter by source (context_origin), agent, or user. " +
+      "Use this to answer which tools are used most. Admin-only.",
+    schema: getTopToolsSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving top tools",
+      done: "Retrieved top tools",
     },
   },
 });

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -12,6 +12,9 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 // are never rejected.
 export const MAX_QUERY_WINDOW_DAYS = 100;
 
+export const DEFAULT_RESULTS = 25;
+export const MAX_RESULTS = 100;
+
 export const ANALYTICS_PERIODS = [
   "this_month",
   "last_7_days",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -28,6 +28,7 @@ describe("workspace_analytics tools", () => {
     "get_top_users",
     "get_agent_details",
     "get_top_skills",
+    "get_top_tools",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -3,15 +3,41 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
-import { resolveTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import {
+  DEFAULT_RESULTS,
+  resolveTimeWindow,
+} from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
+import {
+  fetchAvailableTools,
+  resolveServerDisplayNames,
+} from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
 
-const DEFAULT_LIMIT = 25;
+function scopedBaseQuery(
+  auth: Authenticator,
+  window: ResolvedTimeWindow,
+  {
+    source,
+    agentIds,
+    userIds,
+  }: { source?: string; agentIds?: string[]; userIds?: string[] }
+) {
+  return buildAgentAnalyticsBaseQuery({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    startDate: window.startDate,
+    endDate: window.endDate,
+    contextOrigin: source,
+    agentIds,
+    userIds,
+  });
+}
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   get_top_agents: async (
@@ -31,7 +57,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const result = await fetchTopAgents(auth, {
       startDate: window.value.startDate,
       endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_LIMIT,
+      limit: limit ?? DEFAULT_RESULTS,
       contextOrigin: source,
       agentIds,
       userIds,
@@ -87,7 +113,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const result = await fetchTopUsers(auth, {
       startDate: window.value.startDate,
       endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_LIMIT,
+      limit: limit ?? DEFAULT_RESULTS,
       contextOrigin: source,
       agentIds,
       userIds,
@@ -182,11 +208,8 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
 
-    const baseQuery = buildAgentAnalyticsBaseQuery({
-      workspaceId: auth.getNonNullableWorkspace().sId,
-      startDate: window.value.startDate,
-      endDate: window.value.endDate,
-      contextOrigin: source,
+    const baseQuery = scopedBaseQuery(auth, window.value, {
+      source,
       agentIds,
       userIds,
     });
@@ -199,7 +222,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     }
 
     const { label, timezone: tz } = window.value;
-    const skills = result.value.slice(0, limit ?? DEFAULT_LIMIT);
+    const skills = result.value.slice(0, limit ?? DEFAULT_RESULTS);
 
     if (skills.length === 0) {
       return new Ok([
@@ -220,6 +243,69 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Most-used skills for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_top_tools: async (
+    { limit, period, startDate, endDate, timezone, source, agentIds, userIds },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const baseQuery = scopedBaseQuery(auth, window.value, {
+      source,
+      agentIds,
+      userIds,
+    });
+
+    const result = await fetchAvailableTools(baseQuery);
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to retrieve tool usage: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+    const top = result.value.slice(0, limit ?? DEFAULT_RESULTS);
+
+    if (top.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No tool usage recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const displayNames = await resolveServerDisplayNames(
+      auth,
+      top.map((tool) => tool.serverName)
+    );
+
+    const lines = top.map((tool, index) => {
+      const displayName = displayNames.get(tool.serverName) ?? tool.displayName;
+      const name =
+        displayName === tool.serverName
+          ? displayName
+          : `${displayName} [${tool.serverName}]`;
+      return `${index + 1}. ${name} — ${tool.totalExecutions} executions`;
+    });
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Most-used tools for ${label} (${tz}), most used first:\n` +
           lines.join("\n"),
       },
     ]);


### PR DESCRIPTION
## Description

Add an admin-only get_top_tools tool that ranks the workspace's most-used tools (by MCP server) by execution count over a time window, resolving friendly server display names. Reuses the existing observability fetchAvailableTools + resolveServerDisplayNames over a scoped base query.

Along the way, tidy the tool plumbing now that there are several similar tools: extract a scopedBaseQuery helper (shared by the skills/tools handlers), factor the identical top-N list schemas into a topListSchema(entity) factory, and single-source the result-limit bounds as DEFAULT_RESULTS / MAX_RESULTS in query_input (used by the schema cap, the description, and the handler default).
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
