### PR TITLE
Skip pods sync if the workspace no longer has the right subscription.

### DIFF
--- a/connectors/src/connectors/dust_project/lib/api_errors.test.ts
+++ b/connectors/src/connectors/dust_project/lib/api_errors.test.ts
@@ -1,0 +1,79 @@
+import logger from "@connectors/logger/logger";
+import type { APIError } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  isWorkspaceCanUseProductRequiredError,
+  parseDustApiResult,
+} from "./api_errors";
+
+describe("isWorkspaceCanUseProductRequiredError", () => {
+  it("returns true for workspace_can_use_product_required_error", () => {
+    const error: APIError = {
+      type: "workspace_can_use_product_required_error",
+      message: "Your current plan does not allow API access.",
+    };
+    expect(isWorkspaceCanUseProductRequiredError(error)).toBe(true);
+  });
+
+  it("returns false for other API errors", () => {
+    const error: APIError = {
+      type: "workspace_not_found",
+      message: "The workspace was not found.",
+    };
+    expect(isWorkspaceCanUseProductRequiredError(error)).toBe(false);
+  });
+});
+
+describe("parseDustApiResult", () => {
+  it("returns the value on success", () => {
+    const parsed = parseDustApiResult({
+      result: new Ok({ conversations: [] }),
+      logger: logger.child({ test: true }),
+      projectId: "project-1",
+      workspaceId: "workspace-1",
+      errorPrefix: "Failed to fetch conversations",
+    });
+
+    expect(parsed.skipped).toBe(false);
+    if (!parsed.skipped) {
+      expect(parsed.value).toEqual({ conversations: [] });
+    }
+  });
+
+  it("returns a skip marker for workspace_can_use_product_required_error", () => {
+    const parsed = parseDustApiResult({
+      result: new Err({
+        type: "workspace_can_use_product_required_error",
+        message: "Your current plan does not allow API access.",
+      }),
+      logger: logger.child({ test: true }),
+      projectId: "project-1",
+      workspaceId: "workspace-1",
+      errorPrefix: "Failed to fetch conversations",
+    });
+
+    expect(parsed.skipped).toBe(true);
+    if (parsed.skipped) {
+      expect(parsed.skipResult).toEqual({
+        skippedDueToWorkspaceApiAccess: true,
+      });
+    }
+  });
+
+  it("throws for other API errors", () => {
+    expect(() =>
+      parseDustApiResult({
+        result: new Err({
+          type: "workspace_not_found",
+          message: "The workspace was not found.",
+        }),
+        logger: logger.child({ test: true }),
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        errorPrefix: "Failed to fetch conversations",
+      })
+    ).toThrow("Failed to fetch conversations: The workspace was not found.");
+  });
+});

--- a/connectors/src/connectors/dust_project/lib/api_errors.ts
+++ b/connectors/src/connectors/dust_project/lib/api_errors.ts
@@ -1,0 +1,83 @@
+import type { Logger } from "@connectors/logger/logger";
+import type { APIError, Result } from "@dust-tt/client";
+
+export type DustProjectSyncActivityResult = {
+  skippedDueToWorkspaceApiAccess: boolean;
+};
+
+export const DUST_PROJECT_SYNC_COMPLETED: DustProjectSyncActivityResult = {
+  skippedDueToWorkspaceApiAccess: false,
+};
+
+export type DustApiCallResult<T> =
+  | { skipped: false; value: T }
+  | { skipped: true; skipResult: DustProjectSyncActivityResult };
+
+export function isWorkspaceCanUseProductRequiredError(
+  error: APIError
+): boolean {
+  return error.type === "workspace_can_use_product_required_error";
+}
+
+/**
+ * When the target workspace plan disallows API access, log and signal that
+ * the sync should be skipped without failing the connector workflow.
+ */
+export function skipSyncDueToWorkspaceApiAccess({
+  logger,
+  error,
+  projectId,
+  workspaceId,
+}: {
+  logger: Logger;
+  error: APIError;
+  projectId: string;
+  workspaceId: string;
+}): DustProjectSyncActivityResult {
+  logger.warn(
+    {
+      projectId,
+      workspaceId,
+      errorType: error.type,
+      errorMessage: error.message,
+    },
+    "Workspace plan does not allow API access, skipping dust_project sync"
+  );
+  return { skippedDueToWorkspaceApiAccess: true };
+}
+
+/**
+ * Parses a Dust API result, returning a skip marker when the workspace plan
+ * disallows API access, or throwing for other errors.
+ */
+export function parseDustApiResult<T>({
+  result,
+  logger,
+  projectId,
+  workspaceId,
+  errorPrefix,
+}: {
+  result: Result<T, APIError>;
+  logger: Logger;
+  projectId: string;
+  workspaceId: string;
+  errorPrefix: string;
+}): DustApiCallResult<T> {
+  if (result.isOk()) {
+    return { skipped: false, value: result.value };
+  }
+
+  if (isWorkspaceCanUseProductRequiredError(result.error)) {
+    return {
+      skipped: true,
+      skipResult: skipSyncDueToWorkspaceApiAccess({
+        logger,
+        error: result.error,
+        projectId,
+        workspaceId,
+      }),
+    };
+  }
+
+  throw new Error(`${errorPrefix}: ${result.error.message}`);
+}

--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -1,3 +1,8 @@
+import type { DustProjectSyncActivityResult } from "@connectors/connectors/dust_project/lib/api_errors";
+import {
+  DUST_PROJECT_SYNC_COMPLETED,
+  parseDustApiResult,
+} from "@connectors/connectors/dust_project/lib/api_errors";
 import { sortEntriesByScopedPathDepth } from "@connectors/connectors/dust_project/lib/mount_path_utils";
 import {
   deleteConversation,
@@ -30,6 +35,8 @@ import type {
   ProjectMountListEntryType,
 } from "@dust-tt/client";
 
+export type { DustProjectSyncActivityResult } from "@connectors/connectors/dust_project/lib/api_errors";
+
 /**
  * Full sync activity: Syncs all conversations for a project.
  * This is used for initial syncs or when force resync is requested.
@@ -38,7 +45,7 @@ export async function dustProjectConversationsFullSyncActivity({
   connectorId,
 }: {
   connectorId: ModelId;
-}): Promise<void> {
+}): Promise<DustProjectSyncActivityResult> {
   const localLogger = logger.child({ connectorId });
 
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -69,13 +76,17 @@ export async function dustProjectConversationsFullSyncActivity({
         spaceId: configuration.projectId,
       });
 
-    if (conversationsResult.isErr()) {
-      throw new Error(
-        `Failed to fetch conversations: ${conversationsResult.error.message}`
-      );
+    const conversationsParsed = parseDustApiResult({
+      result: conversationsResult,
+      logger: localLogger,
+      projectId: configuration.projectId,
+      workspaceId: dataSourceConfig.workspaceId,
+      errorPrefix: "Failed to fetch conversations",
+    });
+    if (conversationsParsed.skipped) {
+      return conversationsParsed.skipResult;
     }
-
-    const conversations = conversationsResult.value.conversations;
+    const { conversations } = conversationsParsed.value;
     localLogger.info(
       { projectId: configuration.projectId, count: conversations.length },
       "Fetched conversations for full sync (including deleted)"
@@ -153,6 +164,8 @@ export async function dustProjectConversationsFullSyncActivity({
         "Launched incremental sync workflow after successful full sync"
       );
     }
+
+    return DUST_PROJECT_SYNC_COMPLETED;
   } catch (error) {
     localLogger.error(
       { error, projectId: configuration.projectId },
@@ -170,7 +183,7 @@ export async function dustProjectConversationsIncrementalSyncActivity({
   connectorId,
 }: {
   connectorId: ModelId;
-}): Promise<void> {
+}): Promise<DustProjectSyncActivityResult> {
   const localLogger = logger.child({ connectorId });
 
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -210,13 +223,17 @@ export async function dustProjectConversationsIncrementalSyncActivity({
             : undefined,
       });
 
-    if (conversationsResult.isErr()) {
-      throw new Error(
-        `Failed to fetch conversations: ${conversationsResult.error.message}`
-      );
+    const conversationsParsed = parseDustApiResult({
+      result: conversationsResult,
+      logger: localLogger,
+      projectId: configuration.projectId,
+      workspaceId: dataSourceConfig.workspaceId,
+      errorPrefix: "Failed to fetch conversations",
+    });
+    if (conversationsParsed.skipped) {
+      return conversationsParsed.skipResult;
     }
-
-    const conversations = conversationsResult.value.conversations;
+    const { conversations } = conversationsParsed.value;
     localLogger.info(
       {
         projectId: configuration.projectId,
@@ -245,6 +262,8 @@ export async function dustProjectConversationsIncrementalSyncActivity({
     // Run garbage collection to remove hard-deleted conversations
     // This checks for conversations that were completely removed from the database
     await dustProjectConversationsGarbageCollectActivity({ connectorId });
+
+    return DUST_PROJECT_SYNC_COMPLETED;
   } catch (error) {
     localLogger.error(
       { error, projectId: configuration.projectId },
@@ -293,15 +312,19 @@ async function dustProjectConversationsGarbageCollectActivity({
       spaceId: configuration.projectId,
     });
 
-    if (conversationIdsResult.isErr()) {
-      throw new Error(
-        `Failed to fetch conversation IDs: ${conversationIdsResult.error.message}`
-      );
+    const conversationIdsParsed = parseDustApiResult({
+      result: conversationIdsResult,
+      logger: localLogger,
+      projectId: configuration.projectId,
+      workspaceId: dataSourceConfig.workspaceId,
+      errorPrefix: "Failed to fetch conversation IDs",
+    });
+    if (conversationIdsParsed.skipped) {
+      return;
     }
+    const { conversationIds } = conversationIdsParsed.value;
 
-    const currentConversationIds = new Set(
-      conversationIdsResult.value.conversationIds
-    );
+    const currentConversationIds = new Set(conversationIds);
 
     // Fetch all conversation IDs from dust_project_conversations table
     const syncedConversations =
@@ -384,7 +407,7 @@ export async function dustProjectMountFilesFullSyncActivity({
   connectorId,
 }: {
   connectorId: ModelId;
-}): Promise<void> {
+}): Promise<DustProjectSyncActivityResult> {
   const localLogger = logger.child({ connectorId });
 
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -410,16 +433,22 @@ export async function dustProjectMountFilesFullSyncActivity({
     spaceId: configuration.projectId,
   });
 
-  if (listRes.isErr()) {
-    throw new Error(
-      `Failed to fetch project mount files: ${listRes.error.message}`
-    );
+  const listResParsed = parseDustApiResult({
+    result: listRes,
+    logger: localLogger,
+    projectId: configuration.projectId,
+    workspaceId: dataSourceConfig.workspaceId,
+    errorPrefix: "Failed to fetch project mount files",
+  });
+  if (listResParsed.skipped) {
+    return listResParsed.skipResult;
   }
+  const { files } = listResParsed.value;
 
   const directoryEntries = sortEntriesByScopedPathDepth(
-    listRes.value.files.filter(isMountDirectoryEntry)
+    files.filter(isMountDirectoryEntry)
   );
-  const fileEntries = listRes.value.files.filter(isMountFileEntry);
+  const fileEntries = files.filter(isMountFileEntry);
   const fetchedPaths = new Set(fileEntries.map((e) => e.path));
 
   const syncedRows =
@@ -472,6 +501,8 @@ export async function dustProjectMountFilesFullSyncActivity({
     { projectId: configuration.projectId, count: fileEntries.length },
     "Completed full sync for dust_project mount files"
   );
+
+  return DUST_PROJECT_SYNC_COMPLETED;
 }
 
 /**
@@ -481,7 +512,7 @@ export async function dustProjectMountFilesIncrementalSyncActivity({
   connectorId,
 }: {
   connectorId: ModelId;
-}): Promise<void> {
+}): Promise<DustProjectSyncActivityResult> {
   const localLogger = logger.child({ connectorId });
 
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -507,16 +538,22 @@ export async function dustProjectMountFilesIncrementalSyncActivity({
       maxSourceUpdatedAt != null ? maxSourceUpdatedAt.getTime() + 1 : undefined,
   });
 
-  if (listRes.isErr()) {
-    throw new Error(
-      `Failed to fetch project mount files: ${listRes.error.message}`
-    );
+  const listResParsed = parseDustApiResult({
+    result: listRes,
+    logger: localLogger,
+    projectId: configuration.projectId,
+    workspaceId: dataSourceConfig.workspaceId,
+    errorPrefix: "Failed to fetch project mount files",
+  });
+  if (listResParsed.skipped) {
+    return listResParsed.skipResult;
   }
+  const { files } = listResParsed.value;
 
   const directoryEntries = sortEntriesByScopedPathDepth(
-    listRes.value.files.filter(isMountDirectoryEntry)
+    files.filter(isMountDirectoryEntry)
   );
-  const fileEntries = listRes.value.files.filter(isMountFileEntry);
+  const fileEntries = files.filter(isMountFileEntry);
 
   localLogger.info(
     {
@@ -556,6 +593,8 @@ export async function dustProjectMountFilesIncrementalSyncActivity({
   );
 
   await dustProjectMountFilesGarbageCollectActivity({ connectorId });
+
+  return DUST_PROJECT_SYNC_COMPLETED;
 }
 
 /**
@@ -587,14 +626,20 @@ export async function dustProjectMountFilesGarbageCollectActivity({
       spaceId: configuration.projectId,
     });
 
-    if (listRes.isErr()) {
-      throw new Error(
-        `Failed to list project mount files for GC: ${listRes.error.message}`
-      );
+    const listResParsed = parseDustApiResult({
+      result: listRes,
+      logger: localLogger,
+      projectId: configuration.projectId,
+      workspaceId: dataSourceConfig.workspaceId,
+      errorPrefix: "Failed to list project mount files for GC",
+    });
+    if (listResParsed.skipped) {
+      return;
     }
+    const { files } = listResParsed.value;
 
     const existingPaths = new Set(
-      listRes.value.files.filter(isMountFileEntry).map((e) => e.path)
+      files.filter(isMountFileEntry).map((e) => e.path)
     );
 
     const syncedRows =
@@ -645,7 +690,7 @@ export async function dustProjectSyncMetadataActivity({
   connectorId,
 }: {
   connectorId: ModelId;
-}): Promise<void> {
+}): Promise<DustProjectSyncActivityResult> {
   const localLogger = logger.child({ connectorId });
 
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -671,27 +716,24 @@ export async function dustProjectSyncMetadataActivity({
     spaceId: configuration.projectId,
   });
 
-  if (metadataResult.isErr()) {
-    localLogger.error(
-      {
-        error: metadataResult.error,
-        projectId: configuration.projectId,
-      },
-      "Failed to fetch project metadata"
-    );
-    throw new Error(
-      `Failed to fetch project metadata: ${metadataResult.error.message}`
-    );
+  const metadataParsed = parseDustApiResult({
+    result: metadataResult,
+    logger: localLogger,
+    projectId: configuration.projectId,
+    workspaceId: dataSourceConfig.workspaceId,
+    errorPrefix: "Failed to fetch project metadata",
+  });
+  if (metadataParsed.skipped) {
+    return metadataParsed.skipResult;
   }
-
-  const metadata = metadataResult.value.metadata;
+  const { metadata } = metadataParsed.value;
 
   if (!metadata) {
     localLogger.info(
       { projectId: configuration.projectId },
       "No project metadata from API; skipping metadata upsert"
     );
-    return;
+    return DUST_PROJECT_SYNC_COMPLETED;
   }
 
   const lastSyncedAtMs = configuration.lastSyncedAt?.getTime();
@@ -704,7 +746,7 @@ export async function dustProjectSyncMetadataActivity({
       },
       "Skipping project metadata upsert (API metadata older than last full sync)"
     );
-    return;
+    return DUST_PROJECT_SYNC_COMPLETED;
   }
 
   await syncProjectMetadata({
@@ -718,6 +760,8 @@ export async function dustProjectSyncMetadataActivity({
     { projectId: configuration.projectId },
     "Successfully synced project metadata"
   );
+
+  return DUST_PROJECT_SYNC_COMPLETED;
 }
 
 /**

--- a/connectors/src/connectors/dust_project/temporal/workflows.ts
+++ b/connectors/src/connectors/dust_project/temporal/workflows.ts
@@ -26,6 +26,22 @@ export function dustProjectIncrementalSyncWorkflowId(
   return `dust-project-incremental-sync-${connectorId}`;
 }
 
+type DustProjectSyncActivity = (input: {
+  connectorId: ModelId;
+}) => Promise<{ skippedDueToWorkspaceApiAccess: boolean }>;
+
+async function dustProjectSyncActivitiesCompleted(
+  connectorId: ModelId,
+  activities: ReadonlyArray<DustProjectSyncActivity>
+): Promise<boolean> {
+  for (const activity of activities) {
+    if ((await activity({ connectorId })).skippedDueToWorkspaceApiAccess) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Full sync workflow for dust_project connector.
  * Syncs all conversations for a project from scratch.
@@ -35,10 +51,15 @@ export async function dustProjectFullSyncWorkflow({
 }: {
   connectorId: ModelId;
 }): Promise<void> {
-  await dustProjectConversationsFullSyncActivity({ connectorId });
-  await dustProjectMountFilesFullSyncActivity({ connectorId });
-  await dustProjectSyncMetadataActivity({ connectorId });
-  await dustProjectMarkSyncedActivity({ connectorId });
+  if (
+    await dustProjectSyncActivitiesCompleted(connectorId, [
+      dustProjectConversationsFullSyncActivity,
+      dustProjectMountFilesFullSyncActivity,
+      dustProjectSyncMetadataActivity,
+    ])
+  ) {
+    await dustProjectMarkSyncedActivity({ connectorId });
+  }
 }
 
 /**
@@ -50,8 +71,13 @@ export async function dustProjectIncrementalSyncWorkflow({
 }: {
   connectorId: ModelId;
 }): Promise<void> {
-  await dustProjectConversationsIncrementalSyncActivity({ connectorId });
-  await dustProjectMountFilesIncrementalSyncActivity({ connectorId });
-  await dustProjectSyncMetadataActivity({ connectorId });
-  await dustProjectMarkSyncedActivity({ connectorId });
+  if (
+    await dustProjectSyncActivitiesCompleted(connectorId, [
+      dustProjectConversationsIncrementalSyncActivity,
+      dustProjectMountFilesIncrementalSyncActivity,
+      dustProjectSyncMetadataActivity,
+    ])
+  ) {
+    await dustProjectMarkSyncedActivity({ connectorId });
+  }
 }

--- a/sdks/js/src/errors/errors.ts
+++ b/sdks/js/src/errors/errors.ts
@@ -221,6 +221,7 @@ const errorTypeMapping: Record<
   credits_exhausted: DustPermissionError,
   user_cap_reached: DustPermissionError,
   subscription_required: DustPermissionError,
+  workspace_can_use_product_required_error: DustPermissionError,
   content_too_large: DustContentTooLargeError,
   internal_server_error: DustServerError,
   unexpected_network_error: DustNetworkError,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1840,6 +1840,7 @@ const APIErrorTypeSchema = FlexibleEnumSchema<
   | "user_not_found"
   | "unprocessable_entity"
   | "workspace_auth_error"
+  | "workspace_can_use_product_required_error"
   | "workspace_not_found"
   | "workspace_user_not_found"
 >();


### PR DESCRIPTION
## Description

`dust_project` Temporal sync activities previously threw when the target workspace returned a `workspace_can_use_product_required_error` (subscription downgrade or plan change), causing Temporal workflow failures. Activities now return a `DustProjectSyncActivityResult` skip signal, and both full and incremental sync workflows short-circuit via `dustProjectSyncActivitiesCompleted` — skipping `dustProjectMarkSyncedActivity` — instead of erroring out. New `api_errors.ts` module centralises `parseDustApiResult`, applied uniformly across all 7 sync activities. `workspace_can_use_product_required_error` is also added to the SDK's `APIErrorTypeSchema` and mapped to `DustPermissionError`.

## Tests

Added unit tests in `api_errors.test.ts` covering `isWorkspaceCanUseProductRequiredError` and `parseDustApiResult` (success, skip, throw paths). Tested locally against a connector with a downgraded workspace subscription to confirm graceful skip.

## Risk

Low. Previously these workflows failed with unhandled errors on subscription issues; this change makes them silently skip instead. Workspaces with active subscriptions are completely unaffected — the happy path is unchanged. Rollback is safe (reverts to throwing on plan errors, which was the prior behaviour).

## Deploy Plan

Deploy connectors.
