### PR TITLE
Fair use credit usage component

### DIFF
--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -1,0 +1,87 @@
+import { formatCredits } from "@app/lib/client/credits";
+import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
+import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
+import { cn } from "@dust-tt/sparkle";
+import { useEffect } from "react";
+
+const CREDITS_USAGE_DISPLAY_THRESHOLD = 0.2;
+const CREDITS_USAGE_CRITICAL_THRESHOLD = 0.9;
+
+interface FairUseCreditsUsageProps {
+  workspaceId: string;
+}
+
+export function FairUseCreditsUsage({
+  workspaceId,
+}: FairUseCreditsUsageProps) {
+  const { fairUseAwuCreditsState, mutateFairUseCredits } = useFairUseCredits({
+    workspaceId,
+  });
+
+  useEffect(() => {
+    const handleAgentMessageCompleted = () => {
+      void mutateFairUseCredits();
+    };
+    window.addEventListener(
+      AGENT_MESSAGE_COMPLETED_EVENT,
+      handleAgentMessageCompleted
+    );
+    return () => {
+      window.removeEventListener(
+        AGENT_MESSAGE_COMPLETED_EVENT,
+        handleAgentMessageCompleted
+      );
+    };
+  }, [mutateFairUseCredits]);
+
+  // Covers the unlimited (-1) sentinel as well as degenerate limits.
+  if (!fairUseAwuCreditsState || fairUseAwuCreditsState.limit <= 0) {
+    return null;
+  }
+
+  const { count, limit } = fairUseAwuCreditsState;
+  const percentage = count / limit;
+  if (percentage < CREDITS_USAGE_DISPLAY_THRESHOLD) {
+    return null;
+  }
+
+  const isCritical = percentage >= CREDITS_USAGE_CRITICAL_THRESHOLD;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border p-3",
+        "border-border dark:border-border-night",
+        "bg-background dark:bg-background-night"
+      )}
+    >
+      <div className="mb-2 flex items-center justify-between text-sm">
+        <span className="font-semibold text-foreground dark:text-foreground-night">
+          Fair usage (credits)
+        </span>
+        <span className="font-medium text-foreground dark:text-foreground-night">
+          <span className={cn(isCritical && "text-red-600 dark:text-red-400")}>
+            {formatCredits(count)}
+          </span>{" "}
+          / {formatCredits(limit)}
+        </span>
+      </div>
+      <div
+        className={cn(
+          "h-2 w-full overflow-hidden rounded-full",
+          "bg-gray-100 dark:bg-gray-100-night"
+        )}
+      >
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            isCritical
+              ? "bg-red-700 dark:bg-red-700-night"
+              : "bg-foreground dark:bg-foreground-night"
+          )}
+          style={{ width: `${Math.min(percentage * 100, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -2,10 +2,14 @@ import { formatCredits } from "@app/lib/client/credits";
 import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
 import { useFairUseCredits } from "@app/lib/swr/fair_use_credits";
 import { cn } from "@dust-tt/sparkle";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-const CREDITS_USAGE_DISPLAY_THRESHOLD = 0.2;
+const CREDITS_USAGE_DISPLAY_THRESHOLD = 0.75;
 const CREDITS_USAGE_CRITICAL_THRESHOLD = 0.9;
+
+// Credit accounting runs asynchronously after message completion; give it time to land before
+// refreshing the gauge.
+const MUTATE_DELAY_MS = 3000;
 
 interface FairUseCreditsUsageProps {
   workspaceId: string;
@@ -18,9 +22,17 @@ export function FairUseCreditsUsage({
     workspaceId,
   });
 
+  const mutateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
   useEffect(() => {
     const handleAgentMessageCompleted = () => {
-      void mutateFairUseCredits();
+      if (mutateTimeoutRef.current) {
+        clearTimeout(mutateTimeoutRef.current);
+      }
+      mutateTimeoutRef.current = setTimeout(() => {
+        mutateTimeoutRef.current = null;
+        void mutateFairUseCredits();
+      }, MUTATE_DELAY_MS);
     };
     window.addEventListener(
       AGENT_MESSAGE_COMPLETED_EVENT,
@@ -31,6 +43,9 @@ export function FairUseCreditsUsage({
         AGENT_MESSAGE_COMPLETED_EVENT,
         handleAgentMessageCompleted
       );
+      if (mutateTimeoutRef.current) {
+        clearTimeout(mutateTimeoutRef.current);
+      }
     };
   }, [mutateFairUseCredits]);
 
@@ -50,6 +65,9 @@ export function FairUseCreditsUsage({
   return (
     <div
       className={cn(
+        // Spacing lives here rather than on a wrapper so that it only applies when the gauge is
+        // actually visible.
+        "mx-3 mb-3",
         "rounded-lg border p-3",
         "border-border dark:border-border-night",
         "bg-background dark:bg-background-night"
@@ -57,13 +75,13 @@ export function FairUseCreditsUsage({
     >
       <div className="mb-2 flex items-center justify-between text-sm">
         <span className="font-semibold text-foreground dark:text-foreground-night">
-          Fair usage (credits)
+          Fair usage
         </span>
         <span className="font-medium text-foreground dark:text-foreground-night">
           <span className={cn(isCritical && "text-red-600 dark:text-red-400")}>
             {formatCredits(count)}
           </span>{" "}
-          / {formatCredits(limit)}
+          / {formatCredits(limit)} cr.
         </span>
       </div>
       <div

--- a/front/components/app/FairUseCreditsUsage.tsx
+++ b/front/components/app/FairUseCreditsUsage.tsx
@@ -15,9 +15,7 @@ interface FairUseCreditsUsageProps {
   workspaceId: string;
 }
 
-export function FairUseCreditsUsage({
-  workspaceId,
-}: FairUseCreditsUsageProps) {
+export function FairUseCreditsUsage({ workspaceId }: FairUseCreditsUsageProps) {
   const { fairUseAwuCreditsState, mutateFairUseCredits } = useFairUseCredits({
     workspaceId,
   });

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -161,9 +161,7 @@ export const NavigationSidebar = React.forwardRef<
         // Only mount when the plan has a fair-use credits limit so that the
         // fair-use-credits endpoint is never called for unlimited plans.
         subscription.plan.limits.assistant.maxAwuCredits !== -1 && (
-          <div className="mx-3 mb-3">
-            <FairUseCreditsUsage workspaceId={owner.sId} />
-          </div>
+          <FairUseCreditsUsage workspaceId={owner.sId} />
         )
       )}
       {user && (

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -1,3 +1,4 @@
+import { FairUseCreditsUsage } from "@app/components/app/FairUseCreditsUsage";
 import { TrialMessageUsage } from "@app/components/app/TrialMessageUsage";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { SidebarBanners } from "@app/components/navigation/AppStatusBanner";
@@ -152,10 +153,18 @@ export const NavigationSidebar = React.forwardRef<
         )}
       </div>
       <div className="flex grow flex-col">{children}</div>
-      {subscription.plan.code === FREE_TRIAL_PHONE_PLAN_CODE && (
+      {subscription.plan.code === FREE_TRIAL_PHONE_PLAN_CODE ? (
         <div className="mx-3 mb-3">
           <TrialMessageUsage isAdmin={isAdmin(owner)} workspaceId={owner.sId} />
         </div>
+      ) : (
+        // Only mount when the plan has a fair-use credits limit so that the
+        // fair-use-credits endpoint is never called for unlimited plans.
+        subscription.plan.limits.assistant.maxAwuCredits !== -1 && (
+          <div className="mx-3 mb-3">
+            <FairUseCreditsUsage workspaceId={owner.sId} />
+          </div>
+        )
       )}
       {user && (
         <UserMenu user={user} owner={owner} subscription={subscription} />


### PR DESCRIPTION
## Description

Work for: https://github.com/dust-tt/tasks/issues/8257

Appears:
- only if a non -1 limit is set AND reaches 75% usage
- warning mode at 90%

3s delay (a bit ugly) before mutating the hook since credit count update is run async at the end of the loop.

<img width="1127" height="506" alt="Screenshot 2026-06-10 at 18 47 53" src="https://github.com/user-attachments/assets/57d19c06-c8d6-4b81-8d23-04469d98145f" />
<img width="1128" height="501" alt="Screenshot 2026-06-10 at 18 48 03" src="https://github.com/user-attachments/assets/7e015d63-6d54-46d5-b2dd-30aa7f64480c" />

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy front