### PR TITLE
Self improving skills: expose the AWU consumption in resource and API

### DIFF
--- a/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.test.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.test.ts
@@ -47,18 +47,21 @@ describe("GET /api/w/:wId/skills/reinforcement_daily_spend", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 1_000_000,
+        priceAwuCredits: 118,
       },
       {
         createdAt: day1,
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 500_000,
+        priceAwuCredits: 59,
       },
       {
         createdAt: day2,
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 3_000_000,
+        priceAwuCredits: 353,
       },
       // Excluded: before the current period.
       {
@@ -66,6 +69,7 @@ describe("GET /api/w/:wId/skills/reinforcement_daily_spend", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 999_000_000,
+        priceAwuCredits: 117_530,
       },
     ]);
 
@@ -73,8 +77,12 @@ describe("GET /api/w/:wId/skills/reinforcement_daily_spend", () => {
 
     expect(response.status).toBe(200);
 
-    const { dailySpendMicroUsd, periodStartDate, periodEndDate } =
-      await response.json();
+    const {
+      dailySpendMicroUsd,
+      dailySpendAwuCredits,
+      periodStartDate,
+      periodEndDate,
+    } = await response.json();
 
     // Period boundaries are returned as ISO strings.
     expect(periodStartDate).toBeTruthy();
@@ -83,12 +91,17 @@ describe("GET /api/w/:wId/skills/reinforcement_daily_spend", () => {
     const day1Str = day1.toISOString().slice(0, 10);
     const day2Str = day2.toISOString().slice(0, 10);
 
+    // Micro-USD spend includes the markup.
     expect(dailySpendMicroUsd[day1Str]).toBe(1_500_000 * MARKUP_MULTIPLIER);
     expect(dailySpendMicroUsd[day2Str]).toBe(3_000_000 * MARKUP_MULTIPLIER);
+    // AWU credits already include the margin: no markup applied.
+    expect(dailySpendAwuCredits[day1Str]).toBe(177);
+    expect(dailySpendAwuCredits[day2Str]).toBe(353);
 
     // Before-period row should not appear.
     const beforeStr = beforePeriod.toISOString().slice(0, 10);
     expect(dailySpendMicroUsd[beforeStr]).toBeUndefined();
+    expect(dailySpendAwuCredits[beforeStr]).toBeUndefined();
   });
 
   it("returns 403 for non-admin users", async () => {

--- a/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_daily_spend.ts
@@ -18,21 +18,21 @@ app.get(
     const period = await getCurrentPeriod(auth);
 
     const dailyMap =
-      await SelfImprovingSkillsUsageResource.getDailySpendMicroUsdWithMarkup(
-        auth,
-        {
-          startDate: period.cycleStart,
-          endDate: period.cycleEnd,
-        }
-      );
+      await SelfImprovingSkillsUsageResource.getDailySpendWithMarkup(auth, {
+        startDate: period.cycleStart,
+        endDate: period.cycleEnd,
+      });
 
     const dailySpendMicroUsd: Record<string, number> = {};
+    const dailySpendAwuCredits: Record<string, number> = {};
     for (const [day, spend] of dailyMap) {
-      dailySpendMicroUsd[day] = spend;
+      dailySpendMicroUsd[day] = spend.priceMicroUsd;
+      dailySpendAwuCredits[day] = spend.priceAwuCredits;
     }
 
     return ctx.json({
       dailySpendMicroUsd,
+      dailySpendAwuCredits,
       periodStartDate: period.cycleStart.toISOString(),
       periodEndDate: period.cycleEnd.toISOString(),
     });

--- a/front-api/routes/w/[wId]/skills/reinforcement_spend.test.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_spend.test.ts
@@ -42,12 +42,14 @@ describe("GET /api/w/:wId/skills/reinforcement_spend", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 1_500_000,
+        priceAwuCredits: 177,
       },
       {
         createdAt: inCurrentMonth,
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 500_000,
+        priceAwuCredits: 59,
       },
       // Excluded: before the current period start.
       {
@@ -55,6 +57,7 @@ describe("GET /api/w/:wId/skills/reinforcement_spend", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 999_000_000,
+        priceAwuCredits: 117_530,
       },
       // Different skill, in-period.
       {
@@ -62,16 +65,24 @@ describe("GET /api/w/:wId/skills/reinforcement_spend", () => {
         skillId: otherSkill.id,
         conversationId: null,
         priceMicroUsd: 7_000_000,
+        priceAwuCredits: 824,
       },
     ]);
 
     const response = await get(workspace);
 
     expect(response.status).toBe(200);
-    const { spentMicroUsdBySkillId } = await response.json();
+    const { spentMicroUsdBySkillId, spentAwuCreditsBySkillId } =
+      await response.json();
+    // Micro-USD spend includes the markup.
     expect(spentMicroUsdBySkillId).toEqual({
       [skill.sId]: 2_600_000,
       [otherSkill.sId]: 9_100_000,
+    });
+    // AWU credits already include the margin: no markup applied.
+    expect(spentAwuCreditsBySkillId).toEqual({
+      [skill.sId]: 236,
+      [otherSkill.sId]: 824,
     });
   });
 
@@ -88,7 +99,9 @@ describe("GET /api/w/:wId/skills/reinforcement_spend", () => {
     const response = await get(workspace);
 
     expect(response.status).toBe(200);
-    expect((await response.json()).spentMicroUsdBySkillId).toEqual({});
+    const body = await response.json();
+    expect(body.spentMicroUsdBySkillId).toEqual({});
+    expect(body.spentAwuCreditsBySkillId).toEqual({});
   });
 
   it("returns 403 for non-admin users", async () => {

--- a/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
+++ b/front-api/routes/w/[wId]/skills/reinforcement_spend.ts
@@ -24,7 +24,7 @@ app.get(
     });
 
     const spentByModelId =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDateForSkills(
+      await SelfImprovingSkillsUsageResource.getSumSpendWithMarkupAfterDateForSkills(
         auth,
         {
           createdAfter: (await getCurrentPeriod(auth)).cycleStart,
@@ -33,14 +33,21 @@ app.get(
       );
 
     const spentMicroUsdBySkillId: Record<string, number> = {};
+    const spentAwuCreditsBySkillId: Record<string, number> = {};
     for (const skill of skills) {
       const spent = spentByModelId.get(skill.id);
-      if (spent && spent > 0) {
-        spentMicroUsdBySkillId[skill.sId] = spent;
+      if (!spent) {
+        continue;
+      }
+      if (spent.priceMicroUsd > 0) {
+        spentMicroUsdBySkillId[skill.sId] = spent.priceMicroUsd;
+      }
+      if (spent.priceAwuCredits > 0) {
+        spentAwuCreditsBySkillId[skill.sId] = spent.priceAwuCredits;
       }
     }
 
-    return ctx.json({ spentMicroUsdBySkillId });
+    return ctx.json({ spentMicroUsdBySkillId, spentAwuCreditsBySkillId });
   }
 );
 

--- a/front/lib/api/skills/index.ts
+++ b/front/lib/api/skills/index.ts
@@ -20,6 +20,9 @@ export type PostSkillResponseBody = {
 export type GetReinforcementDailySpendResponseBody = {
   // ISO date strings ("YYYY-MM-DD") → spend in microUSD for that day.
   dailySpendMicroUsd: Record<string, number>;
+  // ISO date strings ("YYYY-MM-DD") → spend in AWU credits for that day
+  // (margin included, as billed to Metronome).
+  dailySpendAwuCredits: Record<string, number>;
   periodStartDate: string;
   periodEndDate: string;
 };
@@ -52,4 +55,8 @@ export type GetSkillsSpendResponseBody = {
   // Map from skill sId to total spent in the current billing period (microUSD).
   // Skills with no usage in the period are omitted.
   spentMicroUsdBySkillId: Record<string, number>;
+  // Map from skill sId to total spent in the current billing period in AWU
+  // credits (margin included, as billed to Metronome). Skills with no usage
+  // in the period are omitted.
+  spentAwuCreditsBySkillId: Record<string, number>;
 };

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -107,7 +107,7 @@ async function fetchEligibleSkillIds(
   // Filter out skills that have reached their per-skill consumption cap.
   const { cycleStart } = await getCurrentPeriod(auth);
   const skillConsumptionMap =
-    await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDateForSkills(
+    await SelfImprovingSkillsUsageResource.getSumSpendWithMarkupAfterDateForSkills(
       auth,
       {
         createdAfter: cycleStart,
@@ -118,7 +118,8 @@ async function fetchEligibleSkillIds(
   const defaultCapMicroUsd =
     getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(workspace);
   const capEligibleSkills = eligibleSkills.filter((skill) => {
-    const consumedMicroUsd = skillConsumptionMap.get(skill.id) ?? 0;
+    const consumedMicroUsd =
+      skillConsumptionMap.get(skill.id)?.priceMicroUsd ?? 0;
     const capMicroUsd =
       skill.selfImprovementCostsCapMicroUsd ?? defaultCapMicroUsd;
     return consumedMicroUsd < capMicroUsd;

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -28,18 +28,21 @@ describe("SelfImprovingSkillsUsageResource", () => {
           skillId: skill.id,
           conversationId: null,
           priceMicroUsd: 50,
+          priceAwuCredits: 1,
         },
         {
           createdAt: new Date("2026-01-03T00:00:00.000Z"),
           skillId: skill.id,
           conversationId: null,
           priceMicroUsd: 100,
+          priceAwuCredits: 2,
         },
         {
           createdAt: new Date("2026-01-04T00:00:00.000Z"),
           skillId: null,
           conversationId: null,
           priceMicroUsd: 200,
+          priceAwuCredits: 3,
         },
       ]
     );
@@ -50,11 +53,12 @@ describe("SelfImprovingSkillsUsageResource", () => {
         skillId: otherWorkspaceSkill.id,
         conversationId: null,
         priceMicroUsd: 500,
+        priceAwuCredits: 50,
       },
     ]);
 
     const sum =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
+      await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
         authenticator,
         cutoff
       );
@@ -63,7 +67,7 @@ describe("SelfImprovingSkillsUsageResource", () => {
     expect(
       usages.every((usage) => usage.workspaceId === skill.workspaceId)
     ).toBe(true);
-    expect(sum).toBe(300);
+    expect(sum).toEqual({ priceMicroUsd: 300, priceAwuCredits: 5 });
   });
 
   it("persists priceAwuCredits when provided and defaults it to 0", async () => {
@@ -140,18 +144,21 @@ describe("SelfImprovingSkillsUsageResource", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 100,
+        priceAwuCredits: 1,
       },
       {
         createdAt: new Date("2026-03-10T20:00:00.000Z"),
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 200,
+        priceAwuCredits: 2,
       },
       {
         createdAt: new Date("2026-03-12T10:00:00.000Z"),
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 500,
+        priceAwuCredits: 5,
       },
       // Outside the queried range.
       {
@@ -159,6 +166,7 @@ describe("SelfImprovingSkillsUsageResource", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 999,
+        priceAwuCredits: 99,
       },
     ]);
 
@@ -176,7 +184,7 @@ describe("SelfImprovingSkillsUsageResource", () => {
     ]);
 
     const result =
-      await SelfImprovingSkillsUsageResource.getDailySpendMicroUsdWithMarkup(
+      await SelfImprovingSkillsUsageResource.getDailySpendWithMarkup(
         authenticator,
         {
           startDate: new Date("2026-03-10T00:00:00.000Z"),
@@ -184,9 +192,17 @@ describe("SelfImprovingSkillsUsageResource", () => {
         }
       );
 
-    expect(result.get("2026-03-10")).toBe(300 * MARKUP_MULTIPLIER);
+    // The markup applies to micro-USD only; AWU credits already include the
+    // margin.
+    expect(result.get("2026-03-10")).toEqual({
+      priceMicroUsd: 300 * MARKUP_MULTIPLIER,
+      priceAwuCredits: 3,
+    });
     expect(result.has("2026-03-11")).toBe(false);
-    expect(result.get("2026-03-12")).toBe(500 * MARKUP_MULTIPLIER);
+    expect(result.get("2026-03-12")).toEqual({
+      priceMicroUsd: 500 * MARKUP_MULTIPLIER,
+      priceAwuCredits: 5,
+    });
     expect(result.has("2026-03-09")).toBe(false);
     expect(result.size).toBe(2);
   });
@@ -208,29 +224,38 @@ describe("SelfImprovingSkillsUsageResource", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 50,
+        priceAwuCredits: 1,
       },
       {
         createdAt: new Date("2026-01-03T00:00:00.000Z"),
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 100,
+        priceAwuCredits: 2,
       },
       {
         createdAt: new Date("2026-01-04T00:00:00.000Z"),
         skillId: otherSkill.id,
         conversationId: null,
         priceMicroUsd: 200,
+        priceAwuCredits: 3,
       },
     ]);
 
     const sums =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+      await SelfImprovingSkillsUsageResource.getSumSpendAfterDateForSkills(
         authenticator,
         { createdAfter: cutoff, skillModelIds: [skill.id, otherSkill.id] }
       );
 
-    expect(sums.get(skill.id)).toBe(100);
-    expect(sums.get(otherSkill.id)).toBe(200);
+    expect(sums.get(skill.id)).toEqual({
+      priceMicroUsd: 100,
+      priceAwuCredits: 2,
+    });
+    expect(sums.get(otherSkill.id)).toEqual({
+      priceMicroUsd: 200,
+      priceAwuCredits: 3,
+    });
   });
 
   it("applies markup multiplier in WithMarkup variants", async () => {
@@ -247,41 +272,51 @@ describe("SelfImprovingSkillsUsageResource", () => {
         skillId: skill.id,
         conversationId: null,
         priceMicroUsd: 100,
+        priceAwuCredits: 2,
       },
       {
         createdAt: new Date("2026-01-04T00:00:00.000Z"),
         skillId: null,
         conversationId: null,
         priceMicroUsd: 200,
+        priceAwuCredits: 3,
       },
     ]);
 
     const sumWithMarkup =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDate(
+      await SelfImprovingSkillsUsageResource.getSumSpendWithMarkupAfterDate(
         authenticator,
         cutoff
       );
     const sumWithoutMarkup =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
+      await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
         authenticator,
         cutoff
       );
 
-    expect(sumWithMarkup).toBe(sumWithoutMarkup * MARKUP_MULTIPLIER);
+    // The markup applies to micro-USD only; AWU credits already include the
+    // margin.
+    expect(sumWithMarkup).toEqual({
+      priceMicroUsd: sumWithoutMarkup.priceMicroUsd * MARKUP_MULTIPLIER,
+      priceAwuCredits: sumWithoutMarkup.priceAwuCredits,
+    });
 
     const sumsWithMarkup =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdWithMarkupAfterDateForSkills(
+      await SelfImprovingSkillsUsageResource.getSumSpendWithMarkupAfterDateForSkills(
         authenticator,
         { createdAfter: cutoff, skillModelIds: [skill.id] }
       );
     const sumsWithoutMarkup =
-      await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDateForSkills(
+      await SelfImprovingSkillsUsageResource.getSumSpendAfterDateForSkills(
         authenticator,
         { createdAfter: cutoff, skillModelIds: [skill.id] }
       );
 
-    expect(sumsWithMarkup.get(skill.id)).toBe(
-      (sumsWithoutMarkup.get(skill.id) ?? 0) * MARKUP_MULTIPLIER
-    );
+    expect(sumsWithMarkup.get(skill.id)).toEqual({
+      priceMicroUsd:
+        (sumsWithoutMarkup.get(skill.id)?.priceMicroUsd ?? 0) *
+        MARKUP_MULTIPLIER,
+      priceAwuCredits: sumsWithoutMarkup.get(skill.id)?.priceAwuCredits,
+    });
   });
 });

--- a/front/lib/resources/self_improving_skills_usage_resource.test.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.test.ts
@@ -57,11 +57,10 @@ describe("SelfImprovingSkillsUsageResource", () => {
       },
     ]);
 
-    const sum =
-      await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
-        authenticator,
-        cutoff
-      );
+    const sum = await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
+      authenticator,
+      cutoff
+    );
 
     expect(usages).toHaveLength(3);
     expect(

--- a/front/lib/resources/self_improving_skills_usage_resource.ts
+++ b/front/lib/resources/self_improving_skills_usage_resource.ts
@@ -16,6 +16,26 @@ export type SelfImprovingSkillsUsageCreateBlob = Omit<
   "workspaceId"
 >;
 
+export type SelfImprovingSkillsSpend = {
+  // Raw provider cost. Includes the markup only when returned by a
+  // `WithMarkup` method.
+  priceMicroUsd: number;
+  // ALWAYS includes the margin (it is baked into the AWU credit conversion,
+  // see awuFromMicroUsd), whether or not the method is a `WithMarkup` one.
+  priceAwuCredits: number;
+};
+
+// The markup only applies to the raw micro-USD cost; AWU credits already
+// include the margin (see awuFromMicroUsd).
+function applyMarkup(
+  spend: SelfImprovingSkillsSpend
+): SelfImprovingSkillsSpend {
+  return {
+    priceMicroUsd: spend.priceMicroUsd * MARKUP_MULTIPLIER,
+    priceAwuCredits: spend.priceAwuCredits,
+  };
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SelfImprovingSkillsUsageResource
   extends ReadonlyAttributesType<SelfImprovingSkillsUsageModel> {}
@@ -90,31 +110,61 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     });
   }
 
-  static async getSumPriceMicroUsdAfterDate(
+  /**
+   * Total workspace spend after the given date.
+   *
+   * `priceMicroUsd` is the raw provider cost, WITHOUT markup.
+   * `priceAwuCredits` includes the margin (always baked into AWU credits).
+   */
+  static async getSumSpendAfterDate(
     auth: Authenticator,
     createdAfter: Date
-  ): Promise<number> {
-    const sum = await this.model.sum("priceMicroUsd", {
+  ): Promise<SelfImprovingSkillsSpend> {
+    const rows = (await this.model.findAll({
+      attributes: [
+        [Sequelize.fn("SUM", Sequelize.col("priceMicroUsd")), "priceMicroUsd"],
+        [
+          Sequelize.fn("SUM", Sequelize.col("priceAwuCredits")),
+          "priceAwuCredits",
+        ],
+      ],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         createdAt: { [Op.gt]: createdAfter },
       },
-    });
+      raw: true,
+    })) as unknown as {
+      priceMicroUsd: string | null;
+      priceAwuCredits: string | null;
+    }[];
 
-    return sum ?? 0;
+    return {
+      priceMicroUsd: Number(rows[0]?.priceMicroUsd ?? 0),
+      priceAwuCredits: Number(rows[0]?.priceAwuCredits ?? 0),
+    };
   }
 
-  static async getSumPriceMicroUsdWithMarkupAfterDate(
+  /**
+   * Total workspace spend after the given date, billable amounts.
+   *
+   * `priceMicroUsd` is the raw provider cost WITH the markup applied.
+   * `priceAwuCredits` is identical to the non-markup variant: the margin is
+   * always baked into AWU credits, so no markup is applied to it.
+   */
+  static async getSumSpendWithMarkupAfterDate(
     auth: Authenticator,
     createdAfter: Date
-  ): Promise<number> {
-    return (
-      (await this.getSumPriceMicroUsdAfterDate(auth, createdAfter)) *
-      MARKUP_MULTIPLIER
-    );
+  ): Promise<SelfImprovingSkillsSpend> {
+    return applyMarkup(await this.getSumSpendAfterDate(auth, createdAfter));
   }
 
-  static async getSumPriceMicroUsdAfterDateForSkills(
+  /**
+   * Per-skill spend after the given date.
+   *
+   * `priceMicroUsd` is the raw provider cost, WITHOUT markup.
+   * `priceAwuCredits` includes the margin (always baked into AWU credits).
+   */
+  static async getSumSpendAfterDateForSkills(
     auth: Authenticator,
     {
       createdAfter,
@@ -123,7 +173,7 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       createdAfter: Date;
       skillModelIds: ModelId[];
     }
-  ): Promise<Map<ModelId, number>> {
+  ): Promise<Map<ModelId, SelfImprovingSkillsSpend>> {
     const uniqueSkillIds = [...new Set(skillModelIds)];
     if (uniqueSkillIds.length === 0) {
       return new Map();
@@ -133,6 +183,10 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       attributes: [
         "skillId",
         [Sequelize.fn("SUM", Sequelize.col("priceMicroUsd")), "priceMicroUsd"],
+        [
+          Sequelize.fn("SUM", Sequelize.col("priceAwuCredits")),
+          "priceAwuCredits",
+        ],
       ],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -143,11 +197,24 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
     });
 
     return new Map(
-      rows.map((row) => [row.skillId as ModelId, Number(row.priceMicroUsd)])
+      rows.map((row) => [
+        row.skillId as ModelId,
+        {
+          priceMicroUsd: Number(row.priceMicroUsd),
+          priceAwuCredits: Number(row.priceAwuCredits),
+        },
+      ])
     );
   }
 
-  static async getSumPriceMicroUsdWithMarkupAfterDateForSkills(
+  /**
+   * Per-skill spend after the given date, billable amounts.
+   *
+   * `priceMicroUsd` is the raw provider cost WITH the markup applied.
+   * `priceAwuCredits` is identical to the non-markup variant: the margin is
+   * always baked into AWU credits, so no markup is applied to it.
+   */
+  static async getSumSpendWithMarkupAfterDateForSkills(
     auth: Authenticator,
     {
       createdAfter,
@@ -156,24 +223,27 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       createdAfter: Date;
       skillModelIds: ModelId[];
     }
-  ): Promise<Map<ModelId, number>> {
-    const raw = await this.getSumPriceMicroUsdAfterDateForSkills(auth, {
+  ): Promise<Map<ModelId, SelfImprovingSkillsSpend>> {
+    const raw = await this.getSumSpendAfterDateForSkills(auth, {
       createdAfter,
       skillModelIds,
     });
 
     return new Map(
-      [...raw.entries()].map(([id, value]) => [id, value * MARKUP_MULTIPLIER])
+      [...raw.entries()].map(([id, spend]) => [id, applyMarkup(spend)])
     );
   }
 
   /**
    * Return total spend per calendar day (UTC) within a date range.
    *
-   * Each entry maps an ISO date string ("YYYY-MM-DD") to the summed spend in
-   * micro-USD for that day. Days with no spend are omitted.
+   * Each entry maps an ISO date string ("YYYY-MM-DD") to the summed spend for
+   * that day. Days with no spend are omitted.
+   *
+   * `priceMicroUsd` is the raw provider cost, WITHOUT markup.
+   * `priceAwuCredits` includes the margin (always baked into AWU credits).
    */
-  private static async getDailySpendMicroUsd(
+  private static async getDailySpend(
     auth: Authenticator,
     {
       startDate,
@@ -182,7 +252,7 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       startDate: Date;
       endDate: Date;
     }
-  ): Promise<Map<string, number>> {
+  ): Promise<Map<string, SelfImprovingSkillsSpend>> {
     const dayExpr = Sequelize.fn(
       "DATE",
       Sequelize.cast(Sequelize.col("createdAt"), "TIMESTAMPTZ")
@@ -192,6 +262,10 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       attributes: [
         [dayExpr, "day"],
         [Sequelize.fn("SUM", Sequelize.col("priceMicroUsd")), "priceMicroUsd"],
+        [
+          Sequelize.fn("SUM", Sequelize.col("priceAwuCredits")),
+          "priceAwuCredits",
+        ],
       ],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
@@ -203,22 +277,41 @@ export class SelfImprovingSkillsUsageResource extends BaseResource<SelfImproving
       group: [dayExpr],
       order: [[dayExpr, "ASC"]],
       raw: true,
-    })) as unknown as { day: string; priceMicroUsd: string }[];
+    })) as unknown as {
+      day: string;
+      priceMicroUsd: string;
+      priceAwuCredits: string;
+    }[];
 
-    return new Map(rows.map((row) => [row.day, Number(row.priceMicroUsd)]));
+    return new Map(
+      rows.map((row) => [
+        row.day,
+        {
+          priceMicroUsd: Number(row.priceMicroUsd),
+          priceAwuCredits: Number(row.priceAwuCredits),
+        },
+      ])
+    );
   }
 
-  static async getDailySpendMicroUsdWithMarkup(
+  /**
+   * Total spend per calendar day (UTC) within a date range, billable amounts.
+   *
+   * `priceMicroUsd` is the raw provider cost WITH the markup applied.
+   * `priceAwuCredits` is identical to the non-markup variant: the margin is
+   * always baked into AWU credits, so no markup is applied to it.
+   */
+  static async getDailySpendWithMarkup(
     auth: Authenticator,
     params: {
       startDate: Date;
       endDate: Date;
     }
-  ): Promise<Map<string, number>> {
-    const raw = await this.getDailySpendMicroUsd(auth, params);
+  ): Promise<Map<string, SelfImprovingSkillsSpend>> {
+    const raw = await this.getDailySpend(auth, params);
 
     return new Map(
-      [...raw.entries()].map(([day, value]) => [day, value * MARKUP_MULTIPLIER])
+      [...raw.entries()].map(([day, spend]) => [day, applyMarkup(spend)])
     );
   }
 

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -602,8 +602,8 @@ export async function getReinforcementSettingsActivity({
 
   const workspace = auth.getNonNullableWorkspace();
   const { cycleStart: periodStart } = await getCurrentPeriod(auth);
-  const globalConsumptionMicroUsd =
-    await SelfImprovingSkillsUsageResource.getSumPriceMicroUsdAfterDate(
+  const { priceMicroUsd: globalConsumptionMicroUsd } =
+    await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
       auth,
       periodStart
     );


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8784

Add resource + API + tests to retrieve the AWU usage

Step by step plan:
 1. Store the AWU in the self_improving_skills_usage table  ✅ done
 2. Update resources and API to retrieve the AWU usage  <-- ℹ️ **You are here**
 3. Store limit in AWU in db and update API to set/get them
 4. Use AWU to enforce the limit for credit based workspaces
 5. Update UI admin apge to display AWU credits when using metronome.


## Tests

Updated the unit tests

## Risk

low, all API are backward compatible, all data is additive

## Deploy Plan

deploy front
