### PR TITLE
Store AWU usage alongside microDollars for self improving skills

### DIFF
--- a/front/lib/models/skill/self_improving_skills_usage.ts
+++ b/front/lib/models/skill/self_improving_skills_usage.ts
@@ -11,7 +11,13 @@ export class SelfImprovingSkillsUsageModel extends WorkspaceAwareModel<SelfImpro
 
   declare skillId: ForeignKey<SkillConfigurationModel["id"]> | null;
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
+  // Old deprecated Micro USD values, kept for legacy workspaces not
+  // yet using metronome.
+  // margin not included
   declare priceMicroUsd: number;
+  // AWU credits as billed to Metronome (margin baked in). 0 on rows recorded
+  // before the column was introduced.
+  declare priceAwuCredits: CreationOptional<number>;
 }
 
 SelfImprovingSkillsUsageModel.init(
@@ -45,6 +51,11 @@ SelfImprovingSkillsUsageModel.init(
     priceMicroUsd: {
       type: DataTypes.BIGINT,
       allowNull: false,
+    },
+    priceAwuCredits: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      defaultValue: 0,
     },
   },
   {

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -66,6 +66,64 @@ describe("SelfImprovingSkillsUsageResource", () => {
     expect(sum).toBe(300);
   });
 
+  it("persists priceAwuCredits when provided and defaults it to 0", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const skill = await SkillFactory.create(authenticator, {
+      name: "AWU Credits Test Skill",
+    });
+
+    const usages = await SelfImprovingSkillsUsageResource.bulkCreate(
+      authenticator,
+      [
+        {
+          createdAt: new Date("2026-01-03T00:00:00.000Z"),
+          skillId: skill.id,
+          conversationId: null,
+          priceMicroUsd: 17_000,
+          priceAwuCredits: 2,
+        },
+        {
+          createdAt: new Date("2026-01-04T00:00:00.000Z"),
+          skillId: skill.id,
+          conversationId: null,
+          priceMicroUsd: 100,
+        },
+      ]
+    );
+
+    expect(usages[0].priceAwuCredits).toBe(2);
+    expect(usages[1].priceAwuCredits).toBe(0);
+  });
+
+  it("includes priceAwuCredits in toLogJSON", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const skill = await SkillFactory.create(authenticator, {
+      name: "Log JSON Test Skill",
+    });
+
+    const usages = await SelfImprovingSkillsUsageResource.bulkCreate(
+      authenticator,
+      [
+        {
+          createdAt: new Date("2026-01-03T00:00:00.000Z"),
+          skillId: skill.id,
+          conversationId: null,
+          priceMicroUsd: 17_000,
+          priceAwuCredits: 2,
+        },
+      ]
+    );
+
+    expect(usages[0].toLogJSON()).toEqual({
+      id: usages[0].id,
+      workspaceId: skill.workspaceId,
+      skillId: skill.id,
+      conversationId: null,
+      priceMicroUsd: 17_000,
+      priceAwuCredits: 2,
+    });
+  });
+
   it("returns daily spend with markup aggregated by calendar day", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const { authenticator: otherAuthenticator } = await createResourceTest({

--- a/front/lib/resources/self_improving_skills_usage_resource.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.ts
@@ -252,6 +252,7 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       skillId: this.skillId,
       conversationId: this.conversationId,
       priceMicroUsd: this.priceMicroUsd,
+      priceAwuCredits: this.priceAwuCredits,
     };
   }
 }

--- a/front/migrations/db/migration_676.sql
+++ b/front/migrations/db/migration_676.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 10, 2026
+ALTER TABLE "public"."self_improving_skills_usage" ADD COLUMN "priceAwuCredits" BIGINT NOT NULL DEFAULT 0;

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -13,6 +13,7 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { intelligenceAwuFromRunUsages } from "@app/lib/metronome/events";
 import {
   isApiBlocked,
   isProgrammaticApiBlocked,
@@ -65,6 +66,7 @@ import {
 } from "@app/lib/reinforcement/workspace_check";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { SelfImprovingSkillsUsageCreateBlob } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
@@ -350,20 +352,22 @@ function getReinforcedSkillIdsFromMetadata(
   ];
 }
 
-function splitPriceMicroUsdAcrossSkills(
-  priceMicroUsd: number,
+// Splits an integer amount (micro-USD or AWU credits) evenly across skills,
+// distributing the remainder one unit at a time so the parts sum to the total.
+function splitAmountAcrossSkills(
+  totalAmount: number,
   skillCount: number
 ): number[] {
   if (skillCount <= 0) {
     return [];
   }
 
-  const basePriceMicroUsd = Math.floor(priceMicroUsd / skillCount);
-  const remainderMicroUsd = priceMicroUsd % skillCount;
+  const baseAmount = Math.floor(totalAmount / skillCount);
+  const remainder = totalAmount % skillCount;
 
   return Array.from(
     { length: skillCount },
-    (_, index) => basePriceMicroUsd + (index < remainderMicroUsd ? 1 : 0)
+    (_, index) => baseAmount + (index < remainder ? 1 : 0)
   );
 }
 
@@ -382,6 +386,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
   conversationsProcessed: number;
   usagesCreated: number;
   totalPriceMicroUsd: number;
+  totalPriceAwuCredits: number;
 }> {
   const uniqueConversationIds = [...new Set(conversationIds)];
   if (uniqueConversationIds.length === 0) {
@@ -389,6 +394,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
       conversationsProcessed: 0,
       usagesCreated: 0,
       totalPriceMicroUsd: 0,
+      totalPriceAwuCredits: 0,
     };
   }
 
@@ -416,6 +422,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
       conversationsProcessed: 0,
       usagesCreated: 0,
       totalPriceMicroUsd: 0,
+      totalPriceAwuCredits: 0,
     };
   }
 
@@ -461,7 +468,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
     ),
   ];
 
-  const runCostMicroUsdByDustRunId = new Map<string, number>();
+  const runUsagesByDustRunId = new Map<string, RunUsageType[]>();
   if (allDustRunIds.length > 0) {
     const runs = await RunResource.listByDustRunIds(auth, {
       dustRunIds: allDustRunIds,
@@ -475,10 +482,9 @@ export async function recordSelfImprovingSkillsUsageActivity({
         continue;
       }
 
-      runCostMicroUsdByDustRunId.set(
-        dustRunId,
-        (runCostMicroUsdByDustRunId.get(dustRunId) ?? 0) + usage.costMicroUsd
-      );
+      const usagesForRun = runUsagesByDustRunId.get(dustRunId) ?? [];
+      usagesForRun.push(usage);
+      runUsagesByDustRunId.set(dustRunId, usagesForRun);
     }
   }
 
@@ -494,13 +500,16 @@ export async function recordSelfImprovingSkillsUsageActivity({
 
   const usages: SelfImprovingSkillsUsageCreateBlob[] = [];
   let totalPriceMicroUsd = 0;
+  let totalPriceAwuCredits = 0;
 
   for (const { conversation, skillIds } of conversationsWithSkills) {
     const dustRunIds =
       runIdsByConversationModelId.get(conversation.id) ?? new Set<string>();
-    const conversationPriceMicroUsd = [...dustRunIds].reduce(
-      (sum, dustRunId) =>
-        sum + (runCostMicroUsdByDustRunId.get(dustRunId) ?? 0),
+    const conversationRunUsages = [...dustRunIds].flatMap(
+      (dustRunId) => runUsagesByDustRunId.get(dustRunId) ?? []
+    );
+    const conversationPriceMicroUsd = conversationRunUsages.reduce(
+      (sum, usage) => sum + usage.costMicroUsd,
       0
     );
 
@@ -508,11 +517,23 @@ export async function recordSelfImprovingSkillsUsageActivity({
       continue;
     }
 
+    // AWU credits as billed to Metronome (margin baked in). The canonical
+    // conversion rounds up per (provider, model) group, applied here at
+    // conversation granularity.
+    const conversationPriceAwuCredits = intelligenceAwuFromRunUsages(
+      conversationRunUsages
+    );
+
     totalPriceMicroUsd += conversationPriceMicroUsd;
+    totalPriceAwuCredits += conversationPriceAwuCredits;
     // A single conversation being analysed can have several skill enabled it it
     // In that case we split the cost of analysis evenly per skill.
-    const prices = splitPriceMicroUsdAcrossSkills(
+    const prices = splitAmountAcrossSkills(
       conversationPriceMicroUsd,
+      skillIds.length
+    );
+    const credits = splitAmountAcrossSkills(
+      conversationPriceAwuCredits,
       skillIds.length
     );
 
@@ -523,6 +544,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
         skillId: skillModelIdById.get(skillIds[i]) ?? null,
         conversationId: conversation.id,
         priceMicroUsd: prices[i],
+        priceAwuCredits: credits[i],
       });
     }
   }
@@ -539,6 +561,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
       conversationCount: conversationModelIds.length,
       usageCount: createdUsages.length,
       totalPriceMicroUsd,
+      totalPriceAwuCredits,
     },
     "ReinforcedSkills: recorded self-improving skills usage"
   );
@@ -547,6 +570,7 @@ export async function recordSelfImprovingSkillsUsageActivity({
     conversationsProcessed: conversationModelIds.length,
     usagesCreated: createdUsages.length,
     totalPriceMicroUsd,
+    totalPriceAwuCredits,
   };
 }
 


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8784

This PR stores the AWU usage alongside the microDollars.
I don't plan to do a migration of values as we are still in beta so lost usage is not an issue.

 Overview of supporting AWU credits for self improving skills control (backend and UI)
  1. Store the AWU in the self_improving_skills_usage table (always with margins) ℹ️  **You are here**
  2. Update resources and API to retrieve the value 
  3. Store limit in AWU in db and update API to set/get them
  4. Use AWU to enforce the limit for credit based workspaces
  5. Update UI admin apge to display AWU credits when using metronome.

## Tests

added unit tests

## Risk

low

## Deploy Plan

lock front
merge
run migration
deploy
unlock front
