### PR TITLE
feat(credits): member-initiated upgrade-request CTA on usage banner

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -35,6 +35,11 @@ function upgradeRequestErrorToApiError(
         status_code: 403,
         api_error: { type: "plan_limit_error", message: error.message },
       };
+    case "upgrade_requests_disabled":
+      return {
+        status_code: 403,
+        api_error: { type: "plan_limit_error", message: error.message },
+      };
     case "user_not_found":
       return {
         status_code: 404,

--- a/front-api/routes/w/[wId]/usage-status.test.ts
+++ b/front-api/routes/w/[wId]/usage-status.test.ts
@@ -1,3 +1,5 @@
+import { Authenticator } from "@app/lib/auth";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
@@ -91,5 +93,43 @@ describe("/api/w/[wId]/usage-status", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.canRequestUpgrade).toBe(false);
+  });
+
+  it("hides the CTA and rejects requests when the workspace disables them", async () => {
+    const workspace = await creditPricedWorkspace();
+
+    // Turn the member upgrade-request toggle off on the workspace config
+    // (Does not use the endpoint to avoid the metronome round trip)
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await CreditUsageConfigurationResource.makeNew(adminAuth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      allowMemberUpgradeRequests: false,
+    });
+
+    // A capped member no longer sees the CTA.
+    const { membership } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+      workspace,
+    });
+    await membership.updateCreditState("capped");
+
+    const statusResponse = await honoApp.request(usageStatusUrl(workspace.sId));
+    expect(statusResponse.status).toBe(200);
+    expect((await statusResponse.json()).canRequestUpgrade).toBe(false);
+
+    // And a direct POST is rejected.
+    const postResponse = await honoApp.request(
+      upgradeRequestsUrl(workspace.sId),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+    expect(postResponse.status).toBe(403);
   });
 });

--- a/front-api/routes/w/[wId]/usage-status.test.ts
+++ b/front-api/routes/w/[wId]/usage-status.test.ts
@@ -1,0 +1,95 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function usageStatusUrl(wId: string) {
+  return `/api/w/${wId}/usage-status`;
+}
+
+function upgradeRequestsUrl(wId: string) {
+  return `/api/w/${wId}/credits/upgrade-requests`;
+}
+
+async function creditPricedWorkspace(): Promise<WorkspaceType> {
+  return WorkspaceFactory.creditPriced();
+}
+
+describe("/api/w/[wId]/usage-status", () => {
+  it("reports no upgrade availability on a non-credit-priced workspace", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await honoApp.request(usageStatusUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.awuStatus).toBe("normal");
+    expect(body.canRequestUpgrade).toBe(false);
+    expect(body.hasPendingUpgradeRequest).toBe(false);
+  });
+
+  it("lets a capped non-admin member request an upgrade", async () => {
+    const workspace = await creditPricedWorkspace();
+    const { membership } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+      workspace,
+    });
+    await membership.updateCreditState("capped");
+
+    const response = await honoApp.request(usageStatusUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.awuStatus).toBe("blocked");
+    expect(body.canRequestUpgrade).toBe(true);
+    expect(body.hasPendingUpgradeRequest).toBe(false);
+  });
+
+  it("flips hasPendingUpgradeRequest once a request exists", async () => {
+    const workspace = await creditPricedWorkspace();
+    const { membership } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+      workspace,
+    });
+    await membership.updateCreditState("capped");
+
+    const postResponse = await honoApp.request(
+      upgradeRequestsUrl(workspace.sId),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+    expect(postResponse.status).toBe(200);
+
+    const response = await honoApp.request(usageStatusUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.canRequestUpgrade).toBe(true);
+    expect(body.hasPendingUpgradeRequest).toBe(true);
+  });
+
+  it("does not offer upgrade requests to admins", async () => {
+    const workspace = await creditPricedWorkspace();
+    const { membership } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+    await membership.updateCreditState("capped");
+
+    const response = await honoApp.request(usageStatusUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.canRequestUpgrade).toBe(false);
+  });
+});

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -1,3 +1,4 @@
+import { getUpgradeRequestAvailabilityForUser } from "@app/lib/api/credits/upgrade_requests";
 import type {
   GetWorkspaceUsageStatusResponseBody,
   ProgrammaticCreditStatus,
@@ -34,6 +35,8 @@ app.get(
         programmaticCreditStatus: "active",
         balanceThresholdReached: false,
         noSeat: false,
+        canRequestUpgrade: false,
+        hasPendingUpgradeRequest: false,
       });
     }
 
@@ -68,12 +71,19 @@ app.get(
       programmaticCreditStatus = "warned";
     }
 
+    const { canRequestUpgrade, hasPendingUpgradeRequest } =
+      await getUpgradeRequestAvailabilityForUser(auth, {
+        isNearOrAtLimit: awuStatus !== "normal",
+      });
+
     return ctx.json({
       awuStatus,
       poolCreditState,
       programmaticCreditStatus,
       balanceThresholdReached,
       noSeat,
+      canRequestUpgrade,
+      hasPendingUpgradeRequest,
     });
   }
 );

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -334,6 +334,7 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
     !isMetronomeContractLoading &&
     !contract?.hasPersonalCreditSeats;
   const showAwuBanner = awuStatus !== "normal";
+  const showUpgradeCta = canRequestUpgrade;
   const showProgrammaticBanner =
     isAdmin(owner) && programmaticCreditStatus !== "active";
   // The admin-configured balance-threshold warning is only relevant before the
@@ -390,7 +391,7 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
           awuStatus === "blocked"
             ? "You can no longer run agents. Contact your admin to increase your limit."
             : "Contact your admin to increase your limit before you are blocked.",
-        footer: canRequestUpgrade ? (
+        footer: showUpgradeCta ? (
           <RequestUpgradeButton
             owner={owner}
             hasPendingUpgradeRequest={hasPendingUpgradeRequest}

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -5,6 +5,7 @@ import {
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
+import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { useMetronomeContract } from "@app/lib/swr/workspaces";
@@ -14,8 +15,19 @@ import type { SubscriptionType } from "@app/types/plan";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import { cn, LinkWrapper } from "@dust-tt/sparkle";
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  LinkWrapper,
+} from "@dust-tt/sparkle";
 import { cva, type VariantProps } from "class-variance-authority";
+import { useState } from "react";
 
 const statusBannerVariants = cva("space-y-2 border-y px-3 py-3 text-xs", {
   variants: {
@@ -201,6 +213,84 @@ function SubscriptionPastDueBanner() {
   );
 }
 
+interface RequestUpgradeButtonProps {
+  owner: LightWorkspaceType;
+  hasPendingUpgradeRequest: boolean;
+}
+
+// Footer CTA on the per-user AWU usage banner: lets a warned/capped non-admin
+// member ask their admins to raise their spend limit, behind a single
+// confirmation. Once a request is pending the action is disabled.
+function RequestUpgradeButton({
+  owner,
+  hasPendingUpgradeRequest,
+}: RequestUpgradeButtonProps) {
+  const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [requested, setRequested] = useState(false);
+
+  const alreadyRequested = hasPendingUpgradeRequest || requested;
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    try {
+      const ok = await doRequestUpgrade();
+      if (ok) {
+        setRequested(true);
+        setIsDialogOpen(false);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (alreadyRequested) {
+    return <Button size="xs" variant="outline" label="Request sent" disabled />;
+  }
+
+  return (
+    <>
+      <Button
+        size="xs"
+        variant="outline"
+        label="Request an upgrade"
+        onClick={() => setIsDialogOpen(true)}
+      />
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => !open && setIsDialogOpen(false)}
+      >
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Request a usage limit upgrade</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Your workspace admins will be notified that you'd like your usage
+              limit increased. They'll review your request and get back to you.
+            </p>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setIsDialogOpen(false),
+            }}
+            rightButtonProps={{
+              label: "Send request",
+              variant: "primary",
+              isLoading: isSubmitting,
+              disabled: isSubmitting,
+              onClick: () => void handleConfirm(),
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 interface UsageStatusBannerProps {
   owner: LightWorkspaceType;
 }
@@ -212,6 +302,8 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
     programmaticCreditStatus,
     balanceThresholdReached,
     noSeat,
+    canRequestUpgrade,
+    hasPendingUpgradeRequest,
   } = useWorkspaceUsageStatus({ owner });
 
   // Pool balance and programmatic cap banners are only shown to admins who
@@ -298,6 +390,12 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
           awuStatus === "blocked"
             ? "You can no longer run agents. Contact your admin to increase your limit."
             : "Contact your admin to increase your limit before you are blocked.",
+        footer: canRequestUpgrade ? (
+          <RequestUpgradeButton
+            owner={owner}
+            hasPendingUpgradeRequest={hasPendingUpgradeRequest}
+          />
+        ) : undefined,
       };
     }
 

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -16,6 +16,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export type UpgradeRequestErrorType =
   | "workspace_not_metronome_billed"
+  | "upgrade_requests_disabled"
   | "user_not_found"
   | "request_not_found"
   | "request_not_pending";
@@ -27,6 +28,14 @@ export class UpgradeRequestError extends Error {
   ) {
     super(message);
   }
+}
+
+async function isMemberUpgradeRequestAllowed(
+  auth: Authenticator
+): Promise<boolean> {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  return config?.allowMemberUpgradeRequests ?? true;
 }
 
 export type GetUpgradeRequestsResponseBody = {
@@ -53,6 +62,15 @@ export async function createUpgradeRequest(
       new UpgradeRequestError(
         "workspace_not_metronome_billed",
         "Upgrade requests are only available on credit-priced workspaces."
+      )
+    );
+  }
+
+  if (!(await isMemberUpgradeRequestAllowed(auth))) {
+    return new Err(
+      new UpgradeRequestError(
+        "upgrade_requests_disabled",
+        "Member-initiated upgrade requests are disabled for this workspace."
       )
     );
   }
@@ -128,9 +146,7 @@ export async function getUpgradeRequestAvailabilityForUser(
     return unavailable;
   }
 
-  const config =
-    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  if (config && !config.allowMemberUpgradeRequests) {
+  if (!(await isMemberUpgradeRequestAllowed(auth))) {
     return unavailable;
   }
 

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -4,6 +4,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
 import type {
@@ -106,6 +107,47 @@ export async function createUpgradeRequest(
   // `upgradeRequestEmail` notification toggle).
 
   return new Ok(request.toJSON());
+}
+
+export type UpgradeRequestAvailability = {
+  canRequestUpgrade: boolean;
+  hasPendingUpgradeRequest: boolean;
+};
+
+// Whether the current member may request a spend-limit upgrade, and whether they
+// already have a pending one. Used by the usage-status endpoint to drive the
+// in-product CTA, so kept cheap: nothing is fetched for admins (who resolve
+// requests rather than make them) or for members who are not near their limit.
+export async function getUpgradeRequestAvailabilityForUser(
+  auth: Authenticator,
+  { isNearOrAtLimit }: { isNearOrAtLimit: boolean }
+): Promise<UpgradeRequestAvailability> {
+  const unavailable: UpgradeRequestAvailability = {
+    canRequestUpgrade: false,
+    hasPendingUpgradeRequest: false,
+  };
+
+  const user = auth.user();
+  if (auth.isAdmin() || !isNearOrAtLimit || !user) {
+    return unavailable;
+  }
+
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  // Enabled by default when no configuration row exists yet (mirrors the
+  // default in `getUsageConfiguration`).
+  if (config && !config.allowMemberUpgradeRequests) {
+    return unavailable;
+  }
+
+  const pending = await MembershipUpgradeRequestResource.getPendingForUser(
+    auth,
+    { user }
+  );
+  return {
+    canRequestUpgrade: true,
+    hasPendingUpgradeRequest: pending !== null,
+  };
 }
 
 // Admin-only: list pending upgrade requests for the workspace.

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -114,10 +114,6 @@ export type UpgradeRequestAvailability = {
   hasPendingUpgradeRequest: boolean;
 };
 
-// Whether the current member may request a spend-limit upgrade, and whether they
-// already have a pending one. Used by the usage-status endpoint to drive the
-// in-product CTA, so kept cheap: nothing is fetched for admins (who resolve
-// requests rather than make them) or for members who are not near their limit.
 export async function getUpgradeRequestAvailabilityForUser(
   auth: Authenticator,
   { isNearOrAtLimit }: { isNearOrAtLimit: boolean }
@@ -134,8 +130,6 @@ export async function getUpgradeRequestAvailabilityForUser(
 
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-  // Enabled by default when no configuration row exists yet (mirrors the
-  // default in `getUsageConfiguration`).
   if (config && !config.allowMemberUpgradeRequests) {
     return unavailable;
   }

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -74,10 +74,6 @@ export type GetWorkspaceUsageStatusResponseBody = {
   // True when the current user has no billable seat in the workspace and is
   // therefore blocked from sending messages.
   noSeat: boolean;
-  // Whether the current member may request a spend-limit upgrade from the
-  // product (non-admin, warned/capped, workspace allows it), and whether they
-  // already have a pending request. Drive the in-product "Request an upgrade"
-  // CTA on the AWU usage banner.
   canRequestUpgrade: boolean;
   hasPendingUpgradeRequest: boolean;
 };

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -74,6 +74,12 @@ export type GetWorkspaceUsageStatusResponseBody = {
   // True when the current user has no billable seat in the workspace and is
   // therefore blocked from sending messages.
   noSeat: boolean;
+  // Whether the current member may request a spend-limit upgrade from the
+  // product (non-admin, warned/capped, workspace allows it), and whether they
+  // already have a pending request. Drive the in-product "Request an upgrade"
+  // CTA on the AWU usage banner.
+  canRequestUpgrade: boolean;
+  hasPendingUpgradeRequest: boolean;
 };
 
 export type GetFairUseCreditsResponseBody = {

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -17,6 +17,46 @@ function upgradeRequestsUrl(workspaceId: string): string {
   return `/api/w/${workspaceId}/credits/upgrade-requests`;
 }
 
+function usageStatusUrl(workspaceId: string): string {
+  return `/api/w/${workspaceId}/usage-status`;
+}
+
+// Member-initiated: request a spend-limit upgrade for the current user. On
+// success the usage-status read is revalidated so the banner reflects the now
+// pending request.
+export function useRequestUpgrade({ workspaceId }: { workspaceId: string }) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRWithDefaults(usageStatusUrl(workspaceId), null);
+
+  const doRequestUpgrade = useCallback(async (): Promise<boolean> => {
+    const res = await clientFetch(upgradeRequestsUrl(workspaceId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    if (!res.ok) {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Failed to request an upgrade",
+        description: errorData.message,
+      });
+      return false;
+    }
+
+    await mutate();
+    sendNotification({
+      type: "success",
+      title: "Upgrade requested",
+      description: "Your workspace admins have been notified.",
+    });
+    return true;
+  }, [workspaceId, sendNotification, mutate]);
+
+  return { doRequestUpgrade };
+}
+
 // Admin-only: pending upgrade requests for the workspace. Fetched on the Usage
 // page both to render the Requests tab and to back its count badge, so it is
 // not gated behind tab visibility.

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -287,6 +287,8 @@ export function useWorkspaceUsageStatus({
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
     balanceThresholdReached: data?.balanceThresholdReached ?? false,
     noSeat: data?.noSeat ?? false,
+    canRequestUpgrade: data?.canRequestUpgrade ?? false,
+    hasPendingUpgradeRequest: data?.hasPendingUpgradeRequest ?? false,
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }


### PR DESCRIPTION
(this PR will not change the banner to another design, I will do it in a subsequent one)


<img width="1899" height="946" alt="image" src="https://github.com/user-attachments/assets/3561f971-37a1-46bc-ad2a-4651d453549b" />

Lets a warned/capped non-admin member request a spend-limit upgrade from the product, reusing the existing per-user AWU usage banner.

- `usage-status` now returns `canRequestUpgrade` / `hasPendingUpgradeRequest`, computed via a new `getUpgradeRequestAvailabilityForUser` business helper. Admins and members who aren't near their limit short-circuit; the toggle defaults on when no config row exists yet. Additive, backward-compatible response change.
- `useWorkspaceUsageStatus` exposes the two new fields; new `useRequestUpgrade` POST hook revalidates `usage-status` on success.
- `UsageStatusBanner` AWU (warned/blocked) branch gains a "Request an upgrade" footer button → confirmation dialog → POST, collapsing to a disabled "Request sent" once a request is pending.

Builds on the data layer / endpoints (#27166) and admin Requests tab (#27167) already in the stack.

## Tests

`front-api/routes/w/[wId]/usage-status.test.ts`: non-credit-priced workspace reports no availability; a capped non-admin can request; the flag flips after a request is created; admins are never offered the CTA.