### PR TITLE
feat(connectors): migrate admin CLI to commander for faster startup and better help

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -82,6 +82,7 @@
     "mdast-util-gfm": "^3.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "micromark-extension-gfm": "^3.0.0",
+    "commander": "^9.5.0",
     "minimist": "^1.2.8",
     "morgan": "^1.10.0",
     "octokit": "^3.1.2",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -33,6 +33,7 @@
     "knip": "knip"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^9.5.0",
     "@dust-tt/client": "file:../sdks/js",
     "@google-cloud/bigquery": "^7.9.2",
     "@google-cloud/resource-manager": "^6.2.1",
@@ -59,6 +60,7 @@
     "axios": "^1.7.9",
     "body-parser": "^1.20.2",
     "botbuilder": "^4.23.3",
+    "commander": "^9.5.0",
     "crawlee": "3.14.1",
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.5.0",
@@ -82,7 +84,6 @@
     "mdast-util-gfm": "^3.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "micromark-extension-gfm": "^3.0.0",
-    "commander": "^9.5.0",
     "minimist": "^1.2.8",
     "morgan": "^1.10.0",
     "octokit": "^3.1.2",

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -1,5 +1,5 @@
+import { Argument, Command } from "@commander-js/extra-typings";
 import { AdminCommandSchema } from "@connectors/types";
-import { Argument, Command } from "commander";
 import { fromError } from "zod-validation-error";
 
 process.env.INTERACTIVE_CLI = process.env.INTERACTIVE_CLI || "1";

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -1,33 +1,18 @@
 import { AdminCommandSchema } from "@connectors/types";
 import { Argument, Command } from "commander";
-import minimist from "minimist";
 import { fromError } from "zod-validation-error";
 
 process.env.INTERACTIVE_CLI = process.env.INTERACTIVE_CLI || "1";
 
-/**
- * Parses the key=value options that follow the subcommand.
- *
- * process.argv layout: [node, script, majorCommand, subcommand, ...options]
- *                       0      1        2             3           4+
- */
-function parseCommandArgs() {
-  const raw = minimist(process.argv.slice(4), {
-    // Force string for args that may exceed Number.MAX_SAFE_INTEGER (e.g. Gong call IDs).
-    string: ["wId", "callId"],
-  });
-  return { ...raw, _: undefined, "--": undefined };
-}
-
 async function dispatch(
   majorCommand: string,
-  subcommand: string
+  subcommand: string,
+  opts: Record<string, unknown>
 ): Promise<void> {
-  const args = parseCommandArgs();
   const validation = AdminCommandSchema.safeParse({
     majorCommand,
     command: subcommand,
-    args,
+    args: opts,
   });
   if (!validation.success) {
     console.error(
@@ -61,9 +46,10 @@ program
       "resume-all",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("batch", subcommand);
+  .option("--provider <provider>", "Connector provider type")
+  .option("--fromTs <timestamp>", "Sync from this Unix timestamp (ms)")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("batch", subcommand, opts);
   });
 
 program
@@ -84,9 +70,16 @@ program
       "upsert-pages",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("confluence", subcommand);
+  .option("--connectorId <id>", "Connector ID", parseInt)
+  .option("--pageId <id>", "Page ID", parseInt)
+  .option("--spaceId <id>", "Space ID", parseInt)
+  .option("--file <path>", "File path")
+  .option("--keyInFile <key>", "Key in file")
+  .option("--url <url>", "URL")
+  .option("--forceUpsert <bool>", 'Force upsert ("true")')
+  .option("--skipReason <reason>", "Skip reason")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("confluence", subcommand, opts);
   });
 
 program
@@ -108,9 +101,19 @@ program
       "unpause",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("connectors", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--connectorId <id>", "Connector ID")
+  .option("--fromTs <timestamp>", "Sync from this Unix timestamp (ms)")
+  .option("--error <errorType>", "Error type to set")
+  .option("--permissionKey <key>", "Permission key (for set-permission)")
+  .option("--permissionValue <value>", "Permission value (for set-permission)")
+  .option(
+    "--permissionsFile <path>",
+    "Path to permissions JSON file (for set-permission)"
+  )
+  .action(async (subcommand: string, opts) => {
+    await dispatch("connectors", subcommand, opts);
   });
 
 program
@@ -132,9 +135,20 @@ program
       "unskip-repo",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("github", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--connectorId <id>", "Connector ID")
+  .option("--owner <owner>", "Repository owner")
+  .option("--repo <repo>", "Repository name")
+  .option("--repoId <id>", "Repository ID")
+  .option("--repoLogin <login>", "Repository login (for sync-issue)")
+  .option("--repoName <name>", "Repository name (for sync-issue)")
+  .option("--issueNumber <number>", "Issue number")
+  .option("--enable <bool>", 'Enable code sync ("true" or "false")')
+  .option("--skipReason <reason>", "Skip reason")
+  .option("--documentId <id>", "Document ID (for skip-code-file)")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("github", subcommand, opts);
   });
 
 program
@@ -143,9 +157,11 @@ program
   .addArgument(
     new Argument("<subcommand>").choices(["delete-transcript", "force-resync"])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("gong", subcommand);
+  .option("--connectorId <id>", "Connector ID", parseInt)
+  .option("--fromTs <timestamp>", "From timestamp", parseInt)
+  .option("--callId <id>", "Call ID")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("gong", subcommand, opts);
   });
 
 program
@@ -171,9 +187,18 @@ program
       "upsert-file",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("google_drive", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--connectorId <id>", "Connector ID")
+  .option("--fileId <id>", "File ID")
+  .option("--fileType <type>", "File type for export (document | presentation)")
+  .option("--folderId <id>", "Folder ID")
+  .option("--rootFolderId <id>", "Root folder ID")
+  .option("--reason <reason>", "Reason")
+  .option("--fix <bool>", "Fix (true/false)")
+  .option("--execute <bool>", "Execute (true/false)")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("google_drive", subcommand, opts);
   });
 
 program
@@ -194,9 +219,23 @@ program
       "set-conversations-sliding-window",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("intercom", subcommand);
+  .option("--force <bool>", 'Force ("true")')
+  .option("--connectorId <id>", "Connector ID", parseInt)
+  .option("--conversationId <id>", "Conversation ID", parseInt)
+  .option("--day <day>", "Day")
+  .option("--helpCenterId <id>", "Help center ID", parseInt)
+  .option(
+    "--conversationsSlidingWindow <window>",
+    "Conversations sliding window",
+    parseInt
+  )
+  .option("--teamId <id>", "Team ID", parseInt)
+  .option("--closedAfter <timestamp>", "Closed after timestamp", parseInt)
+  .option("--state <state>", "Conversation state (open | closed)")
+  .option("--cursor <cursor>", "Pagination cursor")
+  .option("--forceDeleteExisting <bool>", 'Force delete existing ("true")')
+  .action(async (subcommand: string, opts) => {
+    await dispatch("intercom", subcommand, opts);
   });
 
 program
@@ -216,9 +255,15 @@ program
       "update-parent-in-node-table",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("microsoft", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--connectorId <id>", "Connector ID")
+  .option("--folderId <id>", "Folder ID")
+  .option("--internalId <id>", "Internal node ID")
+  .option("--idsFile <path>", "Path to JSON file containing array of IDs")
+  .option("--reason <reason>", "Reason")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("microsoft", subcommand, opts);
   });
 
 program
@@ -243,9 +288,22 @@ program
       "upsert-page",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("notion", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--connectorId <id>", "Connector ID")
+  .option("--pageId <id>", "Page ID")
+  .option("--databaseId <id>", "Database ID")
+  .option("--query <query>", "Search query")
+  .option("--url <url>", "URL")
+  .option("--method <method>", "HTTP method (GET | POST)")
+  .option("--body <json>", "Request body (JSON string)")
+  .option("--remove <bool>", "Remove skip reason (true/false)")
+  .option("--reason <reason>", "Skip reason")
+  .option("--all <bool>", "Apply to all connectors/resources (true/false)")
+  .option("--resetToDate <date>", "Reset parentsLastUpdatedAt to this date")
+  .option("--forceResync <bool>", "Force resync (true/false)")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("notion", subcommand, opts);
   });
 
 program
@@ -259,9 +317,24 @@ program
       "sync-query",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("salesforce", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--soql <query>", "SOQL query")
+  .option("--limit <number>", "Result limit", parseInt)
+  .option(
+    "--lastModifiedDateOrder <order>",
+    "Last modified date order (ASC | DESC)"
+  )
+  .option("--offset <number>", "Result offset", parseInt)
+  .option("--rootNodeName <name>", "Root node name")
+  .option("--titleTemplate <template>", "Title template")
+  .option("--contentTemplate <template>", "Content template")
+  .option("--tagsTemplate <template>", "Tags template")
+  .option("--execute", "Execute the query")
+  .option("--queryId <id>", "Query ID", parseInt)
+  .option("--full", "Full sync")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("salesforce", subcommand, opts);
   });
 
 program
@@ -287,9 +360,25 @@ program
       "whitelist-domains",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("slack", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--channelId <id>", "Channel ID")
+  .option("--threadId <id>", "Thread ID")
+  .option("--threadTs <ts>", "Thread timestamp")
+  .option("--skipReason <reason>", "Skip reason")
+  .option(
+    "--whitelistedDomains <domains>",
+    "Comma-separated domains (e.g. example.com:group1,example2.com:group2)"
+  )
+  .option("--botName <name>", "Bot name (for whitelist-bot)")
+  .option("--groupId <id>", "Group ID (for whitelist-bot, comma-separated)")
+  .option(
+    "--whitelistType <type>",
+    "Whitelist type (summon_agent | index_messages)"
+  )
+  .option("--providerType <type>", "Provider type (slack | slack_bot)")
+  .option("--force <bool>", "Force (true/false)")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("slack", subcommand, opts);
   });
 
 program
@@ -302,9 +391,11 @@ program
       "fetch-tables",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("snowflake", subcommand);
+  .option("--connectorId <id>", "Connector ID", parseInt)
+  .option("--database <name>", "Database name")
+  .option("--schema <name>", "Schema name")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("snowflake", subcommand, opts);
   });
 
 program
@@ -316,9 +407,9 @@ program
       "find-unprocessed-workflows",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("temporal", subcommand);
+  .option("--queue <name>", "Task queue name")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("temporal", subcommand, opts);
   });
 
 program
@@ -331,9 +422,11 @@ program
       "update-frequency",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("webcrawler", subcommand);
+  .option("--connectorId <id>", "Connector ID")
+  .option("--crawlFrequency <frequency>", "Crawl frequency")
+  .option("--actions <actions>", "Actions")
+  .action(async (subcommand: string, opts) => {
+    await dispatch("webcrawler", subcommand, opts);
   });
 
 program
@@ -358,9 +451,21 @@ program
       "sync-ticket",
     ])
   )
-  .allowUnknownOption(true)
-  .action(async (subcommand: string) => {
-    await dispatch("zendesk", subcommand);
+  .option("--wId <workspaceId>", "Workspace ID")
+  .option("--dsId <dataSourceId>", "Data source ID")
+  .option("--connectorId <id>", "Connector ID", parseInt)
+  .option("--brandId <id>", "Brand ID", parseInt)
+  .option("--query <query>", "Query")
+  .option("--forceResync <bool>", 'Force resync ("true")')
+  .option("--ticketId <id>", "Ticket ID", parseInt)
+  .option("--ticketUrl <url>", "Ticket URL")
+  .option("--retentionPeriodDays <days>", "Retention period in days", parseInt)
+  .option("--rateLimitTps <tps>", "Rate limit TPS", parseInt)
+  .option("--tag <tag>", "Tag")
+  .option("--include <bool>", 'Include ("true")')
+  .option("--exclude <bool>", 'Exclude ("true")')
+  .action(async (subcommand: string, opts) => {
+    await dispatch("zendesk", subcommand, opts);
   });
 
 program.parseAsync(process.argv).catch((err: Error) => {

--- a/connectors/src/admin/cli.ts
+++ b/connectors/src/admin/cli.ts
@@ -1,64 +1,369 @@
-import { runCommand } from "@connectors/lib/cli";
-import type { AdminCommandType } from "@connectors/types";
 import { AdminCommandSchema } from "@connectors/types";
-import parseArgs from "minimist";
-import type { z } from "zod";
+import { Argument, Command } from "commander";
+import minimist from "minimist";
 import { fromError } from "zod-validation-error";
 
-const main = async () => {
-  // set env var INTERACTIVE=1 to enable interactive mode
-  process.env.INTERACTIVE_CLI = process.env.INTERACTIVE_CLI || "1";
+process.env.INTERACTIVE_CLI = process.env.INTERACTIVE_CLI || "1";
 
-  const argv = parseArgs(process.argv.slice(2), {
-    // Force string parsing for args that may exceed Number.MAX_SAFE_INTEGER.
-    // This is the case for Gong call IDs.
+/**
+ * Parses the key=value options that follow the subcommand.
+ *
+ * process.argv layout: [node, script, majorCommand, subcommand, ...options]
+ *                       0      1        2             3           4+
+ */
+function parseCommandArgs() {
+  const raw = minimist(process.argv.slice(4), {
+    // Force string for args that may exceed Number.MAX_SAFE_INTEGER (e.g. Gong call IDs).
     string: ["wId", "callId"],
   });
+  return { ...raw, _: undefined, "--": undefined };
+}
 
-  if (argv._.length < 2) {
-    console.error("Usage: cli <majorCommand> <command> [--arg=value ...]");
-    console.error("");
-    console.error("Available commands:");
-    console.error("");
-    for (const schema of AdminCommandSchema.options) {
-      const majorCommand = schema.shape.majorCommand.value;
-      // schema.shape.command is always a ZodUnion of literal strings in these schemas.
-      const commandUnion = schema.shape.command as z.ZodUnion<
-        [z.ZodLiteral<string>, ...z.ZodLiteral<string>[]]
-      >;
-      const subCommands = commandUnion.options.map((c) => c.value);
-      console.error(`  ${majorCommand}:`);
-      console.error(`    ${subCommands.join(", ")}`);
-    }
-    process.exit(0);
-  }
-
-  const [objectType, command] = argv._;
-  const args = { ...argv, _: undefined, "--": undefined };
-
-  const adminCommandValidation = AdminCommandSchema.safeParse({
-    majorCommand: objectType,
-    command,
+async function dispatch(
+  majorCommand: string,
+  subcommand: string
+): Promise<void> {
+  const args = parseCommandArgs();
+  const validation = AdminCommandSchema.safeParse({
+    majorCommand,
+    command: subcommand,
     args,
   });
-
-  if (!adminCommandValidation.success) {
-    throw new Error(
-      `Invalid command: ${fromError(adminCommandValidation.error).toString()}`
+  if (!validation.success) {
+    console.error(
+      `\x1b[31mError: ${fromError(validation.error).toString()}\x1b[0m`
     );
-  }
-  const adminCommand: AdminCommandType = adminCommandValidation.data;
-  return runCommand(adminCommand);
-};
-
-main()
-  .then((res) => {
-    console.log(JSON.stringify(res, null, 2));
-    console.error("\x1b[32m%s\x1b[0m", `Done`);
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
-    console.log(err);
     process.exit(1);
+  }
+
+  // Dynamic import: defers loading all connector code until a command is dispatched.
+  // A static import loads every connector on every invocation, including --help.
+  const { runCommand } = await import("@connectors/lib/cli");
+  const result = await runCommand(validation.data);
+  console.log(JSON.stringify(result, null, 2));
+  console.error("\x1b[32mDone\x1b[0m");
+}
+
+const program = new Command();
+program
+  .name("cli")
+  .description("Admin CLI for connectors")
+  .addHelpCommand(false);
+
+program
+  .command("batch")
+  .description("Batch operations across all connectors of a given provider")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "full-resync",
+      "restart-all",
+      "stop-all",
+      "resume-all",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("batch", subcommand);
   });
+
+program
+  .command("confluence")
+  .description("Confluence connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "check-page-exists",
+      "check-space-access",
+      "ignore-near-rate-limit",
+      "me",
+      "resolve-space-from-url",
+      "skip-page",
+      "sync-space",
+      "unignore-near-rate-limit",
+      "update-parents",
+      "upsert-page",
+      "upsert-pages",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("confluence", subcommand);
+  });
+
+program
+  .command("connectors")
+  .description("Generic connector lifecycle operations")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "clear-error",
+      "delete",
+      "full-resync",
+      "garbage-collect",
+      "get-parents",
+      "pause",
+      "restart",
+      "resume",
+      "set-error",
+      "set-permission",
+      "stop",
+      "unpause",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("connectors", subcommand);
+  });
+
+program
+  .command("github")
+  .description("GitHub connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "clear-installation-id",
+      "code-sync",
+      "force-daily-code-sync",
+      "list-skipped-repos",
+      "resync-repo",
+      "resync-repo-code",
+      "skip-code-file",
+      "skip-issue",
+      "skip-repo",
+      "sync-issue",
+      "unskip-code-file",
+      "unskip-repo",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("github", subcommand);
+  });
+
+program
+  .command("gong")
+  .description("Gong connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices(["delete-transcript", "force-resync"])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("gong", subcommand);
+  });
+
+program
+  .command("google_drive")
+  .description("Google Drive connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "check-file",
+      "clean-invalid-parents",
+      "export-folder-structure",
+      "garbage-collect-all",
+      "get-file-metadata",
+      "get-google-parents",
+      "list-labels",
+      "register-all-webhooks",
+      "register-webhook",
+      "restart-all-incremental-sync-workflows",
+      "restart-google-webhooks",
+      "skip-file",
+      "start-full-sync",
+      "start-incremental-sync",
+      "update-core-parents",
+      "upsert-file",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("google_drive", subcommand);
+  });
+
+program
+  .command("intercom")
+  .description("Intercom connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "check-conversation",
+      "check-missing-conversations",
+      "check-teams",
+      "fetch-articles",
+      "fetch-conversation",
+      "force-resync-all-conversations",
+      "force-resync-articles",
+      "get-conversations-sliding-window",
+      "restart-schedules",
+      "search-conversations",
+      "set-conversations-sliding-window",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("intercom", subcommand);
+  });
+
+program
+  .command("microsoft")
+  .description("Microsoft connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "check-file",
+      "garbage-collect-all",
+      "get-parents",
+      "restart-all-incremental-sync-workflows",
+      "skip-file",
+      "start-full-sync",
+      "start-incremental-sync",
+      "sync-node",
+      "update-core-parents",
+      "update-parent-in-node-table",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("microsoft", subcommand);
+  });
+
+program
+  .command("notion")
+  .description("Notion connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "api-request",
+      "check-url",
+      "clear-parents-last-updated-at",
+      "delete-url",
+      "find-url",
+      "me",
+      "search-pages",
+      "skip-database",
+      "skip-page",
+      "stop-all-garbage-collectors",
+      "update-core-parents",
+      "update-orphaned-resources-parents",
+      "update-parents-fields",
+      "upsert-database",
+      "upsert-page",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("notion", subcommand);
+  });
+
+program
+  .command("salesforce")
+  .description("Salesforce connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "check-connection",
+      "run-soql",
+      "setup-synced-query",
+      "sync-query",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("salesforce", subcommand);
+  });
+
+program
+  .command("slack")
+  .description("Slack connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "add-channel-to-sync",
+      "check-channel",
+      "cutover-legacy-bot",
+      "delete-conversation",
+      "enable-bot",
+      "remove-channel-from-sync",
+      "run-auto-join",
+      "skip-channel",
+      "skip-thread",
+      "sync-channel",
+      "sync-channel-metadata",
+      "sync-thread",
+      "uninstall-for-unknown-team-ids",
+      "unskip-channel",
+      "whitelist-bot",
+      "whitelist-domains",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("slack", subcommand);
+  });
+
+program
+  .command("snowflake")
+  .description("Snowflake connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "fetch-databases",
+      "fetch-schemas",
+      "fetch-tables",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("snowflake", subcommand);
+  });
+
+program
+  .command("temporal")
+  .description("Temporal workflow inspection")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "check-queue",
+      "find-unprocessed-workflows",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("temporal", subcommand);
+  });
+
+program
+  .command("webcrawler")
+  .description("Web crawler connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "set-actions",
+      "start-scheduler",
+      "update-frequency",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("webcrawler", subcommand);
+  });
+
+program
+  .command("zendesk")
+  .description("Zendesk connector management")
+  .addArgument(
+    new Argument("<subcommand>").choices([
+      "add-organization-tag",
+      "add-ticket-tag",
+      "check-is-admin",
+      "count-tickets",
+      "fetch-brand",
+      "fetch-ticket",
+      "get-retention-period",
+      "remove-organization-tag",
+      "remove-ticket-tag",
+      "resync-brand-metadata",
+      "resync-help-centers",
+      "resync-tickets",
+      "set-rate-limit",
+      "set-retention-period",
+      "sync-ticket",
+    ])
+  )
+  .allowUnknownOption(true)
+  .action(async (subcommand: string) => {
+    await dispatch("zendesk", subcommand);
+  });
+
+program.parseAsync(process.argv).catch((err: Error) => {
+  console.error(`\x1b[31mError: ${err.message}\x1b[0m`);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "axios": "^1.7.9",
         "body-parser": "^1.20.2",
         "botbuilder": "^4.23.3",
+        "commander": "^9.5.0",
         "crawlee": "3.14.1",
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.5.0",
@@ -24748,7 +24749,6 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
     "connectors": {
       "version": "0.1.0",
       "dependencies": {
+        "@commander-js/extra-typings": "^9.5.0",
         "@dust-tt/client": "file:../sdks/js",
         "@google-cloud/bigquery": "^7.9.2",
         "@google-cloud/resource-manager": "^6.2.1",
@@ -3359,6 +3360,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-9.5.0.tgz",
+      "integrity": "sha512-OdIzg8hLlFyiV3BOEd7yRMtrqZ+L+bjAjGILpeG0LKUlE+N68tjp65JqKhapqWMHS6nDGGt+KjDf1y+eOQjwfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "9.5.x"
       }
     },
     "node_modules/@connectrpc/connect": {


### PR DESCRIPTION
## Description

Migrates the connectors admin CLI (`connectors/src/admin/cli.ts`) from a hand-rolled minimist-based parser to Commander with full explicit option declarations.

Two commits:
1. **Commander structure** (`feat`): replaced the flat minimist entrypoint with a Commander program routing `<majorCommand> <subcommand>` pairs. Dynamic import of `lib/cli.ts` keeps `--help` instant (no connector code loaded). `allowUnknownOption(true)` + minimist handled option parsing in this first step.
2. **Explicit options** (`refactor`): removed minimist from the CLI entirely. Each connector command now declares all its options via `.option()`, and the action handler passes `command.opts()` directly to the zod validation layer. Commander's `parseInt` coercion is used for numeric fields (`connectorId`, `pageId`, etc.) matching `z.number()` in the schema; string fields stay as strings. `--help` on any connector now lists all accepted options.

The motivation for explicit declarations (beyond ergonomics) is to allow a future plugin to introspect the full option surface of each command via the Commander program object.

Next PR will use this to have a generic (and nice) Poke plugin to run the CLI (no more connection to prodbox, and we get audit)

## Tests

It runs in 1.3 seconds

```
➜ npm run cli -- confluence --help

> connectors@0.1.0 cli
> npx tsx src/admin/cli.ts confluence --help

Usage: cli confluence [options] <subcommand>

Confluence connector management

Options:
  --connectorId <id>     Connector ID
  --pageId <id>          Page ID
  --spaceId <id>         Space ID
  --file <path>          File path
  --keyInFile <key>      Key in file
  --url <url>            URL
  --forceUpsert <bool>   Force upsert ("true")
  --skipReason <reason>  Skip reason
  -h, --help             display help for command
```
## Risk

Low — internal admin tool only. The parsing behavior is equivalent: Commander string options pass through zod validation the same way minimist + `cliArg` preprocessor did. Numeric options use Commander `parseInt` coercion instead of minimist's auto-cast before hitting the same `z.number()` schema fields.
