### PR TITLE
[Skill Builder] Align inline knowledge chips with tool chips

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -518,7 +518,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
   // Show selected knowledge.
   if (selectedItems.length > 0) {
     return (
-      <NodeViewWrapper className="inline" data-drag-handle="">
+      <NodeViewWrapper className="inline-flex align-middle" data-drag-handle="">
         <KnowledgeDisplayComponent
           item={selectedItems[0]}
           owner={owner}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8778

In skill instructions, inline tool chips and knowledge chips did not sit on the same vertical alignment. Tool chips were fixed in https://github.com/dust-tt/dust/pull/26666 by switching their `NodeViewWrapper` from `inline` to `inline-flex align-middle`, but the knowledge node view kept the old `inline` wrapper.

This applies the same wrapper class to the knowledge chip view so both chip types align on the same baseline.

## Risks

Blast radius: rendering of inline knowledge chips in the Skill Builder instructions editor.
Risk: low

## Deploy Plan
- pmrr
- deploy front