### PR TITLE
Handle non-UTF-8 CSV uploads (Windows-1252 from Excel)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -796,6 +796,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1374,7 @@ dependencies = [
  "bb8-postgres",
  "blake3",
  "bstr",
+ "chardetng",
  "chrono",
  "clap",
  "cloud-storage",
@@ -1373,6 +1385,7 @@ dependencies = [
  "dns-lookup",
  "elasticsearch",
  "elasticsearch-dsl",
+ "encoding_rs",
  "eventsource-client",
  "fancy-regex",
  "flate2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -123,6 +123,7 @@ bb8 = "0.8"
 bb8-postgres = "0.8"
 blake3 = "1.3"
 bstr = "1.9"
+chardetng = "0.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 cloud-storage = { version = "0.11", features = ["global-client"] }
@@ -133,6 +134,7 @@ deno_core = "0.292"
 dns-lookup = "1.0"
 elasticsearch = "8.15.0-alpha.1"
 elasticsearch-dsl = "0.4"
+encoding_rs = "0.8"
 eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", rev = "148050f8fb9f8abb25ca171aa68ea817277ca4f6" }
 fancy-regex = "0.13"
 flate2 = "1.0"

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -98,6 +98,9 @@ impl GoogleCloudStorageCSVContent {
     }
 
     fn detected_charset_to_utf8(content: &[u8]) -> Result<Vec<u8>> {
+        // /!\ front matches on "UTF-8" in these error messages to surface an actionable
+        // message to the user (`isNonUtf8CsvError` in front/lib/api/files/upsert.ts). Keep
+        // both sides in sync.
         // NUL bytes never appear in text encoded with a single-byte charset; treat the content
         // as binary rather than transcoding it to mojibake.
         if content.contains(&0) {
@@ -622,7 +625,10 @@ BAR,acme";
         let binary = vec![0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00, 0x0D, 0xFF, 0x81];
         let res = GoogleCloudStorageCSVContent::decode_to_utf8(binary);
         assert!(res.is_err());
-        assert!(res.unwrap_err().to_string().contains("binary"));
+        let err = res.unwrap_err().to_string();
+        assert!(err.contains("binary"));
+        // front matches on "UTF-8" in decode error messages; pin the wording.
+        assert!(err.contains("UTF-8"));
 
         Ok(())
     }

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -52,7 +52,8 @@ impl GoogleCloudStorageCSVContent {
         // This is not the most efficient as we download the entire file here but we will
         // materialize it in memory as Vec<Row> anyway so that's not a massive difference.
         let content = Object::download(bucket, path).await?;
-        // csv_async only accepts UTF-8; transcode if the file starts with a UTF-16 BOM.
+        // csv_async only accepts UTF-8; transcode UTF-16 (BOM-based) and detected single-byte
+        // encodings (e.g. Windows-1252 produced by Excel's default "Save as CSV").
         let content = Self::decode_to_utf8(content)?;
         let rdr = std::io::Cursor::new(content);
 
@@ -89,7 +90,41 @@ impl GoogleCloudStorageCSVContent {
         if content.starts_with(&UTF16_BE_BOM) {
             return Self::utf16_to_utf8(&content[2..], false);
         }
-        Ok(content)
+        // Happy path: valid UTF-8 passes through untouched.
+        if std::str::from_utf8(&content).is_ok() {
+            return Ok(content);
+        }
+        Self::detected_charset_to_utf8(&content)
+    }
+
+    fn detected_charset_to_utf8(content: &[u8]) -> Result<Vec<u8>> {
+        // NUL bytes never appear in text encoded with a single-byte charset; treat the content
+        // as binary rather than transcoding it to mojibake.
+        if content.contains(&0) {
+            return Err(anyhow!(
+                "CSV content is not valid UTF-8 and appears to be binary"
+            ));
+        }
+
+        let mut detector = chardetng::EncodingDetector::new();
+        detector.feed(content, true);
+        // `allow_utf8: false` is safe: content was already checked not to be valid UTF-8.
+        let encoding = detector.guess(None, false);
+
+        let (decoded, _, had_errors) = encoding.decode(content);
+        if had_errors {
+            return Err(anyhow!(
+                "CSV content is not valid UTF-8 and failed to transcode \
+                  from detected charset {}",
+                encoding.name()
+            ));
+        }
+
+        info!(
+            charset = encoding.name(),
+            "Transcoded non-UTF-8 CSV content"
+        );
+        Ok(decoded.into_owned().into_bytes())
     }
 
     fn utf16_to_utf8(bytes: &[u8], little_endian: bool) -> Result<Vec<u8>> {
@@ -562,6 +597,56 @@ BAR,acme";
             GoogleCloudStorageCSVContent::decode_to_utf8(utf16_le_emoji)?,
             "a\t🦄".as_bytes().to_vec()
         );
+
+        // Valid UTF-8 with non-ASCII passes through untouched.
+        let utf8_accents = "name,note\ncafé,“quoted”".as_bytes().to_vec();
+        assert_eq!(
+            GoogleCloudStorageCSVContent::decode_to_utf8(utf8_accents.clone())?,
+            utf8_accents
+        );
+
+        // Windows-1252 without BOM (Excel's default "Save as CSV"): accented characters and
+        // smart quotes transcode to UTF-8.
+        let mut windows_1252 = b"name,note\ncaf".to_vec();
+        windows_1252.push(0xE9); // é
+        windows_1252.extend_from_slice(b",");
+        windows_1252.push(0x93); // “
+        windows_1252.extend_from_slice(b"quoted");
+        windows_1252.push(0x94); // ”
+        assert_eq!(
+            GoogleCloudStorageCSVContent::decode_to_utf8(windows_1252)?,
+            "name,note\ncafé,“quoted”".as_bytes().to_vec()
+        );
+
+        // Genuinely binary content (NUL bytes, invalid UTF-8) fails cleanly.
+        let binary = vec![0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00, 0x0D, 0xFF, 0x81];
+        let res = GoogleCloudStorageCSVContent::decode_to_utf8(binary);
+        assert!(res.is_err());
+        assert!(res.unwrap_err().to_string().contains("binary"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_csv_to_rows_windows_1252() -> anyhow::Result<()> {
+        // End-to-end: a Windows-1252 CSV (no BOM) parses into rows with properly transcoded
+        // values.
+        let mut csv = b"name,price\ncaf".to_vec();
+        csv.push(0xE9); // é
+        csv.extend_from_slice(b",3\nth");
+        csv.push(0xE9); // é
+        csv.extend_from_slice(b",2");
+
+        let content = GoogleCloudStorageCSVContent::decode_to_utf8(csv)?;
+        let (delimiter, rdr) =
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(content)).await?;
+        let rows = GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter).await?;
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].value()["name"], "café");
+        assert_eq!(rows[0].value()["price"], 3.0);
+        assert_eq!(rows[1].value()["name"], "thé");
+        assert_eq!(rows[1].value()["price"], 2.0);
 
         Ok(())
     }

--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -623,12 +623,15 @@ BAR,acme";
 
         // Genuinely binary content (NUL bytes, invalid UTF-8) fails cleanly.
         let binary = vec![0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00, 0x0D, 0xFF, 0x81];
-        let res = GoogleCloudStorageCSVContent::decode_to_utf8(binary);
-        assert!(res.is_err());
-        let err = res.unwrap_err().to_string();
-        assert!(err.contains("binary"));
-        // front matches on "UTF-8" in decode error messages; pin the wording.
-        assert!(err.contains("UTF-8"));
+        match GoogleCloudStorageCSVContent::decode_to_utf8(binary) {
+            Ok(_) => panic!("expected binary content to fail decoding"),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(msg.contains("binary"));
+                // front matches on "UTF-8" in decode error messages; pin the wording.
+                assert!(msg.contains("UTF-8"));
+            }
+        }
 
         Ok(())
     }

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8462,7 +8462,7 @@
             }
           },
           "400": {
-            "description": "Invalid file content (e.g. a CSV that is not UTF-8 encoded)"
+            "description": "Invalid file content (e.g. a CSV with an unsupported encoding)"
           },
           "403": {
             "description": "Permission denied"

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8461,6 +8461,9 @@
               }
             }
           },
+          "400": {
+            "description": "Invalid file content (e.g. a CSV that is not UTF-8 encoded)"
+          },
           "403": {
             "description": "Permission denied"
           },

--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -289,6 +289,17 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
           message: "Failed to upsert the file.",
           error: rUpsert.error,
         });
+        // Invalid CSV content is a user error (e.g. unsupported encoding); surface the
+        // actionable message instead of a generic 500.
+        if (rUpsert.error.code === "invalid_csv_content") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: rUpsert.error.message,
+            },
+          });
+        }
         return apiError(ctx, {
           status_code: 500,
           api_error: {

--- a/front-api/routes/v1/w/[wId]/files/[fileId].ts
+++ b/front-api/routes/v1/w/[wId]/files/[fileId].ts
@@ -280,6 +280,26 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
         { file }
       );
       if (rUpsert.isErr()) {
+        // Invalid CSV content is a user error (e.g. unsupported encoding); surface the
+        // actionable message instead of a generic 500.
+        if (rUpsert.error.code === "invalid_csv_content") {
+          logger.warn({
+            fileModelId: file.id,
+            workspaceId: auth.workspace()?.sId,
+            contentType: file.contentType,
+            useCase: file.useCase,
+            useCaseMetadata: file.useCaseMetadata,
+            message: "Invalid CSV content on file upsert.",
+            error: rUpsert.error,
+          });
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: rUpsert.error.message,
+            },
+          });
+        }
         logger.error({
           fileModelId: file.id,
           workspaceId: auth.workspace()?.sId,
@@ -289,17 +309,6 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
           message: "Failed to upsert the file.",
           error: rUpsert.error,
         });
-        // Invalid CSV content is a user error (e.g. unsupported encoding); surface the
-        // actionable message instead of a generic 500.
-        if (rUpsert.error.code === "invalid_csv_content") {
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: rUpsert.error.message,
-            },
-          });
-        }
         return apiError(ctx, {
           status_code: 500,
           api_error: {

--- a/front-api/routes/v1/w/[wId]/files/fileId.test.ts
+++ b/front-api/routes/v1/w/[wId]/files/fileId.test.ts
@@ -1,5 +1,8 @@
+import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import { DustError } from "@app/lib/error";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { Err } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -221,6 +224,27 @@ describe("POST /api/v1/w/[wId]/files/[fileId]", () => {
       method: "POST",
     });
     expect(response.status).toBe(200);
+  });
+
+  it("should return a 400 with the upsert error message on invalid CSV content", async () => {
+    const { workspace, key } = await createPublicApiMockRequest();
+    setupMockFile(workspace, { useCase: "conversation" });
+
+    const csvErrorMessage = "This CSV file is not UTF-8 encoded.";
+    vi.mocked(processAndUpsertToDataSource).mockResolvedValueOnce(
+      new Err(new DustError("invalid_csv_content", csvErrorMessage))
+    );
+
+    const response = await request(workspace, key, "test_file_id", {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toEqual({
+      type: "invalid_request_error",
+      message: csvErrorMessage,
+    });
   });
 });
 

--- a/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.test.ts
@@ -1,7 +1,9 @@
+import { DustError } from "@app/lib/error";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Err } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -452,6 +454,47 @@ describe("POST /api/w/:wId/files/:fileId", () => {
 
     expect(response.status).toBe(200);
     expect(processAndUpsertToDataSource).toHaveBeenCalled();
+  });
+
+  it("should return a 400 with the upsert error message on invalid CSV content", async () => {
+    const { processAndUpsertToDataSource } = await import(
+      "@app/lib/api/files/upsert"
+    );
+
+    const { auth, user, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [new Date()],
+    });
+
+    const file = await FileFactory.create(auth, user, {
+      contentType: "text/csv",
+      fileName: "report.csv",
+      fileSize: 1024,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: conversation.sId,
+      },
+    });
+
+    const csvErrorMessage = "This CSV file is not UTF-8 encoded.";
+    vi.mocked(processAndUpsertToDataSource).mockResolvedValueOnce(
+      new Err(new DustError("invalid_csv_content", csvErrorMessage))
+    );
+
+    const response = await honoApp.request(fileUrl(workspace, file.sId), {
+      method: "POST",
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toBe(csvErrorMessage);
   });
 
   it("should not upsert raw sandbox delimited conversation files", async () => {

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -160,6 +160,8 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  *               properties:
  *                 file:
  *                   $ref: '#/components/schemas/PrivateFileWithUploadUrl'
+ *       400:
+ *         description: Invalid file content (e.g. a CSV that is not UTF-8 encoded)
  *       403:
  *         description: Permission denied
  *       404:
@@ -425,6 +427,17 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
           message: "Failed to upsert the file.",
           error: rUpsert.error,
         });
+        // Invalid CSV content is a user error (e.g. unsupported encoding); surface the
+        // actionable message instead of a generic 500.
+        if (rUpsert.error.code === "invalid_csv_content") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: rUpsert.error.message,
+            },
+          });
+        }
         return apiError(ctx, {
           status_code: 500,
           api_error: {

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -418,6 +418,26 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
       );
 
       if (rUpsert.isErr()) {
+        // Invalid CSV content is a user error (e.g. unsupported encoding); surface the
+        // actionable message instead of a generic 500.
+        if (rUpsert.error.code === "invalid_csv_content") {
+          logger.warn({
+            fileModelId: file.id,
+            workspaceId: auth.workspace()?.sId,
+            contentType: file.contentType,
+            useCase: file.useCase,
+            useCaseMetadata: file.useCaseMetadata,
+            message: "Invalid CSV content on file upsert.",
+            error: rUpsert.error,
+          });
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: rUpsert.error.message,
+            },
+          });
+        }
         logger.error({
           fileModelId: file.id,
           workspaceId: auth.workspace()?.sId,
@@ -427,17 +447,6 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
           message: "Failed to upsert the file.",
           error: rUpsert.error,
         });
-        // Invalid CSV content is a user error (e.g. unsupported encoding); surface the
-        // actionable message instead of a generic 500.
-        if (rUpsert.error.code === "invalid_csv_content") {
-          return apiError(ctx, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: rUpsert.error.message,
-            },
-          });
-        }
         return apiError(ctx, {
           status_code: 500,
           api_error: {

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -161,7 +161,7 @@ const app = createHono<WorkspaceAwareCtx & { Bindings: HttpBindings }>();
  *                 file:
  *                   $ref: '#/components/schemas/PrivateFileWithUploadUrl'
  *       400:
- *         description: Invalid file content (e.g. a CSV that is not UTF-8 encoded)
+ *         description: Invalid file content (e.g. a CSV with an unsupported encoding)
  *       403:
  *         description: Permission denied
  *       404:

--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -1,7 +1,7 @@
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import {
-  NON_UTF8_CSV_ERROR_MESSAGE,
+  CSV_UNSUPPORTED_ENCODING_ERROR_MESSAGE,
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
@@ -113,7 +113,12 @@ describe("maybeUpsertFileAttachment", () => {
     });
 
     vi.mocked(processAndUpsertToDataSource).mockResolvedValue(
-      new Err(new DustError("invalid_csv_content", NON_UTF8_CSV_ERROR_MESSAGE))
+      new Err(
+        new DustError(
+          "invalid_csv_content",
+          CSV_UNSUPPORTED_ENCODING_ERROR_MESSAGE
+        )
+      )
     );
 
     const result = await maybeUpsertFileAttachment(auth, {
@@ -124,7 +129,9 @@ describe("maybeUpsertFileAttachment", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.message).toContain('"report.csv"');
-      expect(result.error.message).toContain(NON_UTF8_CSV_ERROR_MESSAGE);
+      expect(result.error.message).toContain(
+        CSV_UNSUPPORTED_ENCODING_ERROR_MESSAGE
+      );
     }
   });
 

--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -128,6 +128,27 @@ describe("maybeUpsertFileAttachment", () => {
     }
   });
 
+  it("does not block the attachment on internal upsert errors", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/csv",
+      fileName: "report.csv",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    vi.mocked(processAndUpsertToDataSource).mockResolvedValue(
+      new Err(new DustError("internal_error", "Failed to generate snippet."))
+    );
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
+
   it("does not re-run when conversationId is already set", async () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "text/plain",

--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -1,12 +1,16 @@
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
-import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import {
+  NON_UTF8_CSV_ERROR_MESSAGE,
+  processAndUpsertToDataSource,
+} from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { ConversationType } from "@app/types/assistant/conversation";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -97,6 +101,31 @@ describe("maybeUpsertFileAttachment", () => {
       skipDataSourceIndexing: true,
       conversationId: conversation.sId,
     });
+  });
+
+  it("propagates upsert failures instead of swallowing them", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/csv",
+      fileName: "report.csv",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+    });
+
+    vi.mocked(processAndUpsertToDataSource).mockResolvedValue(
+      new Err(new DustError("invalid_csv_content", NON_UTF8_CSV_ERROR_MESSAGE))
+    );
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain('"report.csv"');
+      expect(result.error.message).toContain(NON_UTF8_CSV_ERROR_MESSAGE);
+    }
   });
 
   it("does not re-run when conversationId is already set", async () => {

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -6,10 +6,11 @@ import {
 } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 // When we send the attachments at the conversation creation, we are missing the useCaseMetadata
@@ -40,8 +41,9 @@ export async function maybeUpsertFileAttachment(
 
   if (filesIds.length > 0) {
     const fileResources = await FileResource.fetchByIds(auth, filesIds);
-    await Promise.all([
-      ...fileResources.map(async (fileResource) => {
+    const results = await concurrentExecutor(
+      fileResources,
+      async (fileResource): Promise<Result<undefined, Error>> => {
         if (
           fileResource.useCase === "conversation" &&
           !fileResource.useCaseMetadata?.conversationId
@@ -83,12 +85,25 @@ export async function maybeUpsertFileAttachment(
                 error: r.error,
               });
 
-              return r;
+              return new Err(
+                new Error(
+                  `Failed to attach the file "${fileResource.fileName}": ${r.error.message}`
+                )
+              );
             }
           }
         }
-      }),
-    ]);
+        return new Ok(undefined);
+      },
+      { concurrency: 4 }
+    );
+
+    const failures = removeNulls(
+      results.map((r) => (r.isErr() ? r.error : null))
+    );
+    if (failures.length > 0) {
+      return new Err(new Error(failures.map((e) => e.message).join(" ")));
+    }
   }
   return new Ok(undefined);
 }

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -64,7 +64,16 @@ export async function maybeUpsertFileAttachment(
                 fileResource
               );
             if (jitDataSource.isErr()) {
-              return jitDataSource;
+              logger.warn({
+                fileModelId: fileResource.id,
+                workspaceId: auth.getNonNullableWorkspace().sId,
+                contentType: fileResource.contentType,
+                useCase: fileResource.useCase,
+                useCaseMetadata: fileResource.useCaseMetadata,
+                message: "Failed to get or create JIT data source.",
+                error: jitDataSource.error,
+              });
+              return new Ok(undefined);
             }
 
             const r = await processAndUpsertToDataSource(
@@ -85,11 +94,18 @@ export async function maybeUpsertFileAttachment(
                 error: r.error,
               });
 
-              return new Err(
-                new Error(
-                  `Failed to attach the file "${fileResource.fileName}": ${r.error.message}`
-                )
-              );
+              // Only surface user-actionable failures (e.g. a CSV the user can re-save in a
+              // supported encoding); transient internal errors must not block the conversation.
+              if (
+                r.error.code === "invalid_csv_content" ||
+                r.error.code === "invalid_file"
+              ) {
+                return new Err(
+                  new Error(
+                    `Failed to attach the file "${fileResource.fileName}": ${r.error.message}`
+                  )
+                );
+              }
             }
           }
         }
@@ -102,7 +118,7 @@ export async function maybeUpsertFileAttachment(
       results.map((r) => (r.isErr() ? r.error : null))
     );
     if (failures.length > 0) {
-      return new Err(new Error(failures.map((e) => e.message).join(" ")));
+      return new Err(new Error(failures.map((e) => e.message).join("; ")));
     }
   }
   return new Ok(undefined);

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -672,11 +672,9 @@ export async function processAndUpsertToDataSource(
         },
         "Rewriting non-UTF-8 CSV error to user-facing message."
       );
-      return new Err<DustError>({
-        name: "dust_error",
-        code: "invalid_csv_content",
-        message: NON_UTF8_CSV_ERROR_MESSAGE,
-      });
+      return new Err(
+        new DustError("invalid_csv_content", NON_UTF8_CSV_ERROR_MESSAGE)
+      );
     }
     return new Err<DustError>(processingRes.error);
   }

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -49,7 +49,9 @@ import {
 export const NON_UTF8_CSV_ERROR_MESSAGE =
   "This CSV file is not UTF-8 encoded. In Excel, use File > Save As > 'CSV UTF-8 (Comma delimited)' and upload the file again.";
 
-export function isNonUtf8CsvError(error: DustError): boolean {
+// /!\ Matches on the wording of core's CSV decode errors (`decode_to_utf8` in
+// core/src/databases/csv.rs), which all mention "UTF-8". Keep both sides in sync.
+function isNonUtf8CsvError(error: DustError): boolean {
   return error.code === "invalid_csv_content" && /utf-?8/i.test(error.message);
 }
 
@@ -661,6 +663,15 @@ export async function processAndUpsertToDataSource(
   if (processingRes.isErr()) {
     // Replace core's raw CSV parse error with an actionable message for the user.
     if (isNonUtf8CsvError(processingRes.error)) {
+      // The original message carries the detected charset; keep it in the logs.
+      logger.info(
+        {
+          workspaceId: auth.workspace()?.sId,
+          fileId: file.sId,
+          coreErrorMessage: processingRes.error.message,
+        },
+        "Rewriting non-UTF-8 CSV error to user-facing message."
+      );
       return new Err<DustError>({
         name: "dust_error",
         code: "invalid_csv_content",

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -46,8 +46,8 @@ import {
 // User-facing message for CSVs that core cannot decode to UTF-8 (e.g. exotic encodings that
 // charset detection cannot transcode). Surfaced as-is by the file upload endpoints and the
 // conversation attachment flow.
-export const NON_UTF8_CSV_ERROR_MESSAGE =
-  "This CSV file is not UTF-8 encoded. In Excel, use File > Save As > 'CSV UTF-8 (Comma delimited)' and upload the file again.";
+export const CSV_UNSUPPORTED_ENCODING_ERROR_MESSAGE =
+  "This CSV file uses an unsupported encoding. In Excel, use File > Save As > 'CSV UTF-8 (Comma delimited)' and upload the file again.";
 
 // /!\ Matches on the wording of core's CSV decode errors (`decode_to_utf8` in
 // core/src/databases/csv.rs), which all mention "UTF-8". Keep both sides in sync.
@@ -673,7 +673,10 @@ export async function processAndUpsertToDataSource(
         "Rewriting non-UTF-8 CSV error to user-facing message."
       );
       return new Err(
-        new DustError("invalid_csv_content", NON_UTF8_CSV_ERROR_MESSAGE)
+        new DustError(
+          "invalid_csv_content",
+          CSV_UNSUPPORTED_ENCODING_ERROR_MESSAGE
+        )
       );
     }
     return new Err<DustError>(processingRes.error);

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -43,6 +43,16 @@ import {
   // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 } from "@dust-tt/client";
 
+// User-facing message for CSVs that core cannot decode to UTF-8 (e.g. exotic encodings that
+// charset detection cannot transcode). Surfaced as-is by the file upload endpoints and the
+// conversation attachment flow.
+export const NON_UTF8_CSV_ERROR_MESSAGE =
+  "This CSV file is not UTF-8 encoded. In Excel, use File > Save As > 'CSV UTF-8 (Comma delimited)' and upload the file again.";
+
+export function isNonUtf8CsvError(error: DustError): boolean {
+  return error.code === "invalid_csv_content" && /utf-?8/i.test(error.message);
+}
+
 export interface UpsertFileToDataSourceRequestBody {
   fileId: string;
   upsertArgs?:
@@ -649,6 +659,14 @@ export async function processAndUpsertToDataSource(
   ]);
 
   if (processingRes.isErr()) {
+    // Replace core's raw CSV parse error with an actionable message for the user.
+    if (isNonUtf8CsvError(processingRes.error)) {
+      return new Err<DustError>({
+        name: "dust_error",
+        code: "invalid_csv_content",
+        message: NON_UTF8_CSV_ERROR_MESSAGE,
+      });
+    }
     return new Err<DustError>(processingRes.error);
   }
 


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#8591. CSVs saved from Excel with the default "Save as CSV" format are Windows-1252, not UTF-8. Core rejected them with a generic "Failed to upsert the file." toast mid-conversation, and silently swallowed the failure when attached on the first message of a conversation (the file looked attached but the table was never upserted, so it was not queryable).

- core: when CSV content is not valid UTF-8 and has no UTF-16 BOM, detect the charset with chardetng and transcode to UTF-8 with encoding_rs. Valid UTF-8 still passes through untouched. Binary content (NUL bytes, undecodable) fails cleanly.
- front: invalid_csv_content errors mentioning UTF-8 are rewritten to an actionable message (save as "CSV UTF-8 (Comma delimited)" in Excel) and the file upload routes return them as 400 instead of a generic 500. Only reachable for encodings the core fallback cannot handle.
- front: maybeUpsertFileAttachment now propagates user-actionable upsert failures (invalid_csv_content, invalid_file), so first-message attachments fail with the same explicit error as mid-conversation ones instead of silently succeeding. Transient internal errors (snippet generation, core hiccups) are still log-only and do not block conversation creation. Also moves from Promise.all to concurrentExecutor.

## Tests

- New core unit tests: Windows-1252 without BOM (unit + end-to-end row parsing), UTF-8 passthrough, binary garbage failing cleanly (with the "UTF-8" wording pinned, front matches on it). Existing UTF-16 BOM tests (#25510) unchanged and green.
- New front tests: upsert failure propagation and internal-error gating in attachments.test.ts, 400 + message on invalid_csv_content in both the private and v1 file route tests.

## Risk

Low. The UTF-8 happy path is unchanged (one validation pass added). Behavior change: a CSV with a user-fixable encoding problem now blocks the attachment on conversation creation with an explicit message instead of silently attaching an unqueryable file. Safe to rollback.

## Deploy Plan

- [ ] Deploy core
- [ ] Deploy front / front-api
- [ ] Check service:front-api "Failed to validate the CSV content" drops for workspace PB2GnsMZte