### PR TITLE
 Add `extract_text` tool to the files MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -114,6 +114,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "copy": "never_ask",
     "create": "never_ask",
     "delete": "medium",
+    "extract_text": "never_ask",
     "grep": "never_ask",
     "list": "never_ask",
     "move": "never_ask",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -19,6 +19,7 @@ export const FILES_DELETE_ACTION_NAME = "delete" as const;
 export const FILES_COPY_ACTION_NAME = "copy" as const;
 export const FILES_MOVE_ACTION_NAME = "move" as const;
 export const FILES_RESOLVE_ACTION_NAME = "resolve" as const;
+export const FILES_EXTRACT_TEXT_ACTION_NAME = "extract_text" as const;
 
 export const CAT_LINES_DEFAULT = 200;
 export const CAT_LINES_MAX = 500;
@@ -278,9 +279,31 @@ const FILES_TOOLS_COMMON_METADATA = {
   },
 };
 
+const EXTRACT_TEXT_TOOL = {
+  description:
+    "Extract text from a binary document (PDF, DOCX, DOC, PPTX, PPT, XLSX, XLS) " +
+    "and save the result as a plain-text file next to the source. " +
+    "Returns the scoped path of the extracted file. " +
+    `Use this before \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` or \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_GREP_ACTION_NAME)}\` ` +
+    "on binary documents that cannot be read as text.",
+  schema: {
+    path: z
+      .string()
+      .describe(
+        `Scoped path to the binary document (e.g. \`conversation-<id>/report.pdf\`)`
+      ),
+  },
+  stake: "never_ask" as const,
+  displayLabels: {
+    running: "Extracting text from document",
+    done: "Extracted text from document",
+  },
+};
+
 export const FILES_TOOLS_METADATA = createToolsRecord({
   [FILES_LIST_ACTION_NAME]: LIST_TOOL,
   ...FILES_TOOLS_COMMON_METADATA,
+  [FILES_EXTRACT_TEXT_ACTION_NAME]: EXTRACT_TEXT_TOOL,
   [FILES_COPY_ACTION_NAME]: COPY_TOOL,
   [FILES_MOVE_ACTION_NAME]: MOVE_TOOL,
 });

--- a/front/lib/api/actions/servers/files/tools/extract_text.ts
+++ b/front/lib/api/actions/servers/files/tools/extract_text.ts
@@ -1,0 +1,147 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
+import { Err, Ok } from "@app/types/shared/result";
+import {
+  isTextExtractionSupportedContentType,
+  TextExtraction,
+} from "@app/types/shared/text_extraction";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { basename, dirname, extname } from "path";
+
+function deriveExtractedPath(sourcePath: string): string {
+  const stem = basename(sourcePath, extname(sourcePath));
+  return `${dirname(sourcePath)}/${stem}.extracted.txt`;
+}
+
+export async function extractTextHandler(
+  { path }: { path: string },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  const dustFs = fsResult.value;
+
+  const statResult = await dustFs.stat(path);
+  if (statResult.isErr()) {
+    return new Err(new MCPError(statResult.error.message, { tracked: false }));
+  }
+
+  if (statResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  const { contentType } = statResult.value;
+
+  if (!isTextExtractionSupportedContentType(contentType)) {
+    return new Err(
+      new MCPError(
+        `\`${contentType}\` is not supported for text extraction. Supported formats: PDF, DOCX, DOC, PPTX, PPT, XLSX, XLS.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const readResult = await dustFs.read(path);
+  if (readResult.isErr()) {
+    return new Err(new MCPError(readResult.error.message, { tracked: false }));
+  }
+
+  if (readResult.value === null) {
+    return new Err(
+      new MCPError(`File not found: \`${path}\`.`, { tracked: false })
+    );
+  }
+
+  let extractedStream;
+  try {
+    extractedStream = await new TextExtraction(config.getTextExtractionUrl(), {
+      enableOcr: true,
+      logger,
+    }).fromStream(readResult.value, contentType);
+  } catch (err) {
+    return new Err(
+      new MCPError(`Text extraction failed: ${normalizeError(err).message}`, {
+        tracked: true,
+      })
+    );
+  }
+
+  const chunks: Buffer[] = [];
+  try {
+    for await (const chunk of extractedStream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+  } catch (err) {
+    return new Err(
+      new MCPError(
+        `Failed to read extracted content: ${normalizeError(err).message}`,
+        { tracked: true }
+      )
+    );
+  }
+
+  const extractedContent = Buffer.concat(chunks);
+  const outputPath = deriveExtractedPath(path);
+
+  const writeResult = await dustFs.write(
+    outputPath,
+    extractedContent,
+    "text/plain"
+  );
+  if (writeResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to write extracted text to \`${outputPath}\`: ${writeResult.error.message}`
+      )
+    );
+  }
+
+  const fileName = outputPath.split("/").pop() ?? outputPath;
+  const sizeKb = Math.ceil(extractedContent.byteLength / 1024);
+
+  const filePathResource: ToolGeneratedFilePathType = {
+    text: `Extracted text from \`${path}\``,
+    uri: outputPath,
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+    path: outputPath,
+    title: fileName,
+    contentType: "text/plain",
+  };
+
+  return new Ok([
+    {
+      type: "text",
+      text: `Extracted text from \`${path}\` to \`${outputPath}\` (${sizeKb} KB). The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+    },
+    {
+      type: "resource",
+      resource: filePathResource,
+    },
+  ]);
+}

--- a/front/lib/api/actions/servers/files/tools/extract_text.ts
+++ b/front/lib/api/actions/servers/files/tools/extract_text.ts
@@ -117,7 +117,8 @@ export async function extractTextHandler(
   if (writeResult.isErr()) {
     return new Err(
       new MCPError(
-        `Failed to write extracted text to \`${outputPath}\`: ${writeResult.error.message}`
+        `Failed to write extracted text to \`${outputPath}\`: ${writeResult.error.message}`,
+        { tracked: true }
       )
     );
   }

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -4,6 +4,7 @@ import {
   FILES_COPY_ACTION_NAME,
   FILES_CREATE_ACTION_NAME,
   FILES_DELETE_ACTION_NAME,
+  FILES_EXTRACT_TEXT_ACTION_NAME,
   FILES_GREP_ACTION_NAME,
   FILES_LIST_ACTION_NAME,
   FILES_MOVE_ACTION_NAME,
@@ -14,6 +15,7 @@ import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
 import { createHandler } from "@app/lib/api/actions/servers/files/tools/create";
 import { deleteHandler } from "@app/lib/api/actions/servers/files/tools/delete";
+import { extractTextHandler } from "@app/lib/api/actions/servers/files/tools/extract_text";
 import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
@@ -24,6 +26,7 @@ const HANDLERS = {
   [FILES_COPY_ACTION_NAME]: copyHandler,
   [FILES_CREATE_ACTION_NAME]: createHandler,
   [FILES_DELETE_ACTION_NAME]: deleteHandler,
+  [FILES_EXTRACT_TEXT_ACTION_NAME]: extractTextHandler,
   [FILES_GREP_ACTION_NAME]: grepHandler,
   [FILES_LIST_ACTION_NAME]: listHandler,
   [FILES_MOVE_ACTION_NAME]: moveHandler,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
File uploads currently run Tika text extraction synchronously at upload time, before the model ever sees the file. This is slow, sometimes times out, and does work that may never be needed if the model doesn't actually read the document. Also, as we release computer, we could expect it to yields better results than Tika on many formats.

This PR adds an `extract_text` tool to the internal files MCP server that defers text extraction to agent-loop time. When the model needs to read a PDF, DOCX, PPTX, or spreadsheet, it calls `extract_text { path }`, which reads the binary file from `DustFileSystem`, sends it through the existing Tika pipeline, and writes the result as `<stem>.extracted.txt` next to the source in the conversation file system. The model gets back a `FILE_PATH` resource it can immediately pass to cat or grep.

This is strictly additive. **No existing upload behavior is changed.** The intent is to use this as the foundation for progressively removing blocking pre-processing from the upload path, replacing it with on-demand extraction that surfaces clearly as an agent step, produces a recoverable error when it fails, and skips entirely when the model doesn't need the document content.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
