### PR TITLE
fix: decode HTML entities in notification subjects

### DIFF
--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -54,7 +54,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { stripMarkdown } from "@app/types/shared/utils/markdown";
+import { decodeHtmlEntities, stripMarkdown } from "@app/types/shared/utils/markdown";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { UserType } from "@app/types/user";
 import { workflow } from "@novu/framework";
@@ -221,7 +221,12 @@ const getConversationDetails = async ({
   const conversation = conversationRes.value;
 
   const workspaceName = auth.getNonNullableWorkspace().name;
-  const subject = getConversationDisplayTitle(conversation);
+  // Decode HTML entities in conversation title (e.g. from email subjects
+  // that may contain &amp;, &lt;, etc.) so notification subjects/bodies
+  // display clean text.
+  const subject = decodeHtmlEntities(
+    getConversationDisplayTitle(conversation)
+  );
   const isFromTrigger = !!conversation.triggerId;
 
   // Retrieve the message that triggered the notification.

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -54,7 +54,10 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { decodeHtmlEntities, stripMarkdown } from "@app/types/shared/utils/markdown";
+import {
+  decodeHtmlEntities,
+  stripMarkdown,
+} from "@app/types/shared/utils/markdown";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { UserType } from "@app/types/user";
 import { workflow } from "@novu/framework";
@@ -224,9 +227,7 @@ const getConversationDetails = async ({
   // Decode HTML entities in conversation title (e.g. from email subjects
   // that may contain &amp;, &lt;, etc.) so notification subjects/bodies
   // display clean text.
-  const subject = decodeHtmlEntities(
-    getConversationDisplayTitle(conversation)
-  );
+  const subject = decodeHtmlEntities(getConversationDisplayTitle(conversation));
   const isFromTrigger = !!conversation.triggerId;
 
   // Retrieve the message that triggered the notification.

--- a/front/lib/resources/storage/models/membership_upgrade_requests.ts
+++ b/front/lib/resources/storage/models/membership_upgrade_requests.ts
@@ -1,4 +1,5 @@
 import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import {
@@ -6,7 +7,6 @@ import {
   type MembershipUpgradeRequestStatus,
 } from "@app/types/memberships";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
 
 // A member-initiated request to have their per-user spend limit raised by a
 // workspace admin. A member can have at most one `pending` request at a time

--- a/front/types/shared/utils/markdown.ts
+++ b/front/types/shared/utils/markdown.ts
@@ -109,7 +109,7 @@ const HTML_ENTITY_PATTERN = new RegExp(
   "g"
 );
 
-function decodeHtmlEntities(text: string): string {
+export function decodeHtmlEntities(text: string): string {
   return text.replace(
     HTML_ENTITY_PATTERN,
     (match) => HTML_ENTITIES[match] ?? match


### PR DESCRIPTION
## Description
Context: https://groups.google.com/a/dust.tt/g/security-archive/c/YLStB_NNHWU

### Problem

Conversation titles originating from email subjects can contain HTML entities (e.g. `&amp;`, `&lt;`, `&quot;`, `&#39;`) which appear un-decoded in:
- Email notification subjects
- In-app notification bodies
- Slack notification messages

For example, an email with subject `Q1 Budget &amp; Forecast` would display literally as `Q1 Budget &amp; Forecast` rather than `Q1 Budget & Forecast` in all notification channels.

### Solution

1. **Export `decodeHtmlEntities`** from `front/types/shared/utils/markdown.ts` (was previously a private function only used inside `stripMarkdown`)
2. **Apply `decodeHtmlEntities`** to the conversation subject in `getConversationDetails()` in `front/lib/notifications/workflows/conversation-unread.ts`

Since `getConversationDetails` is the single source of the `subject` field used by all downstream notification channels (in-app, Slack, email), this fix ensures all channels display clean text.

## Risks
low, minimal blast radius

## Deploy
- front
