### PR TITLE
Pricing: delete the flag metronome_cp_checkout and repalce it by checking for the global kill switch

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/index.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.test.ts
@@ -95,12 +95,16 @@ describe("POST /api/w/:wId/subscriptions", () => {
   });
 
   it("returns embedded clientSecret and sessionId by default", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+    const { workspace, user } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
 
-    const response = await post(workspace, { billingPeriod: "monthly" });
+    const response = await post(workspace, {
+      billingPeriod: "monthly",
+      seatType: "pro",
+      targetUserId: user.sId,
+    });
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -109,8 +113,19 @@ describe("POST /api/w/:wId/subscriptions", () => {
     expect(data.sessionId).toEqual(TEST_SESSION_ID);
   });
 
+  it("returns 400 when seat fields are missing while metronome billing is enabled", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await post(workspace, { billingPeriod: "monthly" });
+
+    expect(response.status).toBe(400);
+  });
+
   it("returns embedded clientSecret when metronome_billing flag overrides the kill switch", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest({
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
@@ -120,7 +135,11 @@ describe("POST /api/w/:wId/subscriptions", () => {
     );
     await FeatureFlagFactory.basic(auth, "metronome_billing");
 
-    const response = await post(workspace, { billingPeriod: "monthly" });
+    const response = await post(workspace, {
+      billingPeriod: "monthly",
+      seatType: "pro",
+      targetUserId: user.sId,
+    });
 
     expect(response.status).toBe(200);
     const data = await response.json();

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -39,7 +39,7 @@ export function VerifyPage() {
   });
 
   // Same gate as the one that routes to /select-subscription (see
-  // `isMetronomeCheckoutEnabled` and SubscribePage): the credit-priced checkout
+  // `isMetronomeBillingEnabled` and SubscribePage): the credit-priced checkout
   // flow gets the new phone verification copy and a welcome screen at the end.
   const isMetronomeCheckout = useIsMetronomeCheckout();
 

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -1,6 +1,6 @@
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
 import {
-  isMetronomeCheckoutEnabled,
+  isMetronomeBillingEnabled,
   restoreWorkspaceAfterSubscription,
 } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
@@ -752,7 +752,7 @@ export async function processBusinessActivation(
     BusinessActivationRequestError
   >
 > {
-  if (!(await isMetronomeCheckoutEnabled(auth))) {
+  if (!(await isMetronomeBillingEnabled(auth))) {
     return new Err({ type: "checkout_not_enabled" });
   }
 

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -55,16 +55,6 @@ export async function isMetronomeBillingEnabled(
   return hasFlag || !killed;
 }
 
-export async function isMetronomeCheckoutEnabled(
-  auth: Authenticator
-): Promise<boolean> {
-  const [metronomeBilling, hasCheckoutFlag] = await Promise.all([
-    isMetronomeBillingEnabled(auth),
-    hasFeatureFlag(auth, "metronome_cp_checkout"),
-  ]);
-  return metronomeBilling && hasCheckoutFlag;
-}
-
 /**
  * Restores a workspace to full functionality after subscription activation/reactivation.
  * This function is called when:

--- a/front/lib/api/subscription/checkout_url.ts
+++ b/front/lib/api/subscription/checkout_url.ts
@@ -7,13 +7,10 @@ import { CheckoutSeatTypeSchema } from "@app/lib/api/checkout/types";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  BUSINESS_PLAN_COST_MONTHLY,
   CP_MAX_SEAT_COST_MONTHLY,
   CP_MAX_SEAT_COST_YEARLY,
   CP_PRO_SEAT_COST_MONTHLY,
   CP_PRO_SEAT_COST_YEARLY,
-  PRO_PLAN_COST_MONTHLY,
-  PRO_PLAN_COST_YEARLY,
 } from "@app/lib/client/subscription";
 import {
   BUSINESS_USD_PACKAGE_ALIAS,
@@ -31,7 +28,6 @@ import {
   createStripeSubscriptionCheckoutSession,
   type SupportedPaymentMethod,
 } from "@app/lib/plans/stripe";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { BillingPeriod, CheckoutUrlResult } from "@app/types/plan";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { z } from "zod";
@@ -126,51 +122,6 @@ async function createCPCheckoutUrl(
   return { mode: "embedded", clientSecret, sessionId };
 }
 
-async function createLegacyMetronomeCheckoutUrl(
-  auth: Authenticator,
-  billingPeriod: BillingPeriod,
-  {
-    planParams,
-    couponCode,
-  }: {
-    planParams: LegacyPlanParams;
-    couponCode?: string;
-  }
-): Promise<CheckoutUrlResult> {
-  const owner = auth.getNonNullableWorkspace();
-  const user = auth.getNonNullableUser().toJSON();
-  const { planCode, allowedPaymentMethods, metronomePackageAlias, isBusiness } =
-    planParams;
-
-  const seatCount = await MembershipResource.countActiveSeatsInWorkspace(
-    owner.sId
-  );
-
-  const pricePerMonth = isBusiness
-    ? BUSINESS_PLAN_COST_MONTHLY
-    : billingPeriod === "yearly"
-      ? PRO_PLAN_COST_YEARLY
-      : PRO_PLAN_COST_MONTHLY;
-  const pricePerMonthCents = pricePerMonth * 100;
-  const monthsInPeriod = !isBusiness && billingPeriod === "yearly" ? 12 : 1;
-  const pricePerSeatCents = pricePerMonthCents * monthsInPeriod;
-
-  const { clientSecret, sessionId } =
-    await createEmbeddedMetronomeSetupCheckoutSession({
-      allowedPaymentMethods,
-      metronomePackageAlias,
-      owner,
-      planCode,
-      billingPeriod,
-      seatCount,
-      pricePerSeatCents,
-      couponCode,
-      user,
-    });
-
-  return { mode: "embedded", clientSecret, sessionId };
-}
-
 async function createLegacyStripeCheckoutUrl(
   auth: Authenticator,
   billingPeriod: BillingPeriod,
@@ -211,8 +162,8 @@ export async function createCheckoutUrl(
     targetUserId?: string;
   }
 ): Promise<Result<CheckoutUrlResult, CheckoutUrlError>> {
-  const useMetronomeCheckout = await isMetronomeBillingEnabled(auth);
-  if (useMetronomeCheckout) {
+  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
+  if (useMetronomeBilling) {
     if (!seatType || !targetUserId) {
       return new Err({ type: "missing_cp_fields" });
     }
@@ -226,6 +177,8 @@ export async function createCheckoutUrl(
     );
   }
 
+  // Metronome billing is disabled here (otherwise the credit-priced checkout
+  // above would have returned): fall back to the legacy Stripe checkout.
   const owner = auth.getNonNullableWorkspace();
   const subscription = auth.getNonNullableSubscriptionResource();
 
@@ -236,16 +189,6 @@ export async function createCheckoutUrl(
   }
 
   const planParams = resolveLegacyPlanParams(owner, billingPeriod);
-
-  const useMetronomeBilling = await isMetronomeBillingEnabled(auth);
-  if (useMetronomeBilling) {
-    return new Ok(
-      await createLegacyMetronomeCheckoutUrl(auth, billingPeriod, {
-        planParams,
-        couponCode,
-      })
-    );
-  }
 
   return new Ok(
     await createLegacyStripeCheckoutUrl(auth, billingPeriod, planParams)

--- a/front/lib/api/subscription/checkout_url.ts
+++ b/front/lib/api/subscription/checkout_url.ts
@@ -4,10 +4,7 @@ import type {
   CheckoutSeatType,
 } from "@app/lib/api/checkout/types";
 import { CheckoutSeatTypeSchema } from "@app/lib/api/checkout/types";
-import {
-  isMetronomeBillingEnabled,
-  isMetronomeCheckoutEnabled,
-} from "@app/lib/api/subscription";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import type { Authenticator } from "@app/lib/auth";
 import {
   BUSINESS_PLAN_COST_MONTHLY,
@@ -42,7 +39,7 @@ import { z } from "zod";
 export const PostSubscriptionRequestBody = z.object({
   billingPeriod: z.enum(["monthly", "yearly"]),
   couponCode: z.string().optional(),
-  // CP self-serve checkout fields (only used when metronome_cp_checkout is enabled)
+  // CP self-serve checkout fields (only used when Metronome billing is enabled)
   seatType: CheckoutSeatTypeSchema.optional(),
   targetUserId: z.string().optional(),
 });
@@ -214,7 +211,7 @@ export async function createCheckoutUrl(
     targetUserId?: string;
   }
 ): Promise<Result<CheckoutUrlResult, CheckoutUrlError>> {
-  const useMetronomeCheckout = await isMetronomeCheckoutEnabled(auth);
+  const useMetronomeCheckout = await isMetronomeBillingEnabled(auth);
   if (useMetronomeCheckout) {
     if (!seatType || !targetUserId) {
       return new Err({ type: "missing_cp_fields" });

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -27,10 +27,11 @@ export const CP_MAX_SEAT_COST_YEARLY = 120;
 export const CP_FREE_PLAN_CREDITS = 300;
 
 /**
- * Client-side mirror of the server-side `isMetronomeCheckoutEnabled` gate: the
- * credit-priced checkout flow is enabled when Metronome billing is on (feature
- * flag, or kill switch not active) and the workspace has the
- * `metronome_cp_checkout` feature flag.
+ * Client-side mirror of the server-side `isMetronomeBillingEnabled` gate: the
+ * credit-priced checkout flow follows Metronome billing, which is enabled by
+ * default for all workspaces. The `global_disable_metronome_billing` kill
+ * switch turns it off globally; the `metronome_billing` feature flag
+ * re-enables it for individual workspaces.
  *
  * Prefer the `useIsMetronomeCheckout` hook; this helper is for components that
  * render outside the auth context provider (e.g. the SPA workspace layout).
@@ -42,10 +43,10 @@ export function computeIsMetronomeCheckout({
   featureFlags: WhitelistableFeature[];
   killSwitches: KillSwitchType[] | null | undefined;
 }): boolean {
-  const isMetronomeEnabled =
+  return (
     featureFlags.includes("metronome_billing") ||
-    !killSwitches?.includes("global_disable_metronome_billing");
-  return isMetronomeEnabled && featureFlags.includes("metronome_cp_checkout");
+    !killSwitches?.includes("global_disable_metronome_billing")
+  );
 }
 
 export function useIsMetronomeCheckout(): boolean {

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -1,4 +1,4 @@
-import { isMetronomeCheckoutEnabled } from "@app/lib/api/subscription";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getUserWithWorkspaces } from "@app/lib/api/user";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { Authenticator, getSession } from "@app/lib/auth";
@@ -192,7 +192,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
         if (redirectTrialPage) {
           // With the Metronome credit-priced checkout flow, the trial page is
           // replaced by the new plan selection page.
-          const metronomeCheckout = await isMetronomeCheckoutEnabled(auth!);
+          const metronomeCheckout = await isMetronomeBillingEnabled(auth!);
           return {
             redirect: {
               permanent: false,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -316,11 +316,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Skip injecting the OpenAI formatting meta prompt entirely (no markdown/paragraph style guidance)",
     stage: "dust_only",
   },
-  metronome_cp_checkout: {
-    description:
-      "Enable the Metronome-owned payment-gated checkout flow for Business plan activation (replaces direct Stripe charge).",
-    stage: "dust_only",
-  },
   dust_desktop: {
     description:
       "Auto-attach the Dust Desktop client-side MCP server to agent runs when registered for the user.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -775,7 +775,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_vertex_for_supported_models"
   | "metronome_billing_usage_page"
   | "user_settings_v2"
-  | "metronome_cp_checkout"
   | "admin_governance"
 >();
 


### PR DESCRIPTION
## Description

 - Drop metronome_cp_checkout feature flag
 - check for the kill switch global_disable_metronome_billing

## Tests

tested the fre flow locally, still working

## Risk

low, still the kill switch

## Deploy Plan

deploy front
