### PR TITLE
Return `getFairUseAwuCreditsStatus` from `usage-status` endpoint

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -3,6 +3,7 @@ import type {
   ProgrammaticCreditStatus,
 } from "@app/lib/metronome/user_block";
 import {
+  getFairUseAwuCreditsStatus,
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
   isUserAwuWarned,
@@ -23,13 +24,20 @@ app.get(
     const auth = ctx.get("auth");
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
-
     const plan = auth.plan();
+
+    const fairUseAwuCreditsState = await getFairUseAwuCreditsStatus({
+      workspace,
+      user: user.toJSON(),
+      plan: auth.plan(),
+    });
+
     const isCreditPriced = plan && isCreditPricedPlan(plan);
     // Workspaces not on Metronome billing have no usage status to report.
     if (!workspace.metronomeCustomerId || !isCreditPriced) {
       return ctx.json({
         awuStatus: "normal",
+        fairUseAwuCreditsState,
         poolCreditState: "active",
         programmaticCreditStatus: "active",
         balanceThresholdReached: false,
@@ -67,6 +75,7 @@ app.get(
 
     return ctx.json({
       awuStatus,
+      fairUseAwuCreditsState,
       poolCreditState,
       programmaticCreditStatus,
       balanceThresholdReached,

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -1,4 +1,8 @@
+import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
+import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import type { MaxAwuCreditsTimeframeType } from "@app/types/plan";
 import {
+  getFairUseAwuCreditsStatus,
   getWorkspaceCreditPoolStatus,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
@@ -9,6 +13,7 @@ const {
   mockFetchWorkspaceById,
   mockFetchUserById,
   mockGetActiveMembershipOfUserInWorkspace,
+  mockGetRateLimiterCount,
   mockRunOnRedis,
 } = vi.hoisted(() => {
   const redisValues = new Map<string, string>();
@@ -34,6 +39,7 @@ const {
     mockFetchWorkspaceById: vi.fn(),
     mockFetchUserById: vi.fn(),
     mockGetActiveMembershipOfUserInWorkspace: vi.fn(),
+    mockGetRateLimiterCount: vi.fn(),
     mockRunOnRedis,
   };
 });
@@ -63,6 +69,12 @@ vi.mock("@app/lib/resources/membership_resource", () => ({
 
 vi.mock("@app/lib/workspace", () => ({
   renderLightWorkspaceType: vi.fn(({ workspace }) => workspace),
+}));
+
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  expireRateLimiterKey: vi.fn(),
+  getRateLimiterCount: mockGetRateLimiterCount,
+  getTimeframeSecondsFromLiteral: vi.fn(() => 60 * 60 * 24),
 }));
 
 vi.mock("@app/logger/logger", () => ({
@@ -265,6 +277,77 @@ describe("isUserBlocked", () => {
     expect(redisValues.get("metronome:pool_credit_status:ws_test")).toBe(
       "depleted"
     );
+  });
+});
+
+describe("getFairUseAwuCreditsStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const workspace = {
+    id: 42,
+    sId: "ws_test",
+  };
+
+  const user = {
+    id: 7,
+    sId: "u_test",
+  };
+
+  function makePlan({
+    maxAwuCredits,
+    maxAwuCreditsTimeframe,
+  }: {
+    maxAwuCredits: number;
+    maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType;
+  }) {
+    return renderPlanFromModel({
+      plan: {
+        ...FREE_NO_PLAN_DATA,
+        maxAwuCredits,
+        maxAwuCreditsTimeframe,
+      },
+    });
+  }
+
+  it("does not read Redis when the AWU fair-use limit is unlimited", async () => {
+    const status = await getFairUseAwuCreditsStatus({
+      workspace,
+      user,
+      plan: makePlan({ maxAwuCredits: -1, maxAwuCreditsTimeframe: "day" }),
+    });
+
+    expect(status).toEqual({
+      limit: -1,
+      timeframe: "day",
+      count: 0,
+    });
+    expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
+  });
+
+  it("reads the Redis-backed AWU fair-use usage for finite limits", async () => {
+    mockGetRateLimiterCount.mockResolvedValue({
+      isErr: () => false,
+      isOk: () => true,
+      value: 12,
+    });
+
+    const status = await getFairUseAwuCreditsStatus({
+      workspace,
+      user,
+      plan: makePlan({ maxAwuCredits: 100, maxAwuCreditsTimeframe: "day" }),
+    });
+
+    expect(status).toEqual({
+      limit: 100,
+      timeframe: "day",
+      count: 12,
+    });
+    expect(mockGetRateLimiterCount).toHaveBeenCalledWith({
+      key: "workspace:42:user:7:fair_use_awu_credit_count:day",
+      timeframeSeconds: 60 * 60 * 24,
+    });
   });
 });
 

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -1,8 +1,4 @@
-import { FREE_NO_PLAN_DATA } from "@app/lib/plans/free_plans";
-import { renderPlanFromModel } from "@app/lib/plans/renderers";
-import type { MaxAwuCreditsTimeframeType } from "@app/types/plan";
 import {
-  getFairUseAwuCreditsStatus,
   getWorkspaceCreditPoolStatus,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
@@ -13,7 +9,6 @@ const {
   mockFetchWorkspaceById,
   mockFetchUserById,
   mockGetActiveMembershipOfUserInWorkspace,
-  mockGetRateLimiterCount,
   mockRunOnRedis,
 } = vi.hoisted(() => {
   const redisValues = new Map<string, string>();
@@ -39,7 +34,6 @@ const {
     mockFetchWorkspaceById: vi.fn(),
     mockFetchUserById: vi.fn(),
     mockGetActiveMembershipOfUserInWorkspace: vi.fn(),
-    mockGetRateLimiterCount: vi.fn(),
     mockRunOnRedis,
   };
 });
@@ -69,12 +63,6 @@ vi.mock("@app/lib/resources/membership_resource", () => ({
 
 vi.mock("@app/lib/workspace", () => ({
   renderLightWorkspaceType: vi.fn(({ workspace }) => workspace),
-}));
-
-vi.mock("@app/lib/utils/rate_limiter", () => ({
-  expireRateLimiterKey: vi.fn(),
-  getRateLimiterCount: mockGetRateLimiterCount,
-  getTimeframeSecondsFromLiteral: vi.fn(() => 60 * 60 * 24),
 }));
 
 vi.mock("@app/logger/logger", () => ({
@@ -277,77 +265,6 @@ describe("isUserBlocked", () => {
     expect(redisValues.get("metronome:pool_credit_status:ws_test")).toBe(
       "depleted"
     );
-  });
-});
-
-describe("getFairUseAwuCreditsStatus", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  const workspace = {
-    id: 42,
-    sId: "ws_test",
-  };
-
-  const user = {
-    id: 7,
-    sId: "u_test",
-  };
-
-  function makePlan({
-    maxAwuCredits,
-    maxAwuCreditsTimeframe,
-  }: {
-    maxAwuCredits: number;
-    maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType;
-  }) {
-    return renderPlanFromModel({
-      plan: {
-        ...FREE_NO_PLAN_DATA,
-        maxAwuCredits,
-        maxAwuCreditsTimeframe,
-      },
-    });
-  }
-
-  it("does not read Redis when the AWU fair-use limit is unlimited", async () => {
-    const status = await getFairUseAwuCreditsStatus({
-      workspace,
-      user,
-      plan: makePlan({ maxAwuCredits: -1, maxAwuCreditsTimeframe: "day" }),
-    });
-
-    expect(status).toEqual({
-      limit: -1,
-      timeframe: "day",
-      count: 0,
-    });
-    expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
-  });
-
-  it("reads the Redis-backed AWU fair-use usage for finite limits", async () => {
-    mockGetRateLimiterCount.mockResolvedValue({
-      isErr: () => false,
-      isOk: () => true,
-      value: 12,
-    });
-
-    const status = await getFairUseAwuCreditsStatus({
-      workspace,
-      user,
-      plan: makePlan({ maxAwuCredits: 100, maxAwuCreditsTimeframe: "day" }),
-    });
-
-    expect(status).toEqual({
-      limit: 100,
-      timeframe: "day",
-      count: 12,
-    });
-    expect(mockGetRateLimiterCount).toHaveBeenCalledWith({
-      key: "workspace:42:user:7:fair_use_awu_credit_count:day",
-      timeframeSeconds: 60 * 60 * 24,
-    });
   });
 });
 

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -18,10 +18,15 @@
 // DB transaction commit via `invalidateCacheAfterCommit`, and cache misses fall
 // back to DB and repopulate the relevant keys.
 //
+import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { runOnRedis } from "@app/lib/api/redis";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import {
+  getRateLimiterCount,
+  getTimeframeSecondsFromLiteral,
+} from "@app/lib/utils/rate_limiter";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type {
@@ -37,13 +42,28 @@ import {
   isSpendingFromPersonalSeat,
   isUserCreditState,
 } from "@app/types/memberships";
+import type { MaxAwuCreditsTimeframeType, PlanType } from "@app/types/plan";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
 
 export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
 
 export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
 
+export type FairUseAwuCreditsStatus = {
+  limit: number;
+  timeframe: MaxAwuCreditsTimeframeType;
+  count: number;
+};
+
+const DEFAULT_FAIR_USE_AWU_CREDITS_STATUS: FairUseAwuCreditsStatus = {
+  limit: -1,
+  timeframe: "lifetime",
+  count: 0,
+};
+
 export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
+  fairUseAwuCreditsState: FairUseAwuCreditsStatus;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditStatus: ProgrammaticCreditStatus;
   balanceThresholdReached: boolean;
@@ -112,6 +132,59 @@ export async function isWorkspaceBalanceThresholdReached(
     client.get(buildWorkspaceBalanceThresholdReachedKey(workspaceId))
   );
   return val === "1";
+}
+
+export async function getFairUseAwuCreditsStatus({
+  workspace,
+  user,
+  plan,
+}: {
+  workspace: LightWorkspaceType;
+  user: UserType;
+  plan: PlanType | null;
+}): Promise<FairUseAwuCreditsStatus> {
+  if (!plan) {
+    return DEFAULT_FAIR_USE_AWU_CREDITS_STATUS;
+  }
+
+  const { maxAwuCredits: limit, maxAwuCreditsTimeframe: timeframe } =
+    plan.limits.assistant;
+
+  if (limit === -1) {
+    return {
+      limit,
+      timeframe,
+      count: 0,
+    };
+  }
+
+  const result = await getRateLimiterCount({
+    key: makeFairUseAwuCreditsRateLimitKeyForUser(workspace, user, timeframe),
+    timeframeSeconds: getTimeframeSecondsFromLiteral(timeframe),
+  });
+
+  if (result.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        error: result.error,
+      },
+      "Failed to read fair-use AWU credits usage status."
+    );
+
+    return {
+      limit,
+      timeframe,
+      count: 0,
+    };
+  }
+
+  return {
+    limit,
+    timeframe,
+    count: Math.min(result.value, limit),
+  };
 }
 
 // Unified read

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -273,6 +273,11 @@ export function useWorkspaceUsageStatus({
 
   return {
     awuStatus: data?.awuStatus ?? "normal",
+    fairUseAwuCreditsState: data?.fairUseAwuCreditsState ?? {
+      limit: -1,
+      timeframe: "lifetime",
+      count: 0,
+    },
     poolCreditState: data?.poolCreditState ?? "active",
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
     balanceThresholdReached: data?.balanceThresholdReached ?? false,


### PR DESCRIPTION
## Description

Work for: https://github.com/dust-tt/tasks/issues/8257

Add `getFairUseAwuCreditsStatus` and return its result in `useWorkspaceUsageStatus` through the existing `usage-status` endpoint. Goal is to be able to show a gauge related to fair use in the left side panel.

This endpoint is called on very load of the app. Performance impact here is small (1 redis ZCOUNT).

## Tests

N/A no impact for now will test locally in follow-up PRs

## Risk

None for now (1 added redis call in the future, none for now as there is no plan with != -1 limit)

## Deploy Plan

- deploy `front`