### PR TITLE
Snippet large pasted content instead of inlining it in full

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -289,8 +289,8 @@ function constructPastedContentSection(): string {
   return (
     "# PASTED CONTENT\n" +
     "The conversation history may contain large pasted contents, indicated by <pastedContent> tags. " +
-    `Pasted content below ${FILE_OFFLOAD_TEXT_SIZE_BYTES} bytes contains the full text (no tool call needed). ` +
-    `Above ${FILE_OFFLOAD_TEXT_SIZE_BYTES} bytes, the attribute \`truncated="true"\` is set, only a ${TRUNCATED_SNIPPET_SIZE}-char snippet is shown, and the full pasted content can be accessed through file utilities on the associated file.\n`
+    `Pasted content of at most ${FILE_OFFLOAD_TEXT_SIZE_BYTES} bytes contains the full text (no tool call needed). ` +
+    `Beyond that, the attribute \`truncated="true"\` is set, only a ${TRUNCATED_SNIPPET_SIZE}-char snippet is shown, and the full pasted content can be accessed through file utilities on the associated file.\n`
   );
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,3 +1,4 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import {
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   ENABLE_SKILL_TOOL_NAME,
@@ -25,10 +26,7 @@ import {
   type EnabledSkill,
   resolveSkillInstructions,
 } from "@app/lib/api/assistant/skills_rendering";
-import {
-  PASTED_CONTENT_MAX_CHARACTERS,
-  TRUNCATED_SNIPPET_SIZE,
-} from "@app/lib/api/files/snippet";
+import { TRUNCATED_SNIPPET_SIZE } from "@app/lib/api/files/snippet";
 import type {
   StructuredSystemPrompt,
   SystemPromptContext,
@@ -291,8 +289,8 @@ function constructPastedContentSection(): string {
   return (
     "# PASTED CONTENT\n" +
     "The conversation history may contain large pasted contents, indicated by <pastedContent> tags. " +
-    `Pasted content below ${PASTED_CONTENT_MAX_CHARACTERS} chars contains the full text (no tool call needed). ` +
-    `Above ${PASTED_CONTENT_MAX_CHARACTERS} chars, the attribute \`truncated="true"\` is set, only a ${TRUNCATED_SNIPPET_SIZE}-char snippet is shown, and the full pasted content can be accessed through file utilities on the associated file.\n`
+    `Pasted content below ${FILE_OFFLOAD_TEXT_SIZE_BYTES} bytes contains the full text (no tool call needed). ` +
+    `Above ${FILE_OFFLOAD_TEXT_SIZE_BYTES} bytes, the attribute \`truncated="true"\` is set, only a ${TRUNCATED_SNIPPET_SIZE}-char snippet is shown, and the full pasted content can be accessed through file utilities on the associated file.\n`
   );
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -289,7 +289,7 @@ function constructPastedContentSection(): string {
   return (
     "# PASTED CONTENT\n" +
     "The conversation history may contain large pasted contents, indicated by <pastedContent> tags. " +
-    `Pasted content of at most ${FILE_OFFLOAD_TEXT_SIZE_BYTES} bytes contains the full text (no tool call needed). ` +
+    `Pasted content of at most ${FILE_OFFLOAD_TEXT_SIZE_BYTES} chars contains the full text (no tool call needed). ` +
     `Beyond that, the attribute \`truncated="true"\` is set, only a ${TRUNCATED_SNIPPET_SIZE}-char snippet is shown, and the full pasted content can be accessed through file utilities on the associated file.\n`
   );
 }

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -8,6 +8,7 @@ import {
   getAttachmentFromContentFragment,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
+import { truncateLegacyPastedSnippet } from "@app/lib/api/files/snippet";
 import type { Authenticator } from "@app/lib/auth";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
@@ -35,7 +36,10 @@ export async function listAttachments(
 
       const attachment = getAttachmentFromContentFragment(m);
       if (attachment) {
-        attachments.set(m.contentFragmentId, attachment);
+        attachments.set(
+          m.contentFragmentId,
+          truncateLegacyPastedSnippet(attachment)
+        );
       }
     } else if (isAgentMessageType(m)) {
       const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -32,6 +32,25 @@ export function isPastedContentOverInlineLimit(content: string): boolean {
   return computeTextByteSize(content) > FILE_OFFLOAD_TEXT_SIZE_BYTES;
 }
 
+export function truncateSnippet(content: string): string {
+  return content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
+}
+
+// Snippets of pasted content stored before the inline limit was lowered may contain the full
+// paste (up to 128KB). Re-truncate them so consumers never inline an oversized paste.
+export function truncateLegacyPastedSnippet<
+  T extends { contentType: string; snippet: string | null },
+>(attachment: T): T {
+  if (
+    isPastedFile(attachment.contentType) &&
+    attachment.snippet !== null &&
+    isPastedContentOverInlineLimit(attachment.snippet)
+  ) {
+    return { ...attachment, snippet: truncateSnippet(attachment.snippet) };
+  }
+  return attachment;
+}
+
 export async function generateSnippet(
   auth: Authenticator,
   {
@@ -67,7 +86,7 @@ export async function generateSnippet(
 
     let snippet = `${file.contentType} file with headers: ${schemaRes.value.schema.map((c) => c.name).join(",")}`;
     if (snippet.length > TRUNCATED_SNIPPET_SIZE) {
-      snippet = snippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
+      snippet = truncateSnippet(snippet);
     }
 
     return new Ok(snippet);
@@ -85,14 +104,14 @@ export async function generateSnippet(
       // context. We really want to avoid having a snippet which is both large and truncated,
       // otherwise the model will pay the cost of the large snippet + read the file.
       if (isPastedContentOverInlineLimit(content)) {
-        return new Ok(content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX);
+        return new Ok(truncateSnippet(content));
       }
       return new Ok(content);
     }
 
     // Take the first 256 characters
     if (content.length > TRUNCATED_SNIPPET_SIZE) {
-      return new Ok(content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX);
+      return new Ok(truncateSnippet(content));
     } else {
       return new Ok(content);
     }
@@ -106,7 +125,7 @@ export async function generateSnippet(
 
     let snippet = `Audio file: ${content}`;
     if (snippet.length > TRUNCATED_SNIPPET_SIZE) {
-      snippet = snippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
+      snippet = truncateSnippet(snippet);
     }
 
     return new Ok(snippet);

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -1,4 +1,8 @@
 import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
+import {
+  computeTextByteSize,
+  FILE_OFFLOAD_TEXT_SIZE_BYTES,
+} from "@app/lib/actions/action_output_limits";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -16,11 +20,17 @@ import { Err, Ok } from "@app/types/shared/result";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { isSupportedPlainTextContentType } from "@dust-tt/client";
 
-export const PASTED_CONTENT_MAX_CHARACTERS = 128 * 1024;
 export const TRUNCATED_SUFFIX = "... (truncated)";
 export const TRUNCATED_SNIPPET_SIZE = 256;
 export const TRUNCATED_TEXT_SIZE =
   TRUNCATED_SNIPPET_SIZE - TRUNCATED_SUFFIX.length;
+
+// Pasted content is inlined in full in the rendered conversation only while it stays below the
+// same threshold used to offload large tool outputs to files. Beyond that, only a truncated
+// snippet is inlined and the model reads the full content through the conversation file tools.
+export function isPastedContentOverInlineLimit(content: string): boolean {
+  return computeTextByteSize(content) > FILE_OFFLOAD_TEXT_SIZE_BYTES;
+}
 
 export async function generateSnippet(
   auth: Authenticator,
@@ -70,11 +80,11 @@ export async function generateSnippet(
     }
 
     if (isPastedFile(file.contentType)) {
-      // Include the full pasted text up to 128K characters. Beyond that, truncate to 256
-      // characters like a regular text file to avoid blowing up the conversation context.
-      // We really want to avoid having a snippet which is both large and truncated,
+      // Include the full pasted text up to the tool-output offload threshold. Beyond that,
+      // truncate to 256 characters like a regular text file to avoid blowing up the conversation
+      // context. We really want to avoid having a snippet which is both large and truncated,
       // otherwise the model will pay the cost of the large snippet + read the file.
-      if (content.length > PASTED_CONTENT_MAX_CHARACTERS) {
+      if (isPastedContentOverInlineLimit(content)) {
         return new Ok(content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX);
       }
       return new Ok(content);

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -1,8 +1,5 @@
 import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
-import {
-  computeTextByteSize,
-  FILE_OFFLOAD_TEXT_SIZE_BYTES,
-} from "@app/lib/actions/action_output_limits";
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,8 +25,10 @@ export const TRUNCATED_TEXT_SIZE =
 // Pasted content is inlined in full in the rendered conversation only while it stays below the
 // same threshold used to offload large tool outputs to files. Beyond that, only a truncated
 // snippet is inlined and the model reads the full content through the conversation file tools.
+// For ASCII-dominant text, 1 char ≈ 1 byte, so we use FILE_OFFLOAD_TEXT_SIZE_BYTES directly as
+// a character count to keep everything here in a single unit.
 export function isPastedContentOverInlineLimit(content: string): boolean {
-  return computeTextByteSize(content) > FILE_OFFLOAD_TEXT_SIZE_BYTES;
+  return content.length > FILE_OFFLOAD_TEXT_SIZE_BYTES;
 }
 
 export function truncateSnippet(content: string): string {

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -1,3 +1,8 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import {
+  TRUNCATED_SUFFIX,
+  TRUNCATED_TEXT_SIZE,
+} from "@app/lib/api/files/snippet";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
@@ -149,6 +154,58 @@ describe("renderLightContentFragmentForModel", () => {
       expect((result?.content[0] as { text: string }).text).toContain(
         "<pastedContent"
       );
+    });
+
+    it("inlines a below-threshold paste in full without truncation", async () => {
+      const pasteContent = "Some pasted content that fits inline.";
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted", {
+          snippet: pasteContent,
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: false }
+      );
+      const text = (result?.content[0] as { text: string }).text;
+      expect(text).toContain(
+        `<pastedContent name="file">${pasteContent}</pastedContent>`
+      );
+      expect(text).not.toContain('truncated="true"');
+    });
+
+    it("renders an above-threshold paste as a truncated snippet with path", async () => {
+      const snippet = "a".repeat(TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted", {
+          snippet,
+          path: "conversation-conv123/pasted-text-1.txt",
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: false }
+      );
+      const text = (result?.content[0] as { text: string }).text;
+      expect(text).toContain('truncated="true"');
+      expect(text).toContain('path="conversation-conv123/pasted-text-1.txt"');
+    });
+
+    it("re-truncates a legacy oversized stored snippet so the full paste is not inlined", async () => {
+      const fullPaste = "b".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted", {
+          snippet: fullPaste,
+          path: "conversation-conv123/pasted-text-1.txt",
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: false }
+      );
+      const text = (result?.content[0] as { text: string }).text;
+      expect(text).not.toContain(fullPaste);
+      expect(text.length).toBeLessThan(1024);
+      expect(text).toContain('truncated="true"');
+      expect(text).toContain('path="conversation-conv123/pasted-text-1.txt"');
+      expect(text).toContain(TRUNCATED_SUFFIX);
     });
 
     it("renders an image with excludeImages as <attachment> with description", async () => {

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -8,6 +8,8 @@ import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { renderLightContentFragmentForModel } from "@app/lib/resources/content_fragment_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ContentFragmentMessageTypeModel } from "@app/types/assistant/generation";
+import { isTextContent } from "@app/types/assistant/generation";
 import type {
   ContentNodeContentFragmentType,
   FileContentFragmentType,
@@ -98,6 +100,14 @@ function makeContentNodeFragment(): ContentNodeContentFragmentType {
   };
 }
 
+function getTextContent(result: ContentFragmentMessageTypeModel | null) {
+  const item = result?.content[0];
+  if (!item || !isTextContent(item)) {
+    throw new Error("Expected a text content item");
+  }
+  return item.text;
+}
+
 const visionModel = getSupportedModelConfigs().find((m) => m.supportsVision)!;
 const nonVisionModel = getSupportedModelConfigs().find(
   (m) => !m.supportsVision
@@ -166,14 +176,14 @@ describe("renderLightContentFragmentForModel", () => {
         visionModel,
         { excludeImages: false, useFileSystem: false }
       );
-      const text = (result?.content[0] as { text: string }).text;
+      const text = getTextContent(result);
       expect(text).toContain(
         `<pastedContent name="file">${pasteContent}</pastedContent>`
       );
       expect(text).not.toContain('truncated="true"');
     });
 
-    it("renders an above-threshold paste as a truncated snippet with path", async () => {
+    it("renders a stored truncated paste snippet with truncated and path attributes", async () => {
       const snippet = "a".repeat(TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX;
       const result = await renderLightContentFragmentForModel(
         authenticator,
@@ -184,7 +194,7 @@ describe("renderLightContentFragmentForModel", () => {
         visionModel,
         { excludeImages: false, useFileSystem: false }
       );
-      const text = (result?.content[0] as { text: string }).text;
+      const text = getTextContent(result);
       expect(text).toContain('truncated="true"');
       expect(text).toContain('path="conversation-conv123/pasted-text-1.txt"');
     });
@@ -200,11 +210,29 @@ describe("renderLightContentFragmentForModel", () => {
         visionModel,
         { excludeImages: false, useFileSystem: false }
       );
-      const text = (result?.content[0] as { text: string }).text;
+      const text = getTextContent(result);
       expect(text).not.toContain(fullPaste);
       expect(text.length).toBeLessThan(1024);
       expect(text).toContain('truncated="true"');
       expect(text).toContain('path="conversation-conv123/pasted-text-1.txt"');
+      expect(text).toContain(TRUNCATED_SUFFIX);
+    });
+
+    it("snippets a paste that is under the limit in characters but over in bytes", async () => {
+      // 2 bytes per char in UTF-8: under the limit in characters, over it in bytes.
+      const fullPaste = "é".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES - 100);
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted", {
+          snippet: fullPaste,
+          path: "conversation-conv123/pasted-text-1.txt",
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: false }
+      );
+      const text = getTextContent(result);
+      expect(text).not.toContain(fullPaste);
+      expect(text).toContain('truncated="true"');
       expect(text).toContain(TRUNCATED_SUFFIX);
     });
 

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -218,24 +218,6 @@ describe("renderLightContentFragmentForModel", () => {
       expect(text).toContain(TRUNCATED_SUFFIX);
     });
 
-    it("snippets a paste that is under the limit in characters but over in bytes", async () => {
-      // 2 bytes per char in UTF-8: under the limit in characters, over it in bytes.
-      const fullPaste = "é".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES - 100);
-      const result = await renderLightContentFragmentForModel(
-        authenticator,
-        makeFileFragment("text/vnd.dust.attachment.pasted", {
-          snippet: fullPaste,
-          path: "conversation-conv123/pasted-text-1.txt",
-        }),
-        visionModel,
-        { excludeImages: false, useFileSystem: false }
-      );
-      const text = getTextContent(result);
-      expect(text).not.toContain(fullPaste);
-      expect(text).toContain('truncated="true"');
-      expect(text).toContain(TRUNCATED_SUFFIX);
-    });
-
     it("renders an image with excludeImages as <attachment> with description", async () => {
       const result = await renderLightContentFragmentForModel(
         authenticator,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -16,7 +16,8 @@ import {
   isPastedContentOverInlineLimit,
   TRUNCATED_SNIPPET_SIZE,
   TRUNCATED_SUFFIX,
-  TRUNCATED_TEXT_SIZE,
+  truncateLegacyPastedSnippet,
+  truncateSnippet,
 } from "@app/lib/api/files/snippet";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -1166,9 +1167,7 @@ export async function getContentFragmentFromAttachmentFile(
     // Check if this is a pasted content (large paste) - use simplified XML format
     if (isPastedFile(attachment.contentType)) {
       const truncated = isPastedContentOverInlineLimit(content);
-      const truncatedContent = truncated
-        ? content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX
-        : content;
+      const truncatedContent = truncated ? truncateSnippet(content) : content;
 
       return new Ok({
         role: "content_fragment",
@@ -1261,10 +1260,11 @@ export async function renderLightContentFragmentForModel(
     };
   }
 
-  const attachment = getAttachmentFromContentFragment(message);
-  if (!attachment) {
+  const rawAttachment = getAttachmentFromContentFragment(message);
+  if (!rawAttachment) {
     return null;
   }
+  const attachment = truncateLegacyPastedSnippet(rawAttachment);
 
   // Get fileId directly from the message based on content fragment type.
   const fileStringId =
@@ -1274,17 +1274,10 @@ export async function renderLightContentFragmentForModel(
 
   // Pasted content is always inlined regardless of feature flags.
   if (fileStringId && isPastedFile(contentType)) {
-    const storedSnippet = attachment.snippet ?? "";
-    // Snippets stored before the inline threshold was lowered may contain the full paste:
-    // re-truncate at render time so a large paste never blows up the model context.
-    const oversizedSnippet = isPastedContentOverInlineLimit(storedSnippet);
-    const snippet = oversizedSnippet
-      ? storedSnippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX
-      : storedSnippet;
+    const snippet = attachment.snippet ?? "";
     const truncated =
-      oversizedSnippet ||
-      (snippet.length === TRUNCATED_SNIPPET_SIZE &&
-        snippet.endsWith(TRUNCATED_SUFFIX));
+      snippet.length === TRUNCATED_SNIPPET_SIZE &&
+      snippet.endsWith(TRUNCATED_SUFFIX);
     return {
       role: "content_fragment",
       name: `attach_pasted_content`,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -13,7 +13,7 @@ import config from "@app/lib/api/config";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system";
 import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import {
-  PASTED_CONTENT_MAX_CHARACTERS,
+  isPastedContentOverInlineLimit,
   TRUNCATED_SNIPPET_SIZE,
   TRUNCATED_SUFFIX,
   TRUNCATED_TEXT_SIZE,
@@ -1165,7 +1165,7 @@ export async function getContentFragmentFromAttachmentFile(
 
     // Check if this is a pasted content (large paste) - use simplified XML format
     if (isPastedFile(attachment.contentType)) {
-      const truncated = content.length > PASTED_CONTENT_MAX_CHARACTERS;
+      const truncated = isPastedContentOverInlineLimit(content);
       const truncatedContent = truncated
         ? content.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX
         : content;
@@ -1274,10 +1274,17 @@ export async function renderLightContentFragmentForModel(
 
   // Pasted content is always inlined regardless of feature flags.
   if (fileStringId && isPastedFile(contentType)) {
-    const snippet = attachment.snippet ?? "";
+    const storedSnippet = attachment.snippet ?? "";
+    // Snippets stored before the inline threshold was lowered may contain the full paste:
+    // re-truncate at render time so a large paste never blows up the model context.
+    const oversizedSnippet = isPastedContentOverInlineLimit(storedSnippet);
+    const snippet = oversizedSnippet
+      ? storedSnippet.slice(0, TRUNCATED_TEXT_SIZE) + TRUNCATED_SUFFIX
+      : storedSnippet;
     const truncated =
-      snippet.length === TRUNCATED_SNIPPET_SIZE &&
-      snippet.endsWith(TRUNCATED_SUFFIX);
+      oversizedSnippet ||
+      (snippet.length === TRUNCATED_SNIPPET_SIZE &&
+        snippet.endsWith(TRUNCATED_SUFFIX));
     return {
       role: "content_fragment",
       name: `attach_pasted_content`,


### PR DESCRIPTION
## Description

Pasted content was inlined in full in the rendered conversation up to a bespoke 128KB limit. Since the context window reduction to 200k tokens, a single large paste can blow the budget on its own and dead-end the conversation ("Your message or retrieved data is too large"), because pruning never drops the latest interaction.

- Reuse `FILE_OFFLOAD_TEXT_SIZE_BYTES` (20K, the threshold already used to offload large tool outputs to files) to decide when a paste is rendered as a truncated 256-char snippet instead of inlined in full. `PASTED_CONTENT_MAX_CHARACTERS` is removed. The check is char-based (1 char ~= 1 byte for ASCII-dominant text, same convention as the conversation_files cat tool).
- Truncated pastes keep `truncated="true"` and a `path` attribute so the model reads the full content via the conversation file tools (pastes are already file-backed).
- Snippets stored before the threshold change can contain up to 128KB of paste, so they are re-truncated when attachments are read (`truncateLegacyPastedSnippet`), covering both conversation rendering and the `conversation_files` list tool.
- System prompt section updated to reflect the new threshold.

## Tests

Added rendering tests: below-threshold paste fully inlined, above-threshold paste rendered as snippet with `truncated`/`path` and full text absent, legacy oversized stored snippet re-truncated.

## Risk

Low. Pastes between 20K and 128K chars now require a file read instead of being inline; behavior matches what already happens for large tool outputs. Safe to rollback.

## Deploy Plan

Standard deploy.