### PR TITLE
Offload large tool outputs to DustFileSystem

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -5,7 +5,6 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 // snippet + file reference.
 export const FILE_OFFLOAD_TEXT_SIZE_BYTES = 20 * 1024; // 20KB.
 export const FILE_OFFLOAD_IMAGE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
-export const FILE_OFFLOAD_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
 
 export const FILE_OFFLOAD_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 
@@ -13,7 +12,7 @@ export const FILE_OFFLOAD_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 // When any content block exceeds these sizes, the entire tool result is rejected.
 export const REMOTE_MAX_TEXT_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
 export const REMOTE_MAX_IMAGE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
-export const REMOTE_MAX_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
+export const REMOTE_MAX_RESOURCE_SIZE_BYTES = FILE_OFFLOAD_TEXT_SIZE_BYTES;
 // Hard limit on the entire array of tool outputs.
 export const REMOTE_MAX_TOOL_RESULT_SIZE_BYTES = 50 * 1024 * 1024; // 50MB.
 

--- a/front/lib/actions/mcp_execution.test.ts
+++ b/front/lib/actions/mcp_execution.test.ts
@@ -1,5 +1,4 @@
 import {
-  FILE_OFFLOAD_RESOURCE_SIZE_BYTES,
   FILE_OFFLOAD_SNIPPET_LENGTH,
   FILE_OFFLOAD_TEXT_SIZE_BYTES,
 } from "@app/lib/actions/action_output_limits";
@@ -114,16 +113,15 @@ describe("processToolResults", () => {
       expect(stored.resource.text).toContain("... (truncated)");
     }
 
-    // Offloaded files must not be indexed in Qdrant. Models read them directly.
-    expect(generatedFiles).toHaveLength(1);
-    expect(generatedFiles[0].skipDataSourceIndexing).toBe(true);
+    // Offloaded to DustFileSystem, so generatedFiles is empty.
+    expect(generatedFiles).toHaveLength(0);
   });
 
   it("should store snippet for large resource text", async () => {
     const { auth, conversation, action, toolConfiguration } = await setupTest();
 
-    // Generate resource text that exceeds FILE_OFFLOAD_RESOURCE_SIZE_BYTES (20MB).
-    const largeResourceText = "y".repeat(FILE_OFFLOAD_RESOURCE_SIZE_BYTES + 1);
+    // Generate resource text that exceeds FILE_OFFLOAD_TEXT_SIZE_BYTES (20KB).
+    const largeResourceText = "y".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
 
     const { outputItems, generatedFiles } = await processToolResults(auth, {
       action,
@@ -149,9 +147,8 @@ describe("processToolResults", () => {
       expect(stored.resource.text).toContain("... (truncated)");
     }
 
-    // Offloaded files must not be indexed in Qdrant. Models read them directly.
-    expect(generatedFiles).toHaveLength(1);
-    expect(generatedFiles[0].skipDataSourceIndexing).toBe(true);
+    // Offloaded to DustFileSystem, so generatedFiles is empty.
+    expect(generatedFiles).toHaveLength(0);
   });
 
   it("should keep small text content as-is", async () => {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -1,13 +1,5 @@
-import {
-  generatePlainTextFile,
-  uploadFileToConversationDataSource,
-} from "@app/lib/actions/action_file_helpers";
-import {
-  computeTextByteSize,
-  FILE_OFFLOAD_RESOURCE_SIZE_BYTES,
-  FILE_OFFLOAD_SNIPPET_LENGTH,
-  FILE_OFFLOAD_TEXT_SIZE_BYTES,
-} from "@app/lib/actions/action_output_limits";
+import { uploadFileToConversationDataSource } from "@app/lib/actions/action_file_helpers";
+import { FILE_OFFLOAD_SNIPPET_LENGTH } from "@app/lib/actions/action_output_limits";
 import type {
   LightMCPToolConfigurationType,
   MCPToolConfigurationType,
@@ -55,12 +47,6 @@ import {
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { extname } from "path";
 import type { Logger } from "pino";
-
-const TEXT_OFFLOAD_EXEMPT_MCP_SERVERS: readonly string[] = [
-  "conversation_files",
-  "files",
-  "sandbox",
-];
 
 /**
  * Recursively sanitizes all string values in an object by removing null bytes and lone surrogates.
@@ -198,39 +184,22 @@ export async function processToolResults(
 
       switch (block.type) {
         case "text": {
-          // If the text is too large we create a file and return a resource block that references the file.
-          // These files are offloaded purely for size reasons. the model reads them directly via the
-          // "cat" approach and never uses semantic search on them. `skipDataSourceIndexing` prevents
-          // them from being indexed in Qdrant, which would bloat the vector store for no benefit.
-          if (
-            computeTextByteSize(block.text) > FILE_OFFLOAD_TEXT_SIZE_BYTES &&
-            !TEXT_OFFLOAD_EXEMPT_MCP_SERVERS.includes(
-              toolConfiguration.mcpServerName
-            )
-          ) {
-            const fileName = `${toolConfiguration.mcpServerName}_${timestamp}_${idx}.txt`;
+          // If persistToolOutput wrote this block to DustFileSystem (too large), return a resource
+          // block pointing at the scoped path. The model reads it via the `cat` tool.
+          if (res.value !== null) {
             const snippet =
               block.text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
               "... (truncated)";
-
-            const file = await generatePlainTextFile(auth, {
-              title: fileName,
-              conversationId: conversation.sId,
-              content: block.text,
-              snippet,
-              hideFromUser: true,
-              skipDataSourceIndexing: true,
-            });
             return {
               content: {
                 type: "resource",
                 resource: {
-                  uri: file.getPublicUrl(auth),
+                  uri: res.value.scopedPath,
                   mimeType: "text/plain",
                   text: snippet,
                 },
               },
-              file,
+              file: null,
             };
           }
           return {
@@ -375,27 +344,13 @@ export async function processToolResults(
             // Sanitize the entire resource object to remove null bytes from all string fields
             const sanitizedResource = sanitizeStringsDeep(block.resource);
 
-            // If the resource text is too large, we create a file and return a resource block that references the file.
-            // Same as the text block case above: offloaded for size, not for search. Skip Qdrant indexing.
-            if (
-              text &&
-              computeTextByteSize(text) > FILE_OFFLOAD_RESOURCE_SIZE_BYTES
-            ) {
-              const fileName =
-                block.resource.uri?.split("/").pop() ??
-                `resource_${Date.now()}.txt`;
+            // Large resource text was already offloaded by persistToolOutput above.
+            if (res.value !== null) {
               const snippet =
-                text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
-                "... (truncated)";
-
-              const file = await generatePlainTextFile(auth, {
-                title: fileName,
-                conversationId: conversation.sId,
-                content: text,
-                snippet,
-                hideFromUser: true,
-                skipDataSourceIndexing: true,
-              });
+                text !== null
+                  ? text.substring(0, FILE_OFFLOAD_SNIPPET_LENGTH) +
+                    "... (truncated)"
+                  : "";
               return {
                 content: {
                   type: block.type,
@@ -404,7 +359,7 @@ export async function processToolResults(
                     text: snippet,
                   },
                 },
-                file,
+                file: null,
               };
             }
             return {

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -1,6 +1,6 @@
 // All mime types are okay to use from the public API.
 
-import { FILE_OFFLOAD_RESOURCE_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import { FILE_OFFLOAD_IMAGE_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import {
   isBlobResource,
   isRunAgentQueryResourceType,
@@ -190,7 +190,7 @@ export async function handleBase64Upload(
     };
   }
 
-  if (base64Data.length > FILE_OFFLOAD_RESOURCE_SIZE_BYTES) {
+  if (base64Data.length > FILE_OFFLOAD_IMAGE_SIZE_BYTES) {
     return {
       content: {
         type: "text",

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -2,6 +2,7 @@ import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_lim
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
+import { isResourceContentWithText } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   resolveResourceOutput,
   shouldOffloadTextBlock,
@@ -111,11 +112,8 @@ export async function persistToolOutput(
 
   // Resource blocks whose text exceeds the offload threshold.
   if (
-    block.type === "resource" &&
-    "text" in block.resource &&
-    typeof block.resource.text === "string" &&
-    Buffer.byteLength(block.resource.text, "utf8") >
-      FILE_OFFLOAD_TEXT_SIZE_BYTES
+    isResourceContentWithText(block) &&
+    Buffer.byteLength(block.resource.text, "utf8") > FILE_OFFLOAD_TEXT_SIZE_BYTES
   ) {
     const text = block.resource.text;
     const { fileName, contentType } = inferTextFileMetadata(text, toolName);

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -1,8 +1,8 @@
 import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import { isResourceContentWithText } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
-import { isResourceContentWithText } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   resolveResourceOutput,
   shouldOffloadTextBlock,
@@ -113,7 +113,8 @@ export async function persistToolOutput(
   // Resource blocks whose text exceeds the offload threshold.
   if (
     isResourceContentWithText(block) &&
-    Buffer.byteLength(block.resource.text, "utf8") > FILE_OFFLOAD_TEXT_SIZE_BYTES
+    Buffer.byteLength(block.resource.text, "utf8") >
+      FILE_OFFLOAD_TEXT_SIZE_BYTES
   ) {
     const text = block.resource.text;
     const { fileName, contentType } = inferTextFileMetadata(text, toolName);

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -1,3 +1,4 @@
+import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
@@ -99,6 +100,29 @@ export async function persistToolOutput(
     const result = await writeToToolOutputsFolder(auth, conversation, {
       fileName,
       content: block.text,
+      contentType,
+    });
+    if (result.isErr()) {
+      return result;
+    }
+
+    return new Ok({ fileName, scopedPath: result.value, contentType });
+  }
+
+  // Resource blocks whose text exceeds the offload threshold.
+  if (
+    block.type === "resource" &&
+    "text" in block.resource &&
+    typeof block.resource.text === "string" &&
+    Buffer.byteLength(block.resource.text, "utf8") >
+      FILE_OFFLOAD_TEXT_SIZE_BYTES
+  ) {
+    const text = block.resource.text;
+    const { fileName, contentType } = inferTextFileMetadata(text, toolName);
+
+    const result = await writeToToolOutputsFolder(auth, conversation, {
+      fileName,
+      content: text,
       contentType,
     });
     if (result.isErr()) {

--- a/front/lib/api/files/action_output_fs/registry.ts
+++ b/front/lib/api/files/action_output_fs/registry.ts
@@ -47,7 +47,10 @@ export function resolveResourceOutput(
 }
 
 const TEXT_OFFLOAD_EXEMPT_MCP_SERVERS: readonly string[] = [
+  "conversation_files",
+  "files",
   "interactive_content",
+  "sandbox",
 ];
 
 export function shouldOffloadTextBlock(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
All size-based offloading now goes through a single function (`persistToolOutput`) using `DustFileSystem` instead of creating `FileResource` records. The resource offload threshold is unified with text at `20KB` (down from 20MB 🤯), and the remote MCP hard limit for resource blocks is lowered to match. This prevents large blobs from reaching the model context and eliminates the double-write that was happening for text offloads.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
