### PR TITLE
fix: resolve blocked tool approvals when an agent message is terminated

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,4 +1,5 @@
 import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
+import { clearActionRequiredIfNoBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import type {
   GetConversationResponseBody,
@@ -285,6 +286,16 @@ app.patch(
         await ConversationResource.markAsReadForAuthUser(auth, {
           conversation,
         });
+
+        // A stale `actionRequired` flag (e.g. left behind by a manual tool approval whose
+        // message got interrupted before blocked actions were resolved on termination) would
+        // keep the conversation stuck in the unread inbox: self-heal it when no actionable
+        // blocked action remains.
+        if (conversation.actionRequired) {
+          await clearActionRequiredIfNoBlockedActions(auth, {
+            conversationId: conversation.sId,
+          });
+        }
       } else {
         await ConversationResource.markAsUnreadForAuthUser(auth, {
           conversation,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3215,16 +3215,6 @@ export async function updateAgentMessageWithFinalStatus(
     };
   });
 
-  // The agent message will never resume: tools still waiting on user input (e.g. a manual
-  // approval that the user skipped by interrupting the message) will never run. Resolve them so
-  // the conversation doesn't stay flagged as requiring an action in the inbox.
-  if (UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)) {
-    await resolveBlockedActionsForTerminatedMessage(auth, {
-      conversation,
-      agentMessage,
-    });
-  }
-
   // Publish events and launch agent loop outside of the advisory lock.
   if (promotedUserMessages.length > 0) {
     for (const userMsg of promotedUserMessages) {
@@ -3266,6 +3256,18 @@ export async function updateAgentMessageWithFinalStatus(
       agentMessages: [newAgentMessage],
       conversation,
       userMessage: promotedUserMessages[promotedUserMessages.length - 1],
+    });
+  }
+
+  // The agent message will never resume: tools still waiting on user input (e.g. a manual
+  // approval that the user skipped by interrupting the message) will never run. Resolve them so
+  // the conversation doesn't stay flagged as requiring an action in the inbox. Runs last so a
+  // cleanup failure cannot strand the promoted messages above (the cleanup itself is
+  // idempotent, so an activity retry converges).
+  if (UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)) {
+    await resolveBlockedActionsForTerminatedMessage(auth, {
+      conversation,
+      agentMessage,
     });
   }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { runAgentLoopWorkflow } from "@app/lib/api/assistant/conversation/agent_loop";
+import { resolveBlockedActionsForTerminatedMessage } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import {
   getConversationRankVersionLock,
@@ -143,6 +144,7 @@ import {
   isCompactionMessageType,
   isPodConversation,
   isUserMessageType,
+  UNRESUMABLE_AGENT_MESSAGE_STATUSES,
 } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import {
@@ -3212,6 +3214,16 @@ export async function updateAgentMessageWithFinalStatus(
       agentMessage: agentMessages[0] ?? null,
     };
   });
+
+  // The agent message will never resume: tools still waiting on user input (e.g. a manual
+  // approval that the user skipped by interrupting the message) will never run. Resolve them so
+  // the conversation doesn't stay flagged as requiring an action in the inbox.
+  if (UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)) {
+    await resolveBlockedActionsForTerminatedMessage(auth, {
+      conversation,
+      agentMessage,
+    });
+  }
 
   // Publish events and launch agent loop outside of the advisory lock.
   if (promotedUserMessages.length > 0) {

--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -85,6 +85,18 @@ export async function registerUserAnswer(
     );
   }
 
+  // A blocked action is only actionable while its agent message can still resume: answering one
+  // left behind by an interrupted, cancelled or failed message would relaunch an agent loop that
+  // was already terminated.
+  if (await action.isAgentMessageUnresumable(auth)) {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "Action belongs to an agent message that can no longer resume"
+      )
+    );
+  }
+
   await action.updateStepContext({
     ...action.stepContext,
     resumeState: {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -16,7 +16,6 @@ import {
   resolveBlockedActionsForTerminatedMessage,
 } from "@app/lib/api/assistant/conversation/blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
@@ -180,10 +179,11 @@ describe("blocked actions resolution", () => {
 
       // Simulate a legacy stuck conversation: the message was interrupted while its blocked
       // action was left pending.
-      await AgentMessageModel.update(
-        { status: "interrupted" },
-        { where: { id: agentMessageRowId, workspaceId: workspace.id } }
-      );
+      await ConversationFactory.setAgentMessageStatus({
+        workspace,
+        agentMessageModelId: agentMessageRowId,
+        status: "interrupted",
+      });
 
       await ConversationResource.markAsActionRequired(auth, { conversation });
       expect(await getActionRequired()).toBe(true);

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Redis hybrid manager to prevent it from removing events
+const { removeEventMock } = vi.hoisted(() => ({
+  removeEventMock: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: vi.fn().mockReturnValue({
+    removeEvent: removeEventMock,
+  }),
+}));
+
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import {
+  clearActionRequiredIfNoBlockedActions,
+  resolveBlockedActionsForTerminatedMessage,
+} from "@app/lib/api/assistant/conversation/blocked_actions";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+
+describe("blocked actions resolution", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  let stepContentIndex = 0;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    stepContentIndex = 0;
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: auth.getNonNullableUser().toJSON(),
+    });
+  });
+
+  /**
+   * Helper to create a blocked MCP action for testing.
+   */
+  async function createBlockedAction({
+    agentMessageId,
+    status = "blocked_validation_required",
+  }: {
+    agentMessageId: number;
+    status?: ToolExecutionStatus;
+  }) {
+    const functionCallId = generateRandomModelSId();
+    const currentIndex = stepContentIndex++;
+
+    const stepContent = await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      step: 1,
+      index: currentIndex,
+      version: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          id: functionCallId,
+          name: "test_tool",
+          arguments: "{}",
+        },
+      },
+    });
+
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "test_tool",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission: "low",
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+    };
+
+    const action = await AgentMCPActionModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      status,
+      citationsAllocated: 0,
+      augmentedInputs: {},
+      toolConfiguration,
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+
+    await AgentStepContentToolExecutionModel.create({
+      workspaceId: workspace.id,
+      conversationId: conversation.id,
+      agentMessageId,
+      agentMCPActionId: action.id,
+      stepContentId: stepContent.id,
+    });
+
+    return { action, stepContent };
+  }
+
+  async function createAgentMessageAtRank(rank: number) {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: `Test Agent ${rank}`,
+    });
+
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: rank - 1,
+      content: "Test message",
+    });
+
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      parentId: userMessageRow.id,
+    });
+
+    return { messageRow, agentMessageRowId: messageRow.agentMessageId! };
+  }
+
+  async function getActionRequired() {
+    const { actionRequired } =
+      await ConversationResource.getActionRequiredAndLastReadAtForUser(
+        auth,
+        conversation.id
+      );
+    return actionRequired;
+  }
+
+  describe("resolveBlockedActionsForTerminatedMessage", () => {
+    it("denies blocked actions and clears actionRequired when none remain", async () => {
+      const { messageRow, agentMessageRowId } =
+        await createAgentMessageAtRank(1);
+      const { action } = await createBlockedAction({
+        agentMessageId: agentMessageRowId,
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+      expect(await getActionRequired()).toBe(true);
+
+      await resolveBlockedActionsForTerminatedMessage(auth, {
+        conversation,
+        agentMessage: {
+          agentMessageId: agentMessageRowId,
+          sId: messageRow.sId,
+        },
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+
+      // The pending approval event was removed from the message channel.
+      expect(removeEventMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.stringContaining(messageRow.sId)
+      );
+
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("keeps actionRequired when another message still has a blocked action", async () => {
+      const { messageRow, agentMessageRowId } =
+        await createAgentMessageAtRank(1);
+      const { action } = await createBlockedAction({
+        agentMessageId: agentMessageRowId,
+      });
+
+      const { agentMessageRowId: otherAgentMessageRowId } =
+        await createAgentMessageAtRank(3);
+      const { action: otherAction } = await createBlockedAction({
+        agentMessageId: otherAgentMessageRowId,
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await resolveBlockedActionsForTerminatedMessage(auth, {
+        conversation,
+        agentMessage: {
+          agentMessageId: agentMessageRowId,
+          sId: messageRow.sId,
+        },
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+
+      // The other message's blocked action is untouched and keeps the flag up.
+      await otherAction.reload();
+      expect(otherAction.status).toBe("blocked_validation_required");
+      expect(await getActionRequired()).toBe(true);
+    });
+
+    it("is a no-op when the message has no blocked action", async () => {
+      const { messageRow, agentMessageRowId } =
+        await createAgentMessageAtRank(1);
+
+      await resolveBlockedActionsForTerminatedMessage(auth, {
+        conversation,
+        agentMessage: {
+          agentMessageId: agentMessageRowId,
+          sId: messageRow.sId,
+        },
+      });
+
+      expect(removeEventMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("clearActionRequiredIfNoBlockedActions", () => {
+    it("clears the flag when the only blocked action belongs to an unresumable message", async () => {
+      const { agentMessageRowId } = await createAgentMessageAtRank(1);
+      await createBlockedAction({ agentMessageId: agentMessageRowId });
+
+      // Simulate a legacy stuck conversation: the message was interrupted while its blocked
+      // action was left pending.
+      await AgentMessageModel.update(
+        { status: "interrupted" },
+        { where: { id: agentMessageRowId, workspaceId: workspace.id } }
+      );
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+      expect(await getActionRequired()).toBe(true);
+
+      await clearActionRequiredIfNoBlockedActions(auth, {
+        conversationId: conversation.sId,
+      });
+
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("does not clear the flag when an actionable blocked action remains", async () => {
+      const { agentMessageRowId } = await createAgentMessageAtRank(1);
+      await createBlockedAction({ agentMessageId: agentMessageRowId });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await clearActionRequiredIfNoBlockedActions(auth, {
+        conversationId: conversation.sId,
+      });
+
+      expect(await getActionRequired()).toBe(true);
+    });
+  });
+
+  describe("updateAgentMessageWithFinalStatus", () => {
+    it("resolves blocked actions when the message is interrupted", async () => {
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        { workspace, conversation, agentConfig }
+      );
+      const { action } = await createBlockedAction({
+        agentMessageId: agentMessage.agentMessageId,
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("leaves blocked actions untouched when the message is gracefully stopped", async () => {
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        { workspace, conversation, agentConfig }
+      );
+      const { action } = await createBlockedAction({
+        agentMessageId: agentMessage.agentMessageId,
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "gracefully_stopped",
+      });
+
+      // A graceful stop keeps pending approvals actionable.
+      await action.reload();
+      expect(action.status).toBe("blocked_validation_required");
+      expect(await getActionRequired()).toBe(true);
+    });
+  });
+});

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -15,7 +15,9 @@ import {
   clearActionRequiredIfNoBlockedActions,
   resolveBlockedActionsForTerminatedMessage,
 } from "@app/lib/api/assistant/conversation/blocked_actions";
+import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
@@ -152,9 +154,13 @@ describe("blocked actions resolution", () => {
       expect(await getActionRequired()).toBe(true);
     });
 
-    it("is a no-op when the message has no blocked action", async () => {
+    it("still clears a stale actionRequired flag when no blocked action remains", async () => {
       const { messageRow, agentMessageRowId } =
         await createAgentMessageAtRank(1);
+
+      // Simulate a partial previous run: blocked actions already denied, but the run failed
+      // before clearing the flag. A retry must converge.
+      await ConversationResource.markAsActionRequired(auth, { conversation });
 
       await resolveBlockedActionsForTerminatedMessage(auth, {
         conversation,
@@ -165,6 +171,100 @@ describe("blocked actions resolution", () => {
       });
 
       expect(removeEventMock).not.toHaveBeenCalled();
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("denies non-approval blocked actions and purges all blocked-action events", async () => {
+      const { messageRow, agentMessageRowId } =
+        await createAgentMessageAtRank(1);
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
+        agentMessageId: agentMessageRowId,
+        status: "blocked_authentication_required",
+      });
+
+      await resolveBlockedActionsForTerminatedMessage(auth, {
+        conversation,
+        agentMessage: {
+          agentMessageId: agentMessageRowId,
+          sId: messageRow.sId,
+        },
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+
+      // The removal predicate matches every blocked-action event type of the denied action,
+      // not only approval events.
+      const [predicate, channel] = removeEventMock.mock.calls[0];
+      expect(channel).toContain(messageRow.sId);
+
+      const actionId = AgentMCPActionResource.modelIdToSId({
+        id: action.id,
+        workspaceId: workspace.id,
+      });
+      const makeEvent = (type: string, eventActionId: string) => ({
+        message: {
+          payload: JSON.stringify({ type, actionId: eventActionId }),
+        },
+      });
+      expect(
+        predicate(makeEvent("tool_personal_auth_required", actionId))
+      ).toBe(true);
+      expect(predicate(makeEvent("tool_ask_user_question", actionId))).toBe(
+        true
+      );
+      expect(predicate(makeEvent("tool_approve_execution", actionId))).toBe(
+        true
+      );
+      expect(
+        predicate(makeEvent("tool_approve_execution", "other_action_id"))
+      ).toBe(false);
+    });
+  });
+
+  describe("validateAction", () => {
+    it("rejects resolving an action whose agent message can no longer resume", async () => {
+      const { messageRow, agentMessageRowId } =
+        await createAgentMessageAtRank(1);
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
+        agentMessageId: agentMessageRowId,
+      });
+
+      // Legacy stuck conversation: the message was interrupted while its blocked action was
+      // left pending. A stale approval (e.g. an old email link) must not resume the loop.
+      await ConversationFactory.setAgentMessageStatus({
+        workspace,
+        agentMessageModelId: agentMessageRowId,
+        status: "interrupted",
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: AgentMCPActionResource.modelIdToSId({
+          id: action.id,
+          workspaceId: workspace.id,
+        }),
+        approvalState: "approved",
+        messageId: messageRow.sId,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("action_not_blocked");
+      }
+
+      // The action was not transitioned.
+      await action.reload();
+      expect(action.status).toBe("blocked_validation_required");
     });
   });
 

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -10,21 +10,16 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
   }),
 }));
 
-import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import {
   clearActionRequiredIfNoBlockedActions,
   resolveBlockedActionsForTerminatedMessage,
 } from "@app/lib/api/assistant/conversation/blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
-import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { ConversationType } from "@app/types/assistant/conversation";
@@ -35,11 +30,8 @@ describe("blocked actions resolution", () => {
   let auth: Authenticator;
   let conversation: ConversationType;
 
-  let stepContentIndex = 0;
-
   beforeEach(async () => {
     vi.clearAllMocks();
-    stepContentIndex = 0;
 
     const setup = await createResourceTest({});
     workspace = setup.workspace;
@@ -57,89 +49,6 @@ describe("blocked actions resolution", () => {
       user: auth.getNonNullableUser().toJSON(),
     });
   });
-
-  /**
-   * Helper to create a blocked MCP action for testing.
-   */
-  async function createBlockedAction({
-    agentMessageId,
-    status = "blocked_validation_required",
-  }: {
-    agentMessageId: number;
-    status?: ToolExecutionStatus;
-  }) {
-    const functionCallId = generateRandomModelSId();
-    const currentIndex = stepContentIndex++;
-
-    const stepContent = await AgentStepContentModel.create({
-      workspaceId: workspace.id,
-      agentMessageId,
-      step: 1,
-      index: currentIndex,
-      version: 0,
-      type: "function_call",
-      value: {
-        type: "function_call",
-        value: {
-          id: functionCallId,
-          name: "test_tool",
-          arguments: "{}",
-        },
-      },
-    });
-
-    const toolConfiguration: LightMCPToolConfigurationType = {
-      id: 1,
-      sId: generateRandomModelSId(),
-      type: "mcp_configuration",
-      name: "test_tool",
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      timeFrame: null,
-      jsonSchema: null,
-      additionalConfiguration: {},
-      mcpServerViewId: "test-server-view",
-      dustAppConfiguration: null,
-      secretName: null,
-      dustProject: null,
-      internalMCPServerId: null,
-      availability: "auto",
-      permission: "low",
-      toolServerId: "test-server",
-      retryPolicy: "no_retry",
-      originalName: "test_tool",
-      mcpServerName: "test_server",
-    };
-
-    const action = await AgentMCPActionModel.create({
-      workspaceId: workspace.id,
-      agentMessageId,
-      mcpServerConfigurationId: generateRandomModelSId(),
-      status,
-      citationsAllocated: 0,
-      augmentedInputs: {},
-      toolConfiguration,
-      stepContentId: stepContent.id,
-      stepContext: {
-        citationsCount: 0,
-        citationsOffset: 0,
-        resumeState: null,
-        retrievalTopK: 10,
-        websearchResultCount: 5,
-      },
-    });
-
-    await AgentStepContentToolExecutionModel.create({
-      workspaceId: workspace.id,
-      conversationId: conversation.id,
-      agentMessageId,
-      agentMCPActionId: action.id,
-      stepContentId: stepContent.id,
-    });
-
-    return { action, stepContent };
-  }
 
   async function createAgentMessageAtRank(rank: number) {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
@@ -179,7 +88,9 @@ describe("blocked actions resolution", () => {
     it("denies blocked actions and clears actionRequired when none remain", async () => {
       const { messageRow, agentMessageRowId } =
         await createAgentMessageAtRank(1);
-      const { action } = await createBlockedAction({
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
         agentMessageId: agentMessageRowId,
       });
 
@@ -209,13 +120,17 @@ describe("blocked actions resolution", () => {
     it("keeps actionRequired when another message still has a blocked action", async () => {
       const { messageRow, agentMessageRowId } =
         await createAgentMessageAtRank(1);
-      const { action } = await createBlockedAction({
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
         agentMessageId: agentMessageRowId,
       });
 
       const { agentMessageRowId: otherAgentMessageRowId } =
         await createAgentMessageAtRank(3);
-      const { action: otherAction } = await createBlockedAction({
+      const { action: otherAction } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
         agentMessageId: otherAgentMessageRowId,
       });
 
@@ -257,7 +172,11 @@ describe("blocked actions resolution", () => {
   describe("clearActionRequiredIfNoBlockedActions", () => {
     it("clears the flag when the only blocked action belongs to an unresumable message", async () => {
       const { agentMessageRowId } = await createAgentMessageAtRank(1);
-      await createBlockedAction({ agentMessageId: agentMessageRowId });
+      await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
+        agentMessageId: agentMessageRowId,
+      });
 
       // Simulate a legacy stuck conversation: the message was interrupted while its blocked
       // action was left pending.
@@ -278,7 +197,11 @@ describe("blocked actions resolution", () => {
 
     it("does not clear the flag when an actionable blocked action remains", async () => {
       const { agentMessageRowId } = await createAgentMessageAtRank(1);
-      await createBlockedAction({ agentMessageId: agentMessageRowId });
+      await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
+        agentMessageId: agentMessageRowId,
+      });
 
       await ConversationResource.markAsActionRequired(auth, { conversation });
 
@@ -300,7 +223,9 @@ describe("blocked actions resolution", () => {
         auth,
         { workspace, conversation, agentConfig }
       );
-      const { action } = await createBlockedAction({
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
         agentMessageId: agentMessage.agentMessageId,
       });
 
@@ -326,7 +251,9 @@ describe("blocked actions resolution", () => {
         auth,
         { workspace, conversation, agentConfig }
       );
-      const { action } = await createBlockedAction({
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationId: conversation.id,
         agentMessageId: agentMessage.agentMessageId,
       });
 

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,5 +1,102 @@
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { isMCPApproveExecutionEvent } from "@app/lib/actions/mcp";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import type {
+  AgentMessageType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 
 export type GetBlockedActionsResponseType = {
   blockedActions: BlockedToolExecution[];
 };
+
+/**
+ * Resolves the blocked actions of an agent message that reached a terminal status (interrupted,
+ * cancelled, failed, ...). The message will never resume, so tools still waiting on user input
+ * (e.g. a manual approval) can never run: deny them so the conversation stops surfacing pending
+ * approvals and doesn't stay flagged as requiring an action in the inbox.
+ */
+export async function resolveBlockedActionsForTerminatedMessage(
+  auth: Authenticator,
+  {
+    conversation,
+    agentMessage,
+  }: {
+    conversation: ConversationWithoutContentType;
+    agentMessage: Pick<AgentMessageType, "agentMessageId" | "sId">;
+  }
+): Promise<void> {
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+      agentMessageId: agentMessage.agentMessageId,
+    });
+
+  if (blockedActions.length === 0) {
+    return;
+  }
+
+  // Sequential DB updates are fine here: the number of blocked actions is bounded by the
+  // per-step action limit.
+  for (const action of blockedActions) {
+    await action.updateStatus("denied");
+  }
+
+  logger.info(
+    {
+      actionIds: blockedActions.map((a) => a.sId),
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    },
+    "Denied blocked actions of terminated agent message"
+  );
+
+  // Remove the pending tool approval request events from the message channel so live clients
+  // stop surfacing approval dialogs for them.
+  const blockedActionIds = new Set(blockedActions.map((a) => a.sId));
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+    return (
+      isMCPApproveExecutionEvent(payload) &&
+      blockedActionIds.has(payload.actionId)
+    );
+  }, getMessageChannelId(agentMessage.sId));
+
+  await clearActionRequiredIfNoBlockedActions(auth, {
+    conversationId: conversation.sId,
+  });
+}
+
+/**
+ * Clears the participants' `actionRequired` flag of a conversation if no blocked action remains.
+ * The flag is denormalized (set when a tool starts waiting on user input, cleared when an agent
+ * loop is launched), so it can go stale when a blocked message is terminated without its blocked
+ * actions being resolved.
+ */
+export async function clearActionRequiredIfNoBlockedActions(
+  auth: Authenticator,
+  { conversationId }: { conversationId: string }
+): Promise<void> {
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return;
+  }
+
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForConversation(
+      auth,
+      conversation
+    );
+
+  if (blockedActions.length === 0) {
+    await ConversationResource.clearActionRequired(auth, conversationId);
+  }
+}

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -40,11 +40,13 @@ export async function resolveBlockedActionsForTerminatedMessage(
     return;
   }
 
-  // Sequential DB updates are fine here: the number of blocked actions is bounded by the
-  // per-step action limit.
-  for (const action of blockedActions) {
-    await action.updateStatus("denied");
-  }
+  // All blocked statuses are denied, not only manual approvals: whatever input the tool was
+  // waiting for (approval, authentication, user answer), the terminated message will never
+  // consume it. The update is guarded on the action still being blocked, so a concurrent
+  // approval is not clobbered.
+  await AgentMCPActionResource.denyIfStillBlocked(auth, {
+    actionModelIds: blockedActions.map((a) => a.id),
+  });
 
   logger.info(
     {
@@ -97,6 +99,9 @@ export async function clearActionRequiredIfNoBlockedActions(
     );
 
   if (blockedActions.length === 0) {
-    await ConversationResource.clearActionRequired(auth, conversationId);
+    await ConversationResource.clearActionRequiredForConversation(
+      auth,
+      conversation
+    );
   }
 }

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,6 +1,11 @@
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { isMCPApproveExecutionEvent } from "@app/lib/actions/mcp";
+import { isBlockedActionEvent } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -10,6 +15,7 @@ import type {
   AgentMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 
 export type GetBlockedActionsResponseType = {
   blockedActions: BlockedToolExecution[];
@@ -36,42 +42,133 @@ export async function resolveBlockedActionsForTerminatedMessage(
       agentMessageId: agentMessage.agentMessageId,
     });
 
-  if (blockedActions.length === 0) {
-    return;
+  if (blockedActions.length > 0) {
+    // All blocked statuses are denied, not only manual approvals: whatever input the tool was
+    // waiting for (approval, authentication, user answer), the terminated message will never
+    // consume it. The update is guarded on the action still being blocked, so a concurrent
+    // approval is not clobbered.
+    const deniedActionModelIds =
+      await AgentMCPActionResource.denyIfStillBlocked(auth, {
+        actionModelIds: blockedActions.map((a) => a.id),
+      });
+
+    emitApprovalResolvedAuditEvents(auth, {
+      conversation,
+      agentMessage,
+      blockedActions,
+      deniedActionModelIds,
+    });
+
+    logger.info(
+      {
+        actionIds: blockedActions.map((a) => a.sId),
+        conversationId: conversation.sId,
+        messageId: agentMessage.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Denied blocked actions of terminated agent message"
+    );
+
+    // Remove the pending blocked-action events (approval requests, auth requests, user
+    // questions) from the message channel so live clients stop surfacing prompts for them.
+    const blockedActionIds = new Set(blockedActions.map((a) => a.sId));
+    await getRedisHybridManager().removeEvent((event) => {
+      const payload = JSON.parse(event.message["payload"]);
+      return (
+        isBlockedActionEvent(payload) && blockedActionIds.has(payload.actionId)
+      );
+    }, getMessageChannelId(agentMessage.sId));
   }
 
-  // All blocked statuses are denied, not only manual approvals: whatever input the tool was
-  // waiting for (approval, authentication, user answer), the terminated message will never
-  // consume it. The update is guarded on the action still being blocked, so a concurrent
-  // approval is not clobbered.
-  await AgentMCPActionResource.denyIfStillBlocked(auth, {
-    actionModelIds: blockedActions.map((a) => a.id),
-  });
-
-  logger.info(
-    {
-      actionIds: blockedActions.map((a) => a.sId),
-      conversationId: conversation.sId,
-      messageId: agentMessage.sId,
-      workspaceId: auth.getNonNullableWorkspace().sId,
-    },
-    "Denied blocked actions of terminated agent message"
-  );
-
-  // Remove the pending tool approval request events from the message channel so live clients
-  // stop surfacing approval dialogs for them.
-  const blockedActionIds = new Set(blockedActions.map((a) => a.sId));
-  await getRedisHybridManager().removeEvent((event) => {
-    const payload = JSON.parse(event.message["payload"]);
-    return (
-      isMCPApproveExecutionEvent(payload) &&
-      blockedActionIds.has(payload.actionId)
-    );
-  }, getMessageChannelId(agentMessage.sId));
-
+  // Always re-check the flag, even when no blocked action remains: a partial previous run may
+  // have denied the actions but failed before clearing it, and a retry must converge.
   await clearActionRequiredIfNoBlockedActions(auth, {
     conversationId: conversation.sId,
   });
+}
+
+/**
+ * Emits a `tool.approval_resolved` audit event for each manual approval that was auto-denied
+ * when its agent message terminated, so the audit trail doesn't keep `tool.approval_requested`
+ * entries without a resolution. Fire-and-forget (AUDIT1): must never block or break the
+ * termination flow.
+ */
+function emitApprovalResolvedAuditEvents(
+  auth: Authenticator,
+  {
+    conversation,
+    agentMessage,
+    blockedActions,
+    deniedActionModelIds,
+  }: {
+    conversation: ConversationWithoutContentType;
+    agentMessage: Pick<AgentMessageType, "agentMessageId" | "sId">;
+    blockedActions: AgentMCPActionResource[];
+    deniedActionModelIds: ModelId[];
+  }
+): void {
+  const deniedModelIds = new Set(deniedActionModelIds);
+  // Only audit manual approvals whose status actually transitioned: other blocked statuses
+  // never emitted `tool.approval_requested`, and concurrently resolved actions were not denied
+  // by us.
+  const deniedApprovals = blockedActions.filter(
+    (a) =>
+      a.status === "blocked_validation_required" && deniedModelIds.has(a.id)
+  );
+  if (deniedApprovals.length === 0) {
+    return;
+  }
+
+  void (async () => {
+    try {
+      // All blocked actions belong to the same agent message, so resolve the agent
+      // configuration once.
+      const auditAgentConfig =
+        await deniedApprovals[0].getLightAgentConfiguration(auth);
+      if (!auditAgentConfig) {
+        return;
+      }
+      const user = auth.user();
+      for (const action of deniedApprovals) {
+        void emitAuditLogEvent({
+          auth,
+          action: "tool.approval_resolved",
+          targets: [
+            buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+            buildAuditLogTarget("agent", auditAgentConfig),
+            buildAuditLogTarget("tool", {
+              sId: action.toolConfiguration.name,
+              name: action.toolConfiguration.originalName,
+            }),
+          ],
+          context: getAuditLogContext(auth),
+          metadata: {
+            // Distinct from the user decisions ("approved", "rejected", ...): the approval was
+            // resolved by the system because the message terminated, not by an explicit user
+            // choice.
+            decision: "auto_rejected",
+            tool_name: action.toolConfiguration.originalName,
+            mcp_server_name: action.toolConfiguration.mcpServerName,
+            stake_level: action.toolConfiguration.permission,
+            conversation_id: conversation.sId,
+            agent_message_id: agentMessage.sId,
+            action_id: action.sId,
+            deciding_user_id: user?.sId ?? "unknown",
+            deciding_user_email: user?.email ?? "unknown",
+          },
+        });
+      }
+    } catch (err) {
+      logger.error(
+        {
+          err,
+          conversationId: conversation.sId,
+          messageId: agentMessage.sId,
+        },
+        "Failed to emit tool.approval_resolved audit events for terminated message"
+      );
+    }
+  })();
 }
 
 /**

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -73,6 +73,13 @@ async function findUserMessageForRetry(
     return new Err(new Error("No blocked actions found"));
   }
 
+  // Blocked actions of a message that can no longer resume (interrupted, cancelled, failed) are
+  // stale leftovers: retrying them would relaunch an agent loop that was already terminated. All
+  // blocked actions belong to the same agent message, so checking the first one is enough.
+  if (await blockedActions[0].isAgentMessageUnresumable(auth)) {
+    return new Err(new Error("Agent message can no longer resume"));
+  }
+
   // Purge blocked actions event message from the stream:
   // - remove tool_approve_execution events (watch out as those events are not republished).
   // - remove tool_personal_auth_required events.

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -102,6 +102,18 @@ export async function validateAction(
     );
   }
 
+  // A blocked action is only actionable while its agent message can still resume: resolving one
+  // left behind by an interrupted, cancelled or failed message (e.g. through a stale approval
+  // link) would relaunch an agent loop that was already terminated.
+  if (await action.isAgentMessageUnresumable(auth)) {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "Action belongs to an agent message that can no longer resume"
+      )
+    );
+  }
+
   const [updatedCount] = await action.updateStatus(
     getMCPApprovalStateFromUserApprovalState(approvalState)
   );

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -12,6 +12,7 @@ import {
   AgentMCPActionOutputItemModel,
 } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import {
   GCS_CONTENT_CACHE_TTL_MS,
   gcsContentCacheKey,
@@ -285,6 +286,62 @@ describe("listBlockedActionsForConversation", () => {
     // Only the blocked action should be returned, not the succeeded one.
     expect(result).toHaveLength(1);
     expect(result[0].status).toBe("blocked_validation_required");
+  });
+
+  it("should not return blocked actions whose agent message can no longer resume", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    // Create user message at rank 0.
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+
+    // Create agent message at rank 1 with a blocked action.
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+
+    await createBlockedAction({
+      agentMessageId: agentMessageRow.agentMessageId!,
+    });
+
+    // Interrupt the agent message (e.g. the user skipped it), leaving the blocked action behind.
+    await AgentMessageModel.update(
+      { status: "interrupted" },
+      {
+        where: {
+          id: agentMessageRow.agentMessageId!,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+
+    const result =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource!
+      );
+
+    // The blocked action is not actionable anymore: it must not be returned.
+    expect(result).toEqual([]);
   });
 
   it("should only return blocked actions from the latest agent message version at a given rank", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -1,17 +1,9 @@
-import type {
-  LightMCPToolConfigurationType,
-  LightServerSideMCPToolConfigurationType,
-} from "@app/lib/actions/mcp";
+import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
-import {
-  AgentMCPActionModel,
-  AgentMCPActionOutputItemModel,
-} from "@app/lib/models/agent/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import {
   GCS_CONTENT_CACHE_TTL_MS,
@@ -20,8 +12,8 @@ import {
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -80,11 +72,7 @@ describe("listBlockedActionsForConversation", () => {
   let auth: Authenticator;
   let conversation: ConversationType;
 
-  let stepContentIndex = 0;
-
   beforeEach(async () => {
-    stepContentIndex = 0;
-
     const setup = await createResourceTest({});
     workspace = setup.workspace;
     auth = setup.authenticator;
@@ -103,76 +91,12 @@ describe("listBlockedActionsForConversation", () => {
     agentMessageId: number;
     status?: ToolExecutionStatus;
   }) {
-    const functionCallId = generateRandomModelSId();
-    const currentIndex = stepContentIndex++;
-
-    const stepContent = await AgentStepContentModel.create({
-      workspaceId: workspace.id,
-      agentMessageId,
-      step: 1,
-      index: currentIndex,
-      version: 0,
-      type: "function_call",
-      value: {
-        type: "function_call",
-        value: {
-          id: functionCallId,
-          name: "test_tool",
-          arguments: "{}",
-        },
-      },
-    });
-
-    const toolConfiguration: LightMCPToolConfigurationType = {
-      id: 1,
-      sId: generateRandomModelSId(),
-      type: "mcp_configuration",
-      name: "test_tool",
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      timeFrame: null,
-      jsonSchema: null,
-      additionalConfiguration: {},
-      mcpServerViewId: "test-server-view",
-      dustAppConfiguration: null,
-      secretName: null,
-      dustProject: null,
-      internalMCPServerId: null,
-      availability: "auto",
-      permission: "low",
-      toolServerId: "test-server",
-      retryPolicy: "no_retry",
-      originalName: "test_tool",
-      mcpServerName: "test_server",
-    };
-
-    const action = await AgentMCPActionModel.create({
-      workspaceId: workspace.id,
-      agentMessageId,
-      mcpServerConfigurationId: generateRandomModelSId(),
-      status,
-      citationsAllocated: 0,
-      augmentedInputs: {},
-      toolConfiguration,
-      stepContext: {
-        citationsCount: 0,
-        citationsOffset: 0,
-        resumeState: null,
-        retrievalTopK: 10,
-        websearchResultCount: 5,
-      },
-    });
-
-    await AgentStepContentToolExecutionModel.create({
-      workspaceId: workspace.id,
+    return AgentMCPActionFactory.create({
+      workspace,
       conversationId: conversation.id,
       agentMessageId,
-      agentMCPActionId: action.id,
-      stepContentId: stepContent.id,
+      status,
     });
-
-    return { action, stepContent };
   }
 
   it("should return empty array for conversation with no agent messages", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -4,7 +4,6 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import {
   GCS_CONTENT_CACHE_TTL_MS,
   gcsContentCacheKey,
@@ -242,15 +241,11 @@ describe("listBlockedActionsForConversation", () => {
     });
 
     // Interrupt the agent message (e.g. the user skipped it), leaving the blocked action behind.
-    await AgentMessageModel.update(
-      { status: "interrupted" },
-      {
-        where: {
-          id: agentMessageRow.agentMessageId!,
-          workspaceId: workspace.id,
-        },
-      }
-    );
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentMessageRow.agentMessageId!,
+      status: "interrupted",
+    });
 
     const conversationResource = await ConversationResource.fetchById(
       auth,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -66,6 +66,7 @@ import type {
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { UNRESUMABLE_AGENT_MESSAGE_STATUSES } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -323,6 +324,12 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             "agentConfigurationId",
             "agentConfigurationVersion",
           ],
+          // A blocked action is only actionable while its agent message can still resume:
+          // exclude actions left behind by messages that were interrupted, cancelled or failed
+          // before their blocked tools got resolved.
+          where: {
+            status: { [Op.notIn]: UNRESUMABLE_AGENT_MESSAGE_STATUSES },
+          },
           include: [
             {
               model: MessageModel,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -753,18 +753,18 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   /**
    * Denies the given actions, guarded on them still being in a blocked status so a concurrent
-   * approval (which flips the action to a ready status) is not clobbered. Returns the number of
-   * actions actually denied.
+   * approval (which flips the action to a ready status) is not clobbered. Returns the ids of
+   * the actions actually denied.
    */
   static async denyIfStillBlocked(
     auth: Authenticator,
     { actionModelIds }: { actionModelIds: ModelId[] }
-  ): Promise<number> {
+  ): Promise<ModelId[]> {
     if (actionModelIds.length === 0) {
-      return 0;
+      return [];
     }
 
-    const [affectedCount] = await AgentMCPActionModel.update(
+    const [, affectedRows] = await AgentMCPActionModel.update(
       { status: "denied" },
       {
         where: {
@@ -772,10 +772,31 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
           status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
         },
+        returning: true,
       }
     );
 
-    return affectedCount;
+    return affectedRows.map((row) => row.id);
+  }
+
+  /**
+   * Whether the agent message owning this action reached a terminal status from which it can
+   * never resume. Resolving a blocked action of such a message (approving, denying, answering,
+   * retrying) would relaunch an agent loop that was already terminated.
+   */
+  async isAgentMessageUnresumable(auth: Authenticator): Promise<boolean> {
+    const agentMessage = await AgentMessageModel.findOne({
+      attributes: ["status"],
+      where: {
+        id: this.agentMessageId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return (
+      agentMessage !== null &&
+      UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(agentMessage.status)
+    );
   }
 
   /**

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -752,6 +752,33 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
+   * Denies the given actions, guarded on them still being in a blocked status so a concurrent
+   * approval (which flips the action to a ready status) is not clobbered. Returns the number of
+   * actions actually denied.
+   */
+  static async denyIfStillBlocked(
+    auth: Authenticator,
+    { actionModelIds }: { actionModelIds: ModelId[] }
+  ): Promise<number> {
+    if (actionModelIds.length === 0) {
+      return 0;
+    }
+
+    const [affectedCount] = await AgentMCPActionModel.update(
+      { status: "denied" },
+      {
+        where: {
+          id: { [Op.in]: actionModelIds },
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
+        },
+      }
+    );
+
+    return affectedCount;
+  }
+
+  /**
    * Creates output items in DB and writes their content to GCS.
    * Content is also written to DB to ease rollback during the migration period.
    */

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2560,6 +2560,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return new Err(new ConversationError("conversation_not_found"));
     }
 
+    return this.clearActionRequiredForConversation(auth, conversation);
+  }
+
+  static async clearActionRequiredForConversation(
+    auth: Authenticator,
+    conversation: ConversationResource
+  ) {
     const updated = await ConversationParticipantModel.update(
       { actionRequired: false },
       {

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -301,7 +301,8 @@ export async function processEventForDatabase(
       break;
 
     case "agent_generation_cancelled":
-      // Store cancellation in database.
+      // Store cancellation in database. Also resolves blocked actions of the cancelled message
+      // (via updateAgentMessageWithFinalStatus).
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         conversation,

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -1,0 +1,104 @@
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { WorkspaceType } from "@app/types/user";
+
+export class AgentMCPActionFactory {
+  // Monotonic counter: step content indexes only need to be unique within an agent message.
+  private static stepContentIndex = 0;
+
+  /**
+   * Creates an MCP action (with its function_call step content and tool execution row),
+   * blocked on tool validation by default.
+   */
+  static async create({
+    workspace,
+    conversationId,
+    agentMessageId,
+    status = "blocked_validation_required",
+  }: {
+    workspace: WorkspaceType;
+    conversationId: ModelId;
+    agentMessageId: ModelId;
+    status?: ToolExecutionStatus;
+  }): Promise<{
+    action: AgentMCPActionModel;
+    stepContent: AgentStepContentModel;
+  }> {
+    const functionCallId = generateRandomModelSId();
+    const currentIndex = this.stepContentIndex++;
+
+    const stepContent = await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      step: 1,
+      index: currentIndex,
+      version: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          id: functionCallId,
+          name: "test_tool",
+          arguments: "{}",
+        },
+      },
+    });
+
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "test_tool",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      dustProject: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission: "low",
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+    };
+
+    const action = await AgentMCPActionModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      status,
+      citationsAllocated: 0,
+      augmentedInputs: {},
+      toolConfiguration,
+      stepContentId: stepContent.id,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+
+    await AgentStepContentToolExecutionModel.create({
+      workspaceId: workspace.id,
+      conversationId,
+      agentMessageId,
+      agentMCPActionId: action.id,
+      stepContentId: stepContent.id,
+    });
+
+    return { action, stepContent };
+  }
+}

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -16,6 +16,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
+  AgentMessageStatus,
   AgentMessageType,
   ConversationType,
   ConversationVisibility,
@@ -317,6 +318,24 @@ export class ConversationFactory {
       agentMessageId: agentMessageRow.id,
       workspaceId: workspace.id,
     });
+  }
+
+  /**
+   * Sets the status of an agent message, e.g. to simulate a message that was interrupted.
+   */
+  static async setAgentMessageStatus({
+    workspace,
+    agentMessageModelId,
+    status,
+  }: {
+    workspace: WorkspaceType;
+    agentMessageModelId: ModelId;
+    status: AgentMessageStatus;
+  }): Promise<void> {
+    await AgentMessageModel.update(
+      { status },
+      { where: { id: agentMessageModelId, workspaceId: workspace.id } }
+    );
   }
 
   /**

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -250,6 +250,16 @@ export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
   "gracefully_stopped",
 ];
 
+// Terminal statuses from which an agent message can never resume. Tools of such a message that
+// are still blocked on user input (e.g. a manual tool approval that was skipped when the message
+// got interrupted) are not actionable anymore. "gracefully_stopped" is not included: a graceful
+// stop keeps pending approvals actionable and approving them resumes the loop.
+export const UNRESUMABLE_AGENT_MESSAGE_STATUSES: AgentMessageStatus[] = [
+  "failed",
+  "cancelled",
+  "interrupted",
+];
+
 export function isTerminalAgentMessageStatus(
   status: AgentMessageStatus
 ): boolean {


### PR DESCRIPTION
## Description

A conversation with a pending manual tool approval kept reappearing unread in the inbox when the user skipped (interrupted) the message instead of approving or declining. The approval stayed in `blocked_validation_required` forever and the participant `actionRequired` flag, which is only cleared when an agent loop launches, kept the conversation pinned in the inbox regardless of mark-as-read.

- When a message reaches a status it cannot resume from (interrupted, cancelled, failed), deny its blocked actions, remove their pending approval events from the message channel, and clear `actionRequired` if no actionable blocked action remains in the conversation.
- `listBlockedActionsForConversation` now excludes blocked actions of unresumable messages, so stale approvals stop surfacing in the UI and in validation checks (this also heals existing stuck data).
- Marking a conversation as read now clears a stale `actionRequired` flag when no actionable blocked action remains.

Fixes dust-tt/tasks#8755

## Tests

Added functional tests: deny-on-termination (direct and through `updateAgentMessageWithFinalStatus`), flag kept when another message still has a live approval, graceful stop keeps approvals actionable, stale-flag self-heal, and the unresumable-message filter.

## Risk

Low. Behavior change is scoped to messages in terminal statuses: their pending approvals are now auto-denied, matching what declining them already did. Graceful stop is excluded and keeps approvals actionable. Safe to rollback.

## Deploy Plan

Standard deploy.