### PR TITLE
Self improving skills in AWU: enforce AWU limits for Credit billed workspaces

### DIFF
--- a/front/lib/metronome/programmatic_awu_usage.ts
+++ b/front/lib/metronome/programmatic_awu_usage.ts
@@ -1,0 +1,187 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getMetronomeProgrammaticCap } from "@app/lib/metronome/alerts/programmatic_cap";
+import {
+  ceilToMidnightUTC,
+  floorToMidnightUTC,
+  listMetronomeUsageWithGroups,
+} from "@app/lib/metronome/client";
+import {
+  getMetricLlmProviderCostAwuId,
+  getMetricToolInvocationsId,
+  USAGE_TYPE_GROUP_KEY,
+  USAGE_TYPE_PROGRAMMATIC,
+} from "@app/lib/metronome/constants";
+import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import {
+  isToolCategory,
+  TOOL_CATEGORY_AWU_WEIGHTS,
+} from "@app/lib/metronome/events";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Remaining programmatic headroom for the current billing period, in AWU
+ * credits: the monthly programmatic cap minus the period's programmatic AWU
+ * spend, both read live from Metronome.
+ *
+ * Fail-open: returns Infinity when the workspace has no Metronome customer,
+ * no programmatic cap, or the cap cannot be fetched; degrades to the cap
+ * alone when the spend query fails. Callers needing a hard stop on cap
+ * depletion should rely on the alert-driven programmatic credit state
+ * (isProgrammaticApiBlocked), not on this estimate.
+ */
+export async function getRemainingProgrammaticUsageFromMetronome(
+  auth: Authenticator
+): Promise<number> {
+  const workspace = auth.getNonNullableWorkspace();
+  const metronomeCustomerId = workspace.metronomeCustomerId;
+  if (!metronomeCustomerId) {
+    return Infinity;
+  }
+
+  const programmaticCapRes = await getMetronomeProgrammaticCap({
+    metronomeCustomerId,
+    workspaceId: workspace.sId,
+  });
+  if (programmaticCapRes.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, error: programmaticCapRes.error },
+      "[Metronome] Failed to fetch the programmatic cap — treating the programmatic headroom as unlimited"
+    );
+    return Infinity;
+  }
+  if (programmaticCapRes.value === null) {
+    // No programmatic cap configured.
+    return Infinity;
+  }
+  const programmaticCapAwuCredits = programmaticCapRes.value;
+
+  const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
+  if (!metronomeContractId) {
+    return programmaticCapAwuCredits;
+  }
+
+  const programmaticSpendRes = await fetchProgrammaticAwuSpend({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (programmaticSpendRes.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, error: programmaticSpendRes.error },
+      "[Metronome] Failed to fetch the programmatic spend — using the cap as the headroom upper bound"
+    );
+    return programmaticCapAwuCredits;
+  }
+
+  return Math.max(
+    0,
+    programmaticCapAwuCredits - (programmaticSpendRes.value ?? 0)
+  );
+}
+
+/**
+ * Workspace-level programmatic AWU spend for the current billing period,
+ * read live from the Metronome grouped usage API. Returns `null` when the
+ * customer has no active billing period.
+ *
+ * Mirrors the query mechanics of `fetchPerUserAwuUsage` (per_user_usage.ts):
+ * the usage endpoint requires midnight-aligned bounds, so query from the
+ * floored period start (at HOUR granularity when the period itself does not
+ * start at midnight) and drop pre-period buckets in code.
+ *
+ * AWU spend has two sources, both priced in the AWU credit type:
+ *   - AI Usage: the `cost_awu` metric, priced 1 AWU per unit.
+ *   - Tool Usage: an invocation count, weighted per category (basic ×1,
+ *     advanced ×3).
+ *
+ * We group by `usage_type` (plus `tool_category` for tools) and keep only the
+ * `programmatic` buckets in code rather than filtering the query on
+ * `usage_type`: filtered queries make Metronome under-aggregate some buckets
+ * (see per_user_usage.ts). Unlike the per-user query, grouping only by
+ * `usage_type` has a handful of groups, so the unfiltered query is not at
+ * risk of being capped server-side.
+ */
+export async function fetchProgrammaticAwuSpend({
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<Result<number | null, Error>> {
+  const periodResult = await getMetronomeCurrentBillingPeriod({
+    metronomeCustomerId,
+    metronomeContractId,
+  });
+  if (periodResult.isErr()) {
+    return new Err(periodResult.error);
+  }
+  if (!periodResult.value) {
+    return new Ok(null);
+  }
+  const { cycleStart, cycleEnd } = periodResult.value;
+  const cycleStartMs = cycleStart.getTime();
+
+  const startingOn = floorToMidnightUTC(cycleStart).toISOString();
+  const requestEnd = new Date(Math.min(cycleEnd.getTime(), Date.now()));
+  const endingBefore = ceilToMidnightUTC(requestEnd).toISOString();
+  const windowSize =
+    cycleStartMs === floorToMidnightUTC(cycleStart).getTime() ? "DAY" : "HOUR";
+
+  const [aiResult, toolResult] = await Promise.all([
+    listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricLlmProviderCostAwuId(),
+      startingOn,
+      endingBefore,
+      windowSize,
+      groupKey: [USAGE_TYPE_GROUP_KEY],
+    }),
+    listMetronomeUsageWithGroups({
+      customerId: metronomeCustomerId,
+      billableMetricId: getMetricToolInvocationsId(),
+      startingOn,
+      endingBefore,
+      windowSize,
+      groupKey: [USAGE_TYPE_GROUP_KEY, "tool_category"],
+    }),
+  ]);
+  if (aiResult.isErr()) {
+    return new Err(aiResult.error);
+  }
+  if (toolResult.isErr()) {
+    return new Err(toolResult.error);
+  }
+
+  let spentAwuCredits = 0;
+
+  // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
+  for (const entry of aiResult.value) {
+    if (
+      entry.value === null ||
+      entry.group?.[USAGE_TYPE_GROUP_KEY] !== USAGE_TYPE_PROGRAMMATIC ||
+      new Date(entry.startingOn).getTime() < cycleStartMs
+    ) {
+      continue;
+    }
+    spentAwuCredits += entry.value;
+  }
+
+  // Tool usage: the value is an invocation count — weight it by the
+  // per-category AWU price to convert it into AWU spend.
+  for (const entry of toolResult.value) {
+    const category = entry.group?.["tool_category"];
+    if (
+      entry.value === null ||
+      entry.group?.[USAGE_TYPE_GROUP_KEY] !== USAGE_TYPE_PROGRAMMATIC ||
+      new Date(entry.startingOn).getTime() < cycleStartMs ||
+      !category ||
+      !isToolCategory(category)
+    ) {
+      continue;
+    }
+    spentAwuCredits += entry.value * TOOL_CATEGORY_AWU_WEIGHTS[category];
+  }
+
+  return new Ok(spentAwuCredits);
+}

--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -85,22 +85,27 @@ export function getMaxConversationsForBudget({
 
 /**
  * AWU credits variant of getMaxConversationsForBudget, for workspaces billed
- * by Metronome. All amounts are in AWU credits (margin baked in).
+ * by Metronome. All amounts are in AWU credits (margin baked in). The budget
+ * is the most restrictive of the reinforcement cap headroom, the programmatic
+ * cap headroom, and the remaining workspace credit pool.
  */
 export function getMaxConversationsForBudgetAwuCredits({
   globalConsumptionAwuCredits,
   globalCapAwuCredits,
   remainingProgrammaticCreditsAwuCredits,
+  remainingPoolCreditsAwuCredits,
 }: {
   globalConsumptionAwuCredits: number;
   globalCapAwuCredits: number;
   remainingProgrammaticCreditsAwuCredits: number;
+  remainingPoolCreditsAwuCredits: number;
 }): number {
   const remainingReinforcementAwuCredits =
     globalCapAwuCredits - globalConsumptionAwuCredits;
   const remainingAwuCredits = Math.min(
     remainingReinforcementAwuCredits,
-    remainingProgrammaticCreditsAwuCredits
+    remainingProgrammaticCreditsAwuCredits,
+    remainingPoolCreditsAwuCredits
   );
   if (remainingAwuCredits <= 0) {
     return 0;

--- a/front/lib/reinforcement/constants.ts
+++ b/front/lib/reinforcement/constants.ts
@@ -48,6 +48,10 @@ export const DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS = 2_000;
 // $0.10 = 100_000 microUSD.
 const ESTIMATED_COST_PER_CONVERSATION_MICRO_USD = 100_000;
 
+// Estimated cost per conversation analysis (in AWU credits).
+// ~$0.10.
+const ESTIMATED_COST_PER_CONVERSATION_AWU_CREDITS = 10;
+
 /**
  * Compute the maximum number of conversations to analyze based on the
  * remaining reinforcement budget and remaining programmatic credits.
@@ -74,6 +78,36 @@ export function getMaxConversationsForBudget({
 
   const fromBudget = Math.floor(
     remainingMicroUsd / ESTIMATED_COST_PER_CONVERSATION_MICRO_USD
+  );
+
+  return Math.min(fromBudget, DEFAULT_MAX_CONVERSATIONS_PER_RUN);
+}
+
+/**
+ * AWU credits variant of getMaxConversationsForBudget, for workspaces billed
+ * by Metronome. All amounts are in AWU credits (margin baked in).
+ */
+export function getMaxConversationsForBudgetAwuCredits({
+  globalConsumptionAwuCredits,
+  globalCapAwuCredits,
+  remainingProgrammaticCreditsAwuCredits,
+}: {
+  globalConsumptionAwuCredits: number;
+  globalCapAwuCredits: number;
+  remainingProgrammaticCreditsAwuCredits: number;
+}): number {
+  const remainingReinforcementAwuCredits =
+    globalCapAwuCredits - globalConsumptionAwuCredits;
+  const remainingAwuCredits = Math.min(
+    remainingReinforcementAwuCredits,
+    remainingProgrammaticCreditsAwuCredits
+  );
+  if (remainingAwuCredits <= 0) {
+    return 0;
+  }
+
+  const fromBudget = Math.floor(
+    remainingAwuCredits / ESTIMATED_COST_PER_CONVERSATION_AWU_CREDITS
   );
 
   return Math.min(fromBudget, DEFAULT_MAX_CONVERSATIONS_PER_RUN);

--- a/front/lib/reinforcement/enforcement.test.ts
+++ b/front/lib/reinforcement/enforcement.test.ts
@@ -1,0 +1,313 @@
+import { MARKUP_MULTIPLIER } from "@app/lib/api/programmatic_usage/common";
+import type { WorkspaceMetadata } from "@app/lib/api/workspace";
+import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import {
+  DEFAULT_MAX_CONVERSATIONS_PER_RUN,
+  getMaxConversationsForBudgetAwuCredits,
+} from "@app/lib/reinforcement/constants";
+import {
+  filterSkillsUnderSelfImprovementCap,
+  getReinforcementBillingUnit,
+  getReinforcementGlobalConsumptionStatus,
+} from "@app/lib/reinforcement/enforcement";
+import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+const CUTOFF = new Date("2026-01-02T00:00:00.000Z");
+const IN_PERIOD = new Date("2026-01-03T00:00:00.000Z");
+
+async function setup({
+  creditPriced = false,
+  metadata,
+}: {
+  creditPriced?: boolean;
+  metadata?: WorkspaceMetadata;
+} = {}) {
+  const workspace = creditPriced
+    ? await WorkspaceFactory.creditPriced()
+    : await WorkspaceFactory.basic();
+
+  if (metadata) {
+    await updateWorkspaceMetadata(workspace, metadata);
+  }
+
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "admin" });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  await SpaceFactory.defaults(auth);
+
+  return { workspace, auth };
+}
+
+async function createSkill(
+  auth: Authenticator,
+  name: string
+): Promise<SkillResource> {
+  const skillModel = await SkillFactory.create(auth, { name });
+  const skill = await SkillResource.fetchByModelIdWithAuth(auth, skillModel.id);
+  if (!skill) {
+    throw new Error("Failed to create skill");
+  }
+  return skill;
+}
+
+async function recordUsage(
+  auth: Authenticator,
+  skill: SkillResource,
+  { microUsd, awuCredits }: { microUsd: number; awuCredits: number }
+) {
+  await SelfImprovingSkillsUsageResource.bulkCreate(auth, [
+    {
+      createdAt: IN_PERIOD,
+      skillId: skill.id,
+      conversationId: null,
+      priceMicroUsd: microUsd,
+      priceAwuCredits: awuCredits,
+    },
+  ]);
+}
+
+describe("getReinforcementBillingUnit", () => {
+  it("returns micro_usd for a workspace not billed by Metronome", async () => {
+    const { auth } = await setup();
+    expect(getReinforcementBillingUnit(auth)).toBe("micro_usd");
+  });
+
+  it("returns awu_credits for a credit-priced Metronome workspace", async () => {
+    const { auth } = await setup({ creditPriced: true });
+    expect(getReinforcementBillingUnit(auth)).toBe("awu_credits");
+  });
+});
+
+describe("getReinforcementGlobalConsumptionStatus", () => {
+  it("enforces in raw micro-USD for non-Metronome workspaces", async () => {
+    const { auth } = await setup({
+      metadata: {
+        reinforcementCapMicroUsd: 50_000_000,
+        // The AWU cap must be ignored on this billing mode.
+        reinforcementCapAwuCredits: 1,
+      },
+    });
+    const skill = await createSkill(auth, "Global Cap Skill");
+    await recordUsage(auth, skill, { microUsd: 40_000_000, awuCredits: 4_706 });
+
+    const status = await getReinforcementGlobalConsumptionStatus(auth, {
+      periodStart: CUTOFF,
+      unit: "micro_usd",
+    });
+
+    expect(status).toEqual({
+      unit: "micro_usd",
+      consumedMicroUsd: 40_000_000,
+      capMicroUsd: 50_000_000,
+      capReached: false,
+    });
+  });
+
+  it("flags the micro-USD cap as reached", async () => {
+    const { auth } = await setup({
+      metadata: { reinforcementCapMicroUsd: 30_000_000 },
+    });
+    const skill = await createSkill(auth, "Global Cap Reached Skill");
+    await recordUsage(auth, skill, { microUsd: 30_000_000, awuCredits: 3_530 });
+
+    const status = await getReinforcementGlobalConsumptionStatus(auth, {
+      periodStart: CUTOFF,
+      unit: "micro_usd",
+    });
+
+    expect(status.unit).toBe("micro_usd");
+    expect(status.capReached).toBe(true);
+  });
+
+  it("enforces in AWU credits for Metronome workspaces", async () => {
+    const { auth } = await setup({
+      creditPriced: true,
+      metadata: {
+        reinforcementCapAwuCredits: 5_000,
+        // The micro-USD cap must be ignored on this billing mode, even when
+        // the micro-USD consumption exceeds it.
+        reinforcementCapMicroUsd: 1,
+      },
+    });
+    const skill = await createSkill(auth, "AWU Global Cap Skill");
+    await recordUsage(auth, skill, { microUsd: 34_000_000, awuCredits: 4_000 });
+
+    const status = await getReinforcementGlobalConsumptionStatus(auth, {
+      periodStart: CUTOFF,
+      unit: "awu_credits",
+    });
+
+    expect(status).toEqual({
+      unit: "awu_credits",
+      consumedAwuCredits: 4_000,
+      capAwuCredits: 5_000,
+      capReached: false,
+    });
+  });
+
+  it("flags the AWU credits cap as reached", async () => {
+    const { auth } = await setup({
+      creditPriced: true,
+      metadata: { reinforcementCapAwuCredits: 3_000 },
+    });
+    const skill = await createSkill(auth, "AWU Global Cap Reached Skill");
+    await recordUsage(auth, skill, { microUsd: 100, awuCredits: 3_000 });
+
+    const status = await getReinforcementGlobalConsumptionStatus(auth, {
+      periodStart: CUTOFF,
+      unit: "awu_credits",
+    });
+
+    expect(status.unit).toBe("awu_credits");
+    expect(status.capReached).toBe(true);
+  });
+});
+
+describe("filterSkillsUnderSelfImprovementCap", () => {
+  it("enforces marked-up micro-USD caps for non-Metronome workspaces", async () => {
+    const { auth } = await setup({
+      metadata: { selfImprovementCapPerSkillMicroUsd: 20_000_000 },
+    });
+
+    // Raw 20M => 26M with markup: over the 20M default cap.
+    const overCapSkill = await createSkill(auth, "Over Cap Skill");
+    await recordUsage(auth, overCapSkill, {
+      microUsd: 20_000_000,
+      // High AWU consumption must be ignored on this billing mode.
+      awuCredits: 1_000_000,
+    });
+
+    // Raw 10M => 13M with markup: under the 20M default cap.
+    const underCapSkill = await createSkill(auth, "Under Cap Skill");
+    await recordUsage(auth, underCapSkill, {
+      microUsd: 10_000_000,
+      awuCredits: 1_177,
+    });
+
+    // Same consumption as overCapSkill but with a higher per-skill override.
+    const customCapSkill = await createSkill(auth, "Custom Cap Skill");
+    await customCapSkill.updateSelfImprovementCostsCap(30_000_000);
+    await recordUsage(auth, customCapSkill, {
+      microUsd: 20_000_000,
+      awuCredits: 2_353,
+    });
+
+    const filtered = await filterSkillsUnderSelfImprovementCap(auth, {
+      skills: [overCapSkill, underCapSkill, customCapSkill],
+      createdAfter: CUTOFF,
+      unit: "micro_usd",
+    });
+
+    expect(filtered.map((skill) => skill.sId).sort()).toEqual(
+      [underCapSkill.sId, customCapSkill.sId].sort()
+    );
+    // Sanity-check the markup assumption behind the over-cap fixture.
+    expect(20_000_000 * MARKUP_MULTIPLIER).toBeGreaterThan(20_000_000);
+  });
+
+  it("enforces AWU credits caps for Metronome workspaces", async () => {
+    const { auth } = await setup({
+      creditPriced: true,
+      metadata: { selfImprovementCapPerSkillAwuCredits: 2_000 },
+    });
+
+    const overCapSkill = await createSkill(auth, "AWU Over Cap Skill");
+    await recordUsage(auth, overCapSkill, {
+      // Low micro-USD consumption must be ignored on this billing mode.
+      microUsd: 100,
+      awuCredits: 2_500,
+    });
+
+    const underCapSkill = await createSkill(auth, "AWU Under Cap Skill");
+    await recordUsage(auth, underCapSkill, {
+      // Micro-USD consumption way over the micro-USD default cap: ignored.
+      microUsd: 999_000_000,
+      awuCredits: 500,
+    });
+
+    // Same consumption as overCapSkill but with a higher per-skill override.
+    const customCapSkill = await createSkill(auth, "AWU Custom Cap Skill");
+    await customCapSkill.updateSelfImprovementCostsCapAwuCredits(3_000);
+    await recordUsage(auth, customCapSkill, {
+      microUsd: 100,
+      awuCredits: 2_500,
+    });
+
+    const filtered = await filterSkillsUnderSelfImprovementCap(auth, {
+      skills: [overCapSkill, underCapSkill, customCapSkill],
+      createdAfter: CUTOFF,
+      unit: "awu_credits",
+    });
+
+    expect(filtered.map((skill) => skill.sId).sort()).toEqual(
+      [underCapSkill.sId, customCapSkill.sId].sort()
+    );
+  });
+
+  it("keeps skills with no usage in the period", async () => {
+    const { auth } = await setup({ creditPriced: true });
+    const idleSkill = await createSkill(auth, "Idle Skill");
+
+    const filtered = await filterSkillsUnderSelfImprovementCap(auth, {
+      skills: [idleSkill],
+      createdAfter: CUTOFF,
+      unit: "awu_credits",
+    });
+
+    expect(filtered.map((skill) => skill.sId)).toEqual([idleSkill.sId]);
+  });
+});
+
+describe("getMaxConversationsForBudgetAwuCredits", () => {
+  it("derives the conversation budget from the remaining credits", () => {
+    // 1_200 credits remaining / 10 credits per conversation = 120.
+    expect(
+      getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: 800,
+        globalCapAwuCredits: 2_000,
+        remainingProgrammaticCreditsAwuCredits: 10_000,
+      })
+    ).toBe(120);
+  });
+
+  it("clamps to the remaining programmatic credits", () => {
+    expect(
+      getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: 0,
+        globalCapAwuCredits: 10_000,
+        remainingProgrammaticCreditsAwuCredits: 120,
+      })
+    ).toBe(12);
+  });
+
+  it("returns 0 when the cap is exhausted", () => {
+    expect(
+      getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: 2_000,
+        globalCapAwuCredits: 2_000,
+        remainingProgrammaticCreditsAwuCredits: 10_000,
+      })
+    ).toBe(0);
+  });
+
+  it("caps at DEFAULT_MAX_CONVERSATIONS_PER_RUN", () => {
+    expect(
+      getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: 0,
+        globalCapAwuCredits: 10_000_000,
+        remainingProgrammaticCreditsAwuCredits: 10_000_000,
+      })
+    ).toBe(DEFAULT_MAX_CONVERSATIONS_PER_RUN);
+  });
+});

--- a/front/lib/reinforcement/enforcement.test.ts
+++ b/front/lib/reinforcement/enforcement.test.ts
@@ -277,6 +277,7 @@ describe("getMaxConversationsForBudgetAwuCredits", () => {
         globalConsumptionAwuCredits: 800,
         globalCapAwuCredits: 2_000,
         remainingProgrammaticCreditsAwuCredits: 10_000,
+        remainingPoolCreditsAwuCredits: 10_000,
       })
     ).toBe(120);
   });
@@ -287,6 +288,18 @@ describe("getMaxConversationsForBudgetAwuCredits", () => {
         globalConsumptionAwuCredits: 0,
         globalCapAwuCredits: 10_000,
         remainingProgrammaticCreditsAwuCredits: 120,
+        remainingPoolCreditsAwuCredits: 10_000,
+      })
+    ).toBe(12);
+  });
+
+  it("clamps to the remaining pool credits", () => {
+    expect(
+      getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: 0,
+        globalCapAwuCredits: 10_000,
+        remainingProgrammaticCreditsAwuCredits: 10_000,
+        remainingPoolCreditsAwuCredits: 120,
       })
     ).toBe(12);
   });
@@ -297,6 +310,18 @@ describe("getMaxConversationsForBudgetAwuCredits", () => {
         globalConsumptionAwuCredits: 2_000,
         globalCapAwuCredits: 2_000,
         remainingProgrammaticCreditsAwuCredits: 10_000,
+        remainingPoolCreditsAwuCredits: 10_000,
+      })
+    ).toBe(0);
+  });
+
+  it("returns 0 when the pool is empty", () => {
+    expect(
+      getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: 0,
+        globalCapAwuCredits: 10_000,
+        remainingProgrammaticCreditsAwuCredits: 10_000,
+        remainingPoolCreditsAwuCredits: 0,
       })
     ).toBe(0);
   });
@@ -307,6 +332,7 @@ describe("getMaxConversationsForBudgetAwuCredits", () => {
         globalConsumptionAwuCredits: 0,
         globalCapAwuCredits: 10_000_000,
         remainingProgrammaticCreditsAwuCredits: 10_000_000,
+        remainingPoolCreditsAwuCredits: 10_000_000,
       })
     ).toBe(DEFAULT_MAX_CONVERSATIONS_PER_RUN);
   });

--- a/front/lib/reinforcement/enforcement.ts
+++ b/front/lib/reinforcement/enforcement.ts
@@ -1,0 +1,158 @@
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getReinforcementMonthlyCapAwuCredits,
+  getReinforcementMonthlyCapMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits,
+  getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
+} from "@app/lib/reinforcement/consumption";
+import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+/**
+ * Billing-unit-aware enforcement of the reinforcement limits.
+ *
+ * Workspaces billed by Metronome (credit-priced plan) are enforced in AWU
+ * credits (margin baked in); other workspaces in micro-USD (raw cost, markup
+ * applied where the legacy path applies it).
+ */
+
+export type ReinforcementBillingUnit = "micro_usd" | "awu_credits";
+
+/**
+ * The unit in which the reinforcement limits of this workspace are enforced:
+ * AWU credits for workspaces billed by Metronome on a credit-priced plan,
+ * micro-USD otherwise.
+ */
+export function getReinforcementBillingUnit(
+  auth: Authenticator
+): ReinforcementBillingUnit {
+  const workspace = auth.workspace();
+  const plan = auth.subscription()?.plan;
+  return workspace?.metronomeCustomerId && plan && isCreditPricedPlan(plan)
+    ? "awu_credits"
+    : "micro_usd";
+}
+
+// Micro-USD amounts are raw, without markup (matching the legacy global cap
+// check); AWU credits have the margin baked in.
+export type ReinforcementGlobalConsumptionStatus =
+  | {
+      unit: "micro_usd";
+      consumedMicroUsd: number;
+      capMicroUsd: number;
+      capReached: boolean;
+    }
+  | {
+      unit: "awu_credits";
+      consumedAwuCredits: number;
+      capAwuCredits: number;
+      capReached: boolean;
+    };
+
+/**
+ * Workspace-level reinforcement consumption for the period, compared against
+ * the workspace monthly cap in the requested billing unit.
+ */
+export async function getReinforcementGlobalConsumptionStatus(
+  auth: Authenticator,
+  {
+    periodStart,
+    unit,
+  }: {
+    periodStart: Date;
+    unit: ReinforcementBillingUnit;
+  }
+): Promise<ReinforcementGlobalConsumptionStatus> {
+  const workspace = auth.getNonNullableWorkspace();
+  const spend = await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
+    auth,
+    periodStart
+  );
+
+  switch (unit) {
+    case "awu_credits": {
+      const capAwuCredits = getReinforcementMonthlyCapAwuCredits(workspace);
+      return {
+        unit,
+        consumedAwuCredits: spend.priceAwuCredits,
+        capAwuCredits,
+        capReached: spend.priceAwuCredits >= capAwuCredits,
+      };
+    }
+    case "micro_usd": {
+      const capMicroUsd = getReinforcementMonthlyCapMicroUsd(workspace);
+      return {
+        unit,
+        consumedMicroUsd: spend.priceMicroUsd,
+        capMicroUsd,
+        capReached: spend.priceMicroUsd >= capMicroUsd,
+      };
+    }
+    default:
+      return assertNever(unit);
+  }
+}
+
+/**
+ * Filter out the skills that have reached their per-skill self-improvement
+ * cap for the period, in the requested billing unit: AWU credits, or
+ * marked-up micro-USD (matching the legacy per-skill cap check).
+ */
+export async function filterSkillsUnderSelfImprovementCap(
+  auth: Authenticator,
+  {
+    skills,
+    createdAfter,
+    unit,
+  }: {
+    skills: SkillResource[];
+    createdAfter: Date;
+    unit: ReinforcementBillingUnit;
+  }
+): Promise<SkillResource[]> {
+  if (skills.length === 0) {
+    return [];
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+
+  // The markup only affects the micro-USD component; AWU credits already
+  // include the margin, so a single marked-up fetch serves both units.
+  const skillConsumptionMap =
+    await SelfImprovingSkillsUsageResource.getSumSpendWithMarkupAfterDateForSkills(
+      auth,
+      {
+        createdAfter,
+        skillModelIds: skills.map((skill) => skill.id),
+      }
+    );
+
+  switch (unit) {
+    case "awu_credits": {
+      const defaultCapAwuCredits =
+        getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(workspace);
+      return skills.filter((skill) => {
+        const consumedAwuCredits =
+          skillConsumptionMap.get(skill.id)?.priceAwuCredits ?? 0;
+        const capAwuCredits =
+          skill.selfImprovementCostsCapAwuCredits ?? defaultCapAwuCredits;
+        return consumedAwuCredits < capAwuCredits;
+      });
+    }
+    case "micro_usd": {
+      const defaultCapMicroUsd =
+        getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(workspace);
+      return skills.filter((skill) => {
+        const consumedMicroUsd =
+          skillConsumptionMap.get(skill.id)?.priceMicroUsd ?? 0;
+        const capMicroUsd =
+          skill.selfImprovementCostsCapMicroUsd ?? defaultCapMicroUsd;
+        return consumedMicroUsd < capMicroUsd;
+      });
+    }
+    default:
+      return assertNever(unit);
+  }
+}

--- a/front/lib/reinforcement/selection.ts
+++ b/front/lib/reinforcement/selection.ts
@@ -1,9 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getCurrentPeriod } from "@app/lib/reinforcement/billing";
-import { getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd } from "@app/lib/reinforcement/consumption";
+import {
+  filterSkillsUnderSelfImprovementCap,
+  getReinforcementBillingUnit,
+} from "@app/lib/reinforcement/enforcement";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { SelfImprovingSkillsUsageResource } from "@app/lib/resources/self_improving_skills_usage_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SkillSuggestionResource } from "@app/lib/resources/skill_suggestion_resource";
 import { daysAgo } from "@app/lib/utils/timestamps";
@@ -106,23 +108,10 @@ async function fetchEligibleSkillIds(
 
   // Filter out skills that have reached their per-skill consumption cap.
   const { cycleStart } = await getCurrentPeriod(auth);
-  const skillConsumptionMap =
-    await SelfImprovingSkillsUsageResource.getSumSpendWithMarkupAfterDateForSkills(
-      auth,
-      {
-        createdAfter: cycleStart,
-        skillModelIds: eligibleSkills.map((s) => s.id),
-      }
-    );
-
-  const defaultCapMicroUsd =
-    getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(workspace);
-  const capEligibleSkills = eligibleSkills.filter((skill) => {
-    const consumedMicroUsd =
-      skillConsumptionMap.get(skill.id)?.priceMicroUsd ?? 0;
-    const capMicroUsd =
-      skill.selfImprovementCostsCapMicroUsd ?? defaultCapMicroUsd;
-    return consumedMicroUsd < capMicroUsd;
+  const capEligibleSkills = await filterSkillsUnderSelfImprovementCap(auth, {
+    skills: eligibleSkills,
+    createdAfter: cycleStart,
+    unit: getReinforcementBillingUnit(auth),
   });
 
   logger.info(

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -10,6 +10,7 @@ import {
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
@@ -39,8 +40,12 @@ import {
   DEFAULT_MAX_CONVERSATIONS_PER_RUN,
   DEFAULT_REINFORCEMENT_LOOKBACK_WINDOW_DAYS,
   getMaxConversationsForBudget,
+  getMaxConversationsForBudgetAwuCredits,
 } from "@app/lib/reinforcement/constants";
-import { getReinforcementMonthlyCapMicroUsd } from "@app/lib/reinforcement/consumption";
+import {
+  getReinforcementBillingUnit,
+  getReinforcementGlobalConsumptionStatus,
+} from "@app/lib/reinforcement/enforcement";
 import {
   buildReinforcedSkillsSpecifications,
   classifySkillToolCalls,
@@ -82,7 +87,7 @@ import {
 } from "@app/temporal/agent_loop/activities/usage_tracking";
 import { ensureReinforcementWorkspaceSchedules } from "@app/temporal/reinforcement/client";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import { isCreditPricedPlan } from "@app/types/plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { ApplicationFailure } from "@temporalio/common";
 import { Op } from "sequelize";
 
@@ -588,8 +593,7 @@ export async function getReinforcementSettingsActivity({
   | {
       reinforcementEnabled: true;
       batchModeAllowed: boolean;
-      globalConsumptionMicroUsd: number;
-      globalCapMicroUsd: number;
+      globalCapReached: boolean;
       programmaticUsageLimitReached: boolean;
       maxConversationsForBudget: number;
     }
@@ -602,47 +606,76 @@ export async function getReinforcementSettingsActivity({
 
   const workspace = auth.getNonNullableWorkspace();
   const { cycleStart: periodStart } = await getCurrentPeriod(auth);
-  const { priceMicroUsd: globalConsumptionMicroUsd } =
-    await SelfImprovingSkillsUsageResource.getSumSpendAfterDate(
-      auth,
-      periodStart
-    );
-  const globalCapMicroUsd = getReinforcementMonthlyCapMicroUsd(workspace);
-
-  // Credit-priced plans check pool + programmatic cap via Metronome state;
-  // legacy plans check programmatic credits via CreditResource.
-  const plan = auth.subscription()?.plan;
-  let programmaticUsageLimitReached: boolean;
-  if (plan && isCreditPricedPlan(plan) && workspace.metronomeCustomerId) {
-    programmaticUsageLimitReached =
-      (await isApiBlocked(workspace.sId)) ||
-      (await isProgrammaticApiBlocked(workspace.sId));
-  } else {
-    // Legacy check for not metronome workspaces
-    programmaticUsageLimitReached = (
-      await checkProgrammaticUsageLimits(auth)
-    ).isErr();
-  }
-
-  // Compute remaining programmatic budget: total remaining credits capped by
-  // the daily usage allowance.
-  // TODO(fabien): use credit pool remaining credit here too.
-  const remainingCreditsMicroUsd =
-    await CreditResource.getRemainingMicroUsd(auth);
-  const remainingDailyCapMicroUsd = await getRemainingDailyCapMicroUsd(auth);
-  const remainingProgrammaticCreditsMicroUsd = Math.min(
-    remainingCreditsMicroUsd,
-    remainingDailyCapMicroUsd
+  const globalConsumption = await getReinforcementGlobalConsumptionStatus(
+    auth,
+    { periodStart, unit: getReinforcementBillingUnit(auth) }
   );
+
+  let programmaticUsageLimitReached: boolean;
+  let maxConversationsForBudget: number;
+  switch (globalConsumption.unit) {
+    case "micro_usd": {
+      // Legacy programmatic usage check via CreditResource.
+      programmaticUsageLimitReached = (
+        await checkProgrammaticUsageLimits(auth)
+      ).isErr();
+
+      // Remaining programmatic budget: total remaining credits capped by the
+      // daily usage allowance.
+      const remainingCreditsMicroUsd =
+        await CreditResource.getRemainingMicroUsd(auth);
+      const remainingDailyCapMicroUsd =
+        await getRemainingDailyCapMicroUsd(auth);
+      maxConversationsForBudget = getMaxConversationsForBudget({
+        globalConsumptionMicroUsd: globalConsumption.consumedMicroUsd,
+        globalCapMicroUsd: globalConsumption.capMicroUsd,
+        remainingProgrammaticCreditsMicroUsd: Math.min(
+          remainingCreditsMicroUsd,
+          remainingDailyCapMicroUsd
+        ),
+      });
+      break;
+    }
+    case "awu_credits": {
+      // Pool + programmatic cap via Metronome state (alert/webhook driven).
+      programmaticUsageLimitReached =
+        (await isApiBlocked(workspace.sId)) ||
+        (await isProgrammaticApiBlocked(workspace.sId));
+
+      // Programmatic usage draws from the workspace AWU credit pool: use the
+      // live Metronome balance as the remaining programmatic budget.
+      // Fail-open on errors: the reinforcement cap stays the only constraint.
+      let remainingProgrammaticCreditsAwuCredits = Infinity;
+      if (workspace.metronomeCustomerId) {
+        const balanceRes = await getWorkspacePoolAwuBalance(
+          workspace.metronomeCustomerId
+        );
+        if (balanceRes.isOk()) {
+          remainingProgrammaticCreditsAwuCredits = balanceRes.value;
+        } else {
+          logger.warn(
+            { workspaceId, error: balanceRes.error },
+            "ReinforcedSkills: failed to fetch AWU pool balance — not constraining the budget"
+          );
+        }
+      }
+      maxConversationsForBudget = getMaxConversationsForBudgetAwuCredits({
+        globalConsumptionAwuCredits: globalConsumption.consumedAwuCredits,
+        globalCapAwuCredits: globalConsumption.capAwuCredits,
+        remainingProgrammaticCreditsAwuCredits,
+      });
+      break;
+    }
+    default:
+      return assertNever(globalConsumption);
+  }
 
   logger.info(
     {
       workspaceId,
-      globalConsumptionMicroUsd,
-      globalCapMicroUsd,
-      capReached: globalConsumptionMicroUsd >= globalCapMicroUsd,
+      globalConsumption,
       programmaticUsageLimitReached,
-      remainingProgrammaticCreditsMicroUsd,
+      maxConversationsForBudget,
     },
     "ReinforcedSkills: workspace consumption check"
   );
@@ -650,14 +683,9 @@ export async function getReinforcementSettingsActivity({
   return {
     reinforcementEnabled: true,
     batchModeAllowed: await isReinforcementBatchModeAllowed(auth),
-    globalConsumptionMicroUsd,
-    globalCapMicroUsd,
+    globalCapReached: globalConsumption.capReached,
     programmaticUsageLimitReached,
-    maxConversationsForBudget: getMaxConversationsForBudget({
-      globalConsumptionMicroUsd,
-      globalCapMicroUsd,
-      remainingProgrammaticCreditsMicroUsd,
-    }),
+    maxConversationsForBudget,
   };
 }
 

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -15,6 +15,7 @@ import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/da
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { intelligenceAwuFromRunUsages } from "@app/lib/metronome/events";
+import { getRemainingProgrammaticUsageFromMetronome } from "@app/lib/metronome/programmatic_awu_usage";
 import {
   isApiBlocked,
   isProgrammaticApiBlocked,
@@ -642,27 +643,36 @@ export async function getReinforcementSettingsActivity({
         (await isApiBlocked(workspace.sId)) ||
         (await isProgrammaticApiBlocked(workspace.sId));
 
-      // Programmatic usage draws from the workspace AWU credit pool: use the
-      // live Metronome balance as the remaining programmatic budget.
-      // Fail-open on errors: the reinforcement cap stays the only constraint.
+      // Both clamps fail-open on errors: the reinforcement cap stays the only
+      // constraint.
+      let remainingPoolCreditsAwuCredits = Infinity;
       let remainingProgrammaticCreditsAwuCredits = Infinity;
       if (workspace.metronomeCustomerId) {
+        // Reinforcement spend draws from the workspace AWU credit pool: clamp
+        // by the live Metronome balance.
         const balanceRes = await getWorkspacePoolAwuBalance(
           workspace.metronomeCustomerId
         );
         if (balanceRes.isOk()) {
-          remainingProgrammaticCreditsAwuCredits = balanceRes.value;
+          remainingPoolCreditsAwuCredits = balanceRes.value;
         } else {
           logger.warn(
             { workspaceId, error: balanceRes.error },
             "ReinforcedSkills: failed to fetch AWU pool balance — not constraining the budget"
           );
         }
+
+        // Remaining programmatic headroom (cap minus period spend, live from
+        // Metronome; fail-open). Actual cap depletion is enforced by the
+        // alert-driven gate above either way.
+        remainingProgrammaticCreditsAwuCredits =
+          await getRemainingProgrammaticUsageFromMetronome(auth);
       }
       maxConversationsForBudget = getMaxConversationsForBudgetAwuCredits({
         globalConsumptionAwuCredits: globalConsumption.consumedAwuCredits,
         globalCapAwuCredits: globalConsumption.capAwuCredits,
         remainingProgrammaticCreditsAwuCredits,
+        remainingPoolCreditsAwuCredits,
       });
       break;
     }

--- a/front/temporal/reinforcement/workflows.ts
+++ b/front/temporal/reinforcement/workflows.ts
@@ -323,7 +323,7 @@ export async function reinforcementWorkspaceWorkflow({
   if (!settings.reinforcementEnabled) {
     return;
   }
-  if (settings.globalConsumptionMicroUsd >= settings.globalCapMicroUsd) {
+  if (settings.globalCapReached) {
     // Cap reached: activity already logged the details. Stop immediately.
     return;
   }


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/8784

Use the AWU limit to restrict the actual usage of the self-improvement skills.
The 2 path coexist and the switch is on whether the workspaces is billed by metronome or not.

I have created a new `front/lib/reinforcement/enforcement.ts` file to extract all the logic about reinforcement.

Limits are applied like this:
 - workspace must not have reach the programmatic limit
 - we estimate how many conversation (N) we can analyse based on avaialble credits (estimate 10 credits / $0.10 per conv)
 - we select the skills which have to reach their limit yet
 - we pick the N best conversations using these skills to analyse.

Step by step plan:
  1. [Store the AWU in the self_improving_skills_usage table (always with margins) ](https://github.com/dust-tt/dust/pull/27190) ✅ done
  2. [Update resources and API to retrieve the value ](https://github.com/dust-tt/dust/pull/27218) ✅ done
  3. [Store limit in AWU in db and update API to set/get them](https://github.com/dust-tt/dust/pull/27227) ✅ done
  4. Use AWU to enforce the limit for credit based workspaces <-- ℹ️ You are here
  5. Update UI admin apge to display AWU credits when using metronome.

## Tests

added unit tests for new enforcement.ts 

## Risk

low, worst case scenarios limit are not correctly enforced.

## Deploy Plan

deploy front 
