### PR TITLE
feat(connectors/cli): display structured help from AdminCommandSchema when no command given

### DIFF
--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -16,9 +16,19 @@ const main = async () => {
   });
 
   if (argv._.length < 2) {
-    throw new Error(
-      "Expects object type and command as first two arguments, eg: `cli connectors stop ...`"
-    );
+    console.error("Usage: cli <majorCommand> <command> [--arg=value ...]");
+    console.error("");
+    console.error("Available commands:");
+    console.error("");
+    for (const schema of AdminCommandSchema.types) {
+      const majorCommand = String(schema.props.majorCommand.value);
+      const subCommands = schema.props.command.types.map((c) =>
+        String(c.value)
+      );
+      console.error(`  ${majorCommand}:`);
+      console.error(`    ${subCommands.join(", ")}`);
+    }
+    process.exit(0);
   }
 
   const [objectType, command] = argv._;


### PR DESCRIPTION
## Description

Replace the generic error thrown when running `cli` without arguments with a structured help display derived from `AdminCommandSchema`. The help lists every major command and its available subcommands, then exits 0 instead of crashing.

## Tests

After
```
➜ npm run cli 

Usage: cli <majorCommand> <command> [--arg=value ...]

Available commands:

  batch:
    full-resync, restart-all, stop-all, resume-all
  confluence:
    check-page-exists, check-space-access, ignore-near-rate-limit, me, resolve-space-from-url, skip-page, sync-space, unignore-near-rate-limit, update-parents, upsert-page, upsert-pages
[...]
```

Before
```
➜ npm run cli                            

> ror: Expects object type and command as first two arguments, eg: `cli connectors stop ...`
Error: Expects object type and command as first two arguments, eg: `cli connectors stop ...`
    at main (/Users/rcs/Projects/dust/connectors/src/admin/cli.ts:19:11)
    at parseArgs (/Users/rcs/Projects/dust/connectors/src/admin/cli.ts:43:1)
    at Object.<anonymous> (/Users/rcs/Projects/dust/connectors/src/admin/cli.ts:53:4)
    at Module.<anonymous> (node:internal/modules/cjs/loader:1812:14)
    at Object.transformer (/Users/rcs/Projects/dust/node_modules/tsx/dist/register-D46fvsV_.cjs:3:1104)
    at Module.load (node:internal/modules/cjs/loader:1533:32)
    at Module._load (node:internal/modules/cjs/loader:1335:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at loadCJSModuleWithModuleLoad (node:internal/modules/esm/translators:328:3)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:233:7)
npm error Lifecycle script `cli` failed with error:
npm error code 1
npm error path /Users/rcs/Projects/dust/connectors
npm error workspace connectors@0.1.0
npm error location /Users/rcs/Projects/dust/connectors
npm error command failed
npm error command sh -c npx tsx src/admin/cli.ts
```

## Risk

Low — no behaviour change for valid invocations, and the previous path was just throwing an error.
