### PR TITLE
[front] fix: render timezone-bucketed analytics dates in that timezone

### DIFF
--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -31,7 +31,7 @@ import {
   fetchToolUsageMetrics,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import { formatUTCDateFromMillis } from "@app/lib/api/elasticsearch";
+import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
@@ -279,7 +279,7 @@ async function exportUsageMetrics({
   }
 
   const rows: UsageMetricsRow[] = result.value.map((point) => ({
-    date: formatUTCDateFromMillis(point.timestamp),
+    date: formatDateFromMillis(point.timestamp, timezone),
     messages: point.count,
     conversations: point.conversations,
     activeUsers: point.activeUsers,

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -1,6 +1,6 @@
 import {
   bucketsToArray,
-  formatUTCDateFromMillis,
+  formatDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -176,7 +176,7 @@ export async function fetchActiveUsersMetrics(
 
     points.push({
       timestamp,
-      date: formatUTCDateFromMillis(timestamp),
+      date: formatDateFromMillis(timestamp, timezone),
       dau,
       wau,
       mau,

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -1,6 +1,6 @@
 import {
   bucketsToArray,
-  formatUTCDateFromMillis,
+  formatDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Result } from "@app/types/shared/result";
@@ -158,7 +158,7 @@ export async function fetchContextOriginDailyBreakdown(
   const points: ContextOriginDailyPoint[] = [];
 
   for (const dateBucket of dateBuckets) {
-    const date = formatUTCDateFromMillis(dateBucket.key);
+    const date = formatDateFromMillis(dateBucket.key, timezone);
     const originBuckets = bucketsToArray<OriginSubBucket>(
       dateBucket.by_origin?.buckets
     );

--- a/front/lib/api/assistant/observability/skill_usage.ts
+++ b/front/lib/api/assistant/observability/skill_usage.ts
@@ -1,6 +1,6 @@
 import {
   bucketsToArray,
-  formatUTCDateFromMillis,
+  formatDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Result } from "@app/types/shared/result";
@@ -70,19 +70,22 @@ type SkillListAggs = {
   };
 };
 
-function bucketToPoint(bucket: DateBucket): SkillUsagePoint {
+function bucketToPoint(bucket: DateBucket, timezone: string): SkillUsagePoint {
   return {
     timestamp: bucket.key,
-    date: formatUTCDateFromMillis(bucket.key),
+    date: formatDateFromMillis(bucket.key, timezone),
     uniqueUsers: bucket.skills_nested?.unique_users?.cardinality?.value ?? 0,
     executionCount: bucket.skills_nested?.doc_count ?? 0,
   };
 }
 
-function filteredBucketToPoint(bucket: FilteredDateBucket): SkillUsagePoint {
+function filteredBucketToPoint(
+  bucket: FilteredDateBucket,
+  timezone: string
+): SkillUsagePoint {
   return {
     timestamp: bucket.key,
-    date: formatUTCDateFromMillis(bucket.key),
+    date: formatDateFromMillis(bucket.key, timezone),
     uniqueUsers:
       bucket.skills_nested?.filtered?.unique_users?.cardinality?.value ?? 0,
     executionCount: bucket.skills_nested?.filtered?.doc_count ?? 0,
@@ -152,7 +155,9 @@ export async function fetchSkillUsageMetrics(
       result.value.aggregations?.by_date?.buckets
     );
 
-    return new Ok(dateBuckets.map(filteredBucketToPoint));
+    return new Ok(
+      dateBuckets.map((bucket) => filteredBucketToPoint(bucket, timezone))
+    );
   }
 
   const result = await searchAnalytics<never, SkillUsageAggs>(baseQuery, {
@@ -168,7 +173,7 @@ export async function fetchSkillUsageMetrics(
     result.value.aggregations?.by_date?.buckets
   );
 
-  return new Ok(dateBuckets.map(bucketToPoint));
+  return new Ok(dateBuckets.map((bucket) => bucketToPoint(bucket, timezone)));
 }
 
 export async function fetchAvailableSkills(

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -1,6 +1,6 @@
 import {
   bucketsToArray,
-  formatUTCDateFromMillis,
+  formatDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -78,19 +78,22 @@ type ToolListAggs = {
   };
 };
 
-function bucketToPoint(bucket: DateBucket): ToolUsagePoint {
+function bucketToPoint(bucket: DateBucket, timezone: string): ToolUsagePoint {
   return {
     timestamp: bucket.key,
-    date: formatUTCDateFromMillis(bucket.key),
+    date: formatDateFromMillis(bucket.key, timezone),
     uniqueUsers: bucket.tools_nested?.unique_users?.cardinality?.value ?? 0,
     executionCount: bucket.tools_nested?.doc_count ?? 0,
   };
 }
 
-function filteredBucketToPoint(bucket: FilteredDateBucket): ToolUsagePoint {
+function filteredBucketToPoint(
+  bucket: FilteredDateBucket,
+  timezone: string
+): ToolUsagePoint {
   return {
     timestamp: bucket.key,
-    date: formatUTCDateFromMillis(bucket.key),
+    date: formatDateFromMillis(bucket.key, timezone),
     uniqueUsers:
       bucket.tools_nested?.filtered?.unique_users?.cardinality?.value ?? 0,
     executionCount: bucket.tools_nested?.filtered?.doc_count ?? 0,
@@ -162,7 +165,9 @@ export async function fetchToolUsageMetrics(
       result.value.aggregations?.by_date?.buckets
     );
 
-    return new Ok(dateBuckets.map(filteredBucketToPoint));
+    return new Ok(
+      dateBuckets.map((bucket) => filteredBucketToPoint(bucket, timezone))
+    );
   }
 
   const result = await searchAnalytics<never, ToolUsageAggs>(baseQuery, {
@@ -178,7 +183,7 @@ export async function fetchToolUsageMetrics(
     result.value.aggregations?.by_date?.buckets
   );
 
-  return new Ok(dateBuckets.map(bucketToPoint));
+  return new Ok(dateBuckets.map((bucket) => bucketToPoint(bucket, timezone)));
 }
 
 export async function fetchAvailableTools(

--- a/front/lib/api/elasticsearch.test.ts
+++ b/front/lib/api/elasticsearch.test.ts
@@ -1,0 +1,20 @@
+import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
+import { describe, expect, it } from "vitest";
+
+describe("formatDateFromMillis", () => {
+  // 2026-06-09T15:00:00Z is local midnight 2026-06-10 in Asia/Tokyo (UTC+9):
+  // the kind of date_histogram bucket key that was mis-rendered as 2026-06-09.
+  const ms = Date.parse("2026-06-09T15:00:00Z");
+
+  it("formats the day in UTC", () => {
+    expect(formatDateFromMillis(ms, "UTC")).toBe("2026-06-09");
+  });
+
+  it("rolls to the local day for a positive-offset timezone", () => {
+    expect(formatDateFromMillis(ms, "Asia/Tokyo")).toBe("2026-06-10");
+  });
+
+  it("keeps the local day for a negative-offset timezone", () => {
+    expect(formatDateFromMillis(ms, "America/New_York")).toBe("2026-06-09");
+  });
+});

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -4,6 +4,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { estypes } from "@elastic/elasticsearch";
 import { Client, errors as esErrors } from "@elastic/elasticsearch";
+import moment from "moment-timezone";
 
 let esClient: Client | null = null;
 
@@ -145,6 +146,10 @@ export function formatUTCDateFromMillis(ms: number): string {
   const m = String(d.getUTCMonth() + 1).padStart(2, "0");
   const day = String(d.getUTCDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
+}
+
+export function formatDateFromMillis(ms: number, timezone: string): string {
+  return moment.tz(ms, timezone).format("YYYY-MM-DD");
 }
 
 /**


### PR DESCRIPTION
## Description

The skill/tool/context-origin daily metrics bucket by the requested time_zone (date_histogram), but rendered each bucket's date with formatUTCDateFromMillis, formatting the local-midnight bucket key in UTC. For positive-offset timezones that shifts the label back a day (e.g. Asia/Tokyo 2026-06-10 rendered as 2026-06-09). Counts were correct, only the date label was wrong.

Add a timezone-aware formatDateFromMillis and use it in fetchSkillUsageMetrics, fetchToolUsageMetrics, and fetchContextOriginDailyBreakdown (threading the timezone through their bucket->point helpers). UTC-identical for existing UTC callers. Corrects the workspace_analytics get_usage_timeseries tool and the skill/tool usage dashboards + exports for non-UTC users.

## Tests

Units
## Risk

Low
## Deploy Plan

Front