### PR TITLE
Migrate tool binary file outputs away from FileResource to DustFileSystem

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -220,9 +220,7 @@ export async function processToolResults(
             base64Data: block.data,
             mimeType: block.mimeType,
             fileName,
-            block,
-            fileUseCase,
-            fileUseCaseMetadata,
+            conversation,
           });
         }
 
@@ -297,10 +295,8 @@ export async function processToolResults(
               return handleBase64Upload(auth, {
                 base64Data: block.resource.blob,
                 mimeType: block.resource.mimeType,
-                fileName: fileName,
-                block,
-                fileUseCase,
-                fileUseCaseMetadata,
+                fileName,
+                conversation,
               });
             }
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -68,6 +68,11 @@ const ToolGeneratedFileSchema = z.object({
   hidden: z.boolean().optional(),
 });
 
+export const TOOL_GENERATED_FILE_MIME_TYPE =
+  INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE;
+export const TOOL_GENERATED_FILE_PATH_MIME_TYPE =
+  INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH;
+
 export type ToolGeneratedFileType = z.infer<typeof ToolGeneratedFileSchema>;
 
 export function isToolGeneratedFile(

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -1,29 +1,32 @@
 // All mime types are okay to use from the public API.
 
 import { FILE_OFFLOAD_IMAGE_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
+import type {
+  ToolGeneratedFilePathType,
+  ToolGeneratedFileType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
-  isBlobResource,
   isRunAgentQueryResourceType,
   isToolGeneratedFile,
   isToolMarkerResourceType,
+  TOOL_GENERATED_FILE_MIME_TYPE,
+  TOOL_GENERATED_FILE_PATH_MIME_TYPE,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import {
   makeFileAttachment,
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
+import { writeToConversationFolder } from "@app/lib/api/files/action_output_fs";
+import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import type { ProcessAndStoreFileError } from "@app/lib/api/files/processing";
-import {
-  uploadBase64DataToFileStorage,
-  uploadBase64ImageToFileStorage,
-} from "@app/lib/api/files/upload";
+import { uploadBase64ImageToFileStorage } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { FileModel } from "@app/lib/resources/storage/models/files";
 import logger from "@app/logger/logger";
+import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
-  FileUseCase,
-  FileUseCaseMetadata,
   SupportedFileContentType,
   SupportedImageContentType,
 } from "@app/types/files";
@@ -35,6 +38,7 @@ import { hasNullUnicodeCharacter } from "@app/types/shared/utils/string_utils";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { isSupportedImageContentType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { basename, extname } from "path";
 
 type ResourceInfo =
   | { type: "image"; contentType: SupportedImageContentType }
@@ -162,17 +166,13 @@ export async function handleBase64Upload(
   {
     base64Data,
     fileName,
-    block,
     mimeType,
-    fileUseCase,
-    fileUseCaseMetadata,
+    conversation,
   }: {
     base64Data: string;
     mimeType: string;
     fileName: string;
-    block: CallToolResult["content"][number];
-    fileUseCase: FileUseCase;
-    fileUseCaseMetadata: FileUseCaseMetadata;
+    conversation: ConversationType;
   }
 ): Promise<{
   content: CallToolResult["content"][number];
@@ -200,55 +200,90 @@ export async function handleBase64Upload(
     };
   }
 
-  let uploadResult: Result<FileResource, ProcessAndStoreFileError>;
-
   if (resourceInfo.type === "image") {
-    uploadResult = await uploadBase64ImageToFileStorage(auth, {
-      base64: base64Data,
-      contentType: resourceInfo.contentType,
-      fileName,
-      useCase: fileUseCase,
-      useCaseMetadata: fileUseCaseMetadata,
-    });
-  } else {
-    uploadResult = await uploadBase64DataToFileStorage(auth, {
-      base64: base64Data,
-      contentType: resourceInfo.contentType,
-      fileName,
-      useCase: fileUseCase,
-      useCaseMetadata: fileUseCaseMetadata,
-    });
-  }
+    // Images stay on FileResource so they go through the resize pipeline.
+    // Tool-generated images can be fed back to the model for vision tasks,
+    // so correct sizing matters.
+    const uploadResult: Result<FileResource, ProcessAndStoreFileError> =
+      await uploadBase64ImageToFileStorage(auth, {
+        base64: base64Data,
+        contentType: resourceInfo.contentType,
+        fileName,
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
 
-  if (uploadResult.isErr()) {
-    logger.error(
-      {
-        action: "mcp_tool",
-        tool: `generate_${resourceInfo.type}`,
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        error: uploadResult.error,
-      },
-      `Failed to save the generated ${resourceInfo.type}.`
-    );
+    if (uploadResult.isErr()) {
+      logger.error(
+        {
+          action: "mcp_tool",
+          tool: "generate_image",
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          error: uploadResult.error,
+        },
+        "Failed to save the generated image."
+      );
+      return {
+        content: { type: "text", text: "Failed to save the generated image." },
+        file: null,
+      };
+    }
+
+    const resource: ToolGeneratedFileType = {
+      mimeType: TOOL_GENERATED_FILE_MIME_TYPE,
+      uri: `file://${uploadResult.value.id}`,
+      fileId: uploadResult.value.sId,
+      title: fileName,
+      contentType: resourceInfo.contentType,
+      snippet: uploadResult.value.snippet,
+      text: `Generated image: ${fileName}`,
+    };
 
     return {
       content: {
-        type: "text",
-        text: `Failed to save the generated ${resourceInfo.type}.`,
+        type: "resource",
+        resource,
       },
+      file: uploadResult.value,
+    };
+  }
+
+  const ext = extname(fileName);
+  const uniqueFileName = makeFileName({ name: basename(fileName, ext), ext });
+
+  const writeResult = await writeToConversationFolder(auth, conversation, {
+    fileName: uniqueFileName,
+    content: Buffer.from(base64Data, "base64"),
+    contentType: resourceInfo.contentType,
+  });
+
+  if (writeResult.isErr()) {
+    logger.error(
+      {
+        action: "mcp_tool",
+        tool: "generate_file",
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        error: writeResult.error,
+      },
+      "Failed to save the generated file."
+    );
+    return {
+      content: { type: "text", text: "Failed to save the generated file." },
       file: null,
     };
   }
 
+  const resource: ToolGeneratedFilePathType = {
+    mimeType: TOOL_GENERATED_FILE_PATH_MIME_TYPE,
+    uri: writeResult.value,
+    path: writeResult.value,
+    title: uniqueFileName,
+    contentType: resourceInfo.contentType,
+    text: `Generated file: ${uniqueFileName}`,
+  };
+
   return {
-    content: {
-      ...block,
-      // Remove the data from the block to avoid storing it in the database.
-      ...(block.type === "image" ? { data: "" } : {}),
-      ...(isBlobResource(block)
-        ? { resource: { ...block.resource, blob: "" } }
-        : {}),
-    },
-    file: uploadResult.value,
+    content: { type: "resource", resource },
+    file: null,
   };
 }

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -231,7 +231,7 @@ export async function handleBase64Upload(
 
     const resource: ToolGeneratedFileType = {
       mimeType: TOOL_GENERATED_FILE_MIME_TYPE,
-      uri: `file://${uploadResult.value.id}`,
+      uri: `file://${uploadResult.value.sId}`,
       fileId: uploadResult.value.sId,
       title: fileName,
       contentType: resourceInfo.contentType,

--- a/front/lib/api/files/action_output_fs/index.ts
+++ b/front/lib/api/files/action_output_fs/index.ts
@@ -22,6 +22,43 @@ export interface PersistedToolOutput {
 }
 
 /**
+ * Writes content to the conversation root via DustFileSystem.
+ * Returns the scoped path (e.g. "conversation-{cId}/{fileName}") on success.
+ * Use for user-facing generated files (PDFs, audio, etc.) that should be visible at the top level.
+ * Use writeToToolOutputsFolder for internal outputs the model reads back during execution.
+ */
+export async function writeToConversationFolder(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType,
+  {
+    content,
+    contentType,
+    fileName,
+  }: {
+    content: string | Buffer;
+    contentType: AllSupportedFileContentType;
+    fileName: string;
+  }
+): Promise<Result<string, Error>> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new Error(fsResult.error.message));
+  }
+
+  const scopedPath = `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${fileName}`;
+  const writeResult = await fsResult.value.write(
+    scopedPath,
+    content,
+    contentType
+  );
+  if (writeResult.isErr()) {
+    return new Err(new Error(writeResult.error.message));
+  }
+
+  return new Ok(scopedPath);
+}
+
+/**
  * Writes content to the conversation's .tool_outputs folder via DustFileSystem.
  * Returns the scoped path (e.g. "conversation-{cId}/.tool_outputs/{fileName}") on success.
  */


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Tool-generated binary files (non-image blobs from MCP tools like `file_generation`, `speech_generator`, `google_drive`, etc.) were being stored as `FileResource` records in the database. This moves them to `DustFileSystem`, writing directly to the conversation root folder so they appear at the top level rather than buried in `.tool_outputs`. Images stay on `FileResource` since they go through the resize pipeline and can be fed back to the model for vision tasks. Will tackle them later.

A new `writeToConversationFolder` function is introduced alongside the existing `writeToToolOutputsFolder`, with a clear semantic boundary: the root is for user-facing outputs people download, `.tool_outputs` is for internal data the model reads back during execution.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
