### PR TITLE
[front] Add get_credit_usage tool to workspace_analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -704,6 +704,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "workspace_analytics": {
     "get_agent_details": "never_ask",
+    "get_credit_usage": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_skills": "never_ask",
     "get_top_tools": "never_ask",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -156,6 +156,9 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
       "billing computes them. IMPORTANT: these figures are ESTIMATES derived " +
       "from usage logs — always tell the user they are approximate and point " +
       "them to the workspace Usage page for exact, billed credit amounts. " +
+      "When grouped by agent or user in very large workspaces, the ranking is " +
+      "also approximate: it is computed from the most active groups by message " +
+      "volume and may miss low-message, high-tool-usage outliers." +
       "Optionally filter by source (context_origin), agent, or user. " +
       "Admin-only.",
     schema: getCreditUsageSchema,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -38,6 +38,28 @@ const getAgentDetailsSchema = {
     ),
 };
 
+const getCreditUsageSchema = {
+  ...timeWindowSchemaShape,
+  ...usageFilterSchema,
+  groupBy: z
+    .enum(["agent", "user", "none"])
+    .optional()
+    .describe(
+      "Break the estimated credits down by top 'agent' or 'user', or 'none' " +
+        "(default) for the workspace total only."
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_RESULTS)
+    .optional()
+    .describe(
+      `When grouping, the maximum number of rows to return ` +
+        `(default ${DEFAULT_RESULTS}, max ${MAX_RESULTS}).`
+    ),
+};
+
 const getUsageTimeseriesSchema = {
   ...timeWindowSchemaShape,
   ...usageFilterSchema,
@@ -124,6 +146,23 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving top tools",
       done: "Retrieved top tools",
+    },
+  },
+  get_credit_usage: {
+    description:
+      "Estimate AWU credit consumption over a time window (defaults to the " +
+      "current calendar month), optionally broken down by the top agents or " +
+      "users. Credits combine model compute and tool usage, mirroring how " +
+      "billing computes them. IMPORTANT: these figures are ESTIMATES derived " +
+      "from usage logs — always tell the user they are approximate and point " +
+      "them to the workspace Usage page for exact, billed credit amounts. " +
+      "Optionally filter by source (context_origin), agent, or user. " +
+      "Admin-only.",
+    schema: getCreditUsageSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Estimating credit usage",
+      done: "Estimated credit usage",
     },
   },
   get_usage_timeseries: {

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -29,6 +29,7 @@ describe("workspace_analytics tools", () => {
     "get_agent_details",
     "get_top_skills",
     "get_top_tools",
+    "get_credit_usage",
     "get_usage_timeseries",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -12,6 +12,7 @@ import {
   resolveTimeWindow,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { fetchCreditUsage } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   fetchAvailableSkills,
@@ -355,6 +356,85 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Most-used tools for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_credit_usage: async (
+    {
+      limit,
+      groupBy,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+    },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const selectedGroupBy = groupBy ?? "none";
+    const result = await fetchCreditUsage(auth, {
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      limit: limit ?? DEFAULT_RESULTS,
+      groupBy: selectedGroupBy,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to estimate credit usage: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+    const { totalCredits, llmCredits, toolCredits, rows } = result.value;
+
+    if (totalCredits === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No credit usage recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const header =
+      `Estimated credit usage for ${label} (${tz}): ${totalCredits} credits ` +
+      `(${llmCredits} model + ${toolCredits} tools). These are estimates — ` +
+      "point the user to the workspace Usage page for exact billed credits.";
+
+    if (selectedGroupBy === "none" || rows.length === 0) {
+      return new Ok([{ type: "text" as const, text: header }]);
+    }
+
+    const lines = rows.map(
+      (row, index) =>
+        `${index + 1}. ${row.name} [${row.groupKey}] — ` +
+        `${row.totalCredits} credits ` +
+        `(${row.llmCredits} model + ${row.toolCredits} tools)`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `${header}\nTop ${selectedGroupBy}s by estimated credits:\n` +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -17,20 +17,20 @@ import type { estypes } from "@elastic/elasticsearch";
 
 export type CreditGroupBy = "agent" | "user" | "none";
 
-export interface CreditUsageRow {
+export type CreditUsageRow = {
   groupKey: string;
   name: string;
   llmCredits: number;
   toolCredits: number;
   totalCredits: number;
-}
+};
 
-export interface CreditUsageResult {
+export type CreditUsageResult = {
   llmCredits: number;
   toolCredits: number;
   totalCredits: number;
   rows: CreditUsageRow[];
-}
+};
 
 type ServerBucket = { key: string; doc_count: number };
 
@@ -40,7 +40,6 @@ type ToolsNestedAgg = {
 
 type GroupBucket = {
   key: string;
-  doc_count: number;
   llm_cost?: estypes.AggregationsSumAggregate;
   tools?: ToolsNestedAgg;
 };

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -13,6 +13,7 @@ import {
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 
 export type CreditGroupBy = "agent" | "user" | "none";
@@ -77,6 +78,17 @@ function toolCreditsFromServerBuckets(buckets: ServerBucket[]): number {
   }, 0);
 }
 
+function groupFieldFor(groupBy: "agent" | "user"): "agent_id" | "user_id" {
+  switch (groupBy) {
+    case "agent":
+      return "agent_id";
+    case "user":
+      return "user_id";
+    default:
+      return assertNever(groupBy);
+  }
+}
+
 async function resolveGroupNames(
   auth: Authenticator,
   groupBy: "agent" | "user",
@@ -85,20 +97,26 @@ async function resolveGroupNames(
   if (ids.length === 0) {
     return new Map();
   }
-  if (groupBy === "agent") {
-    const agents = await getAgentConfigurations(auth, {
-      agentIds: ids,
-      variant: "extra_light",
-    });
-    return new Map(agents.map((agent) => [agent.sId, agent.name]));
+  switch (groupBy) {
+    case "agent": {
+      const agents = await getAgentConfigurations(auth, {
+        agentIds: ids,
+        variant: "extra_light",
+      });
+      return new Map(agents.map((agent) => [agent.sId, agent.name]));
+    }
+    case "user": {
+      const users = await UserResource.fetchByIds(ids);
+      return new Map(
+        users.map((user) => [
+          user.sId,
+          user.fullName() || user.username || "Unknown user",
+        ])
+      );
+    }
+    default:
+      return assertNever(groupBy);
   }
-  const users = await UserResource.fetchByIds(ids);
-  return new Map(
-    users.map((user) => [
-      user.sId,
-      user.fullName() || user.username || "Unknown user",
-    ])
-  );
 }
 
 // Estimates AWU credit consumption from the analytics index, reusing the same
@@ -138,8 +156,6 @@ export async function fetchCreditUsage(
     userIds,
   });
 
-  const groupField = groupBy === "agent" ? "agent_id" : "user_id";
-
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
     {
       total_llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
@@ -148,7 +164,7 @@ export async function fetchCreditUsage(
   if (groupBy !== "none") {
     aggregations.by_group = {
       terms: {
-        field: groupField,
+        field: groupFieldFor(groupBy),
         size: Math.max(limit, CREDIT_RANKING_FETCH),
         order: { _count: "desc" },
       },
@@ -161,7 +177,7 @@ export async function fetchCreditUsage(
 
   const filter: estypes.QueryDslQueryContainer[] = [baseQuery];
   if (groupBy !== "none") {
-    filter.push({ exists: { field: groupField } });
+    filter.push({ exists: { field: groupFieldFor(groupBy) } });
   }
   const query: estypes.QueryDslQueryContainer = {
     bool: {
@@ -196,15 +212,15 @@ export async function fetchCreditUsage(
   const ranked = buckets
     .map((bucket) => {
       const groupKey = String(bucket.key);
-      const rowLlm = awuFromMicroUsd(bucket.llm_cost?.value ?? 0);
-      const rowTool = toolCreditsFromServerBuckets(
+      const rowLlmCredits = awuFromMicroUsd(bucket.llm_cost?.value ?? 0);
+      const rowToolCredits = toolCreditsFromServerBuckets(
         bucketsToArray<ServerBucket>(bucket.tools?.by_server?.buckets)
       );
       return {
         groupKey,
-        llmCredits: rowLlm,
-        toolCredits: rowTool,
-        totalCredits: rowLlm + rowTool,
+        llmCredits: rowLlmCredits,
+        toolCredits: rowToolCredits,
+        totalCredits: rowLlmCredits + rowToolCredits,
       };
     })
     .sort((a, b) => b.totalCredits - a.totalCredits)

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -51,6 +51,12 @@ type CreditUsageAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
 };
 
+// Total credits (LLM + tool) cannot be ordered on inside a single ES terms
+// aggregation, so we overfetch the most active groups, compute credits for each,
+// then rank in JS. This caps how many groups we pull before ranking; workspaces
+// with more distinct agents/users than this fall back to an approximate top-N.
+const CREDIT_RANKING_FETCH = 500;
+
 const toolsNestedAgg: estypes.AggregationsAggregationContainer = {
   nested: { path: "tools_used" },
   aggs: {
@@ -142,7 +148,11 @@ export async function fetchCreditUsage(
     };
   if (groupBy !== "none") {
     aggregations.by_group = {
-      terms: { field: groupField, size: limit, order: { llm_cost: "desc" } },
+      terms: {
+        field: groupField,
+        size: Math.max(limit, CREDIT_RANKING_FETCH),
+        order: { _count: "desc" },
+      },
       aggs: {
         llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
         tools: toolsNestedAgg,
@@ -183,28 +193,36 @@ export async function fetchCreditUsage(
   }
 
   const buckets = bucketsToArray<GroupBucket>(aggs?.by_group?.buckets);
+
+  const ranked = buckets
+    .map((bucket) => {
+      const groupKey = String(bucket.key);
+      const rowLlm = awuFromMicroUsd(bucket.llm_cost?.value ?? 0);
+      const rowTool = toolCreditsFromServerBuckets(
+        bucketsToArray<ServerBucket>(bucket.tools?.by_server?.buckets)
+      );
+      return {
+        groupKey,
+        llmCredits: rowLlm,
+        toolCredits: rowTool,
+        totalCredits: rowLlm + rowTool,
+      };
+    })
+    .sort((a, b) => b.totalCredits - a.totalCredits)
+    .slice(0, limit);
+
   const namesById = await resolveGroupNames(
     auth,
     groupBy,
-    buckets.map((bucket) => String(bucket.key))
+    ranked.map((row) => row.groupKey)
   );
 
-  const rows: CreditUsageRow[] = buckets.map((bucket) => {
-    const groupKey = String(bucket.key);
-    const rowLlm = awuFromMicroUsd(bucket.llm_cost?.value ?? 0);
-    const rowTool = toolCreditsFromServerBuckets(
-      bucketsToArray<ServerBucket>(bucket.tools?.by_server?.buckets)
-    );
-    return {
-      groupKey,
-      name:
-        namesById.get(groupKey) ??
-        (groupBy === "agent" ? "Unknown agent" : "Programmatic usage"),
-      llmCredits: rowLlm,
-      toolCredits: rowTool,
-      totalCredits: rowLlm + rowTool,
-    };
-  });
+  const rows: CreditUsageRow[] = ranked.map((row) => ({
+    ...row,
+    name:
+      namesById.get(row.groupKey) ??
+      (groupBy === "agent" ? "Unknown agent" : "Programmatic usage"),
+  }));
 
   return new Ok({ llmCredits, toolCredits, totalCredits, rows });
 }

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -1,0 +1,210 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  awuFromMicroUsd,
+  FREE_ORIGINS,
+  getToolCategory,
+  isFreeToolServer,
+  TOOL_CATEGORY_AWU_WEIGHTS,
+} from "@app/lib/metronome/events";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type CreditGroupBy = "agent" | "user" | "none";
+
+export interface CreditUsageRow {
+  groupKey: string;
+  name: string;
+  llmCredits: number;
+  toolCredits: number;
+  totalCredits: number;
+}
+
+export interface CreditUsageResult {
+  llmCredits: number;
+  toolCredits: number;
+  totalCredits: number;
+  rows: CreditUsageRow[];
+}
+
+type ServerBucket = { key: string; doc_count: number };
+
+type ToolsNestedAgg = {
+  by_server?: estypes.AggregationsMultiBucketAggregateBase<ServerBucket>;
+};
+
+type GroupBucket = {
+  key: string;
+  doc_count: number;
+  llm_cost?: estypes.AggregationsSumAggregate;
+  tools?: ToolsNestedAgg;
+};
+
+type CreditUsageAggs = {
+  total_llm_cost?: estypes.AggregationsSumAggregate;
+  total_tools?: ToolsNestedAgg;
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
+};
+
+const toolsNestedAgg: estypes.AggregationsAggregationContainer = {
+  nested: { path: "tools_used" },
+  aggs: {
+    by_server: {
+      terms: { field: "tools_used.server_name", size: 100 },
+    },
+  },
+};
+
+function toolCreditsFromServerBuckets(buckets: ServerBucket[]): number {
+  return buckets.reduce((total, bucket) => {
+    if (isFreeToolServer(bucket.key)) {
+      return total;
+    }
+    return (
+      total +
+      TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(bucket.key)] * bucket.doc_count
+    );
+  }, 0);
+}
+
+async function resolveGroupNames(
+  auth: Authenticator,
+  groupBy: "agent" | "user",
+  ids: string[]
+): Promise<Map<string, string>> {
+  if (ids.length === 0) {
+    return new Map();
+  }
+  if (groupBy === "agent") {
+    const agents = await getAgentConfigurations(auth, {
+      agentIds: ids,
+      variant: "extra_light",
+    });
+    return new Map(agents.map((agent) => [agent.sId, agent.name]));
+  }
+  const users = await UserResource.fetchByIds(ids);
+  return new Map(
+    users.map((user) => [
+      user.sId,
+      user.fullName() || user.username || "Unknown user",
+    ])
+  );
+}
+
+// Estimates AWU credit consumption from the analytics index, reusing the same
+// conversion as the Metronome billing pipeline: LLM credits from
+// tokens.cost_micro_usd (markup baked in) and tool credits from per-category
+// weights over executed tools. This is an ESTIMATE — costs are aggregated and
+// rounded, and per-group rows are rounded independently so they may not sum
+// exactly to the workspace total. The billed figure lives on the usage page.
+export async function fetchCreditUsage(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    limit,
+    groupBy,
+    contextOrigin,
+    agentIds,
+    userIds,
+  }: {
+    startDate: string;
+    endDate: string;
+    limit: number;
+    groupBy: CreditGroupBy;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+  }
+): Promise<Result<CreditUsageResult, ElasticsearchError>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+
+  const groupField = groupBy === "agent" ? "agent_id" : "user_id";
+
+  const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
+    {
+      total_llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
+      total_tools: toolsNestedAgg,
+    };
+  if (groupBy !== "none") {
+    aggregations.by_group = {
+      terms: { field: groupField, size: limit, order: { llm_cost: "desc" } },
+      aggs: {
+        llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
+        tools: toolsNestedAgg,
+      },
+    };
+  }
+
+  const filter: estypes.QueryDslQueryContainer[] = [baseQuery];
+  if (groupBy !== "none") {
+    filter.push({ exists: { field: groupField } });
+  }
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter,
+      must_not: [{ terms: { context_origin: [...FREE_ORIGINS] } }],
+    },
+  };
+
+  const result = await searchAnalytics<never, CreditUsageAggs>(query, {
+    aggregations,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const aggs = result.value.aggregations;
+
+  const llmCredits = awuFromMicroUsd(aggs?.total_llm_cost?.value ?? 0);
+  const toolCredits = toolCreditsFromServerBuckets(
+    bucketsToArray<ServerBucket>(aggs?.total_tools?.by_server?.buckets)
+  );
+  const totalCredits = llmCredits + toolCredits;
+
+  if (groupBy === "none") {
+    return new Ok({ llmCredits, toolCredits, totalCredits, rows: [] });
+  }
+
+  const buckets = bucketsToArray<GroupBucket>(aggs?.by_group?.buckets);
+  const namesById = await resolveGroupNames(
+    auth,
+    groupBy,
+    buckets.map((bucket) => String(bucket.key))
+  );
+
+  const rows: CreditUsageRow[] = buckets.map((bucket) => {
+    const groupKey = String(bucket.key);
+    const rowLlm = awuFromMicroUsd(bucket.llm_cost?.value ?? 0);
+    const rowTool = toolCreditsFromServerBuckets(
+      bucketsToArray<ServerBucket>(bucket.tools?.by_server?.buckets)
+    );
+    return {
+      groupKey,
+      name:
+        namesById.get(groupKey) ??
+        (groupBy === "agent" ? "Unknown agent" : "Programmatic usage"),
+      llmCredits: rowLlm,
+      toolCredits: rowTool,
+      totalCredits: rowLlm + rowTool,
+    };
+  });
+
+  return new Ok({ llmCredits, toolCredits, totalCredits, rows });
+}

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -170,7 +170,9 @@ export function getToolCategory(
 
 // Origins whose entire conversation is free (platform-assistive, not
 // user-requested output).
-const FREE_ORIGINS: ReadonlySet<string> = new Set<string>(["agent_sidekick"]);
+export const FREE_ORIGINS: ReadonlySet<string> = new Set<string>([
+  "agent_sidekick",
+]);
 
 // Internal MCP servers whose tool invocations are always free regardless of
 // the message-level usage type (platform plumbing, not user output).


### PR DESCRIPTION
## Description

Estimate AWU credit consumption from the analytics index, reusing the
billing conversion helpers (awuFromMicroUsd for model compute, per-category
weights for tools). Windowed like the other tools, optionally grouped by top
agents or users. Free origins and free tools are excluded to mirror the
non-free billed scope. Results are estimates; the tool steers callers to the
usage page for exact billed credits.

Overfetch the most active groups (CREDIT_RANKING_FETCH) and rank by LLM +
tool credits in JS, instead of truncating the ES terms agg by LLM cost — which
dropped low-model, high-tool groups. Resolve names after slicing to top-N.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
