### PR TITLE
fix: prevent ERR_STREAM_UNABLE_TO_PIPE for canonicalPath files endpoint

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -6,7 +6,6 @@ import {
   renameCanonicalFile,
   streamThumbnail,
 } from "@app/lib/api/files/file_system_ops";
-import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
@@ -163,21 +162,11 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const nodeStream = readResult.value;
-  const webStream = new ReadableStream({
-    start(controller) {
-      nodeStream.on("data", (chunk) => controller.enqueue(chunk));
-      nodeStream.on("end", () => controller.close());
-      nodeStream.on("error", (err) => {
-        logger.error({ err, canonicalPath }, "Error streaming canonical file");
-        controller.error(err);
-      });
-    },
-    cancel() {
-      nodeStream.destroy();
-    },
-  });
 
-  return new Response(webStream, { status: 200, headers });
+  return new Response(readableToReadableStream(nodeStream), {
+    status: 200,
+    headers,
+  });
 });
 
 app.on(


### PR DESCRIPTION


## Description

This PR applies the safe stream cancellation logic introduced in #26953 to the canonical file path endpoint:

`/w/:wId/files/path/[...canonicalPath]`

The normal file streaming branch in `front-api/routes/w/[wId]/files/path/[...canonicalPath].ts` was still manually wrapping the Node stream in a Web `ReadableStream` and calling `nodeStream.destroy()` from `cancel()`. This kept the endpoint vulnerable to the same `ERR_STREAM_UNABLE_TO_PIPE` crash when a client disconnected mid-download before the underlying GCS stream had finished setting up its internal pipeline.

Datadog error [here](https://app.datadoghq.eu/logs?query=%40panic%3Atrue%20region%3Aeurope-west1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ6xw437Qh6nDwAAABhBWjZ4dzUyLUFBRDR3SVR0R0p6bzNnQmgAAAAkZjE5ZWIxYzQtMTNkYS00ZGI0LWJiMTUtZmUzZTVlZDMyZWM4AABS2g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1781097081000&to_ts=1781098881000&live=false).

- Replaces the manual `new ReadableStream({ ... cancel() { nodeStream.destroy(); } })` wrapper with `readableToReadableStream(nodeStream)`.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low. Fix already applied in other endpoints.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Standard deployment.
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->


