### PR TITLE
fix: advance to next blocked action card after resolving a connection

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1249,6 +1249,11 @@ function AgentMessageContent({
 
   const blockedActionElement = blockedAction ? (
     <BlockedAction
+      // Key on the action id so that when the queue advances to the next
+      // blocked action of the same type, React mounts a fresh component
+      // instead of reusing the previous instance's local state (e.g. the
+      // "connected" state of a resolved personal authentication card).
+      key={blockedAction.actionId}
       blockedAction={blockedAction}
       triggeringUser={triggeringUser}
       owner={owner}

--- a/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
@@ -1,0 +1,150 @@
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import type { ConversationListItemType } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BlockedActionsProvider,
+  useBlockedActionsContext,
+} from "./BlockedActionsProvider";
+
+const mutateBlockedActionsMock = vi.fn();
+let blockedActionsMock: BlockedToolExecution[] = [];
+
+vi.mock("@app/lib/swr/blocked_actions", () => ({
+  useBlockedActions: () => ({
+    blockedActions: blockedActionsMock,
+    isLoading: false,
+    isError: false,
+    mutate: mutateBlockedActionsMock,
+  }),
+}));
+
+vi.mock("@app/hooks/conversations", () => ({
+  useConversations: () => ({
+    mutateConversations: vi.fn(),
+  }),
+}));
+
+const owner: LightWorkspaceType = {
+  id: 1,
+  sId: "w_1",
+  name: "Workspace",
+  role: "user",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  regionalModelsOnly: false,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+const conversation: ConversationListItemType = {
+  actionRequired: true,
+  created: 1,
+  hasError: false,
+  lastReadMs: null,
+  metadata: {},
+  requestedSpaceIds: [],
+  sId: "conv_1",
+  spaceId: null,
+  title: "Conversation",
+  triggerId: null,
+  unread: false,
+  updated: 1,
+  isRunningAgentLoop: false,
+};
+
+function makeAuthBlockedAction(
+  actionId: string
+): BlockedToolExecution & { status: "blocked_authentication_required" } {
+  return {
+    conversationId: "conv_1",
+    messageId: "msg_1",
+    actionId,
+    userId: "user_1",
+    configurationId: "config_1",
+    created: 1,
+    inputs: {},
+    status: "blocked_authentication_required",
+    metadata: {
+      toolName: "tool",
+      mcpServerName: "server",
+      agentName: "agent",
+      mcpServerId: "mcp_1",
+      mcpServerDisplayName: "Server",
+    },
+    authorizationInfo: {
+      provider: "salesforce",
+      supported_use_cases: [],
+    },
+  };
+}
+
+function Consumer() {
+  const { getFirstBlockedActionForMessage, removeCompletedAction } =
+    useBlockedActionsContext();
+
+  const firstAction = getFirstBlockedActionForMessage("msg_1");
+
+  return (
+    <div>
+      <span data-testid="first-action">{firstAction?.actionId ?? "none"}</span>
+      <button
+        type="button"
+        onClick={() => {
+          if (firstAction) {
+            removeCompletedAction(firstAction.actionId);
+          }
+        }}
+      >
+        resolve
+      </button>
+    </div>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <BlockedActionsProvider owner={owner} conversation={conversation}>
+      <Consumer />
+    </BlockedActionsProvider>
+  );
+}
+
+describe("BlockedActionsProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    blockedActionsMock = [];
+  });
+
+  it("advances to the next blocked action when one is resolved", async () => {
+    const user = userEvent.setup();
+    blockedActionsMock = [
+      makeAuthBlockedAction("action_1"),
+      makeAuthBlockedAction("action_2"),
+    ];
+
+    renderProvider();
+
+    expect(screen.getByTestId("first-action")).toHaveTextContent("action_1");
+
+    await user.click(screen.getByRole("button", { name: "resolve" }));
+
+    expect(screen.getByTestId("first-action")).toHaveTextContent("action_2");
+  });
+
+  it("revalidates the blocked actions cache when an action is resolved", async () => {
+    const user = userEvent.setup();
+    blockedActionsMock = [makeAuthBlockedAction("action_1")];
+
+    renderProvider();
+
+    await user.click(screen.getByRole("button", { name: "resolve" }));
+
+    expect(screen.getByTestId("first-action")).toHaveTextContent("none");
+    expect(mutateBlockedActionsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -73,7 +73,7 @@ export function BlockedActionsProvider({
   const conversationId = conversation?.sId || null;
 
   // Fetch blocked actions from the database.
-  const { blockedActions } = useBlockedActions({
+  const { blockedActions, mutate: mutateBlockedActions } = useBlockedActions({
     conversationId,
     workspaceId: owner.sId,
   });
@@ -192,8 +192,16 @@ export function BlockedActionsProvider({
       setBlockedActionsQueue((prevQueue) =>
         prevQueue.filter((item) => item.blockedAction.actionId !== actionId)
       );
+
+      // Revalidate the blocked actions cache. Resolving an action happens
+      // right after the OAuth popup closes, which refocuses the window and
+      // can trigger an SWR focus revalidation that still sees the action as
+      // blocked in the database. Mutating here discards that in-flight stale
+      // response and refetches, so the resolved action is not re-inserted in
+      // the queue.
+      void mutateBlockedActions();
     },
-    [stopPulsingAction]
+    [stopPulsingAction, mutateBlockedActions]
   );
 
   const hasPendingValidations = useCallback(


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#8746.

When an agent message needs several personal connection approvals (e.g. Outlook email and Outlook calendar), completing the first one never surfaces the second card, and the conversation stays blocked until the page is refreshed.

Root cause: the next blocked action card renders at the same tree position with the same component type and no key, so React reuses the previous card's instance, including its local `isConnected` state. The second action therefore renders as "Connected successfully" with no Connect button.

Regression from #24507: it removed the `retryHandler()` call on auth completion, which used to retry the whole message and remount the cards with fresh state. The unkeyed card with sticky local state was introduced in #22840 but stayed masked until then.

- Key `BlockedAction` on `actionId` so each blocked action mounts a fresh card.
- Revalidate the blocked actions cache in `removeCompletedAction`: the OAuth popup closing refocuses the window and can trigger an SWR focus revalidation that still sees the resolved action as blocked, which would re-insert it at the front of the queue.

## Tests

Added `BlockedActionsProvider.test.tsx`: resolving an action advances the queue to the next blocked action and revalidates the blocked actions cache. Repro from the issue code-traced, not reproduced end to end locally (needs two disconnected personal connections).

## Risk

Low. Frontend only, scoped to the blocked action cards. Safe to rollback.

## Deploy Plan

Standard deploy.