### PR TITLE
[front] seats: allow free seat for Free plans when remapping to contract

### DIFF
--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -138,29 +138,50 @@ describe("resolveRemappedSeatType", () => {
   });
 
   it("keeps a seat type the contract still bills", () => {
-    expect(resolveRemappedSeatType("max", contract, productSeatTypes)).toBe(
-      "max"
-    );
     expect(
-      resolveRemappedSeatType("pro_yearly", contract, productSeatTypes)
+      resolveRemappedSeatType("max", contract, productSeatTypes, false)
+    ).toBe("max");
+    expect(
+      resolveRemappedSeatType("pro_yearly", contract, productSeatTypes, false)
     ).toBe("pro_yearly");
   });
 
   it("converts a monthly seat to its yearly equivalent when present", () => {
-    expect(resolveRemappedSeatType("pro", contract, productSeatTypes)).toBe(
-      "pro_yearly"
-    );
+    expect(
+      resolveRemappedSeatType("pro", contract, productSeatTypes, false)
+    ).toBe("pro_yearly");
   });
 
   it("falls back to the default tier (no free) otherwise", () => {
     // `free` has no yearly equivalent on the contract → default lowest tier.
-    expect(resolveRemappedSeatType("free", contract, productSeatTypes)).toBe(
-      "pro_yearly"
-    );
+    expect(
+      resolveRemappedSeatType("free", contract, productSeatTypes, false)
+    ).toBe("pro_yearly");
     // `max_yearly` (already yearly) isn't billed → default tier.
     expect(
-      resolveRemappedSeatType("max_yearly", contract, productSeatTypes)
+      resolveRemappedSeatType("max_yearly", contract, productSeatTypes, false)
     ).toBe("pro_yearly");
+  });
+});
+
+describe("resolveRemappedSeatType (useFreeSeat)", () => {
+  // Contract bills `free` (0 AWU) and `pro` (8000 AWU).
+  const { contract, productSeatTypes } = makeContract({
+    seats: [{ seatType: "free" }, { seatType: "pro", awu: 8000 }],
+  });
+
+  it("falls back to free when useFreeSeat is true", () => {
+    // `workspace` is not on the contract → falls back to the default tier.
+    // With useFreeSeat=true the lowest tier (`free`) is eligible.
+    expect(
+      resolveRemappedSeatType("workspace", contract, productSeatTypes, true)
+    ).toBe("free");
+  });
+
+  it("skips free and falls back to the next tier when useFreeSeat is false", () => {
+    expect(
+      resolveRemappedSeatType("workspace", contract, productSeatTypes, false)
+    ).toBe("pro");
   });
 });
 
@@ -179,21 +200,26 @@ describe("resolveRemappedSeatType (entitlement-aware)", () => {
     // `workspace` has a (dormant) subscription but isn't entitled → convert to
     // its entitled yearly equivalent.
     expect(
-      resolveRemappedSeatType("workspace", contract, productSeatTypes)
+      resolveRemappedSeatType("workspace", contract, productSeatTypes, false)
     ).toBe("workspace_yearly");
   });
 
   it("keeps an entitled seat type", () => {
     expect(
-      resolveRemappedSeatType("workspace_yearly", contract, productSeatTypes)
+      resolveRemappedSeatType(
+        "workspace_yearly",
+        contract,
+        productSeatTypes,
+        false
+      )
     ).toBe("workspace_yearly");
   });
 
   it("falls back to the only entitled tier for unrelated seats", () => {
     // `pro` is on the contract but not entitled, no `pro_yearly` entitled →
     // default tier among entitled seats = `workspace_yearly`.
-    expect(resolveRemappedSeatType("pro", contract, productSeatTypes)).toBe(
-      "workspace_yearly"
-    );
+    expect(
+      resolveRemappedSeatType("pro", contract, productSeatTypes, false)
+    ).toBe("workspace_yearly");
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -5,6 +5,7 @@ import {
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
+import { PLAN_CODE_CUSTOM_FIELD_KEY } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
@@ -15,6 +16,7 @@ import {
   isMauContract,
 } from "@app/lib/metronome/seat_types";
 import type { BillingFrequency } from "@app/lib/metronome/types";
+import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
@@ -206,7 +208,8 @@ export function classifySeatChange({
 export function resolveRemappedSeatType(
   currentSeatType: MembershipSeatType,
   contract: CachedContract,
-  productSeatTypes: Map<string, MembershipSeatType>
+  productSeatTypes: Map<string, MembershipSeatType>,
+  useFreeSeat: boolean
 ): MembershipSeatType | undefined {
   const onContract = new Set(
     getSeatSubscriptionsFromContract(contract, productSeatTypes).keys()
@@ -221,7 +224,7 @@ export function resolveRemappedSeatType(
     }
   }
   return getDefaultSeatTypeForContract(contract, productSeatTypes, {
-    useFreeSeat: false,
+    useFreeSeat,
   });
 }
 
@@ -273,6 +276,11 @@ export async function remapMembershipSeatTypesForContract({
     }
     resolvedContract = fetched.value;
   }
+
+  const targetPlanCode =
+    resolvedContract.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
+  const isFreePlanContract =
+    targetPlanCode !== undefined ? isFreePlan(targetPlanCode) : false;
 
   const productSeatTypes = await getProductSeatTypes();
   const onContract = getSeatSubscriptionsFromContract(
@@ -350,7 +358,8 @@ export async function remapMembershipSeatTypesForContract({
     const target = resolveRemappedSeatType(
       membership.seatType,
       resolvedContract,
-      productSeatTypes
+      productSeatTypes,
+      isFreePlanContract
     );
     if (!target || target === membership.seatType) {
       logger.info(


### PR DESCRIPTION
## Description

Update remapMembershipSeatTypesForContract to allow free seats (based on exiting useFreeSeat flag) for Free plans.

## Tests

Tested locally, creating a Free Plan => free seat

## Risk

Low, specific to free plans

## Deploy Plan

Deploy front
