### PR TITLE
Fair use credits endpoint

### DIFF
--- a/front-api/routes/w/[wId]/fair-use-credits.ts
+++ b/front-api/routes/w/[wId]/fair-use-credits.ts
@@ -1,0 +1,24 @@
+import type { GetFairUseCreditsResponseBody } from "@app/lib/metronome/user_block";
+import { getFairUseAwuCreditsStatus } from "@app/lib/metronome/user_block";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/fair-use-credits.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetFairUseCreditsResponseBody> => {
+  const auth = ctx.get("auth");
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+
+  const fairUseAwuCreditsState = await getFairUseAwuCreditsStatus({
+    workspace,
+    user: user.toJSON(),
+    plan: auth.plan(),
+  });
+
+  return ctx.json({ fairUseAwuCreditsState });
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -35,6 +35,7 @@ import domains from "./domains";
 import dsync from "./dsync";
 import dustAppSecrets from "./dust_app_secrets";
 import extension from "./extension";
+import fairUseCredits from "./fair-use-credits";
 import featureFlags from "./feature-flags";
 import files from "./files";
 import googleDrivePickerToken from "./google_drive/picker_token";
@@ -251,6 +252,10 @@ app.use(
 );
 app.use(
   "/usage-status/*",
+  workspaceAuth({ doesNotRequireCanUseProduct: true })
+);
+app.use(
+  "/fair-use-credits/*",
   workspaceAuth({ doesNotRequireCanUseProduct: true })
 );
 app.use("/seats/count", workspaceAuth({ doesNotRequireCanUseProduct: true }));
@@ -602,6 +607,7 @@ app.route("/domains", domains);
 app.route("/dsync", dsync);
 app.route("/dust_app_secrets", dustAppSecrets);
 app.route("/extension", extension);
+app.route("/fair-use-credits", fairUseCredits);
 app.route("/files", files);
 app.route("/google_drive/picker_token", googleDrivePickerToken);
 app.route(

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -3,7 +3,6 @@ import type {
   ProgrammaticCreditStatus,
 } from "@app/lib/metronome/user_block";
 import {
-  getFairUseAwuCreditsStatus,
   getWorkspaceCreditPoolStatus,
   getWorkspaceProgrammaticCreditStatus,
   isUserAwuWarned,
@@ -26,18 +25,11 @@ app.get(
     const user = auth.getNonNullableUser();
     const plan = auth.plan();
 
-    const fairUseAwuCreditsState = await getFairUseAwuCreditsStatus({
-      workspace,
-      user: user.toJSON(),
-      plan: auth.plan(),
-    });
-
     const isCreditPriced = plan && isCreditPricedPlan(plan);
     // Workspaces not on Metronome billing have no usage status to report.
     if (!workspace.metronomeCustomerId || !isCreditPriced) {
       return ctx.json({
         awuStatus: "normal",
-        fairUseAwuCreditsState,
         poolCreditState: "active",
         programmaticCreditStatus: "active",
         balanceThresholdReached: false,
@@ -75,7 +67,6 @@ app.get(
 
     return ctx.json({
       awuStatus,
-      fairUseAwuCreditsState,
       poolCreditState,
       programmaticCreditStatus,
       balanceThresholdReached,

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -63,10 +63,13 @@ const DEFAULT_FAIR_USE_AWU_CREDITS_STATUS: FairUseAwuCreditsStatus = {
 
 export type GetWorkspaceUsageStatusResponseBody = {
   awuStatus: "normal" | "warned" | "blocked";
-  fairUseAwuCreditsState: FairUseAwuCreditsStatus;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditStatus: ProgrammaticCreditStatus;
   balanceThresholdReached: boolean;
+};
+
+export type GetFairUseCreditsResponseBody = {
+  fairUseAwuCreditsState: FairUseAwuCreditsStatus;
 };
 
 const REDIS_ORIGIN = "metronome_limit" as const;

--- a/front/lib/swr/fair_use_credits.ts
+++ b/front/lib/swr/fair_use_credits.ts
@@ -1,0 +1,29 @@
+import type { GetFairUseCreditsResponseBody } from "@app/lib/metronome/user_block";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { Fetcher } from "swr";
+
+export function useFairUseCredits({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fairUseCreditsFetcher: Fetcher<GetFairUseCreditsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/fair-use-credits`,
+    fairUseCreditsFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    fairUseAwuCreditsState: data?.fairUseAwuCreditsState ?? null,
+    isFairUseCreditsLoading: !error && !data && !disabled,
+    isFairUseCreditsError: error,
+    mutateFairUseCredits: mutate,
+  };
+}

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -283,11 +283,6 @@ export function useWorkspaceUsageStatus({
 
   return {
     awuStatus: data?.awuStatus ?? "normal",
-    fairUseAwuCreditsState: data?.fairUseAwuCreditsState ?? {
-      limit: -1,
-      timeframe: "lifetime",
-      count: 0,
-    },
     poolCreditState: data?.poolCreditState ?? "active",
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
     balanceThresholdReached: data?.balanceThresholdReached ?? false,


### PR DESCRIPTION
## Description

Move `fairUseAwuCreditsState` to its own endpoint since it's going to be called on each message success. `/usage-status` is a bit heavy for that based on [logs](https://app.datadoghq.eu/logs?query=service%3Afront-api%20%40route%3A%22%2Fapi%2Fw%2F%3AwId%2Fusage-status%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40durationMs&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1748852391672&to_ts=1748853291672&live=true)

## Tests

Tested non breaking locally

## Risk

None

## Deploy Plan

- deploy `front`