### PR TITLE
[front] feat: add get_usage_timeseries to workspace_analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -708,6 +708,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_top_skills": "never_ask",
     "get_top_tools": "never_ask",
     "get_top_users": "never_ask",
+    "get_usage_timeseries": "never_ask",
   },
   "zendesk": {
     "draft_reply": "low",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -38,6 +38,25 @@ const getAgentDetailsSchema = {
     ),
 };
 
+const getUsageTimeseriesSchema = {
+  ...timeWindowSchemaShape,
+  ...usageFilterSchema,
+  metric: z
+    .enum(["messages", "skills", "tools"])
+    .optional()
+    .describe(
+      "What to plot over time. 'messages' (default): messages, conversations " +
+        "and active users. 'skills'/'tools': executions and unique users."
+    ),
+  granularity: z
+    .enum(["day", "week"])
+    .optional()
+    .describe(
+      "Bucket granularity (default day). Only applies to the messages metric; " +
+        "skills and tools are always daily."
+    ),
+};
+
 export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
   get_top_agents: {
     description:
@@ -105,6 +124,21 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving top tools",
       done: "Retrieved top tools",
+    },
+  },
+  get_usage_timeseries: {
+    description:
+      "Return a usage time series over a window (defaults to the last 30 " +
+      "days). The metric parameter selects what is plotted: messages " +
+      "(messages/conversations/active users, default), skills, or tools " +
+      "(executions/unique users). Use this for any trend over time — it is a " +
+      "single call, do not call other tools once per day. Combine with the " +
+      "source/agent/user filters to narrow. Chart the result. Admin-only.",
+    schema: getUsageTimeseriesSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving usage time series",
+      done: "Retrieved usage time series",
     },
   },
 });

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -29,6 +29,7 @@ describe("workspace_analytics tools", () => {
     "get_agent_details",
     "get_top_skills",
     "get_top_tools",
+    "get_usage_timeseries",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -1,5 +1,8 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  ToolHandlerResult,
+  ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
@@ -23,7 +26,9 @@ import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents"
 import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import moment from "moment-timezone";
 
 function scopedBaseQuery(
@@ -43,6 +48,44 @@ function scopedBaseQuery(
     agentIds,
     userIds,
   });
+}
+
+function renderExecutionSeries<
+  T extends { date: string; executionCount: number; uniqueUsers: number },
+>(
+  result: Result<T[], Error>,
+  metricLabel: string,
+  windowLabel: string,
+  tz: string
+): ToolHandlerResult {
+  if (result.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to retrieve usage time series: ${result.error.message}`
+      )
+    );
+  }
+  if (result.value.length === 0) {
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `No ${metricLabel} usage recorded for ${windowLabel} (${tz}).`,
+      },
+    ]);
+  }
+  const lines = result.value.map(
+    (point) =>
+      `${point.date}: ${point.executionCount} executions, ` +
+      `${point.uniqueUsers} unique users`
+  );
+  return new Ok([
+    {
+      type: "text" as const,
+      text:
+        `${metricLabel} usage per day for ${windowLabel} (${tz}):\n` +
+        lines.join("\n"),
+    },
+  ]);
 }
 
 const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
@@ -352,85 +395,64 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const { label, timezone: tz } = window.value;
     const selectedMetric = metric ?? "messages";
 
-    if (selectedMetric === "messages") {
-      const interval = granularity ?? "day";
-      const result = await fetchMessageMetrics(
-        baseQuery,
-        interval,
-        ["conversations", "activeUsers"],
-        tz
-      );
-      if (result.isErr()) {
-        return new Err(
-          new MCPError(
-            `Failed to retrieve usage time series: ${result.error.message}`
-          )
+    switch (selectedMetric) {
+      case "messages": {
+        const interval = granularity ?? "day";
+        const result = await fetchMessageMetrics(
+          baseQuery,
+          interval,
+          ["conversations", "activeUsers"],
+          tz
         );
-      }
-      if (result.value.length === 0) {
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(
+              `Failed to retrieve usage time series: ${result.error.message}`
+            )
+          );
+        }
+        if (result.value.length === 0) {
+          return new Ok([
+            {
+              type: "text" as const,
+              text: `No messages usage recorded for ${label} (${tz}).`,
+            },
+          ]);
+        }
+        const lines = result.value.map((point) => {
+          const date = moment.tz(point.timestamp, tz).format("YYYY-MM-DD");
+          return (
+            `${date}: ${point.count} messages, ` +
+            `${point.conversations} conversations, ` +
+            `${point.activeUsers} active users`
+          );
+        });
         return new Ok([
           {
             type: "text" as const,
-            text: `No messages usage recorded for ${label} (${tz}).`,
+            text:
+              `messages usage per ${interval} for ${label} (${tz}):\n` +
+              lines.join("\n"),
           },
         ]);
       }
-      const lines = result.value.map((point) => {
-        const date = moment.tz(point.timestamp, tz).format("YYYY-MM-DD");
-        return (
-          `${date}: ${point.count} messages, ` +
-          `${point.conversations} conversations, ` +
-          `${point.activeUsers} active users`
+      case "skills":
+        return renderExecutionSeries(
+          await fetchSkillUsageMetrics(baseQuery, null, tz),
+          "skills",
+          label,
+          tz
         );
-      });
-      return new Ok([
-        {
-          type: "text" as const,
-          text:
-            `messages usage per ${interval} for ${label} (${tz}):\n` +
-            lines.join("\n"),
-        },
-      ]);
+      case "tools":
+        return renderExecutionSeries(
+          await fetchToolUsageMetrics(baseQuery, null, tz),
+          "tools",
+          label,
+          tz
+        );
+      default:
+        return assertNever(selectedMetric);
     }
-
-    const result =
-      selectedMetric === "skills"
-        ? await fetchSkillUsageMetrics(baseQuery, null, tz)
-        : await fetchToolUsageMetrics(baseQuery, null, tz);
-    if (result.isErr()) {
-      return new Err(
-        new MCPError(
-          `Failed to retrieve usage time series: ${result.error.message}`
-        )
-      );
-    }
-
-    const points: {
-      date: string;
-      executionCount: number;
-      uniqueUsers: number;
-    }[] = result.value;
-    if (points.length === 0) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `No ${selectedMetric} usage recorded for ${label} (${tz}).`,
-        },
-      ]);
-    }
-    const lines = points.map(
-      (point) =>
-        `${point.date}: ${point.executionCount} executions, ` +
-        `${point.uniqueUsers} unique users`
-    );
-    return new Ok([
-      {
-        type: "text" as const,
-        text:
-          `${selectedMetric} usage per day for ${label} (${tz}):\n` +
-          lines.join("\n"),
-      },
-    ]);
   },
 };
 

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -9,9 +9,14 @@ import {
   resolveTimeWindow,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { fetchAvailableSkills } from "@app/lib/api/assistant/observability/skill_usage";
+import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import {
+  fetchAvailableSkills,
+  fetchSkillUsageMetrics,
+} from "@app/lib/api/assistant/observability/skill_usage";
 import {
   fetchAvailableTools,
+  fetchToolUsageMetrics,
   resolveServerDisplayNames,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { fetchTopAgents } from "@app/lib/api/assistant/observability/top_agents";
@@ -19,6 +24,7 @@ import { fetchTopUsers } from "@app/lib/api/assistant/observability/top_users";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { Err, Ok } from "@app/types/shared/result";
+import moment from "moment-timezone";
 
 function scopedBaseQuery(
   auth: Authenticator,
@@ -306,6 +312,122 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Most-used tools for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_usage_timeseries: async (
+    {
+      metric,
+      granularity,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+    },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      "last_30_days"
+    );
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const baseQuery = scopedBaseQuery(auth, window.value, {
+      source,
+      agentIds,
+      userIds,
+    });
+    const { label, timezone: tz } = window.value;
+    const selectedMetric = metric ?? "messages";
+
+    if (selectedMetric === "messages") {
+      const interval = granularity ?? "day";
+      const result = await fetchMessageMetrics(
+        baseQuery,
+        interval,
+        ["conversations", "activeUsers"],
+        tz
+      );
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to retrieve usage time series: ${result.error.message}`
+          )
+        );
+      }
+      if (result.value.length === 0) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `No messages usage recorded for ${label} (${tz}).`,
+          },
+        ]);
+      }
+      const lines = result.value.map((point) => {
+        const date = moment.tz(point.timestamp, tz).format("YYYY-MM-DD");
+        return (
+          `${date}: ${point.count} messages, ` +
+          `${point.conversations} conversations, ` +
+          `${point.activeUsers} active users`
+        );
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `messages usage per ${interval} for ${label} (${tz}):\n` +
+            lines.join("\n"),
+        },
+      ]);
+    }
+
+    const result =
+      selectedMetric === "skills"
+        ? await fetchSkillUsageMetrics(baseQuery, null, tz)
+        : await fetchToolUsageMetrics(baseQuery, null, tz);
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to retrieve usage time series: ${result.error.message}`
+        )
+      );
+    }
+
+    const points: {
+      date: string;
+      executionCount: number;
+      uniqueUsers: number;
+    }[] = result.value;
+    if (points.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No ${selectedMetric} usage recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+    const lines = points.map(
+      (point) =>
+        `${point.date}: ${point.executionCount} executions, ` +
+        `${point.uniqueUsers} unique users`
+    );
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `${selectedMetric} usage per day for ${label} (${tz}):\n` +
           lines.join("\n"),
       },
     ]);


### PR DESCRIPTION
## Description

Add an admin-only get_usage_timeseries tool that plots a usage trend over a window (default last 30 days). The metric parameter selects what is plotted: messages (messages/conversations/active users, with day or week granularity), skills, or tools (executions/unique users, daily). Reuses the existing observability fetchMessageMetrics / fetchSkillUsageMetrics / fetchToolUsageMetrics over a scoped base query. The breakdownBy dimension (per agent/skill/tool/source series) lands in a follow-up.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
