### PR TITLE
fix(front): close conversation side panel when switching conversations

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -1,4 +1,5 @@
 import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
+import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useHashParam } from "@app/hooks/useHashParams";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
@@ -174,6 +175,27 @@ export function ConversationSidePanelProvider({
     },
     [setCurrentPanel, setData, data, closePanel, currentPanel]
   );
+
+  // Close the panel when switching conversations: the provider stays mounted
+  // across conversation navigation and useHashParam does not re-sync on
+  // pushState navigation, so without this the previous conversation's panel
+  // (e.g. a Frame) stays open. Skip the null -> id transition so a panel
+  // auto-opened while creating a new conversation is not closed when the
+  // conversation gets its id, and skip the initial mount to keep deep links
+  // (#spt=...&spid=...) working.
+  const activeConversationId = useActiveConversationId();
+  const previousConversationIdRef = React.useRef(activeConversationId);
+  useEffect(() => {
+    const previousConversationId = previousConversationIdRef.current;
+    previousConversationIdRef.current = activeConversationId;
+
+    if (
+      previousConversationId &&
+      previousConversationId !== activeConversationId
+    ) {
+      closePanel();
+    }
+  }, [activeConversationId, closePanel]);
 
   // Initialize panel state from URL hash parameters
   useEffect(() => {

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -181,13 +181,9 @@ export function ConversationSidePanelProvider({
   );
 
   // Close the panel when switching conversations: the provider stays mounted
-  // across conversation navigation and useHashParam does not re-sync on
-  // pushState navigation, so without this the previous conversation's panel
-  // (e.g. a Frame) stays open. Skip the null -> id transition so a panel
-  // auto-opened while creating a new conversation is not closed when the
-  // conversation gets its id, and skip the initial mount to keep deep links
-  // (#spt=...&spid=...) working. The id -> null transition (navigating to a
-  // new conversation) does close the panel.
+  // across navigation and useHashParam does not re-sync on pushState, so the
+  // previous conversation's panel would otherwise stay open. Skips the initial
+  // mount (deep links) and the null -> id transition (new conversation flow).
   useEffect(() => {
     const previousConversationId = previousConversationIdRef.current;
     previousConversationIdRef.current = activeConversationId;
@@ -196,8 +192,7 @@ export function ConversationSidePanelProvider({
       previousConversationId &&
       previousConversationId !== activeConversationId
     ) {
-      // Also exit full screen, mirroring FrameRenderer's close button: without
-      // this the layout stays in full screen mode after the panel is gone.
+      // Exit full screen too, mirroring FrameRenderer's close button.
       setFullScreenHash(undefined);
       closePanel();
     }

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -5,6 +5,7 @@ import type { ConversationSidePanelType } from "@app/types/conversation_side_pan
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
+  FULL_SCREEN_HASH_PARAM,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   PLAN_SIDE_PANEL_TYPE,
   SIDE_PANEL_HASH_PARAM,
@@ -92,6 +93,7 @@ export function ConversationSidePanelProvider({
   const [currentPanel, setCurrentPanel] = useHashParam(
     SIDE_PANEL_TYPE_HASH_PARAM
   );
+  const [, setFullScreenHash] = useHashParam(FULL_SCREEN_HASH_PARAM);
   const activeConversationId = useActiveConversationId();
   const previousConversationIdRef = React.useRef(activeConversationId);
 
@@ -194,9 +196,12 @@ export function ConversationSidePanelProvider({
       previousConversationId &&
       previousConversationId !== activeConversationId
     ) {
+      // Also exit full screen, mirroring FrameRenderer's close button: without
+      // this the layout stays in full screen mode after the panel is gone.
+      setFullScreenHash(undefined);
       closePanel();
     }
-  }, [activeConversationId, closePanel]);
+  }, [activeConversationId, closePanel, setFullScreenHash]);
 
   // Initialize panel state from URL hash parameters
   useEffect(() => {

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -92,6 +92,8 @@ export function ConversationSidePanelProvider({
   const [currentPanel, setCurrentPanel] = useHashParam(
     SIDE_PANEL_TYPE_HASH_PARAM
   );
+  const activeConversationId = useActiveConversationId();
+  const previousConversationIdRef = React.useRef(activeConversationId);
 
   const panelRef = React.useRef<ImperativePanelHandle | null>(null);
   const [virtuosoMsg, setVirtuosoMsg] =
@@ -182,9 +184,8 @@ export function ConversationSidePanelProvider({
   // (e.g. a Frame) stays open. Skip the null -> id transition so a panel
   // auto-opened while creating a new conversation is not closed when the
   // conversation gets its id, and skip the initial mount to keep deep links
-  // (#spt=...&spid=...) working.
-  const activeConversationId = useActiveConversationId();
-  const previousConversationIdRef = React.useRef(activeConversationId);
+  // (#spt=...&spid=...) working. The id -> null transition (navigating to a
+  // new conversation) does close the panel.
   useEffect(() => {
     const previousConversationId = previousConversationIdRef.current;
     previousConversationIdRef.current = activeConversationId;


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#8777: a Frame (or any side panel: actions, files, plan) opened in one conversation stayed open after switching to another conversation, showing the previous conversation's content.

### Root cause

Regression from #26995. Before it, useHashParam cleared its state on the router's routeChangeComplete event; that is what closed the panel on conversation switch. #26995 replaced the router events with hashchange/popstate listeners, which do not fire on client-side (pushState) navigation. ConversationSidePanelProvider stays mounted across conversation navigation, so its hash-backed state (#spt/#spid) kept the old panel open.

### Fix

An effect in the provider closes the panel (and exits full screen, like FrameRenderer's close button) when the active conversation id changes. It skips:
- the initial mount, so deep links (#spt=...&spid=...) still auto-open the panel
- the null to id transition, so a panel auto-opened while creating a new conversation is not closed when the conversation gets its id

### Why not fix useHashParam instead

Restoring the route-event re-sync in the hook would re-couple it to the Next router, which #26995 deliberately removed for the SPA build. Stale hook state only matters for components that survive navigation: the side panel provider/container and AppContentLayout's full screen flag, both covered here. Every other consumer (agent browser tabs, space search viewType, manage pages, pagination) is page-scoped and unmounts on navigation.

## Tests

Reasoned through the edge cases (deep link, new conversation flow, full screen, agent builder preview where there is no cId). Not covered by automated tests, the provider has none today.

## Risk

Low. One effect in the provider, inert outside conversation pages (cId is null there). Safe to rollback.

## Deploy Plan

Standard deploy.