### PR TITLE
[Skills] Derive skill references from instructions on skill writes

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -327,7 +327,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     expect(updatedSkill?.agentFacingDescription).toBe(newDescription);
   });
 
-  it("syncs nested skill references", async () => {
+  it("recomputes nested skill references from instructions", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",
     });
@@ -335,12 +335,7 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
     const childSkill = await SkillFactory.create(requestUserAuth, {
       name: "Referenced Skill",
     });
-    const instructionsWithReference =
-      "Use the referenced skill for deeper analysis.";
-    const buildBody = (
-      instructions: string,
-      referencedSkillIds?: string[]
-    ) => ({
+    const buildBody = (instructions: string) => ({
       name: skill.name,
       agentFacingDescription: skill.agentFacingDescription,
       userFacingDescription: skill.userFacingDescription,
@@ -349,13 +344,12 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       tools: [],
       attachedKnowledge: [],
       instructionsHtml: null,
-      ...(referencedSkillIds !== undefined ? { referencedSkillIds } : {}),
     });
 
     const addResponse = await patchSkill(
       workspace,
       skill.sId,
-      buildBody(instructionsWithReference, [childSkill.sId])
+      buildBody(`Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`)
     );
     expect(addResponse.status).toBe(200);
     const skillWithReference = await SkillResource.fetchById(
@@ -371,30 +365,13 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       }),
     ]);
 
-    const omittedResponse = await patchSkill(
-      workspace,
-      skill.sId,
-      buildBody(instructionsWithReference)
-    );
-    expect(omittedResponse.status).toBe(200);
-    const skillAfterOmittedReferences = await SkillResource.fetchById(
-      requestUserAuth,
-      skill.sId
-    );
-    expect(skillAfterOmittedReferences).not.toBeNull();
-    await expect(
-      skillAfterOmittedReferences!.fetchChildSkills(requestUserAuth)
-    ).resolves.toEqual([
-      expect.objectContaining({
-        sId: childSkill.sId,
-      }),
-    ]);
-
-    const removeResponse = await patchSkill(
-      workspace,
-      skill.sId,
-      buildBody("No nested skill references here.", [])
-    );
+    // Restoring a previous version goes through this same endpoint: saving
+    // instructions without the reference tag must clear the denormalized
+    // references, even if the client still sends a stale referencedSkillIds.
+    const removeResponse = await patchSkill(workspace, skill.sId, {
+      ...buildBody("No nested skill references here."),
+      referencedSkillIds: [childSkill.sId],
+    });
     expect(removeResponse.status).toBe(200);
     const skillWithoutReference = await SkillResource.fetchById(
       requestUserAuth,
@@ -420,11 +397,10 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       name: skill.name,
       agentFacingDescription: skill.agentFacingDescription,
       userFacingDescription: skill.userFacingDescription,
-      instructions: "Use the other workspace skill.",
+      instructions: `Use <skill id="${outOfWorkspaceSkillId}" name="Other Workspace Skill" />.`,
       icon: null,
       tools: [],
       attachedKnowledge: [],
-      referencedSkillIds: [outOfWorkspaceSkillId],
       instructionsHtml: null,
     });
 
@@ -464,7 +440,6 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       icon: null,
       tools: [],
       attachedKnowledge: [],
-      referencedSkillIds: [childSkill.sId],
       instructionsHtml: null,
     });
 

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -50,7 +50,6 @@ const PatchSkillRequestBodySchema = z.object({
   attachedKnowledge: z.array(AttachedKnowledgeSchema),
   instructionsHtml: z.string().nullable(),
   additionalRequestedSpaceIds: z.array(z.string()).optional(),
-  referencedSkillIds: z.array(z.string()).optional(),
   fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
   isDefault: z.boolean().optional(),
   reinforcement: z.enum(["auto", "on", "off"]).optional(),
@@ -317,14 +316,6 @@ app.patch(
       ...additionalRequestedSpaceIds,
     ]);
 
-    const referencedSkillIds =
-      body.referencedSkillIds !== undefined
-        ? uniq(
-            body.referencedSkillIds.filter(
-              (referencedSkillId) => referencedSkillId !== skill.sId
-            )
-          )
-        : undefined;
     const featureFlags = await getFeatureFlags(auth);
 
     // Validate file attachments if provided (gated behind sandbox_tools).
@@ -393,7 +384,6 @@ app.patch(
       name,
       reinforcement: body.reinforcement,
       requestedSpaceIds,
-      referencedSkillIds,
       userFacingDescription: body.userFacingDescription,
       ...(shouldActivate ? { status: "active" as const } : {}),
     });

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -622,12 +622,11 @@ describe("POST /api/w/:wId/skills", () => {
       name: "Parent Skill",
       agentFacingDescription: "To use with another skill",
       userFacingDescription: "A skill with a nested reference",
-      instructions: "Start with the referenced skill.",
+      instructions: `Start with ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
       icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
-      referencedSkillIds: [childSkill.sId],
       instructionsHtml: null,
     });
 
@@ -653,12 +652,12 @@ describe("POST /api/w/:wId/skills", () => {
       name: "Parent Skill",
       agentFacingDescription: "To use with another skill",
       userFacingDescription: "A skill with an invalid nested reference",
-      instructions: "Start with an invalid nested reference.",
+      instructions:
+        'Start with <skill id="not-a-skill-reference" name="Ghost Skill" />.',
       icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
-      referencedSkillIds: ["not-a-skill-reference"],
       instructionsHtml: null,
     });
 

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -52,7 +52,6 @@ const PostSkillRequestBodySchema = z.intersection(
     attachedKnowledge: z.array(AttachedKnowledgeSchema),
     instructionsHtml: z.string().nullable(),
     additionalRequestedSpaceIds: z.array(z.string()).optional(),
-    referencedSkillIds: z.array(z.string()).optional(),
     fileAttachments: z.array(z.object({ fileId: z.string() })).optional(),
     isDefault: z.boolean().optional(),
     reinforcement: z.enum(SKILL_REINFORCEMENT_MODES).optional(),
@@ -343,7 +342,6 @@ app.post(
       });
     }
 
-    const referencedSkillIds = uniq(body.referencedSkillIds ?? []);
     const featureFlags = await getFeatureFlags(auth);
 
     // Validate file attachments if provided (gated behind sandbox_tools).
@@ -428,7 +426,6 @@ app.post(
         mcpServerViews,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
         fileAttachments: files,
-        referencedSkillIds,
       }
     );
 

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.test.ts
@@ -550,7 +550,6 @@ describe("skill_authoring tools", () => {
     const parentSkill = await seedSkill(authenticator, {
       name: "Parent Skill",
       instructions: originalInstructions,
-      referencedSkillIds: [childSkill.sId],
     });
 
     await expect(parentSkill.fetchChildSkills(authenticator)).resolves.toEqual([
@@ -671,17 +670,15 @@ describe("skill_authoring tools", () => {
     });
     const skillReferenceTag =
       SkillFactory.serializeSkillReferenceTag(childSkill);
-    // Seed a parent whose instructions mention the reference but whose links are
-    // not wired yet, mirroring a skill whose references are out of sync.
     const parentSkill = await seedSkill(authenticator, {
       name: "Parent Skill",
       instructions: `Use ${skillReferenceTag} when needed.`,
-      referencedSkillIds: [],
     });
 
-    await expect(parentSkill.fetchChildSkills(authenticator)).resolves.toEqual(
-      []
-    );
+    // References are derived from the instruction tags at creation.
+    await expect(parentSkill.fetchChildSkills(authenticator)).resolves.toEqual([
+      expect.objectContaining({ sId: childSkill.sId }),
+    ]);
 
     // A targeted edit that keeps the reference tag re-derives the references.
     const updateResult = await getTool(UPDATE_SKILL_TOOL_NAME).handler(

--- a/front/lib/api/actions/servers/skill_authoring/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_authoring/tools/index.ts
@@ -297,7 +297,6 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       {
         mcpServerViews: [],
         attachedKnowledge: [],
-        referencedSkillIds: [],
       }
     );
 
@@ -469,14 +468,6 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
 
     const attachedKnowledge = await skill.getAttachedKnowledge(auth);
 
-    // When the instructions change, re-derive the referenced skills from the new
-    // text so the nested-skill links stay in sync with the tags (the builder UI
-    // does the same). Leave them untouched when the instructions are unchanged.
-    const referencedSkillIds =
-      resolvedInstructions !== undefined
-        ? extractUniqueSkillReferenceIds(resolvedInstructions)
-        : undefined;
-
     await skill.updateSkill(auth, {
       agentFacingDescription:
         agentFacingDescription ?? skill.agentFacingDescription,
@@ -490,7 +481,6 @@ const handlers: ToolHandlers<typeof SKILL_AUTHORING_TOOLS_METADATA> = {
       mcpServerViews: skill.mcpServerViews,
       name: trimmedName,
       requestedSpaceIds: skill.requestedSpaceIds,
-      referencedSkillIds,
       userFacingDescription:
         userFacingDescription ?? skill.userFacingDescription,
     });

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -675,7 +675,6 @@ describe("SkillResource", () => {
         name: "Parent Skill",
         instructions: `Use ${skillReferenceTag}.`,
         instructionsHtml: `<p>Use ${skillReferenceHtmlTag}.</p>`,
-        referencedSkillIds: [childSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -702,7 +701,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: parentSkill.requestedSpaceIds,
-        referencedSkillIds: [childSkill.sId],
       });
 
       const updatedParentSkill = await SkillResource.fetchById(
@@ -740,7 +738,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent Skill",
         instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
-        referencedSkillIds: [childSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -757,7 +754,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [restrictedSpace.id],
-        referencedSkillIds: [childSkill.sId],
       });
 
       const updatedParentSkill = await SkillResource.fetchById(
@@ -770,7 +766,7 @@ describe("SkillResource", () => {
       );
     });
 
-    it("preserves nested skill references when referencedSkillIds is omitted", async () => {
+    it("recomputes nested skill references from instructions on update", async () => {
       const { childSkill, parentSkill, skillReferenceTag } =
         await SkillFactory.createWithNestedSkill(testContext.authenticator, {
           childOverrides: { name: "Omitted References Child Skill" },
@@ -812,7 +808,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: updatedParentSkill!.requestedSpaceIds,
-        referencedSkillIds: [],
       });
 
       const clearedParentSkill = await SkillResource.fetchById(
@@ -833,7 +828,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent Skill",
         instructions: `Use ${SkillFactory.serializeSkillReferenceTag(childSkill)}.`,
-        referencedSkillIds: [childSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -850,7 +844,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [restrictedSpace.id],
-        referencedSkillIds: [],
       });
 
       const unavailableParentSkill = await SkillResource.fetchById(
@@ -872,7 +865,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: [],
-        referencedSkillIds: [],
       });
 
       const availableParentSkill = await SkillResource.fetchById(
@@ -906,7 +898,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: childSkill.requestedSpaceIds,
-        referencedSkillIds: [],
         status: "archived",
       });
 
@@ -928,7 +919,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: childSkill.requestedSpaceIds,
-        referencedSkillIds: [],
         status: "active",
       });
 
@@ -954,7 +944,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent With Missing Skill Reference",
         instructions: `Use ${missingSkillReferenceTag}.`,
-        referencedSkillIds: [missingSkillId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -979,7 +968,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent With Archived Skill Reference",
         instructions: `Use ${skillReferenceTag}.`,
-        referencedSkillIds: [archivedChildSkill.sId],
       });
 
       expect(parentSkill.instructions).toContain(
@@ -996,7 +984,6 @@ describe("SkillResource", () => {
       const parentSkill = await SkillFactory.create(testContext.authenticator, {
         name: "Parent With Global Skill Reference",
         instructions: `Use ${globalSkillReferenceTag}.`,
-        referencedSkillIds: ["frames"],
       });
 
       const childSkills = await parentSkill.fetchChildSkills(
@@ -1045,13 +1032,16 @@ describe("SkillResource", () => {
         name: parentSkill.name,
         agentFacingDescription: parentSkill.agentFacingDescription,
         userFacingDescription: parentSkill.userFacingDescription,
-        instructions: parentSkill.instructions,
+        instructions: `Use ${serializeSkillTag({
+          id: missingSkillId,
+          icon: null,
+          name: "Deleted Skill",
+        })}.`,
         instructionsHtml: parentSkill.instructionsHtml,
         icon: parentSkill.icon,
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: parentSkill.requestedSpaceIds,
-        referencedSkillIds: [missingSkillId],
       });
 
       await expect(
@@ -1219,7 +1209,6 @@ describe("SkillResource", () => {
         name: "Parent Skill",
         instructions: `Use ${skillReferenceTag}.`,
         instructionsHtml: `<p>Use ${skillReferenceHtmlTag}.</p>`,
-        referencedSkillIds: [childSkill.sId],
       });
 
       const { affectedCount: archiveCount } = await childSkill.archive(
@@ -1251,7 +1240,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: archivedParentSkill!.requestedSpaceIds,
-        referencedSkillIds: [childSkill.sId],
       });
 
       const updatedArchivedParentSkill = await SkillResource.fetchById(

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -820,6 +820,28 @@ describe("SkillResource", () => {
       ).resolves.toHaveLength(0);
     });
 
+    it("keeps nested skill self-references", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Self Referencing Skill",
+      });
+
+      await skill.updateSkill(testContext.authenticator, {
+        name: skill.name,
+        agentFacingDescription: skill.agentFacingDescription,
+        userFacingDescription: skill.userFacingDescription,
+        instructions: `Recurse with ${SkillFactory.serializeSkillReferenceTag(skill)}.`,
+        instructionsHtml: skill.instructionsHtml,
+        icon: skill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: skill.requestedSpaceIds,
+      });
+
+      await expect(
+        skill.fetchChildSkills(testContext.authenticator)
+      ).resolves.toEqual([expect.objectContaining({ sId: skill.sId })]);
+    });
+
     it("updates parent skill references when child requested spaces change", async () => {
       const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
       const childSkill = await SkillFactory.create(testContext.authenticator, {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2682,9 +2682,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
 
+    // Self-references are intentionally kept (#26680 allows them).
     const referencedSkillIds = extractUniqueSkillReferenceIds(
       this.instructions
-    ).filter((sId) => sId !== this.sId);
+    );
 
     // Retrieve what we want the end state to be.
     const referencedCustomSkillIds = uniq(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -382,13 +382,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       addCurrentUserAsEditor = true,
       attachedKnowledge = [],
       fileAttachments = [],
-      referencedSkillIds = [],
     }: {
       mcpServerViews: MCPServerViewResource[];
       addCurrentUserAsEditor?: boolean;
       attachedKnowledge?: SkillAttachedKnowledge[];
       fileAttachments?: FileResource[];
-      referencedSkillIds?: string[];
     }
   ): Promise<SkillResource> {
     const owner = auth.getNonNullableWorkspace();
@@ -454,11 +452,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
       await skillResource.normalizeSkillReferenceTags(auth, { transaction });
-      await skillResource.syncSkillReferences(
-        auth,
-        { referencedSkillIds },
-        { transaction }
-      );
+      await skillResource.syncSkillReferences(auth, { transaction });
 
       return skillResource;
     });
@@ -2441,7 +2435,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source,
       sourceMetadata,
       status,
-      referencedSkillIds,
       userFacingDescription,
     }: {
       agentFacingDescription: string;
@@ -2458,7 +2451,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
       status?: SkillStatus;
-      referencedSkillIds?: string[];
       userFacingDescription: string;
     }
   ): Promise<void> {
@@ -2510,13 +2502,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
 
       await this.normalizeSkillReferenceTags(auth, { transaction });
-      if (referencedSkillIds !== undefined) {
-        await this.syncSkillReferences(
-          auth,
-          { referencedSkillIds },
-          { transaction }
-        );
-      }
+      await this.syncSkillReferences(auth, { transaction });
 
       if (name !== previousName || requestedSpaceIdsChanged || statusChanged) {
         await this.propagateReferenceUpdatesToParentSkills(
@@ -2685,18 +2671,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * Persist the skills referenced by the skill form.
+   * Sync the denormalized skill_references rows with the inline skill reference
+   * tags found in the instructions (the source of truth). Deriving from the
+   * instructions keeps the table consistent on every write path, including
+   * restoring a previous version whose references differ from the current ones.
    */
   private async syncSkillReferences(
     auth: Authenticator,
-    {
-      referencedSkillIds,
-    }: {
-      referencedSkillIds: string[];
-    },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
+
+    const referencedSkillIds = extractUniqueSkillReferenceIds(
+      this.instructions
+    ).filter((sId) => sId !== this.sId);
 
     // Retrieve what we want the end state to be.
     const referencedCustomSkillIds = uniq(

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -23,7 +23,6 @@ type CreateSkillOverrides = Partial<{
   addCurrentUserAsEditor: boolean;
   attachedKnowledge: SkillAttachedKnowledge[];
   mcpServerViews: MCPServerViewResource[];
-  referencedSkillIds: string[];
 }>;
 
 export class SkillFactory {
@@ -71,7 +70,6 @@ export class SkillFactory {
         mcpServerViews,
         addCurrentUserAsEditor: overrides.addCurrentUserAsEditor,
         attachedKnowledge,
-        referencedSkillIds: overrides.referencedSkillIds ?? [],
       }
     );
   }
@@ -105,7 +103,6 @@ export class SkillFactory {
     const parentSkill = await this.create(auth, {
       ...parentOverrides,
       instructions: parentOverrides.instructions ?? `Use ${skillReferenceTag}.`,
-      referencedSkillIds: [childSkill.sId],
     });
 
     return { parentSkill, childSkill, skillReferenceTag };
@@ -141,7 +138,6 @@ export class SkillFactory {
       mcpServerViews: parentSkill.mcpServerViews,
       attachedKnowledge: await parentSkill.getAttachedKnowledge(auth),
       requestedSpaceIds: parentSkill.requestedSpaceIds,
-      referencedSkillIds: childSkills.map((childSkill) => childSkill.sId),
     });
 
     const updatedParentSkill = await SkillResource.fetchById(


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8617

Skill references are stored as inline tags in the skill instructions and denormalized in the `skill_references` table. The table was synced from a `referencedSkillIds` list provided by the caller (builder form, routes, skill_authoring tools). Restoring a previous version from the skill builder saves the restored instructions through the regular PATCH endpoint, but the form still sends the pre-restore ids: the denormalized references end up out of sync with the restored instructions.

Instead of trusting the caller, `syncSkillReferences` now derives the referenced skill ids from the instructions themselves (`extractUniqueSkillReferenceIds`, self-references excluded) and runs on every create/update. The `referencedSkillIds` parameter is removed from `makeNew`/`updateSkill`, the create/PATCH routes, and the skill_authoring update tool (which already derived it from instructions when they changed).

Handling of deleted, archived, out-of-workspace and global references is unchanged: ids are preserved by tag normalization (`unavailable_skill` tags keep their id), so archived/unavailable references keep their rows, while ids whose skill row doesn't exist in the workspace are dropped, as before.

The builder client still sends `referencedSkillIds`; the field is now stripped by the request schemas (non-strict zod objects), which keeps old clients working during deploy. Removing it from the client form can be a follow-up.

## Risks

Blast radius: skill create/update/version-restore reference sync (builder, internal API, skill_authoring tools, skill imports)
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Tests
- local tests
- [x] Resource tests: references derived/recomputed from instructions on create and update (missing, archived, global, out-of-workspace, restored-version cases)
- [x] Route tests: PATCH with stale `referencedSkillIds` in the body (version-restore scenario) clears references not present in the saved instructions
- [x] skill_authoring tool tests
