### PR TITLE
fix(frames): link to the Pod files tab when referencing Pod frames

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/helpers.test.ts
+++ b/front/lib/api/actions/servers/interactive_content/helpers.test.ts
@@ -1,0 +1,53 @@
+import { getPodFrameLinkNotice } from "@app/lib/api/actions/servers/interactive_content/helpers";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType } from "@app/types/files";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getAppUrl: vi.fn(() => "https://app.dust.tt"),
+  },
+}));
+
+describe("getPodFrameLinkNotice", () => {
+  it("returns a Pod files tab link for project_context files", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const user = auth.getNonNullableUser();
+    const space = await SpaceFactory.project(workspace, user.id);
+
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "Chart.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    expect(getPodFrameLinkNotice(auth, file)).toContain(
+      `https://app.dust.tt/w/${workspace.sId}/pods/${space.sId}#files`
+    );
+  });
+
+  it("returns an empty string for conversation files", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+    const user = auth.getNonNullableUser();
+
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "Chart.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: "cId" },
+    });
+
+    expect(getPodFrameLinkNotice(auth, file)).toBe("");
+  });
+});

--- a/front/lib/api/actions/servers/interactive_content/helpers.ts
+++ b/front/lib/api/actions/servers/interactive_content/helpers.ts
@@ -1,5 +1,28 @@
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { getPodRoute } from "@app/lib/utils/router";
+
+/**
+ * For frames that live in a Pod (`project_context` files), returns a notice pointing the agent at
+ * the Pod's Files tab — the most precise UI location for such frames (there is no per-file deep
+ * link on the Pod page). Returns the empty string for other files.
+ */
+export function getPodFrameLinkNotice(
+  auth: Authenticator,
+  fileResource: FileResource
+): string {
+  const { useCase, useCaseMetadata } = fileResource;
+  if (useCase !== "project_context" || !useCaseMetadata?.spaceId) {
+    return "";
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const url = `${config.getAppUrl()}${getPodRoute(owner.sId, useCaseMetadata.spaceId)}#files`;
+
+  return ` This frame lives in a Pod; when linking to it in your response, use ${url}`;
+}
 
 /**
  * Builds a progress notification for interactive content file operations.

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -6,7 +6,10 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { buildInteractiveContentFileNotification } from "@app/lib/api/actions/servers/interactive_content/helpers";
+import {
+  buildInteractiveContentFileNotification,
+  getPodFrameLinkNotice,
+} from "@app/lib/api/actions/servers/interactive_content/helpers";
 import { INTERACTIVE_CONTENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/interactive_content/metadata";
 import { fetchTemplateContent } from "@app/lib/api/actions/servers/interactive_content/template_utils";
 import {
@@ -153,6 +156,7 @@ export function createInteractiveContentTools(
       if (referencedFilesChangeNotice) {
         responseText += referencedFilesChangeNotice;
       }
+      responseText += getPodFrameLinkNotice(auth, fileResource);
 
       if (_meta?.progressToken) {
         const notification: MCPProgressNotificationType =
@@ -218,7 +222,9 @@ export function createInteractiveContentTools(
       return new Ok([
         {
           type: "text",
-          text: `File '${fileResource.sId}' reverted successfully.`,
+          text:
+            `File '${fileResource.sId}' reverted successfully.` +
+            getPodFrameLinkNotice(auth, fileResource),
         },
       ]);
     },
@@ -245,7 +251,9 @@ export function createInteractiveContentTools(
 
       const fileResource = result.value;
 
-      const responseText = `File '${fileResource.sId}' renamed successfully to '${fileResource.fileName}'.`;
+      const responseText =
+        `File '${fileResource.sId}' renamed successfully to '${fileResource.fileName}'.` +
+        getPodFrameLinkNotice(auth, fileResource);
 
       if (_meta?.progressToken) {
         const notification: MCPProgressNotificationType =

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -455,6 +455,9 @@ export function createProjectManagerTools(
               contentNodes,
               files: {
                 count: projectFileCount,
+                // The Pod page defaults to the conversations tab; the `#files` anchor is required
+                // for links meant to land on the Pod's files (e.g. when referencing a frame).
+                url: `${projectUrl}#files`,
                 hint: `Use \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_LIST_ACTION_NAME)}\` with \`scope: { type: "pod" }\` to enumerate.`,
               },
             },


### PR DESCRIPTION
## Description

When an agent edits a frame that lives in a Pod, its response links to the bare Pod URL, which lands on the conversations tab instead of the frame (dust-tt/tasks#8757).

Two fixes:
- The interactive_content edit/revert/rename/retrieve tools now append a notice with the Pod files tab URL (`/w/{wId}/pods/{podId}#files`, via the new `getPodFilesRoute`) when the file is a Pod file (`project_context` use case), so the agent has the right link in the tool result it reads before answering.
- `pod_manager.get_information` now exposes `files.url` with the `#files` anchor next to the existing count/hint.

There is no per-file deep link on the Pod page today (the frame sheet opens via local state), so `#files` is the most precise URL available.

## Tests

Added a test for the new `getPodFrameLinkNotice` helper (pod file vs conversation file).

## Risk

Low: additive tool output changes only, no behavior change for non-Pod frames.

## Deploy Plan

Standard deploy.