### PR TITLE
Support downloading non-native Google Drive files

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -7,18 +7,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-export const SUPPORTED_MIMETYPES = [
-  "application/vnd.google-apps.document",
-  "application/vnd.google-apps.presentation",
-  "application/vnd.google-apps.spreadsheet",
-  "text/plain",
-  "text/markdown",
-  "text/csv",
-  "application/pdf",
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-];
-
 export const MAX_CONTENT_SIZE = 32000; // Max characters to return for file content
 export const MAX_FILE_SIZE = 64 * 1024 * 1024; // 64 MB max original file size
 
@@ -122,7 +110,11 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
   },
   get_file_content: {
-    description: `Get the content of a Google Drive file (Docs, Slides, Sheets, text, PDF, PowerPoint, Word) as text with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}.`,
+    description:
+      "Get the content of a Google Drive file as text with offset-based pagination. " +
+      "Google Docs and Slides are exported as plain text. Google Sheets are exported as XLSX. " +
+      "Any other file (XLSX, PDF, Office, images, ...) is downloaded in its original format. " +
+      "Binary files are attached to the conversation so other tools can use them, alongside extracted text when available.",
     schema: {
       fileId: z
         .string()

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -1,9 +1,27 @@
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { extractTextFromBuffer } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
+import { getDriveClient } from "@app/lib/api/actions/servers/google_drive/helpers";
+import { Err, Ok } from "@app/types/shared/result";
+import { isTextExtractionSupportedContentType } from "@app/types/shared/text_extraction";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { Common } from "googleapis";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildBinaryFileResource, handleFileAccessError } from "./index";
+import { buildBinaryFileResource, handleFileAccessError, TOOLS } from "./index";
+
+vi.mock("@app/lib/api/actions/servers/google_drive/helpers", () => ({
+  getDriveClient: vi.fn(),
+  getDocsClient: vi.fn(),
+  getSheetsClient: vi.fn(),
+  getSlidesClient: vi.fn(),
+}));
+
+vi.mock(
+  "@app/lib/actions/mcp_internal_actions/utils/attachment_processing",
+  () => ({
+    extractTextFromBuffer: vi.fn(),
+  })
+);
 
 // Helper to create a mock GaxiosError
 function createGaxiosError(code: number, message: string): Common.GaxiosError {
@@ -210,5 +228,256 @@ describe("buildBinaryFileResource", () => {
     expect(block.resource.uri).not.toContain("/");
     expect(block.resource.uri).not.toContain("..");
     expect(block.resource._meta.text).toBe(`File: ${block.resource.uri}`);
+  });
+});
+
+describe("get_file_content", () => {
+  const XLSX_MIMETYPE =
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+  const extra = {
+    authInfo: undefined,
+    agentLoopContext: undefined,
+  } as ToolHandlerExtra;
+
+  // Builds the ArrayBuffer with the global constructor so the handler's
+  // `instanceof ArrayBuffer` check passes under the jsdom test environment.
+  function toArrayBuffer(content: string): ArrayBuffer {
+    const arrayBuffer = new ArrayBuffer(content.length);
+    const view = new Uint8Array(arrayBuffer);
+    for (let i = 0; i < content.length; i++) {
+      view[i] = content.charCodeAt(i);
+    }
+    return arrayBuffer;
+  }
+
+  function createFakeDrive() {
+    return {
+      files: {
+        get: vi.fn(),
+        export: vi.fn(),
+      },
+    };
+  }
+
+  function mockDrive(fakeDrive: ReturnType<typeof createFakeDrive>) {
+    vi.mocked(getDriveClient).mockResolvedValue(
+      fakeDrive as unknown as Awaited<ReturnType<typeof getDriveClient>>
+    );
+  }
+
+  async function callTool(fileId: string) {
+    const tool = TOOLS.find((t) => t.name === "get_file_content");
+    if (!tool) {
+      throw new Error("get_file_content tool not found");
+    }
+    return tool.handler({ fileId, offset: 0, limit: 32000 }, extra);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // `@app/types/shared/text_extraction` is globally mocked in vite.setup.ts;
+    // mirror the real behavior of marking only Tika-supported types.
+    vi.mocked(isTextExtractionSupportedContentType).mockImplementation(
+      (contentType: string) =>
+        contentType === "application/pdf" || contentType === XLSX_MIMETYPE
+    );
+  });
+
+  it("downloads a non-native binary file (XLSX) and attaches it as a resource", async () => {
+    const fakeDrive = createFakeDrive();
+    fakeDrive.files.get.mockImplementation(async (params: { alt?: string }) => {
+      if (params.alt === "media") {
+        return { data: toArrayBuffer("xlsx-bytes") };
+      }
+      return {
+        data: {
+          id: "f1",
+          name: "data.xlsx",
+          mimeType: XLSX_MIMETYPE,
+          size: "1000",
+          capabilities: {},
+        },
+      };
+    });
+    mockDrive(fakeDrive);
+    vi.mocked(extractTextFromBuffer).mockResolvedValue(new Ok("a,b,c"));
+
+    const result = await callTool("f1");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [textBlock, resourceBlock] = result.value as any[];
+      const payload = JSON.parse(textBlock.text);
+      expect(payload.mimeType).toBe(XLSX_MIMETYPE);
+      expect(payload.content).toBe("a,b,c");
+      expect(resourceBlock.type).toBe("resource");
+      expect(resourceBlock.resource.mimeType).toBe(XLSX_MIMETYPE);
+      expect(resourceBlock.resource.uri).toBe("data.xlsx");
+      expect(resourceBlock.resource.blob).toBe(
+        Buffer.from("xlsx-bytes").toString("base64")
+      );
+    }
+  });
+
+  it("attaches files without text extraction support (PNG) with a placeholder", async () => {
+    const fakeDrive = createFakeDrive();
+    fakeDrive.files.get.mockImplementation(async (params: { alt?: string }) => {
+      if (params.alt === "media") {
+        return { data: toArrayBuffer("png-bytes") };
+      }
+      return {
+        data: {
+          id: "f1",
+          name: "chart.png",
+          mimeType: "image/png",
+          size: "1000",
+          capabilities: {},
+        },
+      };
+    });
+    mockDrive(fakeDrive);
+
+    const result = await callTool("f1");
+
+    expect(extractTextFromBuffer).not.toHaveBeenCalled();
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [textBlock, resourceBlock] = result.value as any[];
+      const payload = JSON.parse(textBlock.text);
+      expect(payload.content).toContain("No text extraction available");
+      expect(resourceBlock.resource.mimeType).toBe("image/png");
+      expect(resourceBlock.resource.uri).toBe("chart.png");
+    }
+  });
+
+  it("exports Google Sheets as XLSX and attaches the file", async () => {
+    const fakeDrive = createFakeDrive();
+    fakeDrive.files.get.mockResolvedValue({
+      data: {
+        id: "f1",
+        name: "Budget",
+        mimeType: "application/vnd.google-apps.spreadsheet",
+        capabilities: {},
+      },
+    });
+    fakeDrive.files.export.mockResolvedValue({
+      data: toArrayBuffer("exported-xlsx"),
+    });
+    mockDrive(fakeDrive);
+    vi.mocked(extractTextFromBuffer).mockResolvedValue(new Ok("rows"));
+
+    const result = await callTool("f1");
+
+    expect(fakeDrive.files.export).toHaveBeenCalledWith(
+      { fileId: "f1", mimeType: XLSX_MIMETYPE },
+      { responseType: "arraybuffer" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [textBlock, resourceBlock] = result.value as any[];
+      const payload = JSON.parse(textBlock.text);
+      expect(payload.content).toBe("rows");
+      expect(resourceBlock.resource.mimeType).toBe(XLSX_MIMETYPE);
+      expect(resourceBlock.resource.uri).toBe("Budget.xlsx");
+    }
+  });
+
+  it("attaches the binary resource with a placeholder when extraction fails", async () => {
+    const fakeDrive = createFakeDrive();
+    fakeDrive.files.get.mockImplementation(async (params: { alt?: string }) => {
+      if (params.alt === "media") {
+        return { data: toArrayBuffer("pdf-bytes") };
+      }
+      return {
+        data: {
+          id: "f1",
+          name: "scan.pdf",
+          mimeType: "application/pdf",
+          size: "1000",
+          capabilities: {},
+        },
+      };
+    });
+    mockDrive(fakeDrive);
+    vi.mocked(extractTextFromBuffer).mockResolvedValue(
+      new Err("extraction failed")
+    );
+
+    const result = await callTool("f1");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [textBlock, resourceBlock] = result.value as any[];
+      const payload = JSON.parse(textBlock.text);
+      expect(payload.content).toContain("Text extraction failed");
+      expect(resourceBlock.resource.uri).toBe("scan.pdf");
+    }
+  });
+
+  it("errors on Google-native types without a binary representation", async () => {
+    const fakeDrive = createFakeDrive();
+    fakeDrive.files.get.mockResolvedValue({
+      data: {
+        id: "f1",
+        name: "My folder",
+        mimeType: "application/vnd.google-apps.folder",
+        capabilities: {},
+      },
+    });
+    mockDrive(fakeDrive);
+
+    const result = await callTool("f1");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Unsupported Google-native file type"
+      );
+    }
+  });
+
+  it("resolves shortcuts to their target file", async () => {
+    const fakeDrive = createFakeDrive();
+    fakeDrive.files.get.mockImplementation(
+      async (params: { fileId: string; alt?: string }) => {
+        if (params.alt === "media") {
+          return { data: toArrayBuffer("target-bytes") };
+        }
+        if (params.fileId === "shortcut-id") {
+          return {
+            data: {
+              id: "shortcut-id",
+              name: "Shortcut to data",
+              mimeType: "application/vnd.google-apps.shortcut",
+              shortcutDetails: { targetId: "target-id" },
+            },
+          };
+        }
+        return {
+          data: {
+            id: "target-id",
+            name: "data.xlsx",
+            mimeType: XLSX_MIMETYPE,
+            size: "1000",
+            capabilities: {},
+          },
+        };
+      }
+    );
+    mockDrive(fakeDrive);
+    vi.mocked(extractTextFromBuffer).mockResolvedValue(new Ok("a,b,c"));
+
+    const result = await callTool("shortcut-id");
+
+    expect(result.isOk()).toBe(true);
+    expect(fakeDrive.files.get).toHaveBeenCalledWith(
+      expect.objectContaining({ fileId: "target-id", alt: "media" }),
+      { responseType: "arraybuffer" }
+    );
+    if (result.isOk()) {
+      const [, resourceBlock] = result.value as any[];
+      expect(resourceBlock.resource.uri).toBe("data.xlsx");
+    }
   });
 });

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -7,6 +7,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { Common } from "googleapis";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { BinaryFileResourceBlock } from "./index";
 import { buildBinaryFileResource, handleFileAccessError, TOOLS } from "./index";
 
 vi.mock("@app/lib/api/actions/servers/google_drive/helpers", () => ({
@@ -248,10 +249,56 @@ describe("get_file_content", () => {
   const XLSX_MIMETYPE =
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
+  // Partial stub: the get_file_content handler only reads authInfo and
+  // agentLoopContext. Same pattern as the other MCP tool tests (files/tools).
   const extra = {
     authInfo: undefined,
     agentLoopContext: undefined,
-  } as ToolHandlerExtra;
+  } as unknown as ToolHandlerExtra;
+
+  function isTextBlock(
+    block: unknown
+  ): block is { type: "text"; text: string } {
+    return (
+      typeof block === "object" &&
+      block !== null &&
+      "type" in block &&
+      block.type === "text" &&
+      "text" in block &&
+      typeof block.text === "string"
+    );
+  }
+
+  function isBinaryFileResourceBlock(
+    block: unknown
+  ): block is BinaryFileResourceBlock {
+    return (
+      typeof block === "object" &&
+      block !== null &&
+      "type" in block &&
+      block.type === "resource" &&
+      "resource" in block &&
+      typeof block.resource === "object" &&
+      block.resource !== null
+    );
+  }
+
+  function getBlocks(result: Awaited<ReturnType<typeof callTool>>): {
+    payload: Record<string, unknown>;
+    resourceBlock: BinaryFileResourceBlock | null;
+  } {
+    if (result.isErr()) {
+      throw new Error(`Expected Ok result, got: ${result.error.message}`);
+    }
+    const [first, second] = result.value;
+    if (!isTextBlock(first)) {
+      throw new Error("Expected the first block to be a text block");
+    }
+    return {
+      payload: JSON.parse(first.text),
+      resourceBlock: isBinaryFileResourceBlock(second) ? second : null,
+    };
+  }
 
   // Builds the ArrayBuffer with the global constructor so the handler's
   // `instanceof ArrayBuffer` check passes under the jsdom test environment.
@@ -274,6 +321,8 @@ describe("get_file_content", () => {
   }
 
   function mockDrive(fakeDrive: ReturnType<typeof createFakeDrive>) {
+    // The fake client only implements the methods the handler calls; same
+    // mock pattern as the other MCP tool tests (files/tools).
     vi.mocked(getDriveClient).mockResolvedValue(
       fakeDrive as unknown as Awaited<ReturnType<typeof getDriveClient>>
     );
@@ -318,19 +367,14 @@ describe("get_file_content", () => {
 
     const result = await callTool("f1");
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      const [textBlock, resourceBlock] = result.value as any[];
-      const payload = JSON.parse(textBlock.text);
-      expect(payload.mimeType).toBe(XLSX_MIMETYPE);
-      expect(payload.content).toBe("a,b,c");
-      expect(resourceBlock.type).toBe("resource");
-      expect(resourceBlock.resource.mimeType).toBe(XLSX_MIMETYPE);
-      expect(resourceBlock.resource.uri).toBe("data.xlsx");
-      expect(resourceBlock.resource.blob).toBe(
-        Buffer.from("xlsx-bytes").toString("base64")
-      );
-    }
+    const { payload, resourceBlock } = getBlocks(result);
+    expect(payload.mimeType).toBe(XLSX_MIMETYPE);
+    expect(payload.content).toBe("a,b,c");
+    expect(resourceBlock?.resource.mimeType).toBe(XLSX_MIMETYPE);
+    expect(resourceBlock?.resource.uri).toBe("data.xlsx");
+    expect(resourceBlock?.resource.blob).toBe(
+      Buffer.from("xlsx-bytes").toString("base64")
+    );
   });
 
   it("attaches files without text extraction support (PNG) with a placeholder", async () => {
@@ -354,14 +398,10 @@ describe("get_file_content", () => {
     const result = await callTool("f1");
 
     expect(extractTextFromBuffer).not.toHaveBeenCalled();
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      const [textBlock, resourceBlock] = result.value as any[];
-      const payload = JSON.parse(textBlock.text);
-      expect(payload.content).toContain("No text extraction available");
-      expect(resourceBlock.resource.mimeType).toBe("image/png");
-      expect(resourceBlock.resource.uri).toBe("chart.png");
-    }
+    const { payload, resourceBlock } = getBlocks(result);
+    expect(payload.content).toContain("No text extraction available");
+    expect(resourceBlock?.resource.mimeType).toBe("image/png");
+    expect(resourceBlock?.resource.uri).toBe("chart.png");
   });
 
   it("exports Google Sheets as XLSX and attaches the file", async () => {
@@ -386,14 +426,10 @@ describe("get_file_content", () => {
       { fileId: "f1", mimeType: XLSX_MIMETYPE },
       { responseType: "arraybuffer" }
     );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      const [textBlock, resourceBlock] = result.value as any[];
-      const payload = JSON.parse(textBlock.text);
-      expect(payload.content).toBe("rows");
-      expect(resourceBlock.resource.mimeType).toBe(XLSX_MIMETYPE);
-      expect(resourceBlock.resource.uri).toBe("Budget.xlsx");
-    }
+    const { payload, resourceBlock } = getBlocks(result);
+    expect(payload.content).toBe("rows");
+    expect(resourceBlock?.resource.mimeType).toBe(XLSX_MIMETYPE);
+    expect(resourceBlock?.resource.uri).toBe("Budget.xlsx");
   });
 
   it("attaches the binary resource with a placeholder when extraction fails", async () => {
@@ -419,13 +455,9 @@ describe("get_file_content", () => {
 
     const result = await callTool("f1");
 
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      const [textBlock, resourceBlock] = result.value as any[];
-      const payload = JSON.parse(textBlock.text);
-      expect(payload.content).toContain("Text extraction failed");
-      expect(resourceBlock.resource.uri).toBe("scan.pdf");
-    }
+    const { payload, resourceBlock } = getBlocks(result);
+    expect(payload.content).toContain("Text extraction failed");
+    expect(resourceBlock?.resource.uri).toBe("scan.pdf");
   });
 
   it("errors on Google-native types without a binary representation", async () => {
@@ -483,16 +515,12 @@ describe("get_file_content", () => {
 
     const result = await callTool("shortcut-id");
 
-    expect(result.isOk()).toBe(true);
     expect(fakeDrive.files.get).toHaveBeenCalledWith(
       expect.objectContaining({ fileId: "target-id", alt: "media" }),
       { responseType: "arraybuffer" }
     );
-    if (result.isOk()) {
-      const [textBlock, resourceBlock] = result.value as any[];
-      const payload = JSON.parse(textBlock.text);
-      expect(payload.fileId).toBe("target-id");
-      expect(resourceBlock.resource.uri).toBe("data.xlsx");
-    }
+    const { payload, resourceBlock } = getBlocks(result);
+    expect(payload.fileId).toBe("target-id");
+    expect(resourceBlock?.resource.uri).toBe("data.xlsx");
   });
 });

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -126,6 +126,19 @@ describe("handleFileAccessError", () => {
     }
   });
 
+  it("should return a non-auth error for 403 export size limit errors", async () => {
+    const result = await handleFileAccessError(
+      createGaxiosError(403, "This file is too large to be exported."),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("too large to be exported");
+    }
+  });
+
   it("should return OAuth re-auth for general 403 errors without permission keywords", async () => {
     const result = await handleFileAccessError(
       createGaxiosError(403, "Forbidden"),
@@ -476,7 +489,9 @@ describe("get_file_content", () => {
       { responseType: "arraybuffer" }
     );
     if (result.isOk()) {
-      const [, resourceBlock] = result.value as any[];
+      const [textBlock, resourceBlock] = result.value as any[];
+      const payload = JSON.parse(textBlock.text);
+      expect(payload.fileId).toBe("target-id");
       expect(resourceBlock.resource.uri).toBe("data.xlsx");
     }
   });

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -27,13 +27,13 @@ import {
   GOOGLE_DRIVE_WRITE_TOOLS_METADATA,
   MAX_CONTENT_SIZE,
   MAX_FILE_SIZE,
-  SUPPORTED_MIMETYPES,
 } from "@app/lib/api/actions/servers/google_drive/metadata";
 import { resolveDocOperations } from "@app/lib/api/actions/servers/google_drive/resolution/docs_resolver";
 import { resolveSpreadsheetOperations } from "@app/lib/api/actions/servers/google_drive/resolution/sheets_resolver";
 import { resolvePresentationOperations } from "@app/lib/api/actions/servers/google_drive/resolution/slides_resolver";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
+import { isTextExtractionSupportedContentType } from "@app/types/shared/text_extraction";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { Common } from "googleapis";
 import { Readable } from "stream";
@@ -76,6 +76,53 @@ export function buildBinaryFileResource({
 
 const EXTRACTION_FAILED_PLACEHOLDER =
   "[Text extraction failed — file attached as binary resource]";
+
+const XLSX_MIMETYPE =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+const GOOGLE_APPS_MIMETYPE_PREFIX = "application/vnd.google-apps.";
+
+/**
+ * Extracts text from a downloaded binary file when the type is supported and
+ * always builds a binary resource block so downstream tools (sandbox upload,
+ * file viewer, etc.) can consume the raw bytes.
+ */
+async function extractTextAndBuildResource({
+  buffer,
+  mimeType,
+  fileName,
+  fileId,
+}: {
+  buffer: Buffer;
+  mimeType: string;
+  fileName: string | null | undefined;
+  fileId: string;
+}): Promise<{ content: string; binaryResource: BinaryFileResourceBlock }> {
+  let content: string;
+  if (isTextExtractionSupportedContentType(mimeType)) {
+    const extractionResult = await extractTextFromBuffer(buffer, mimeType);
+    if (extractionResult.isErr()) {
+      logger.warn(
+        {
+          fileId,
+          mimeType,
+          error: extractionResult.error,
+        },
+        "Text extraction failed for Google Drive binary file"
+      );
+    }
+    content = extractionResult.isOk()
+      ? extractionResult.value
+      : EXTRACTION_FAILED_PLACEHOLDER;
+  } else {
+    content = `[No text extraction available for file type ${mimeType} — file attached as binary resource]`;
+  }
+
+  return {
+    content,
+    binaryResource: buildBinaryFileResource({ buffer, fileName, mimeType }),
+  };
+}
 
 /**
  * Normalizes GaxiosError code to string for comparison.
@@ -394,23 +441,41 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     }
 
     try {
+      const metadataFields =
+        "id, name, mimeType, size, shortcutDetails, capabilities(canEdit,canComment,canShare,canCopy)";
+
       // First, get file metadata to determine the mimetype
       const fileMetadata = await drive.files.get({
         fileId,
         supportsAllDrives: true,
-        fields:
-          "id, name, mimeType, size, capabilities(canEdit,canComment,canShare,canCopy)",
+        fields: metadataFields,
       });
-      const file = fileMetadata.data;
+      let file = fileMetadata.data;
+      let effectiveFileId = fileId;
 
-      if (!file.mimeType || !SUPPORTED_MIMETYPES.includes(file.mimeType)) {
-        return new Err(
-          new MCPError(
-            `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`,
-            {
+      // Resolve shortcuts to their target file so the content of the target
+      // is returned instead of an error.
+      if (file.mimeType === `${GOOGLE_APPS_MIMETYPE_PREFIX}shortcut`) {
+        const targetId = file.shortcutDetails?.targetId;
+        if (!targetId) {
+          return new Err(
+            new MCPError("This shortcut has no target file.", {
               tracked: false,
-            }
-          )
+            })
+          );
+        }
+        const targetMetadata = await drive.files.get({
+          fileId: targetId,
+          supportsAllDrives: true,
+          fields: metadataFields,
+        });
+        file = targetMetadata.data;
+        effectiveFileId = targetId;
+      }
+
+      if (!file.mimeType) {
+        return new Err(
+          new MCPError("The file has no mime type.", { tracked: false })
         );
       }
       if (file.size && parseInt(file.size, 10) > MAX_FILE_SIZE) {
@@ -432,7 +497,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         case "application/vnd.google-apps.presentation": {
           // Export Google Docs and Presentations as plain text
           const exportRes = await drive.files.export({
-            fileId,
+            fileId: effectiveFileId,
             mimeType: "text/plain",
           });
           if (typeof exportRes.data !== "string") {
@@ -443,12 +508,36 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
           content = exportRes.data;
           break;
         }
+        case "application/vnd.google-apps.spreadsheet": {
+          // Export Google Sheets as XLSX so the raw file can be consumed by
+          // downstream tools, with extracted text alongside. Note that the
+          // export API is capped at 10MB by Google.
+          const exportRes = await drive.files.export(
+            { fileId: effectiveFileId, mimeType: XLSX_MIMETYPE },
+            { responseType: "arraybuffer" }
+          );
+          if (!(exportRes.data instanceof ArrayBuffer)) {
+            return new Err(
+              new MCPError("Failed to export spreadsheet as XLSX")
+            );
+          }
+          const fileName = file.name?.endsWith(".xlsx")
+            ? file.name
+            : `${file.name ?? "spreadsheet"}.xlsx`;
+          ({ content, binaryResource } = await extractTextAndBuildResource({
+            buffer: Buffer.from(exportRes.data),
+            mimeType: XLSX_MIMETYPE,
+            fileName,
+            fileId: effectiveFileId,
+          }));
+          break;
+        }
         case "text/plain":
         case "text/markdown":
         case "text/csv": {
           // Download regular text files
           const downloadRes = await drive.files.get({
-            fileId,
+            fileId: effectiveFileId,
             alt: "media",
           });
 
@@ -460,15 +549,27 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
           content = downloadRes.data;
           break;
         }
-        case "application/pdf":
-        case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
-        case "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
-          // Binary documents: download as an arraybuffer, extract text via Tika
-          // (OCR enabled), and always attach the raw bytes as a resource block
-          // so downstream tools can consume the file even when extraction yields
-          // little or nothing.
+        default: {
+          // Remaining Google-native types (folders, forms, maps, ...) have no
+          // binary representation that can be downloaded.
+          if (file.mimeType.startsWith(GOOGLE_APPS_MIMETYPE_PREFIX)) {
+            return new Err(
+              new MCPError(
+                `Unsupported Google-native file type: ${file.mimeType}.`,
+                {
+                  tracked: false,
+                }
+              )
+            );
+          }
+
+          // Any other file (XLSX, PDF, Office, images, ...): download the raw
+          // bytes in their original format, extract text via Tika (OCR
+          // enabled) when supported, and always attach the raw bytes as a
+          // resource block so downstream tools can consume the file even when
+          // extraction yields little or nothing.
           const downloadRes = await drive.files.get(
-            { fileId, alt: "media" },
+            { fileId: effectiveFileId, alt: "media" },
             { responseType: "arraybuffer" }
           );
           if (!(downloadRes.data instanceof ArrayBuffer)) {
@@ -476,38 +577,14 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
               new MCPError("Failed to download file content as arraybuffer")
             );
           }
-          const buffer = Buffer.from(downloadRes.data);
-
-          const extractionResult = await extractTextFromBuffer(
-            buffer,
-            file.mimeType
-          );
-          if (extractionResult.isErr()) {
-            logger.warn(
-              {
-                fileId,
-                mimeType: file.mimeType,
-                error: extractionResult.error,
-              },
-              "Text extraction failed for Google Drive binary file"
-            );
-          }
-          content = extractionResult.isOk()
-            ? extractionResult.value
-            : EXTRACTION_FAILED_PLACEHOLDER;
-          binaryResource = buildBinaryFileResource({
-            buffer,
-            fileName: file.name,
+          ({ content, binaryResource } = await extractTextAndBuildResource({
+            buffer: Buffer.from(downloadRes.data),
             mimeType: file.mimeType,
-          });
+            fileName: file.name,
+            fileId: effectiveFileId,
+          }));
           break;
         }
-        default:
-          return new Err(
-            new MCPError(`Unsupported file type: ${file.mimeType}`, {
-              tracked: false,
-            })
-          );
       }
 
       // Apply offset and limit

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -82,6 +82,9 @@ const XLSX_MIMETYPE =
 
 const GOOGLE_APPS_MIMETYPE_PREFIX = "application/vnd.google-apps.";
 
+const FILE_METADATA_FIELDS =
+  "id, name, mimeType, size, shortcutDetails, capabilities(canEdit,canComment,canShare,canCopy)";
+
 /**
  * Extracts text from a downloaded binary file when the type is supported and
  * always builds a binary resource block so downstream tools (sandbox upload,
@@ -154,6 +157,17 @@ export async function handleFileAccessError(
     const message = err.message?.toLowerCase() ?? "";
 
     // Check for file-specific permission issues that should trigger file picker
+    // Export size limit errors are 403s but are not auth issues: Google caps
+    // file exports at 10MB.
+    if (status === "403" && message.includes("too large")) {
+      return new Err(
+        new MCPError(
+          "This file is too large to be exported (Google caps exports at 10MB). For spreadsheets, use get_spreadsheet and get_worksheet to read the data instead.",
+          { tracked: false }
+        )
+      );
+    }
+
     if (
       (status === "403" || status === "404") &&
       (message.includes("caller does not have permission") ||
@@ -441,20 +455,18 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     }
 
     try {
-      const metadataFields =
-        "id, name, mimeType, size, shortcutDetails, capabilities(canEdit,canComment,canShare,canCopy)";
-
       // First, get file metadata to determine the mimetype
       const fileMetadata = await drive.files.get({
         fileId,
         supportsAllDrives: true,
-        fields: metadataFields,
+        fields: FILE_METADATA_FIELDS,
       });
       let file = fileMetadata.data;
       let effectiveFileId = fileId;
 
       // Resolve shortcuts to their target file so the content of the target
-      // is returned instead of an error.
+      // is returned instead of an error. Note that errors on the target are
+      // attributed to the shortcut's fileId in handleFileAccessError below.
       if (file.mimeType === `${GOOGLE_APPS_MIMETYPE_PREFIX}shortcut`) {
         const targetId = file.shortcutDetails?.targetId;
         if (!targetId) {
@@ -467,7 +479,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         const targetMetadata = await drive.files.get({
           fileId: targetId,
           supportsAllDrives: true,
-          fields: metadataFields,
+          fields: FILE_METADATA_FIELDS,
         });
         file = targetMetadata.data;
         effectiveFileId = targetId;
@@ -604,7 +616,9 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
           type: "text" as const,
           text: JSON.stringify(
             {
-              fileId,
+              // The resolved file (shortcuts are resolved to their target), so
+              // follow-up tool calls target the right id.
+              fileId: effectiveFileId,
               fileName: file.name,
               mimeType: file.mimeType,
               capabilities: {

--- a/front/lib/providers/google_drive/search.ts
+++ b/front/lib/providers/google_drive/search.ts
@@ -1,4 +1,3 @@
-import { SUPPORTED_MIMETYPES } from "@app/lib/api/actions/servers/google_drive/metadata";
 import {
   PROVIDER_DOWNLOAD_MAX_FILE_SIZE,
   PROVIDER_SEARCH_MAX_PAGE_SIZE,
@@ -12,6 +11,18 @@ import type {
 } from "@app/lib/search/tools/types";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import TurndownService from "turndown";
+
+const SUPPORTED_MIMETYPES = [
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+  "application/vnd.google-apps.spreadsheet",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
 
 const turndownService = new TurndownService({
   headingStyle: "atx",


### PR DESCRIPTION
## Description

The google_drive `get_file_content` tool gated downloads on a mimetype allowlist, so non-Google-native files like XLSX stored in Drive could not be retrieved at all (the Microsoft Drive equivalent has no such restriction).

- Drop the allowlist: any non-Google-native file (XLSX, images, ...) is downloaded in its original format, with text extracted via Tika when supported and the raw bytes always attached as a resource block so downstream tools (Pods, Computer) can use the file.
- Export Google Sheets as XLSX (the type was allowlisted but had no handler, so it errored).
- Resolve Drive shortcuts to their target file.
- Remaining Google-native types (folders, forms, ...) return a clear error.

Fixes https://github.com/dust-tt/tasks/issues/8751

## Tests

Added unit tests for the new get_file_content paths (binary download, missing extraction support, sheet export, shortcut resolution, native types without a binary representation).

## Risk

Low. Behavior for previously supported types is unchanged; the 64MB size cap still applies. Sheet exports are capped at 10MB by the Google export API. Safe to rollback.

## Deploy Plan

Standard deploy.