### PR TITLE
Make Usage page available readonly

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -59,11 +59,13 @@ export function InviteEmailButtonWithModal({
   prefillText,
   perSeatPricing,
   onInviteClick,
+  disabled = false,
 }: {
   owner: WorkspaceType;
   prefillText: string;
   perSeatPricing: SubscriptionPerSeatPricing | null;
   onInviteClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
 }) {
   const [inviteEmails, setInviteEmails] = useState<string>("");
   const { inviteEmailsList, emailError } =
@@ -202,6 +204,7 @@ export function InviteEmailButtonWithModal({
           label="Invite members"
           variant="primary"
           onClick={onInviteClick}
+          disabled={disabled}
         />
       </SheetTrigger>
       <SheetContent size="lg">

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -54,19 +54,21 @@ const useGetEmailsListAndError = (
   }, [inviteEmails]);
 };
 
+interface InviteEmailButtonWithModalProps {
+  owner: WorkspaceType;
+  prefillText: string;
+  perSeatPricing: SubscriptionPerSeatPricing | null;
+  onInviteClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+}
+
 export function InviteEmailButtonWithModal({
   owner,
   prefillText,
   perSeatPricing,
   onInviteClick,
   disabled = false,
-}: {
-  owner: WorkspaceType;
-  prefillText: string;
-  perSeatPricing: SubscriptionPerSeatPricing | null;
-  onInviteClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  disabled?: boolean;
-}) {
+}: InviteEmailButtonWithModalProps) {
   const [inviteEmails, setInviteEmails] = useState<string>("");
   const { inviteEmailsList, emailError } =
     useGetEmailsListAndError(inviteEmails);

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -233,7 +233,7 @@ export const getTopNavigationTabs = (
 export const subNavigationAdmin = ({
   owner,
   currentRoute,
-  featureFlags: _featureFlags,
+  featureFlags,
   subscription,
 }: {
   owner: WorkspaceType;
@@ -285,7 +285,8 @@ export const subNavigationAdmin = ({
         current: isCurrent("workspace"),
         disabled: !hasWorkspaceAdminPermission,
       },
-      ...(isCreditPricedPlan(subscription.plan)
+      ...(isCreditPricedPlan(subscription.plan) ||
+      featureFlags.includes("usage_page_read_only")
         ? [
             {
               id: "usage" as const,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -11,7 +11,11 @@ import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNot
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { isEnterprisePlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
@@ -26,6 +30,7 @@ import {
   useUpdateMemberSeatType,
 } from "@app/lib/swr/memberships";
 import {
+  useAwuUsage,
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
@@ -48,7 +53,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -56,7 +61,13 @@ export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
   const router = useAppRouter();
+  const { hasFeature } = useFeatureFlags();
   const isCreditPriced = isCreditPricedPlan(subscription.plan);
+  // Legacy-contract workspaces can view this page in read-only mode behind a
+  // flag: analytics and member spend render as usual, but every action (top up,
+  // invite, seat changes, spend limits, settings) is disabled.
+  const isReadOnly = !isCreditPriced && hasFeature("usage_page_read_only");
+  const canViewUsage = isCreditPriced || isReadOnly;
   const [searchTerm, setSearchTerm] = useState("");
   const [seatTypeFilter, setSeatTypeFilter] = useState<
     MembershipSeatType | "none" | null
@@ -144,10 +155,10 @@ export function UsagePage() {
   const [inviteBlockedPopupReason, setInviteBlockedPopupReason] =
     useState<WorkspaceLimit | null>(null);
   useEffect(() => {
-    if (!isCreditPriced) {
+    if (!canViewUsage) {
       void router.push(`/w/${owner.sId}/members`);
     }
-  }, [isCreditPriced, router, owner.sId]);
+  }, [canViewUsage, router, owner.sId]);
 
   const {
     totalRemainingCredits,
@@ -169,6 +180,27 @@ export function UsagePage() {
     useCreditPurchaseInfo({
       workspaceId: owner.sId,
     });
+
+  // Legacy contracts have no pool credits or commits, so the pool summary's
+  // overage figure is meaningless. In read-only mode we instead show the
+  // period's raw consumption from the AWU usage analytics endpoint (the same
+  // data the chart below renders), summing its ungrouped "total" series for the
+  // current billing cycle.
+  const { awuUsageData } = useAwuUsage({
+    workspaceId: owner.sId,
+    billingCycleStartDay: billingCycleStartDay ?? 1,
+    windowSize: "DAY",
+    disabled: !isReadOnly,
+  });
+  const periodSpendCredits = useMemo(
+    () =>
+      (awuUsageData?.points ?? []).reduce(
+        (sum, point) =>
+          sum + point.groups.reduce((s, group) => s + group.valueCredits, 0),
+        0
+      ),
+    [awuUsageData]
+  );
 
   const { membersUsage, isMembersUsageLoading, totalMembersUsage } =
     useMembersUsage({
@@ -221,7 +253,7 @@ export function UsagePage() {
   );
   const initialTotalCredits = totalActiveCredits;
 
-  if (!isCreditPriced) {
+  if (!canViewUsage) {
     return null;
   }
 
@@ -279,23 +311,32 @@ export function UsagePage() {
                 </span>
               </div>
               <div className="flex items-center gap-2">
-                {overageCredits !== null && overageCredits > 0 && (
+                {isReadOnly ? (
                   <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                    {formatCredits(overageCredits)} overage credits
-                  </span>
-                )}
-                {isEnterprise ? (
-                  <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Contact your Dust sales representative to buy credits
+                    {formatCredits(periodSpendCredits)} credits spent this
+                    period
                   </span>
                 ) : (
-                  <Button
-                    label="Top up"
-                    icon={ArrowUp}
-                    size="xs"
-                    variant="ghost"
-                    onClick={() => setShowBuyCreditDialog(true)}
-                  />
+                  <>
+                    {overageCredits !== null && overageCredits > 0 && (
+                      <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                        {formatCredits(overageCredits)} overage credits
+                      </span>
+                    )}
+                    {isEnterprise ? (
+                      <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                        Contact your Dust sales representative to buy credits
+                      </span>
+                    ) : (
+                      <Button
+                        label="Top up"
+                        icon={ArrowUp}
+                        size="xs"
+                        variant="ghost"
+                        onClick={() => setShowBuyCreditDialog(true)}
+                      />
+                    )}
+                  </>
                 )}
               </div>
             </>
@@ -311,11 +352,14 @@ export function UsagePage() {
           />
         )}
 
-        <UsageSettingsCard workspaceId={owner.sId} />
+        <UsageSettingsCard workspaceId={owner.sId} readOnly={isReadOnly} />
 
-        <UsageProgrammaticLimitCard workspaceId={owner.sId} />
+        <UsageProgrammaticLimitCard
+          workspaceId={owner.sId}
+          readOnly={isReadOnly}
+        />
 
-        <UsageNotificationsCard workspaceId={owner.sId} />
+        <UsageNotificationsCard workspaceId={owner.sId} readOnly={isReadOnly} />
 
         <Page.Vertical gap="sm" align="stretch">
           <span className="heading-2xl text-foreground dark:text-foreground-night">
@@ -335,6 +379,7 @@ export function UsagePage() {
                 prefillText=""
                 perSeatPricing={perSeatPricing}
                 onInviteClick={onInviteClick}
+                disabled={isReadOnly}
               />
             )}
           </div>
@@ -384,6 +429,7 @@ export function UsagePage() {
           <MembersUsageTable
             members={membersUsage}
             isLoading={isMembersUsageLoading}
+            readOnly={isReadOnly}
             totalAllowedUsagePendingMemberIds={
               totalAllowedUsagePendingMemberIds
             }

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -431,6 +431,7 @@ interface MembersUsageTableProps {
   seatChangePendingMemberIds: ReadonlySet<string>;
   seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
+  readOnly: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
   onEditSpendLimit: (member: MemberUsageType) => void;
@@ -448,6 +449,7 @@ export function MembersUsageTable({
   seatChangePendingMemberIds,
   seatTypeFilter,
   isSeatBased,
+  readOnly,
   onChangeSeat,
   onRemoveSeat,
   onEditSpendLimit,
@@ -502,6 +504,7 @@ export function MembersUsageTable({
                 {
                   kind: "item" as const,
                   label: m.seatType ? "Change seat type" : "Assign seat",
+                  disabled: readOnly,
                   onClick: () => onChangeSeat(m),
                 },
               ]
@@ -509,6 +512,7 @@ export function MembersUsageTable({
           {
             kind: "item" as const,
             label: "Edit spend limit",
+            disabled: readOnly,
             onClick: () => onEditSpendLimit(m),
           },
           // Only members who currently hold a billable seat can have it removed.
@@ -518,6 +522,7 @@ export function MembersUsageTable({
                   kind: "item" as const,
                   label: "Remove seat",
                   variant: "warning" as const,
+                  disabled: readOnly,
                   onClick: () => onRemoveSeat(m),
                 },
               ]
@@ -529,6 +534,7 @@ export function MembersUsageTable({
       totalAllowedUsagePendingMemberIds,
       seatChangePendingMemberIds,
       isSeatBased,
+      readOnly,
       onChangeSeat,
       onRemoveSeat,
       onEditSpendLimit,

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -7,10 +7,12 @@ import { useEffect, useState } from "react";
 
 interface UsageNotificationsCardProps {
   workspaceId: string;
+  readOnly: boolean;
 }
 
 export function UsageNotificationsCard({
   workspaceId,
+  readOnly,
 }: UsageNotificationsCardProps) {
   const { usageNotifications, isUsageNotificationsLoading } =
     useUsageNotifications({ workspaceId });
@@ -95,7 +97,9 @@ export function UsageNotificationsCard({
                 }
                 onBlur={() => void handleCommitBalanceThreshold()}
                 disabled={
-                  isSavingBalanceThreshold || isUsageNotificationsLoading
+                  readOnly ||
+                  isSavingBalanceThreshold ||
+                  isUsageNotificationsLoading
                 }
                 className="pr-16 text-right"
               />
@@ -112,7 +116,9 @@ export function UsageNotificationsCard({
             <SliderToggle
               selected={usageNotifications.upgradeRequestEmail}
               disabled={
-                isSavingUpgradeRequestEmail || isUsageNotificationsLoading
+                readOnly ||
+                isSavingUpgradeRequestEmail ||
+                isUsageNotificationsLoading
               }
               onClick={() => void handleToggleUpgradeRequestEmail()}
             />

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -7,10 +7,12 @@ import { useEffect, useState } from "react";
 
 interface UsageProgrammaticLimitCardProps {
   workspaceId: string;
+  readOnly: boolean;
 }
 
 export function UsageProgrammaticLimitCard({
   workspaceId,
+  readOnly,
 }: UsageProgrammaticLimitCardProps) {
   const { programmaticUsageLimit, isProgrammaticUsageLimitLoading } =
     useProgrammaticUsageLimit({ workspaceId });
@@ -67,7 +69,8 @@ export function UsageProgrammaticLimitCard({
     }
   };
 
-  const isInputDisabled = isSaving || isProgrammaticUsageLimitLoading;
+  const isInputDisabled =
+    readOnly || isSaving || isProgrammaticUsageLimitLoading;
 
   return (
     <Page.Vertical gap="sm" align="stretch">

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -19,9 +19,13 @@ import { useEffect, useState } from "react";
 
 interface UsageSettingsCardProps {
   workspaceId: string;
+  readOnly: boolean;
 }
 
-export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
+export function UsageSettingsCard({
+  workspaceId,
+  readOnly,
+}: UsageSettingsCardProps) {
   const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
     useDefaultUserSpendLimit({ workspaceId });
   const { doUpdateDefaultUserSpendLimit } = useUpdateDefaultUserSpendLimit({
@@ -82,7 +86,7 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
   };
 
   const isDefaultLimitInputDisabled =
-    isSavingLimit || isDefaultUserSpendLimitLoading;
+    readOnly || isSavingLimit || isDefaultUserSpendLimitLoading;
 
   return (
     <Page.Vertical gap="sm" align="stretch">
@@ -125,7 +129,11 @@ export function UsageSettingsCard({ workspaceId }: UsageSettingsCardProps) {
           action={
             <SliderToggle
               selected={usageSettings.allowUpgradeRequest}
-              disabled={isSavingAllowUpgradeRequest || isUsageSettingsLoading}
+              disabled={
+                readOnly ||
+                isSavingAllowUpgradeRequest ||
+                isUsageSettingsLoading
+              }
               onClick={() => void handleToggleAllowUpgradeRequest()}
             />
           }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -138,6 +138,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Admin-only workspace usage analytics: the workspace_analytics MCP server, its skill, and the Workspace Analyst agent.",
     stage: "on_demand",
   },
+  usage_page_read_only: {
+    description:
+      "Allow legacy-contract workspaces to view the Usage page in read-only mode (analytics and member spend visible; all actions disabled).",
+    stage: "on_demand",
+  },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -760,6 +760,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "skills_as_user_messages"
   | "run_tools_from_prompt"
   | "usage_data_api"
+  | "usage_page_read_only"
   | "workspace_analytics"
   | "xai_feature"
   | "conversations_slack_notifications"


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/8761

## Description

Adds a `usage_page_read_only` feature flag that lets **legacy-contract workspaces** view the **Usage** page in read-only mode. Today the page (and its nav entry) is gated on `isCreditPricedPlan` and redirects everyone else to `/members`. Some customers on legacy contracts want to see their usage without being migrated.

When the flag is on for a non-credit-priced workspace:
- The page renders instead of redirecting, and the **Usage** item appears in the admin nav.
- **Analytics** (AWU usage chart) and **per-member spend** render as-is — legacy workspaces have a shadow Metronome contract that defines billing periods, so this data loads.
- The credit **pool bar** shows only the current period's spend with a "credits used this period" label (no pool total — legacy contracts have no prepaid pool).
- **All actions are disabled**: Top up (hidden), Invite, Change/Assign seat, Remove seat, Edit spend limit, and the default spend-limit / programmatic-limit / notification settings.

### Changes

- **`feature_flags.ts`** — new `usage_page_read_only` flag (`on_demand`).
- **`navigation/config.ts`** — show the Usage nav item when credit-priced **or** flag is on (wires up the previously-unused `featureFlags` param).
- **`UsagePage.tsx`** — `isReadOnly`/`canViewUsage` gating; spend-only pool bar; Top-up row hidden; threads `readOnly` to children.
- **`InviteEmailButtonWithModal.tsx`** — optional `disabled` prop (defaults `false`, other call sites unaffected).
- **`MembersUsageTable.tsx`** — `readOnly` disables row menu actions.
- **`UsageSettingsCard` / `UsageProgrammaticLimitCard` / `UsageNotificationsCard`** — `readOnly` disables their inputs/toggles.

## Tests

Manual. Type-checks clean (`tsgo`). With the flag enabled on a legacy-contract workspace, the page loads read-only: chart + member spend visible, all action controls disabled, pool bar shows period spend only. Without the flag, behavior is unchanged (non-credit-priced workspaces still redirect to `/members`).

## Risk

Low. New functionality is fully gated behind an `on_demand` flag that defaults off, so credit-priced and unflagged legacy workspaces are unaffected. The only shared component touched outside the Usage page is `InviteEmailButtonWithModal`, where the new `disabled` prop defaults to `false`. Safe to roll back.

One thing to validate in staging: the read-only spend headline is `consumedFromPool + overage`. For a legacy shadow contract with no prepaid pool, Metronome reports consumption as `cpu_conversion` overage, so this resolves to the period spend — worth confirming against a real shadow contract.

## Deploy Plan

Standard deploy. After deploy, enable `usage_page_read_only` on the targeted legacy-contract workspaces on demand.
