### PR TITLE
Resource cache invalidation in Poke

### DIFF
--- a/front-api/routes/poke/cache.ts
+++ b/front-api/routes/poke/cache.ts
@@ -1,4 +1,5 @@
 import type {
+  DeleteAllPokeCacheResponseBody,
   DeletePokeCacheResponseBody,
   GetPokeCacheResponseBody,
   RedisCacheResult,
@@ -7,6 +8,7 @@ import { runOnRedis, runOnRedisCache } from "@app/lib/api/redis";
 import logger from "@app/logger/logger";
 import {
   buildCacheKey,
+  buildCacheKeyPattern,
   getCacheResourceById,
 } from "@app/types/shared/cache_resource_registry";
 import { isString } from "@app/types/shared/utils/general";
@@ -183,6 +185,77 @@ app.delete("/", async (ctx): HandlerResult<DeletePokeCacheResponseBody> => {
     key: cacheKey,
     redisInstance,
     deleted: true,
+  });
+});
+
+const DELETE_ALL_BATCH_SIZE = 500;
+
+// Deletes all cache entries of a resource type by scanning for its key pattern. Only targets the
+// cache Redis instance since `cacheWithRedis` exclusively writes there.
+app.delete("/all", async (ctx): HandlerResult<DeleteAllPokeCacheResponseBody> => {
+  const resourceId = ctx.req.query("resourceId");
+  if (!isString(resourceId)) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The 'resourceId' query parameter must be provided.",
+      },
+    });
+  }
+
+  const resource = getCacheResourceById(resourceId);
+  if (!resource) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Unknown resource ID: '${resourceId}'.`,
+      },
+    });
+  }
+
+  const pattern = buildCacheKeyPattern(resource);
+  if (!pattern) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Resource '${resourceId}' does not support bulk deletion.`,
+      },
+    });
+  }
+
+  const deletedCount = await runOnRedisCache(
+    { origin: "poke_cache_invalidation" },
+    async (client) => {
+      let count = 0;
+      let batch: string[] = [];
+      for await (const key of client.scanIterator({
+        MATCH: pattern,
+        COUNT: DELETE_ALL_BATCH_SIZE,
+      })) {
+        batch.push(key);
+        if (batch.length >= DELETE_ALL_BATCH_SIZE) {
+          count += await client.del(batch);
+          batch = [];
+        }
+      }
+      if (batch.length > 0) {
+        count += await client.del(batch);
+      }
+      return count;
+    }
+  );
+
+  logger.info(
+    { redisKeyPattern: pattern, deletedCount },
+    "Poke cache bulk invalidation performed"
+  );
+
+  return ctx.json({
+    pattern,
+    deletedCount,
   });
 });
 

--- a/front-api/routes/poke/cache.ts
+++ b/front-api/routes/poke/cache.ts
@@ -192,71 +192,74 @@ const DELETE_ALL_BATCH_SIZE = 500;
 
 // Deletes all cache entries of a resource type by scanning for its key pattern. Only targets the
 // cache Redis instance since `cacheWithRedis` exclusively writes there.
-app.delete("/all", async (ctx): HandlerResult<DeleteAllPokeCacheResponseBody> => {
-  const resourceId = ctx.req.query("resourceId");
-  if (!isString(resourceId)) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "The 'resourceId' query parameter must be provided.",
-      },
-    });
-  }
-
-  const resource = getCacheResourceById(resourceId);
-  if (!resource) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Unknown resource ID: '${resourceId}'.`,
-      },
-    });
-  }
-
-  const pattern = buildCacheKeyPattern(resource);
-  if (!pattern) {
-    return apiError(ctx, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: `Resource '${resourceId}' does not support bulk deletion.`,
-      },
-    });
-  }
-
-  const deletedCount = await runOnRedisCache(
-    { origin: "poke_cache_invalidation" },
-    async (client) => {
-      let count = 0;
-      let batch: string[] = [];
-      for await (const key of client.scanIterator({
-        MATCH: pattern,
-        COUNT: DELETE_ALL_BATCH_SIZE,
-      })) {
-        batch.push(key);
-        if (batch.length >= DELETE_ALL_BATCH_SIZE) {
-          count += await client.del(batch);
-          batch = [];
-        }
-      }
-      if (batch.length > 0) {
-        count += await client.del(batch);
-      }
-      return count;
+app.delete(
+  "/all",
+  async (ctx): HandlerResult<DeleteAllPokeCacheResponseBody> => {
+    const resourceId = ctx.req.query("resourceId");
+    if (!isString(resourceId)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "The 'resourceId' query parameter must be provided.",
+        },
+      });
     }
-  );
 
-  logger.info(
-    { redisKeyPattern: pattern, deletedCount },
-    "Poke cache bulk invalidation performed"
-  );
+    const resource = getCacheResourceById(resourceId);
+    if (!resource) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Unknown resource ID: '${resourceId}'.`,
+        },
+      });
+    }
 
-  return ctx.json({
-    pattern,
-    deletedCount,
-  });
-});
+    const pattern = buildCacheKeyPattern(resource);
+    if (!pattern) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Resource '${resourceId}' does not support bulk deletion.`,
+        },
+      });
+    }
+
+    const deletedCount = await runOnRedisCache(
+      { origin: "poke_cache_invalidation" },
+      async (client) => {
+        let count = 0;
+        let batch: string[] = [];
+        for await (const key of client.scanIterator({
+          MATCH: pattern,
+          COUNT: DELETE_ALL_BATCH_SIZE,
+        })) {
+          batch.push(key);
+          if (batch.length >= DELETE_ALL_BATCH_SIZE) {
+            count += await client.del(batch);
+            batch = [];
+          }
+        }
+        if (batch.length > 0) {
+          count += await client.del(batch);
+        }
+        return count;
+      }
+    );
+
+    logger.info(
+      { redisKeyPattern: pattern, deletedCount },
+      "Poke cache bulk invalidation performed"
+    );
+
+    return ctx.json({
+      pattern,
+      deletedCount,
+    });
+  }
+);
 
 export default app;

--- a/front/components/poke/pages/CacheLookupPage.tsx
+++ b/front/components/poke/pages/CacheLookupPage.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { RedisCacheResult, RedisInstance } from "@app/lib/api/poke/cache";
 import {
+  usePokeCacheDeleteAll,
   usePokeCacheInvalidate,
   usePokeCacheLookup,
 } from "@app/poke/swr/cache";
@@ -8,6 +9,7 @@ import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import type { CacheResourceDefinition } from "@app/types/shared/cache_resource_registry";
 import {
   buildCacheKey,
+  buildCacheKeyPattern,
   CACHE_RESOURCE_REGISTRY,
 } from "@app/types/shared/cache_resource_registry";
 import {
@@ -408,6 +410,110 @@ function RawKeyForm({ onSubmit }: RawKeyFormProps) {
   );
 }
 
+function ResourceInvalidateForm() {
+  const [selectedResource, setSelectedResource] =
+    useState<CacheResourceDefinition | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const { doDeleteAll, isDeletingAll } = usePokeCacheDeleteAll();
+
+  const pattern = selectedResource
+    ? buildCacheKeyPattern(selectedResource)
+    : null;
+
+  return (
+    <div className="space-y-4 py-4">
+      <div>
+        <Label className="mb-1 block">Resource Type</Label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              isSelect
+              label={selectedResource?.label ?? "Select a resource..."}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-72">
+            {CACHE_RESOURCE_REGISTRY.map((resource) => (
+              <DropdownMenuItem
+                key={resource.id}
+                onClick={() => setSelectedResource(resource)}
+              >
+                {resource.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {selectedResource && !pattern && (
+        <ContentMessage
+          variant="warning"
+          size="sm"
+          title="This resource does not support bulk invalidation."
+        />
+      )}
+
+      {selectedResource && pattern && (
+        <>
+          <div>
+            <Label isMuted>Key Pattern</Label>
+            <code className="mt-1 block break-all rounded bg-muted-background p-2 text-xs text-muted-foreground dark:bg-muted-background-night dark:text-muted-foreground-night">
+              {pattern}
+            </code>
+          </div>
+
+          <Button
+            label={isDeletingAll ? "Deleting..." : "Invalidate entire cache"}
+            variant="warning"
+            disabled={isDeletingAll}
+            onClick={() => setShowConfirm(true)}
+          />
+
+          <Dialog
+            open={showConfirm}
+            onOpenChange={(open) => {
+              if (!open) {
+                setShowConfirm(false);
+              }
+            }}
+          >
+            <DialogContent size="md" isAlertDialog>
+              <DialogHeader hideButton>
+                <DialogTitle>Delete all cache entries?</DialogTitle>
+              </DialogHeader>
+              <DialogContainer>
+                <p>
+                  This will delete all{" "}
+                  <span className="font-bold">{selectedResource.label}</span>{" "}
+                  entries matching <code className="break-all">{pattern}</code>{" "}
+                  from Cache Redis (REDIS_CACHE_URI). This action cannot be
+                  undone.
+                </p>
+              </DialogContainer>
+              <DialogFooter
+                leftButtonProps={{
+                  label: "Cancel",
+                  variant: "outline",
+                }}
+                rightButtonProps={{
+                  label: "Invalidate all",
+                  variant: "warning",
+                  onClick: async () => {
+                    await doDeleteAll({ resourceId: selectedResource.id });
+                    setShowConfirm(false);
+                  },
+                }}
+              />
+            </DialogContent>
+          </Dialog>
+        </>
+      )}
+    </div>
+  );
+}
+
 export function CacheLookupPage() {
   usePokePageMetadata({ name: "Cache Lookup" });
 
@@ -457,8 +563,9 @@ export function CacheLookupPage() {
           <div className="w-80 shrink-0 rounded-lg bg-background p-4 dark:bg-background-night">
             <Tabs defaultValue="resource">
               <TabsList>
-                <TabsTrigger value="resource" label="Resource Lookup" />
-                <TabsTrigger value="raw" label="Raw Key" />
+                <TabsTrigger value="resource" label="Resource" />
+                <TabsTrigger value="raw" label="Raw" />
+                <TabsTrigger value="invalidate" label="Invalidate" />
               </TabsList>
 
               <TabsContent value="resource">
@@ -467,6 +574,10 @@ export function CacheLookupPage() {
 
               <TabsContent value="raw">
                 <RawKeyForm onSubmit={setQuery} />
+              </TabsContent>
+
+              <TabsContent value="invalidate">
+                <ResourceInvalidateForm />
               </TabsContent>
             </Tabs>
           </div>

--- a/front/lib/api/poke/cache.ts
+++ b/front/lib/api/poke/cache.ts
@@ -19,3 +19,8 @@ export type DeletePokeCacheResponseBody = {
   redisInstance: RedisInstance;
   deleted: true;
 };
+
+export type DeleteAllPokeCacheResponseBody = {
+  pattern: string;
+  deletedCount: number;
+};

--- a/front/poke/swr/cache.ts
+++ b/front/poke/swr/cache.ts
@@ -1,9 +1,12 @@
+import { useSendNotification } from "@app/hooks/useNotification";
 import type {
+  DeleteAllPokeCacheResponseBody,
   GetPokeCacheResponseBody,
   RedisInstance,
 } from "@app/lib/api/poke/cache";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useState } from "react";
 import type { Fetcher } from "swr";
 
@@ -92,4 +95,57 @@ export function usePokeCacheInvalidate() {
   };
 
   return { doInvalidate, isInvalidating };
+}
+
+export function usePokeCacheDeleteAll() {
+  const sendNotification = useSendNotification();
+  const [isDeletingAll, setIsDeletingAll] = useState(false);
+
+  const doDeleteAll = async ({
+    resourceId,
+  }: {
+    resourceId: string;
+  }): Promise<boolean> => {
+    setIsDeletingAll(true);
+    try {
+      const queryParams = new URLSearchParams();
+      queryParams.set("resourceId", resourceId);
+
+      const res = await clientFetch(
+        `/api/poke/cache/all?${queryParams.toString()}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await res.json();
+        sendNotification({
+          title: "Failed to delete cache entries",
+          description: errorData.error?.message ?? "Unknown error",
+          type: "error",
+        });
+        return false;
+      }
+
+      const body: DeleteAllPokeCacheResponseBody = await res.json();
+      sendNotification({
+        title: "Cache entries deleted",
+        description: `Deleted ${body.deletedCount} entries matching '${body.pattern}'.`,
+        type: "success",
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        title: "Failed to delete cache entries",
+        description: normalizeError(error).message,
+        type: "error",
+      });
+      return false;
+    } finally {
+      setIsDeletingAll(false);
+    }
+  };
+
+  return { doDeleteAll, isDeletingAll };
 }

--- a/front/types/shared/cache_resource_registry.ts
+++ b/front/types/shared/cache_resource_registry.ts
@@ -20,6 +20,11 @@ export interface CacheResourceDefinition {
   fnName: string;
   params: CacheResourceParam[];
   buildResolverKey: (params: Record<string, string>) => string;
+  // Redis glob pattern matching the resolver keys of all entries of this resource type. Used by
+  // poke to bulk-delete every cache entry for the resource. Omit when the full key (fnName +
+  // resolver key) is too generic to match safely (e.g. an anonymous fnName with an unprefixed
+  // resolver key).
+  resolverKeyPattern?: string;
 }
 
 export function buildCacheKey(
@@ -27,6 +32,15 @@ export function buildCacheKey(
   params: Record<string, string>
 ): string {
   return `cacheWithRedis-${resource.fnName}-${resource.buildResolverKey(params)}`;
+}
+
+export function buildCacheKeyPattern(
+  resource: CacheResourceDefinition
+): string | null {
+  if (!resource.resolverKeyPattern) {
+    return null;
+  }
+  return `cacheWithRedis-${resource.fnName}-${resource.resolverKeyPattern}`;
 }
 
 export const WORKSPACE_CACHE_KEY_VERSION = 2;
@@ -46,6 +60,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
     ],
     buildResolverKey: (p) =>
       `workspace:v${WORKSPACE_CACHE_KEY_VERSION}:${p.wId}`,
+    resolverKeyPattern: `workspace:v${WORKSPACE_CACHE_KEY_VERSION}:*`,
   },
   {
     id: "user_by_workos_id",
@@ -60,6 +75,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `user:workos:${p.workOSUserId}`,
+    resolverKeyPattern: "user:workos:*",
   },
   {
     id: "subscription_by_workspace",
@@ -75,6 +91,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
     ],
     buildResolverKey: (p) =>
       `subscription:active:workspaceId:${p.workspaceModelId}`,
+    resolverKeyPattern: "subscription:active:workspaceId:*",
   },
   {
     id: "membership_role",
@@ -96,6 +113,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
     ],
     buildResolverKey: (p) =>
       `role:user:${p.userModelId}:workspace:${p.workspaceModelId}`,
+    resolverKeyPattern: "role:user:*",
   },
   {
     id: "membership_seats",
@@ -110,6 +128,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `count-active-seats-in-workspace:${p.workspaceId}`,
+    resolverKeyPattern: "count-active-seats-in-workspace:*",
   },
   {
     id: "workos_orgs_for_user",
@@ -124,6 +143,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `workos-orgs-${p.userId}`,
+    resolverKeyPattern: "workos-orgs-*",
   },
   {
     id: "workspace_region",
@@ -138,6 +158,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `workspace-region:${p.wId}`,
+    resolverKeyPattern: "workspace-region:*",
   },
   {
     id: "provider_status",
@@ -152,6 +173,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `provider-status-${p.region}`,
+    resolverKeyPattern: "provider-status-*",
   },
   {
     id: "dust_status",
@@ -166,6 +188,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `dust-status-${p.region}`,
+    resolverKeyPattern: "dust-status-*",
   },
   {
     id: "key_monthly_cap",
@@ -180,6 +203,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `key-cap:${p.keyId}`,
+    resolverKeyPattern: "key-cap:*",
   },
   {
     id: "slack_channels",
@@ -208,6 +232,7 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `slack_users_${p.mcpServerId}`,
+    resolverKeyPattern: "slack_users_*",
   },
   {
     id: "metronome_balance_threshold",
@@ -228,6 +253,8 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+    // The resolver key has no static prefix; the unique fnName scopes the pattern.
+    resolverKeyPattern: "*",
   },
   {
     id: "metronome_per_user_cap_alert_ids",
@@ -248,6 +275,8 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+    // The resolver key has no static prefix; the unique fnName scopes the pattern.
+    resolverKeyPattern: "*",
   },
   {
     id: "metronome_default_cap_thresholds_by_seat_type",
@@ -268,6 +297,8 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+    // The resolver key has no static prefix; the unique fnName scopes the pattern.
+    resolverKeyPattern: "*",
   },
   {
     id: "metronome_workspace_alert_ids",
@@ -288,6 +319,8 @@ export const CACHE_RESOURCE_REGISTRY: CacheResourceDefinition[] = [
       },
     ],
     buildResolverKey: (p) => `${p.metronomeCustomerId}-${p.workspaceId}`,
+    // The resolver key has no static prefix; the unique fnName scopes the pattern.
+    resolverKeyPattern: "*",
   },
 ];
 


### PR DESCRIPTION
## Description

Adds capability to invalidate entire cache per resource in poke. Handy in case of incidents.

<img width="352" height="487" alt="Screenshot 2026-06-10 at 13 28 17" src="https://github.com/user-attachments/assets/26c71d03-63b4-458b-a940-2d845d7fd705" />
<img width="428" height="272" alt="Screenshot 2026-06-10 at 13 28 20" src="https://github.com/user-attachments/assets/3a0b7d04-1950-4245-a653-4537c29128f9" />


## Tests

Tested locally

## Risk

Low cache only

## Deploy Plan

- deploy `front`