### PR TITLE
fix(sandbox): align child tool approval keys with direct tool calls

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1236,7 +1236,7 @@ export async function listToolsForServerSideMCPServer(
   );
 }
 
-async function buildToolConfigurationsFromRawTools(
+export async function buildToolConfigurationsFromRawTools(
   auth: Authenticator,
   mcpServerId: string,
   config: ServerSideMCPServerConfigurationType,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -63,7 +63,7 @@ import {
   makeToolInterruptionError,
   shouldRetryToolInterruption,
 } from "@app/lib/actions/tool_interruptions";
-import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type {
   AgentLoopListToolsContextType,
   AgentLoopRunContextType,
@@ -1031,11 +1031,12 @@ export async function tryListMCPTools(
       const processedTools: MCPToolConfigurationType[] = [];
 
       for (const toolConfig of rawToolsFromServer) {
-        let toolName: string;
         // Fix the tool name to be valid for the model.
-        try {
-          toolName = getPrefixedToolName(action.name, toolConfig.name);
-        } catch (error) {
+        const toolNameRes = tryGetPrefixedToolName(
+          action.name,
+          toolConfig.name
+        );
+        if (toolNameRes.isErr()) {
           logger.warn(
             {
               workspaceId: owner.sId,
@@ -1044,12 +1045,13 @@ export async function tryListMCPTools(
               actionId: action.sId,
               mcpServerName: action.name,
               toolName: toolConfig.name,
-              error: error,
+              error: toolNameRes.error,
             },
             `Invalid tool name, skipping the tool.`
           );
           continue;
         }
+        const toolName = toolNameRes.value;
 
         // Check that all tools arguments names are valid for the model (a-zA-Z0-9_.-).
         const toolArgumentsNames = Object.keys(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -833,7 +833,7 @@ type AgentLoopListToolsContextWithoutConfigurationType = Omit<
  * When multiple server-side configs share the same name but have different viewIds (e.g.,
  * the same server in different spaces), prepends the space name to disambiguate them.
  */
-async function disambiguateServerNamesBySpace(
+export async function disambiguateServerNamesBySpace(
   auth: Authenticator,
   configs: MCPServerConfigurationType[]
 ): Promise<MCPServerConfigurationType[]> {
@@ -891,7 +891,7 @@ async function disambiguateServerNamesBySpace(
  * Deduplicates MCP server configurations by view ID and name.
  * Priority order: agent actions > client-side > skill servers > JIT servers.
  */
-function deduplicateMCPServerConfigurations({
+export function deduplicateMCPServerConfigurations({
   agentActions,
   clientSideActions,
   skillServers,

--- a/front/lib/actions/tool_name_utils.ts
+++ b/front/lib/actions/tool_name_utils.ts
@@ -1,12 +1,14 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { slugify } from "@app/types/shared/utils/string_utils";
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
-export function getPrefixedToolName(
+export function tryGetPrefixedToolName(
   serverName: string,
   originalName: string
-): string {
+): Result<string, Error> {
   // Slugify each part separately to preserve separators (used for space disambiguation notably).
   const slugifiedConfigName = serverName
     .split(TOOL_NAME_SEPARATOR)
@@ -22,8 +24,10 @@ export function getPrefixedToolName(
 
   // If the original name is already too long, we can't use it.
   if (slugifiedOriginalName.length > MAX_TOOL_NAME_LENGTH) {
-    throw new Error(
-      `Tool name "${originalName}" is too long. Maximum length is ${MAX_TOOL_NAME_LENGTH} characters.`
+    return new Err(
+      new Error(
+        `Tool name "${originalName}" is too long. Maximum length is ${MAX_TOOL_NAME_LENGTH} characters.`
+      )
     );
   }
 
@@ -33,7 +37,7 @@ export function getPrefixedToolName(
 
   // If we don't have enough room for a meaningful prefix, just return the original name
   if (availableSpace < minPrefixLength) {
-    return slugifiedOriginalName;
+    return new Ok(slugifiedOriginalName);
   }
 
   // Calculate the maximum allowed length for the config name portion
@@ -41,5 +45,19 @@ export function getPrefixedToolName(
   const truncatedConfigName = slugifiedConfigName.slice(0, maxConfigNameLength);
   const prefixedName = `${truncatedConfigName}${separator}${slugifiedOriginalName}`;
 
-  return prefixedName;
+  return new Ok(prefixedName);
+}
+
+// Throwing variant for call sites passing compile-time constant names (e.g.
+// tool references embedded in prompts), where a failure is a programming
+// error. Dynamic or user-provided names must use `tryGetPrefixedToolName`.
+export function getPrefixedToolName(
+  serverName: string,
+  originalName: string
+): string {
+  const result = tryGetPrefixedToolName(serverName, originalName);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
 }

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -18,6 +18,7 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
   }),
 }));
 
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
@@ -759,9 +760,19 @@ describe("validateAction", () => {
   async function createBlockedAction({
     agentMessageId,
     status = "blocked_validation_required",
+    functionCallName = "test_tool",
+    configurationName = "test_tool",
+    permission = "low",
+    argumentsRequiringApproval,
+    augmentedInputs = {},
   }: {
     agentMessageId: number;
     status?: ToolExecutionStatus;
+    functionCallName?: string;
+    configurationName?: string;
+    permission?: MCPToolStakeLevelType;
+    argumentsRequiringApproval?: string[];
+    augmentedInputs?: Record<string, unknown>;
   }) {
     const functionCallId = generateRandomModelSId();
     const currentIndex = stepContentIndex++;
@@ -778,7 +789,7 @@ describe("validateAction", () => {
         type: "function_call",
         value: {
           id: functionCallId,
-          name: "test_tool",
+          name: functionCallName,
           arguments: "{}",
         },
       },
@@ -789,7 +800,7 @@ describe("validateAction", () => {
       id: 1,
       sId: generateRandomModelSId(),
       type: "mcp_configuration",
-      name: "test_tool",
+      name: configurationName,
       dataSources: null,
       tables: null,
       childAgentId: null,
@@ -802,11 +813,12 @@ describe("validateAction", () => {
       dustProject: null,
       internalMCPServerId: null,
       availability: "auto",
-      permission: "low",
+      permission,
       toolServerId: "test-server",
       retryPolicy: "no_retry",
-      originalName: "test_tool",
+      originalName: configurationName,
       mcpServerName: "test_server",
+      argumentsRequiringApproval,
     };
 
     // Create MCP action
@@ -816,7 +828,7 @@ describe("validateAction", () => {
       mcpServerConfigurationId: generateRandomModelSId(),
       status,
       citationsAllocated: 0,
-      augmentedInputs: {},
+      augmentedInputs,
       toolConfiguration,
       stepContentId: stepContent.id,
       stepContext: {
@@ -1304,6 +1316,128 @@ describe("validateAction", () => {
       // Verify action status was updated to denied
       await action.reload();
       expect(action.status).toBe("denied");
+    });
+  });
+
+  describe("always_approved recording", () => {
+    // Creates the user message → agent message chain shared by both tests.
+    async function createAgentMessageChain() {
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      return { agentConfig, agentMessageRow, agentMessageMessage };
+    }
+
+    it("records medium-stake approvals under the tool configuration name, not the function-call name", async () => {
+      const { agentConfig, agentMessageRow, agentMessageMessage } =
+        await createAgentMessageChain();
+
+      // Sandbox child actions share their parent's step content, so the
+      // function-call name is the parent sandbox tool, not the child tool.
+      const { actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        functionCallName: "sandbox__bash",
+        configurationName: "salesforce__update_object",
+        permission: "medium",
+        argumentsRequiringApproval: ["objectName"],
+        augmentedInputs: { objectName: "Contact", records: [{ Id: "1" }] },
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await validateAction(auth, conversationResource!, {
+        actionId,
+        approvalState: "always_approved",
+        messageId: agentMessageMessage.sId,
+      });
+      expect(result.isOk()).toBe(true);
+
+      const user = auth.getNonNullableUser();
+      expect(
+        await user.hasApprovedTool(auth, {
+          mcpServerId: "test-server",
+          toolName: "salesforce__update_object",
+          agentId: agentConfig.sId,
+          argsAndValues: { objectName: "Contact" },
+        })
+      ).toBe(true);
+      expect(
+        await user.hasApprovedTool(auth, {
+          mcpServerId: "test-server",
+          toolName: "sandbox__bash",
+          agentId: agentConfig.sId,
+          argsAndValues: { objectName: "Contact" },
+        })
+      ).toBe(false);
+    });
+
+    it("records low-stake approvals under the tool configuration name, not the function-call name", async () => {
+      const { agentMessageRow, agentMessageMessage } =
+        await createAgentMessageChain();
+
+      const { actionId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+        functionCallName: "sandbox__bash",
+        configurationName: "salesforce__execute_read_query",
+        permission: "low",
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await validateAction(auth, conversationResource!, {
+        actionId,
+        approvalState: "always_approved",
+        messageId: agentMessageMessage.sId,
+      });
+      expect(result.isOk()).toBe(true);
+
+      const user = auth.getNonNullableUser();
+      expect(
+        await user.hasApprovedTool(auth, {
+          mcpServerId: "test-server",
+          toolName: "salesforce__execute_read_query",
+        })
+      ).toBe(true);
+      expect(
+        await user.hasApprovedTool(auth, {
+          mcpServerId: "test-server",
+          toolName: "sandbox__bash",
+        })
+      ).toBe(false);
     });
   });
 

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -1334,34 +1334,33 @@ describe("validateAction", () => {
         { name: "Test Agent" }
       );
 
-      const agentMessageRow = await AgentMessageModel.create({
-        workspaceId: workspace.id,
-        status: "created",
-        agentConfigurationId: agentConfig.sId,
-        agentConfigurationVersion: 0,
-        skipToolsValidation: false,
-      });
+      const agentMessageMessage =
+        await ConversationFactory.createAgentMessageWithRank({
+          workspace,
+          conversationId: conversation.id,
+          rank: 1,
+          agentConfigurationId: agentConfig.sId,
+          parentId: messageRow.id,
+        });
+      if (!agentMessageMessage.agentMessageId) {
+        throw new Error("Expected an agent message id on the message row.");
+      }
 
-      const agentMessageMessage = await MessageModel.create({
-        workspaceId: workspace.id,
-        sId: generateRandomModelSId(),
-        conversationId: conversation.id,
-        rank: 1,
-        parentId: messageRow.id,
-        agentMessageId: agentMessageRow.id,
-      });
-
-      return { agentConfig, agentMessageRow, agentMessageMessage };
+      return {
+        agentConfig,
+        agentMessageId: agentMessageMessage.agentMessageId,
+        agentMessageMessage,
+      };
     }
 
     it("records medium-stake approvals under the tool configuration name, not the function-call name", async () => {
-      const { agentConfig, agentMessageRow, agentMessageMessage } =
+      const { agentConfig, agentMessageId, agentMessageMessage } =
         await createAgentMessageChain();
 
       // Sandbox child actions share their parent's step content, so the
       // function-call name is the parent sandbox tool, not the child tool.
       const { actionId } = await createBlockedAction({
-        agentMessageId: agentMessageRow.id,
+        agentMessageId,
         functionCallName: "sandbox__bash",
         configurationName: "salesforce__update_object",
         permission: "medium",
@@ -1402,11 +1401,11 @@ describe("validateAction", () => {
     });
 
     it("records low-stake approvals under the tool configuration name, not the function-call name", async () => {
-      const { agentMessageRow, agentMessageMessage } =
+      const { agentMessageId, agentMessageMessage } =
         await createAgentMessageChain();
 
       const { actionId } = await createBlockedAction({
-        agentMessageId: agentMessageRow.id,
+        agentMessageId,
         functionCallName: "sandbox__bash",
         configurationName: "salesforce__execute_read_query",
         permission: "low",

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -109,9 +109,13 @@ export async function validateAction(
   if (approvalState === "always_approved" && user) {
     switch (action.toolConfiguration.permission) {
       case "low":
+        // Key the approval on the configuration name, not the step content's
+        // function-call name: sandbox child actions share their parent's step
+        // content, so `action.functionCallName` would be the parent sandbox
+        // tool there. Both names are identical for direct tool calls.
         await setUserAlwaysApprovedTool(auth, {
           mcpServerId: action.toolConfiguration.toolServerId,
-          functionCallName: action.functionCallName,
+          functionCallName: action.toolConfiguration.name,
         });
         break;
       case "medium":
@@ -129,9 +133,11 @@ export async function validateAction(
             action.augmentedInputs
           );
 
+          // Same as the "low" case: use the configuration name so sandbox
+          // child approvals are keyed on the tool, not the parent sandbox tool.
           await user.createToolApproval(auth, {
             mcpServerId: action.toolConfiguration.toolServerId,
-            toolName: action.functionCallName,
+            toolName: action.toolConfiguration.name,
             agentId: agentMessage.agentConfigurationId,
             argsAndValues,
           });

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -28,10 +28,8 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
-import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -108,12 +106,11 @@ describe("createSandboxChildAction", () => {
 
     // Parent sandbox bash action whose step content carries the sandbox tool
     // function-call name, as in production.
-    const stepContent = await AgentStepContentModel.create({
+    const stepContent = await AgentStepContentResource.createNewVersion({
       workspaceId: workspace.id,
       agentMessageId: agentMessage.agentMessageId,
       step: 0,
       index: 0,
-      version: 0,
       type: "function_call",
       value: {
         type: "function_call",
@@ -147,34 +144,27 @@ describe("createSandboxChildAction", () => {
       originalName: "bash",
       mcpServerName: "sandbox",
     };
-    const parentAction = await AgentMCPActionModel.create({
-      workspaceId: workspace.id,
-      agentMessageId: agentMessage.agentMessageId,
-      mcpServerConfigurationId: generateRandomModelSId(),
-      status: "running",
-      citationsAllocated: 0,
-      augmentedInputs: {},
-      toolConfiguration: parentToolConfiguration,
-      stepContentId: stepContent.id,
-      stepContext: {
-        citationsCount: 0,
-        citationsOffset: 0,
-        resumeState: null,
-        retrievalTopK: 10,
-        websearchResultCount: 5,
-      },
-    });
-    await AgentStepContentToolExecutionModel.create({
-      workspaceId: workspace.id,
-      conversationId: conversation.id,
-      agentMessageId: agentMessage.agentMessageId,
-      agentMCPActionId: parentAction.id,
-      stepContentId: stepContent.id,
-    });
-    parentActionId = AgentMCPActionResource.modelIdToSId({
-      id: parentAction.id,
-      workspaceId: workspace.id,
-    });
+    const parentAction = await AgentMCPActionResource.makeNew(
+      auth,
+      { conversation: conversationResult.value, stepContent },
+      {
+        agentMessageId: agentMessage.agentMessageId,
+        augmentedInputs: {},
+        citationsAllocated: 0,
+        mcpServerConfigurationId: generateRandomModelSId(),
+        status: "running",
+        stepContentId: stepContent.id,
+        stepContext: {
+          citationsCount: 0,
+          citationsOffset: 0,
+          resumeState: null,
+          retrievalTopK: 10,
+          websearchResultCount: 5,
+        },
+        toolConfiguration: parentToolConfiguration,
+      }
+    );
+    parentActionId = parentAction.sId;
   });
 
   async function callChildTool(
@@ -191,12 +181,15 @@ describe("createSandboxChildAction", () => {
     });
   }
 
-  async function setToolPermission(permission: "medium" | "never_ask") {
+  async function setToolPermission(
+    permission: "medium" | "never_ask",
+    { enabled = true }: { enabled?: boolean } = {}
+  ) {
     await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
       serverSId,
       toolName: TOOL_NAME,
       permission,
-      enabled: true,
+      enabled,
     });
   }
 
@@ -221,7 +214,6 @@ describe("createSandboxChildAction", () => {
 
     const result = await callChildTool();
 
-    expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
@@ -251,7 +243,6 @@ describe("createSandboxChildAction", () => {
 
     const result = await callChildTool();
 
-    expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
@@ -274,7 +265,6 @@ describe("createSandboxChildAction", () => {
 
     const result = await callChildTool();
 
-    expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }
@@ -288,10 +278,24 @@ describe("createSandboxChildAction", () => {
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects tools disabled by an admin", async () => {
+    await setToolPermission("never_ask", { enabled: false });
+
+    const result = await callChildTool();
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("Expected the disabled tool call to fail.");
+    }
+    expect(result.error.message).toBe(
+      "Tool is not available to this agent or conversation."
+    );
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
   it("defaults to high stake and blocks when the tool has no configured permission", async () => {
     const result = await callChildTool();
 
-    expect(result.isOk()).toBe(true);
     if (result.isErr()) {
       throw result.error;
     }

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -60,7 +60,7 @@ describe("createSandboxChildAction", () => {
   let conversation: ConversationType;
   let agentMessage: AgentMessageType;
   let view: MCPServerViewResource;
-  let serverSId: string;
+  let serverId: string;
   let parentActionId: string;
 
   beforeEach(async () => {
@@ -79,7 +79,7 @@ describe("createSandboxChildAction", () => {
         },
       ],
     });
-    serverSId = server.sId;
+    serverId = server.sId;
     view = await MCPServerViewFactory.create(
       workspace,
       server.sId,
@@ -191,7 +191,7 @@ describe("createSandboxChildAction", () => {
     { enabled = true }: { enabled?: boolean } = {}
   ) {
     await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
-      serverSId,
+      serverSId: serverId,
       toolName: TOOL_NAME,
       permission,
       enabled,
@@ -240,7 +240,7 @@ describe("createSandboxChildAction", () => {
     // prior "always approve" on a direct (non-sandbox) call records.
     const directCallToolName = await getDirectCallToolName();
     await auth.getNonNullableUser().createToolApproval(auth, {
-      mcpServerId: serverSId,
+      mcpServerId: serverId,
       toolName: directCallToolName,
       agentId: agentConfig.sId,
       argsAndValues: {},
@@ -305,7 +305,7 @@ describe("createSandboxChildAction", () => {
     });
     const otherView = await MCPServerViewFactory.create(
       workspace,
-      serverSId,
+      serverId,
       refreshedOtherSpace
     );
     await AgentMCPServerConfigurationFactory.create(auth, refreshedOtherSpace, {
@@ -334,7 +334,7 @@ describe("createSandboxChildAction", () => {
     );
 
     await auth.getNonNullableUser().createToolApproval(auth, {
-      mcpServerId: serverSId,
+      mcpServerId: serverId,
       toolName: disambiguatedKey,
       agentId: agentConfig.sId,
       argsAndValues: {},

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Prevent the Temporal child-tool workflow from actually starting.
+vi.mock(import("@app/temporal/agent_loop/client"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    launchSandboxChildToolWorkflow: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// The blocked path publishes the approval event to Redis; keep it out of tests.
+vi.mock(
+  import("@app/temporal/agent_loop/activities/common"),
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      ...mod,
+      updateResourceAndPublishEvent: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+);
+
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPServerConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentMessageType,
+  ConversationType,
+} from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+
+const TOOL_NAME = "tool";
+
+describe("createSandboxChildAction", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let agentConfig: AgentConfigurationType;
+  let conversation: ConversationType;
+  let agentMessage: AgentMessageType;
+  let view: MCPServerViewResource;
+  let serverSId: string;
+  let parentActionId: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const setup = await createResourceTest({ role: "admin" });
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      tools: [
+        {
+          name: TOOL_NAME,
+          description: "Tool description",
+          inputSchema: undefined,
+        },
+      ],
+    });
+    serverSId = server.sId;
+    view = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      setup.globalSpace
+    );
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth);
+    await AgentMCPServerConfigurationFactory.create(auth, setup.globalSpace, {
+      agent: agentConfig,
+      mcpServerView: view,
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversationResult = await getConversation(auth, conversation.sId);
+    if (conversationResult.isErr()) {
+      throw conversationResult.error;
+    }
+    const foundAgentMessage = conversationResult.value.content
+      .flat()
+      .find((m): m is AgentMessageType => m.type === "agent_message");
+    if (!foundAgentMessage) {
+      throw new Error("Expected an agent message in the test conversation.");
+    }
+    agentMessage = foundAgentMessage;
+
+    // Parent sandbox bash action whose step content carries the sandbox tool
+    // function-call name, as in production.
+    const stepContent = await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: 0,
+      index: 0,
+      version: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          id: generateRandomModelSId(),
+          name: "sandbox__bash",
+          arguments: "{}",
+        },
+      },
+    });
+    const parentToolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "sandbox__bash",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "sandbox-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "manual",
+      permission: "never_ask",
+      toolServerId: "sandbox-server",
+      retryPolicy: "no_retry",
+      originalName: "bash",
+      mcpServerName: "sandbox",
+    };
+    const parentAction = await AgentMCPActionModel.create({
+      workspaceId: workspace.id,
+      agentMessageId: agentMessage.agentMessageId,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      status: "running",
+      citationsAllocated: 0,
+      augmentedInputs: {},
+      toolConfiguration: parentToolConfiguration,
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+    await AgentStepContentToolExecutionModel.create({
+      workspaceId: workspace.id,
+      conversationId: conversation.id,
+      agentMessageId: agentMessage.agentMessageId,
+      agentMCPActionId: parentAction.id,
+      stepContentId: stepContent.id,
+    });
+    parentActionId = AgentMCPActionResource.modelIdToSId({
+      id: parentAction.id,
+      workspaceId: workspace.id,
+    });
+  });
+
+  async function callChildTool(
+    rawInputs: Record<string, unknown> = { objectName: "Contact" }
+  ) {
+    return createSandboxChildAction(auth, {
+      parentActionId,
+      agentId: agentConfig.sId,
+      conversationId: conversation.sId,
+      agentMessageId: agentMessage.sId,
+      serverViewId: view.sId,
+      toolName: TOOL_NAME,
+      rawInputs,
+    });
+  }
+
+  async function setToolPermission(permission: "medium" | "never_ask") {
+    await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
+      serverSId,
+      toolName: TOOL_NAME,
+      permission,
+      enabled: true,
+    });
+  }
+
+  // Resolves the function-call name the model sees on direct calls for this
+  // tool, going through the same agent configuration the child path uses.
+  async function getDirectCallToolName(): Promise<string> {
+    const fullConfig = await getAgentConfiguration(auth, {
+      agentId: agentConfig.sId,
+      variant: "full",
+    });
+    const serverConfig = fullConfig?.actions
+      .filter(isServerSideMCPServerConfiguration)
+      .find((a) => a.mcpServerViewId === view.sId);
+    if (!serverConfig) {
+      throw new Error("Expected the MCP server to be attached to the agent.");
+    }
+    return getPrefixedToolName(serverConfig.name, TOOL_NAME);
+  }
+
+  it("blocks medium-stake tools when the user has no matching approval", async () => {
+    await setToolPermission("medium");
+
+    const result = await callChildTool();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.pauseSandbox).toBeDefined();
+
+    const child = await AgentMCPActionResource.fetchById(
+      auth,
+      result.value.actionId
+    );
+    expect(child?.status).toBe("blocked_validation_required");
+    expect(child?.toolConfiguration.permission).toBe("medium");
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).not.toHaveBeenCalled();
+  });
+
+  it("auto-approves medium-stake tools when an approval recorded on a direct call exists", async () => {
+    await setToolPermission("medium");
+
+    // Approvals are keyed on the prefixed function-call name; this is what a
+    // prior "always approve" on a direct (non-sandbox) call records.
+    const directCallToolName = await getDirectCallToolName();
+    await auth.getNonNullableUser().createToolApproval(auth, {
+      mcpServerId: serverSId,
+      toolName: directCallToolName,
+      agentId: agentConfig.sId,
+      argsAndValues: {},
+    });
+
+    const result = await callChildTool();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.pauseSandbox).toBeUndefined();
+
+    const child = await AgentMCPActionResource.fetchById(
+      auth,
+      result.value.actionId
+    );
+    expect(child?.status).toBe("ready_allowed_implicitly");
+    // The child configuration must carry the same function-call name as direct
+    // calls so approval checks and recordings share one key.
+    expect(child?.toolConfiguration.name).toBe(directCallToolName);
+    expect(child?.toolConfiguration.originalName).toBe(TOOL_NAME);
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs never_ask tools without requesting approval", async () => {
+    await setToolPermission("never_ask");
+
+    const result = await callChildTool();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.pauseSandbox).toBeUndefined();
+
+    const child = await AgentMCPActionResource.fetchById(
+      auth,
+      result.value.actionId
+    );
+    expect(child?.status).toBe("ready_allowed_implicitly");
+    expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to high stake and blocks when the tool has no configured permission", async () => {
+    const result = await callChildTool();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.pauseSandbox).toBeDefined();
+
+    const child = await AgentMCPActionResource.fetchById(
+      auth,
+      result.value.actionId
+    );
+    expect(child?.status).toBe("blocked_validation_required");
+    expect(child?.toolConfiguration.permission).toBe("high");
+  });
+});

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -21,17 +21,19 @@ vi.mock(
   }
 );
 
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -40,11 +42,13 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
+import { slugify } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 
 const TOOL_NAME = "tool";
@@ -168,14 +172,15 @@ describe("createSandboxChildAction", () => {
   });
 
   async function callChildTool(
-    rawInputs: Record<string, unknown> = { objectName: "Contact" }
+    rawInputs: Record<string, unknown> = { objectName: "Contact" },
+    { serverViewId = view.sId }: { serverViewId?: string } = {}
   ) {
     return createSandboxChildAction(auth, {
       parentActionId,
       agentId: agentConfig.sId,
       conversationId: conversation.sId,
       agentMessageId: agentMessage.sId,
-      serverViewId: view.sId,
+      serverViewId,
       toolName: TOOL_NAME,
       rawInputs,
     });
@@ -276,6 +281,79 @@ describe("createSandboxChildAction", () => {
     );
     expect(child?.status).toBe("ready_allowed_implicitly");
     expect(vi.mocked(launchSandboxChildToolWorkflow)).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys approvals on the space-disambiguated name when same-named servers are attached", async () => {
+    await setToolPermission("medium");
+
+    // Attach a second view of the same server from another space. The direct
+    // path space-prefixes both colliding config names before prefixing tools,
+    // so approval keys carry the space name.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const otherSpace = await SpaceFactory.regular(workspace);
+    const refreshedOtherSpace = await SpaceResource.fetchById(
+      adminAuth,
+      otherSpace.sId
+    );
+    if (!refreshedOtherSpace) {
+      throw new Error("Expected the other space to exist.");
+    }
+    await refreshedOtherSpace.addMembers(adminAuth, {
+      userIds: [auth.getNonNullableUser().sId],
+    });
+    const otherView = await MCPServerViewFactory.create(
+      workspace,
+      serverSId,
+      refreshedOtherSpace
+    );
+    await AgentMCPServerConfigurationFactory.create(auth, refreshedOtherSpace, {
+      agent: agentConfig,
+      mcpServerView: otherView,
+    });
+    // Refresh auth so the new space membership is visible to the child path.
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      auth.getNonNullableUser().sId,
+      workspace.sId
+    );
+
+    const fullConfig = await getAgentConfiguration(auth, {
+      agentId: agentConfig.sId,
+      variant: "full",
+    });
+    const rawConfigName = fullConfig?.actions
+      .filter(isServerSideMCPServerConfiguration)
+      .find((a) => a.mcpServerViewId === otherView.sId)?.name;
+    if (!rawConfigName) {
+      throw new Error("Expected the second MCP server view on the agent.");
+    }
+    const disambiguatedKey = getPrefixedToolName(
+      `${slugify(refreshedOtherSpace.name)}${TOOL_NAME_SEPARATOR}${rawConfigName}`,
+      TOOL_NAME
+    );
+
+    await auth.getNonNullableUser().createToolApproval(auth, {
+      mcpServerId: serverSId,
+      toolName: disambiguatedKey,
+      agentId: agentConfig.sId,
+      argsAndValues: {},
+    });
+
+    const result = await callChildTool(undefined, {
+      serverViewId: otherView.sId,
+    });
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.pauseSandbox).toBeUndefined();
+
+    const child = await AgentMCPActionResource.fetchById(
+      auth,
+      result.value.actionId
+    );
+    expect(child?.status).toBe("ready_allowed_implicitly");
+    expect(child?.toolConfiguration.name).toBe(disambiguatedKey);
   });
 
   it("rejects tools disabled by an admin", async () => {

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -2,16 +2,19 @@ import {
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
 } from "@app/lib/actions/constants";
-import { makeServerSideMCPToolConfigurations } from "@app/lib/actions/mcp_actions";
+import {
+  getToolExtraFields,
+  makeServerSideMCPToolConfigurations,
+} from "@app/lib/actions/mcp_actions";
 import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerDisplayedAs,
   getInternalMCPServerNameFromSId,
-  getInternalMCPServerToolStakes,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -25,6 +28,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
@@ -123,20 +127,39 @@ export async function createSandboxChildAction(
     );
   }
 
+  // Resolve stakes, enabled state and approval-requiring arguments exactly like
+  // the direct agent-loop path (`buildToolConfigurationsFromRawTools`), so that
+  // approvals recorded on direct tool calls apply to sandbox child calls too.
+  const metadata = await RemoteMCPServerToolMetadataResource.fetchByServerId(
+    auth,
+    view.mcpServerId
+  );
+  const extraFieldsRes = getToolExtraFields(view.mcpServerId, metadata);
+  if (extraFieldsRes.isErr()) {
+    return extraFieldsRes;
+  }
+  const {
+    toolsEnabled,
+    toolsStakes,
+    toolsRetryPolicies,
+    serverTimeoutMs,
+    toolsArgumentsRequiringApproval,
+  } = extraFieldsRes.value;
+
+  if (toolsEnabled[toolName] === false) {
+    return new Err(new Error("Tool is disabled for this server."));
+  }
+
   const availability = getAvailabilityOfInternalMCPServerById(view.mcpServerId);
-  const internalServerName = getInternalMCPServerNameFromSId(view.mcpServerId);
-  const serverDefaultStake = internalServerName
-    ? getInternalMCPServerToolStakes(internalServerName)[toolName]
-    : undefined;
 
   const stakeLevel =
-    view.getToolPermission(toolName) ??
-    serverDefaultStake ??
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    toolsStakes[toolName] ||
     (availability === "manual"
       ? FALLBACK_MCP_TOOL_STAKE_LEVEL
       : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL);
 
-  const [fullToolConfiguration] = makeServerSideMCPToolConfigurations(
+  const [toolConfiguration] = makeServerSideMCPToolConfigurations(
     serverSideConfig,
     [
       {
@@ -145,16 +168,32 @@ export async function createSandboxChildAction(
         availability,
         stakeLevel,
         toolServerId: view.mcpServerId,
-        retryPolicy: DEFAULT_MCP_TOOL_RETRY_POLICY,
+        ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
+        retryPolicy:
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          toolsRetryPolicies?.[toolName] ||
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          toolsRetryPolicies?.["default"] ||
+          DEFAULT_MCP_TOOL_RETRY_POLICY,
       },
-    ]
+    ],
+    toolsArgumentsRequiringApproval
   );
 
-  if (!fullToolConfiguration) {
+  if (!toolConfiguration) {
     return new Err(
       new Error("Tool is not available to this agent or conversation.")
     );
   }
+
+  // User tool approvals ("low"/"medium" stakes) are keyed on the prefixed
+  // function-call name the model sees on direct calls (e.g.
+  // `salesforce__update_object`), while `dsbx` sends the raw tool name. Align
+  // the configuration name so approval checks and recordings share one key.
+  const fullToolConfiguration = {
+    ...toolConfiguration,
+    name: getPrefixedToolName(serverSideConfig.name, toolName),
+  };
 
   const validateInputsResult = validateToolInputs(rawInputs);
   if (validateInputsResult.isErr()) {

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -6,7 +6,7 @@ import {
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
-import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -24,7 +24,6 @@ import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client"
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export type CreateSandboxChildActionResult = {
   actionId: string;
@@ -144,18 +143,17 @@ export async function createSandboxChildAction(
   // function-call name the model sees on direct calls (e.g.
   // `salesforce__update_object`), while `dsbx` sends the raw tool name. Align
   // the configuration name so approval checks and recordings share one key.
-  // `getPrefixedToolName` throws on oversized tool names; `toolName` is
-  // sandbox-workload-controlled input, so surface that as a request error.
-  let prefixedToolName: string;
-  try {
-    prefixedToolName = getPrefixedToolName(serverSideConfig.name, toolName);
-  } catch (err) {
-    return new Err(normalizeError(err));
+  const prefixedToolNameRes = tryGetPrefixedToolName(
+    serverSideConfig.name,
+    toolName
+  );
+  if (prefixedToolNameRes.isErr()) {
+    return prefixedToolNameRes;
   }
 
   const fullToolConfiguration = {
     ...toolConfiguration,
-    name: prefixedToolName,
+    name: prefixedToolNameRes.value,
   };
 
   const validateInputsResult = validateToolInputs(rawInputs);

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -1,13 +1,5 @@
+import { buildToolConfigurationsFromRawTools } from "@app/lib/actions/mcp_actions";
 import {
-  FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
-  FALLBACK_MCP_TOOL_STAKE_LEVEL,
-} from "@app/lib/actions/constants";
-import {
-  getToolExtraFields,
-  makeServerSideMCPToolConfigurations,
-} from "@app/lib/actions/mcp_actions";
-import {
-  getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerDisplayedAs,
   getInternalMCPServerNameFromSId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -21,19 +13,18 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
-import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export type CreateSandboxChildActionResult = {
   actionId: string;
@@ -127,58 +118,21 @@ export async function createSandboxChildAction(
     );
   }
 
-  // Resolve stakes, enabled state and approval-requiring arguments exactly like
-  // the direct agent-loop path (`buildToolConfigurationsFromRawTools`), so that
-  // approvals recorded on direct tool calls apply to sandbox child calls too.
-  const metadata = await RemoteMCPServerToolMetadataResource.fetchByServerId(
+  // Resolve the tool configuration (stake, enabled state, approval-requiring
+  // arguments, retry policy, timeout) through the same code path as direct
+  // agent-loop tool calls, so that approvals recorded on direct calls apply to
+  // sandbox child calls too.
+  const toolConfigurationsRes = await buildToolConfigurationsFromRawTools(
     auth,
-    view.mcpServerId
-  );
-  const extraFieldsRes = getToolExtraFields(view.mcpServerId, metadata);
-  if (extraFieldsRes.isErr()) {
-    return extraFieldsRes;
-  }
-  const {
-    toolsEnabled,
-    toolsStakes,
-    toolsRetryPolicies,
-    serverTimeoutMs,
-    toolsArgumentsRequiringApproval,
-  } = extraFieldsRes.value;
-
-  if (toolsEnabled[toolName] === false) {
-    return new Err(new Error("Tool is disabled for this server."));
-  }
-
-  const availability = getAvailabilityOfInternalMCPServerById(view.mcpServerId);
-
-  const stakeLevel =
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    toolsStakes[toolName] ||
-    (availability === "manual"
-      ? FALLBACK_MCP_TOOL_STAKE_LEVEL
-      : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL);
-
-  const [toolConfiguration] = makeServerSideMCPToolConfigurations(
+    view.mcpServerId,
     serverSideConfig,
-    [
-      {
-        name: toolName,
-        description: "",
-        availability,
-        stakeLevel,
-        toolServerId: view.mcpServerId,
-        ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
-        retryPolicy:
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          toolsRetryPolicies?.[toolName] ||
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          toolsRetryPolicies?.["default"] ||
-          DEFAULT_MCP_TOOL_RETRY_POLICY,
-      },
-    ],
-    toolsArgumentsRequiringApproval
+    [{ name: toolName, description: "" }]
   );
+  if (toolConfigurationsRes.isErr()) {
+    return toolConfigurationsRes;
+  }
+  // Empty when the tool has been disabled by an admin.
+  const [toolConfiguration] = toolConfigurationsRes.value;
 
   if (!toolConfiguration) {
     return new Err(
@@ -190,9 +144,18 @@ export async function createSandboxChildAction(
   // function-call name the model sees on direct calls (e.g.
   // `salesforce__update_object`), while `dsbx` sends the raw tool name. Align
   // the configuration name so approval checks and recordings share one key.
+  // `getPrefixedToolName` throws on oversized tool names; `toolName` is
+  // sandbox-workload-controlled input, so surface that as a request error.
+  let prefixedToolName: string;
+  try {
+    prefixedToolName = getPrefixedToolName(serverSideConfig.name, toolName);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+
   const fullToolConfiguration = {
     ...toolConfiguration,
-    name: getPrefixedToolName(serverSideConfig.name, toolName),
+    name: prefixedToolName,
   };
 
   const validateInputsResult = validateToolInputs(rawInputs);

--- a/front/lib/api/sandbox/create_child_action.ts
+++ b/front/lib/api/sandbox/create_child_action.ts
@@ -1,4 +1,8 @@
-import { buildToolConfigurationsFromRawTools } from "@app/lib/actions/mcp_actions";
+import {
+  buildToolConfigurationsFromRawTools,
+  deduplicateMCPServerConfigurations,
+  disambiguateServerNamesBySpace,
+} from "@app/lib/actions/mcp_actions";
 import {
   getInternalMCPServerDisplayedAs,
   getInternalMCPServerNameFromSId,
@@ -13,6 +17,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getUserMessageIdFromMessageId } from "@app/lib/api/assistant/conversation/messages";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
+import { resolveSkillMCPServers } from "@app/lib/api/assistant/skill_actions";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import { pauseSandboxBashForBlockedChild } from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
@@ -97,19 +102,34 @@ export async function createSandboxChildAction(
     return new Err(new Error("Agent message not found."));
   }
 
-  // JIT servers cover tools added via the conversation input bar.
-  let serverSideConfig = agentConfiguration.actions
+  // JIT servers cover tools added via the conversation input bar, skill
+  // servers cover tools attached through skills. Resolve the server config
+  // through the same deduplication and space-name disambiguation as the direct
+  // agent-loop path (`tryListMCPTools`): when several configs share a name
+  // across spaces, the model-visible name is space-prefixed, and approval keys
+  // are derived from it.
+  const { servers: jitServers } = await getJITServers(auth, {
+    agentConfiguration,
+    conversation,
+    attachments: [],
+  });
+  const skillServers = await resolveSkillMCPServers(auth, {
+    agentConfiguration,
+    conversation,
+  });
+
+  const serverConfigs = await disambiguateServerNamesBySpace(
+    auth,
+    deduplicateMCPServerConfigurations({
+      agentActions: agentConfiguration.actions,
+      clientSideActions: [],
+      skillServers,
+      jitServers,
+    })
+  );
+  const serverSideConfig = serverConfigs
     .filter(isServerSideMCPServerConfiguration)
     .find((a) => a.mcpServerViewId === view.sId);
-
-  if (!serverSideConfig) {
-    const { servers: jitServers } = await getJITServers(auth, {
-      agentConfiguration,
-      conversation,
-      attachments: [],
-    });
-    serverSideConfig = jitServers.find((s) => s.mcpServerViewId === view.sId);
-  }
 
   if (!serverSideConfig) {
     return new Err(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1,4 +1,3 @@
-import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   autoInternalMCPServerNameToSId,
   getServerTypeAndIdFromSId,
@@ -1190,11 +1189,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       ...(this.internalToolsMetadata ?? []),
       ...(this.remoteToolsMetadata ?? []),
     ];
-  }
-
-  getToolPermission(toolName: string): MCPToolStakeLevelType | undefined {
-    return this.allToolsMetadata.find((m) => m.toolName === toolName)
-      ?.permission;
   }
 
   // Serialization.


### PR DESCRIPTION
## Description

Tools invoked through the sandbox (`dsbx tools ...`) re-prompted for approval on every call, even after "always approve" (dust-tt/tasks#8759).

Two key mismatches against the direct tool-call path:

- The child action's tool configuration used the raw tool name (`update_object`) while user approvals are keyed on the prefixed function-call name (`salesforce__update_object`), and it never wired `argumentsRequiringApproval`. The medium/low stake approval check could never match an existing approval.
- "Always approve" on a child action recorded the approval under `action.functionCallName`, which for sandbox children is the parent bash function-call name (they share the parent's step content). The recorded row could never match anything.

Fix: `createSandboxChildAction` now resolves the server config through the same dedup + space-name disambiguation as `tryListMCPTools` (so colliding names across spaces produce the same `space__server__tool` key), builds the tool configuration through `buildToolConfigurationsFromRawTools` (stake, enabled state, `argumentsRequiringApproval`, retry policy, timeout), then sets the configuration name to the prefixed function-call name. `validateAction` records approvals under `toolConfiguration.name` (identical to `functionCallName` for direct calls, correct for children).

Drive-by 🚗:

- Child calls now pick up per-tool retry policy and server timeout, and reject admin-disabled tools (previously always `DEFAULT_MCP_TOOL_RETRY_POLICY`, no timeout, no enabled check).
- Skill-attached servers are now resolvable by `/sandbox/actions/call` (the GET list endpoint exposed them, but `/call` only searched agent actions and JIT servers).
- Added `tryGetPrefixedToolName` returning a `Result` and used it at the dynamic call sites (direct tool listing, sandbox child), removing try/catch around our own error. The throwing variant remains for compile-time constant names embedded in prompts.
- Removed `MCPServerViewResource.getToolPermission`, dead after this change.

## Tests

- New `create_child_action.test.ts`: medium stake blocks without approval, auto-approves with an approval recorded under the direct-call name, `never_ask` runs without prompting, defaults to high for unconfigured remote tools, rejects admin-disabled tools, and keys approvals on the space-disambiguated name when two same-named servers are attached.
- New cases in `validate_actions.test.ts`: medium and low "always approve" record under the configuration name, not the step-content function-call name.
- Verified the root cause against production data from the affected workspace (approval rows keyed `salesforce__update_object` vs child checks on `update_object`, plus a stray `sandbox__bash` row recorded against the Salesforce server).

## Risk

Low. For direct tool calls `toolConfiguration.name` equals the function-call name, so recording is unchanged there. Child calls now resolve stakes through the same helpers as direct calls; the fallback levels are unchanged. Safe to rollback.

## Deploy Plan

Standard deploy.