### PR TITLE
Inverse priorities between user_cap_reached and pool_exhausted errors

### DIFF
--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -87,13 +87,13 @@ describe("isUserBlocked", () => {
     expect(mockGetActiveMembershipOfUserInWorkspace).not.toHaveBeenCalled();
   });
 
-  it("returns 'credits_exhausted' when the pool is depleted, even if user is also capped", async () => {
+  it("returns 'user_cap_reached' when the user is capped, even if the pool is also depleted", async () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
     const blocked = await isUserBlocked("ws_test", "u_test");
 
-    expect(blocked).toBe("credits_exhausted");
+    expect(blocked).toBe("user_cap_reached");
   });
 
   it("returns null when user is on_pool and pool is active", async () => {

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -14,7 +14,9 @@
 // `isUserBlocked` is the unified read: a user is blocked iff the pool is
 // depleted or the user's credit state is "capped". It returns the reason
 // ("credits_exhausted" / "user_cap_reached") so callers can surface a tailored
-// message. The DB columns remain the source of truth; cache writes are gated on
+// message. When both conditions hold, "user_cap_reached" wins: the per-user cap
+// is the user's actionable blocker, whereas refilling the pool would not unblock
+// them. The DB columns remain the source of truth; cache writes are gated on
 // DB transaction commit via `invalidateCacheAfterCommit`, and cache misses fall
 // back to DB and repopulate the relevant keys.
 //
@@ -199,11 +201,15 @@ function deriveBlockedReason({
   userCapBlocked: boolean;
   workspacePoolDepleted: boolean;
 }): UserBlockedReason | null {
-  if (workspacePoolDepleted) {
-    return "credits_exhausted";
-  }
+  // The per-user cap takes precedence over pool depletion: when a user has hit
+  // their own cap, that is their actionable blocker. Refilling the workspace
+  // pool would not unblock them, so surfacing "workspace out of credits" would
+  // be misleading. The pool reason is only relevant when the user is not capped.
   if (userCapBlocked) {
     return "user_cap_reached";
+  }
+  if (workspacePoolDepleted) {
+    return "credits_exhausted";
   }
   return null;
 }


### PR DESCRIPTION
## Description

If we have both user_cap_reached and pool_depleted, show in priority the user_cap_reached error  : 
When both conditions hold, "user_cap_reached" wins: the per-user cap is the user's actionable blocker, whereas refilling the pool would not unblock


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
