### PR TITLE
Use useMemo in SubscriptionContext

### DIFF
--- a/front/components/workspace/billing/SubscriptionContext.tsx
+++ b/front/components/workspace/billing/SubscriptionContext.tsx
@@ -12,7 +12,7 @@ import type { SubscriptionType } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 import type { SubscriptionStatus } from "./SubscriptionStatusChip";
 
 interface SubscriptionContextType {
@@ -131,31 +131,53 @@ export function SubscriptionProvider({
     ? formatTimestampToFriendlyDate(subscriptionEndsAtMs, "short")
     : null;
 
+  const value = useMemo(
+    () => ({
+      owner,
+      subscription,
+      invoice,
+      isMetronomeInvoiceLoading,
+      isCancellablePlan,
+      isCancellationScheduled,
+      subscriptionEndsAtMs,
+      subscriptionStatus,
+      canCancelSubscription,
+      canReactivateSubscription,
+      isCancellingSubscription,
+      isReactivatingSubscription,
+      periodEndLabel,
+      subscriptionEndLabel,
+      showCancelDialog,
+      setShowCancelDialog,
+      showReactivateDialog,
+      setShowReactivateDialog,
+      cancelSubscription,
+      reactivateSubscription,
+    }),
+    [
+      owner,
+      subscription,
+      invoice,
+      isMetronomeInvoiceLoading,
+      isCancellablePlan,
+      isCancellationScheduled,
+      subscriptionEndsAtMs,
+      subscriptionStatus,
+      canCancelSubscription,
+      canReactivateSubscription,
+      isCancellingSubscription,
+      isReactivatingSubscription,
+      periodEndLabel,
+      subscriptionEndLabel,
+      showCancelDialog,
+      showReactivateDialog,
+      cancelSubscription,
+      reactivateSubscription,
+    ]
+  );
+
   return (
-    <SubscriptionContext.Provider
-      value={{
-        owner,
-        subscription,
-        invoice,
-        isMetronomeInvoiceLoading,
-        isCancellablePlan,
-        isCancellationScheduled,
-        subscriptionEndsAtMs,
-        subscriptionStatus,
-        canCancelSubscription,
-        canReactivateSubscription,
-        isCancellingSubscription,
-        isReactivatingSubscription,
-        periodEndLabel,
-        subscriptionEndLabel,
-        showCancelDialog,
-        setShowCancelDialog,
-        showReactivateDialog,
-        setShowReactivateDialog,
-        cancelSubscription,
-        reactivateSubscription,
-      }}
-    >
+    <SubscriptionContext.Provider value={value}>
       {children}
     </SubscriptionContext.Provider>
   );


### PR DESCRIPTION
## Description

Wraps the `SubscriptionContext` provider value in `useMemo` to avoid creating a new object reference on every render. Without this, all consumers of `useSubscriptionContext` would re-render on every parent render even when no relevant state had changed. This follows the [REACT4] coding rule enforced in the codebase (`front/CODING_RULES.md`). The `SubscriptionContext` was introduced in #27086 without this memoization.

## Tests

No behaviour change — tested by verifying the billing/subscription pages continue to function correctly.

## Risk

None.

## Deploy Plan

Deploy `front`.