### PR TITLE
run_dust_app: migrate document outputs to DustFileSystem

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -9,59 +9,12 @@ import logger from "@app/logger/logger";
 import type { CoreAPIDataSourceDocumentSection } from "@app/types/core/data_source";
 
 /**
- * Generate a plain text file.
- * Save the file to the database and return it.
- */
-export async function generatePlainTextFile(
-  auth: Authenticator,
-  {
-    title,
-    conversationId,
-    content,
-    snippet,
-    hideFromUser,
-    skipDataSourceIndexing,
-  }: {
-    title: string;
-    conversationId: string;
-    content: string;
-    snippet?: string;
-    hideFromUser?: boolean;
-    skipDataSourceIndexing?: boolean;
-  }
-): Promise<FileResource> {
-  const workspace = auth.getNonNullableWorkspace();
-  const user = auth.user();
-
-  const plainTextFile = await FileResource.makeNew({
-    workspaceId: workspace.id,
-    userId: user?.id ?? null,
-    contentType: "text/plain",
-    fileName: title,
-    fileSize: Buffer.byteLength(content),
-    useCase: "tool_output",
-    useCaseMetadata: {
-      conversationId,
-      ...(hideFromUser ? { hideFromUser: true } : {}),
-      ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
-    },
-    snippet,
-  });
-
-  await processAndStoreFile(auth, {
-    file: plainTextFile,
-    content: {
-      type: "string",
-      value: content,
-    },
-  });
-
-  return plainTextFile;
-}
-
-/**
  * Generate a CSV file and a snippet of the file.
  * Save the file to the database and return the file and the snippet.
+ *
+ * TODO(FILE_SYSTEM/COMPUTER): migrate to DustFileSystem once query_tables is ported to the computer world.
+ * Kept on FileResource because tabular results are indexed into the conversation SQLite data
+ * source so query_tables can re-query them.
  */
 export async function generateCSVFileAndSnippet(
   auth: Authenticator,

--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -85,6 +85,9 @@ export async function generateCSVFileAndSnippet(
  * Generate a json file representing a table as a section.
  * This type of file is used to store the results of a tool call coming up from a csv in a way that can be searched.
  * Save it to the database and return it.
+ *
+ * TODO(FILE_SYSTEM/COMPUTER): remove once semantic search for tool outputs is killed.
+ * The section file only exists to feed the indexing pipeline for text search within query results.
  */
 export async function generateSectionFile(
   auth: Authenticator,

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -1,7 +1,5 @@
 import {
   generateCSVFileAndSnippet,
-  generateJSONFileAndSnippet,
-  generatePlainTextFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
 import { DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY } from "@app/lib/actions/constants";
@@ -9,15 +7,19 @@ import type {
   LightServerSideMCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type {
+  ToolGeneratedFilePathType,
+  ToolGeneratedFileType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { getDatasetSchema } from "@app/lib/api/datasets";
+import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import type { Authenticator } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AppResource } from "@app/lib/resources/app_resource";
-import type { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { BlockRunConfig, SpecificationBlockType } from "@app/types/app";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -156,8 +158,16 @@ export async function processDustFileOutput(
   sanitizedOutput: DustFileOutput,
   conversation: ConversationWithoutContentType,
   appName: string
-): Promise<{ type: "resource"; resource: ToolGeneratedFileType }[]> {
-  const content: { type: "resource"; resource: ToolGeneratedFileType }[] = [];
+): Promise<
+  {
+    type: "resource";
+    resource: ToolGeneratedFileType | ToolGeneratedFilePathType;
+  }[]
+> {
+  const content: {
+    type: "resource";
+    resource: ToolGeneratedFileType | ToolGeneratedFilePathType;
+  }[] = [];
 
   const containsValidStructuredOutput = (
     output: DustFileOutput
@@ -204,10 +214,7 @@ export async function processDustFileOutput(
       results: sanitizedOutput.__dust_file?.content ?? [],
     });
 
-    await uploadFileToConversationDataSource({
-      auth,
-      file: csvFile,
-    });
+    await uploadFileToConversationDataSource({ auth, file: csvFile });
 
     content.push({
       type: "resource",
@@ -224,50 +231,41 @@ export async function processDustFileOutput(
 
     delete sanitizedOutput.__dust_file;
   } else if (containsValidDocumentOutput(sanitizedOutput)) {
-    let fileTitle = "";
-    let file: FileResource;
+    const rawContent = sanitizedOutput.__dust_file?.content ?? "";
+    const jsonOutputRes = safeParseJSON(rawContent);
 
-    const jsonOutputRes = safeParseJSON(
-      sanitizedOutput.__dust_file?.content ?? ""
-    );
+    let fileName: string;
+    let fileContent: string;
+    let contentType: "application/json" | "text/plain";
+
     if (jsonOutputRes.isOk()) {
-      // If the output is a valid json object, generate a json file.
-      fileTitle = getDustAppRunResultsFileTitle({
-        appName,
-        resultsFileContentType: "application/json",
-      });
-      const { jsonFile } = await generateJSONFileAndSnippet(auth, {
-        title: fileTitle,
-        conversationId: conversation.sId,
-        data: jsonOutputRes.value,
-      });
-      file = jsonFile;
+      fileContent = JSON.stringify(jsonOutputRes.value, null, 2);
+      contentType = "application/json";
+      fileName = makeFileName({ name: appName, ext: ".json" });
     } else {
-      // If the output is not a valid json object, generate a text file.
-      fileTitle = getDustAppRunResultsFileTitle({
-        appName,
-        resultsFileContentType: "text/plain",
-      });
-
-      file = await generatePlainTextFile(auth, {
-        title: fileTitle,
-        conversationId: conversation.sId,
-        content: sanitizedOutput.__dust_file?.content ?? "",
-      });
+      fileContent = rawContent;
+      contentType = "text/plain";
+      fileName = makeFileName({ name: appName, ext: ".txt" });
     }
 
-    content.push({
-      type: "resource",
-      resource: {
-        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-        uri: `file://${file.id}`,
-        fileId: file.sId,
-        title: fileTitle,
-        contentType: file.contentType,
-        snippet: file.snippet,
-        text: `Generated text file: ${fileTitle}`,
-      },
+    const result = await writeToToolOutputsFolder(auth, conversation, {
+      fileName,
+      content: fileContent,
+      contentType,
     });
+    if (result.isOk()) {
+      content.push({
+        type: "resource",
+        resource: {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+          uri: result.value,
+          path: result.value,
+          title: fileName,
+          contentType,
+          text: `Generated file: ${fileName}`,
+        },
+      });
+    }
 
     delete sanitizedOutput.__dust_file;
   }

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -162,7 +162,10 @@ export async function processDustFileOutput(
   appName: string
 ): Promise<
   Result<
-    { type: "resource"; resource: ToolGeneratedFileType | ToolGeneratedFilePathType }[],
+    {
+      type: "resource";
+      resource: ToolGeneratedFileType | ToolGeneratedFilePathType;
+    }[],
     Error
   >
 > {

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -253,19 +253,21 @@ export async function processDustFileOutput(
       content: fileContent,
       contentType,
     });
-    if (result.isOk()) {
-      content.push({
-        type: "resource",
-        resource: {
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
-          uri: result.value,
-          path: result.value,
-          title: fileName,
-          contentType,
-          text: `Generated file: ${fileName}`,
-        },
-      });
+    if (result.isErr()) {
+      throw result.error;
     }
+
+    content.push({
+      type: "resource",
+      resource: {
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+        uri: result.value,
+        path: result.value,
+        title: fileName,
+        contentType,
+        text: `Generated file: ${fileName}`,
+      },
+    });
 
     delete sanitizedOutput.__dust_file;
   }

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -26,6 +26,8 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import type { DatasetSchema } from "@app/types/dataset";
 import type { SupportedFileContentType } from "@app/types/files";
 import { extensionsForContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { ZodRawShape } from "zod";
@@ -159,10 +161,10 @@ export async function processDustFileOutput(
   conversation: ConversationWithoutContentType,
   appName: string
 ): Promise<
-  {
-    type: "resource";
-    resource: ToolGeneratedFileType | ToolGeneratedFilePathType;
-  }[]
+  Result<
+    { type: "resource"; resource: ToolGeneratedFileType | ToolGeneratedFilePathType }[],
+    Error
+  >
 > {
   const content: {
     type: "resource";
@@ -254,7 +256,7 @@ export async function processDustFileOutput(
       contentType,
     });
     if (result.isErr()) {
-      throw result.error;
+      return result;
     }
 
     content.push({
@@ -272,7 +274,7 @@ export async function processDustFileOutput(
     delete sanitizedOutput.__dust_file;
   }
 
-  return content;
+  return new Ok(content);
 }
 
 export async function prepareParamsWithHistory(

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -205,13 +205,16 @@ export default async function createServer(
           containsFileOutput(sanitizedOutput) &&
           agentLoopContext.runContext?.conversation
         ) {
-          const fileContent = await processDustFileOutput(
+          const fileContentResult = await processDustFileOutput(
             auth,
             sanitizedOutput,
             agentLoopContext.runContext.conversation,
             app.name
           );
-          content.push(...fileContent);
+          if (fileContentResult.isErr()) {
+            return new Err(new MCPError(fileContentResult.error.message));
+          }
+          content.push(...fileContentResult.value);
         }
 
         content.push({

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -1,6 +1,9 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type {
+  ToolGeneratedFilePathType,
+  ToolGeneratedFileType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -126,7 +129,10 @@ export default async function createServer(
       handler: async (params) => {
         const content: (
           | TextContent
-          | { type: "resource"; resource: ToolGeneratedFileType }
+          | {
+              type: "resource";
+              resource: ToolGeneratedFileType | ToolGeneratedFilePathType;
+            }
         )[] = [];
 
         const preparedParams = await prepareParamsWithHistory(

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -9,7 +9,7 @@ import {
 } from "@app/lib/api/files/action_output_fs/registry";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { slugify } from "@app/types/shared/utils/string_utils";
@@ -27,7 +27,7 @@ export interface PersistedToolOutput {
  */
 export async function writeToToolOutputsFolder(
   auth: Authenticator,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   {
     fileName,
     content,
@@ -64,7 +64,7 @@ export async function writeToToolOutputsFolder(
  */
 export async function persistToolOutput(
   auth: Authenticator,
-  conversation: ConversationType,
+  conversation: ConversationWithoutContentType,
   block: CallToolResult["content"][number],
   { toolName, serverName }: { toolName: string; serverName: string }
 ): Promise<Result<PersistedToolOutput | null, Error>> {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
`processDustFileOutput` was creating a `FileResource` DB record for every file output from a Dust app run, regardless of whether that file needed to be indexed. This migrates the document cases (JSON and plain text) to write directly via `DustFileSystem`.

The CSV/structured output case is intentionally kept on `FileResource`: those files are indexed into the conversation SQLite data source so `query_tables` can re-query them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
