### PR TITLE
fix: clear stale actionRequired flag for conversations stuck in the inbox

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,4 +1,5 @@
 import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
+import { clearActionRequiredIfNoBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import type {
   GetConversationResponseBody,
@@ -285,6 +286,16 @@ app.patch(
         await ConversationResource.markAsReadForAuthUser(auth, {
           conversation,
         });
+
+        // A stale `actionRequired` flag (e.g. left behind by a manual tool approval whose
+        // message got interrupted before blocked actions were resolved on termination) would
+        // keep the conversation stuck in the unread inbox: self-heal it when no actionable
+        // blocked action remains.
+        if (conversation.actionRequired) {
+          await clearActionRequiredIfNoBlockedActions(auth, {
+            conversationId: conversation.sId,
+          });
+        }
       } else {
         await ConversationResource.markAsUnreadForAuthUser(auth, {
           conversation,

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -1,0 +1,111 @@
+import { clearActionRequiredIfNoBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("blocked actions resolution", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+
+    await ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+      user: auth.getNonNullableUser().toJSON(),
+    });
+  });
+
+  async function createAgentMessageAtRank(rank: number) {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: `Test Agent ${rank}`,
+    });
+
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: rank - 1,
+      content: "Test message",
+    });
+
+    const messageRow = await ConversationFactory.createAgentMessageWithRank({
+      workspace,
+      conversationId: conversation.id,
+      rank,
+      agentConfigurationId: agentConfig.sId,
+      agentConfigurationVersion: agentConfig.version,
+      parentId: userMessageRow.id,
+    });
+
+    return { messageRow, agentMessageRowId: messageRow.agentMessageId! };
+  }
+
+  async function getActionRequired() {
+    const { actionRequired } =
+      await ConversationResource.getActionRequiredAndLastReadAtForUser(
+        auth,
+        conversation.id
+      );
+    return actionRequired;
+  }
+
+  describe("clearActionRequiredIfNoBlockedActions", () => {
+    it("clears the flag when the only blocked action belongs to an unresumable message", async () => {
+      const { agentMessageRowId } = await createAgentMessageAtRank(1);
+      await AgentMCPActionFactory.create({
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: agentMessageRowId,
+      });
+      await ConversationFactory.setAgentMessageStatus({
+        workspace,
+        agentMessageModelId: agentMessageRowId,
+        status: "interrupted",
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+      expect(await getActionRequired()).toBe(true);
+
+      await clearActionRequiredIfNoBlockedActions(auth, {
+        conversationId: conversation.sId,
+      });
+
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("does not clear the flag when an actionable blocked action remains", async () => {
+      const { agentMessageRowId } = await createAgentMessageAtRank(1);
+      await AgentMCPActionFactory.create({
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: agentMessageRowId,
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+      expect(await getActionRequired()).toBe(true);
+
+      await clearActionRequiredIfNoBlockedActions(auth, {
+        conversationId: conversation.sId,
+      });
+
+      expect(await getActionRequired()).toBe(true);
+    });
+  });
+});

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,5 +1,40 @@
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 
 export type GetBlockedActionsResponseType = {
   blockedActions: BlockedToolExecution[];
 };
+
+/**
+ * Clears the participants' `actionRequired` flag of a conversation if no blocked action remains.
+ * The flag is denormalized (set when a tool starts waiting on user input, cleared when an agent
+ * loop is launched), so it can go stale when a blocked message is terminated without its blocked
+ * actions being resolved.
+ */
+export async function clearActionRequiredIfNoBlockedActions(
+  auth: Authenticator,
+  { conversationId }: { conversationId: string }
+): Promise<void> {
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId
+  );
+  if (!conversation) {
+    return;
+  }
+
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForConversation(
+      auth,
+      conversation
+    );
+
+  if (blockedActions.length === 0) {
+    await ConversationResource.clearActionRequiredForConversation(
+      auth,
+      conversation
+    );
+  }
+}

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -212,6 +212,58 @@ describe("listBlockedActionsForConversation", () => {
     expect(result[0].status).toBe("blocked_validation_required");
   });
 
+  it("should not return blocked actions whose agent message can no longer resume", async () => {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    // Create user message at rank 0.
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank: 0,
+      content: "Test message",
+    });
+
+    // Create agent message at rank 1 with a blocked action.
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+
+    await createBlockedAction({
+      agentMessageModelId: agentMessageRow.agentMessageId!,
+    });
+
+    // Interrupt the agent message (e.g. the user skipped it), leaving the blocked action behind.
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId: agentMessageRow.agentMessageId!,
+      status: "interrupted",
+    });
+
+    const conversationResource = await ConversationResource.fetchById(
+      auth,
+      conversation.sId
+    );
+    expect(conversationResource).not.toBeNull();
+
+    const result =
+      await AgentMCPActionResource.listBlockedActionsForConversation(
+        auth,
+        conversationResource!
+      );
+
+    // The blocked action is not actionable anymore: it must not be returned.
+    expect(result).toEqual([]);
+  });
+
   it("should only return blocked actions from the latest agent message version at a given rank", async () => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -313,7 +313,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     // Scope by agentMessageId to fully use the (workspaceId, agentMessageId, status) index,
     // avoiding a broad scan + join through messages to filter by conversationId.
-    const blockedActions = await AgentMCPActionModel.findAll({
+    const blockedActionRows = await AgentMCPActionModel.findAll({
       include: [
         {
           model: AgentMessageModel,
@@ -323,6 +323,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             "id",
             "agentConfigurationId",
             "agentConfigurationVersion",
+            "status",
           ],
           include: [
             {
@@ -343,6 +344,15 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       },
       order: [["createdAt", "ASC"]],
     });
+
+    // A blocked action is only actionable while its agent message can still resume: exclude
+    // actions left behind by messages that were interrupted, cancelled or failed before their
+    // blocked tools got resolved. Filtered application-side: agent_messages has no index on
+    // status, and the rows are already narrowed to the conversation's latest agent messages.
+    const blockedActions = blockedActionRows.filter(
+      (a) =>
+        !UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(a.agentMessage!.status)
+    );
 
     const parentUserMessageIds = removeNulls(
       blockedActions.map((a) => a.agentMessage!.message!.parentId)

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -2560,6 +2560,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return new Err(new ConversationError("conversation_not_found"));
     }
 
+    return this.clearActionRequiredForConversation(auth, conversation);
+  }
+
+  static async clearActionRequiredForConversation(
+    auth: Authenticator,
+    conversation: ConversationResource
+  ) {
     const updated = await ConversationParticipantModel.update(
       { actionRequired: false },
       {


### PR DESCRIPTION
## Description

Follow up of #27212. PR 3 of 5 for dust-tt/tasks#8755.

Filters unresumable message actions out of conversation blocked-action lists and clears stale `actionRequired` when marking a conversation read if no actionable blocked action remains. Fixes the existing stuck inbox symptom.

Stack: #27211 -> #27212 -> #27213 -> #27214 -> #27215.

## Tests

Tested locally: `NODE_ENV=test npm run test -- ./lib/resources/agent_mcp_action_resource.test.ts ./lib/api/assistant/conversation/blocked_actions.test.ts`; `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` from `front/` and `front-api/`.

## Risk

Medium. Changes read handling and a denormalized inbox flag, guarded by the blocked-action lookup.

## Deploy Plan

Deploy after #27212.