### PR TITLE
feat(clair copilot mcp) rm ff for clari copilot mcp

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1106,6 +1106,7 @@ export const INTERNAL_MCP_SERVERS = {
     id: 1030,
     availability: "manual",
     allowMultipleInstances: true,
+    isRestricted: undefined,
     isPreview: false,
     requiresBearerToken: true,
     tools_arguments_requiring_approval: undefined,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1106,9 +1106,7 @@ export const INTERNAL_MCP_SERVERS = {
     id: 1030,
     availability: "manual",
     allowMultipleInstances: true,
-    isRestricted: ({ featureFlags }) =>
-      !featureFlags.includes("clari_copilot_mcp"),
-    isPreview: true,
+    isPreview: false,
     requiresBearerToken: true,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -247,12 +247,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable Metronome usage event emission (llm_usage, tool_use) for this workspace.",
     stage: "dust_only",
   },
-  clari_copilot_mcp: {
-    description:
-      "Enable the Clari Copilot MCP server for call transcript and summary access.",
-    stage: "on_demand",
-  },
-  plan_mode: {
+plan_mode: {
     description:
       "Enable the Plan Mode skill: agents maintain a live plan.md for non-trivial tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -247,7 +247,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable Metronome usage event emission (llm_usage, tool_use) for this workspace.",
     stage: "dust_only",
   },
-plan_mode: {
+  plan_mode: {
     description:
       "Enable the Plan Mode skill: agents maintain a live plan.md for non-trivial tasks, with an optional human-approval checkpoint.",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -721,7 +721,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "fireworks_new_model_feature"
   | "force_us_api_url"
   | "gemini_3_1_pro_feature"
-  | "clari_copilot_mcp"
   | "google_sheets_tool"
   | "gpt_image_2_feature"
   | "hootl_subscriptions"


### PR DESCRIPTION
## Description

Removes the `clari_copilot_mcp` feature flag and makes the Clari Copilot internal MCP server generally available. The server was previously gated behind an `on_demand` feature flag and marked as preview. This PR drops the `isRestricted` guard, sets `isPreview: false`, and removes the feature flag definition from both `feature_flags.ts` and the JS SDK types.

## Tests

Manually tested (the Clari Copilot MCP integration was validated when it was originally introduced under the flag).

## Risk

Low.

## Deploy Plan

Deploy front, sdks.