### PR TITLE
extract_data: migrate file output to DustFileSystem

### DIFF
--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -4,7 +4,9 @@ import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { getFilePathDownloadUrl } from "@app/lib/swr/files";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Citation,
   CitationIcons,
@@ -26,6 +28,7 @@ interface MCPExtractActionQueryProps {
 }
 
 interface MCPExtractActionResultsProps {
+  owner: LightWorkspaceType;
   resultResource?: {
     text: string;
     uri: string;
@@ -42,6 +45,7 @@ export function MCPExtractActionDetails({
   toolParams,
   toolOutput,
   displayContext,
+  owner,
 }: ToolExecutionDetailsProps) {
   const queryResource = toolOutput
     ?.filter(isExtractQueryResourceType)
@@ -93,7 +97,10 @@ export function MCPExtractActionDetails({
             <span className="font-medium text-foreground dark:text-foreground-night">
               Results
             </span>
-            <MCPExtractActionResults resultResource={resultResource} />
+            <MCPExtractActionResults
+              owner={owner}
+              resultResource={resultResource}
+            />
           </div>
         )}
       </div>
@@ -132,6 +139,7 @@ function MCPExtractActionQuery({
 }
 
 function MCPExtractActionResults({
+  owner,
   resultResource,
 }: MCPExtractActionResultsProps) {
   const [isDownloading, setIsDownloading] = useState(false);
@@ -144,12 +152,18 @@ function MCPExtractActionResults({
     );
   }
 
+  const downloadUrl = resultResource.path
+    ? getFilePathDownloadUrl(owner, resultResource.path)
+    : resultResource.uri || null;
+
   const handleDownload = async () => {
+    if (!downloadUrl) {
+      return;
+    }
+
     setIsDownloading(true);
     try {
-      window.open(resultResource.uri, "_blank");
-    } catch (error) {
-      console.error("Download failed:", error);
+      window.open(downloadUrl, "_blank");
     } finally {
       setIsDownloading(false);
     }
@@ -161,7 +175,7 @@ function MCPExtractActionResults({
         <Citation
           className="w-48 min-w-48 max-w-48"
           containerClassName="my-2"
-          onClick={handleDownload}
+          onClick={downloadUrl ? handleDownload : undefined}
           tooltip={resultResource.title}
           isLoading={isDownloading}
         >

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -30,7 +30,8 @@ interface MCPExtractActionResultsProps {
     text: string;
     uri: string;
     mimeType: string;
-    fileId: string;
+    path?: string;
+    fileId?: string;
     title: string;
     contentType: string;
     snippet: string | null;

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -645,7 +645,8 @@ export const ExtractResultResourceSchema = z.object({
   text: z.string(),
 
   // File metadata
-  fileId: z.string(),
+  path: z.string().optional(), // scoped DustFileSystem path (new records)
+  fileId: z.string().optional(), // legacy FileResource sId (old records)
   title: z.string(),
   contentType: z.string(),
   snippet: z.string().nullable(),

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -1,12 +1,13 @@
-import { generateJSONFileAndSnippet } from "@app/lib/actions/action_file_helpers";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
+import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { getFilePathDownloadUrl } from "@app/lib/swr/files";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationType,
@@ -26,21 +27,6 @@ export type ProcessActionOutputsType = {
   data: unknown[];
   total_documents?: number;
 };
-
-/**
- * Generates a title for an extract results JSON file based on the schema
- */
-export function getExtractFileTitle({
-  schema,
-}: {
-  schema: JSONSchema | null;
-}): string {
-  const schemaNames = Object.keys(schema?.properties ?? {}).join("_");
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const title = schema?.title || schemaNames || "extract_results";
-  // Make sure title is truncated to 100 characters
-  return `${title.substring(0, 100)}.json`;
-}
 
 export async function getCoreDataSourceSearchCriterias(
   auth: Authenticator,
@@ -157,25 +143,71 @@ export async function generateProcessToolOutput({
   jsonSchema: JSONSchema;
   timeFrame: TimeFrame | null;
   objective: string;
+}): Promise<
+  Result<
+    { processToolOutput: ReturnType<typeof buildProcessToolOutput> },
+    Error
+  >
+> {
+  const schemaNames = Object.keys(jsonSchema?.properties ?? {}).join("_");
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const stem = (
+    jsonSchema?.title ||
+    schemaNames ||
+    "extract_results"
+  ).substring(0, EXTRACT_RESULT_FILE_STEM_MAX_LENGTH);
+  const fileName = makeFileName({ name: stem, ext: ".json" });
+  const content = JSON.stringify(outputs?.data ?? [], null, 2);
+
+  const writeResult = await writeToToolOutputsFolder(auth, conversation, {
+    fileName,
+    content,
+    contentType: "application/json",
+  });
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  return new Ok({
+    processToolOutput: buildProcessToolOutput({
+      outputs,
+      timeFrame,
+      objective,
+      fileName,
+      content,
+      scopedPath: writeResult.value,
+      downloadUri: getFilePathDownloadUrl(owner, writeResult.value),
+    }),
+  });
+}
+
+const EXTRACT_RESULT_FILE_STEM_MAX_LENGTH = 100;
+const EXTRACT_RESULT_SNIPPET_MAX_LENGTH = 1000;
+
+function buildProcessToolOutput({
+  outputs,
+  timeFrame,
+  objective,
+  fileName,
+  content,
+  scopedPath,
+  downloadUri,
+}: {
+  outputs: ProcessActionOutputsType | null;
+  timeFrame: TimeFrame | null;
+  objective: string;
+  fileName: string;
+  content: string;
+  scopedPath: string;
+  downloadUri: string;
 }) {
-  const fileTitle = getExtractFileTitle({
-    schema: jsonSchema,
-  });
-  const { jsonFile, jsonSnippet } = await generateJSONFileAndSnippet(auth, {
-    title: fileTitle,
-    conversationId: conversation.sId,
-    data: outputs?.data,
-  });
-  const generatedFile: ActionGeneratedFileType = {
-    fileId: jsonFile.sId,
-    title: fileTitle,
-    contentType: jsonFile.contentType,
-    snippet: jsonSnippet,
-    isInProjectContext: jsonFile.useCase === "project_context",
-    createdAt: jsonFile.createdAt.getTime(),
-    updatedAt: jsonFile.updatedAt.getTime(),
-    hidden: jsonFile.useCaseMetadata?.hideFromUser ?? false,
-  };
+  const snippet =
+    content.length > EXTRACT_RESULT_SNIPPET_MAX_LENGTH
+      ? content.substring(0, EXTRACT_RESULT_SNIPPET_MAX_LENGTH) +
+        "... (truncated)"
+      : content;
+
   const timeFrameAsString = timeFrame
     ? "the last " +
       (timeFrame.duration > 1
@@ -189,29 +221,26 @@ export async function generateProcessToolOutput({
       ? outputs.data.map((d) => JSON.stringify(d)).join("\n")
       : "(none)");
 
-  return {
-    jsonFile,
-    processToolOutput: [
-      {
-        type: "resource" as const,
-        resource: {
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_QUERY,
-          text: `Extracted from ${outputs?.total_documents} documents over ${timeFrameAsString}.\nObjective: ${objective}`,
-          uri: "",
-        },
+  return [
+    {
+      type: "resource" as const,
+      resource: {
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_QUERY,
+        text: `Extracted from ${outputs?.total_documents} documents over ${timeFrameAsString}.\nObjective: ${objective}`,
+        uri: "",
       },
-      {
-        type: "resource" as const,
-        resource: {
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
-          text: extractResult,
-          uri: jsonFile.getPrivateUrl(auth),
-          fileId: generatedFile.fileId,
-          title: generatedFile.title,
-          contentType: generatedFile.contentType,
-          snippet: generatedFile.snippet,
-        },
+    },
+    {
+      type: "resource" as const,
+      resource: {
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
+        text: extractResult,
+        uri: downloadUri,
+        path: scopedPath,
+        title: fileName,
+        contentType: "application/json" as const,
+        snippet,
       },
-    ],
-  };
+    },
+  ];
 }

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -7,7 +7,6 @@ import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import { getFilePathDownloadUrl } from "@app/lib/swr/files";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationType,
@@ -129,6 +128,9 @@ export async function getPromptForProcessDustApp({
   );
 }
 
+const EXTRACT_RESULT_FILE_STEM_MAX_LENGTH = 100;
+const EXTRACT_RESULT_SNIPPET_MAX_LENGTH = 1000;
+
 export async function generateProcessToolOutput({
   auth,
   conversation,
@@ -168,7 +170,6 @@ export async function generateProcessToolOutput({
     return writeResult;
   }
 
-  const owner = auth.getNonNullableWorkspace();
   return new Ok({
     processToolOutput: buildProcessToolOutput({
       outputs,
@@ -177,13 +178,9 @@ export async function generateProcessToolOutput({
       fileName,
       content,
       scopedPath: writeResult.value,
-      downloadUri: getFilePathDownloadUrl(owner, writeResult.value),
     }),
   });
 }
-
-const EXTRACT_RESULT_FILE_STEM_MAX_LENGTH = 100;
-const EXTRACT_RESULT_SNIPPET_MAX_LENGTH = 1000;
 
 function buildProcessToolOutput({
   outputs,
@@ -192,7 +189,6 @@ function buildProcessToolOutput({
   fileName,
   content,
   scopedPath,
-  downloadUri,
 }: {
   outputs: ProcessActionOutputsType | null;
   timeFrame: TimeFrame | null;
@@ -200,7 +196,6 @@ function buildProcessToolOutput({
   fileName: string;
   content: string;
   scopedPath: string;
-  downloadUri: string;
 }) {
   const snippet =
     content.length > EXTRACT_RESULT_SNIPPET_MAX_LENGTH
@@ -235,7 +230,7 @@ function buildProcessToolOutput({
       resource: {
         mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
         text: extractResult,
-        uri: downloadUri,
+        uri: "",
         path: scopedPath,
         title: fileName,
         contentType: "application/json" as const,

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -1,4 +1,3 @@
-import { uploadFileToConversationDataSource } from "@app/lib/actions/action_file_helpers";
 import { PROCESS_ACTION_TOP_K } from "@app/lib/actions/constants";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -144,8 +143,7 @@ export function createExtractDataTools(
       total_documents: res.value.totalDocuments,
     };
 
-    // Generate file and process tool output
-    const { jsonFile, processToolOutput } = await generateProcessToolOutput({
+    const result = await generateProcessToolOutput({
       auth,
       conversation,
       outputs,
@@ -153,15 +151,11 @@ export function createExtractDataTools(
       timeFrame: timeFrame ?? null,
       objective,
     });
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
 
-    // Upload the file to the conversation data source.
-    // This step is critical for file persistence across sessions.
-    await uploadFileToConversationDataSource({
-      auth,
-      file: jsonFile,
-    });
-
-    return new Ok(processToolOutput);
+    return new Ok(result.value.processToolOutput);
   }
 
   if (!areTagsDynamic) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Replaces the `FileResource`-based JSON output in the `extract_data` tool with `writeToToolOutputsFolder`. No DB record is created for extract results.

`ExtractResultResourceSchema` gains an optional path field (`DustFileSystem` path) alongside the now-optional `fileId` (kept for backwards compatibility with stored action outputs that still reference a `FileResource` id).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
