### PR TITLE
feat(billing): surface free-seat credit balance and alerts in poke and usage table (5/5)

### DIFF
--- a/front/components/poke/credits/AlertChip.tsx
+++ b/front/components/poke/credits/AlertChip.tsx
@@ -1,0 +1,54 @@
+import type {
+  MetronomeAlertRef,
+  MetronomeAlertStatus,
+} from "@app/lib/metronome/alerts/types";
+import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Chip, LinkExternal01 } from "@dust-tt/sparkle";
+
+// Maps a Metronome alert's evaluation status to a Chip color and readable
+// label. `in_alarm` (breached) reads red; `ok` (resolved) green; `evaluating`
+// (pending) amber; `null` (unknown) neutral.
+function alertStatusChip(status: MetronomeAlertStatus): {
+  color: "rose" | "success" | "warning" | "info";
+  label: string;
+} {
+  switch (status) {
+    case "in_alarm":
+      return { color: "rose", label: "in alarm" };
+    case "ok":
+      return { color: "success", label: "ok" };
+    case "evaluating":
+      return { color: "warning", label: "evaluating" };
+    case null:
+      return { color: "info", label: "unknown" };
+    default:
+      assertNeverAndIgnore(status);
+      return { color: "info", label: "unknown" };
+  }
+}
+
+interface AlertChipProps {
+  alert: MetronomeAlertRef | null;
+  label: string;
+}
+
+// A clickable badge deep-linking to a Metronome alert, labelled with the alert
+// name and its current evaluation status and colored by that status. Renders
+// nothing when the alert is unknown (not configured).
+export function AlertChip({ alert, label }: AlertChipProps) {
+  if (!alert) {
+    return null;
+  }
+  const { color, label: statusLabel } = alertStatusChip(alert.status);
+  return (
+    <Chip
+      size="xs"
+      color={color}
+      label={`${label}: ${statusLabel}`}
+      icon={LinkExternal01}
+      href={getMetronomeAlertUrl(alert.id)}
+      target="_blank"
+    />
+  );
+}

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -1,11 +1,16 @@
+import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
 import { usePokeMembersUsage } from "@app/poke/swr/credits";
-import type { UserCreditState } from "@app/types/memberships";
+import type {
+  MembershipSeatType,
+  UserCreditState,
+} from "@app/types/memberships";
 import type { WorkspaceType } from "@app/types/user";
 import {
   AlertCircle,
@@ -55,6 +60,32 @@ const USER_CREDIT_STATE_CHIP_COLOR: Record<
   on_pool_low_balance: "warning",
   capped: "rose",
 };
+
+// Free seats hold a per-user credit with two balance alerts: "low" (≤20%) and
+// "empty" (0). Both are shown beside the balance via the shared `AlertChip`,
+// colored by each alert's Metronome status (ok = green, in alarm = red) and
+// deep-linked. Other seat types draw from the pool and have no such alerts.
+interface FreeSeatBalanceBadgesProps {
+  seatType: MembershipSeatType | null;
+  lowAlert: MetronomeAlertRef | null;
+  emptyAlert: MetronomeAlertRef | null;
+}
+
+function FreeSeatBalanceBadges({
+  seatType,
+  lowAlert,
+  emptyAlert,
+}: FreeSeatBalanceBadgesProps) {
+  if (seatType !== "free") {
+    return null;
+  }
+  return (
+    <>
+      <AlertChip alert={lowAlert} label="low" />
+      <AlertChip alert={emptyAlert} label="empty" />
+    </>
+  );
+}
 
 interface PokeMembersUsageTableProps {
   owner: WorkspaceType;
@@ -158,15 +189,26 @@ function makeColumns({
       header: "Seat balance / allowance",
       enableSorting: false,
       cell: ({ row }) => {
-        const { memberUsageLimit, seatBalanceAwu } = row.original;
+        const {
+          memberUsageLimit,
+          seatBalanceAwu,
+          seatType,
+          freeCreditLowAlert,
+          freeCreditEmptyAlert,
+        } = row.original;
         if (memberUsageLimit === null) {
           return <span>-</span>;
         }
         return (
-          <span>
+          <span className="inline-flex items-center gap-1">
             {seatBalanceAwu !== null ? formatCredits(seatBalanceAwu) : "-"}
             {" / "}
             {formatCredits(memberUsageLimit)}
+            <FreeSeatBalanceBadges
+              seatType={seatType}
+              lowAlert={freeCreditLowAlert}
+              emptyAlert={freeCreditEmptyAlert}
+            />
           </span>
         );
       },

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -1,3 +1,4 @@
+import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { PokeAwuUsageChart } from "@app/components/poke/credits/PokeAwuUsageChart";
 import { PokeMembersUsageTable } from "@app/components/poke/credits/PokeMembersUsageTable";
@@ -9,11 +10,7 @@ import type {
 } from "@app/lib/api/poke/workspace_info";
 import { formatCredits } from "@app/lib/client/credits";
 import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_alerts";
-import type {
-  MetronomeAlertRef,
-  MetronomeAlertStatus,
-} from "@app/lib/metronome/alerts/types";
-import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { usePokeAwuPoolSummary } from "@app/poke/swr/credits";
 import type {
   WorkspacePoolCreditState,
@@ -22,13 +19,7 @@ import type {
 import type { SubscriptionType } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  AlertCircle,
-  Chip,
-  ContentMessage,
-  LinkExternal01,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { AlertCircle, Chip, ContentMessage, Spinner } from "@dust-tt/sparkle";
 
 interface PokeUsageTabProps {
   owner: WorkspaceType;
@@ -41,53 +32,6 @@ interface PokeUsageTabProps {
   programmaticAlerts: PokeProgrammaticAlerts;
   usageCapAlert: MetronomeAlertRef | null;
   defaultAlerts: DefaultMetronomeAlerts;
-}
-
-// Maps a Metronome alert's evaluation status to a Chip color and readable
-// label. `in_alarm` (breached) reads red; `ok` (resolved) green; `evaluating`
-// (pending) amber; `null` (unknown) neutral.
-function alertStatusChip(status: MetronomeAlertStatus): {
-  color: "rose" | "success" | "warning" | "info";
-  label: string;
-} {
-  switch (status) {
-    case "in_alarm":
-      return { color: "rose", label: "in alarm" };
-    case "ok":
-      return { color: "success", label: "ok" };
-    case "evaluating":
-      return { color: "warning", label: "evaluating" };
-    case null:
-      return { color: "info", label: "unknown" };
-    default:
-      assertNeverAndIgnore(status);
-      return { color: "info", label: "unknown" };
-  }
-}
-
-interface AlertChipProps {
-  alert: MetronomeAlertRef | null;
-  label: string;
-}
-
-// A clickable badge deep-linking to a Metronome alert, labelled with the alert
-// name and its current evaluation status and colored by that status. Renders
-// nothing when the alert is unknown (not configured).
-function AlertChip({ alert, label }: AlertChipProps) {
-  if (!alert) {
-    return null;
-  }
-  const { color, label: statusLabel } = alertStatusChip(alert.status);
-  return (
-    <Chip
-      size="xs"
-      color={color}
-      label={`${label}: ${statusLabel}`}
-      icon={LinkExternal01}
-      href={getMetronomeAlertUrl(alert.id)}
-      target="_blank"
-    />
-  );
 }
 
 type CreditStateChipColor = "success" | "warning" | "rose" | "info";

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -2,6 +2,7 @@ import {
   getSeatBarClasses,
   getSeatIconColorClass,
   MUTED_BAR_CLASSES,
+  OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
@@ -146,18 +147,25 @@ function AwuUsageBar({
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
 
-  // The bar is up to four contiguous sections, each with its own tooltip:
-  //   seat consumed · seat remaining · pool consumed · pool remaining
-  // Zero-width sections are skipped, so in practice it renders as:
-  //   - within allowance:   seat consumed · seat remaining · pool remaining
-  //   - overflowed to pool: seat consumed · pool consumed · pool remaining
-  //   - no seat allowance:  pool consumed · pool remaining
-  // `pool remaining` is omitted when the user is uncapped (no finite headroom).
+  // The bar splits consumption into seat → pool → overage:
+  //   seat consumed · seat remaining · pool consumed · pool remaining · overage
+  // `poolLimit` is the headroom on top of the seat allowance (null = uncapped).
+  // A seat with no pool (poolLimit === 0, e.g. free) shows no pool section —
+  // any spend beyond the seat allowance is overage. Zero-width sections are
+  // skipped. `pool remaining` is omitted when uncapped (no finite headroom).
   const seatConsumed = consumedFromAllowance;
   const seatRemaining = Math.max(0, allowance - seatConsumed);
-  const poolConsumed = consumedFromPool;
+  const poolLimit = limit !== null ? Math.max(0, limit - allowance) : null;
+  // Of the pool consumption, the part within the pool limit vs. the overage
+  // beyond it (only capped seats can have overage).
+  const poolConsumed =
+    poolLimit !== null
+      ? Math.min(consumedFromPool, poolLimit)
+      : consumedFromPool;
   const poolRemaining =
-    limit !== null ? Math.max(0, limit - allowance - poolConsumed) : null;
+    poolLimit !== null ? Math.max(0, poolLimit - poolConsumed) : null;
+  const overage =
+    poolLimit !== null ? Math.max(0, consumedFromPool - poolLimit) : 0;
 
   const sections: Array<{
     key: string;
@@ -197,12 +205,16 @@ function AwuUsageBar({
       label: `${formatCredits(poolRemaining)} credits remaining before spend limit`,
     });
   }
+  // Overage is surfaced in the tooltip only, not as a bar segment.
 
   const total = sections.reduce((sum, s) => sum + s.value, 0);
 
   const hasSeatSections = seatConsumed > 0 || seatRemaining > 0;
+  // Only surface the pool when there's actually a pool to spend from: a finite
+  // positive limit, or uncapped (null). A zero pool limit (free) has no pool.
   const hasPoolSections =
-    poolConsumed > 0 || (poolRemaining !== null && poolRemaining > 0);
+    (poolLimit === null || poolLimit > 0) &&
+    (poolConsumed > 0 || (poolRemaining !== null && poolRemaining > 0));
 
   const tooltipLines: Array<{
     track: string;
@@ -219,15 +231,22 @@ function AwuUsageBar({
     });
   }
   if (hasPoolSections) {
-    const poolTotal = limit !== null ? limit - allowance : null;
     tooltipLines.push({
       track: MUTED_BAR_CLASSES.track,
       fill: MUTED_BAR_CLASSES.fill,
       legend: "Pool usage",
       usage:
-        poolTotal !== null
-          ? `${formatCredits(poolConsumed)} credits used out of ${formatCredits(poolTotal)}`
+        poolLimit !== null
+          ? `${formatCredits(poolConsumed)} credits used out of ${formatCredits(poolLimit)}`
           : `${formatCredits(poolConsumed)} credits used`,
+    });
+  }
+  if (overage > 0) {
+    tooltipLines.push({
+      track: OVERAGE_BAR_CLASSES.track,
+      fill: OVERAGE_BAR_CLASSES.fill,
+      legend: "Overage",
+      usage: `${formatCredits(overage)} credits over the spend limit`,
     });
   }
 

--- a/front/components/workspace/seat_styles.ts
+++ b/front/components/workspace/seat_styles.ts
@@ -26,6 +26,13 @@ export const MUTED_BAR_CLASSES = {
   fill: SEAT_TIER_STYLES.muted.barFill,
 };
 
+// Overage bar colors (spend beyond the seat allowance + pool limit) — red, to
+// signal the user is over their cap.
+export const OVERAGE_BAR_CLASSES = {
+  track: "bg-red-200 dark:bg-red-200-night",
+  fill: "bg-red-700 dark:bg-red-700-night",
+};
+
 // Seat icon text color: golden for max, highlight blue for pro, muted grey
 // otherwise (free / none / workspace).
 export function getSeatIconColorClass(seatType: MembershipSeatType): string {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import { listPerUserCreditBalanceAlertsForWorkspace } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import type {
   MetronomeCapAlertIds,
   MetronomeCapAlertInfo,
@@ -11,8 +12,16 @@ import {
   listMetronomePerUserCapsForWorkspace,
   listMetronomePerUserWarningAlertsForWorkspace,
 } from "@app/lib/metronome/alerts/spend_limits";
-import { listMetronomeSeatBalances } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
+import {
+  listContractPerUserCreditBalances,
+  listMetronomeSeatBalances,
+} from "@app/lib/metronome/client";
+import {
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  FREE_SEAT_LIFETIME_AWU_CREDITS,
+  getCreditTypeAwuId,
+} from "@app/lib/metronome/constants";
 import {
   fetchPerUserAwuUsage,
   getPerUserAwuUsage,
@@ -91,6 +100,11 @@ export type MemberUsageType = {
   // Id of the companion 80% warning alert for the effective cap. Null when
   // uncapped or no warning alert exists.
   spendLimitWarningAlertId: string | null;
+  // Per-user free-credit balance alerts (low at 20%, empty at 0), each with its
+  // current Metronome status for the `AlertChip` badges. Free seats only, and
+  // only populated when alert links are requested (poke). Null otherwise.
+  freeCreditLowAlert: MetronomeAlertRef | null;
+  freeCreditEmptyAlert: MetronomeAlertRef | null;
   // Per-user credit state machine state (personal-credits → pool → capped
   // progression) persisted on the membership. Surfaced for debugging.
   creditState: UserCreditState;
@@ -279,6 +293,31 @@ async function fetchSeatBalancesForMembersTable({
       balanceByUserId.set(seat.seat_id, awu.balance);
     }
   }
+
+  // Free seats hold a per-user contract credit rather than a seat balance, so
+  // they're absent from `listMetronomeSeatBalances`. Fill their remaining
+  // balance in from the per-user credits — but only when the user has no seat
+  // balance: a user who switched free → pro/max still has a leftover free
+  // credit, and it must not overwrite their (real) pro/max seat balance.
+  // Degrades silently on read failure.
+  const perUserCreditBalances = await listContractPerUserCreditBalances({
+    metronomeCustomerId,
+    metronomeContractId,
+    contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+  });
+  if (perUserCreditBalances.isOk()) {
+    for (const [userId, { balanceAwu }] of perUserCreditBalances.value) {
+      if (!balanceByUserId.has(userId)) {
+        balanceByUserId.set(userId, balanceAwu);
+      }
+    }
+  } else {
+    logger.warn(
+      { err: perUserCreditBalances.error, metronomeCustomerId },
+      "[MembersUsage] Failed to fetch per-user credit balances, skipping"
+    );
+  }
+
   return balanceByUserId;
 }
 
@@ -623,10 +662,18 @@ export async function getMemberUsage({
           ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
           : 0)
       : null;
+  // Free seats have no pool, so their total spend cap is just the seat
+  // allowance (allowance + 0 pool) — like every other seat the cap includes the
+  // allowance, it just has no pool headroom on top. There's no default cap alert
+  // for free (normalizeToPoolLimitSeatType is null), so we supply it explicitly.
+  const effectiveDefaultAwuCredits =
+    membership.seatType === "free"
+      ? FREE_SEAT_LIFETIME_AWU_CREDITS
+      : (defaultCap?.threshold ?? null);
 
   const spendLimitSource = resolveEffectiveSpendLimitSource({
     overrideAwuCredits,
-    defaultAwuCredits: defaultCap?.threshold ?? null,
+    defaultAwuCredits: effectiveDefaultAwuCredits,
   });
 
   return {
@@ -648,11 +695,13 @@ export async function getMemberUsage({
       scheduledSeatChangeAt: null,
       spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
         overrideAwuCredits,
-        defaultAwuCredits: defaultCap?.threshold ?? null,
+        defaultAwuCredits: effectiveDefaultAwuCredits,
       }),
       spendLimitSource,
       spendLimitAlertId: null,
       spendLimitWarningAlertId: null,
+      freeCreditLowAlert: null,
+      freeCreditEmptyAlert: null,
       creditState: membership.creditState,
     },
   };
@@ -704,6 +753,7 @@ export async function getMembersUsage({
     seatDataByUserId,
     seatBalanceByUserId,
     perUserSpendLimits,
+    freeCreditAlertIdsByUserId,
   ] = await Promise.all([
     MembershipResource.getActiveMemberships({ workspace, users }),
     fetchPerUserUsageCreditsForMembersTable({
@@ -726,7 +776,20 @@ export async function getMembersUsage({
       workspaceId: workspace.sId,
       includeAlertLinks,
     }),
+    // Free-seat balance-alert ids (low + empty) for deep-linking — poke-only,
+    // gated on `includeAlertLinks` so the customer page doesn't pay the extra
+    // alert-list call.
+    includeAlertLinks && metronomeCustomerId
+      ? listPerUserCreditBalanceAlertsForWorkspace({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+        })
+      : Promise.resolve(null),
   ]);
+  const freeCreditAlertIds =
+    freeCreditAlertIdsByUserId?.isOk() === true
+      ? freeCreditAlertIdsByUserId.value
+      : null;
   const {
     perUserOverrideAlerts,
     defaultAwuCreditsBySeatType,
@@ -780,10 +843,17 @@ export async function getMembersUsage({
             ? (seatAllowanceBySeatType[normalizedSeatType] ?? 0)
             : 0)
         : null;
+    // Free seats have no pool, so their total spend cap is just the seat
+    // allowance (allowance + 0 pool) — the cap includes the allowance like every
+    // other seat, it just has no pool headroom on top.
+    const effectiveDefaultAwuCredits =
+      membership.seatType === "free"
+        ? FREE_SEAT_LIFETIME_AWU_CREDITS
+        : (defaultCap?.threshold ?? null);
 
     const spendLimitSource = resolveEffectiveSpendLimitSource({
       overrideAwuCredits,
-      defaultAwuCredits: defaultCap?.threshold ?? null,
+      defaultAwuCredits: effectiveDefaultAwuCredits,
     });
     const effectiveCapAlert =
       spendLimitSource === "override"
@@ -797,6 +867,13 @@ export async function getMembersUsage({
     const spendLimitWarningAlertId = includeAlertLinks
       ? (effectiveCapAlert?.warningAlertId ?? null)
       : null;
+
+    // Free-seat balance-alert deep links (poke-only). Only free seats have
+    // these per-user credit-balance alerts.
+    const freeCreditAlerts =
+      membership.seatType === "free"
+        ? (freeCreditAlertIds?.get(userId) ?? null)
+        : null;
 
     return [
       {
@@ -820,11 +897,13 @@ export async function getMembersUsage({
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
           overrideAwuCredits,
-          defaultAwuCredits: defaultCap?.threshold ?? null,
+          defaultAwuCredits: effectiveDefaultAwuCredits,
         }),
         spendLimitSource,
         spendLimitAlertId,
         spendLimitWarningAlertId,
+        freeCreditLowAlert: freeCreditAlerts?.low ?? null,
+        freeCreditEmptyAlert: freeCreditAlerts?.empty ?? null,
         creditState: membership.creditState,
       },
     ];


### PR DESCRIPTION
## Description

**PR 5 of 5.** Observability / UI for the per-user free credits.

- **Poke** — `AlertChip` (status-coloured, links to the Metronome alert) and free-seat low / empty badges in the members usage table.
- **Workspace usage table** — seat-allowance + pool-usage breakdown, with overage shown in the tooltip only.
- **`members_usage.ts`** — expose the per-user free-credit balance and alert refs (alert links loaded only for poke).

## Tests

`npx tsgo --noEmit` clean. This is the tip of the stack and is byte-for-byte identical to the original `fix-free-credits-allocation` branch.
---

**Stacked PR — review/merge in order.** Splits the work formerly in #27003.
1. #27183 `free-credits-1-metronome-primitives` (→ `main`)
2. #27184 `free-credits-2-state-core`
3. #27185 `free-credits-3-alerts-webhook`
4. #27186 `free-credits-4-grant-revoke`
5. #27187 `free-credits-5-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)