### PR TITLE
Fix: regression in the perceived height of Frame when in a drawer / pod banner

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -436,7 +436,12 @@ export const VisualizationActionIframe = forwardRef<
               />
             </div>
           ) : (
-            <div className="relative flex h-panel w-full shrink-0 items-center justify-center">
+            <div
+              className={cn(
+                "relative flex w-full shrink-0 items-center justify-center",
+                isInDrawer ? "h-full" : "h-panel"
+              )}
+            >
               {codeFullyGenerated && !isErrored && (
                 <div
                   style={
@@ -465,7 +470,12 @@ export const VisualizationActionIframe = forwardRef<
               )}
 
               {isErrored && !retryClicked && !isPublic && (
-                <div className="flex h-panel w-full items-center justify-center p-6">
+                <div
+                  className={cn(
+                    "flex w-full items-center justify-center p-6",
+                    isInDrawer ? "h-full" : "h-panel"
+                  )}
+                >
                   <ContentMessage
                     title="Visualization failed"
                     variant="warning"


### PR DESCRIPTION
## Description

`VisualizationActionIframe` was using `h-panel` unconditionally on both the loading and error state containers, which broke height rendering when the frame is mounted inside a drawer or pod banner with a specific height. Fixed by switching to `h-full` when `isInDrawer` is true, using `cn()` for the conditional class.

see https://dust4ai.slack.com/archives/C09T7N4S6GG/p1781154110779299

Before
<img width="1182" height="705" alt="image" src="https://github.com/user-attachments/assets/9e6a6591-a9c2-4839-8457-532a90264408" />

After:
<img width="1129" height="583" alt="image" src="https://github.com/user-attachments/assets/a535e966-af6b-49dd-90d0-4265285a851c" />


## Tests

Tested locally by rendering a Frame in:
- preview in pod file
- preview in conversation file
- pod banner
- full screen

Confirm that the frame fills the available height correctly.

## Risk

Low. But I'm not sure why the h-panel original change so please keep me honest @ykmsd.

## Deploy Plan

Deploy front.
