### PR TITLE
audit: emit tool.approval_resolved for auto-denied approvals

### DIFF
--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock Redis hybrid manager to prevent it from removing events
-const { removeEventMock } = vi.hoisted(() => ({
+const { emitAuditLogEventDirectMock, removeEventMock } = vi.hoisted(() => ({
+  emitAuditLogEventDirectMock: vi.fn().mockResolvedValue(undefined),
   removeEventMock: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
@@ -9,6 +10,15 @@ vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
     removeEvent: removeEventMock,
   }),
 }));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+  return {
+    ...actual,
+    emitAuditLogEventDirect: emitAuditLogEventDirectMock,
+  };
+});
 
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import {
@@ -103,6 +113,30 @@ describe("blocked actions resolution", () => {
 
       await action.reload();
       expect(action.status).toBe("denied");
+
+      const actionId = AgentMCPActionResource.modelIdToSId({
+        id: action.id,
+        workspaceId: workspace.id,
+      });
+      await vi.waitFor(() =>
+        expect(emitAuditLogEventDirectMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: "tool.approval_resolved",
+            actor: {
+              type: "system",
+              id: "agent-message-termination",
+              name: "Agent message termination",
+            },
+            context: { location: "internal" },
+            metadata: expect.objectContaining({
+              action_id: actionId,
+              decision: "auto_rejected",
+              deciding_user_email: "system",
+              deciding_user_id: "system",
+            }),
+          })
+        )
+      );
 
       // The pending approval event was removed from the message channel.
       expect(removeEventMock).toHaveBeenCalledWith(
@@ -212,6 +246,57 @@ describe("blocked actions resolution", () => {
       expect(
         predicate(makeEvent("tool_approve_execution", "other_action_id"))
       ).toBe(false);
+      expect(emitAuditLogEventDirectMock).not.toHaveBeenCalled();
+    });
+
+    it("emits approval audit events only for actions actually denied", async () => {
+      const { agentMessage, action: deniedAction } =
+        await AgentMCPActionFactory.createWithAgentMessage(auth, {
+          workspace,
+          conversation,
+        });
+      const { action: alreadyResolvedAction } =
+        await AgentMCPActionFactory.create({
+          workspace,
+          conversationModelId: conversation.id,
+          agentMessageModelId: agentMessage.agentMessageId,
+        });
+      await alreadyResolvedAction.update({
+        status: "ready_allowed_explicitly",
+      });
+
+      await updateAgentMessageWithFinalStatus(auth, {
+        conversation,
+        agentMessage,
+        status: "interrupted",
+      });
+
+      await vi.waitFor(() =>
+        expect(emitAuditLogEventDirectMock).toHaveBeenCalledTimes(1)
+      );
+
+      const deniedActionId = AgentMCPActionResource.modelIdToSId({
+        id: deniedAction.id,
+        workspaceId: workspace.id,
+      });
+      const alreadyResolvedActionId = AgentMCPActionResource.modelIdToSId({
+        id: alreadyResolvedAction.id,
+        workspaceId: workspace.id,
+      });
+      expect(emitAuditLogEventDirectMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            action_id: deniedActionId,
+          }),
+        })
+      );
+      expect(emitAuditLogEventDirectMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            action_id: alreadyResolvedActionId,
+          }),
+        })
+      );
     });
 
     it("commits the deny with the terminal status update", async () => {

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -111,13 +111,12 @@ describe("blocked actions resolution", () => {
         status: "interrupted",
       });
 
-      await action.reload();
-      expect(action.status).toBe("denied");
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
 
-      const actionId = AgentMCPActionResource.modelIdToSId({
-        id: action.id,
-        workspaceId: workspace.id,
-      });
       await vi.waitFor(() =>
         expect(emitAuditLogEventDirectMock).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -129,7 +128,7 @@ describe("blocked actions resolution", () => {
             },
             context: { location: "internal" },
             metadata: expect.objectContaining({
-              action_id: actionId,
+              action_id: action.sId,
               decision: "auto_rejected",
               deciding_user_email: "system",
               deciding_user_id: "system",
@@ -156,7 +155,7 @@ describe("blocked actions resolution", () => {
 
       const { agentMessageRowId: otherAgentMessageRowId } =
         await createAgentMessageAtRank(3);
-      const { action: otherAction } = await AgentMCPActionFactory.create({
+      const { action: otherAction } = await AgentMCPActionFactory.create(auth, {
         workspace,
         conversationModelId: conversation.id,
         agentMessageModelId: otherAgentMessageRowId,
@@ -170,12 +169,18 @@ describe("blocked actions resolution", () => {
         status: "interrupted",
       });
 
-      await action.reload();
-      expect(action.status).toBe("denied");
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
 
       // The other message's blocked action is untouched and keeps the flag up.
-      await otherAction.reload();
-      expect(otherAction.status).toBe("blocked_validation_required");
+      const reloadedOtherAction = await AgentMCPActionResource.fetchById(
+        auth,
+        otherAction.sId
+      );
+      expect(reloadedOtherAction?.status).toBe("blocked_validation_required");
       expect(await getActionRequired()).toBe(true);
     });
 
@@ -217,18 +222,18 @@ describe("blocked actions resolution", () => {
         status: "interrupted",
       });
 
-      await action.reload();
-      expect(action.status).toBe("denied");
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
 
       // The removal predicate matches every blocked-action event type of the denied action,
       // not only approval events.
       const [predicate, channel] = removeEventMock.mock.calls[0];
       expect(channel).toContain(messageRow.sId);
 
-      const actionId = AgentMCPActionResource.modelIdToSId({
-        id: action.id,
-        workspaceId: workspace.id,
-      });
+      const actionId = action.sId;
       const makeEvent = (type: string, eventActionId: string) => ({
         message: {
           payload: JSON.stringify({ type, actionId: eventActionId }),
@@ -256,14 +261,12 @@ describe("blocked actions resolution", () => {
           conversation,
         });
       const { action: alreadyResolvedAction } =
-        await AgentMCPActionFactory.create({
+        await AgentMCPActionFactory.create(auth, {
           workspace,
           conversationModelId: conversation.id,
           agentMessageModelId: agentMessage.agentMessageId,
         });
-      await alreadyResolvedAction.update({
-        status: "ready_allowed_explicitly",
-      });
+      await alreadyResolvedAction.updateStatus("ready_allowed_explicitly");
 
       await updateAgentMessageWithFinalStatus(auth, {
         conversation,
@@ -275,25 +278,17 @@ describe("blocked actions resolution", () => {
         expect(emitAuditLogEventDirectMock).toHaveBeenCalledTimes(1)
       );
 
-      const deniedActionId = AgentMCPActionResource.modelIdToSId({
-        id: deniedAction.id,
-        workspaceId: workspace.id,
-      });
-      const alreadyResolvedActionId = AgentMCPActionResource.modelIdToSId({
-        id: alreadyResolvedAction.id,
-        workspaceId: workspace.id,
-      });
       expect(emitAuditLogEventDirectMock).toHaveBeenCalledWith(
         expect.objectContaining({
           metadata: expect.objectContaining({
-            action_id: deniedActionId,
+            action_id: deniedAction.sId,
           }),
         })
       );
       expect(emitAuditLogEventDirectMock).not.toHaveBeenCalledWith(
         expect.objectContaining({
           metadata: expect.objectContaining({
-            action_id: alreadyResolvedActionId,
+            action_id: alreadyResolvedAction.sId,
           }),
         })
       );
@@ -323,7 +318,7 @@ describe("blocked actions resolution", () => {
   describe("clearActionRequiredIfNoBlockedActions", () => {
     it("clears the flag when the only blocked action belongs to an unresumable message", async () => {
       const { agentMessageRowId } = await createAgentMessageAtRank(1);
-      await AgentMCPActionFactory.create({
+      await AgentMCPActionFactory.create(auth, {
         workspace,
         conversationModelId: conversation.id,
         agentMessageModelId: agentMessageRowId,
@@ -349,7 +344,7 @@ describe("blocked actions resolution", () => {
 
     it("does not clear the flag when an actionable blocked action remains", async () => {
       const { agentMessageRowId } = await createAgentMessageAtRank(1);
-      await AgentMCPActionFactory.create({
+      await AgentMCPActionFactory.create(auth, {
         workspace,
         conversationModelId: conversation.id,
         agentMessageModelId: agentMessageRowId,
@@ -381,8 +376,11 @@ describe("blocked actions resolution", () => {
         status: "interrupted",
       });
 
-      await action.reload();
-      expect(action.status).toBe("denied");
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("denied");
       expect(await getActionRequired()).toBe(false);
     });
 
@@ -402,8 +400,11 @@ describe("blocked actions resolution", () => {
       });
 
       // A graceful stop keeps pending approvals actionable.
-      await action.reload();
-      expect(action.status).toBe("blocked_validation_required");
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("blocked_validation_required");
       expect(await getActionRequired()).toBe(true);
     });
   });

--- a/front/lib/api/assistant/conversation/blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.ts
@@ -1,6 +1,10 @@
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { isBlockedActionEvent } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -10,6 +14,7 @@ import type {
   AgentMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export type GetBlockedActionsResponseType = {
   blockedActions: BlockedToolExecution[];
@@ -33,6 +38,12 @@ export async function cleanupDeniedBlockedActions(
   }
 ): Promise<void> {
   if (deniedActions.length > 0) {
+    emitApprovalResolvedAuditEvents(auth, {
+      conversation,
+      agentMessage,
+      deniedActions,
+    });
+
     logger.info(
       {
         actionIds: deniedActions.map((a) => a.sId),
@@ -59,6 +70,91 @@ export async function cleanupDeniedBlockedActions(
   await clearActionRequiredIfNoBlockedActions(auth, {
     conversationId: conversation.sId,
   });
+}
+
+/**
+ * Emits a `tool.approval_resolved` audit event for each manual approval that was auto-denied
+ * when its agent message terminated, so the audit trail doesn't keep `tool.approval_requested`
+ * entries without a resolution. Fire-and-forget (AUDIT1): must never block or break the
+ * termination flow.
+ */
+function emitApprovalResolvedAuditEvents(
+  auth: Authenticator,
+  {
+    conversation,
+    agentMessage,
+    deniedActions,
+  }: {
+    conversation: ConversationWithoutContentType;
+    agentMessage: Pick<AgentMessageType, "agentMessageId" | "sId">;
+    deniedActions: AgentMCPActionResource[];
+  }
+): void {
+  // `deniedActions` are resources fetched before the transaction updates their rows, so their
+  // in-memory status still identifies which blocked state they had before being denied.
+  const deniedApprovals = deniedActions.filter(
+    (a) => a.status === "blocked_validation_required"
+  );
+  if (deniedApprovals.length === 0) {
+    return;
+  }
+
+  void (async () => {
+    try {
+      // All blocked actions belong to the same agent message, so resolve the agent
+      // configuration once.
+      const auditAgentConfig =
+        await deniedApprovals[0].getLightAgentConfiguration(auth);
+      if (!auditAgentConfig) {
+        return;
+      }
+      const workspace = auth.getNonNullableWorkspace();
+      for (const action of deniedApprovals) {
+        void emitAuditLogEventDirect({
+          workspace,
+          action: "tool.approval_resolved",
+          // Auto-denial is a mechanical termination cleanup, not a user approval decision.
+          actor: {
+            type: "system",
+            id: "agent-message-termination",
+            name: "Agent message termination",
+          },
+          targets: [
+            buildAuditLogTarget("workspace", workspace),
+            buildAuditLogTarget("agent", auditAgentConfig),
+            buildAuditLogTarget("tool", {
+              sId: action.toolConfiguration.name,
+              name: action.toolConfiguration.originalName,
+            }),
+          ],
+          context: { location: "internal" },
+          metadata: {
+            // Distinct from the user decisions ("approved", "rejected", ...): the approval was
+            // resolved by the system because the message terminated, not by an explicit user
+            // choice.
+            decision: "auto_rejected",
+            tool_name: action.toolConfiguration.originalName,
+            mcp_server_name: action.toolConfiguration.mcpServerName,
+            stake_level: action.toolConfiguration.permission,
+            conversation_id: conversation.sId,
+            agent_message_id: agentMessage.sId,
+            action_id: action.sId,
+            deciding_user_id: "system",
+            deciding_user_email: "system",
+          },
+        });
+      }
+    } catch (err) {
+      logger.error(
+        {
+          err: normalizeError(err),
+          conversationId: conversation.sId,
+          messageId: agentMessage.sId,
+        },
+        "Failed to emit tool.approval_resolved audit events for terminated message"
+      );
+    }
+  })();
 }
 
 /**

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -1283,7 +1283,7 @@ describe("validateAction", () => {
         parentId: userMessageRow.id,
       });
 
-      const { action } = await AgentMCPActionFactory.create({
+      const { action } = await AgentMCPActionFactory.create(auth, {
         workspace,
         conversationModelId: conversation.id,
         agentMessageModelId: messageRow.agentMessageId!,
@@ -1304,10 +1304,7 @@ describe("validateAction", () => {
       expect(conversationResource).not.toBeNull();
 
       const result = await validateAction(auth, conversationResource!, {
-        actionId: AgentMCPActionResource.modelIdToSId({
-          id: action.id,
-          workspaceId: workspace.id,
-        }),
+        actionId: action.sId,
         approvalState: "approved",
         messageId: messageRow.sId,
       });
@@ -1318,8 +1315,11 @@ describe("validateAction", () => {
       }
 
       // The action was not transitioned.
-      await action.reload();
-      expect(action.status).toBe("blocked_validation_required");
+      const reloadedAction = await AgentMCPActionResource.fetchById(
+        auth,
+        action.sId
+      );
+      expect(reloadedAction?.status).toBe("blocked_validation_required");
     });
 
     it("rejects resolving authentication or file authorization whose agent message can no longer resume", async () => {

--- a/front/lib/api/assistant/email/validate_tool_from_email.test.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.test.ts
@@ -59,7 +59,7 @@ describe("validateActionFromEmail", () => {
       agentConfigurationVersion: agentConfig.version,
       parentId: userMessageRow.id,
     });
-    const { action } = await AgentMCPActionFactory.create({
+    const { action } = await AgentMCPActionFactory.create(auth, {
       workspace,
       conversationModelId: conversation.id,
       agentMessageModelId: messageRow.agentMessageId!,
@@ -72,10 +72,7 @@ describe("validateActionFromEmail", () => {
     });
 
     const result = await validateActionFromEmail(auth, {
-      actionId: AgentMCPActionResource.modelIdToSId({
-        id: action.id,
-        workspaceId: workspace.id,
-      }),
+      actionId: action.sId,
       approvalState: "approved",
     });
 
@@ -84,8 +81,11 @@ describe("validateActionFromEmail", () => {
       expect(result.error.code).toBe("action_not_blocked");
     }
 
-    await action.reload();
-    expect(action.status).toBe("blocked_validation_required");
+    const reloadedAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId
+    );
+    expect(reloadedAction?.status).toBe("blocked_validation_required");
     expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -91,7 +91,7 @@ describe("listBlockedActionsForConversation", () => {
     agentMessageModelId: number;
     status?: ToolExecutionStatus;
   }) {
-    return AgentMCPActionFactory.create({
+    return AgentMCPActionFactory.create(auth, {
       workspace,
       conversationModelId: conversation.id,
       agentMessageModelId,
@@ -326,11 +326,7 @@ describe("listBlockedActionsForConversation", () => {
     expect(result).toHaveLength(1);
 
     // Verify the returned action belongs to the v1 agent message (not v0).
-    const expectedActionId = AgentMCPActionResource.modelIdToSId({
-      id: v1Action.id,
-      workspaceId: workspace.id,
-    });
-    expect(result[0].actionId).toBe(expectedActionId);
+    expect(result[0].actionId).toBe(v1Action.sId);
   });
 
   it("returns zero and leaves the action unchanged when the expected status does not match", async () => {
@@ -344,19 +340,16 @@ describe("listBlockedActionsForConversation", () => {
     const { action } = await createBlockedAction({
       agentMessageModelId: agentMessage.id,
     });
-    const actionResource = await AgentMCPActionResource.fetchByModelIdWithAuth(
-      auth,
-      action.id
-    );
-    const [affectedCount] = await actionResource!.updateStatusFromExpected(
-      auth,
-      {
-        status: "denied",
-        expectedStatus: "blocked_authentication_required",
-      }
-    );
+    const [affectedCount] = await action.updateStatusFromExpected(auth, {
+      status: "denied",
+      expectedStatus: "blocked_authentication_required",
+    });
     expect(affectedCount).toBe(0);
-    expect((await action.reload()).status).toBe("blocked_validation_required");
+    const reloadedAction = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId
+    );
+    expect(reloadedAction?.status).toBe("blocked_validation_required");
   });
 });
 

--- a/front/tests/utils/AgentMCPActionFactory.ts
+++ b/front/tests/utils/AgentMCPActionFactory.ts
@@ -5,6 +5,7 @@ import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/action
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -24,19 +25,21 @@ export class AgentMCPActionFactory {
    * Creates an MCP action (with its function_call step content and tool execution row),
    * blocked on tool validation by default.
    */
-  static async create({
-    workspace,
-    conversationModelId,
-    agentMessageModelId,
-    status = "blocked_validation_required",
-  }: {
-    workspace: WorkspaceType;
-    conversationModelId: ModelId;
-    agentMessageModelId: ModelId;
-    status?: ToolExecutionStatus;
-  }): Promise<{
-    action: AgentMCPActionModel;
-    stepContent: AgentStepContentModel;
+  static async create(
+    auth: Authenticator,
+    {
+      workspace,
+      conversationModelId,
+      agentMessageModelId,
+      status = "blocked_validation_required",
+    }: {
+      workspace: WorkspaceType;
+      conversationModelId: ModelId;
+      agentMessageModelId: ModelId;
+      status?: ToolExecutionStatus;
+    }
+  ): Promise<{
+    action: AgentMCPActionResource;
   }> {
     const functionCallId = generateRandomModelSId();
     const currentIndex = this.stepContentIndex++;
@@ -108,7 +111,18 @@ export class AgentMCPActionFactory {
       stepContentId: stepContent.id,
     });
 
-    return { action, stepContent };
+    const actionResource = await AgentMCPActionResource.fetchById(
+      auth,
+      AgentMCPActionResource.modelIdToSId({
+        id: action.id,
+        workspaceId: workspace.id,
+      })
+    );
+    if (!actionResource) {
+      throw new Error("Just-created MCP action not found.");
+    }
+
+    return { action: actionResource };
   }
 
   /**
@@ -129,7 +143,7 @@ export class AgentMCPActionFactory {
   ): Promise<{
     messageRow: MessageModel;
     agentMessage: AgentMessageType;
-    action: AgentMCPActionModel;
+    action: AgentMCPActionResource;
   }> {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",
@@ -142,7 +156,7 @@ export class AgentMCPActionFactory {
         agentConfig,
       });
 
-    const { action } = await this.create({
+    const { action } = await this.create(auth, {
       workspace,
       conversationModelId: conversation.id,
       agentMessageModelId: agentMessage.agentMessageId,


### PR DESCRIPTION
## Description

Follow up of #27214. PR 5 of 5 for dust-tt/tasks#8755.

Emits `tool.approval_resolved` audit events for manual approvals auto-denied by terminated-message cleanup. The event uses a system actor deliberately because auto-denial is a mechanical cleanup consequence of message termination, not a user approval decision, and the same path also covers failures with no human actor. It filters denied actions by their pre-deny in-memory blocked status.

Stack: #27211 -> #27212 -> #27213 -> #27214 -> #27215.

## Tests

Tested locally: `NODE_ENV=test npm run test -- ./lib/api/assistant/conversation/blocked_actions.test.ts ./lib/resources/agent_mcp_action_resource.test.ts ./lib/api/assistant/conversation/validate_actions.test.ts ./lib/api/assistant/email/validate_tool_from_email.test.ts`; `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` from `front/` and `front-api/`. Added audit assertions for system attribution, non-approval blocks, and filtering out actions that were already resolved.

## Risk

Low. Audit emission is fire-and-forget and only runs for actions actually denied by cleanup.

## Deploy Plan

Deploy after #27214.
