### PR TITLE
[front] Frames: release the v2 prompt for everyone

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front-api/routes/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -12,7 +12,6 @@ import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import { hasFeatureFlag } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { constructProjectContext } from "@app/lib/resources/skill/code_defined/projects";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -209,7 +208,6 @@ app.post(
     });
 
     const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
-    const useFramesV2 = await hasFeatureFlag(auth, "frames_skill_v2");
 
     const promptSections = constructPromptMultiActions(auth, {
       userMessage,
@@ -226,7 +224,6 @@ app.post(
       equippedSkills,
       projectContext,
       isNewFileExplorer,
-      useFramesV2,
     });
     const prompt = systemPromptToText(promptSections);
     const leadingMessages = removeNulls([
@@ -265,7 +262,6 @@ app.post(
       agentConfiguration,
       leadingMessages,
       enabledSkills,
-      useFramesV2,
     });
 
     if (convoRes.isErr()) {

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -16,7 +16,7 @@ import {
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
 
-export const INTERACTIVE_CONTENT_TOOLS_PROSE_BEFORE_AUTHORING = `\
+const INTERACTIVE_CONTENT_TOOLS_PROSE_BEFORE_AUTHORING = `\
 ## CREATING VISUALIZATIONS WITH INTERACTIVE CONTENT
 
 You have access to an Interactive Content system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
@@ -148,7 +148,7 @@ Fix syntax errors before the file can be created/edited.
 - Renaming only changes the file name; the content remains unchanged
 `;
 
-export const INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING = `\
+const INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING = `\
 - When to Create Files:
   - Create files for data visualizations such as graphs, charts, and plots
   - Create files for complex visualizations that require user interaction

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -1,14 +1,6 @@
 import {
-  VIZ_CHART_EXAMPLES,
-  VIZ_FILE_HANDLING_GUIDELINES,
-  VIZ_FRAME_IMPORT_EXAMPLE,
-  VIZ_LIBRARY_USAGE,
   VIZ_MIME_TYPE,
-  VIZ_MISCELLANEOUS_GUIDELINES,
-  VIZ_REACT_COMPONENT_GUIDELINES,
   VIZ_SLIDESHOW_MIME_TYPE,
-  VIZ_STYLING_GUIDELINES,
-  VIZ_USE_FILE_EXAMPLES,
 } from "@app/lib/api/actions/servers/common/viz/instructions";
 import {
   INTERACTIVE_CONTENT_AUTHORING_PROSE_V2,
@@ -156,106 +148,7 @@ Fix syntax errors before the file can be created/edited.
 - Renaming only changes the file name; the content remains unchanged
 `;
 
-export const INTERACTIVE_CONTENT_AUTHORING_PROSE_DEFAULT = `\
-${VIZ_REACT_COMPONENT_GUIDELINES}
-
-${VIZ_STYLING_GUIDELINES}
-
-${VIZ_FILE_HANDLING_GUIDELINES}
-
-${VIZ_LIBRARY_USAGE}
-
-${VIZ_MISCELLANEOUS_GUIDELINES}
-`;
-
 export const INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING = `\
-- When to Create Files:
-  - Create files for data visualizations such as graphs, charts, and plots
-  - Create files for complex visualizations that require user interaction
-  - Create files for slideshow presentations (use the Slideshow component)
-  - Do not create files for simple text-based content that can be rendered in Markdown
-  - Do not create files for content that does not require user interaction
-
-### Slideshows
-
-When the user asks for a presentation, slideshow, deck, or multi-slide content, create an interactive
-content file using the \`Slideshow\` and \`Slide\` components.
-
-**MIME type:** Always set \`mime_type\` to \`${VIZ_SLIDESHOW_MIME_TYPE}\` when creating a slideshow.
-
-**Import:** \`import { Slideshow, Slide } from "@dust/slideshow/v2";\`
-
-**Components:**
-- \`<Slideshow>\` wraps all slides. It handles navigation (prev/next arrows, dot indicators, keyboard
-  arrow keys) and PDF export automatically. Accepts an optional \`className\` prop.
-- \`<Slide>\` represents one slide. Each slide takes the full viewport height, centers its children,
-  and accepts a \`className\` prop (commonly used for background colors like \`bg-slate-50\`).
-  Inside a \`<Slide>\`, use any React and Tailwind — standard HTML elements, Recharts charts,
-  grid layouts, etc.
-
-**Content guidelines:**
-- One main idea per slide. Avoid overcrowding.
-- Use a consistent background color across slides for cohesion (e.g. all \`bg-white\` or all \`bg-slate-50\`).
-  Use 1-2 accent colors for emphasis elements.
-- Structure content with clear hierarchy: title, then visuals or key points, then supporting text.
-- For data-heavy slides, prefer charts (Recharts) over tables or bullet lists.
-
-**Do not:**
-- Do not build navigation controls (buttons, arrows, dots, keyboard handlers). They are built in.
-- Do not import from \`@dust/slideshow/v1\`. Always use \`@dust/slideshow/v2\`.
-- Do not set explicit heights on \`<Slide>\` — it fills the viewport automatically.
-- Do not use gradients unless the user explicitly requests them.
-
-\`\`\`tsx
-import { Slideshow, Slide } from "@dust/slideshow/v2";
-
-export default function Deck() {
-  return (
-    <Slideshow>
-      <Slide className="bg-slate-50">
-        <h1 className="text-6xl font-bold text-slate-900 mb-4">Q4 Revenue Analysis</h1>
-        <p className="text-xl text-slate-500">Annual review & key insights</p>
-      </Slide>
-      <Slide className="bg-white">
-        <h2 className="text-4xl font-semibold mb-8">Key Metrics</h2>
-        <div className="grid grid-cols-3 gap-8">
-          <div className="text-center">
-            <p className="text-5xl font-bold text-blue-600">+25%</p>
-            <p className="text-lg text-slate-500 mt-2">YoY Growth</p>
-          </div>
-          <div className="text-center">
-            <p className="text-5xl font-bold text-green-600">92%</p>
-            <p className="text-lg text-slate-500 mt-2">Retention</p>
-          </div>
-          <div className="text-center">
-            <p className="text-5xl font-bold text-purple-600">1.2k</p>
-            <p className="text-lg text-slate-500 mt-2">New Customers</p>
-          </div>
-        </div>
-      </Slide>
-      <Slide className="bg-slate-50">
-        <h2 className="text-4xl font-semibold mb-6">Next Steps</h2>
-        <ul className="space-y-4 text-xl text-slate-700">
-          <li>Expand into EU markets</li>
-          <li>Launch premium tier</li>
-          <li>Revamp onboarding flow</li>
-        </ul>
-      </Slide>
-    </Slideshow>
-  );
-}
-\`\`\`
-
-${VIZ_USE_FILE_EXAMPLES}
-
-${VIZ_FRAME_IMPORT_EXAMPLE}
-
-Examples:
-
-${VIZ_CHART_EXAMPLES}
-`;
-
-export const INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING_V2 = `\
 - When to Create Files:
   - Create files for data visualizations such as graphs, charts, and plots
   - Create files for complex visualizations that require user interaction
@@ -342,24 +235,4 @@ Examples:
 ${INTERACTIVE_CONTENT_CHART_EXAMPLES_V2}
 `;
 
-function buildInteractiveContentInstructions({
-  afterAuthoringProse,
-  authoringProse,
-}: {
-  afterAuthoringProse: string;
-  authoringProse: string;
-}): string {
-  return `${INTERACTIVE_CONTENT_TOOLS_PROSE_BEFORE_AUTHORING}\n${authoringProse}\n${afterAuthoringProse}`;
-}
-
-export const INTERACTIVE_CONTENT_INSTRUCTIONS =
-  buildInteractiveContentInstructions({
-    afterAuthoringProse: INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING,
-    authoringProse: INTERACTIVE_CONTENT_AUTHORING_PROSE_DEFAULT,
-  });
-
-export const INTERACTIVE_CONTENT_INSTRUCTIONS_V2 =
-  buildInteractiveContentInstructions({
-    afterAuthoringProse: INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING_V2,
-    authoringProse: INTERACTIVE_CONTENT_AUTHORING_PROSE_V2,
-  });
+export const INTERACTIVE_CONTENT_INSTRUCTIONS = `${INTERACTIVE_CONTENT_TOOLS_PROSE_BEFORE_AUTHORING}\n${INTERACTIVE_CONTENT_AUTHORING_PROSE_V2}\n${INTERACTIVE_CONTENT_TOOLS_PROSE_AFTER_AUTHORING}`;

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -76,10 +76,8 @@ function renderEnabledSkillMessagesForAction(
   action: AgentMCPActionWithOutputType,
   {
     enabledSkillById,
-    useFramesV2,
   }: {
     enabledSkillById: ReadonlyMap<string, EnabledSkill>;
-    useFramesV2: boolean;
   }
 ): UserMessageTypeModel[] {
   const enabledSkillMessages: UserMessageTypeModel[] = [];
@@ -98,7 +96,6 @@ function renderEnabledSkillMessagesForAction(
     enabledSkillMessages.push(
       renderEnabledSkillUserMessageFromInstructions({
         skill,
-        useFramesV2,
       })
     );
   }
@@ -219,7 +216,6 @@ export async function getSteps(
     conversationId,
     onMissingAction,
     enabledSkillById,
-    useFramesV2 = false,
   }: {
     model: ModelConfigurationType;
     message: AgentMessageType;
@@ -227,7 +223,6 @@ export async function getSteps(
     conversationId: string;
     onMissingAction: "inject-placeholder" | "skip";
     enabledSkillById: ReadonlyMap<string, EnabledSkill>;
-    useFramesV2?: boolean;
   }
 ): Promise<Step[]> {
   const supportedModel = getSupportedModelConfig(model);
@@ -255,7 +250,6 @@ export async function getSteps(
       }),
       enabledSkillMessages: renderEnabledSkillMessagesForAction(action, {
         enabledSkillById,
-        useFramesV2,
       }),
     }),
     { concurrency: RENDER_ACTIONS_CONCURRENCY }

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -55,7 +55,6 @@ export async function renderConversationForModel(
     onMissingAction = "inject-placeholder",
     agentConfiguration,
     enabledSkills,
-    useFramesV2 = false,
   }: {
     leadingMessages?: ModelMessageTypeMultiActionsWithoutContentFragment[];
     conversation: ConversationType;
@@ -69,7 +68,6 @@ export async function renderConversationForModel(
     enablePreviousInteractionsPruning?: boolean;
     agentConfiguration?: AgentConfigurationType;
     enabledSkills: EnabledSkill[];
-    useFramesV2?: boolean;
   }
 ): Promise<
   Result<
@@ -92,7 +90,6 @@ export async function renderConversationForModel(
     onMissingAction,
     agentConfiguration,
     enabledSkills,
-    useFramesV2,
   });
   const messages = [...leadingMessages, ...renderedMessages];
   const renderAllMessagesMs = Date.now() - stepStart;

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -147,7 +147,6 @@ export async function renderAllMessages(
     onMissingAction,
     agentConfiguration,
     enabledSkills,
-    useFramesV2 = false,
   }: {
     conversation: ConversationType;
     model: ModelConfigurationType;
@@ -156,7 +155,6 @@ export async function renderAllMessages(
     onMissingAction: "inject-placeholder" | "skip";
     agentConfiguration?: AgentConfigurationType;
     enabledSkills: EnabledSkill[];
-    useFramesV2?: boolean;
   }
 ): Promise<ModelMessageTypeMultiActions[]> {
   const messages: ModelMessageTypeMultiActions[] = [];
@@ -196,7 +194,6 @@ export async function renderAllMessages(
             conversationId: conversation.sId,
             onMissingAction,
             enabledSkillById,
-            useFramesV2,
           });
 
           const agentMessages = renderAgentSteps(

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -22,10 +22,7 @@ import {
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
-import {
-  type EnabledSkill,
-  resolveSkillInstructions,
-} from "@app/lib/api/assistant/skills_rendering";
+import type { EnabledSkill } from "@app/lib/api/assistant/skills_rendering";
 import { TRUNCATED_SNIPPET_SIZE } from "@app/lib/api/files/snippet";
 import type {
   StructuredSystemPrompt,
@@ -204,10 +201,8 @@ function constructToolsSection({
 
 function constructSkillsSection({
   systemSkills,
-  useFramesV2,
 }: {
   systemSkills: SkillResource[];
-  useFramesV2: boolean;
 }): string {
   const toolDisplayName = `${SKILL_MANAGEMENT_SERVER_NAME}${TOOL_NAME_SEPARATOR}${ENABLE_SKILL_TOOL_NAME}`;
 
@@ -238,11 +233,7 @@ function constructSkillsSection({
       "The following baseline skills are always active for this agent:\n" +
       systemSkills
         .map(
-          (skill) =>
-            `<${skill.name}>\n${resolveSkillInstructions({
-              skill,
-              useFramesV2,
-            })}\n</${skill.name}>`
+          (skill) => `<${skill.name}>\n${skill.instructions}\n</${skill.name}>`
         )
         .join("\n") +
       "\n";
@@ -405,7 +396,6 @@ export function constructPromptMultiActions(
     projectContext,
     isNewFileExplorer = false,
     hasSandboxTools = false,
-    useFramesV2 = false,
     disableFormattingPrompt = false,
   }: {
     userMessage: UserMessageType;
@@ -427,7 +417,6 @@ export function constructPromptMultiActions(
     projectContext?: string;
     isNewFileExplorer?: boolean;
     hasSandboxTools?: boolean;
-    useFramesV2?: boolean;
     disableFormattingPrompt?: boolean;
   }
 ): SystemPromptSections {
@@ -467,7 +456,6 @@ export function constructPromptMultiActions(
   });
   const skillsSection = constructSkillsSection({
     systemSkills,
-    useFramesV2,
   });
   const attachmentsSection = isNewFileExplorer
     ? constructAttachmentsSectionNewFileExplorer({ hasSandboxTools })

--- a/front/lib/api/assistant/skills_rendering.test.ts
+++ b/front/lib/api/assistant/skills_rendering.test.ts
@@ -1,11 +1,5 @@
-import {
-  INTERACTIVE_CONTENT_INSTRUCTIONS,
-  INTERACTIVE_CONTENT_INSTRUCTIONS_V2,
-} from "@app/lib/api/actions/servers/interactive_content/instructions";
-import {
-  getEnabledSkillInstructions,
-  resolveSkillInstructions,
-} from "@app/lib/api/assistant/skills_rendering";
+import { INTERACTIVE_CONTENT_INSTRUCTIONS } from "@app/lib/api/actions/servers/interactive_content/instructions";
+import { getEnabledSkillInstructions } from "@app/lib/api/assistant/skills_rendering";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { describe, expect, it } from "vitest";
 
@@ -57,30 +51,6 @@ describe("getEnabledSkillInstructions", () => {
     );
   });
 
-  it("uses default frame instructions when the v2 flag is off", () => {
-    expect(
-      resolveSkillInstructions({
-        skill: {
-          sId: "frames",
-          instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
-        },
-        useFramesV2: false,
-      })
-    ).toBe(INTERACTIVE_CONTENT_INSTRUCTIONS);
-  });
-
-  it("uses v2 frame instructions when the v2 flag is on", () => {
-    expect(
-      resolveSkillInstructions({
-        skill: {
-          sId: "frames",
-          instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
-        },
-        useFramesV2: true,
-      })
-    ).toBe(INTERACTIVE_CONTENT_INSTRUCTIONS_V2);
-  });
-
   it("renders enabled frame skill messages with v2 authoring prose", () => {
     const skill = makeEnabledSkill({
       sId: "frames",
@@ -88,34 +58,20 @@ describe("getEnabledSkillInstructions", () => {
       instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
     });
 
-    const instructions = getEnabledSkillInstructions(skill, {
-      useFramesV2: true,
-    });
+    const instructions = getEnabledSkillInstructions(skill);
 
     expect(instructions).toContain("### Rendering Context");
     expect(instructions).toContain("### Creating Files");
   });
 
-  it("v2 frame instructions do not contain v1-only markers", () => {
+  it("frame instructions do not contain v1-only markers", () => {
     // Guards against regressions where v1 prose chunks leak into v2 (e.g. a
     // missed `.replace()` target, or a stale import).
-    expect(INTERACTIVE_CONTENT_INSTRUCTIONS_V2).not.toContain(
+    expect(INTERACTIVE_CONTENT_INSTRUCTIONS).not.toContain(
       "### Frame Authoring Rules"
     );
-    expect(INTERACTIVE_CONTENT_INSTRUCTIONS_V2).not.toContain(
+    expect(INTERACTIVE_CONTENT_INSTRUCTIONS).not.toContain(
       "Premium, Minimalist Aesthetic"
     );
-  });
-
-  it("does not change non-frame skill instructions when the v2 flag is on", () => {
-    expect(
-      resolveSkillInstructions({
-        skill: {
-          sId: "research",
-          instructions: "Use the research process.",
-        },
-        useFramesV2: true,
-      })
-    ).toBe("Use the research process.");
   });
 });

--- a/front/lib/api/assistant/skills_rendering.test.ts
+++ b/front/lib/api/assistant/skills_rendering.test.ts
@@ -65,11 +65,8 @@ describe("getEnabledSkillInstructions", () => {
   });
 
   it("frame instructions do not contain v1-only markers", () => {
-    // Guards against regressions where v1 prose chunks leak into v2 (e.g. a
-    // missed `.replace()` target, or a stale import).
-    expect(INTERACTIVE_CONTENT_INSTRUCTIONS).not.toContain(
-      "### Frame Authoring Rules"
-    );
+    // Guards against re-importing the legacy viz authoring prose (still used
+    // by other servers) into the frames instructions.
     expect(INTERACTIVE_CONTENT_INSTRUCTIONS).not.toContain(
       "Premium, Minimalist Aesthetic"
     );

--- a/front/lib/api/assistant/skills_rendering.ts
+++ b/front/lib/api/assistant/skills_rendering.ts
@@ -3,8 +3,6 @@ import {
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/constants";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-import { INTERACTIVE_CONTENT_INSTRUCTIONS_V2 } from "@app/lib/api/actions/servers/interactive_content/instructions";
-import { framesSkill } from "@app/lib/resources/skill/code_defined/frames";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { stripSkillTagPresentationAttributes } from "@app/lib/skills/format";
 import { stripToolTagPresentationAttributes } from "@app/lib/tools/format";
@@ -15,24 +13,6 @@ export type EnabledSkill = SkillResource & {
 };
 
 type SkillInstructionsSource = Pick<SkillResource, "sId" | "instructions">;
-
-// `useFramesV2` is a workspace-level feature flag gate, not a per-agent
-// switch. When a third variant lands, replace the boolean with a
-// discriminated union + exhaustive `switch` so reviewers can't forget a
-// branch (the previous shape used `assertNever` on a `FramesVariant` union).
-export function resolveSkillInstructions({
-  skill,
-  useFramesV2,
-}: {
-  skill: SkillInstructionsSource;
-  useFramesV2: boolean;
-}): string {
-  if (skill.sId !== framesSkill.sId) {
-    return skill.instructions;
-  }
-
-  return useFramesV2 ? INTERACTIVE_CONTENT_INSTRUCTIONS_V2 : skill.instructions;
-}
 
 function renderSystemSkillMessage(text: string): UserMessageTypeModel {
   return {
@@ -51,16 +31,11 @@ function stripInstructionPresentationAttributes(content: string): string {
 export function getEnabledSkillInstructions(
   skill: Pick<SkillResource, "sId" | "name" | "instructions"> & {
     extendedSkill: SkillInstructionsSource | null;
-  },
-  {
-    useFramesV2 = false,
-  }: {
-    useFramesV2?: boolean;
-  } = {}
+  }
 ): string {
   const { name, extendedSkill } = skill;
   const modelInstructions = stripInstructionPresentationAttributes(
-    resolveSkillInstructions({ skill, useFramesV2 })
+    skill.instructions
   );
 
   if (!extendedSkill) {
@@ -68,7 +43,7 @@ export function getEnabledSkillInstructions(
   }
 
   const extendedModelInstructions = stripInstructionPresentationAttributes(
-    resolveSkillInstructions({ skill: extendedSkill, useFramesV2 })
+    extendedSkill.instructions
   );
 
   return [
@@ -104,14 +79,10 @@ export function renderEquippedSkillsUserMessage(
 
 export function renderEnabledSkillUserMessageFromInstructions({
   skill,
-  useFramesV2 = false,
 }: {
   skill: EnabledSkill;
-  useFramesV2?: boolean;
 }): UserMessageTypeModel {
-  const skillInstructions = getEnabledSkillInstructions(skill, {
-    useFramesV2,
-  });
+  const skillInstructions = getEnabledSkillInstructions(skill);
 
   return renderSystemSkillMessage(
     `<dust_system>\n${skillInstructions}\n</dust_system>`

--- a/front/lib/api/llm/batch_llm.ts
+++ b/front/lib/api/llm/batch_llm.ts
@@ -13,7 +13,7 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
-import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
   MessageModel,
@@ -299,7 +299,6 @@ export async function sendBatchCallToLlm(
   const batchMap = new Map<string, LLMStreamParameters>();
 
   const modelConfig = llm.getModelConfig();
-  const useFramesV2 = await hasFeatureFlag(auth, "frames_skill_v2");
 
   for (const input of conversations) {
     // Store new messages in DB.
@@ -342,7 +341,6 @@ export async function sendBatchCallToLlm(
       tools,
       allowedTokenCount:
         modelConfig.contextSize - modelConfig.generationTokensCount,
-      useFramesV2,
     });
 
     if (modelConversationRes.isErr()) {

--- a/front/lib/resources/skill/code_defined/frames.ts
+++ b/front/lib/resources/skill/code_defined/frames.ts
@@ -16,6 +16,6 @@ export const framesSkill = {
     "content tool is mentioned.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   mcpServers: [{ name: "interactive_content" }],
-  version: 2,
+  version: 3,
   icon: "ActionFrameIcon",
 } as const satisfies GlobalSkillDefinition;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -391,7 +391,6 @@ export async function runModel(
   const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
   const featureFlags = await getFeatureFlags(auth);
   const hasSandboxTools = featureFlags.includes("sandbox_tools");
-  const useFramesV2 = featureFlags.includes("frames_skill_v2");
   const disableFormattingPrompt = featureFlags.includes(
     "disable_formatting_prompt"
   );
@@ -416,7 +415,6 @@ export async function runModel(
     projectContext,
     isNewFileExplorer,
     hasSandboxTools,
-    useFramesV2,
     disableFormattingPrompt,
   });
   const leadingMessages = removeNulls([
@@ -453,7 +451,6 @@ export async function runModel(
           agentConfiguration,
           leadingMessages,
           enabledSkills,
-          useFramesV2,
         })
       )
   );

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -163,11 +163,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Slideshow MCP tool",
     stage: "dust_only",
   },
-  frames_skill_v2: {
-    description:
-      "Use the merged Frames skill v2 prose for every agent in the workspace. Temporary, remove after global rollout.",
-    stage: "dust_only",
-  },
   slack_message_splitting: {
     description:
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -720,7 +720,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_spa"
   | "fireworks_new_model_feature"
   | "force_us_api_url"
-  | "frames_skill_v2"
   | "gemini_3_1_pro_feature"
   | "clari_copilot_mcp"
   | "google_sheets_tool"


### PR DESCRIPTION
## Description

Follow up of #26598.

Releases the Frames v2 prompt globally by removing the `frames_skill_v2` feature flag (it was marked "remove after global rollout"):

- The v2 prose is now the only Frames skill instructions; the v1 authoring/after-authoring prose is deleted.
- Removes the `useFramesV2` threading through `constructPromptMultiActions`, conversation rendering, the agent loop, batch LLM calls, and the poke render route.
- `resolveSkillInstructions` is gone; skill instructions are used as-is since the frames code-defined skill now carries the v2 prose directly.
- Bumps the frames skill `version` to 3 since its instructions changed.

## Tests

Updated `skills_rendering.test.ts`: kept the strip tests, plus guards that the default frame instructions contain the v2 markers and none of the legacy viz prose.

## Risk

Low. Workspaces without the flag switch from the v1 to the v2 Frames prose; workspaces that had the flag see no change. First message after deploy cold-starts the prompt cache for frames-equipped agents in previously unflagged workspaces (one-time, expected). Rollback is a revert.

## Deploy Plan

Standard deploy.