### PR TITLE
fix: reject resolving blocked actions of unresumable agent messages

### DIFF
--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -85,6 +85,18 @@ export async function registerUserAnswer(
     );
   }
 
+  // A blocked action is only actionable while its agent message can still resume: answering one
+  // left behind by an interrupted, cancelled or failed message would relaunch an agent loop that
+  // was already terminated.
+  if (!(await action.canAgentMessageResume(auth))) {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "Action belongs to an agent message that can no longer resume"
+      )
+    );
+  }
+
   await action.updateStepContext({
     ...action.stepContext,
     resumeState: {
@@ -94,7 +106,10 @@ export async function registerUserAnswer(
   });
 
   // Change status to ready so the tool re-runs.
-  const [updatedCount] = await action.updateStatus("ready_allowed_explicitly");
+  const [updatedCount] = await action.updateStatusFromExpected(auth, {
+    status: "ready_allowed_explicitly",
+    expectedStatus: "blocked_user_answer_required",
+  });
 
   if (updatedCount === 0) {
     logger.info(

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -120,9 +120,22 @@ export async function resolveAuthentication(
     );
   }
 
-  const [updatedCount] = await action.updateStatus(
-    outcome === "completed" ? "ready_allowed_explicitly" : "denied"
-  );
+  // A blocked action is only actionable while its agent message can still resume: resolving one
+  // left behind by an interrupted, cancelled or failed message would relaunch an agent loop that
+  // was already terminated.
+  if (!(await action.canAgentMessageResume(auth))) {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "Action belongs to an agent message that can no longer resume"
+      )
+    );
+  }
+
+  const [updatedCount] = await action.updateStatusFromExpected(auth, {
+    status: outcome === "completed" ? "ready_allowed_explicitly" : "denied",
+    expectedStatus: blockedStatus,
+  });
 
   if (updatedCount === 0) {
     logger.info(

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -73,6 +73,13 @@ async function findUserMessageForRetry(
     return new Err(new Error("No blocked actions found"));
   }
 
+  // Blocked actions of a message that can no longer resume (interrupted, cancelled, failed) are
+  // stale leftovers: retrying them would relaunch an agent loop that was already terminated. All
+  // blocked actions belong to the same agent message, so checking the first one is enough.
+  if (!(await blockedActions[0].canAgentMessageResume(auth))) {
+    return new Err(new Error("Agent message can no longer resume"));
+  }
+
   // Purge blocked actions event message from the stream:
   // - remove tool_approve_execution events (watch out as those events are not republished).
   // - remove tool_personal_auth_required events.

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -52,6 +52,7 @@ import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -1256,6 +1257,148 @@ describe("validateAction", () => {
       if (result.isErr()) {
         expect(result.error.code).toBe("action_not_blocked");
       }
+    });
+
+    it("rejects resolving an action whose agent message can no longer resume", async () => {
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const userMessageRow =
+        await ConversationFactory.createUserMessageWithRank({
+          auth,
+          workspace,
+          conversationId: conversation.id,
+          rank: 0,
+          content: "Test message",
+        });
+
+      const messageRow = await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+
+      const { action } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: messageRow.agentMessageId!,
+      });
+
+      // Legacy stuck conversation: the message was interrupted while its blocked action was
+      // left pending. A stale approval (e.g. an old email link) must not resume the loop.
+      await ConversationFactory.setAgentMessageStatus({
+        workspace,
+        agentMessageModelId: messageRow.agentMessageId!,
+        status: "interrupted",
+      });
+
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: AgentMCPActionResource.modelIdToSId({
+          id: action.id,
+          workspaceId: workspace.id,
+        }),
+        approvalState: "approved",
+        messageId: messageRow.sId,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("action_not_blocked");
+      }
+
+      // The action was not transitioned.
+      await action.reload();
+      expect(action.status).toBe("blocked_validation_required");
+    });
+
+    it("rejects resolving authentication or file authorization whose agent message can no longer resume", async () => {
+      async function expectResolveAuthenticationRejected({
+        status,
+        kind,
+        rank,
+      }: {
+        status:
+          | "blocked_authentication_required"
+          | "blocked_file_authorization_required";
+        kind?: "file_authorization";
+        rank: number;
+      }) {
+        const messageRow = await ConversationFactory.createUserMessageWithRank({
+          auth,
+          workspace,
+          conversationId: conversation.id,
+          rank: rank - 1,
+          content: "Test message",
+        });
+        const agentConfig = await AgentConfigurationFactory.createTestAgent(
+          auth,
+          { name: `Test Agent ${rank}` }
+        );
+        const agentMessageMessage =
+          await ConversationFactory.createAgentMessageWithRank({
+            workspace,
+            conversationId: conversation.id,
+            rank,
+            agentConfigurationId: agentConfig.sId,
+            parentId: messageRow.id,
+          });
+        const { action, actionId } = await createBlockedAction({
+          agentMessageId: agentMessageMessage.agentMessageId!,
+          status,
+        });
+
+        await ConversationFactory.setAgentMessageStatus({
+          workspace,
+          agentMessageModelId: agentMessageMessage.agentMessageId!,
+          status: "interrupted",
+        });
+
+        const conversationResource = await ConversationResource.fetchById(
+          auth,
+          conversation.sId
+        );
+        expect(conversationResource).not.toBeNull();
+
+        const result = await resolveAuthentication(
+          auth,
+          conversationResource!,
+          {
+            actionId,
+            messageId: agentMessageMessage.sId,
+            outcome: "completed",
+            ...(kind ? { kind } : {}),
+          }
+        );
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+          expect(result.error.code).toBe("action_not_blocked");
+        }
+
+        await action.reload();
+        expect(action.status).toBe(status);
+      }
+
+      await expectResolveAuthenticationRejected({
+        status: "blocked_authentication_required",
+        rank: 1,
+      });
+      await expectResolveAuthenticationRejected({
+        status: "blocked_file_authorization_required",
+        kind: "file_authorization",
+        rank: 3,
+      });
     });
   });
 

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -102,11 +102,22 @@ export async function validateAction(
     );
   }
 
-  const [updatedCount] = await action.updateStatus(
-    getMCPApprovalStateFromUserApprovalState(approvalState)
-  );
+  // Stale approval links must not relaunch an already terminated agent message.
+  if (!(await action.canAgentMessageResume(auth))) {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "Action belongs to an agent message that can no longer resume"
+      )
+    );
+  }
 
-  if (approvalState === "always_approved" && user) {
+  const [updatedCount] = await action.updateStatusFromExpected(auth, {
+    status: getMCPApprovalStateFromUserApprovalState(approvalState),
+    expectedStatus: "blocked_validation_required",
+  });
+
+  if (updatedCount > 0 && approvalState === "always_approved" && user) {
     switch (action.toolConfiguration.permission) {
       case "low":
         // Key the approval on the configuration name, not the step content's

--- a/front/lib/api/assistant/email/validate_tool_from_email.test.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: vi.fn().mockReturnValue({
+    removeEvent: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("@app/temporal/agent_loop/client", () => ({
+  launchAgentLoopWorkflow: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { validateActionFromEmail } from "@app/lib/api/assistant/email/validate_tool_from_email";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+
+describe("validateActionFromEmail", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  });
+
+  it("rejects resolving an action whose agent message can no longer resume", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank: 1,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      parentId: userMessageRow.id,
+    });
+    const { action } = await AgentMCPActionFactory.create({
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: messageRow.agentMessageId!,
+    });
+
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: messageRow.agentMessageId!,
+      status: "interrupted",
+    });
+
+    const result = await validateActionFromEmail(auth, {
+      actionId: AgentMCPActionResource.modelIdToSId({
+        id: action.id,
+        workspaceId: workspace.id,
+      }),
+      approvalState: "approved",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("action_not_blocked");
+    }
+
+    await action.reload();
+    expect(action.status).toBe("blocked_validation_required");
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/assistant/email/validate_tool_from_email.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.ts
@@ -228,9 +228,22 @@ export async function validateActionFromEmail(
     );
   }
 
-  const [updatedCount] = await action.updateStatus(
-    getMCPApprovalStateFromUserApprovalState(approvalState)
-  );
+  // A blocked action is only actionable while its agent message can still resume: resolving one
+  // from a stale email link after interruption, cancellation or failure would relaunch an agent
+  // loop that was already terminated.
+  if (!(await action.canAgentMessageResume(auth))) {
+    return new Err(
+      new DustError(
+        "action_not_blocked",
+        "Action belongs to an agent message that can no longer resume"
+      )
+    );
+  }
+
+  const [updatedCount] = await action.updateStatusFromExpected(auth, {
+    status: getMCPApprovalStateFromUserApprovalState(approvalState),
+    expectedStatus: "blocked_validation_required",
+  });
 
   if (updatedCount === 0) {
     logger.info(

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -4,6 +4,7 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import {
   GCS_CONTENT_CACHE_TTL_MS,
   gcsContentCacheKey,
@@ -278,6 +279,32 @@ describe("listBlockedActionsForConversation", () => {
       workspaceId: workspace.id,
     });
     expect(result[0].actionId).toBe(expectedActionId);
+  });
+
+  it("returns zero and leaves the action unchanged when the expected status does not match", async () => {
+    const agentMessage = await AgentMessageModel.create({
+      workspaceId: workspace.id,
+      agentConfigurationId: "test-agent",
+      agentConfigurationVersion: 0,
+      status: "created",
+      skipToolsValidation: false,
+    });
+    const { action } = await createBlockedAction({
+      agentMessageModelId: agentMessage.id,
+    });
+    const actionResource = await AgentMCPActionResource.fetchByModelIdWithAuth(
+      auth,
+      action.id
+    );
+    const [affectedCount] = await actionResource!.updateStatusFromExpected(
+      auth,
+      {
+        status: "denied",
+        expectedStatus: "blocked_authentication_required",
+      }
+    );
+    expect(affectedCount).toBe(0);
+    expect((await action.reload()).status).toBe("blocked_validation_required");
   });
 });
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -66,6 +66,7 @@ import type {
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { AgentFunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { UNRESUMABLE_AGENT_MESSAGE_STATUSES } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -745,6 +746,27 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
+   * Whether the agent message owning this action can still resume, i.e. has not reached a
+   * terminal status (interrupted, cancelled, failed). Resolving a blocked action (approving,
+   * denying, answering, retrying) is only allowed while the message can resume: otherwise it
+   * would relaunch an agent loop that was already terminated.
+   */
+  async canAgentMessageResume(auth: Authenticator): Promise<boolean> {
+    const agentMessage = await AgentMessageModel.findOne({
+      attributes: ["status"],
+      where: {
+        id: this.agentMessageId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return (
+      agentMessage !== null &&
+      !UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(agentMessage.status)
+    );
+  }
+
+  /**
    * Creates output items in DB and writes their content to GCS.
    * Content is also written to DB to ease rollback during the migration period.
    */
@@ -1211,6 +1233,33 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     return this.update({
       status,
     });
+  }
+
+  /**
+   * Updates only if the action still has the expected status. Combined with the invariant that
+   * blocked actions are denied in the same transaction as their message's terminal status update
+   * (see updateAgentMessageWithFinalStatus), a blocked-status transition implies resumability.
+   */
+  async updateStatusFromExpected(
+    auth: Authenticator,
+    {
+      status,
+      expectedStatus,
+    }: {
+      status: ToolExecutionStatus;
+      expectedStatus: ToolExecutionStatus;
+    }
+  ): Promise<[affectedCount: number]> {
+    return AgentMCPActionModel.update(
+      { status },
+      {
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: expectedStatus,
+        },
+      }
+    );
   }
 
   /**

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -250,6 +250,16 @@ export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
   "gracefully_stopped",
 ];
 
+// Terminal statuses from which an agent message can never resume. Tools of such a message that
+// are still blocked on user input (e.g. a manual tool approval that was skipped when the message
+// got interrupted) are not actionable anymore. "gracefully_stopped" is not included: a graceful
+// stop keeps pending approvals actionable and approving them resumes the loop.
+export const UNRESUMABLE_AGENT_MESSAGE_STATUSES: AgentMessageStatus[] = [
+  "failed",
+  "cancelled",
+  "interrupted",
+];
+
 export function isTerminalAgentMessageStatus(
   status: AgentMessageStatus
 ): boolean {


### PR DESCRIPTION
## Description

Follow up of #27211. PR 2 of 5 for dust-tt/tasks#8755.

Rejects approving, answering, retrying, auth resolution, file authorization resolution, and email approval when the owning agent message is failed, cancelled, or interrupted. Status transitions are compare-and-swap updates on the expected blocked status. Protection against concurrent termination is completed by #27214, which denies blocked actions in the same transaction as the terminal message status update.

Stack: #27211 -> #27212 -> #27213 -> #27214 -> #27215.

## Tests

Tested locally: `NODE_ENV=test npm run test -- ./lib/api/assistant/conversation/blocked_actions.test.ts ./lib/resources/agent_mcp_action_resource.test.ts ./lib/api/assistant/conversation/validate_actions.test.ts ./lib/api/assistant/email/validate_tool_from_email.test.ts`; `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` from `front/` and `front-api/`.

## Risk

Low. Only blocks actions whose agent message cannot resume, and leaves already-resolved races as no-op transitions.

## Deploy Plan

Deploy after #27211.
