### PR TITLE
feat(credits): add upgrade-requests data layer and requests table

### DIFF
--- a/front/components/workspace/ChangeSeatModal.tsx
+++ b/front/components/workspace/ChangeSeatModal.tsx
@@ -201,6 +201,9 @@ interface ChangeSeatModalProps {
   owner: WorkspaceType;
   seatPlans: SeatPlanResponseBody;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
+  // Fired once the seat change has been persisted successfully (not on cancel
+  // or a no-op close). Used to resolve a linked upgrade request as approved.
+  onSaved?: () => void;
 }
 
 export function ChangeSeatModal({
@@ -210,6 +213,7 @@ export function ChangeSeatModal({
   owner,
   seatPlans,
   onSavingChange,
+  onSaved,
 }: ChangeSeatModalProps) {
   const { subscription } = useAuth();
   const router = useAppRouter();
@@ -403,6 +407,7 @@ export function ChangeSeatModal({
         hasSeatPool: (seatPlans[selectedSeat]?.awuCredits ?? 0) > 0,
       });
       if (ok) {
+        onSaved?.();
         onClose();
       }
     } finally {

--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -37,6 +37,9 @@ interface EditSpendLimitModalProps {
   member: MemberUsageType | null;
   owner: WorkspaceType;
   onSavingChange?: (memberId: string, isSaving: boolean) => void;
+  // Fired once the spend limit has been persisted successfully (not on cancel
+  // or a load error). Used to resolve a linked upgrade request as approved.
+  onSaved?: () => void;
 }
 
 export function EditSpendLimitModal({
@@ -45,6 +48,7 @@ export function EditSpendLimitModal({
   member,
   owner,
   onSavingChange,
+  onSaved,
 }: EditSpendLimitModalProps) {
   // Keep the last non-null member so the dialog can render its content through
   // the exit animation after the parent has cleared `member`.
@@ -170,6 +174,7 @@ export function EditSpendLimitModal({
         limit,
       });
       if (body) {
+        onSaved?.();
         onClose();
       }
     } finally {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -1,3 +1,4 @@
+import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
 import {
   getSeatBarClasses,
   getSeatIconColorClass,
@@ -10,7 +11,6 @@ import {
   type MembershipSeatType,
   SEAT_TYPE_ORDER,
 } from "@app/types/memberships";
-import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   AlertCircle,
   Clock,
@@ -297,28 +297,7 @@ function AwuUsageBar({
   );
 }
 
-const nameColumn: ColumnDef<RowData, string> = {
-  id: "name" as const,
-  header: "Name",
-  enableSorting: true,
-  accessorFn: (row) => row.name,
-  cell: (info: Info) => (
-    <DataTable.CellContent
-      avatarUrl={info.row.original.image ?? ANONYMOUS_USER_IMAGE_URL}
-      roundedAvatar
-    >
-      <div>
-        <div>{info.row.original.name}</div>
-        {info.row.original.email &&
-          info.row.original.email !== info.row.original.name && (
-            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-              {info.row.original.email}
-            </div>
-          )}
-      </div>
-    </DataTable.CellContent>
-  ),
-};
+const nameColumn = buildMemberNameColumn<RowData>();
 
 const seatTypeColumn: ColumnDef<RowData, string> = {
   id: "seatType" as const,

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -1,0 +1,240 @@
+import { timeAgoFrom } from "@app/lib/utils";
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+import { SEAT_TYPE_ORDER } from "@app/types/memberships";
+import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
+import {
+  Button,
+  Check,
+  DataTable,
+  LoadingBlock,
+  Spinner,
+  X,
+} from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+type RowData = {
+  sId: string;
+  name: string;
+  email: string | null;
+  image: string | null;
+  createdAt: number;
+  request: MembershipUpgradeRequestType;
+  isPending: boolean;
+  // Rows are not clickable (actions live in explicit buttons), but DataTable's
+  // row type requires at least one of its optional fields to be present.
+  onClick?: () => void;
+};
+
+type Info = CellContext<RowData, string>;
+
+const nameColumn: ColumnDef<RowData, string> = {
+  id: "name" as const,
+  header: "Name",
+  enableSorting: true,
+  accessorFn: (row) => row.name,
+  cell: (info: Info) => (
+    <DataTable.CellContent
+      avatarUrl={info.row.original.image ?? ANONYMOUS_USER_IMAGE_URL}
+      roundedAvatar
+    >
+      <div>
+        <div>{info.row.original.name}</div>
+        {info.row.original.email &&
+          info.row.original.email !== info.row.original.name && (
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {info.row.original.email}
+            </div>
+          )}
+      </div>
+    </DataTable.CellContent>
+  ),
+};
+
+const reasonColumn: ColumnDef<RowData, string> = {
+  id: "reason" as const,
+  header: "",
+  enableSorting: false,
+  accessorFn: () => "Reached credit limit",
+  cell: () => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Reached credit limit
+      </span>
+    </DataTable.CellContent>
+  ),
+};
+
+const requestedColumn: ColumnDef<RowData, string> = {
+  id: "requested" as const,
+  header: "",
+  accessorFn: (row) => row.createdAt.toString(),
+  cell: (info: Info) => (
+    <DataTable.CellContent>
+      <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {timeAgoFrom(info.row.original.createdAt, { useLongFormat: true })} ago
+      </span>
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "w-32",
+  },
+};
+
+function buildActionsColumn({
+  isSeatBased,
+  isTopWorkspacePlan,
+  highestSeatTypeOrder,
+  onUpgradePlan,
+  onEditLimit,
+  onDeny,
+}: {
+  isSeatBased: boolean;
+  isTopWorkspacePlan: boolean;
+  highestSeatTypeOrder: number | null;
+  onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
+  onEditLimit: (request: MembershipUpgradeRequestType) => void;
+  onDeny: (request: MembershipUpgradeRequestType) => void;
+}): ColumnDef<RowData, string> {
+  return {
+    id: "actions" as const,
+    header: "",
+    enableSorting: false,
+    accessorKey: "actions",
+    cell: (info: Info) => {
+      const { request, isPending } = info.row.original;
+      if (isPending) {
+        return (
+          <div className="flex w-full justify-end pr-2">
+            <Spinner size="xs" />
+          </div>
+        );
+      }
+      // Hide "Upgrade plan" when there is no higher seat tier to move the
+      // requester to: the workspace is already on its top plan, or the
+      // requester's current seat is at/above the highest offered seat tier.
+      const requesterSeatOrder =
+        SEAT_TYPE_ORDER[request.requester.seatType ?? "none"];
+      const canUpgradePlan =
+        isSeatBased &&
+        !isTopWorkspacePlan &&
+        highestSeatTypeOrder !== null &&
+        requesterSeatOrder < highestSeatTypeOrder;
+      return (
+        <div className="flex w-full items-center justify-end gap-2">
+          <Button
+            size="sm"
+            variant="warning-secondary"
+            icon={X}
+            label="Deny"
+            onClick={() => onDeny(request)}
+          />
+          {canUpgradePlan && (
+            <Button
+              size="sm"
+              variant="highlight-secondary"
+              icon={Check}
+              label="Upgrade plan"
+              onClick={() => onUpgradePlan(request)}
+            />
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            label="Edit limit"
+            onClick={() => onEditLimit(request)}
+          />
+        </div>
+      );
+    },
+    meta: {
+      className: "w-96",
+    },
+  };
+}
+
+interface UpgradeRequestsTableProps {
+  requests: MembershipUpgradeRequestType[];
+  isLoading: boolean;
+  isSeatBased: boolean;
+  isTopWorkspacePlan: boolean;
+  highestSeatTypeOrder: number | null;
+  pendingRequestIds: ReadonlySet<string>;
+  onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
+  onEditLimit: (request: MembershipUpgradeRequestType) => void;
+  onDeny: (request: MembershipUpgradeRequestType) => void;
+}
+
+export function UpgradeRequestsTable({
+  requests,
+  isLoading,
+  isSeatBased,
+  isTopWorkspacePlan,
+  highestSeatTypeOrder,
+  pendingRequestIds,
+  onUpgradePlan,
+  onEditLimit,
+  onDeny,
+}: UpgradeRequestsTableProps) {
+  const rows: RowData[] = useMemo(
+    () =>
+      requests
+        .filter((request) => request.status === "pending")
+        .map((request) => ({
+          sId: request.sId,
+          name: request.requester.name,
+          email: request.requester.email,
+          image: request.requester.image,
+          createdAt: request.createdAt,
+          request,
+          isPending: pendingRequestIds.has(request.sId),
+        })),
+    [requests, pendingRequestIds]
+  );
+
+  const columns = useMemo(
+    () => [
+      nameColumn,
+      reasonColumn,
+      requestedColumn,
+      buildActionsColumn({
+        isSeatBased,
+        isTopWorkspacePlan,
+        highestSeatTypeOrder,
+        onUpgradePlan,
+        onEditLimit,
+        onDeny,
+      }),
+    ],
+    [
+      isSeatBased,
+      isTopWorkspacePlan,
+      highestSeatTypeOrder,
+      onUpgradePlan,
+      onEditLimit,
+      onDeny,
+    ]
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full flex-col space-y-2">
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+        <LoadingBlock className="h-8 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex w-full justify-center py-8">
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No pending upgrade requests.
+        </span>
+      </div>
+    );
+  }
+
+  return <DataTable<RowData> data={rows} columns={columns} />;
+}

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -1,7 +1,10 @@
 import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
+import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { MembershipUpgradeRequestType } from "@app/types/memberships";
-import { SEAT_TYPE_ORDER } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  MembershipUpgradeRequestType,
+} from "@app/types/memberships";
 import {
   Button,
   Check,
@@ -31,6 +34,26 @@ type Info = CellContext<RowData, string>;
 const nameColumn = buildMemberNameColumn<RowData>();
 
 const REASON_LABEL = "Reached credit limit";
+
+function seatAwuCredits(
+  seatType: MembershipSeatType | null,
+  seatPlans: SeatPlanResponseBody
+): number {
+  if (!seatType || seatType === "none") {
+    return -1;
+  }
+  return seatPlans[seatType]?.awuCredits ?? 0;
+}
+
+function canUpgrade(
+  currentSeatType: MembershipSeatType | null,
+  seatPlans: SeatPlanResponseBody
+): boolean {
+  const currentCredits = seatAwuCredits(currentSeatType, seatPlans);
+  return Object.values(seatPlans).some(
+    (info) => (info?.awuCredits ?? 0) > currentCredits
+  );
+}
 
 const reasonColumn: ColumnDef<RowData, string> = {
   id: "reason" as const,
@@ -62,14 +85,12 @@ const requestedColumn: ColumnDef<RowData, string> = {
 };
 
 function buildActionsColumn({
-  isSeatBased,
-  highestSeatTypeOrder,
+  seatPlans,
   onUpgradePlan,
   onEditLimit,
   onDeny,
 }: {
-  isSeatBased: boolean;
-  highestSeatTypeOrder: number | null;
+  seatPlans: SeatPlanResponseBody;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
   onEditLimit: (request: MembershipUpgradeRequestType) => void;
   onDeny: (request: MembershipUpgradeRequestType) => void;
@@ -89,14 +110,9 @@ function buildActionsColumn({
         );
       }
       // Hide "Upgrade plan" when there is no higher seat tier to move the
-      // requester to: their current seat is already at/above the highest seat
-      // tier offered to the workspace.
-      const requesterSeatOrder =
-        SEAT_TYPE_ORDER[request.requester.seatType ?? "none"];
-      const canUpgradePlan =
-        isSeatBased &&
-        highestSeatTypeOrder !== null &&
-        requesterSeatOrder < highestSeatTypeOrder;
+      // requester to: their current seat already grants as many AWU credits as
+      // the richest seat the plan offers.
+      const canUpgradePlan = canUpgrade(request.requester.seatType, seatPlans);
       return (
         <div className="flex w-full items-center justify-end gap-2">
           <Button
@@ -133,8 +149,7 @@ function buildActionsColumn({
 interface UpgradeRequestsTableProps {
   requests: MembershipUpgradeRequestType[];
   isLoading: boolean;
-  isSeatBased: boolean;
-  highestSeatTypeOrder: number | null;
+  seatPlans: SeatPlanResponseBody;
   pendingRequestIds: ReadonlySet<string>;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
   onEditLimit: (request: MembershipUpgradeRequestType) => void;
@@ -144,8 +159,7 @@ interface UpgradeRequestsTableProps {
 export function UpgradeRequestsTable({
   requests,
   isLoading,
-  isSeatBased,
-  highestSeatTypeOrder,
+  seatPlans,
   pendingRequestIds,
   onUpgradePlan,
   onEditLimit,
@@ -171,14 +185,13 @@ export function UpgradeRequestsTable({
       reasonColumn,
       requestedColumn,
       buildActionsColumn({
-        isSeatBased,
-        highestSeatTypeOrder,
+        seatPlans,
         onUpgradePlan,
         onEditLimit,
         onDeny,
       }),
     ],
-    [isSeatBased, highestSeatTypeOrder, onUpgradePlan, onEditLimit, onDeny]
+    [seatPlans, onUpgradePlan, onEditLimit, onDeny]
   );
 
   if (isLoading) {

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -158,17 +158,15 @@ export function UpgradeRequestsTable({
 }: UpgradeRequestsTableProps) {
   const rows: RowData[] = useMemo(
     () =>
-      requests
-        .filter((request) => request.status === "pending")
-        .map((request) => ({
-          sId: request.sId,
-          name: request.requester.name,
-          email: request.requester.email,
-          image: request.requester.image,
-          createdAt: request.createdAt,
-          request,
-          isPending: pendingRequestIds.has(request.sId),
-        })),
+      requests.map((request) => ({
+        sId: request.sId,
+        name: request.requester.name,
+        email: request.requester.email,
+        image: request.requester.image,
+        createdAt: request.createdAt,
+        request,
+        isPending: pendingRequestIds.has(request.sId),
+      })),
     [requests, pendingRequestIds]
   );
 

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -30,15 +30,16 @@ type Info = CellContext<RowData, string>;
 
 const nameColumn = buildMemberNameColumn<RowData>();
 
+const REASON_LABEL = "Reached credit limit";
+
 const reasonColumn: ColumnDef<RowData, string> = {
   id: "reason" as const,
   header: "",
   enableSorting: false,
-  accessorFn: () => "Reached credit limit",
   cell: () => (
     <DataTable.CellContent>
       <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Reached credit limit
+        {REASON_LABEL}
       </span>
     </DataTable.CellContent>
   ),

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -1,7 +1,7 @@
+import { buildMemberNameColumn } from "@app/components/workspace/member_name_column";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { MembershipUpgradeRequestType } from "@app/types/memberships";
 import { SEAT_TYPE_ORDER } from "@app/types/memberships";
-import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
   Button,
   Check,
@@ -28,28 +28,7 @@ type RowData = {
 
 type Info = CellContext<RowData, string>;
 
-const nameColumn: ColumnDef<RowData, string> = {
-  id: "name" as const,
-  header: "Name",
-  enableSorting: true,
-  accessorFn: (row) => row.name,
-  cell: (info: Info) => (
-    <DataTable.CellContent
-      avatarUrl={info.row.original.image ?? ANONYMOUS_USER_IMAGE_URL}
-      roundedAvatar
-    >
-      <div>
-        <div>{info.row.original.name}</div>
-        {info.row.original.email &&
-          info.row.original.email !== info.row.original.name && (
-            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-              {info.row.original.email}
-            </div>
-          )}
-      </div>
-    </DataTable.CellContent>
-  ),
-};
+const nameColumn = buildMemberNameColumn<RowData>();
 
 const reasonColumn: ColumnDef<RowData, string> = {
   id: "reason" as const,

--- a/front/components/workspace/UpgradeRequestsTable.tsx
+++ b/front/components/workspace/UpgradeRequestsTable.tsx
@@ -63,14 +63,12 @@ const requestedColumn: ColumnDef<RowData, string> = {
 
 function buildActionsColumn({
   isSeatBased,
-  isTopWorkspacePlan,
   highestSeatTypeOrder,
   onUpgradePlan,
   onEditLimit,
   onDeny,
 }: {
   isSeatBased: boolean;
-  isTopWorkspacePlan: boolean;
   highestSeatTypeOrder: number | null;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
   onEditLimit: (request: MembershipUpgradeRequestType) => void;
@@ -91,13 +89,12 @@ function buildActionsColumn({
         );
       }
       // Hide "Upgrade plan" when there is no higher seat tier to move the
-      // requester to: the workspace is already on its top plan, or the
-      // requester's current seat is at/above the highest offered seat tier.
+      // requester to: their current seat is already at/above the highest seat
+      // tier offered to the workspace.
       const requesterSeatOrder =
         SEAT_TYPE_ORDER[request.requester.seatType ?? "none"];
       const canUpgradePlan =
         isSeatBased &&
-        !isTopWorkspacePlan &&
         highestSeatTypeOrder !== null &&
         requesterSeatOrder < highestSeatTypeOrder;
       return (
@@ -137,7 +134,6 @@ interface UpgradeRequestsTableProps {
   requests: MembershipUpgradeRequestType[];
   isLoading: boolean;
   isSeatBased: boolean;
-  isTopWorkspacePlan: boolean;
   highestSeatTypeOrder: number | null;
   pendingRequestIds: ReadonlySet<string>;
   onUpgradePlan: (request: MembershipUpgradeRequestType) => void;
@@ -149,7 +145,6 @@ export function UpgradeRequestsTable({
   requests,
   isLoading,
   isSeatBased,
-  isTopWorkspacePlan,
   highestSeatTypeOrder,
   pendingRequestIds,
   onUpgradePlan,
@@ -177,21 +172,13 @@ export function UpgradeRequestsTable({
       requestedColumn,
       buildActionsColumn({
         isSeatBased,
-        isTopWorkspacePlan,
         highestSeatTypeOrder,
         onUpgradePlan,
         onEditLimit,
         onDeny,
       }),
     ],
-    [
-      isSeatBased,
-      isTopWorkspacePlan,
-      highestSeatTypeOrder,
-      onUpgradePlan,
-      onEditLimit,
-      onDeny,
-    ]
+    [isSeatBased, highestSeatTypeOrder, onUpgradePlan, onEditLimit, onDeny]
   );
 
   if (isLoading) {

--- a/front/components/workspace/member_name_column.tsx
+++ b/front/components/workspace/member_name_column.tsx
@@ -1,0 +1,38 @@
+import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
+import { DataTable } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+
+// The minimal row shape the name column needs.
+interface MemberNameRow {
+  name: string;
+  email: string | null;
+  image: string | null;
+}
+
+export function buildMemberNameColumn<TRow extends MemberNameRow>(): ColumnDef<
+  TRow,
+  string
+> {
+  return {
+    id: "name" as const,
+    header: "Name",
+    enableSorting: true,
+    accessorFn: (row) => row.name,
+    cell: (info: CellContext<TRow, string>) => (
+      <DataTable.CellContent
+        avatarUrl={info.row.original.image ?? ANONYMOUS_USER_IMAGE_URL}
+        roundedAvatar
+      >
+        <div>
+          <div>{info.row.original.name}</div>
+          {info.row.original.email &&
+            info.row.original.email !== info.row.original.name && (
+              <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                {info.row.original.email}
+              </div>
+            )}
+        </div>
+      </DataTable.CellContent>
+    ),
+  };
+}

--- a/front/lib/resources/membership_upgrade_request_resource.ts
+++ b/front/lib/resources/membership_upgrade_request_resource.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestModel } from "@app/lib/resources/storage/models/membership_upgrade_requests";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -8,6 +9,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
+  MembershipSeatType,
   MembershipUpgradeRequestStatus,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
@@ -26,14 +28,22 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     MembershipUpgradeRequestModel;
 
   readonly requester: UserResource;
+  readonly requesterSeatType: MembershipSeatType | null;
 
   constructor(
     _: ModelStatic<MembershipUpgradeRequestModel>,
     blob: Attributes<MembershipUpgradeRequestModel>,
-    { requester }: { requester: UserResource }
+    {
+      requester,
+      requesterSeatType,
+    }: {
+      requester: UserResource;
+      requesterSeatType: MembershipSeatType | null;
+    }
   ) {
     super(MembershipUpgradeRequestModel, blob);
     this.requester = requester;
+    this.requesterSeatType = requesterSeatType;
   }
 
   get sId(): string {
@@ -83,7 +93,17 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         { transaction }
       );
     });
-    return new Ok(new this(this.model, row.get(), { requester: user }));
+    const membership =
+      await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace,
+      });
+    return new Ok(
+      new this(this.model, row.get(), {
+        requester: user,
+        requesterSeatType: membership?.seatType ?? null,
+      })
+    );
   }
 
   private static async baseFetch(
@@ -108,12 +128,25 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
     );
     const requesterByModelId = new Map(requesters.map((u) => [u.id, u]));
 
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      users: requesters,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    const seatTypeByUserModelId = new Map(
+      memberships.map((m) => [m.userId, m.seatType])
+    );
+
     return rows.flatMap((r) => {
       const requester = requesterByModelId.get(r.userId);
       if (!requester) {
         return [];
       }
-      return [new this(this.model, r.get(), { requester })];
+      return [
+        new this(this.model, r.get(), {
+          requester,
+          requesterSeatType: seatTypeByUserModelId.get(r.userId) ?? null,
+        }),
+      ];
     });
   }
 
@@ -221,6 +254,7 @@ export class MembershipUpgradeRequestResource extends BaseResource<MembershipUpg
         name: this.requester.fullName() || this.requester.name,
         email: this.requester.email ?? null,
         image: this.requester.imageUrl ?? null,
+        seatType: this.requesterSeatType,
       },
     };
   }

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -1,0 +1,108 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { GetUpgradeRequestsResponseBody } from "@app/lib/api/credits/upgrade_requests";
+import { clientFetch } from "@app/lib/egress/client";
+import { invalidateMembersUsage } from "@app/lib/swr/memberships";
+import {
+  emptyArray,
+  getErrorFromResponse,
+  useFetcher,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
+import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+function upgradeRequestsUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/credits/upgrade-requests`;
+}
+
+// Admin-only: pending upgrade requests for the workspace. Fetched on the Usage
+// page both to render the Requests tab and to back its count badge, so it is
+// not gated behind tab visibility.
+export function useUpgradeRequests({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const upgradeRequestsFetcher: Fetcher<GetUpgradeRequestsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    upgradeRequestsUrl(workspaceId),
+    upgradeRequestsFetcher,
+    { disabled }
+  );
+
+  const requests = data?.requests ?? emptyArray();
+
+  return {
+    upgradeRequests: requests,
+    isUpgradeRequestsLoading: !error && !data && !disabled,
+    isUpgradeRequestsError: !!error,
+    mutateUpgradeRequests: mutate,
+  };
+}
+
+export function useResolveUpgradeRequest({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRWithDefaults(upgradeRequestsUrl(workspaceId), null);
+
+  const doResolveUpgradeRequest = useCallback(
+    async ({
+      requestId,
+      requesterName,
+      status,
+    }: {
+      requestId: string;
+      requesterName: string;
+      status: Exclude<MembershipUpgradeRequestStatus, "pending">;
+    }): Promise<boolean> => {
+      const res = await clientFetch(
+        `${upgradeRequestsUrl(workspaceId)}/${requestId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to resolve upgrade request",
+          description: errorData.message,
+        });
+        return false;
+      }
+
+      // Resolving removes the request from the pending list and may change the
+      // member's seat / limit, so refresh both surfaces.
+      await mutate();
+      await invalidateMembersUsage(workspaceId);
+
+      sendNotification({
+        type: "success",
+        title:
+          status === "approved"
+            ? "Upgrade request approved"
+            : "Upgrade request denied",
+        description:
+          status === "approved"
+            ? `${requesterName}'s upgrade request has been approved.`
+            : `${requesterName}'s upgrade request has been denied.`,
+      });
+      return true;
+    },
+    [workspaceId, sendNotification, mutate]
+  );
+
+  return { doResolveUpgradeRequest };
+}

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -84,10 +84,15 @@ export function useResolveUpgradeRequest({
         return false;
       }
 
-      // Resolving removes the request from the pending list and may change the
-      // member's seat / limit, so refresh both surfaces.
-      await mutate();
-      await invalidateMembersUsage(workspaceId);
+      // Resolving always removes the request from the pending list. Only an
+      // approval edits the member's seat / limit, so the members-usage surface
+      // only needs refreshing on approve.
+      await Promise.all([
+        mutate(),
+        status === "approved"
+          ? invalidateMembersUsage(workspaceId)
+          : Promise.resolve(),
+      ]);
 
       switch (status) {
         case "approved":

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -9,6 +9,7 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
@@ -88,17 +89,24 @@ export function useResolveUpgradeRequest({
       await mutate();
       await invalidateMembersUsage(workspaceId);
 
-      sendNotification({
-        type: "success",
-        title:
-          status === "approved"
-            ? "Upgrade request approved"
-            : "Upgrade request denied",
-        description:
-          status === "approved"
-            ? `${requesterName}'s upgrade request has been approved.`
-            : `${requesterName}'s upgrade request has been denied.`,
-      });
+      switch (status) {
+        case "approved":
+          sendNotification({
+            type: "success",
+            title: "Upgrade request approved",
+            description: `${requesterName}'s upgrade request has been approved.`,
+          });
+          break;
+        case "denied":
+          sendNotification({
+            type: "success",
+            title: "Upgrade request denied",
+            description: `${requesterName}'s upgrade request has been denied.`,
+          });
+          break;
+        default:
+          assertNeverAndIgnore(status);
+      }
       return true;
     },
     [workspaceId, sendNotification, mutate]

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -238,6 +238,7 @@ export interface MembershipUpgradeRequestType {
     name: string;
     email: string | null;
     image: string | null;
+    seatType: MembershipSeatType | null;
   };
 }
 


### PR DESCRIPTION
## Description

(see other PR for how it looks!)

Followed by #27167 that adds an admin-only "Requests" tab to the Usage page for resolving member-initiated spend-limit upgrade requests. Split out so each PR stays under 500 line changes.

This PR contains the data layer and the reusable UI building blocks

(The other one integrates those in the Usage page!)

- `MembershipUpgradeRequestType` gains a `requester.seatType` field, populated in `MembershipUpgradeRequestResource` (single batched membership fetch in `baseFetch`, plus the create path) so the table can decide whether a plan upgrade is offered.
- New SWR hooks in `lib/swr/upgrade_requests.ts`: `useUpgradeRequests` (admin-only, backs both the tab and its count badge) and `useResolveUpgradeRequest` (PATCH approve/deny, invalidates the members-usage surface on success).
- New `UpgradeRequestsTable` component rendering pending requests with Deny / Upgrade plan / Edit limit actions. "Upgrade plan" is hidden when there is no higher seat tier to move the requester to.
- `ChangeSeatModal` and `EditSpendLimitModal` gain an optional `onSaved` callback (fired only on successful persist) so the next PR can mark a linked request approved.

The backend route handlers (`GET`/`PATCH .../credits/upgrade-requests`) already exist on `main` in `front-api`.

## Tests

Type-check / lint pass via pre-commit hooks. The new table component and hooks are exercised end-to-end once #27167 wires them into the Usage page.
