### PR TITLE
Improve tabular file previews

### DIFF
--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -4,6 +4,7 @@ import {
   getFileDownloadUrl,
   getFilePathDownloadUrl,
   getFilePathViewUrl,
+  getFileProcessedUrl,
   getFileViewUrl,
 } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -44,6 +45,7 @@ export function FilePreviewProvider({
     entry: FileEntry;
     fileUrl: string;
     downloadUrl: string;
+    processedFileUrl: string | null;
   } | null>(null);
 
   const openFilePreview = useCallback(
@@ -78,6 +80,9 @@ export function FilePreviewProvider({
         },
         fileUrl,
         downloadUrl,
+        processedFileUrl: file.fileId
+          ? getFileProcessedUrl(owner, file.fileId)
+          : null,
       });
     },
     [owner]
@@ -98,6 +103,7 @@ export function FilePreviewProvider({
         entry={previewState?.entry ?? null}
         fileUrl={previewState?.fileUrl ?? null}
         isOpen={!!previewState}
+        processedFileUrl={previewState?.processedFileUrl ?? null}
         onOpenChange={(open) => {
           if (!open) {
             setPreviewState(null);

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -3,7 +3,11 @@ import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
-import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
+import {
+  downloadFile,
+  getFilePathViewUrl,
+  getFileProcessedUrl,
+} from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
 import {
   type ConversationWithoutContentType,
@@ -41,6 +45,12 @@ export function ConversationFileExplorer({
 
   const getFileUrl = useCallback(
     (path: string) => getFilePathViewUrl(owner, path),
+    [owner]
+  );
+
+  const getProcessedFileUrl = useCallback(
+    (entry: { fileId: string | null }) =>
+      entry.fileId ? getFileProcessedUrl(owner, entry.fileId) : null,
     [owner]
   );
 
@@ -105,6 +115,7 @@ export function ConversationFileExplorer({
             hideBreadcrumbAtRoot
             isLoading={isSandboxFilesLoading}
             getFileUrl={getFileUrl}
+            getProcessedFileUrl={getProcessedFileUrl}
             onFileDownload={onFileDownload}
             onOpenInteractive={onOpenInteractive}
           />
@@ -123,6 +134,7 @@ export function ConversationFileExplorer({
               hideBreadcrumbAtRoot
               isLoading={isPodFilesLoading}
               getFileUrl={getFileUrl}
+              getProcessedFileUrl={getProcessedFileUrl}
               onFileDownload={onFileDownload}
               onOpenInteractive={onOpenInteractive}
             />

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -40,6 +40,7 @@ interface FileExplorerProps {
   hideBreadcrumbAtRoot?: boolean;
   files: FileSystemEntry[];
   getFileUrl: (path: string) => string;
+  getProcessedFileUrl?: (entry: FileEntry) => string | null;
   toolbarExtraActions?: React.ReactNode;
   isLoading: boolean;
   navigationResetKey?: number;
@@ -64,6 +65,7 @@ export function FileExplorer({
   emptyState,
   files,
   getFileUrl,
+  getProcessedFileUrl,
   toolbarExtraActions,
   hideBreadcrumbAtRoot = false,
   isLoading,
@@ -332,6 +334,9 @@ export function FileExplorer({
       <FilePreviewDialog
         entry={previewFile}
         fileUrl={previewFile ? getFileUrl(previewFile.path) : null}
+        processedFileUrl={
+          previewFile ? (getProcessedFileUrl?.(previewFile) ?? null) : null
+        }
         isOpen={showPreviewSheet}
         onOpenChange={setShowPreviewSheet}
         onDownload={onFileDownload}

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,4 +1,8 @@
 import type { FileEntry } from "@app/components/file_explorer/types";
+import {
+  getTabularPreviewStats,
+  TabularFilePreview,
+} from "@app/components/file_explorer/TabularFilePreview";
 import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
 import { useFileContent } from "@app/hooks/useFileContent";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
@@ -12,7 +16,6 @@ import {
   ChevronRight,
   CodeBlock,
   cn,
-  DataTable,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -21,13 +24,10 @@ import {
   Download01,
   Icon,
   Markdown,
-  ScrollableDataTable,
   Spinner,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useEffect, useState } from "react";
 
-const MAX_CSV_ROWS = 200;
 const MAX_TEXT_CHARS = 100_000;
 
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {
@@ -66,79 +66,13 @@ function getCodeLanguage(fileName: string): string {
   return EXTENSION_TO_LANGUAGE[ext] ?? "text";
 }
 
-function getDelimitedRecordCount({
-  content,
-}: {
-  content: string;
-}): { displayed: number; total: number } | null {
-  const lines = content.split("\n").filter((l) => l.trim());
-  if (lines.length < 2) {
-    return null;
-  }
-
-  const [, ...dataLines] = lines;
-  const total = dataLines.length;
-
-  return { displayed: Math.min(total, MAX_CSV_ROWS), total };
-}
-
 interface DelimitedPreviewProps {
   content: string;
   mimeType: string;
 }
 
-type Row = Record<string, string>;
-
 function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
-  const isTsv =
-    mimeType === "text/tsv" || mimeType === "text/tab-separated-values";
-
-  const delimiter = isTsv ? "\t" : ",";
-  const lines = content.split("\n").filter((l) => l.trim());
-
-  if (lines.length < 2) {
-    return (
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        No data to preview.
-      </p>
-    );
-  }
-
-  const [headerLine, ...dataLines] = lines;
-  const headers = headerLine!
-    .split(delimiter)
-    .map((c) => c.trim().replace(/^"|"$/g, ""));
-  const allRows = dataLines.map((line) =>
-    line.split(delimiter).map((c) => c.trim().replace(/^"|"$/g, ""))
-  );
-  const displayed = allRows.slice(0, MAX_CSV_ROWS);
-
-  const baseRatio = Math.floor(100 / headers.length);
-  const columns: ColumnDef<Row>[] = headers.map((header, idx) => ({
-    id: header,
-    accessorFn: (row: Row) => row[header] ?? "",
-    header,
-    cell: (info: CellContext<Row, unknown>) => (
-      <DataTable.BasicCellContent label={String(info.getValue() ?? "")} />
-    ),
-    meta: {
-      // Last column absorbs rounding remainder so ratios always sum to 100.
-      sizeRatio:
-        idx < headers.length - 1
-          ? baseRatio
-          : 100 - baseRatio * (headers.length - 1),
-    },
-  }));
-
-  const data: Row[] = displayed.map((row) =>
-    Object.fromEntries(headers.map((h, i) => [h, row[i] ?? ""]))
-  );
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <ScrollableDataTable data={data} columns={columns} maxHeight={true} />
-    </div>
-  );
+  return <TabularFilePreview content={content} mimeType={mimeType} />;
 }
 
 interface FilePreviewDialogContentProps {
@@ -263,6 +197,7 @@ interface FilePreviewDialogProps {
   onNext?: () => void;
   onOpenChange: (open: boolean) => void;
   onPrev?: () => void;
+  processedFileUrl?: string | null;
 }
 
 export function FilePreviewDialog({
@@ -273,6 +208,7 @@ export function FilePreviewDialog({
   onDownload,
   onPrev,
   onNext,
+  processedFileUrl,
 }: FilePreviewDialogProps) {
   const [isDownloading, setIsDownloading] = useState(false);
 
@@ -314,7 +250,11 @@ export function FilePreviewDialog({
   }, [isOpen, onPrev, onNext]);
 
   const mimeType = stripMimeParameters(entry?.contentType ?? "");
-  const { category } = getFilePreviewConfig(mimeType);
+  const previewConfig = getFilePreviewConfig(mimeType);
+  const { category } = previewConfig;
+  const contentUrl = previewConfig.needsProcessedVersion
+    ? (processedFileUrl ?? null)
+    : fileUrl;
 
   const needsTextContent =
     category === "code" ||
@@ -324,11 +264,13 @@ export function FilePreviewDialog({
 
   const { fileContent, isFileContentLoading, fileContentError } =
     useFileContent({
-      url: fileUrl,
-      disabled: !isOpen || !entry || !needsTextContent,
+      url: contentUrl,
+      disabled: !isOpen || !entry || !needsTextContent || !contentUrl,
     });
 
-  const hasError = needsTextContent && !!fileContentError;
+  const hasError =
+    needsTextContent &&
+    (!!fileContentError || (!contentUrl && !isFileContentLoading));
   const isContentLoading =
     isOpen && !!entry && !hasError && needsTextContent && isFileContentLoading;
 
@@ -345,7 +287,7 @@ export function FilePreviewDialog({
 
   const recordCounts =
     category === "delimited" && truncatedContent
-      ? getDelimitedRecordCount({ content: truncatedContent })
+      ? getTabularPreviewStats({ content: truncatedContent, mimeType })
       : null;
 
   return (
@@ -379,7 +321,7 @@ export function FilePreviewDialog({
                 )}
               >
                 Showing {recordCounts.displayed} of {recordCounts.total} records
-                {recordCounts.total > MAX_CSV_ROWS && " (truncated)"}
+                {recordCounts.isTruncated && " (truncated)"}
               </span>
             )}
           </div>

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,8 +1,8 @@
-import type { FileEntry } from "@app/components/file_explorer/types";
 import {
   getTabularPreviewStats,
   TabularFilePreview,
 } from "@app/components/file_explorer/TabularFilePreview";
+import type { FileEntry } from "@app/components/file_explorer/types";
 import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
 import { useFileContent } from "@app/hooks/useFileContent";
 import type { ProcessedContent } from "@app/lib/file_content_utils";

--- a/front/components/file_explorer/TabularFilePreview.tsx
+++ b/front/components/file_explorer/TabularFilePreview.tsx
@@ -1,10 +1,18 @@
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { stripMimeParameters } from "@app/types/files";
 import { cn } from "@dust-tt/sparkle";
+import type { ColumnRegular, DataType } from "@revolist/react-datagrid";
+import { RevoGrid } from "@revolist/react-datagrid";
+import { useMemo } from "react";
 
-export const MAX_TABULAR_PREVIEW_ROWS = 200;
+// RevoGrid virtualizes rendering, so we can preview many more rows than the
+// previous hand-rolled table comfortably allowed.
+export const MAX_TABULAR_PREVIEW_ROWS = 10_000;
 
-const MAX_COLUMN_WIDTH_CHARS = 48;
-const MIN_COLUMN_WIDTH_CHARS = 12;
+const MAX_COLUMN_WIDTH_PX = 420;
+const MIN_COLUMN_WIDTH_PX = 120;
+const APPROX_PX_PER_CHAR = 9;
+const COLUMN_PADDING_PX = 24;
 
 type ParsedTable = {
   headers: string[];
@@ -135,9 +143,11 @@ function parseTable(content: string, mimeType: string): ParsedTable | null {
   }
 
   const headers = normalizeHeaders(rawHeaders ?? [], columnCount);
-  const rows = rawRows.slice(0, MAX_TABULAR_PREVIEW_ROWS).map((row) =>
-    Array.from({ length: columnCount }, (_, index) => row[index] ?? "")
-  );
+  const rows = rawRows
+    .slice(0, MAX_TABULAR_PREVIEW_ROWS)
+    .map((row) =>
+      Array.from({ length: columnCount }, (_, index) => row[index] ?? "")
+    );
 
   return {
     headers,
@@ -166,16 +176,57 @@ export function getTabularPreviewStats({
   };
 }
 
+function columnWidthForHeader(header: string): number {
+  const estimated = header.length * APPROX_PX_PER_CHAR + COLUMN_PADDING_PX;
+
+  return Math.max(
+    MIN_COLUMN_WIDTH_PX,
+    Math.min(MAX_COLUMN_WIDTH_PX, estimated)
+  );
+}
+
+interface TabularFilePreviewProps {
+  className?: string;
+  content: string;
+  mimeType: string;
+}
+
 export function TabularFilePreview({
   className,
   content,
   mimeType,
-}: {
-  className?: string;
-  content: string;
-  mimeType: string;
-}) {
-  const table = parseTable(content, mimeType);
+}: TabularFilePreviewProps) {
+  const { isDark } = useTheme();
+
+  const table = useMemo(
+    () => parseTable(content, mimeType),
+    [content, mimeType]
+  );
+
+  // Column keys are the (numeric) column indexes, matching how each row is
+  // serialized into the data source below.
+  const columns = useMemo<ColumnRegular[]>(
+    () =>
+      table?.headers.map((header, index) => ({
+        prop: index,
+        name: header,
+        size: columnWidthForHeader(header),
+      })) ?? [],
+    [table]
+  );
+
+  const source = useMemo<DataType[]>(
+    () =>
+      table?.rows.map((row) => {
+        const record: Record<number, string> = {};
+        row.forEach((cell, index) => {
+          record[index] = cell;
+        });
+
+        return record;
+      }) ?? [],
+    [table]
+  );
 
   if (!table || table.totalRows === 0) {
     return (
@@ -188,57 +239,19 @@ export function TabularFilePreview({
   return (
     <div
       className={cn(
-        "min-h-0 flex-1 overflow-auto rounded-xl border border-border bg-background shadow-sm dark:border-border-night dark:bg-background-night",
+        "flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm dark:border-border-night dark:bg-background-night",
         className
       )}
     >
-      <table className="border-separate border-spacing-0 text-left text-sm">
-        <thead>
-          <tr>
-            <th className="sticky left-0 top-0 z-30 w-12 border-b border-r border-border bg-muted-background px-3 py-2 text-right text-xs font-medium text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
-              #
-            </th>
-            {table.headers.map((header, index) => (
-              <th
-                key={`${header}-${index}`}
-                className="sticky top-0 z-20 border-b border-r border-border bg-muted-background px-3 py-2 text-xs font-semibold text-foreground dark:border-border-night dark:bg-muted-background-night dark:text-foreground-night"
-                style={{
-                  minWidth: `${Math.max(
-                    MIN_COLUMN_WIDTH_CHARS,
-                    Math.min(MAX_COLUMN_WIDTH_CHARS, header.length + 4)
-                  )}ch`,
-                }}
-                title={header}
-              >
-                <div className="max-w-80 truncate">{header}</div>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {table.rows.map((row, rowIndex) => (
-            <tr
-              key={rowIndex}
-              className="odd:bg-background even:bg-muted-background/40 dark:odd:bg-background-night dark:even:bg-muted-background-night/30"
-            >
-              <th className="sticky left-0 z-10 border-b border-r border-border bg-inherit px-3 py-2 text-right text-xs font-medium text-muted-foreground dark:border-border-night dark:text-muted-foreground-night">
-                {rowIndex + 1}
-              </th>
-              {row.map((cell, cellIndex) => (
-                <td
-                  key={cellIndex}
-                  className="max-w-80 border-b border-r border-border px-3 py-2 align-top text-foreground dark:border-border-night dark:text-foreground-night"
-                  title={cell}
-                >
-                  <div className="max-h-24 overflow-hidden whitespace-pre-wrap break-words leading-5">
-                    {cell}
-                  </div>
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <RevoGrid
+        columns={columns}
+        source={source}
+        theme={isDark ? "darkCompact" : "compact"}
+        readonly
+        resize
+        rowHeaders
+        style={{ flex: "1 1 auto", minHeight: 0, width: "100%" }}
+      />
     </div>
   );
 }

--- a/front/components/file_explorer/TabularFilePreview.tsx
+++ b/front/components/file_explorer/TabularFilePreview.tsx
@@ -1,0 +1,244 @@
+import { stripMimeParameters } from "@app/types/files";
+import { cn } from "@dust-tt/sparkle";
+
+export const MAX_TABULAR_PREVIEW_ROWS = 200;
+
+const MAX_COLUMN_WIDTH_CHARS = 48;
+const MIN_COLUMN_WIDTH_CHARS = 12;
+
+type ParsedTable = {
+  headers: string[];
+  rows: string[][];
+  totalRows: number;
+  isTruncated: boolean;
+};
+
+function getPreferredDelimiter(content: string, mimeType: string): string {
+  const normalizedMimeType = stripMimeParameters(mimeType);
+  if (
+    normalizedMimeType === "text/tsv" ||
+    normalizedMimeType === "text/tab-separated-values"
+  ) {
+    return "\t";
+  }
+
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? "";
+  const candidates = [",", ";", "\t"];
+
+  let bestDelimiter = ",";
+  let bestCount = -1;
+
+  for (const delimiter of candidates) {
+    let count = 0;
+    let inQuotes = false;
+
+    for (let i = 0; i < firstLine.length; i++) {
+      const char = firstLine[i];
+      if (char === '"') {
+        if (inQuotes && firstLine[i + 1] === '"') {
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char === delimiter && !inQuotes) {
+        count++;
+      }
+    }
+
+    if (count > bestCount) {
+      bestCount = count;
+      bestDelimiter = delimiter;
+    }
+  }
+
+  return bestDelimiter;
+}
+
+function parseDelimitedRows(content: string, delimiter: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let value = "";
+  let inQuotes = false;
+
+  const pushValue = () => {
+    row.push(value);
+    value = "";
+  };
+
+  const pushRow = () => {
+    pushValue();
+    if (row.some((cell) => cell.trim() !== "")) {
+      rows.push(row);
+    }
+    row = [];
+  };
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+
+    if (char === '"') {
+      if (inQuotes && content[i + 1] === '"') {
+        value += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === delimiter && !inQuotes) {
+      pushValue();
+    } else if ((char === "\n" || char === "\r") && !inQuotes) {
+      if (char === "\r" && content[i + 1] === "\n") {
+        i++;
+      }
+      pushRow();
+    } else {
+      value += char;
+    }
+  }
+
+  if (value !== "" || row.length > 0) {
+    pushRow();
+  }
+
+  return rows;
+}
+
+function normalizeHeaders(headers: string[], columnCount: number): string[] {
+  const seen = new Map<string, number>();
+
+  return Array.from({ length: columnCount }, (_, index) => {
+    const rawHeader = headers[index]?.trim() || `Column ${index + 1}`;
+    const previousCount = seen.get(rawHeader) ?? 0;
+    seen.set(rawHeader, previousCount + 1);
+
+    return previousCount === 0
+      ? rawHeader
+      : `${rawHeader} (${previousCount + 1})`;
+  });
+}
+
+function parseTable(content: string, mimeType: string): ParsedTable | null {
+  const delimiter = getPreferredDelimiter(content, mimeType);
+  const records = parseDelimitedRows(content, delimiter);
+
+  if (records.length === 0) {
+    return null;
+  }
+
+  const [rawHeaders, ...rawRows] = records;
+  const columnCount = Math.max(
+    rawHeaders?.length ?? 0,
+    ...rawRows.map((row) => row.length)
+  );
+
+  if (columnCount === 0) {
+    return null;
+  }
+
+  const headers = normalizeHeaders(rawHeaders ?? [], columnCount);
+  const rows = rawRows.slice(0, MAX_TABULAR_PREVIEW_ROWS).map((row) =>
+    Array.from({ length: columnCount }, (_, index) => row[index] ?? "")
+  );
+
+  return {
+    headers,
+    rows,
+    totalRows: rawRows.length,
+    isTruncated: rawRows.length > MAX_TABULAR_PREVIEW_ROWS,
+  };
+}
+
+export function getTabularPreviewStats({
+  content,
+  mimeType,
+}: {
+  content: string;
+  mimeType: string;
+}): { displayed: number; total: number; isTruncated: boolean } | null {
+  const table = parseTable(content, mimeType);
+  if (!table) {
+    return null;
+  }
+
+  return {
+    displayed: table.rows.length,
+    total: table.totalRows,
+    isTruncated: table.isTruncated,
+  };
+}
+
+export function TabularFilePreview({
+  className,
+  content,
+  mimeType,
+}: {
+  className?: string;
+  content: string;
+  mimeType: string;
+}) {
+  const table = parseTable(content, mimeType);
+
+  if (!table || table.totalRows === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-xl border border-border bg-muted-background text-sm text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
+        No data to preview.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "min-h-0 flex-1 overflow-auto rounded-xl border border-border bg-background shadow-sm dark:border-border-night dark:bg-background-night",
+        className
+      )}
+    >
+      <table className="border-separate border-spacing-0 text-left text-sm">
+        <thead>
+          <tr>
+            <th className="sticky left-0 top-0 z-30 w-12 border-b border-r border-border bg-muted-background px-3 py-2 text-right text-xs font-medium text-muted-foreground dark:border-border-night dark:bg-muted-background-night dark:text-muted-foreground-night">
+              #
+            </th>
+            {table.headers.map((header, index) => (
+              <th
+                key={`${header}-${index}`}
+                className="sticky top-0 z-20 border-b border-r border-border bg-muted-background px-3 py-2 text-xs font-semibold text-foreground dark:border-border-night dark:bg-muted-background-night dark:text-foreground-night"
+                style={{
+                  minWidth: `${Math.max(
+                    MIN_COLUMN_WIDTH_CHARS,
+                    Math.min(MAX_COLUMN_WIDTH_CHARS, header.length + 4)
+                  )}ch`,
+                }}
+                title={header}
+              >
+                <div className="max-w-80 truncate">{header}</div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row, rowIndex) => (
+            <tr
+              key={rowIndex}
+              className="odd:bg-background even:bg-muted-background/40 dark:odd:bg-background-night dark:even:bg-muted-background-night/30"
+            >
+              <th className="sticky left-0 z-10 border-b border-r border-border bg-inherit px-3 py-2 text-right text-xs font-medium text-muted-foreground dark:border-border-night dark:text-muted-foreground-night">
+                {rowIndex + 1}
+              </th>
+              {row.map((cell, cellIndex) => (
+                <td
+                  key={cellIndex}
+                  className="max-w-80 border-b border-r border-border px-3 py-2 align-top text-foreground dark:border-border-night dark:text-foreground-night"
+                  title={cell}
+                >
+                  <div className="max-h-24 overflow-hidden whitespace-pre-wrap break-words leading-5">
+                    {cell}
+                  </div>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -23,7 +23,11 @@ import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import type { ContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { useAppRouter } from "@app/lib/platform";
-import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
+import {
+  downloadFile,
+  getFilePathViewUrl,
+  getFileProcessedUrl,
+} from "@app/lib/swr/files";
 import {
   useAddPodContextContentNodes,
   useDeletePodFile,
@@ -556,6 +560,12 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     [owner]
   );
 
+  const getProcessedFileUrl = useCallback(
+    (entry: { fileId: string | null }) =>
+      entry.fileId ? getFileProcessedUrl(owner, entry.fileId) : null,
+    [owner]
+  );
+
   const getFileResponse = useCallback(
     (path: string) => downloadFile(owner, path),
     [owner]
@@ -772,6 +782,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         emptyState={hasFiles ? undefined : emptyState}
         files={podGCSFiles}
         getFileUrl={getFileUrl}
+        getProcessedFileUrl={getProcessedFileUrl}
         navigationResetKey={navigationResetKey}
         onCurrentFolderChange={setCurrentFolderPath}
         onFileDownload={onFileDownload}

--- a/front/components/spaces/FilePreviewSheet.tsx
+++ b/front/components/spaces/FilePreviewSheet.tsx
@@ -1,4 +1,5 @@
 import { FrameRenderer } from "@app/components/assistant/conversation/interactive_content/FrameRenderer";
+import { TabularFilePreview } from "@app/components/file_explorer/TabularFilePreview";
 import { clientFetch } from "@app/lib/egress/client";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
 import { processFileContent } from "@app/lib/file_content_utils";
@@ -60,6 +61,17 @@ const VIEWER_CONTENT_TYPES = [
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 ] as const;
 
+const SPREADSHEET_CONTENT_TYPES = [
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+] as const;
+
+function isSpreadsheetContentType(contentType: string): boolean {
+  return SPREADSHEET_CONTENT_TYPES.includes(
+    contentType as (typeof SPREADSHEET_CONTENT_TYPES)[number]
+  );
+}
+
 function isViewerCompatible(contentType: string): boolean {
   return VIEWER_CONTENT_TYPES.includes(
     contentType as (typeof VIEWER_CONTENT_TYPES)[number]
@@ -99,6 +111,15 @@ export function getFilePreviewConfig(contentType: string): FilePreviewConfig {
   if (isPdfContentType(contentType)) {
     return {
       category: "pdf",
+      needsProcessedVersion: true,
+      supportsExternalViewer: true,
+      supportsCopyContent: false,
+    };
+  }
+
+  if (isSpreadsheetContentType(contentType)) {
+    return {
+      category: "delimited",
       needsProcessedVersion: true,
       supportsExternalViewer: true,
       supportsCopyContent: false,
@@ -284,10 +305,20 @@ function FileContentRenderer({
         </CodeBlock>
       );
     case "markdown":
-    case "delimited":
     case "text":
       if (processedContent) {
         return <TextContent text={processedContent.text} />;
+      }
+      return null;
+    case "delimited":
+      if (rawFileContent) {
+        return (
+          <TabularFilePreview
+            className="min-h-[600px]"
+            content={rawFileContent}
+            mimeType={file.contentType}
+          />
+        );
       }
       return null;
     default:

--- a/front/package.json
+++ b/front/package.json
@@ -90,6 +90,7 @@
     "@radix-ui/react-visually-hidden": "^1.1.2",
     "@react-email/html": "0.0.11",
     "@react-email/render": "1.4.0",
+    "@revolist/react-datagrid": "^4.23.7",
     "@sendgrid/mail": "^8.0.0",
     "@slack/web-api": "^7.10.0",
     "@stripe/react-stripe-js": "^3.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,6 +537,7 @@
         "@radix-ui/react-visually-hidden": "^1.1.2",
         "@react-email/html": "0.0.11",
         "@react-email/render": "1.4.0",
+        "@revolist/react-datagrid": "^4.23.7",
         "@sendgrid/mail": "^8.0.0",
         "@slack/web-api": "^7.10.0",
         "@stripe/react-stripe-js": "^3.10.0",
@@ -15237,6 +15238,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
+    "node_modules/@revolist/react-datagrid": {
+      "version": "4.23.7",
+      "resolved": "https://registry.npmjs.org/@revolist/react-datagrid/-/react-datagrid-4.23.7.tgz",
+      "integrity": "sha512-9x2N6zFvOtvO+/lilZAF5ugZGjUI1bUrT7TzMP7mMiPwQAizxvdMCf/gJAoGq0E4QqQ/oISMxk4fQ7hJaFJ2iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@revolist/revogrid": "4.23.7"
+      }
+    },
+    "node_modules/@revolist/revogrid": {
+      "version": "4.23.7",
+      "resolved": "https://registry.npmjs.org/@revolist/revogrid/-/revogrid-4.23.7.tgz",
+      "integrity": "sha512-5L6PhA9CyBiQIrQx1D1kGNX+wHJADlFQCLpbpbVeNTlFZRIl4esf4Ruc4j9H7WXdLi/jfAJuFs3WVH70h7pRcQ==",
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {


### PR DESCRIPTION
## Description

Improves the file preview experience for tabular files (CSV / TSV / spreadsheets).

The custom hand-rolled HTML `<table>` renderer is replaced by [RevoGrid](https://rv-grid.com/) (`@revolist/react-datagrid`, MIT), an Excel-like virtualized data grid. The CSV/TSV parsing (delimiter detection, quoted-field handling, header normalization) and the `getTabularPreviewStats` helper are kept as-is — only the rendering layer changes.

- Read-only grid with sticky column headers, row-number headers, and resizable columns.
- Light / dark theming wired through the existing `useTheme().isDark` (`compact` / `darkCompact`).
- Virtualized rendering, so the preview row cap is raised from 200 to 10,000 (the "Showing X of Y records (truncated)" indicator still works).
- Both consumers (`FilePreviewDialog` and the space `FilePreviewSheet`) keep the same component API.

No SSR shim needed: the RevoGrid Stencil loader no-ops when `window` is undefined, so the module is safe to import on the server.

## Tests

Manual verification recommended:
- Open a CSV and a TSV preview in both the file dialog and the space sheet.
- Toggle light / dark mode and confirm the grid theme follows.
- Confirm the grid fills its container in the sheet (relies on `min-h-[600px]` → flex fill) and in the dialog.
- Preview a wide file (many columns) and a large file (thousands of rows) to confirm virtualization and the truncation indicator.
