### PR TITLE
Stop pre processing binary documents at upload time

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -37,8 +37,8 @@ const LIST_DESCRIPTION_PREFIX =
   "or passed to other tools that accept a file path. " +
   "Some files have an auto-generated `*.processed.<ext>` sibling carrying a " +
   "model-friendly representation of their source: a resized version for images, " +
-  "a transcript for audio, or extracted text for PDFs and other documents. " +
-  `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of binary sources.`;
+  "or a transcript for audio. " +
+  `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of audio uploads.`;
 
 const SCOPED_PATH_HINT =
   "Paths use `conversation-<id>/...` or `pod-<id>/...` for any conversation or Pod you can access; " +
@@ -176,8 +176,9 @@ const FILES_TOOLS_COMMON_METADATA = {
       "Use `offset` to start at a specific line and `limit` to control how many lines to return. " +
       "When the output is truncated, a footer indicates the next offset to use. " +
       "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly. " +
-      "For binary sources such as PDFs, scanned documents, or audio files, prefer the " +
-      `\`*.processed.<ext>\` sibling listed in \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\`. It carries the extracted text or transcript.`,
+      "For binary documents (PDF, DOCX, PPTX, etc.), call " +
+      `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EXTRACT_TEXT_ACTION_NAME)}\` first to extract their text content. ` +
+      "For audio files, prefer the `*.processed.<ext>` sibling which carries the transcript.",
     schema: {
       path: z
         .string()
@@ -319,9 +320,8 @@ export const FILES_SERVER = {
       "Scoped paths such as `conversation-<id>/chart.png` or `pod-<id>/spec.md` identify files " +
       "and can be used to reference, display, or link them in responses. " +
       "Files whose name follows the `*.processed.<ext>` pattern are auto-generated " +
-      "model-friendly representations of their source (resized image, audio transcript, " +
-      "or text extracted from a document). Read those siblings to access the content " +
-      "of binary uploads.",
+      "model-friendly representations of their source (resized image or audio transcript). " +
+      "Read those siblings to access the content of audio uploads.",
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -35,10 +35,7 @@ const LIST_DESCRIPTION_PREFIX =
   "content type, and size in KB. " +
   "Scoped paths can be used to reference or display a file in a response, " +
   "or passed to other tools that accept a file path. " +
-  "Some files have an auto-generated `*.processed.<ext>` sibling carrying a " +
-  "model-friendly representation of their source: a resized version for images, " +
-  "or a transcript for audio. " +
-  `Read the sibling with \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` to access the content of audio uploads.`;
+  "Processed siblings (e.g. audio transcripts) are listed alongside their source with an annotation.";
 
 const SCOPED_PATH_HINT =
   "Paths use `conversation-<id>/...` or `pod-<id>/...` for any conversation or Pod you can access; " +
@@ -177,8 +174,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       "When the output is truncated, a footer indicates the next offset to use. " +
       "For images (JPEG, PNG, GIF), returns a vision block the model can inspect directly. " +
       "For binary documents (PDF, DOCX, PPTX, etc.), call " +
-      `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EXTRACT_TEXT_ACTION_NAME)}\` first to extract their text content. ` +
-      "For audio files, prefer the `*.processed.<ext>` sibling which carries the transcript.",
+      `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_EXTRACT_TEXT_ACTION_NAME)}\` first to extract their text content.`,
     schema: {
       path: z
         .string()
@@ -319,9 +315,7 @@ export const FILES_SERVER = {
       "Files include user uploads, sandbox outputs, and tool results. " +
       "Scoped paths such as `conversation-<id>/chart.png` or `pod-<id>/spec.md` identify files " +
       "and can be used to reference, display, or link them in responses. " +
-      "Files whose name follows the `*.processed.<ext>` pattern are auto-generated " +
-      "model-friendly representations of their source (resized image or audio transcript). " +
-      "Read those siblings to access the content of audio uploads.",
+      "Processed siblings (resized images, audio transcripts) are listed alongside their source with an annotation.",
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,
     documentationUrl: null,

--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -43,23 +43,23 @@ describe("hasProcessedVersion", () => {
     expect(hasProcessedVersion("image/svg+xml")).toBe(false);
   });
 
-  it("should return true for PDF files (text extraction)", () => {
-    expect(hasProcessedVersion("application/pdf")).toBe(true);
+  it("should return false for PDF files (lazy extraction via extract_text tool)", () => {
+    expect(hasProcessedVersion("application/pdf")).toBe(false);
   });
 
-  it("should return true for Word documents (text extraction)", () => {
+  it("should return false for Word documents (lazy extraction via extract_text tool)", () => {
     expect(
       hasProcessedVersion(
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("should return true for image files (resize)", () => {
     expect(hasProcessedVersion("image/png")).toBe(true);
   });
 
-  it("should return true for Excel files (text extraction)", () => {
+  it("should return true for Excel files (text extraction required for table upsert)", () => {
     expect(
       hasProcessedVersion(
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -78,16 +78,16 @@ describe("getProcessedContentType", () => {
     expect(getProcessedContentType("application/json")).toBeUndefined();
   });
 
-  it("should return text/plain for PDFs", () => {
-    expect(getProcessedContentType("application/pdf")).toBe("text/plain");
+  it("should return undefined for PDFs (no pre-processing; use extract_text tool)", () => {
+    expect(getProcessedContentType("application/pdf")).toBeUndefined();
   });
 
-  it("should return text/plain for Word documents", () => {
+  it("should return undefined for Word documents (no pre-processing; use extract_text tool)", () => {
     expect(
       getProcessedContentType(
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
       )
-    ).toBe("text/plain");
+    ).toBeUndefined();
   });
 
   it("should return text/plain for audio files", () => {

--- a/front/lib/api/files/processing.test.ts
+++ b/front/lib/api/files/processing.test.ts
@@ -184,7 +184,7 @@ describe("isUploadSupportedForContentType", () => {
 });
 
 describe("processAndStoreFile", () => {
-  it("should store extracted text from PDF with text/plain content type", async () => {
+  it("should store PDF as original only (no pre-processing; extraction is lazy via extract_text tool)", async () => {
     const { authenticator: auth } = await createResourceTest({
       role: "admin",
     });
@@ -207,11 +207,10 @@ describe("processAndStoreFile", () => {
       `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
     );
 
-    // Should have 2 writes: original (application/pdf) + processed (text/plain).
+    // Only one write: original (application/pdf). No processed version is created at upload time.
     const writes = fileStorageMock.writeStreamCalls;
-    expect(writes).toHaveLength(2);
+    expect(writes).toHaveLength(1);
     expect(writes[0].contentType).toBe("application/pdf");
-    expect(writes[1].contentType).toBe("text/plain");
   });
 
   it("should not create a processed version for plain text files", async () => {

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -252,7 +252,7 @@ const extractTextFromFileAndUpload: ProcessingFunction = async (
     const writeStream = file.getWriteStream({
       auth,
       version: "processed",
-      overrideContentType: "text/plain", // Text extractor extracts plain text from binary documents.
+      overrideContentType: "text/plain",
     });
 
     await pipeline(processedStream, writeStream);
@@ -443,58 +443,8 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
     },
   ],
 
-  // Documents (text extracted via Tika -> plain text).
-  [
-    "application/pdf",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-  [
-    "application/msword",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-  [
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-  [
-    "application/vnd.ms-powerpoint",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-  [
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-  [
-    "application/vnd.google-apps.document",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-  [
-    "application/vnd.google-apps.presentation",
-    {
-      process: extractTextFromFileAndUpload,
-      processedContentType: "text/plain",
-    },
-  ],
-
-  // Excel (text extracted via Tika -> HTML table).
+  // Spreadsheets: served through the conversation data source as queryable tables until we
+  // settle on handing this off to the computer/sandbox.
   [
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     {

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -969,7 +969,7 @@ describe("FileResource", () => {
       expect(path).toContain("/original");
     });
 
-    it("should resolve to 'processed' version for PDF files", async () => {
+    it("should resolve to 'original' version for PDF files (no pre-processing; lazy via extract_text tool)", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -984,10 +984,10 @@ describe("FileResource", () => {
       });
 
       const { path } = file.getContentBucketAndPath(auth);
-      expect(path).toContain("/processed");
+      expect(path).toContain("/original");
     });
 
-    it("should resolve to 'processed' version for Word documents", async () => {
+    it("should resolve to 'original' version for Word documents (no pre-processing; lazy via extract_text tool)", async () => {
       const { authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -1003,7 +1003,7 @@ describe("FileResource", () => {
       });
 
       const { path } = file.getContentBucketAndPath(auth);
-      expect(path).toContain("/processed");
+      expect(path).toContain("/original");
     });
 
     it("should resolve to 'original' version for spreadsheets when file processing is skipped", async () => {

--- a/front/lib/utils/files.test.ts
+++ b/front/lib/utils/files.test.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { FileVersion } from "@app/lib/resources/file_resource";
 import { copyContent } from "@app/lib/utils/files";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -72,12 +73,15 @@ function makeTargetFile() {
 }
 
 describe("copyContent", () => {
-  beforeEach(() => {
+  let auth: Authenticator;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
   });
 
   it("copies only the original version for files without processing", async () => {
-    const auth = {} as Authenticator;
     const sourceFile = makeSourceFile("text/plain");
     const targetFile = makeTargetFile();
 
@@ -106,9 +110,10 @@ describe("copyContent", () => {
     expect(sourceFile.sourceBuckets.processed.copyFile).not.toHaveBeenCalled();
   });
 
-  it("copies only the original version for processed files by default", async () => {
-    const auth = {} as Authenticator;
-    const sourceFile = makeSourceFile("application/pdf");
+  it("copies only the original version for files with processing by default", async () => {
+    const sourceFile = makeSourceFile(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
     const targetFile = makeTargetFile();
 
     await copyContent(
@@ -127,8 +132,9 @@ describe("copyContent", () => {
   });
 
   it("copies both original and processed versions when requested", async () => {
-    const auth = {} as Authenticator;
-    const sourceFile = makeSourceFile("application/pdf");
+    const sourceFile = makeSourceFile(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    );
     const targetFile = makeTargetFile();
 
     await copyContent(
@@ -155,7 +161,6 @@ describe("copyContent", () => {
   });
 
   it("does not copy a processed version when upload-time processing was skipped", async () => {
-    const auth = {} as Authenticator;
     const sourceFile = makeSourceFile(
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       { skipFileProcessing: true }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/27148.

File uploads for PDFs, Word documents, and presentations now skip the synchronous Tika extraction step that was previously blocking the upload response. The extraction happens on demand when the agent calls the new `extract_text` tool or use a tool on the associated computer, which means uploads complete as fast as the raw file transfer allows. Spreadsheets are unchanged, they still go through Tika extraction since their processed form is what gets indexed as a queryable table in the conversation data source.

Users uploading heavy documents should see a noticeable improvement in upload speed and reliability, since the most common source of upload timeouts was Tika stalling or timing out on large PDFs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
