### PR TITLE
feat(billing): free-aware credit-state core (2/5)

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -9,7 +9,10 @@ import {
   getMetronomePerUserCap,
 } from "@app/lib/metronome/alerts/spend_limits";
 import { getNetBalance } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import {
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
@@ -62,6 +65,15 @@ async function resolvePoolLimitForUser({
     return null;
   }
 
+  // Free seats have no pool access — their pool limit is always 0, regardless
+  // of any per-user cap override (a cap bounds personal spend; it is not a pool
+  // budget). This is the single source of "free has no pool": downstream
+  // routing (capped vs on_pool) then falls out of `poolLimit === 0` with no
+  // seat-type special-casing.
+  if (seatType === "free") {
+    return 0;
+  }
+
   // 1. Per-user override.
   const userCapResult = await getMetronomePerUserCap({
     metronomeCustomerId,
@@ -108,6 +120,11 @@ async function getSeatAllowance(
   workspace: WorkspaceResource,
   seatType: MembershipSeatType | null | undefined
 ): Promise<number> {
+  // Free seats carry a fixed personal allocation that isn't a contract
+  // recurring credit, so it's a code constant rather than a contract lookup.
+  if (seatType === "free") {
+    return FREE_SEAT_LIFETIME_AWU_CREDITS;
+  }
   const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
   if (!normalizedSeatType) {
     return 0;
@@ -179,12 +196,13 @@ export async function dispatchSeatBalanceExhausted({
 
   const result = await transitionUserCreditState(
     membership,
-    { type: "seat_balance_exhausted", poolLimitAwuCredits },
+    { type: "seat_balance_exhausted" },
     {
       workspaceId: workspace.sId,
       userId,
       seatType: membership.seatType,
       remainingCapCreditsPercentage,
+      poolLimitAwuCredits,
     }
   );
   if (result.isErr()) {
@@ -241,10 +259,25 @@ export async function dispatchSeatBalanceResolved({
     userId,
   });
 
+  // The seat balance came back; the band the user lands in depends on how much
+  // is left. Read the live balance so the state machine can route to
+  // `user_seat` vs `user_seat_low_balance` (or the pool for non-seat users).
+  const liveBalance = await resolveLiveUserBalance({
+    workspace,
+    userId,
+    seatType: membership.seatType,
+    poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
+  });
+
   const result = await transitionUserCreditState(
     membership,
     { type: "seat_balance_resolved" },
-    { workspaceId: workspace.sId, userId, seatType: membership.seatType }
+    {
+      workspaceId: workspace.sId,
+      userId,
+      seatType: membership.seatType,
+      liveBalance,
+    }
   );
   if (result.isErr()) {
     logger.warn(
@@ -484,7 +517,7 @@ export async function dispatchPerUserCapResolved({
   // `user_seat_low_balance`; otherwise the pool). When the live read isn't
   // available the transition defaults to `on_pool` and the reconcile / billing
   // webhooks correct it later.
-  const liveBalance = await resolveLiveBalanceForCapResolved({
+  const liveBalance = await resolveLiveUserBalance({
     workspace,
     userId,
     seatType: membership.seatType,
@@ -507,10 +540,11 @@ export async function dispatchPerUserCapResolved({
   return new Ok(undefined);
 }
 
-// Read the live per-user balance snapshot used to resolve the seat↔pool band on
-// cap resolution. Returns `undefined` when there's no Metronome customer or the
-// live read fails — the transition then defaults to `on_pool`.
-async function resolveLiveBalanceForCapResolved({
+// Read the live per-user balance snapshot used to recompute the seat↔pool band
+// when a per-user cap resolves or a seat balance is replenished. Returns
+// `undefined` when there's no Metronome customer or the live read fails — the
+// transition then falls back to its unguarded default.
+async function resolveLiveUserBalance({
   workspace,
   userId,
   seatType,
@@ -542,7 +576,7 @@ async function resolveLiveBalanceForCapResolved({
   if (liveResult.isErr()) {
     logger.warn(
       { workspaceId: workspace.sId, userId, seatType, err: liveResult.error },
-      "[CreditStateDispatcher] per_user_cap_resolved: live balance read failed, defaulting to on_pool"
+      "[CreditStateDispatcher] live balance read failed; transition uses default band"
     );
     return undefined;
   }

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -4,7 +4,10 @@ import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
 import type { MetronomeCapAlertInfo } from "@app/lib/metronome/alerts/spend_limits";
 import { getCachedDefaultCapThresholdsBySeatType } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import {
+  listContractPerUserCreditBalances,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
 import {
   awuSeatBalanceForUser,
   fetchLiveUserCreditInputs,
@@ -389,6 +392,25 @@ export async function reconcileWorkspaceUserCreditStates({
   }
   const seatBalances = seatBalancesResult.value;
 
+  // Free seats hold a per-user contract credit, not a seat balance, so they're
+  // absent from `listMetronomeSeatBalances`. Read their balances separately so a
+  // free user with credit remaining lands on `user_seat` (not `on_pool`) and is
+  // moved to `capped` once exhausted. A read failure leaves the map empty —
+  // free users then fall back to the seat-balance path (null) as before.
+  const perUserCreditBalancesResult = await listContractPerUserCreditBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (perUserCreditBalancesResult.isErr()) {
+    logger.warn(
+      { workspaceId, err: perUserCreditBalancesResult.error },
+      "[ReconcileCreditState] Failed to load per-user credit balances"
+    );
+  }
+  const perUserCreditBalances = perUserCreditBalancesResult.isOk()
+    ? perUserCreditBalancesResult.value
+    : new Map<string, { balanceAwu: number; startingBalanceAwu: number }>();
+
   // The cap-threshold caches (Metronome alert list / contract) and the
   // membership query (DB) can genuinely throw, so they stay wrapped — the
   // ERR1-authorised case. The per-user overrides themselves come from the
@@ -454,7 +476,15 @@ export async function reconcileWorkspaceUserCreditStates({
           ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
           : null;
 
-    const seat = awuSeatBalanceForUser(seatBalances, userId);
+    // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
+    // seats read their per-user credit balance instead (not a seat balance).
+    // Pro/max read their seat balance. `expectedUserCreditState` decides routing
+    // from the seat type — a free seat is never `on_pool`, and a null (unknown)
+    // balance leaves it on the seat rather than mis-capping it.
+    const seat =
+      awuSeatBalanceForUser(seatBalances, userId) ??
+      perUserCreditBalances.get(userId) ??
+      null;
     const expectedState = expectedUserCreditState({
       seatType,
       seatBalanceAwu: seat?.balanceAwu ?? null,

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -475,7 +475,6 @@ export async function reconcileWorkspaceUserCreditStates({
         : normalizedSeatType
           ? (defaultCaps[normalizedSeatType]?.threshold ?? null)
           : null;
-
     // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
     // seats read their per-user credit balance instead (not a seat balance).
     // Pro/max read their seat balance. `expectedUserCreditState` decides routing

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -11,7 +11,10 @@
 // reconcile module back.
 
 import { getMetronomeDefaultUserCapAlertForSeatType } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
+import {
+  listContractPerUserCreditBalances,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
@@ -82,24 +85,45 @@ export async function fetchLiveUserCreditInputs({
   metronomeContractId: string | null;
 }): Promise<Result<LiveUserCreditInputs, Error>> {
   // Live per-user seat balance (the seat↔pool dimension's source of truth).
+  // Pro/max read their SEAT_BASED seat balance; free seats hold a per-user
+  // contract credit instead (not a seat balance), so read that.
   let seatBalanceAwu: number | null = null;
   let seatStartingBalanceAwu: number | null = null;
   if (metronomeContractId) {
-    const seatBalancesResult = await listMetronomeSeatBalances({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
-    if (seatBalancesResult.isErr()) {
-      return new Err(
-        new Error(
-          `Failed to read seat balances: ${seatBalancesResult.error.message}`
-        )
-      );
-    }
-    const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
-    if (seat) {
-      seatBalanceAwu = seat.balanceAwu;
-      seatStartingBalanceAwu = seat.startingBalanceAwu;
+    if (seatType === "free") {
+      const creditBalancesResult = await listContractPerUserCreditBalances({
+        metronomeCustomerId,
+        metronomeContractId,
+      });
+      if (creditBalancesResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to read per-user credit balances: ${creditBalancesResult.error.message}`
+          )
+        );
+      }
+      const credit = creditBalancesResult.value.get(userId);
+      if (credit) {
+        seatBalanceAwu = credit.balanceAwu;
+        seatStartingBalanceAwu = credit.startingBalanceAwu;
+      }
+    } else {
+      const seatBalancesResult = await listMetronomeSeatBalances({
+        metronomeCustomerId,
+        metronomeContractId,
+      });
+      if (seatBalancesResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to read seat balances: ${seatBalancesResult.error.message}`
+          )
+        );
+      }
+      const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
+      if (seat) {
+        seatBalanceAwu = seat.balanceAwu;
+        seatStartingBalanceAwu = seat.startingBalanceAwu;
+      }
     }
   }
 

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -291,8 +291,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "free" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "free", poolLimitAwuCredits: 0 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -313,8 +313,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat_low_balance", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "free" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "free", poolLimitAwuCredits: 0 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -335,8 +335,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
-      { ...baseCtx, seatType: "pro" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: 5000 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -357,8 +357,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: null }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -379,8 +379,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 0 },
-      { ...baseCtx, seatType: "pro" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "pro", poolLimitAwuCredits: 0 }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -401,8 +401,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     const membership = makeMembership("user_seat_low_balance", "max");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "max" }
+      { type: "seat_balance_exhausted" },
+      { ...baseCtx, seatType: "max", poolLimitAwuCredits: null }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -430,8 +430,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0,
+        poolLimitAwuCredits: 5000,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -448,8 +453,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat_low_balance", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: 5000 },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0,
+        poolLimitAwuCredits: 5000,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -466,8 +476,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.1 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.1,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -484,8 +499,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.19 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.19,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -502,8 +522,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.2 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.2,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -520,8 +545,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: 0.5 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: 0.5,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -538,8 +568,13 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "pro", remainingCapCreditsPercentage: null }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        remainingCapCreditsPercentage: null,
+        poolLimitAwuCredits: null,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -551,13 +586,18 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
   });
 
-  // Guard 1 (free seat) takes precedence regardless of percentage.
-  it("user_seat + free + 50% cap remaining → capped (free-seat guard wins)", async () => {
+  // Pool limit 0 (free has no pool) → capped, regardless of cap percentage.
+  it("user_seat + poolLimit 0 + 50% cap remaining → capped (no pool budget)", async () => {
     const membership = makeMembership("user_seat", "free");
     const result = await transitionUserCreditState(
       membership,
-      { type: "seat_balance_exhausted", poolLimitAwuCredits: null },
-      { ...baseCtx, seatType: "free", remainingCapCreditsPercentage: 0.5 }
+      { type: "seat_balance_exhausted" },
+      {
+        ...baseCtx,
+        seatType: "free",
+        remainingCapCreditsPercentage: 0.5,
+        poolLimitAwuCredits: 0,
+      }
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -617,6 +657,21 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
     );
   });
 
+  it("user_seat + free seat → user_seat_low_balance (no threshold matching)", async () => {
+    const membership = makeMembership("user_seat", "free");
+    // The per-user free-credit alert is scoped to this user, so the free guard
+    // matches on seat type alone — the threshold value is not checked.
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_low_balance", threshold: 60 },
+      { ...baseCtx, seatType: "free" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat_low_balance");
+    }
+  });
+
   it("user_seat + max threshold + pro seat → no transition (guard mismatch)", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
@@ -652,6 +707,106 @@ describe("UserCreditStateMachine — seat_low_balance", () => {
       "u_test",
       "user_seat_low_balance"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seat balance replenished
+// ---------------------------------------------------------------------------
+
+describe("UserCreditStateMachine — seat_balance_resolved", () => {
+  it("free capped → user_seat when the credit is fully replenished", async () => {
+    const membership = makeMembership("capped", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      {
+        ...baseCtx,
+        seatType: "free",
+        liveBalance: {
+          seatBalanceAwu: 300,
+          seatStartingBalanceAwu: 300,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+  });
+
+  it("free capped → user_seat_low_balance when only a low balance is left", async () => {
+    const membership = makeMembership("capped", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      {
+        ...baseCtx,
+        seatType: "free",
+        liveBalance: {
+          seatBalanceAwu: 40,
+          seatStartingBalanceAwu: 300,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat_low_balance");
+    }
+    expect(membership.updateCreditState).toHaveBeenCalledWith(
+      "user_seat_low_balance",
+      undefined
+    );
+  });
+
+  it("pro user_seat_low_balance → user_seat on a full billing-period renewal", async () => {
+    const membership = makeMembership("user_seat_low_balance", "pro");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      {
+        ...baseCtx,
+        seatType: "pro",
+        liveBalance: {
+          seatBalanceAwu: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          seatStartingBalanceAwu: PRO_SEAT_MONTHLY_AWU_CREDITS,
+          perUserCapAwuCredits: null,
+          consumedAwuCredits: null,
+        },
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+  });
+
+  it("free capped → user_seat without a live balance (default)", async () => {
+    const membership = makeMembership("capped", "free");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      { ...baseCtx, seatType: "free" }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe("user_seat");
+    }
+  });
+
+  it("workspace (pool-based) seat → no transition", async () => {
+    const membership = makeMembership("on_pool", "workspace");
+    const result = await transitionUserCreditState(
+      membership,
+      { type: "seat_balance_resolved" },
+      { ...baseCtx, seatType: "workspace" }
+    );
+    expect(result.isErr()).toBe(true);
+    expect(membership.updateCreditState).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -9,6 +9,7 @@ import type {
 import {
   CAP_WARNING_FRACTION,
   expectedUserCreditState,
+  isSeatBased,
   SEAT_LOW_BALANCE_FRACTION,
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
@@ -50,6 +51,14 @@ export type UserCreditContext = {
    * whether to land on `on_pool`, `on_pool_low_balance`, or `capped`.
    */
   remainingCapCreditsPercentage?: number | null;
+  /**
+   * The user's effective pool budget in AWU credits: `0` = no pool access
+   * (e.g. free seats), `> 0` = capped pool, `null` = unlimited. A property of
+   * the user's situation (like `remainingCapCreditsPercentage`), so it lives in
+   * the context — it's what the `seat_balance_exhausted` guards use to route
+   * `capped` vs `on_pool`, with no seat-type special-casing.
+   */
+  poolLimitAwuCredits?: number | null;
 };
 
 export type UserCreditEvent =
@@ -67,13 +76,12 @@ export type UserCreditEvent =
    */
   | { type: "admin_raised_user_cap" }
   /**
-   * This user's personal seat balance is exhausted. The user's effective pool
-   * limit determines the next state:
-   *   - free seats → always `capped` (no pool access)
-   *   - paid seats with `poolLimitAwuCredits === 0` → `capped`
-   *   - paid seats with `poolLimitAwuCredits > 0` or `null` (unlimited) → `on_pool`
+   * This user's personal seat balance is exhausted. The next state is decided
+   * by `ctx.poolLimitAwuCredits`:
+   *   - `0` (no pool access, e.g. free seats) → `capped`
+   *   - `> 0` or `null` (unlimited) → `on_pool` (band depends on cap usage)
    */
-  | { type: "seat_balance_exhausted"; poolLimitAwuCredits: number | null }
+  | { type: "seat_balance_exhausted" }
   /**
    * This user's personal seat balance crossed a low-balance warning threshold
    * (balance > 0). Moves `user_seat` → `user_seat_low_balance`.
@@ -109,12 +117,14 @@ type UserCreditTransition = {
   to: UserCreditState;
 };
 
-// Seat↔pool band a user should land in when their per-user cap resolves,
-// derived from the live balance snapshot carried in the context. Used by the
-// guards on the `per_user_cap_resolved` transitions below (mirroring how the
-// `seat_balance_exhausted` guards branch on seat type / pool limit). Without a
-// snapshot we can't distinguish seat from pool, so default to the pool.
-function targetAfterCapResolved(ctx: UserCreditContext): UserCreditState {
+// Seat↔pool band a user should land in once a blocking dimension clears (a
+// per-user cap resolving, or a seat balance replenishing), derived from the
+// live balance snapshot carried in the context. Used by the guards on the
+// `per_user_cap_resolved` / `seat_balance_resolved` transitions below
+// (mirroring how the `seat_balance_exhausted` guards branch on seat type / pool
+// limit). Without a snapshot we can't distinguish seat from pool, so default to
+// the pool.
+function targetBandFromLiveBalance(ctx: UserCreditContext): UserCreditState {
   if (!ctx.liveBalance) {
     return "on_pool";
   }
@@ -157,7 +167,7 @@ const TRANSITIONS: UserCreditTransition[] = [
       "capped",
     ],
     event: "per_user_cap_resolved",
-    guard: (ctx) => targetAfterCapResolved(ctx) === "user_seat",
+    guard: (ctx) => targetBandFromLiveBalance(ctx) === "user_seat",
     to: "user_seat",
   },
   {
@@ -169,7 +179,7 @@ const TRANSITIONS: UserCreditTransition[] = [
       "capped",
     ],
     event: "per_user_cap_resolved",
-    guard: (ctx) => targetAfterCapResolved(ctx) === "user_seat_low_balance",
+    guard: (ctx) => targetBandFromLiveBalance(ctx) === "user_seat_low_balance",
     to: "user_seat_low_balance",
   },
   {
@@ -181,7 +191,7 @@ const TRANSITIONS: UserCreditTransition[] = [
       "capped",
     ],
     event: "per_user_cap_resolved",
-    guard: (ctx) => targetAfterCapResolved(ctx) === "on_pool_low_balance",
+    guard: (ctx) => targetBandFromLiveBalance(ctx) === "on_pool_low_balance",
     to: "on_pool_low_balance",
   },
   {
@@ -195,43 +205,32 @@ const TRANSITIONS: UserCreditTransition[] = [
     event: "per_user_cap_resolved",
     to: "on_pool",
   },
-  // Seat balance exhausted. Order matters: most specific guard first.
-  //  1. Free seats → always capped (no pool access).
+  // Seat balance exhausted. Routing is driven by `ctx.poolLimitAwuCredits`, not
+  // the seat type — a no-pool seat (free) simply has poolLimit 0. Order matters:
+  // most specific guard first.
+  //  1. No pool budget (poolLimit 0, incl. free) or per-user cap also exhausted
+  //     → capped.
   {
     from: ["user_seat", "user_seat_low_balance", "capped"],
     event: "seat_balance_exhausted",
-    guard: (ctx) => ctx.seatType === "free",
+    guard: (ctx) =>
+      ctx.poolLimitAwuCredits === 0 || ctx.remainingCapCreditsPercentage === 0,
     to: "capped",
   },
-  // 2. Paid seats whose per-user cap is also exhausted (0 % remaining) or with pool limit = 0 → capped (no pool budget).
-  {
-    from: ["user_seat", "user_seat_low_balance", "capped"],
-    event: "seat_balance_exhausted",
-    guard: (ctx, event) =>
-      ctx.seatType !== "free" &&
-      event.type === "seat_balance_exhausted" &&
-      (event.poolLimitAwuCredits === 0 ||
-        ctx.remainingCapCreditsPercentage === 0),
-    to: "capped",
-  },
-  // 3. Paid seats with < 20 % of cap remaining → on_pool_low_balance.
+  //  2. Pool budget left but < 20 % of cap remaining → on_pool_low_balance.
   {
     from: ["user_seat", "user_seat_low_balance"],
     event: "seat_balance_exhausted",
     guard: (ctx) =>
-      ctx.seatType !== "free" &&
       ctx.remainingCapCreditsPercentage != null &&
       ctx.remainingCapCreditsPercentage < 1 - CAP_WARNING_FRACTION,
     to: "on_pool_low_balance",
   },
-  // 4. Paid seats with ≥ 20 % of cap remaining, with pool limit > 0 or null (unlimited) → on_pool
+  //  3. Pool budget left (poolLimit > 0 or null/unlimited) → on_pool.
   {
     from: ["user_seat", "user_seat_low_balance", "on_pool"],
     event: "seat_balance_exhausted",
-    guard: (ctx, event) =>
-      ctx.seatType !== "free" &&
-      event.type === "seat_balance_exhausted" &&
-      event.poolLimitAwuCredits !== 0,
+    guard: (ctx) => ctx.poolLimitAwuCredits !== 0,
     to: "on_pool",
   },
 
@@ -256,6 +255,16 @@ const TRANSITIONS: UserCreditTransition[] = [
       (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
     to: "user_seat_low_balance",
   },
+  // Free seats: the per-user credit-balance alert is scoped to this one user
+  // (not a workspace-wide fan-out), so it's always relevant — no threshold
+  // disambiguation needed. Match on seat type alone, with no hardcoded
+  // threshold value.
+  {
+    from: ["user_seat", "user_seat_low_balance"],
+    event: "seat_low_balance",
+    guard: (ctx) => ctx.seatType === "free",
+    to: "user_seat_low_balance",
+  },
 
   // Per-user cap 80% warning: move on_pool → on_pool_low_balance.
   {
@@ -271,22 +280,37 @@ const TRANSITIONS: UserCreditTransition[] = [
     to: "on_pool",
   },
 
-  // Billing-period renewal for pro/max seats: reset to user_seat regardless
-  // of current state. Workspace seats are reset by per_user_cap_resolved;
-  // free seats are not reset.
+  // Seat balance replenished — for pro/max a billing-period renewal, for free a
+  // fresh credit clearing its low/empty alert. Reset any seat-based user
+  // (pro/max/free) from any state, including `capped` (a free seat exhausted to
+  // 0 is `capped`, so it must be reachable here). The live balance decides the
+  // band: a partial refill that's still under the low-balance threshold lands
+  // in `user_seat_low_balance`, otherwise `user_seat`. Workspace (pool-based)
+  // seats have no seat balance and are reset by per_user_cap_resolved instead.
   {
     from: [
       "user_seat",
       "user_seat_low_balance",
       "on_pool",
       "on_pool_low_balance",
+      "capped",
     ],
     event: "seat_balance_resolved",
     guard: (ctx) =>
-      ctx.seatType === "pro" ||
-      ctx.seatType === "pro_yearly" ||
-      ctx.seatType === "max" ||
-      ctx.seatType === "max_yearly",
+      isSeatBased(ctx.seatType) &&
+      targetBandFromLiveBalance(ctx) === "user_seat_low_balance",
+    to: "user_seat_low_balance",
+  },
+  {
+    from: [
+      "user_seat",
+      "user_seat_low_balance",
+      "on_pool",
+      "on_pool_low_balance",
+      "capped",
+    ],
+    event: "seat_balance_resolved",
+    guard: (ctx) => isSeatBased(ctx.seatType),
     to: "user_seat",
   },
 ];

--- a/front/types/memberships.test.ts
+++ b/front/types/memberships.test.ts
@@ -106,6 +106,20 @@ describe("expectedUserCreditState", () => {
     ).toBe("capped");
   });
 
+  it("free seat with unknown balance → user_seat (never on_pool)", () => {
+    // A free seat has no pool fallback, so an unknown (null) balance must not
+    // route to on_pool — it stays on the seat until the balance is known 0.
+    expect(
+      expectedUserCreditState({
+        seatType: "free",
+        seatBalanceAwu: null,
+        seatStartingBalanceAwu: null,
+        perUserCapAwuCredits: null,
+        consumedAwuCredits: null,
+      })
+    ).toBe("user_seat");
+  });
+
   it("pool-based (workspace) seat → on_pool (no personal seat balance)", () => {
     expect(
       expectedUserCreditState({

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -279,12 +279,19 @@ export function initialCreditStateForSeatType(
  *     they are seat-based but have no pool fallback, so an exhausted free seat
  *     is `capped`.
  *
- * `seatBalanceAwu` / `seatStartingBalanceAwu` come from the live Metronome
- * per-seat balance (`listMetronomeSeatBalances`); `null` means the user has no
- * individual seat allocation (pool-based seat), so they are treated as
- * spending from the pool. `perUserCapAwuCredits` / `consumedAwuCredits` are
- * `null` when no cap is configured or usage is unknown, in which case the cap
- * bands are skipped.
+ * `seatBalanceAwu` / `seatStartingBalanceAwu` come from the live per-seat /
+ * per-user credit balance; `seatBalanceAwu > 0` means the user still holds
+ * personal credit. `perUserCapAwuCredits` / `consumedAwuCredits` are `null`
+ * when no cap is configured or usage is unknown, in which case the cap bands
+ * are skipped.
+ *
+ * Crucially, where a seat-based user goes once their personal credit is gone is
+ * decided by the SEAT TYPE, not by the balance value: a seat with no pool
+ * fallback (free) is never `on_pool` — it stays on its seat until the balance
+ * is known-exhausted (0), then `capped`. Seats with a pool fallback (pro/max)
+ * fall back to the workspace pool. A `null` (unknown) balance never downgrades
+ * a free user — only a known 0 does — so a transient read miss can't wrongly
+ * cap or pool them; the exhaustion alert is the authoritative capped trigger.
  */
 export function expectedUserCreditState({
   seatType,
@@ -306,28 +313,29 @@ export function expectedUserCreditState({
     return "capped";
   }
 
-  // Seat-based user (pro/max/free) with a known personal balance.
-  if (isSeatBased(seatType) && seatBalanceAwu !== null) {
-    if (seatBalanceAwu > 0) {
-      // Still spending personal credits.
-      if (
-        seatStartingBalanceAwu !== null &&
-        seatBalanceAwu <= SEAT_LOW_BALANCE_FRACTION * seatStartingBalanceAwu
-      ) {
-        return "user_seat_low_balance";
-      }
-      return "user_seat";
+  // Seat-based user still holding personal credit.
+  if (isSeatBased(seatType) && seatBalanceAwu !== null && seatBalanceAwu > 0) {
+    if (
+      seatStartingBalanceAwu !== null &&
+      seatBalanceAwu <= SEAT_LOW_BALANCE_FRACTION * seatStartingBalanceAwu
+    ) {
+      return "user_seat_low_balance";
     }
-    // Personal balance exhausted. Free seats have no pool fallback, so they are
-    // capped; pro/max fall through to the workspace-pool bands below.
-    if (normalizeToPoolLimitSeatType(seatType) === null) {
-      return "capped";
-    }
+    return "user_seat";
   }
 
-  // Otherwise spending from the workspace pool (pool-based seat, or pro/max
-  // whose personal balance is exhausted). Surface the 80% cap warning when
-  // applicable.
+  // Seats with no pool fallback (free) never spend from the pool: they stay on
+  // their personal seat until the balance is known-exhausted (0 → capped). An
+  // unknown (null) balance leaves them on the seat — never `on_pool`.
+  if (
+    isSeatBased(seatType) &&
+    normalizeToPoolLimitSeatType(seatType) === null
+  ) {
+    return seatBalanceAwu === 0 ? "capped" : "user_seat";
+  }
+
+  // Pool-backed seats (pro/max with depleted balance) and pool-based seats spend
+  // from the workspace pool. Surface the 80% cap warning when applicable.
   if (
     capKnown &&
     consumedAwuCredits >= CAP_WARNING_FRACTION * perUserCapAwuCredits


### PR DESCRIPTION
## Description

**PR 2 of 5.** Models a free seat as *seat-based with no pool fallback* (poolLimit 0) instead of special-casing it across the credit-state logic. This changes the shape of `expectedUserCreditState` and the state-machine event/context, so it lands **with all of its callers** (the reason it isn't split further — they wouldn't typecheck apart).

- **`expectedUserCreditState`** routes by seat type + pool limit: a free seat with balance left stays `user_seat` / `user_seat_low_balance`, never `on_pool`; a known-exhausted free seat is `capped`; an unknown (null) balance never downgrades it.
- **State machine** — `seat_balance_exhausted` routes on `poolLimitAwuCredits` carried in context (0 → `capped`) rather than hardcoded seat types; `seat_low_balance` matches free on seat type alone (no hardcoded threshold); `seat_balance_resolved` now allows free and routes to `user_seat` / `user_seat_low_balance` from the live balance.
- **dispatcher / reconcile / live-inputs** — the live-balance read is now free-aware (reads the per-user contract credit, not the empty seat balance), so reconcile and the resolved transition land free seats in the correct band.

## Tests

`types/memberships.test.ts` (14) and `lib/metronome/user_credit_state_machine.test.ts` (40) pass. `npx tsgo --noEmit` clean.

---

**Stacked PR — review/merge in order.** Splits the work formerly in #27003 (replace the recurring free-seat credit with a manually-granted per-user lifetime credit).
1. #27183 `free-credits-1-metronome-primitives` (→ `main`)
2. #27184 `free-credits-2-state-core`
3. #27185 `free-credits-3-alerts-webhook`
4. #27186 `free-credits-4-grant-revoke`
5. #27187 `free-credits-5-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)