### PR TITLE
fix: resumable GCS uploads for large files, retry replayable streamed writes

### DIFF
--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -12,6 +12,7 @@ import { parseUploadRequest } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { untrustedFetch } from "@app/lib/egress/server";
 import type { DustError } from "@app/lib/error";
+import { withRetryOnTransientGCSError } from "@app/lib/file_storage";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { transcribeFile } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
@@ -332,14 +333,28 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
       );
     }
 
-    // 4) Store transcript in processed version as plain text.
+    // 4) Store transcript in processed version as plain text. The source is an
+    //    in-memory string, so the streams can safely be re-created on each
+    //    retry attempt.
     const transcript = tr.value;
-    const writeStream = file.getWriteStream({
-      auth,
-      version: "processed",
-      overrideContentType: "text/plain", // Explicitly set content type to plain text as it's a transcription
-    });
-    await pipeline(Readable.from(transcript), writeStream);
+    await withRetryOnTransientGCSError(
+      () =>
+        pipeline(
+          Readable.from(transcript),
+          file.getWriteStream({
+            auth,
+            version: "processed",
+            overrideContentType: "text/plain", // Explicitly set content type to plain text as it's a transcription
+          })
+        ),
+      {
+        operationName: "transcript upload",
+        logContext: {
+          fileModelId: file.id,
+          workspaceId: auth.workspace()?.sId,
+        },
+      }
+    );
 
     return new Ok(undefined);
   } catch (err) {
@@ -659,9 +674,22 @@ export async function processAndStoreFile(
 
   try {
     if (content.type === "string") {
-      await pipeline(
-        Readable.from(content.value),
-        file.getWriteStream({ auth, version: "original" })
+      // The source is an in-memory string, so the streams can safely be
+      // re-created on each attempt.
+      const stringContent = content.value;
+      await withRetryOnTransientGCSError(
+        () =>
+          pipeline(
+            Readable.from(stringContent),
+            file.getWriteStream({ auth, version: "original" })
+          ),
+        {
+          operationName: "file upload (string content)",
+          logContext: {
+            fileModelId: file.id,
+            workspaceId: auth.workspace()?.sId,
+          },
+        }
       );
     } else if (content.type === "readable") {
       await pipeline(

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -3,7 +3,7 @@ import {
   type GCSAPIError,
   isGCSNotFoundError,
 } from "@app/lib/file_storage/types";
-import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import { setTimeoutAsync, withRetry } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { frameContentType } from "@app/types/files";
@@ -11,20 +11,18 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stripNullBytes } from "@app/types/shared/utils/string_utils";
-import type {
-  ApiError,
-  Bucket,
-  File,
-  SaveOptions,
-} from "@google-cloud/storage";
+import type { Bucket, File, SaveOptions } from "@google-cloud/storage";
 import { RETRYABLE_ERR_FN_DEFAULT, Storage } from "@google-cloud/storage";
 import type formidable from "formidable";
 import fs from "fs";
 import isNumber from "lodash/isNumber";
 import { pipeline } from "stream/promises";
 
-const GCS_COPY_MAX_RETRIES = 3;
-const GCS_COPY_BASE_DELAY_MS = 500;
+const GCS_TRANSIENT_RETRY_MAX_ATTEMPTS = 3;
+const GCS_TRANSIENT_RETRY_BASE_DELAY_MS = 500;
+// Preserves the 500ms, 2000ms backoff curve of the copyFile retry loop
+// (delayMs = base * attempt²).
+const GCS_TRANSIENT_RETRY_BACKOFF_MULTIPLIER = 4;
 const GCS_MAX_RETRIES = 3; // Same as the SDK default.
 const GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX = /socket hang up/i;
 // GCS generations are object versions. Matching generation 0 means "create only
@@ -48,10 +46,14 @@ type RawContentSaveOptions = Pick<
   "preconditionOpts" | "resumable"
 >;
 
-function isRetryableGCSError(err: ApiError): boolean {
+function isRetryableGCSError(err: unknown): boolean {
+  // ApiError only adds optional fields on top of Error, so a normalized Error
+  // is safe to hand to the SDK's default retryable check.
+  const error = normalizeError(err);
+
   return (
-    RETRYABLE_ERR_FN_DEFAULT(err) ||
-    GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX.test(err.message)
+    RETRYABLE_ERR_FN_DEFAULT(error) ||
+    GCS_EXTRA_RETRYABLE_ERROR_MESSAGE_REGEX.test(error.message)
   );
 }
 
@@ -70,35 +72,34 @@ export async function withRetryOnTransientGCSError<T>(
     logContext,
   }: { operationName: string; logContext: Record<string, unknown> }
 ): Promise<T> {
-  for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
-    try {
-      return await operation();
-    } catch (err) {
-      if (
-        attempt === GCS_COPY_MAX_RETRIES ||
-        !isRetryableGCSError(err as ApiError)
-      ) {
-        throw err;
+  const result = await withRetry(operation, {
+    maxRetries: GCS_TRANSIENT_RETRY_MAX_ATTEMPTS - 1,
+    initialDelayMs: GCS_TRANSIENT_RETRY_BASE_DELAY_MS,
+    backoffMultiplier: GCS_TRANSIENT_RETRY_BACKOFF_MULTIPLIER,
+    shouldRetry: (err, attempt) => {
+      if (!isRetryableGCSError(err)) {
+        return false;
       }
-
-      const delayMs = GCS_COPY_BASE_DELAY_MS * attempt ** 2;
 
       logger.warn(
         {
-          error: normalizeError(err),
+          err: normalizeError(err),
           ...logContext,
-          attempt,
-          maxRetries: GCS_COPY_MAX_RETRIES,
-          delayMs,
+          attempt: attempt + 1,
+          maxAttempts: GCS_TRANSIENT_RETRY_MAX_ATTEMPTS,
         },
         `GCS ${operationName} failed, retrying.`
       );
 
-      await setTimeoutAsync(delayMs);
-    }
+      return true;
+    },
+  });
+
+  if (result.isErr()) {
+    throw result.error;
   }
 
-  throw new Error("Unreachable: GCS retry loop exited without returning.");
+  return result.value;
 }
 
 export class FileStorage {
@@ -389,16 +390,20 @@ export class FileStorage {
       ? this.bucket.file(srcPath, { generation: sourceGeneration })
       : this.file(srcPath);
 
-    for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
+    for (
+      let attempt = 1;
+      attempt <= GCS_TRANSIENT_RETRY_MAX_ATTEMPTS;
+      attempt++
+    ) {
       try {
         await sourceFile.copy(destinationFile);
         return;
       } catch (err) {
-        if (attempt === GCS_COPY_MAX_RETRIES) {
+        if (attempt === GCS_TRANSIENT_RETRY_MAX_ATTEMPTS) {
           throw err;
         }
 
-        const delayMs = GCS_COPY_BASE_DELAY_MS * attempt ** 2;
+        const delayMs = GCS_TRANSIENT_RETRY_BASE_DELAY_MS * attempt ** 2;
 
         logger.warn(
           {
@@ -408,7 +413,7 @@ export class FileStorage {
             destBucket: destinationStorage.name,
             destPath,
             attempt,
-            maxRetries: GCS_COPY_MAX_RETRIES,
+            maxRetries: GCS_TRANSIENT_RETRY_MAX_ATTEMPTS,
             delayMs,
           },
           "GCS copy failed, retrying."

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -55,6 +55,52 @@ function isRetryableGCSError(err: ApiError): boolean {
   );
 }
 
+/**
+ * Retry an operation that fails with a transient GCS error ("socket hang up"
+ * and other errors the SDK considers retryable).
+ *
+ * Needed for streamed uploads, which bypass the SDK's built-in retryOptions.
+ * Only use when the operation can safely be re-run from scratch (e.g. the
+ * source stream can be re-created on each attempt).
+ */
+export async function withRetryOnTransientGCSError<T>(
+  operation: () => Promise<T>,
+  {
+    operationName,
+    logContext,
+  }: { operationName: string; logContext: Record<string, unknown> }
+): Promise<T> {
+  for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (
+        attempt === GCS_COPY_MAX_RETRIES ||
+        !isRetryableGCSError(err as ApiError)
+      ) {
+        throw err;
+      }
+
+      const delayMs = GCS_COPY_BASE_DELAY_MS * attempt ** 2;
+
+      logger.warn(
+        {
+          error: normalizeError(err),
+          ...logContext,
+          attempt,
+          maxRetries: GCS_COPY_MAX_RETRIES,
+          delayMs,
+        },
+        `GCS ${operationName} failed, retrying.`
+      );
+
+      await setTimeoutAsync(delayMs);
+    }
+  }
+
+  throw new Error("Unreachable: GCS retry loop exited without returning.");
+}
+
 export class FileStorage {
   private readonly bucket: Bucket;
   private readonly storage: Storage;
@@ -82,8 +128,8 @@ export class FileStorage {
     // Stream-based uploads via pipeline() + createWriteStream() bypass the
     // SDK's built-in retryOptions, so we need application-level retry.
     // Since the source is a local file we can safely re-create the read stream.
-    for (let attempt = 1; attempt <= GCS_COPY_MAX_RETRIES; attempt++) {
-      try {
+    await withRetryOnTransientGCSError(
+      async () => {
         const gcsFile = this.file(destPath);
         const fileStream = fs.createReadStream(file.filepath);
 
@@ -95,32 +141,12 @@ export class FileStorage {
             },
           })
         );
-
-        return;
-      } catch (err) {
-        if (
-          attempt === GCS_COPY_MAX_RETRIES ||
-          !isRetryableGCSError(err as ApiError)
-        ) {
-          throw err;
-        }
-
-        const delayMs = GCS_COPY_BASE_DELAY_MS * attempt ** 2;
-
-        logger.warn(
-          {
-            error: normalizeError(err),
-            destPath,
-            attempt,
-            maxRetries: GCS_COPY_MAX_RETRIES,
-            delayMs,
-          },
-          "GCS file upload failed (stream), retrying."
-        );
-
-        await setTimeoutAsync(delayMs);
+      },
+      {
+        operationName: "file upload (stream)",
+        logContext: { destPath },
       }
-    }
+    );
   }
 
   async uploadRawContentToBucket({

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -111,6 +111,12 @@ import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_mod
 
 export type FileVersion = "processed" | "original" | "public";
 
+// Threshold above which file uploads switch from a single multipart POST to a
+// resumable upload (see getWriteStream). Chunk size must be a multiple of
+// 256 KiB; GCS recommends at least 8 MiB for performance.
+const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
+const GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024;
+
 const FRAME_CONTENT_TYPES = new Set([
   frameContentType,
   frameSlideshowContentType,
@@ -898,10 +904,20 @@ export class FileResource extends BaseResource<FileModel> {
     version: FileVersion;
     overrideContentType?: string;
   }): Writable {
+    // Non-resumable streamed uploads are sent as a single multipart POST that
+    // the SDK cannot retry (the stream is not replayable): one transient
+    // connection reset fails the whole upload. Large files hold the connection
+    // long enough to make resets likely, so upload them resumably with an
+    // explicit chunkSize: the SDK buffers each chunk and retries it on
+    // transient errors (per the Storage retryOptions). Small files keep the
+    // single-request upload, which avoids the resumable initiation round trip.
+    const resumable = this.fileSize >= GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES;
+
     return this.getBucketForVersion(version)
       .file(this.getCloudStoragePath(auth, version))
       .createWriteStream({
-        resumable: false,
+        resumable,
+        ...(resumable && { chunkSize: GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES }),
         contentType: overrideContentType ?? this.contentType,
       });
   }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -911,13 +911,18 @@ export class FileResource extends BaseResource<FileModel> {
     // explicit chunkSize: the SDK buffers each chunk and retries it on
     // transient errors (per the Storage retryOptions). Small files keep the
     // single-request upload, which avoids the resumable initiation round trip.
+    // fileSize is the declared size of the original content, so processed and
+    // public writes of a large file pay the resumable overhead even when their
+    // payload is small (e.g. an audio transcript): accepted for simplicity.
     const resumable = this.fileSize >= GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES;
 
     return this.getBucketForVersion(version)
       .file(this.getCloudStoragePath(auth, version))
       .createWriteStream({
         resumable,
-        ...(resumable && { chunkSize: GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES }),
+        chunkSize: resumable
+          ? GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES
+          : undefined,
         contentType: overrideContentType ?? this.contentType,
       });
   }

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -46,6 +46,10 @@ class FileStorageMock {
 
     return {
       FileStorage: vi.fn().mockImplementation(createStorage),
+      // Passthrough: run the operation once, without retry or backoff.
+      withRetryOnTransientGCSError: vi.fn(
+        async (operation: () => Promise<unknown>) => operation()
+      ),
       getPrivateUploadBucket: vi.fn(createStorage),
       getPublicUploadBucket: vi.fn(createStorage),
       getUpsertQueueBucket: vi.fn(createStorage),


### PR DESCRIPTION
## Description

File uploads fail in prod with "socket hang up" on the GCS multipart upload (dust-tt/tasks#8701). The resets themselves are chronic (2-7k/day for 30+ days, traffic-correlated, EU and US buckets), what makes them user-facing is that POST /files/[fileId] streams the request body to GCS as a single non-resumable multipart POST: streamed uploads bypass the SDK retryOptions, and the request stream cannot be replayed, so one reset = one 500. 97% of failing uploads in Datadog are these multipart POSTs, with large audio files (15-50 MB) hit hardest since transfer time scales exposure.

- `FileResource.getWriteStream`: use resumable uploads with an 8 MiB chunkSize for files >= 8 MB. The SDK buffers each chunk and retries it on transient errors (our `retryableErrorFn` already covers "socket hang up"). Small files keep the single-request upload, avoiding the resumable initiation round trip.
- Extract the `uploadFileToBucket` retry loop into `withRetryOnTransientGCSError` (a thin wrapper over the existing `withRetry`) and reuse it for the replayable string-content writes in processing.ts (agent-generated files, audio transcripts), which covers the worker-side "Failed to upload file to storage" errors.

> [!NOTE]
> Non-replayable streamed uploads under 8 MB keep the single unretried POST: exposure is short at that size and the readable-content path cannot be replayed. GCS download resets (`createReadStream`) are also out of scope.

## Tests

Ran the file_resource, processing, upsert, mcp_execution and file_paths suites locally. Added a passthrough for the new helper to the global file_storage mock.

## Risk

Low. Upload behavior is unchanged for files under 8 MB. For larger files the resumable protocol adds one initiation round trip, negligible at that size. Safe to rollback.

## Deploy Plan

- [ ] Standard deploy.
- [ ] Watch "socket hang up" upload errors in Datadog post-deploy (baseline: ~2.6k/day on weekdays, 97% of failing uploads are multipart POSTs).