### PR TITLE
[front] Fix activity-chart window to be timezone-aware and N-day

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/usage-metrics.ts
@@ -4,7 +4,10 @@ import type {
   UsageMetricsInterval,
 } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  daysToInstantRange,
+} from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -36,9 +39,11 @@ app.get("/", validate("query", QuerySchema), async (ctx) => {
 
   const { days, interval, timezone } = ctx.req.valid("query");
 
+  const { startDate, endDate } = daysToInstantRange(days, timezone);
   const baseQuery = buildAgentAnalyticsBaseQuery({
     workspaceId: owner.sId,
-    days,
+    startDate,
+    endDate,
   });
 
   const usageMetricsResult = await fetchMessageMetrics(

--- a/front-api/routes/w/[wId]/analytics/usage-metrics.ts
+++ b/front-api/routes/w/[wId]/analytics/usage-metrics.ts
@@ -1,7 +1,10 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  daysToInstantRange,
+} from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureHasPermission } from "@front-api/middlewares/ensure_role";
@@ -30,9 +33,11 @@ app.get(
     const { days, interval, timezone } = ctx.req.valid("query");
     const owner = auth.getNonNullableWorkspace();
 
+    const { startDate, endDate } = daysToInstantRange(days, timezone);
     const baseQuery = buildAgentAnalyticsBaseQuery({
       workspaceId: owner.sId,
-      days,
+      startDate,
+      endDate,
     });
 
     const usageMetricsResult = await fetchMessageMetrics(

--- a/front/lib/api/assistant/observability/utils.test.ts
+++ b/front/lib/api/assistant/observability/utils.test.ts
@@ -1,4 +1,8 @@
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import {
+  buildAgentAnalyticsBaseQuery,
+  daysToInstantRange,
+} from "@app/lib/api/assistant/observability/utils";
+import moment from "moment-timezone";
 import { describe, expect, it } from "vitest";
 
 describe("buildAgentAnalyticsBaseQuery", () => {
@@ -60,5 +64,25 @@ describe("buildAgentAnalyticsBaseQuery", () => {
       agentId: "a1",
       agentIds: ["a2"],
     });
+  });
+});
+
+describe("daysToInstantRange", () => {
+  it("spans N calendar days ending now, anchored at start-of-day in the tz", () => {
+    const timezone = "America/New_York";
+    const { startDate, endDate } = daysToInstantRange(30, timezone);
+
+    const start = moment.tz(startDate, timezone);
+    const end = moment.tz(endDate, timezone);
+
+    expect(start.format("HH:mm:ss.SSS")).toBe("00:00:00.000");
+    expect(end.startOf("day").diff(start, "days")).toBe(29);
+  });
+
+  it("includes the whole current day (end is now, not start-of-day)", () => {
+    const { endDate } = daysToInstantRange(7, "UTC");
+    expect(moment.utc(endDate).diff(moment.utc(), "minutes")).toBeGreaterThan(
+      -2
+    );
   });
 });

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -14,6 +14,24 @@ export function daysToDateRange(
   return { startDate: start, endDate: end };
 }
 
+// Tz-aware [start-of-day (days-1 ago), now] window as ISO instants. Mirrors the
+// window the workspace_analytics tools resolve for a relative "last N days"
+// period, so the dashboard and the analyst agent query the exact same range.
+export function daysToInstantRange(
+  days: number,
+  timezone: string = "UTC"
+): { startDate: string; endDate: string } {
+  const now = moment.tz(timezone);
+  return {
+    startDate: now
+      .clone()
+      .subtract(days - 1, "days")
+      .startOf("day")
+      .toISOString(),
+    endDate: now.toISOString(),
+  };
+}
+
 function termFilter(
   field: string,
   value: string | string[] | undefined


### PR DESCRIPTION
## Description

The usage-metrics endpoints fed raw days into buildAgentAnalyticsBaseQuery's now-Nd/d branch, which rounds the window edge in UTC while the date_histogram buckets in the requested timezone, and spans N+1 calendar days. This diverged from the active-users sibling endpoint and the analyst tools, both of which use a tz-aware, N-calendar-day window.

Add daysToInstantRange(days, timezone) returning [startOf(now-(N-1)) in tz, now] and use it in both usage-metrics endpoints (regular + poke), leaving the shared now-Nd/d branch untouched for its other consumers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
