### PR TITLE
fix: deny blocked tool actions when an agent message is terminated

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getRelatedContentFragments } from "@app/lib/api/assistant/content_fragments";
 import { runAgentLoopWorkflow } from "@app/lib/api/assistant/conversation/agent_loop";
+import { cleanupDeniedBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import {
   getConversationRankVersionLock,
@@ -87,6 +88,7 @@ import {
 import { notifyNewProjectConversation } from "@app/lib/notifications/triggers/project-new-conversation";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
 import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -143,6 +145,7 @@ import {
   isCompactionMessageType,
   isPodConversation,
   isUserMessageType,
+  UNRESUMABLE_AGENT_MESSAGE_STATUSES,
 } from "@app/types/assistant/conversation";
 import type { MentionType } from "@app/types/assistant/mentions";
 import {
@@ -3065,6 +3068,7 @@ export async function updateAgentMessageWithFinalStatus(
     promotedUserMessages,
     promotedAuth,
     agentMessage: newAgentMessage,
+    deniedActions,
   } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
@@ -3089,6 +3093,13 @@ export async function updateAgentMessageWithFinalStatus(
       }
     );
 
+    const deniedActions = UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)
+      ? await AgentMCPActionResource.denyBlockedActionsForAgentMessage(auth, {
+          agentMessageId: agentMessage.agentMessageId,
+          transaction: t,
+        })
+      : [];
+
     // Promote *all* pending messages when the agent loop ends. If a pending message exists it
     // will be promoted and will trigger the ending agentMessage. The `enableSteering` invariants
     // of postUserMessage ensure that we have only one running agentic loop so we can just
@@ -3109,6 +3120,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
         promotedAuth: auth,
         agentMessage: null as AgentMessageType | null,
+        deniedActions,
       };
     }
 
@@ -3164,6 +3176,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages,
         promotedAuth,
         agentMessage: null,
+        deniedActions,
       };
     }
 
@@ -3175,6 +3188,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedUserMessages,
         promotedAuth,
         agentMessage: null,
+        deniedActions,
       };
     }
 
@@ -3201,6 +3215,7 @@ export async function updateAgentMessageWithFinalStatus(
       promotedUserMessages,
       promotedAuth,
       agentMessage: agentMessages[0] ?? null,
+      deniedActions,
     };
   });
 
@@ -3245,6 +3260,20 @@ export async function updateAgentMessageWithFinalStatus(
       agentMessages: [newAgentMessage],
       conversation,
       userMessage: promotedUserMessages[promotedUserMessages.length - 1],
+    });
+  }
+
+  // The agent message will never resume: tools still waiting on user input (e.g. a manual
+  // approval that the user skipped by interrupting the message) will never run. They were
+  // denied with the terminal status update; clean up side effects so the conversation doesn't
+  // stay flagged as requiring an action in the inbox. Runs last so a cleanup failure cannot
+  // strand the promoted messages above (the cleanup itself is
+  // idempotent, so an activity retry converges).
+  if (UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)) {
+    await cleanupDeniedBlockedActions(auth, {
+      conversation,
+      agentMessage,
+      deniedActions,
     });
   }
 

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -1,5 +1,22 @@
-import { clearActionRequiredIfNoBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Redis hybrid manager to prevent it from removing events
+const { removeEventMock } = vi.hoisted(() => ({
+  removeEventMock: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: vi.fn().mockReturnValue({
+    removeEvent: removeEventMock,
+  }),
+}));
+
+import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import {
+  cleanupDeniedBlockedActions,
+  clearActionRequiredIfNoBlockedActions,
+} from "@app/lib/api/assistant/conversation/blocked_actions";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
@@ -7,7 +24,6 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
 
 describe("blocked actions resolution", () => {
   let workspace: WorkspaceType;
@@ -15,6 +31,8 @@ describe("blocked actions resolution", () => {
   let conversation: ConversationType;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+
     const setup = await createResourceTest({});
     workspace = setup.workspace;
     auth = setup.authenticator;
@@ -66,6 +84,157 @@ describe("blocked actions resolution", () => {
     return actionRequired;
   }
 
+  describe("cleanupDeniedBlockedActions", () => {
+    it("denies blocked actions and clears actionRequired when none remain", async () => {
+      const { messageRow, agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+      expect(await getActionRequired()).toBe(true);
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+
+      // The pending approval event was removed from the message channel.
+      expect(removeEventMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.stringContaining(messageRow.sId)
+      );
+
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("keeps actionRequired when another message still has a blocked action", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+
+      const { agentMessageRowId: otherAgentMessageRowId } =
+        await createAgentMessageAtRank(3);
+      const { action: otherAction } = await AgentMCPActionFactory.create({
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId: otherAgentMessageRowId,
+      });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+
+      // The other message's blocked action is untouched and keeps the flag up.
+      await otherAction.reload();
+      expect(otherAction.status).toBe("blocked_validation_required");
+      expect(await getActionRequired()).toBe(true);
+    });
+
+    it("still clears a stale actionRequired flag when no blocked action remains", async () => {
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        { workspace, conversation, agentConfig }
+      );
+
+      // Simulate a partial previous run: blocked actions already denied, but the run failed
+      // before clearing the flag. A retry must converge.
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await cleanupDeniedBlockedActions(auth, {
+        conversation,
+        agentMessage,
+        deniedActions: [],
+      });
+
+      expect(removeEventMock).not.toHaveBeenCalled();
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("denies non-approval blocked actions and purges all blocked-action events", async () => {
+      const { messageRow, agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+          status: "blocked_authentication_required",
+        });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+
+      // The removal predicate matches every blocked-action event type of the denied action,
+      // not only approval events.
+      const [predicate, channel] = removeEventMock.mock.calls[0];
+      expect(channel).toContain(messageRow.sId);
+
+      const actionId = AgentMCPActionResource.modelIdToSId({
+        id: action.id,
+        workspaceId: workspace.id,
+      });
+      const makeEvent = (type: string, eventActionId: string) => ({
+        message: {
+          payload: JSON.stringify({ type, actionId: eventActionId }),
+        },
+      });
+      expect(
+        predicate(makeEvent("tool_personal_auth_required", actionId))
+      ).toBe(true);
+      expect(predicate(makeEvent("tool_ask_user_question", actionId))).toBe(
+        true
+      );
+      expect(predicate(makeEvent("tool_approve_execution", actionId))).toBe(
+        true
+      );
+      expect(
+        predicate(makeEvent("tool_approve_execution", "other_action_id"))
+      ).toBe(false);
+    });
+
+    it("commits the deny with the terminal status update", async () => {
+      const { agentMessage } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await expect(
+        AgentMCPActionResource.listBlockedActionsForAgentMessage(auth, {
+          agentMessageId: agentMessage.agentMessageId,
+        })
+      ).resolves.toEqual([]);
+    });
+  });
+
   describe("clearActionRequiredIfNoBlockedActions", () => {
     it("clears the flag when the only blocked action belongs to an unresumable message", async () => {
       const { agentMessageRowId } = await createAgentMessageAtRank(1);
@@ -74,6 +243,9 @@ describe("blocked actions resolution", () => {
         conversationModelId: conversation.id,
         agentMessageModelId: agentMessageRowId,
       });
+
+      // Simulate a legacy stuck conversation: the message was interrupted while its blocked
+      // action was left pending.
       await ConversationFactory.setAgentMessageStatus({
         workspace,
         agentMessageModelId: agentMessageRowId,
@@ -99,12 +271,54 @@ describe("blocked actions resolution", () => {
       });
 
       await ConversationResource.markAsActionRequired(auth, { conversation });
-      expect(await getActionRequired()).toBe(true);
 
       await clearActionRequiredIfNoBlockedActions(auth, {
         conversationId: conversation.sId,
       });
 
+      expect(await getActionRequired()).toBe(true);
+    });
+  });
+
+  describe("updateAgentMessageWithFinalStatus", () => {
+    it("denies blocked actions when the message is interrupted", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await action.reload();
+      expect(action.status).toBe("denied");
+      expect(await getActionRequired()).toBe(false);
+    });
+
+    it("leaves blocked actions untouched when the message is gracefully stopped", async () => {
+      const { agentMessage, action } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+
+      await ConversationResource.markAsActionRequired(auth, { conversation });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "gracefully_stopped",
+      });
+
+      // A graceful stop keeps pending approvals actionable.
+      await action.reload();
+      expect(action.status).toBe("blocked_validation_required");
       expect(await getActionRequired()).toBe(true);
     });
   });

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,11 +1,65 @@
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { isBlockedActionEvent } from "@app/lib/actions/mcp";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import type {
+  AgentMessageType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 
 export type GetBlockedActionsResponseType = {
   blockedActions: BlockedToolExecution[];
 };
+
+/**
+ * Cleans up the blocked actions of an agent message that reached a terminal status
+ * (interrupted, cancelled, failed, ...). The actions were already denied in the same
+ * transaction as the message's terminal status update; post-commit side effects happen here.
+ */
+export async function cleanupDeniedBlockedActions(
+  auth: Authenticator,
+  {
+    conversation,
+    agentMessage,
+    deniedActions,
+  }: {
+    conversation: ConversationWithoutContentType;
+    agentMessage: Pick<AgentMessageType, "agentMessageId" | "sId">;
+    deniedActions: AgentMCPActionResource[];
+  }
+): Promise<void> {
+  if (deniedActions.length > 0) {
+    logger.info(
+      {
+        actionIds: deniedActions.map((a) => a.sId),
+        conversationId: conversation.sId,
+        messageId: agentMessage.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+      },
+      "Denied blocked actions of terminated agent message"
+    );
+
+    // Remove the pending blocked-action events (approval requests, auth requests, user
+    // questions) from the message channel so live clients stop surfacing prompts for them.
+    const deniedActionIds = new Set(deniedActions.map((a) => a.sId));
+    await getRedisHybridManager().removeEvent((event) => {
+      const payload = JSON.parse(event.message["payload"]);
+      return (
+        isBlockedActionEvent(payload) && deniedActionIds.has(payload.actionId)
+      );
+    }, getMessageChannelId(agentMessage.sId));
+  }
+
+  // Always re-check the flag, even when no blocked action remains: a partial previous run may
+  // have denied the actions but failed before clearing it, and a retry must converge.
+  await clearActionRequiredIfNoBlockedActions(auth, {
+    conversationId: conversation.sId,
+  });
+}
 
 /**
  * Clears the participants' `actionRequired` flag of a conversation if no blocked action remains.

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -729,16 +729,23 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   static async listBlockedActionsForAgentMessage(
     auth: Authenticator,
-    { agentMessageId }: { agentMessageId: ModelId }
+    {
+      agentMessageId,
+      transaction,
+    }: { agentMessageId: ModelId; transaction?: Transaction }
   ): Promise<AgentMCPActionResource[]> {
-    const actions = await this.baseFetch(auth, {
-      where: {
-        agentMessageId,
-        status: {
-          [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES,
+    const actions = await this.baseFetch(
+      auth,
+      {
+        where: {
+          agentMessageId,
+          status: {
+            [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES,
+          },
         },
       },
-    });
+      transaction
+    );
 
     if (actions.length === 0) {
       return [];
@@ -753,6 +760,50 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
 
     return actions;
+  }
+
+  /**
+   * Denies all still-blocked actions of an agent message. Must run inside the same
+   * transaction as the message's terminal status update so that "message terminal" and
+   * "blocked actions denied" commit atomically. Guarded on blocked statuses so a concurrent
+   * approval that already transitioned the action is not clobbered. Returns the actions
+   * actually denied, with their pre-deny resources.
+   */
+  static async denyBlockedActionsForAgentMessage(
+    auth: Authenticator,
+    {
+      agentMessageId,
+      transaction,
+    }: { agentMessageId: ModelId; transaction: Transaction }
+  ): Promise<AgentMCPActionResource[]> {
+    const blockedActions = await this.listBlockedActionsForAgentMessage(auth, {
+      agentMessageId,
+      transaction,
+    });
+
+    if (blockedActions.length === 0) {
+      return [];
+    }
+
+    const [, affectedRows] = await AgentMCPActionModel.update(
+      { status: "denied" },
+      {
+        where: {
+          // Scoping by agentMessageId lets the (workspaceId, agentMessageId, status) index
+          // drive the update; the id list keeps it restricted to the rows fetched above.
+          agentMessageId,
+          id: { [Op.in]: blockedActions.map((a) => a.id) },
+          workspaceId: auth.getNonNullableWorkspace().id,
+          status: { [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES },
+        },
+        returning: true,
+        transaction,
+      }
+    );
+
+    const deniedActionIds = new Set(affectedRows.map((a) => a.id));
+
+    return blockedActions.filter((a) => deniedActionIds.has(a.id));
   }
 
   /**

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -301,7 +301,8 @@ export async function processEventForDatabase(
       break;
 
     case "agent_generation_cancelled":
-      // Store cancellation in database.
+      // Store cancellation in database. Also denies blocked actions of the cancelled message
+      // (via updateAgentMessageWithFinalStatus).
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         conversation,

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -1,9 +1,18 @@
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import type {
+  AgentMessageType,
+  ConversationType,
+  ConversationWithoutContentType,
+} from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
 
@@ -100,5 +109,46 @@ export class AgentMCPActionFactory {
     });
 
     return { action, stepContent };
+  }
+
+  /**
+   * Creates an agent message (with a fresh test agent configuration) holding a single MCP
+   * action, blocked on tool validation by default.
+   */
+  static async createWithAgentMessage(
+    auth: Authenticator,
+    {
+      workspace,
+      conversation,
+      status = "blocked_validation_required",
+    }: {
+      workspace: WorkspaceType;
+      conversation: ConversationType | ConversationWithoutContentType;
+      status?: ToolExecutionStatus;
+    }
+  ): Promise<{
+    messageRow: MessageModel;
+    agentMessage: AgentMessageType;
+    action: AgentMCPActionModel;
+  }> {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+
+    const { messageRow, agentMessage } =
+      await ConversationFactory.createAgentMessage(auth, {
+        workspace,
+        conversation,
+        agentConfig,
+      });
+
+    const { action } = await this.create({
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status,
+    });
+
+    return { messageRow, agentMessage, action };
   }
 }


### PR DESCRIPTION
## Description

Follow up of #27213. PR 4 of 5 for dust-tt/tasks#8755.

Denies still-blocked tool actions in the same transaction as the failed, cancelled, or interrupted agent-message status update. After commit, it purges pending blocked-action stream events and rechecks `actionRequired` so retries converge.

Stack: #27211 -> #27212 -> #27213 -> #27214 -> #27215.

## Tests

Tested locally: `NODE_ENV=test npm run test -- ./lib/api/assistant/conversation/blocked_actions.test.ts ./lib/resources/agent_mcp_action_resource.test.ts ./lib/api/assistant/conversation/validate_actions.test.ts ./lib/api/assistant/email/validate_tool_from_email.test.ts`; `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` from `front/` and `front-api/`.

## Risk

Medium. Denial is guarded on blocked statuses to avoid clobbering concurrent resolution. The status update and denial commit atomically, and post-commit cleanup remains idempotent.

## Deploy Plan

Deploy after #27213.
