### PR TITLE
Store in DB the workspace default credit pool cap

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.test.ts
@@ -21,7 +21,6 @@ vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
     ...actual,
     upsertMetronomePerUserCapAlert: vi.fn(),
     clearMetronomePerUserCapAlert: vi.fn(),
-    getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
   };
 });
 
@@ -84,9 +83,6 @@ beforeEach(() => {
   vi.mocked(spendLimits.clearMetronomePerUserCapAlert).mockResolvedValue(
     new Ok(undefined)
   );
-  vi.mocked(
-    spendLimits.getMetronomeDefaultUserCapAlertForSeatType
-  ).mockResolvedValue(new Ok(null));
   vi.mocked(perUserUsage.fetchPerUserAwuUsage).mockResolvedValue(
     new Ok(new Map())
   );

--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.test.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.test.ts
@@ -119,9 +119,9 @@ describe("/api/w/[wId]/usage_settings/default_user_spend_limit", () => {
       expect(await response.json()).toEqual({ awuCredits: 25_000 });
     });
 
-    it("returns 200 with plan default when no default is configured (pro plan → 0)", async () => {
+    it("returns 200 with the resolved default (plan-tier fallback, pro plan → 0)", async () => {
       vi.mocked(businessLayer.getDefaultUserSpendLimit).mockResolvedValueOnce(
-        new Err(new DefaultUserSpendLimitError("not_found", "no default"))
+        new Ok({ awuCredits: 0 })
       );
 
       const workspace = await makeMetronomeWorkspace();

--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -8,7 +8,6 @@ import {
   type PutDefaultUserSpendLimitResponseBody,
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
-import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -38,14 +37,6 @@ function mapErrorToApiError(
         status_code: 403,
         api_error: {
           type: "plan_limit_error",
-          message: error.message,
-        },
-      };
-    case "not_found":
-      return {
-        status_code: 404,
-        api_error: {
-          type: "workspace_not_found",
           message: error.message,
         },
       };
@@ -101,14 +92,6 @@ app.get(
 
     const result = await getDefaultUserSpendLimit(auth);
     if (result.isErr()) {
-      if (result.error.type === "not_found") {
-        const planCode = auth
-          .getNonNullableSubscriptionResource()
-          .getPlan().code;
-        return ctx.json({
-          awuCredits: getPlanDefaultPoolLimitAwuCredits(planCode),
-        });
-      }
       return apiError(ctx, mapErrorToApiError(result.error));
     }
     return ctx.json(result.value);

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -34,6 +34,7 @@ import {
   type SeatData,
 } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
@@ -409,23 +410,32 @@ async function fetchDefaultCapsBySeatTypeUncached({
 /**
  * Resolve the inputs needed to compute the effective per-user spend limit for
  * the members table:
- *   - the per-seat-type default cap thresholds (Metronome alerts)
+ *   - the per-seat-type default cap totals, derived from the pool-only
+ *     workspace default
+ *     (`credit_usage_configurations.defaultPoolCapAwuCredits`) plus each
+ *     seat type's allowance
  *   - the per-seat-type seat allowances, used to derive the total threshold
  *     from the pool-only override persisted on each membership
- *   - the per-user override alerts, fetched from Metronome only when alert
- *     deep links are requested (the override *threshold* comes from the DB)
+ *   - the per-user override and per-seat-type default alerts, fetched from
+ *     Metronome only when alert deep links are requested (the thresholds
+ *     come from the DB)
  */
 async function fetchEffectivePerUserSpendLimits({
   metronomeCustomerId,
   workspaceId,
+  defaultPoolCapAwuCredits,
   includeAlertLinks,
 }: {
   metronomeCustomerId: string | null;
   workspaceId: string;
+  defaultPoolCapAwuCredits: number | null;
   includeAlertLinks: boolean;
 }): Promise<{
   perUserOverrideAlerts: Map<string, MetronomeCapAlertIds>;
-  defaultAwuCreditsBySeatType: Partial<
+  defaultCapAwuCreditsBySeatType: Partial<
+    Record<NormalizedPoolLimitSeatType, number>
+  >;
+  defaultCapAlertsBySeatType: Partial<
     Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>
   >;
   seatAllowanceBySeatType: Partial<Record<NormalizedPoolLimitSeatType, number>>;
@@ -433,18 +443,22 @@ async function fetchEffectivePerUserSpendLimits({
   if (!metronomeCustomerId) {
     return {
       perUserOverrideAlerts: new Map(),
-      defaultAwuCreditsBySeatType: {},
+      defaultCapAwuCreditsBySeatType: {},
+      defaultCapAlertsBySeatType: {},
       seatAllowanceBySeatType: {},
     };
   }
 
-  const [perUserOverrideAlerts, defaultAwuCreditsBySeatType] =
-    await Promise.all([
+  const [perUserOverrideAlerts, defaultCapAlertsBySeatType] = await Promise.all(
+    [
       includeAlertLinks
         ? fetchPerUserCapAlertIds({ metronomeCustomerId, workspaceId })
         : Promise.resolve(new Map<string, MetronomeCapAlertIds>()),
-      fetchDefaultCapsBySeatType({ metronomeCustomerId, workspaceId }),
-    ]);
+      includeAlertLinks
+        ? fetchDefaultCapsBySeatType({ metronomeCustomerId, workspaceId })
+        : Promise.resolve({}),
+    ]
+  );
 
   let seatAllowanceBySeatType: Partial<
     Record<NormalizedPoolLimitSeatType, number>
@@ -455,13 +469,24 @@ async function fetchEffectivePerUserSpendLimits({
   } catch (err) {
     logger.warn(
       { err: normalizeError(err), workspaceId },
-      "[MembersUsage] Failed to resolve seat allowances, degrading to pool-only override thresholds"
+      "[MembersUsage] Failed to resolve seat allowances, degrading to pool-only thresholds"
     );
+  }
+
+  const defaultCapAwuCreditsBySeatType: Partial<
+    Record<NormalizedPoolLimitSeatType, number>
+  > = {};
+  if (defaultPoolCapAwuCredits !== null) {
+    for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+      defaultCapAwuCreditsBySeatType[seatType] =
+        defaultPoolCapAwuCredits + (seatAllowanceBySeatType[seatType] ?? 0);
+    }
   }
 
   return {
     perUserOverrideAlerts,
-    defaultAwuCreditsBySeatType,
+    defaultCapAwuCreditsBySeatType,
+    defaultCapAlertsBySeatType,
     seatAllowanceBySeatType,
   };
 }
@@ -534,12 +559,14 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  defaultPoolCapAwuCredits,
 }: {
   metronomeCustomerId: string | null;
   workspaceId: string;
   userId: string;
   seatType: MembershipSeatType | null | undefined;
   poolCapOverrideAwuCredits: number | null;
+  defaultPoolCapAwuCredits: number | null;
 }): Promise<number | null> {
   const contract = metronomeCustomerId
     ? await getActiveContract(workspaceId)
@@ -548,7 +575,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
 
   const [
     perUserTotalConsumedCredits,
-    { defaultAwuCreditsBySeatType, seatAllowanceBySeatType },
+    { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
   ] = await Promise.all([
     fetchPerUserUsageCreditsForMembersTable({
       metronomeCustomerId,
@@ -558,13 +585,14 @@ export async function fetchRemainingCapCreditsPercentageForUser({
     fetchEffectivePerUserSpendLimits({
       metronomeCustomerId,
       workspaceId,
+      defaultPoolCapAwuCredits,
       includeAlertLinks: false,
     }),
   ]);
 
   const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
-  const defaultCap = normalizedSeatType
-    ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
+  const defaultAwuCredits = normalizedSeatType
+    ? (defaultCapAwuCreditsBySeatType[normalizedSeatType] ?? null)
     : null;
 
   // Mirror `getMembersUsage`: the override threshold stored on the membership is
@@ -579,10 +607,10 @@ export async function fetchRemainingCapCreditsPercentageForUser({
 
   const spendLimitAwuCredits = resolveEffectiveSpendLimitAwuCredits({
     overrideAwuCredits,
-    defaultAwuCredits: defaultCap?.threshold ?? null,
+    defaultAwuCredits,
   });
 
-  if (!spendLimitAwuCredits) {
+  if (spendLimitAwuCredits === null) {
     return null;
   }
 
@@ -611,6 +639,11 @@ export async function getMemberUsage({
   const metronomeContractId = subscription?.metronomeContractId ?? null;
   const userId = userResource.sId;
 
+  // The workspace-wide default pool cap lives on the credit-usage
+  // configuration row (created lazily; absent → no default configured).
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
   const [
     membershipsResult,
     perUserTotalConsumedCredits,
@@ -633,11 +666,13 @@ export async function getMemberUsage({
     fetchEffectivePerUserSpendLimits({
       metronomeCustomerId: metronomeCustomerId ?? null,
       workspaceId: workspace.sId,
+      defaultPoolCapAwuCredits:
+        creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
       includeAlertLinks: false,
     }),
   ]);
 
-  const { defaultAwuCreditsBySeatType, seatAllowanceBySeatType } =
+  const { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType } =
     perUserSpendLimits;
   const { memberships } = membershipsResult;
   const membership = memberships.find((m) => m.userId === userResource.id);
@@ -658,8 +693,8 @@ export async function getMemberUsage({
     totalConsumedCredits - consumedFromAllowanceAwuCredits;
 
   const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
-  const defaultCap = normalizedSeatType
-    ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
+  const defaultAwuCredits = normalizedSeatType
+    ? (defaultCapAwuCreditsBySeatType[normalizedSeatType] ?? null)
     : null;
   const overrideAwuCredits =
     membership.poolCapOverrideAwuCredits !== null
@@ -675,7 +710,7 @@ export async function getMemberUsage({
   const effectiveDefaultAwuCredits =
     membership.seatType === "free"
       ? FREE_SEAT_LIFETIME_AWU_CREDITS
-      : (defaultCap?.threshold ?? null);
+      : defaultAwuCredits;
 
   const spendLimitSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits,
@@ -797,6 +832,11 @@ export async function getMembersUsage({
     return { members: [], total };
   }
 
+  // The workspace-wide default pool cap lives on the credit-usage
+  // configuration row (created lazily; absent → no default configured).
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
   // Fetch membership details and Metronome data in parallel for the
   // current page of users.
   const [
@@ -826,6 +866,8 @@ export async function getMembersUsage({
     fetchEffectivePerUserSpendLimits({
       metronomeCustomerId: metronomeCustomerId ?? null,
       workspaceId: workspace.sId,
+      defaultPoolCapAwuCredits:
+        creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
       includeAlertLinks,
     }),
     // Free-seat balance-alert ids (low + empty) for deep-linking — poke-only,
@@ -844,7 +886,8 @@ export async function getMembersUsage({
       : null;
   const {
     perUserOverrideAlerts,
-    defaultAwuCreditsBySeatType,
+    defaultCapAwuCreditsBySeatType,
+    defaultCapAlertsBySeatType,
     seatAllowanceBySeatType,
   } = perUserSpendLimits;
 
@@ -879,14 +922,14 @@ export async function getMembersUsage({
       totalConsumedCredits - consumedFromAllowanceAwuCredits;
 
     // Resolve the default cap for this member's seat type, and the user's
-    // override if any. The override threshold is derived from the pool-only
-    // value persisted on the membership plus the seat allowance; the
+    // override if any. Both thresholds are derived from pool-only DB values
+    // (membership override / workspace default) plus the seat allowance; the
     // Metronome alert ids are only resolved for deep links.
     const normalizedSeatType = normalizeToPoolLimitSeatType(
       membership.seatType
     );
-    const defaultCap = normalizedSeatType
-      ? (defaultAwuCreditsBySeatType[normalizedSeatType] ?? null)
+    const defaultAwuCredits = normalizedSeatType
+      ? (defaultCapAwuCreditsBySeatType[normalizedSeatType] ?? null)
       : null;
     const overrideAwuCredits =
       membership.poolCapOverrideAwuCredits !== null
@@ -901,7 +944,7 @@ export async function getMembersUsage({
     const effectiveDefaultAwuCredits =
       membership.seatType === "free"
         ? FREE_SEAT_LIFETIME_AWU_CREDITS
-        : (defaultCap?.threshold ?? null);
+        : defaultAwuCredits;
 
     const spendLimitSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits,
@@ -910,8 +953,8 @@ export async function getMembersUsage({
     const effectiveCapAlert =
       spendLimitSource === "override"
         ? (perUserOverrideAlerts.get(userId) ?? null)
-        : spendLimitSource === "default"
-          ? defaultCap
+        : spendLimitSource === "default" && normalizedSeatType
+          ? (defaultCapAlertsBySeatType[normalizedSeatType] ?? null)
           : null;
     const spendLimitAlertId = includeAlertLinks
       ? (effectiveCapAlert?.alertId ?? null)

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -4,23 +4,11 @@ import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCap } from "@app/lib/metronome/alerts/programmatic_cap";
-import {
-  getMetronomeDefaultUserCapAlertForSeatType,
-  getMetronomePerUserCap,
-} from "@app/lib/metronome/alerts/spend_limits";
 import { getNetBalance } from "@app/lib/metronome/client";
-import {
-  FREE_SEAT_LIFETIME_AWU_CREDITS,
-  getCreditTypeAwuId,
-} from "@app/lib/metronome/constants";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
-import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
-import {
-  getAwuAllocationForSeatType,
-  getProductSeatTypes,
-} from "@app/lib/metronome/seat_types";
 import {
   setUserCreditState,
   setWorkspaceProgrammaticCreditStatus,
@@ -31,6 +19,7 @@ import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_s
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
 import { notifyAdminsProgrammaticCapReached } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -53,12 +42,12 @@ import { Ok } from "@app/types/shared/result";
  */
 async function resolvePoolLimitForUser({
   workspace,
-  userId,
-  seatType,
+  membership,
+  defaultPoolCapAwuCredits,
 }: {
   workspace: WorkspaceResource;
-  userId: string;
-  seatType: MembershipSeatType | null | undefined;
+  membership: MembershipResource;
+  defaultPoolCapAwuCredits: number | null;
 }): Promise<number | null> {
   const { metronomeCustomerId } = workspace;
   if (!metronomeCustomerId) {
@@ -70,39 +59,20 @@ async function resolvePoolLimitForUser({
   // budget). This is the single source of "free has no pool": downstream
   // routing (capped vs on_pool) then falls out of `poolLimit === 0` with no
   // seat-type special-casing.
-  if (seatType === "free") {
+  if (membership.seatType === "free") {
     return 0;
   }
 
-  // 1. Per-user override.
-  const userCapResult = await getMetronomePerUserCap({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-    userId,
-  });
-  if (userCapResult.isOk() && userCapResult.value) {
-    // The threshold includes the seat allowance; subtract it to get the pool limit.
-    const totalThresholdAwuCredits = userCapResult.value.alert.threshold;
-    const seatAllowanceAwuCredits = await getSeatAllowance(workspace, seatType);
-    return Math.max(0, totalThresholdAwuCredits - seatAllowanceAwuCredits);
+  // 1. Per-user override (pool-only, persisted on the membership).
+  if (membership.poolCapOverrideAwuCredits !== null) {
+    return membership.poolCapOverrideAwuCredits;
   }
 
-  // 2. Per-seat-type workspace default.
-  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
-  if (normalizedSeatType) {
-    const defaultCapResult = await getMetronomeDefaultUserCapAlertForSeatType({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-      seatType: normalizedSeatType,
-    });
-    if (defaultCapResult.isOk() && defaultCapResult.value) {
-      const totalThresholdAwuCredits = defaultCapResult.value.alert.threshold;
-      const seatAllowanceAwuCredits = await getSeatAllowance(
-        workspace,
-        seatType
-      );
-      return Math.max(0, totalThresholdAwuCredits - seatAllowanceAwuCredits);
-    }
+  // 2. Workspace default (pool-only, persisted on the credit-usage
+  // configuration), for pool-limit seat types.
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
+  if (normalizedSeatType && defaultPoolCapAwuCredits !== null) {
+    return defaultPoolCapAwuCredits;
   }
 
   // 3. Plan-tier fallback: enterprise → unlimited, everything else → 0.
@@ -114,31 +84,6 @@ async function resolvePoolLimitForUser({
     return 0;
   }
   return getPlanDefaultPoolLimitAwuCredits(planCode);
-}
-
-async function getSeatAllowance(
-  workspace: WorkspaceResource,
-  seatType: MembershipSeatType | null | undefined
-): Promise<number> {
-  // Free seats carry a fixed personal allocation that isn't a contract
-  // recurring credit, so it's a code constant rather than a contract lookup.
-  if (seatType === "free") {
-    return FREE_SEAT_LIFETIME_AWU_CREDITS;
-  }
-  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
-  if (!normalizedSeatType) {
-    return 0;
-  }
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    return 0;
-  }
-  const productSeatTypes = await getProductSeatTypes();
-  return getAwuAllocationForSeatType(
-    contract,
-    normalizedSeatType,
-    productSeatTypes
-  );
 }
 
 /**
@@ -180,10 +125,17 @@ export async function dispatchSeatBalanceExhausted({
     return;
   }
 
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+      workspace.id
+    );
+  const defaultPoolCapAwuCredits =
+    creditUsageConfig?.defaultPoolCapAwuCredits ?? null;
+
   const poolLimitAwuCredits = await resolvePoolLimitForUser({
     workspace,
-    userId,
-    seatType: membership.seatType,
+    membership,
+    defaultPoolCapAwuCredits,
   });
   const remainingCapCreditsPercentage =
     await fetchRemainingCapCreditsPercentageForUser({
@@ -192,6 +144,7 @@ export async function dispatchSeatBalanceExhausted({
       userId,
       seatType: membership.seatType,
       poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+      defaultPoolCapAwuCredits,
     });
 
   const result = await transitionUserCreditState(
@@ -565,11 +518,18 @@ async function resolveLiveUserBalance({
   );
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+      workspace.id
+    );
+
   const liveResult = await fetchLiveUserCreditInputs({
     workspaceId: workspace.sId,
     userId,
     seatType,
     poolCapOverrideAwuCredits,
+    defaultPoolCapAwuCredits:
+      creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
     metronomeCustomerId,
     metronomeContractId,
   });

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -2,8 +2,6 @@ import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_
 import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
-import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limits";
-import { getCachedDefaultCapThresholdsBySeatType } from "@app/lib/metronome/alerts/spend_limits";
 import {
   listContractPerUserCreditBalances,
   listMetronomeSeatBalances,
@@ -24,6 +22,7 @@ import {
   expectedPoolCreditStateFromBalance,
   setWorkspacePoolCreditStateReconciled,
 } from "@app/lib/metronome/workspace_credit_state_machine";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -298,13 +297,18 @@ async function reconcileUser({
   const seatType = membership.seatType;
   const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
 
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
   const liveResult = await fetchLiveUserCreditInputs({
     workspaceId: workspace.sId,
     userId,
     seatType,
-    // Pool-only override persisted on the membership; the live-inputs helper
-    // adds the seat allowance back to get the total threshold.
+    // Pool-only values persisted in the DB; the live-inputs helper adds the
+    // seat allowance back to get the total threshold.
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+    defaultPoolCapAwuCredits:
+      creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
     metronomeCustomerId,
     metronomeContractId,
   });
@@ -413,20 +417,22 @@ export async function reconcileWorkspaceUserCreditStates({
     ? perUserCreditBalancesResult.value
     : new Map<string, { balanceAwu: number; startingBalanceAwu: number }>();
 
-  // The cap-threshold caches (Metronome alert list / contract) and the
-  // membership query (DB) can genuinely throw, so they stay wrapped — the
-  // ERR1-authorised case. The per-user overrides themselves come from the
-  // memberships (pool-only values); the seat allowances are needed to derive
-  // the total thresholds.
+  // The seat-allowance cache (contract) and the DB queries can genuinely
+  // throw, so they stay wrapped — the ERR1-authorised case. The per-user
+  // overrides come from the memberships and the workspace default from the
+  // credit-usage configuration (both pool-only values); the seat allowances
+  // are needed to derive the total thresholds.
   let seatAllowances: Partial<Record<NormalizedPoolLimitSeatType, number>>;
-  let defaultCaps: Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>;
+  let defaultPoolCapAwuCredits: number | null;
   let memberships: MembershipResource[];
   try {
     seatAllowances = await getSeatAllowancesByNormalizedSeatType(workspaceId);
-    defaultCaps = await getCachedDefaultCapThresholdsBySeatType({
-      metronomeCustomerId,
-      workspaceId,
-    });
+    const creditUsageConfig =
+      await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+        workspace.id
+      );
+    defaultPoolCapAwuCredits =
+      creditUsageConfig?.defaultPoolCapAwuCredits ?? null;
     ({ memberships } = await MembershipResource.getActiveMemberships({
       workspace,
     }));
@@ -470,13 +476,14 @@ export async function reconcileWorkspaceUserCreditStates({
     const seatType = membership.seatType;
 
     const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+    const poolCapAwuCredits =
+      membership.poolCapOverrideAwuCredits ??
+      (normalizedSeatType ? defaultPoolCapAwuCredits : null);
     const effectiveCapAwuCredits =
-      membership.poolCapOverrideAwuCredits !== null
-        ? membership.poolCapOverrideAwuCredits +
+      poolCapAwuCredits !== null
+        ? poolCapAwuCredits +
           (normalizedSeatType ? (seatAllowances[normalizedSeatType] ?? 0) : 0)
-        : normalizedSeatType
-          ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
-          : null;
+        : null;
     // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
     // seats read their per-user credit balance instead (not a seat balance).
     // Pro/max read their seat balance. `expectedUserCreditState` decides routing

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -13,12 +13,12 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomePerUserCapAlert,
   clearMetronomePerUserWarningAlert,
-  getMetronomeDefaultUserCapAlertForSeatType,
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -341,45 +341,27 @@ export async function setUserSpendLimit(
         userId,
       });
 
-      // Look up the user's seat type to find the matching default cap.
+      // With the override cleared, the workspace default (pool-only value
+      // persisted on the credit-usage configuration) applies for the user's
+      // seat type.
       const normalizedSeatType = normalizeToPoolLimitSeatType(
         membership.seatType
       );
+      const creditUsageConfig =
+        await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+      const defaultPoolCapAwuCredits =
+        creditUsageConfig?.defaultPoolCapAwuCredits ?? null;
 
-      let defaultAlert = null;
-      if (normalizedSeatType) {
-        const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          workspaceId: workspace.sId,
-          seatType: normalizedSeatType,
-        });
-        if (defaultResult.isErr()) {
-          logger.error(
-            {
-              workspaceId: workspace.sId,
-              metronomeCustomerId: workspace.metronomeCustomerId,
-              userId: user.sId,
-              seatType: normalizedSeatType,
-              err: defaultResult.error,
-            },
-            "[Metronome PerUserCap] set(unlimited): failed to read default cap alert for seat type"
-          );
-          return new Err(
-            new UserSpendLimitError(
-              "metronome_error",
-              defaultResult.error.message
-            )
-          );
-        }
-        defaultAlert = defaultResult.value;
-      }
-
-      if (defaultAlert) {
+      if (normalizedSeatType && defaultPoolCapAwuCredits !== null) {
+        const seatAllowanceAwuCredits = await resolveUserSeatAllowance(
+          auth,
+          membership
+        );
         transitionedTo = await resolveLocalCapState({
           metronomeCustomerId: workspace.metronomeCustomerId,
           metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
           userId: user.sId,
-          awuCapCredits: defaultAlert.alert.threshold,
+          awuCapCredits: defaultPoolCapAwuCredits + seatAllowanceAwuCredits,
         });
       } else {
         transitionedTo = "resolved";
@@ -398,8 +380,11 @@ export async function setUserSpendLimit(
     case "limited": {
       // The admin enters pool credits. Add the seat allowance to get the
       // total Metronome threshold.
-      const seatAllowance = await resolveUserSeatAllowance(auth, membership);
-      const totalAwuCredits = limit.awuCredits + seatAllowance;
+      const seatAllowanceAwuCredits = await resolveUserSeatAllowance(
+        auth,
+        membership
+      );
+      const totalAwuCredits = limit.awuCredits + seatAllowanceAwuCredits;
 
       const upsertResult = await upsertMetronomePerUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
@@ -413,7 +398,7 @@ export async function setUserSpendLimit(
             workspaceId: workspace.sId,
             userId: user.sId,
             awuCredits: totalAwuCredits,
-            seatAllowance,
+            seatAllowance: seatAllowanceAwuCredits,
             err: upsertResult.error,
           },
           "[Metronome PerUserCap] Failed to upsert per-user cap alert"

--- a/front/lib/api/workspace/default_user_spend_limit.test.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.test.ts
@@ -7,7 +7,7 @@ import { Authenticator } from "@app/lib/auth";
 import * as defaultUserCapAlert from "@app/lib/metronome/alerts/spend_limits";
 import * as planType from "@app/lib/metronome/plan_type";
 import * as seatTypes from "@app/lib/metronome/seat_types";
-import { buildCustomerAlertMock } from "@app/tests/utils/metronome_alerts";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { Err, Ok } from "@app/types/shared/result";
@@ -103,33 +103,27 @@ beforeEach(() => {
 });
 
 describe("getDefaultUserSpendLimit", () => {
-  it("returns the configured threshold minus seat allowance", async () => {
+  it("returns the configured workspace default pool cap", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).mockResolvedValue(
-      new Ok(
-        buildCustomerAlertMock({
-          id: "alert_default_xxx",
-          threshold: 50_000,
-          customerStatus: "ok",
-        })
-      )
-    );
+
+    await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      defaultPoolCapAwuCredits: 25_000,
+    });
 
     const result = await getDefaultUserSpendLimit(auth);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      // 50_000 (Metronome threshold) - 8_000 (seat allowance) = 42_000
-      expect(result.value).toEqual({ awuCredits: 42_000 });
+      expect(result.value).toEqual({ awuCredits: 25_000 });
     }
   });
 
-  it("returns not_found when no default is configured", async () => {
+  it("falls back to the plan-tier default when no workspace default is configured (pro plan → 0)", async () => {
     const workspace = await WorkspaceFactory.metronome({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -137,9 +131,9 @@ describe("getDefaultUserSpendLimit", () => {
 
     const result = await getDefaultUserSpendLimit(auth);
 
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe("not_found");
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ awuCredits: 0 });
     }
   });
 
@@ -152,26 +146,6 @@ describe("getDefaultUserSpendLimit", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.type).toBe("workspace_not_metronome_billed");
-    }
-    expect(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).not.toHaveBeenCalled();
-  });
-
-  it("surfaces Metronome errors as metronome_error", async () => {
-    const workspace = await WorkspaceFactory.metronome({
-      metronomeCustomerId: METRONOME_CUSTOMER_ID,
-    });
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).mockResolvedValue(new Err(new Error("metronome down")));
-
-    const result = await getDefaultUserSpendLimit(auth);
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe("metronome_error");
     }
   });
 });
@@ -208,17 +182,11 @@ describe("setDefaultUserSpendLimit", () => {
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).mockResolvedValue(
-      new Ok(
-        buildCustomerAlertMock({
-          id: "alert_default_xxx",
-          threshold: 18_000, // 8_000 seat + 10_000 pool
-          customerStatus: "ok",
-        })
-      )
-    );
+    await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      defaultPoolCapAwuCredits: 10_000,
+    });
 
     await setDefaultUserSpendLimit(auth, {
       awuCredits: 25_000,

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -5,7 +5,6 @@ import {
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  getMetronomeDefaultUserCapAlertForSeatType,
   upsertMetronomeDefaultUserCapAlertForSeatType,
   upsertMetronomeDefaultUserWarningAlertForSeatType,
 } from "@app/lib/metronome/alerts/spend_limits";
@@ -15,13 +14,14 @@ import {
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
+import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/types/credits";
 import {
-  NORMALIZED_POOL_LIMIT_SEAT_TYPES,
   type NormalizedPoolLimitSeatType,
   normalizeToPoolLimitSeatType,
 } from "@app/types/memberships";
@@ -41,7 +41,6 @@ export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;
 export type DefaultUserSpendLimitErrorType =
   | "workspace_not_metronome_billed"
   | "metronome_error"
-  | "not_found"
   | "invalid_threshold"
   | "contract_not_found";
 
@@ -55,15 +54,18 @@ export class DefaultUserSpendLimitError extends Error {
 }
 
 /**
- * Read the default pool credit limit for the workspace. Reads per-seat-type
- * alerts and recovers the pool limit by subtracting the seat allowance.
- *
- * Since all seat types share the same pool limit, we read the first
- * per-seat-type alert we find and subtract its seat type's AWU allocation.
+ * Read the default pool credit limit for the workspace. The pool-only value
+ * persisted on the credit-usage configuration
+ * (`credit_usage_configurations.defaultPoolCapAwuCredits`) is the source of
+ * truth — the per-seat-type Metronome alerts (threshold = seatAllowance +
+ * poolLimit) are derived from it. When no workspace default is configured,
+ * falls back to the plan-tier default (`null` for enterprise = unlimited).
  */
 export async function getDefaultUserSpendLimit(
   auth: Authenticator
-): Promise<Result<DefaultUserSpendLimit, DefaultUserSpendLimitError>> {
+): Promise<
+  Result<GetDefaultUserSpendLimitResponseBody, DefaultUserSpendLimitError>
+> {
   const workspace = auth.getNonNullableWorkspace();
   if (!workspace.metronomeCustomerId) {
     logger.info(
@@ -78,79 +80,24 @@ export async function getDefaultUserSpendLimit(
     );
   }
 
-  const contract = await getActiveContract(workspace.sId);
-  const productSeatTypes = contract ? await getProductSeatTypes() : null;
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      hasContract: Boolean(contract),
-      productSeatTypeCount: productSeatTypes?.size ?? 0,
-    },
-    "[DefaultUserSpendLimit] get: resolved contract and product seat types"
-  );
-
-  // Try each normalized seat type until we find one with an alert configured.
-  for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
-    const result = await getMetronomeDefaultUserCapAlertForSeatType({
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      workspaceId: workspace.sId,
-      seatType,
-    });
-    if (result.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          seatType,
-          err: result.error,
-        },
-        "[DefaultUserSpendLimit] get: failed to read default per-user cap alert from Metronome"
-      );
-      return new Err(
-        new DefaultUserSpendLimitError("metronome_error", result.error.message)
-      );
-    }
-    if (result.value) {
-      const totalThreshold = result.value.alert.threshold;
-      const seatAllowance =
-        contract && productSeatTypes
-          ? getAwuAllocationForNormalizedSeatType(
-              contract,
-              seatType,
-              productSeatTypes
-            )
-          : 0;
-      const poolAwuCredits = totalThreshold - seatAllowance;
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          seatType,
-          alertId: result.value.alert.id,
-          totalThreshold,
-          seatAllowance,
-          poolAwuCredits,
-        },
-        "[DefaultUserSpendLimit] get: resolved default pool limit from cap alert"
-      );
-      return new Ok({ awuCredits: poolAwuCredits });
-    }
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if (!config || config.defaultPoolCapAwuCredits === null) {
+    // No workspace-specific default configured: fall back to the plan-tier
+    // default (same resolution the per-user cap path applies).
+    const planCode = auth.getNonNullableSubscriptionResource().getPlan().code;
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        planCode,
+      },
+      "[DefaultUserSpendLimit] get: no workspace default configured, falling back to plan-tier default"
+    );
+    return new Ok({ awuCredits: getPlanDefaultPoolLimitAwuCredits(planCode) });
   }
 
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      metronomeCustomerId: workspace.metronomeCustomerId,
-    },
-    "[DefaultUserSpendLimit] get: no default per-user cap alert configured for any seat type"
-  );
-  return new Err(
-    new DefaultUserSpendLimitError(
-      "not_found",
-      "No default per-user spend limit configured for this workspace."
-    )
-  );
+  return new Ok({ awuCredits: config.defaultPoolCapAwuCredits });
 }
 
 /**
@@ -271,11 +218,25 @@ export async function setDefaultUserSpendLimit(
     );
   }
 
-  // Read previous pool limit for audit metadata (best-effort).
-  const previousResult = await getDefaultUserSpendLimit(auth);
-  const previousAwuCredits = previousResult.isOk()
-    ? previousResult.value.awuCredits
-    : null;
+  // Persist the admin's intent first: the credit-usage configuration column is
+  // the source of truth, the per-seat-type Metronome alerts below are derived
+  // enforcement (a failed sync can be retried and re-derives from this value).
+  // The config row is created lazily, so upsert it.
+  const existingConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const previousAwuCredits = existingConfig?.defaultPoolCapAwuCredits ?? null;
+
+  if (existingConfig) {
+    await existingConfig.updateConfiguration(auth, {
+      defaultPoolCapAwuCredits: poolAwuCredits,
+    });
+  } else {
+    await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      defaultPoolCapAwuCredits: poolAwuCredits,
+    });
+  }
 
   // Create per-seat-type alerts.
   for (const seatType of normalizedSeatTypes) {

--- a/front/lib/metronome/live_user_credit_inputs.test.ts
+++ b/front/lib/metronome/live_user_credit_inputs.test.ts
@@ -3,15 +3,12 @@ import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_i
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mockListMetronomeSeatBalances,
-  mockFetchPerUserAwuUsage,
-  mockGetMetronomeDefaultUserCapAlertForSeatType,
-} = vi.hoisted(() => ({
-  mockListMetronomeSeatBalances: vi.fn(),
-  mockFetchPerUserAwuUsage: vi.fn(),
-  mockGetMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
-}));
+const { mockListMetronomeSeatBalances, mockFetchPerUserAwuUsage } = vi.hoisted(
+  () => ({
+    mockListMetronomeSeatBalances: vi.fn(),
+    mockFetchPerUserAwuUsage: vi.fn(),
+  })
+);
 
 vi.mock("@app/lib/metronome/client", async () => {
   const actual = await vi.importActual<
@@ -28,17 +25,6 @@ vi.mock("@app/lib/metronome/per_user_usage", async () => {
     typeof import("@app/lib/metronome/per_user_usage")
   >("@app/lib/metronome/per_user_usage");
   return { ...actual, fetchPerUserAwuUsage: mockFetchPerUserAwuUsage };
-});
-
-vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
-  const actual = await vi.importActual<
-    typeof import("@app/lib/metronome/alerts/spend_limits")
-  >("@app/lib/metronome/alerts/spend_limits");
-  return {
-    ...actual,
-    getMetronomeDefaultUserCapAlertForSeatType:
-      mockGetMetronomeDefaultUserCapAlertForSeatType,
-  };
 });
 
 const CUSTOMER_ID = "cust_test";
@@ -63,9 +49,6 @@ function seatBalance(balanceAwu: number, startingAwu: number) {
 beforeEach(() => {
   vi.clearAllMocks();
   mockFetchPerUserAwuUsage.mockResolvedValue(new Ok(new Map<string, number>()));
-  mockGetMetronomeDefaultUserCapAlertForSeatType.mockResolvedValue(
-    new Ok(null)
-  );
 });
 
 describe("fetchLiveUserCreditInputs", () => {
@@ -79,6 +62,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      defaultPoolCapAwuCredits: null,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });
@@ -109,6 +93,7 @@ describe("fetchLiveUserCreditInputs", () => {
       // Pool-only override from the membership; no contract resolves for
       // "ws_test" so the seat allowance is 0 and the total cap equals it.
       poolCapOverrideAwuCredits: 50000,
+      defaultPoolCapAwuCredits: null,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });
@@ -132,6 +117,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
+      defaultPoolCapAwuCredits: null,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -10,7 +10,6 @@
 // reconcile module imports the dispatcher, so the dispatcher cannot import the
 // reconcile module back.
 
-import { getMetronomeDefaultUserCapAlertForSeatType } from "@app/lib/metronome/alerts/spend_limits";
 import {
   listContractPerUserCreditBalances,
   listMetronomeSeatBalances,
@@ -65,10 +64,12 @@ export type LiveUserCreditInputs = {
  * derive the actual state — this only reads the numbers.
  *
  * `poolCapOverrideAwuCredits` is the pool-only override persisted on the
- * membership (`memberships.poolCapOverrideAwuCredits`) — the source of truth
- * for per-user overrides. When set, the seat allowance is added back to get
- * the total cap threshold; the seat-type default alert is only consulted when
- * no override is set.
+ * membership (`memberships.poolCapOverrideAwuCredits`) and
+ * `defaultPoolCapAwuCredits` the pool-only workspace default persisted on the
+ * credit-usage configuration
+ * (`credit_usage_configurations.defaultPoolCapAwuCredits`) — the DB sources of
+ * truth for the cap. The override wins; the seat allowance is added back to get
+ * the total cap threshold.
  *
  * Surfaces Metronome read failures as `Err` so callers can fall back.
  */
@@ -77,6 +78,7 @@ export async function fetchLiveUserCreditInputs({
   userId,
   seatType,
   poolCapOverrideAwuCredits,
+  defaultPoolCapAwuCredits,
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -84,6 +86,7 @@ export async function fetchLiveUserCreditInputs({
   userId: string;
   seatType: MembershipSeatType | null;
   poolCapOverrideAwuCredits: number | null;
+  defaultPoolCapAwuCredits: number | null;
   metronomeCustomerId: string;
   metronomeContractId: string | null;
 }): Promise<Result<LiveUserCreditInputs, Error>> {
@@ -133,14 +136,23 @@ export async function fetchLiveUserCreditInputs({
 
   // Resolve the effective per-user cap threshold (in AWU credits, seat
   // allowance included): the user-specific override if present, otherwise the
-  // seat-type default. `null` means no cap is configured for this user. The
-  // override is the pool-only value persisted on the membership; the seat
-  // allowance is added back to get the total threshold.
+  // workspace default for pool-limit seat types. `null` means no cap is
+  // configured for this user. Both are pool-only values persisted in the DB;
+  // the seat allowance is added back to get the total threshold.
   let effectiveCapAwuCredits: number | null = null;
   let capSource: LiveUserCreditInputs["capSource"] = "none";
 
   const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
+  let poolCapAwuCredits: number | null = null;
   if (poolCapOverrideAwuCredits !== null) {
+    poolCapAwuCredits = poolCapOverrideAwuCredits;
+    capSource = "override";
+  } else if (normalizedSeatType && defaultPoolCapAwuCredits !== null) {
+    poolCapAwuCredits = defaultPoolCapAwuCredits;
+    capSource = "default";
+  }
+
+  if (poolCapAwuCredits !== null) {
     let seatAllowance = 0;
     if (normalizedSeatType) {
       try {
@@ -155,25 +167,7 @@ export async function fetchLiveUserCreditInputs({
         );
       }
     }
-    effectiveCapAwuCredits = poolCapOverrideAwuCredits + seatAllowance;
-    capSource = "override";
-  } else if (normalizedSeatType) {
-    const defaultResult = await getMetronomeDefaultUserCapAlertForSeatType({
-      metronomeCustomerId,
-      workspaceId,
-      seatType: normalizedSeatType,
-    });
-    if (defaultResult.isErr()) {
-      return new Err(
-        new Error(
-          `Failed to read default per-user cap: ${defaultResult.error.message}`
-        )
-      );
-    }
-    if (defaultResult.value) {
-      effectiveCapAwuCredits = defaultResult.value.alert.threshold;
-      capSource = "default";
-    }
+    effectiveCapAwuCredits = poolCapAwuCredits + seatAllowance;
   }
 
   // Consumption is only needed for the cap bands (capped / on_pool_low_balance),

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -85,6 +85,21 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
     return rows[0] ?? null;
   }
 
+  /**
+   * Internal, auth-less fetch by workspace model id. For system flows (Temporal
+   * activities, Metronome webhook dispatchers, reconcile) that operate on a
+   * workspace they don't have an `Authenticator` for. Request-scoped code should
+   * prefer `fetchByWorkspaceId(auth)`.
+   */
+  static async fetchByWorkspaceModelId(
+    workspaceModelId: ModelId
+  ): Promise<CreditUsageConfigurationResource | null> {
+    const row = await this.model.findOne({
+      where: { workspaceId: workspaceModelId },
+    });
+    return row ? new this(this.model, row.get()) : null;
+  }
+
   static async fetchById(
     auth: Authenticator,
     sId: string
@@ -109,6 +124,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: number | null;
       allowMemberUpgradeRequests: boolean;
       upgradeRequestEmailEnabled: boolean;
+      defaultPoolCapAwuCredits: number | null;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -170,6 +186,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: this.usageCapCredits,
       allowMemberUpgradeRequests: this.allowMemberUpgradeRequests,
       upgradeRequestEmailEnabled: this.upgradeRequestEmailEnabled,
+      defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
     };
   }
 
@@ -182,6 +199,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       usageCapCredits: this.usageCapCredits,
       allowMemberUpgradeRequests: String(this.allowMemberUpgradeRequests),
       upgradeRequestEmailEnabled: String(this.upgradeRequestEmailEnabled),
+      defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -25,6 +25,10 @@ import type { CreationOptional } from "sequelize";
  *   Defaults to true.
  * - upgradeRequestEmailEnabled: Whether workspace admins are emailed when a
  *   member requests an upgrade. Defaults to true.
+ * - defaultPoolCapAwuCredits: Workspace-wide default per-user cap on
+ *   workspace-pool AWU consumption, in AWU credits, excluding the seat
+ *   allowance. NULL means no default is configured (the plan-tier default
+ *   applies).
  *
  * The credit-cap-warning notification settings (whether to warn, and at which
  * balance) are NOT stored here: they are derived from the workspace's Metronome
@@ -39,6 +43,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare usageCapCredits: number | null;
   declare allowMemberUpgradeRequests: CreationOptional<boolean>;
   declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
+  declare defaultPoolCapAwuCredits: number | null;
 }
 
 CreditUsageConfigurationModel.init(
@@ -90,6 +95,11 @@ CreditUsageConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: true,
+    },
+    defaultPoolCapAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/20260605_backfill_workspace_default_pool_caps.ts
+++ b/front/migrations/20260605_backfill_workspace_default_pool_caps.ts
@@ -1,0 +1,134 @@
+import { Authenticator } from "@app/lib/auth";
+import { getMetronomeDefaultUserCapAlertForSeatType } from "@app/lib/metronome/alerts/spend_limits";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { NORMALIZED_POOL_LIMIT_SEAT_TYPES } from "@app/types/memberships";
+
+/**
+ * Backfill `credit_usage_configurations.defaultPoolCapAwuCredits` from the
+ * existing Metronome per-seat-type default cap alerts. The alert threshold is
+ * the total cap (seat allowance + pool limit); we subtract the seat type's
+ * allowance to recover the pool-only value the admin entered, which is what the
+ * column stores (all seat types share the same pool limit, so the first alert
+ * found is enough). The credit-usage configuration row is created lazily, so
+ * upsert it.
+ *
+ * Idempotent: workspaces already carrying the expected value are skipped.
+ *
+ * Pass `--wId <workspaceId>` to run on a single workspace.
+ */
+makeScript(
+  {
+    wId: {
+      type: "string",
+      required: false,
+      description: "Run on a single workspace (sId).",
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    let updated = 0;
+    let alreadySet = 0;
+    let skipped = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const { metronomeCustomerId } = workspace;
+        if (!metronomeCustomerId) {
+          return;
+        }
+
+        const contract = await getActiveContract(workspace.sId);
+        if (!contract) {
+          // Seat allowance is unavailable without an active contract; cannot
+          // safely derive the pool-only value from the Metronome threshold.
+          return;
+        }
+
+        const seatAllowances = await getSeatAllowancesByNormalizedSeatType(
+          workspace.sId
+        );
+
+        // Find the first seat type with a default cap alert configured (all
+        // seat types share the same pool limit).
+        let defaultPoolCapAwuCredits: number | null = null;
+        for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+          const result = await getMetronomeDefaultUserCapAlertForSeatType({
+            metronomeCustomerId,
+            workspaceId: workspace.sId,
+            seatType,
+          });
+          if (result.isErr()) {
+            logger.error(
+              { workspaceId: workspace.sId, seatType, err: result.error },
+              "Failed to read default cap alert; skipping workspace."
+            );
+            skipped++;
+            return;
+          }
+          if (result.value) {
+            defaultPoolCapAwuCredits =
+              result.value.alert.threshold - (seatAllowances[seatType] ?? 0);
+            break;
+          }
+        }
+
+        if (defaultPoolCapAwuCredits === null) {
+          // No default cap configured for this workspace.
+          return;
+        }
+        if (defaultPoolCapAwuCredits < 0) {
+          logger.warn(
+            { workspaceId: workspace.sId, defaultPoolCapAwuCredits },
+            "Alert threshold below seat allowance; skipping."
+          );
+          skipped++;
+          return;
+        }
+
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const config =
+          await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+        if (config?.defaultPoolCapAwuCredits === defaultPoolCapAwuCredits) {
+          alreadySet++;
+          return;
+        }
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            defaultPoolCapAwuCredits,
+            previous: config?.defaultPoolCapAwuCredits ?? null,
+          },
+          execute
+            ? "Backfilling workspace default pool cap."
+            : "Would backfill workspace default pool cap."
+        );
+        if (execute) {
+          if (config) {
+            await config.updateConfiguration(auth, {
+              defaultPoolCapAwuCredits,
+            });
+          } else {
+            await CreditUsageConfigurationResource.makeNew(auth, {
+              defaultDiscountPercent: 0,
+              usageCapCredits: null,
+              defaultPoolCapAwuCredits,
+            });
+          }
+        }
+        updated++;
+      },
+      { wId }
+    );
+
+    logger.info(
+      { updated, alreadySet, skipped },
+      execute ? "Backfill completed." : "Dry run completed."
+    );
+  }
+);

--- a/front/migrations/db/migration_681.sql
+++ b/front/migrations/db/migration_681.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jun 8, 2026
+-- Workspace-wide default per-user pool cap (in AWU credits, seat allowance
+-- excluded). Stored on credit_usage_configurations alongside the other
+-- credit-usage knobs. NULL means no default is configured.
+SET statement_timeout = '2s';
+SET lock_timeout = '2s';
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "defaultPoolCapAwuCredits" INTEGER;


### PR DESCRIPTION
## Description
 
 - store the default workspace credit limit in DB so we don't have to rely on metronome for it.

## Tests

updated tests

## Risk

low

## Deploy Plan

lock front
merge
apply SQL migration
deploy
apply migration script to fill DB
unlock front
