### PR TITLE
Self improving skills in AWU: Store limits in AWU + APi to set/get them

### DIFF
--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -1,0 +1,73 @@
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { honoApp } from "@front-api/app";
+import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_role";
+import { describe, expect, it } from "vitest";
+
+async function setup(role: MembershipRoleType = "admin") {
+  return createPrivateApiMockRequest({ method: "POST", role });
+}
+
+function post(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(`/api/w/${workspace.sId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId (reinforcement caps)", () => {
+  it("updates reinforcementCapAwuCredits in workspace metadata", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      reinforcementCapAwuCredits: 5_000,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.reinforcementCapAwuCredits).toBe(5_000);
+  });
+
+  it("updates selfImprovementCapPerSkillAwuCredits and preserves other metadata", async () => {
+    const { workspace } = await setup();
+
+    // Set the microUSD cap first; the AWU credits cap must not clobber it.
+    const microResponse = await post(workspace, {
+      selfImprovementCapPerSkillMicroUsd: 10_000_000,
+    });
+    expect(microResponse.status).toBe(200);
+
+    const response = await post(workspace, {
+      selfImprovementCapPerSkillAwuCredits: 1_500,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.selfImprovementCapPerSkillAwuCredits).toBe(1_500);
+    expect(updated?.metadata?.selfImprovementCapPerSkillMicroUsd).toBe(
+      10_000_000
+    );
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { workspace } = await setup(role);
+
+      const response = await post(workspace, {
+        reinforcementCapAwuCredits: 5_000,
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: {
+          type: "workspace_auth_error",
+          message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
+        },
+      });
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -170,6 +170,15 @@ const WorkspaceSelfImprovementCapPerSkillUpdateBodySchema = z.object({
   selfImprovementCapPerSkillMicroUsd: z.number(),
 });
 
+// Same caps in AWU credits, used for workspaces billed by Metronome.
+const WorkspaceReinforcementCapAwuCreditsUpdateBodySchema = z.object({
+  reinforcementCapAwuCredits: z.number(),
+});
+
+const WorkspaceSelfImprovementCapPerSkillAwuCreditsUpdateBodySchema = z.object({
+  selfImprovementCapPerSkillAwuCredits: z.number(),
+});
+
 const WorkspaceAuditLogsUpdateBodySchema = z.object({
   disableAuditLogs: z.boolean(),
 });
@@ -195,6 +204,8 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceSandboxAgentEgressRequestsUpdateBodySchema,
   WorkspaceReinforcementCapUpdateBodySchema,
   WorkspaceSelfImprovementCapPerSkillUpdateBodySchema,
+  WorkspaceReinforcementCapAwuCreditsUpdateBodySchema,
+  WorkspaceSelfImprovementCapPerSkillAwuCreditsUpdateBodySchema,
   WorkspaceAuditLogsUpdateBodySchema,
 ]);
 
@@ -498,6 +509,23 @@ app.post(
         ...previousMetadata,
         selfImprovementCapPerSkillMicroUsd:
           body.selfImprovementCapPerSkillMicroUsd,
+      };
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+    } else if ("reinforcementCapAwuCredits" in body) {
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+        reinforcementCapAwuCredits: body.reinforcementCapAwuCredits,
+      };
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+    } else if ("selfImprovementCapPerSkillAwuCredits" in body) {
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+        selfImprovementCapPerSkillAwuCredits:
+          body.selfImprovementCapPerSkillAwuCredits,
       };
       await workspace.updateWorkspaceSettings({ metadata: newMetadata });
       owner.metadata = newMetadata;

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.test.ts
@@ -221,6 +221,39 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
     expect(updated?.selfImprovementCostsCapMicroUsd).toBeNull();
   });
 
+  it("updates selfImprovementCostsCapAwuCredits", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      selfImprovementCostsCapAwuCredits: 2_500,
+    });
+
+    expect(response.status).toBe(200);
+    const updated = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(updated?.selfImprovementCostsCapAwuCredits).toBe(2_500);
+    // The microUSD cap is independent and untouched.
+    expect(updated?.selfImprovementCostsCapMicroUsd).toBeNull();
+  });
+
+  it("sets selfImprovementCostsCapAwuCredits to null (use default)", async () => {
+    const { workspace, skill, requestUserAuth } = await setupTest({
+      requestUserRole: "admin",
+    });
+
+    // First set a custom cap.
+    await skill.updateSelfImprovementCostsCapAwuCredits(1_000);
+
+    const response = await patch(workspace, skill.sId, {
+      selfImprovementCostsCapAwuCredits: null,
+    });
+
+    expect(response.status).toBe(200);
+    const updated = await SkillResource.fetchById(requestUserAuth, skill.sId);
+    expect(updated?.selfImprovementCostsCapAwuCredits).toBeNull();
+  });
+
   it("updates multiple fields in a single request", async () => {
     const { workspace, skill, requestUserAuth } = await setupTest({
       requestUserRole: "admin",
@@ -230,6 +263,7 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
       reinforcement: "off",
       selfImprovementLock: true,
       selfImprovementCostsCapMicroUsd: 5_000_000,
+      selfImprovementCostsCapAwuCredits: 500,
     });
 
     expect(response.status).toBe(200);
@@ -237,6 +271,7 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
     expect(updated?.reinforcement).toBe("off");
     expect(updated?.selfImprovementLock).toBe(true);
     expect(updated?.selfImprovementCostsCapMicroUsd).toBe(5_000_000);
+    expect(updated?.selfImprovementCostsCapAwuCredits).toBe(500);
   });
 
   it("returns 403 when a non-admin tries to set selfImprovementLock", async () => {
@@ -271,6 +306,19 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
     expect(response.status).toBe(403);
   });
 
+  it("returns 403 when a non-admin tries to set the per-skill AWU credits cap", async () => {
+    const { workspace, skill } = await setupTest({
+      skillOwnerRole: "builder",
+      requestUserRole: "builder",
+    });
+
+    const response = await patch(workspace, skill.sId, {
+      selfImprovementCostsCapAwuCredits: 500,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
   it("returns 403 when a non-admin tries to flip reinforcement on a locked skill", async () => {
     const { workspace, skill } = await setupTest({
       skillOwnerRole: "builder",
@@ -299,6 +347,16 @@ describe("PATCH /api/w/:wId/skills/:sId/reinforcement", () => {
 
     const response = await patch(workspace, skill.sId, {
       selfImprovementCostsCapMicroUsd: -1,
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects negative AWU credits cap values", async () => {
+    const { workspace, skill } = await setupTest({ requestUserRole: "admin" });
+
+    const response = await patch(workspace, skill.sId, {
+      selfImprovementCostsCapAwuCredits: -1,
     });
 
     expect(response.status).toBe(400);

--- a/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/reinforcement.ts
@@ -22,12 +22,19 @@ const PatchSkillReinforcementBodySchema = z
       .nonnegative()
       .nullable() // use default
       .optional(), // not updated
+    selfImprovementCostsCapAwuCredits: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable() // use default
+      .optional(), // not updated
   })
   .refine(
     (b) =>
       b.reinforcement !== undefined ||
       b.selfImprovementLock !== undefined ||
-      b.selfImprovementCostsCapMicroUsd !== undefined,
+      b.selfImprovementCostsCapMicroUsd !== undefined ||
+      b.selfImprovementCostsCapAwuCredits !== undefined,
     { message: "At least one field must be provided." }
   );
 
@@ -66,12 +73,14 @@ app.patch(
       reinforcement,
       selfImprovementLock,
       selfImprovementCostsCapMicroUsd,
+      selfImprovementCostsCapAwuCredits,
     } = ctx.req.valid("json");
 
-    // The lock and per-skill cap are admin-only controls.
+    // The lock and per-skill caps are admin-only controls.
     const requiresAdmin =
       selfImprovementLock !== undefined ||
-      selfImprovementCostsCapMicroUsd !== undefined;
+      selfImprovementCostsCapMicroUsd !== undefined ||
+      selfImprovementCostsCapAwuCredits !== undefined;
     if (requiresAdmin && !auth.isAdmin()) {
       return apiError(ctx, {
         status_code: 403,
@@ -129,6 +138,11 @@ app.patch(
     if (selfImprovementCostsCapMicroUsd !== undefined) {
       await skill.updateSelfImprovementCostsCap(
         selfImprovementCostsCapMicroUsd
+      );
+    }
+    if (selfImprovementCostsCapAwuCredits !== undefined) {
+      await skill.updateSelfImprovementCostsCapAwuCredits(
+        selfImprovementCostsCapAwuCredits
       );
     }
 

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -555,8 +555,13 @@ export interface WorkspaceMetadata {
   isBusiness?: boolean;
   phoneCountry?: string;
   sandboxAllowAgentEgressRequests?: boolean;
+  // Caps for self-improving skills.
+  // USD are the legacy ones, AWU are the new ones for workspaces
+  // billed by metronome.
   reinforcementCapMicroUsd?: number;
   selfImprovementCapPerSkillMicroUsd?: number;
+  reinforcementCapAwuCredits?: number;
+  selfImprovementCapPerSkillAwuCredits?: number;
   webSearchProvider?: WebSearchProvider;
   webBrowseProvider?: WebBrowseProvider;
 }

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -122,6 +122,9 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
   declare reinforcement: CreationOptional<SkillReinforcementMode>;
   declare lastReinforcementAnalysisAt: CreationOptional<Date | null>;
   declare selfImprovementCostsCapMicroUsd: CreationOptional<number | null>;
+  // Same cap expressed in AWU credits, used for workspaces billed by
+  // Metronome. Null means "use the workspace default".
+  declare selfImprovementCostsCapAwuCredits: CreationOptional<number | null>;
   // Lock toggling of self-improvement to admin only.
   declare selfImprovementLock: CreationOptional<boolean>;
 
@@ -142,6 +145,11 @@ SkillConfigurationModel.init(
       defaultValue: null,
     },
     selfImprovementCostsCapMicroUsd: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      defaultValue: null,
+    },
+    selfImprovementCostsCapAwuCredits: {
       type: DataTypes.BIGINT,
       allowNull: true,
       defaultValue: null,

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -22,6 +22,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     reinforcement: "auto",
     selfImprovementLock: false,
     selfImprovementCostsCapMicroUsd: null,
+    selfImprovementCostsCapAwuCredits: null,
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -21,6 +21,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     reinforcement: "auto",
     selfImprovementLock: false,
     selfImprovementCostsCapMicroUsd: null,
+    selfImprovementCostsCapAwuCredits: null,
     requestedSpaceIds: [],
     tools: [],
     fileAttachments: [],

--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -32,9 +32,17 @@ export const PER_SKILL_CONVERSATION_CAP = 20;
 // $100 = 100_000_000 microUSD.
 export const DEFAULT_REINFORCEMENT_CAP_MICRO_USD = 100_000_000;
 
+// Default monthly cap for reinforcement cost for the whole workspace, in AWU
+// credits (workspaces billed by Metronome). ~$100.
+export const DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS = 10_000;
+
 // Default per-skill cap for self-improvement cost (in microUSD).
 // $20 = 20_000_000 microUSD.
 export const DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD = 20_000_000;
+
+// Default per-skill cap for self-improvement cost, in AWU credits (workspaces
+// billed by Metronome). ~$20.
+export const DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS = 2_000;
 
 // Estimated cost per conversation analysis (in microUSD).
 // $0.10 = 100_000 microUSD.

--- a/front/lib/reinforcement/consumption.test.ts
+++ b/front/lib/reinforcement/consumption.test.ts
@@ -2,11 +2,15 @@ import type { Authenticator } from "@app/lib/auth";
 import * as metronomeContracts from "@app/lib/metronome/contracts";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
 import {
+  DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS,
   DEFAULT_REINFORCEMENT_CAP_MICRO_USD,
+  DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS,
   DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD,
 } from "@app/lib/reinforcement/constants";
 import {
+  getReinforcementMonthlyCapAwuCredits,
   getReinforcementMonthlyCapMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits,
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { Err, Ok } from "@app/types/shared/result";
@@ -31,6 +35,8 @@ function makeAuth({
 function makeWorkspace(metadata?: {
   reinforcementCapMicroUsd?: number;
   selfImprovementCapPerSkillMicroUsd?: number;
+  reinforcementCapAwuCredits?: number;
+  selfImprovementCapPerSkillAwuCredits?: number;
 }): LightWorkspaceType {
   return { sId: "ws-1", metadata: metadata ?? null } as LightWorkspaceType;
 }
@@ -65,6 +71,44 @@ describe("getReinforcementMonthlyCapMicroUsd", () => {
   });
 });
 
+describe("getReinforcementMonthlyCapAwuCredits", () => {
+  it("returns default cap when workspace has no metadata", () => {
+    expect(getReinforcementMonthlyCapAwuCredits(makeWorkspace())).toBe(
+      DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS
+    );
+  });
+
+  it("returns default cap when metadata has no reinforcementCapAwuCredits", () => {
+    expect(getReinforcementMonthlyCapAwuCredits(makeWorkspace({}))).toBe(
+      DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS
+    );
+  });
+
+  it("ignores the microUSD override", () => {
+    expect(
+      getReinforcementMonthlyCapAwuCredits(
+        makeWorkspace({ reinforcementCapMicroUsd: 50_000_000 })
+      )
+    ).toBe(DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS);
+  });
+
+  it("returns workspace override when set", () => {
+    expect(
+      getReinforcementMonthlyCapAwuCredits(
+        makeWorkspace({ reinforcementCapAwuCredits: 5_000 })
+      )
+    ).toBe(5_000);
+  });
+
+  it("allows cap of 0", () => {
+    expect(
+      getReinforcementMonthlyCapAwuCredits(
+        makeWorkspace({ reinforcementCapAwuCredits: 0 })
+      )
+    ).toBe(0);
+  });
+});
+
 describe("getSelfImprovementCapPerSkillMicroUsd", () => {
   it("returns default cap when workspace has no metadata", () => {
     expect(
@@ -90,6 +134,44 @@ describe("getSelfImprovementCapPerSkillMicroUsd", () => {
     expect(
       getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(
         makeWorkspace({ selfImprovementCapPerSkillMicroUsd: 0 })
+      )
+    ).toBe(0);
+  });
+});
+
+describe("getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits", () => {
+  it("returns default cap when workspace has no metadata", () => {
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(makeWorkspace())
+    ).toBe(DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS);
+  });
+
+  it("returns default cap when metadata has no selfImprovementCapPerSkillAwuCredits", () => {
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(makeWorkspace({}))
+    ).toBe(DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS);
+  });
+
+  it("ignores the microUSD override", () => {
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(
+        makeWorkspace({ selfImprovementCapPerSkillMicroUsd: 10_000_000 })
+      )
+    ).toBe(DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS);
+  });
+
+  it("returns workspace override when set", () => {
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(
+        makeWorkspace({ selfImprovementCapPerSkillAwuCredits: 1_000 })
+      )
+    ).toBe(1_000);
+  });
+
+  it("allows cap of 0", () => {
+    expect(
+      getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(
+        makeWorkspace({ selfImprovementCapPerSkillAwuCredits: 0 })
       )
     ).toBe(0);
   });

--- a/front/lib/reinforcement/consumption.ts
+++ b/front/lib/reinforcement/consumption.ts
@@ -1,5 +1,7 @@
 import {
+  DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS,
   DEFAULT_REINFORCEMENT_CAP_MICRO_USD,
+  DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS,
   DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD,
 } from "@app/lib/reinforcement/constants";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -17,6 +19,19 @@ export function getReinforcementMonthlyCapMicroUsd(
 }
 
 /**
+ * Return the workspace's monthly reinforcement cap in AWU credits (workspaces
+ * billed by Metronome).
+ * Uses the workspace metadata override if set, otherwise the default (10,000).
+ */
+export function getReinforcementMonthlyCapAwuCredits(
+  workspace: LightWorkspaceType
+): number {
+  return typeof workspace.metadata?.reinforcementCapAwuCredits === "number"
+    ? workspace.metadata.reinforcementCapAwuCredits
+    : DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS;
+}
+
+/**
  * Return the workspace's self-improvement cost cap per skill in microUSD.
  * Uses the workspace metadata override if set, otherwise the default ($20).
  */
@@ -27,4 +42,18 @@ export function getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(
     "number"
     ? workspace.metadata.selfImprovementCapPerSkillMicroUsd
     : DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD;
+}
+
+/**
+ * Return the workspace's self-improvement cost cap per skill in AWU credits
+ * (workspaces billed by Metronome).
+ * Uses the workspace metadata override if set, otherwise the default (2,000).
+ */
+export function getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(
+  workspace: LightWorkspaceType
+): number {
+  return typeof workspace.metadata?.selfImprovementCapPerSkillAwuCredits ===
+    "number"
+    ? workspace.metadata.selfImprovementCapPerSkillAwuCredits
+    : DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS;
 }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1705,6 +1705,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         reinforcement: "auto",
         lastReinforcementAnalysisAt: null,
         selfImprovementCostsCapMicroUsd: null,
+        selfImprovementCostsCapAwuCredits: null,
         selfImprovementLock: false,
       },
       {
@@ -1977,6 +1978,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           lastReinforcementAnalysisAt: null,
           selfImprovementCostsCapMicroUsd:
             versionModel.selfImprovementCostsCapMicroUsd,
+          selfImprovementCostsCapAwuCredits:
+            versionModel.selfImprovementCostsCapAwuCredits,
           selfImprovementLock: versionModel.selfImprovementLock,
         },
         {
@@ -2678,6 +2681,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     selfImprovementCostsCapMicroUsd: number | null
   ): Promise<void> {
     await this.update({ selfImprovementCostsCapMicroUsd });
+  }
+
+  async updateSelfImprovementCostsCapAwuCredits(
+    selfImprovementCostsCapAwuCredits: number | null
+  ): Promise<void> {
+    await this.update({ selfImprovementCostsCapAwuCredits });
   }
 
   async recordReinforcementAnalysisCompletion(): Promise<void> {
@@ -3600,6 +3609,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         this.lastReinforcementAnalysisAt?.toISOString() ?? null,
       selfImprovementLock: this.selfImprovementLock,
       selfImprovementCostsCapMicroUsd: this.selfImprovementCostsCapMicroUsd,
+      selfImprovementCostsCapAwuCredits: this.selfImprovementCostsCapAwuCredits,
       source: this.source,
       sourceMetadata: this.sourceMetadata,
       tools: this.mcpServerViews.map((view) => {

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -271,6 +271,7 @@ type SkillReinforcementUpdate = {
   reinforcement?: SkillReinforcementMode;
   selfImprovementLock?: boolean;
   selfImprovementCostsCapMicroUsd?: number | null;
+  selfImprovementCostsCapAwuCredits?: number | null;
 };
 
 export function useUpdateSkillReinforcement({

--- a/front/migrations/db/migration_677.sql
+++ b/front/migrations/db/migration_677.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 11, 2026
+ALTER TABLE "public"."skill_configurations" ADD COLUMN "selfImprovementCostsCapAwuCredits" BIGINT;

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -61,6 +61,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     reinforcement: "auto",
     selfImprovementLock: false,
     selfImprovementCostsCapMicroUsd: null,
+    selfImprovementCostsCapAwuCredits: null,
     requestedSpaceIds: [],
     tools: (config.tools ?? []).map((t) => ({
       id: 0,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -46,6 +46,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   lastReinforcementAnalysisAt: z.string().nullable().optional(),
   selfImprovementLock: z.boolean(),
   selfImprovementCostsCapMicroUsd: z.number().nullable(),
+  selfImprovementCostsCapAwuCredits: z.number().nullable(),
   requestedSpaceIds: z.array(z.string()),
   fileAttachments: z.array(
     z.object({


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8784


 - Store limit in AWU in DB:
   - per skill limit is stored in the skill_configurations table
   - workspace global limit and default per skill limit are stored in the workspace metadatas
 - no sync between limit, they are set and fetch separatly
 - updated all the resources/api and related tests to get/set the limit


Step by step plan:
  1. [Store the AWU in the self_improving_skills_usage table (always with margins) ](https://github.com/dust-tt/dust/pull/27190) ✅ done
  2. [Update resources and API to retrieve the value ](https://github.com/dust-tt/dust/pull/27218) ✅ done
  3. Store limit in AWU in db and update API to set/get them <-- ℹ️ You are here
  4. Use AWU to enforce the limit for credit based workspaces
  5. Update UI admin apge to display AWU credits when using metronome.


## Tests

updated unit tests

## Risk

low, all apis are backward compatible 

## Deploy Plan

lock front
merge PR
migration
deploy front
unlock front