### PR TITLE
Exa MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -97,6 +97,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "databricks": {
     "list_warehouses": "never_ask",
   },
+  "exa": {
+    "search_companies": "never_ask",
+    "search_people": "never_ask",
+  },
   "extract_data": {
     "extract_information_from_documents": "never_ask",
   },

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -20,6 +20,7 @@ import { CONVERSATION_FILES_SERVER } from "@app/lib/api/actions/servers/conversa
 import { DATA_SOURCES_FILE_SYSTEM_SERVER } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { DATA_WAREHOUSES_SERVER } from "@app/lib/api/actions/servers/data_warehouses/metadata";
 import { DATABRICKS_SERVER } from "@app/lib/api/actions/servers/databricks/metadata";
+import { EXA_SERVER } from "@app/lib/api/actions/servers/exa/metadata";
 import { EXTRACT_DATA_SERVER } from "@app/lib/api/actions/servers/extract_data/metadata";
 import { FATHOM_SERVER } from "@app/lib/api/actions/servers/fathom/metadata";
 import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_generation/metadata";
@@ -156,6 +157,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "data_sources_file_system",
   DATA_WAREHOUSE_SERVER_NAME,
   "extract_data",
+  "exa",
   "file_generation",
   "fathom",
   "freshservice",
@@ -1151,6 +1153,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: WORKSPACE_ANALYTICS_SERVER,
+  },
+  exa: {
+    id: 1036,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => !featureFlags.includes("exa_mcp"),
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: EXA_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -1,310 +1,82 @@
 {
   "auto": [
-    {
-      "name": "image_generation",
-      "id": 2
-    },
-    {
-      "name": "file_generation",
-      "id": 3
-    },
-    {
-      "name": "web_search_&_browse",
-      "id": 5
-    },
-    {
-      "name": "agent_router",
-      "id": 8
-    },
-    {
-      "name": "include_data",
-      "id": 9
-    },
-    {
-      "name": "run_dust_app",
-      "id": 10
-    },
-    {
-      "name": "extract_data",
-      "id": 12
-    },
-    {
-      "name": "missing_action_catcher",
-      "id": 13
-    },
-    {
-      "name": "conversation_files",
-      "id": 17
-    },
-    {
-      "name": "agent_memory",
-      "id": 21
-    },
-    {
-      "name": "interactive_content",
-      "id": 23
-    },
-    {
-      "name": "slideshow",
-      "id": 28
-    },
-    {
-      "name": "speech_generator",
-      "id": 34
-    },
-    {
-      "name": "search",
-      "id": 1006
-    },
-    {
-      "name": "run_agent",
-      "id": 1008
-    },
-    {
-      "name": "query_tables_v2",
-      "id": 1009
-    },
-    {
-      "name": "data_sources_file_system",
-      "id": 1010
-    },
-    {
-      "name": "data_warehouses",
-      "id": 1012
-    },
-    {
-      "name": "toolsets",
-      "id": 1013
-    },
-    {
-      "name": "common_utilities",
-      "id": 1017
-    },
-    {
-      "name": "skill_management",
-      "id": 1019
-    },
-    {
-      "name": "schedules_management",
-      "id": 1020
-    },
-    {
-      "name": "pod_manager",
-      "id": 1021
-    },
-    {
-      "name": "agent_sidekick_context",
-      "id": 1022
-    },
-    {
-      "name": "agent_sidekick_agent_state",
-      "id": 1023
-    },
-    {
-      "name": "sandbox",
-      "id": 1024
-    },
-    {
-      "name": "user_mentions",
-      "id": 1026
-    },
-    {
-      "name": "ask_user_question",
-      "id": 1028
-    },
-    {
-      "name": "pod_tasks",
-      "id": 1029
-    },
-    {
-      "name": "wakeups",
-      "id": 1031
-    },
-    {
-      "name": "plan_mode",
-      "id": 1032
-    },
-    {
-      "name": "files",
-      "id": 1033
-    },
-    {
-      "name": "skill_authoring",
-      "id": 1034
-    },
-    {
-      "name": "workspace_analytics",
-      "id": 1035
-    }
+    { "name": "image_generation", "id": 2 },
+    { "name": "file_generation", "id": 3 },
+    { "name": "web_search_&_browse", "id": 5 },
+    { "name": "agent_router", "id": 8 },
+    { "name": "include_data", "id": 9 },
+    { "name": "run_dust_app", "id": 10 },
+    { "name": "extract_data", "id": 12 },
+    { "name": "missing_action_catcher", "id": 13 },
+    { "name": "conversation_files", "id": 17 },
+    { "name": "agent_memory", "id": 21 },
+    { "name": "interactive_content", "id": 23 },
+    { "name": "slideshow", "id": 28 },
+    { "name": "speech_generator", "id": 34 },
+    { "name": "search", "id": 1006 },
+    { "name": "run_agent", "id": 1008 },
+    { "name": "query_tables_v2", "id": 1009 },
+    { "name": "data_sources_file_system", "id": 1010 },
+    { "name": "data_warehouses", "id": 1012 },
+    { "name": "toolsets", "id": 1013 },
+    { "name": "common_utilities", "id": 1017 },
+    { "name": "skill_management", "id": 1019 },
+    { "name": "schedules_management", "id": 1020 },
+    { "name": "pod_manager", "id": 1021 },
+    { "name": "agent_sidekick_context", "id": 1022 },
+    { "name": "agent_sidekick_agent_state", "id": 1023 },
+    { "name": "sandbox", "id": 1024 },
+    { "name": "user_mentions", "id": 1026 },
+    { "name": "ask_user_question", "id": 1028 },
+    { "name": "pod_tasks", "id": 1029 },
+    { "name": "wakeups", "id": 1031 },
+    { "name": "plan_mode", "id": 1032 },
+    { "name": "files", "id": 1033 },
+    { "name": "skill_authoring", "id": 1034 },
+    { "name": "workspace_analytics", "id": 1035 }
   ],
   "manual": [
-    {
-      "name": "github",
-      "id": 1
-    },
-    {
-      "name": "hubspot",
-      "id": 7
-    },
-    {
-      "name": "notion",
-      "id": 11
-    },
-    {
-      "name": "salesforce",
-      "id": 14
-    },
-    {
-      "name": "gmail",
-      "id": 15
-    },
-    {
-      "name": "google_calendar",
-      "id": 16
-    },
-    {
-      "name": "slack",
-      "id": 18
-    },
-    {
-      "name": "google_sheets",
-      "id": 19
-    },
-    {
-      "name": "monday",
-      "id": 20
-    },
-    {
-      "name": "jira",
-      "id": 22
-    },
-    {
-      "name": "outlook",
-      "id": 24
-    },
-    {
-      "name": "outlook_calendar",
-      "id": 25
-    },
-    {
-      "name": "freshservice",
-      "id": 26
-    },
-    {
-      "name": "google_drive",
-      "id": 27
-    },
-    {
-      "name": "slack_bot",
-      "id": 31
-    },
-    {
-      "name": "openai_usage",
-      "id": 32
-    },
-    {
-      "name": "confluence",
-      "id": 33
-    },
-    {
-      "name": "microsoft_drive",
-      "id": 35
-    },
-    {
-      "name": "microsoft_teams",
-      "id": 36
-    },
-    {
-      "name": "sound_studio",
-      "id": 37
-    },
-    {
-      "name": "microsoft_excel",
-      "id": 38
-    },
-    {
-      "name": "http_client",
-      "id": 39
-    },
-    {
-      "name": "ashby",
-      "id": 40
-    },
-    {
-      "name": "salesloft",
-      "id": 41
-    },
-    {
-      "name": "zendesk",
-      "id": 42
-    },
-    {
-      "name": "slab",
-      "id": 43
-    },
-    {
-      "name": "vanta",
-      "id": 44
-    },
-    {
-      "name": "databricks",
-      "id": 45
-    },
-    {
-      "name": "productboard",
-      "id": 46
-    },
-    {
-      "name": "snowflake",
-      "id": 47
-    },
-    {
-      "name": "ukg_ready",
-      "id": 48
-    },
-    {
-      "name": "statuspage",
-      "id": 49
-    },
-    {
-      "name": "fathom",
-      "id": 50
-    },
-    {
-      "name": "luma",
-      "id": 51
-    },
-    {
-      "name": "gong",
-      "id": 52
-    },
-    {
-      "name": "primitive_types_debugger",
-      "id": 1004
-    },
-    {
-      "name": "val_town",
-      "id": 1014
-    },
-    {
-      "name": "jit_testing",
-      "id": 1016
-    },
-    {
-      "name": "front",
-      "id": 1018
-    },
-    {
-      "name": "poke",
-      "id": 1027
-    },
-    {
-      "name": "clari_copilot",
-      "id": 1030
-    },
-    {
-      "name": "exa",
-      "id": 1036
-    }
+    { "name": "github", "id": 1 },
+    { "name": "hubspot", "id": 7 },
+    { "name": "notion", "id": 11 },
+    { "name": "salesforce", "id": 14 },
+    { "name": "gmail", "id": 15 },
+    { "name": "google_calendar", "id": 16 },
+    { "name": "slack", "id": 18 },
+    { "name": "google_sheets", "id": 19 },
+    { "name": "monday", "id": 20 },
+    { "name": "jira", "id": 22 },
+    { "name": "outlook", "id": 24 },
+    { "name": "outlook_calendar", "id": 25 },
+    { "name": "freshservice", "id": 26 },
+    { "name": "google_drive", "id": 27 },
+    { "name": "slack_bot", "id": 31 },
+    { "name": "openai_usage", "id": 32 },
+    { "name": "confluence", "id": 33 },
+    { "name": "microsoft_drive", "id": 35 },
+    { "name": "microsoft_teams", "id": 36 },
+    { "name": "sound_studio", "id": 37 },
+    { "name": "microsoft_excel", "id": 38 },
+    { "name": "http_client", "id": 39 },
+    { "name": "ashby", "id": 40 },
+    { "name": "salesloft", "id": 41 },
+    { "name": "zendesk", "id": 42 },
+    { "name": "slab", "id": 43 },
+    { "name": "vanta", "id": 44 },
+    { "name": "databricks", "id": 45 },
+    { "name": "productboard", "id": 46 },
+    { "name": "snowflake", "id": 47 },
+    { "name": "ukg_ready", "id": 48 },
+    { "name": "statuspage", "id": 49 },
+    { "name": "fathom", "id": 50 },
+    { "name": "luma", "id": 51 },
+    { "name": "gong", "id": 52 },
+    { "name": "primitive_types_debugger", "id": 1004 },
+    { "name": "val_town", "id": 1014 },
+    { "name": "jit_testing", "id": 1016 },
+    { "name": "front", "id": 1018 },
+    { "name": "poke", "id": 1027 },
+    { "name": "clari_copilot", "id": 1030 },
+    { "name": "exa", "id": 1036 }
   ]
 }

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -1,81 +1,310 @@
 {
   "auto": [
-    { "name": "image_generation", "id": 2 },
-    { "name": "file_generation", "id": 3 },
-    { "name": "web_search_&_browse", "id": 5 },
-    { "name": "agent_router", "id": 8 },
-    { "name": "include_data", "id": 9 },
-    { "name": "run_dust_app", "id": 10 },
-    { "name": "extract_data", "id": 12 },
-    { "name": "missing_action_catcher", "id": 13 },
-    { "name": "conversation_files", "id": 17 },
-    { "name": "agent_memory", "id": 21 },
-    { "name": "interactive_content", "id": 23 },
-    { "name": "slideshow", "id": 28 },
-    { "name": "speech_generator", "id": 34 },
-    { "name": "search", "id": 1006 },
-    { "name": "run_agent", "id": 1008 },
-    { "name": "query_tables_v2", "id": 1009 },
-    { "name": "data_sources_file_system", "id": 1010 },
-    { "name": "data_warehouses", "id": 1012 },
-    { "name": "toolsets", "id": 1013 },
-    { "name": "common_utilities", "id": 1017 },
-    { "name": "skill_management", "id": 1019 },
-    { "name": "schedules_management", "id": 1020 },
-    { "name": "pod_manager", "id": 1021 },
-    { "name": "agent_sidekick_context", "id": 1022 },
-    { "name": "agent_sidekick_agent_state", "id": 1023 },
-    { "name": "sandbox", "id": 1024 },
-    { "name": "user_mentions", "id": 1026 },
-    { "name": "ask_user_question", "id": 1028 },
-    { "name": "pod_tasks", "id": 1029 },
-    { "name": "wakeups", "id": 1031 },
-    { "name": "plan_mode", "id": 1032 },
-    { "name": "files", "id": 1033 },
-    { "name": "skill_authoring", "id": 1034 },
-    { "name": "workspace_analytics", "id": 1035 }
+    {
+      "name": "image_generation",
+      "id": 2
+    },
+    {
+      "name": "file_generation",
+      "id": 3
+    },
+    {
+      "name": "web_search_&_browse",
+      "id": 5
+    },
+    {
+      "name": "agent_router",
+      "id": 8
+    },
+    {
+      "name": "include_data",
+      "id": 9
+    },
+    {
+      "name": "run_dust_app",
+      "id": 10
+    },
+    {
+      "name": "extract_data",
+      "id": 12
+    },
+    {
+      "name": "missing_action_catcher",
+      "id": 13
+    },
+    {
+      "name": "conversation_files",
+      "id": 17
+    },
+    {
+      "name": "agent_memory",
+      "id": 21
+    },
+    {
+      "name": "interactive_content",
+      "id": 23
+    },
+    {
+      "name": "slideshow",
+      "id": 28
+    },
+    {
+      "name": "speech_generator",
+      "id": 34
+    },
+    {
+      "name": "search",
+      "id": 1006
+    },
+    {
+      "name": "run_agent",
+      "id": 1008
+    },
+    {
+      "name": "query_tables_v2",
+      "id": 1009
+    },
+    {
+      "name": "data_sources_file_system",
+      "id": 1010
+    },
+    {
+      "name": "data_warehouses",
+      "id": 1012
+    },
+    {
+      "name": "toolsets",
+      "id": 1013
+    },
+    {
+      "name": "common_utilities",
+      "id": 1017
+    },
+    {
+      "name": "skill_management",
+      "id": 1019
+    },
+    {
+      "name": "schedules_management",
+      "id": 1020
+    },
+    {
+      "name": "pod_manager",
+      "id": 1021
+    },
+    {
+      "name": "agent_sidekick_context",
+      "id": 1022
+    },
+    {
+      "name": "agent_sidekick_agent_state",
+      "id": 1023
+    },
+    {
+      "name": "sandbox",
+      "id": 1024
+    },
+    {
+      "name": "user_mentions",
+      "id": 1026
+    },
+    {
+      "name": "ask_user_question",
+      "id": 1028
+    },
+    {
+      "name": "pod_tasks",
+      "id": 1029
+    },
+    {
+      "name": "wakeups",
+      "id": 1031
+    },
+    {
+      "name": "plan_mode",
+      "id": 1032
+    },
+    {
+      "name": "files",
+      "id": 1033
+    },
+    {
+      "name": "skill_authoring",
+      "id": 1034
+    },
+    {
+      "name": "workspace_analytics",
+      "id": 1035
+    }
   ],
   "manual": [
-    { "name": "github", "id": 1 },
-    { "name": "hubspot", "id": 7 },
-    { "name": "notion", "id": 11 },
-    { "name": "salesforce", "id": 14 },
-    { "name": "gmail", "id": 15 },
-    { "name": "google_calendar", "id": 16 },
-    { "name": "slack", "id": 18 },
-    { "name": "google_sheets", "id": 19 },
-    { "name": "monday", "id": 20 },
-    { "name": "jira", "id": 22 },
-    { "name": "outlook", "id": 24 },
-    { "name": "outlook_calendar", "id": 25 },
-    { "name": "freshservice", "id": 26 },
-    { "name": "google_drive", "id": 27 },
-    { "name": "slack_bot", "id": 31 },
-    { "name": "openai_usage", "id": 32 },
-    { "name": "confluence", "id": 33 },
-    { "name": "microsoft_drive", "id": 35 },
-    { "name": "microsoft_teams", "id": 36 },
-    { "name": "sound_studio", "id": 37 },
-    { "name": "microsoft_excel", "id": 38 },
-    { "name": "http_client", "id": 39 },
-    { "name": "ashby", "id": 40 },
-    { "name": "salesloft", "id": 41 },
-    { "name": "zendesk", "id": 42 },
-    { "name": "slab", "id": 43 },
-    { "name": "vanta", "id": 44 },
-    { "name": "databricks", "id": 45 },
-    { "name": "productboard", "id": 46 },
-    { "name": "snowflake", "id": 47 },
-    { "name": "ukg_ready", "id": 48 },
-    { "name": "statuspage", "id": 49 },
-    { "name": "fathom", "id": 50 },
-    { "name": "luma", "id": 51 },
-    { "name": "gong", "id": 52 },
-    { "name": "primitive_types_debugger", "id": 1004 },
-    { "name": "val_town", "id": 1014 },
-    { "name": "jit_testing", "id": 1016 },
-    { "name": "front", "id": 1018 },
-    { "name": "poke", "id": 1027 },
-    { "name": "clari_copilot", "id": 1030 }
+    {
+      "name": "github",
+      "id": 1
+    },
+    {
+      "name": "hubspot",
+      "id": 7
+    },
+    {
+      "name": "notion",
+      "id": 11
+    },
+    {
+      "name": "salesforce",
+      "id": 14
+    },
+    {
+      "name": "gmail",
+      "id": 15
+    },
+    {
+      "name": "google_calendar",
+      "id": 16
+    },
+    {
+      "name": "slack",
+      "id": 18
+    },
+    {
+      "name": "google_sheets",
+      "id": 19
+    },
+    {
+      "name": "monday",
+      "id": 20
+    },
+    {
+      "name": "jira",
+      "id": 22
+    },
+    {
+      "name": "outlook",
+      "id": 24
+    },
+    {
+      "name": "outlook_calendar",
+      "id": 25
+    },
+    {
+      "name": "freshservice",
+      "id": 26
+    },
+    {
+      "name": "google_drive",
+      "id": 27
+    },
+    {
+      "name": "slack_bot",
+      "id": 31
+    },
+    {
+      "name": "openai_usage",
+      "id": 32
+    },
+    {
+      "name": "confluence",
+      "id": 33
+    },
+    {
+      "name": "microsoft_drive",
+      "id": 35
+    },
+    {
+      "name": "microsoft_teams",
+      "id": 36
+    },
+    {
+      "name": "sound_studio",
+      "id": 37
+    },
+    {
+      "name": "microsoft_excel",
+      "id": 38
+    },
+    {
+      "name": "http_client",
+      "id": 39
+    },
+    {
+      "name": "ashby",
+      "id": 40
+    },
+    {
+      "name": "salesloft",
+      "id": 41
+    },
+    {
+      "name": "zendesk",
+      "id": 42
+    },
+    {
+      "name": "slab",
+      "id": 43
+    },
+    {
+      "name": "vanta",
+      "id": 44
+    },
+    {
+      "name": "databricks",
+      "id": 45
+    },
+    {
+      "name": "productboard",
+      "id": 46
+    },
+    {
+      "name": "snowflake",
+      "id": 47
+    },
+    {
+      "name": "ukg_ready",
+      "id": 48
+    },
+    {
+      "name": "statuspage",
+      "id": 49
+    },
+    {
+      "name": "fathom",
+      "id": 50
+    },
+    {
+      "name": "luma",
+      "id": 51
+    },
+    {
+      "name": "gong",
+      "id": 52
+    },
+    {
+      "name": "primitive_types_debugger",
+      "id": 1004
+    },
+    {
+      "name": "val_town",
+      "id": 1014
+    },
+    {
+      "name": "jit_testing",
+      "id": 1016
+    },
+    {
+      "name": "front",
+      "id": 1018
+    },
+    {
+      "name": "poke",
+      "id": 1027
+    },
+    {
+      "name": "clari_copilot",
+      "id": 1030
+    },
+    {
+      "name": "exa",
+      "id": 1036
+    }
   ]
 }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -18,6 +18,7 @@ import { default as conversationFilesServer } from "@app/lib/api/actions/servers
 import { default as dataSourcesFileSystemServer } from "@app/lib/api/actions/servers/data_sources_file_system";
 import { default as dataWarehousesServer } from "@app/lib/api/actions/servers/data_warehouses";
 import { default as databricksServer } from "@app/lib/api/actions/servers/databricks";
+import { default as exaServer } from "@app/lib/api/actions/servers/exa";
 import { default as extractDataServer } from "@app/lib/api/actions/servers/extract_data";
 import { default as fathomServer } from "@app/lib/api/actions/servers/fathom";
 import { default as fileGenerationServer } from "@app/lib/api/actions/servers/file_generation";
@@ -225,6 +226,8 @@ export async function getInternalMCPServer(
       return agentSidekickAgentStateServer(auth, agentLoopContext);
     case "agent_sidekick_context":
       return agentSidekickContextServer(auth, agentLoopContext);
+    case "exa":
+      return exaServer(auth, agentLoopContext);
     case "fathom":
       return fathomServer(auth, agentLoopContext);
     case "freshservice":

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -996,6 +996,7 @@ function getDynamicToolDisplayLabels({
     case "agent_router":
     case "ashby":
     case "databricks":
+    case "exa":
     case "fathom":
     case "freshservice":
     case "gong":

--- a/front/lib/api/actions/servers/exa/index.ts
+++ b/front/lib/api/actions/servers/exa/index.ts
@@ -1,0 +1,23 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { TOOLS } from "@app/lib/api/actions/servers/exa/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("exa");
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: "exa",
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -20,11 +20,18 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe("Number of results to return. Defaults to 5."),
       type: z
-        .enum(["fast", "auto", "instant"])
+        .enum([
+          "auto",
+          "instant",
+          "fast",
+          "deep-lite",
+          "deep",
+          "deep-reasoning",
+        ])
         .optional()
-        .default("fast")
+        .default("auto")
         .describe(
-          "Search type. Use 'fast' for low latency (recommended), 'auto' for best quality."
+          "Search type. 'auto' (~1s, default), 'instant' (~250ms, real-time), 'fast' (~450ms), 'deep-lite' (~4s), 'deep' (4-15s, complex queries), 'deep-reasoning' (12-40s, hard research)."
         ),
     },
     stake: "never_ask",
@@ -48,11 +55,18 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe("Number of results to return. Defaults to 5."),
       type: z
-        .enum(["fast", "auto", "instant"])
+        .enum([
+          "auto",
+          "instant",
+          "fast",
+          "deep-lite",
+          "deep",
+          "deep-reasoning",
+        ])
         .optional()
-        .default("fast")
+        .default("auto")
         .describe(
-          "Search type. Use 'fast' for low latency (recommended), 'auto' for best quality."
+          "Search type. 'auto' (~1s, default), 'instant' (~250ms, real-time), 'fast' (~450ms), 'deep-lite' (~4s), 'deep' (4-15s, complex queries), 'deep-reasoning' (12-40s, hard research)."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -1,0 +1,88 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export const EXA_TOOLS_METADATA = createToolsRecord({
+  search_people: {
+    description:
+      "Search for people by name, role, or company using Exa's people index. Use this to find LinkedIn profiles, professional backgrounds, or identify people at specific companies (e.g. 'CTO of Mistral AI', 'VP of Sales at French SaaS startups').",
+    schema: {
+      query: z
+        .string()
+        .describe("The search query to find information about a person."),
+      num_results: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .describe("Number of results to return. Defaults to 5."),
+      type: z
+        .enum(["fast", "auto", "instant"])
+        .optional()
+        .default("fast")
+        .describe(
+          "Search type. Use 'fast' for low latency (recommended), 'auto' for best quality."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching for people",
+      done: "Search people",
+    },
+  },
+  search_companies: {
+    description:
+      "Search for companies by name, industry, or criteria using Exa's company index. Use this to find company profiles, competitors, or market research (e.g. 'French AI startups', 'competitors of Notion').",
+    schema: {
+      query: z
+        .string()
+        .describe("The search query to find information about a company."),
+      num_results: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .describe("Number of results to return. Defaults to 5."),
+      type: z
+        .enum(["fast", "auto", "instant"])
+        .optional()
+        .default("fast")
+        .describe(
+          "Search type. Use 'fast' for low latency (recommended), 'auto' for best quality."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching for companies",
+      done: "Search companies",
+    },
+  },
+});
+
+export const EXA_SERVER_NAME = "exa" as const;
+
+export const EXA_SERVER = {
+  serverInfo: {
+    name: EXA_SERVER_NAME,
+    version: "1.0.0",
+    description:
+      "Search for people and companies using Exa's AI-powered search.",
+    authorization: null,
+    icon: "ActionMagnifyingGlassIcon",
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(EXA_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(EXA_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/exa/tools/index.ts
+++ b/front/lib/api/actions/servers/exa/tools/index.ts
@@ -19,7 +19,7 @@ async function exaSearch({
 }: {
   query: string;
   num_results?: number;
-  type?: "fast" | "auto" | "instant";
+  type?: "auto" | "instant" | "fast" | "deep-lite" | "deep" | "deep-reasoning";
   category: "people" | "company";
 }) {
   if (!credentials.EXA_API_KEY) {
@@ -31,7 +31,7 @@ async function exaSearch({
   try {
     res = await exa.search(query, {
       numResults: num_results ?? 5,
-      type: type ?? "fast",
+      type: type ?? "auto",
       category,
       contents: { highlights: true },
     });

--- a/front/lib/api/actions/servers/exa/tools/index.ts
+++ b/front/lib/api/actions/servers/exa/tools/index.ts
@@ -1,0 +1,62 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { EXA_TOOLS_METADATA } from "@app/lib/api/actions/servers/exa/metadata";
+import logger from "@app/logger/logger";
+import { dustManagedServiceCredentials } from "@app/types/api/credentials";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import Exa from "exa-js";
+
+const credentials = dustManagedServiceCredentials();
+
+async function exaSearch({
+  query,
+  num_results,
+  type,
+  category,
+}: {
+  query: string;
+  num_results?: number;
+  type?: "fast" | "auto" | "instant";
+  category: "people" | "company";
+}) {
+  if (!credentials.EXA_API_KEY) {
+    return new Err(new MCPError("EXA_API_KEY is required for Exa search."));
+  }
+  const exa = new Exa(credentials.EXA_API_KEY);
+
+  let res;
+  try {
+    res = await exa.search(query, {
+      numResults: num_results ?? 5,
+      type: type ?? "fast",
+      category,
+      contents: { highlights: true },
+    });
+  } catch (error) {
+    logger.error({ error, category }, "Unexpected error on Exa search");
+    return new Err(new MCPError(normalizeError(error).message));
+  }
+
+  return new Ok(
+    res.results.map((result) => ({
+      type: "resource" as const,
+      resource: {
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.WEBSEARCH_RESULT,
+        title: result.title ?? result.url ?? "Untitled result",
+        text: result.highlights?.[0] ?? "",
+        uri: result.url,
+        reference: "",
+      },
+    }))
+  );
+}
+
+const handlers: ToolHandlers<typeof EXA_TOOLS_METADATA> = {
+  search_people: (params) => exaSearch({ ...params, category: "people" }),
+  search_companies: (params) => exaSearch({ ...params, category: "company" }),
+};
+
+export const TOOLS = buildTools(EXA_TOOLS_METADATA, handlers);

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -113,6 +113,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   interactive_content: "advanced",
   confluence: "advanced",
   databricks: "advanced",
+  exa: "advanced",
   fathom: "advanced",
   freshservice: "advanced",
   github: "advanced",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -305,6 +305,14 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the new user settings v2 experience",
     stage: "dust_only",
   },
+  exa_search: {
+    description: "Use Exa as web search provider",
+    stage: "dust_only",
+  },
+  exa_browse: {
+    description: "Use Exa as web browse provider",
+    stage: "dust_only",
+  },
   force_us_api_url: {
     description:
       "Force the SPA to use the regional API subdomain (us-api/eu-api.dust.tt) " +

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -61,6 +61,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "MCP tools currently in development",
     stage: "dust_only",
   },
+  exa_mcp: {
+    description: "Access to Exa MCP server (search_people, search_companies)",
+    stage: "dust_only",
+  },
   disable_run_logs: {
     description: "Disable logging of agent runs",
     stage: "dust_only",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -305,14 +305,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the new user settings v2 experience",
     stage: "dust_only",
   },
-  exa_search: {
-    description: "Use Exa as web search provider",
-    stage: "dust_only",
-  },
-  exa_browse: {
-    description: "Use Exa as web browse provider",
-    stage: "dust_only",
-  },
   force_us_api_url: {
     description:
       "Force the SPA to use the regional API subdomain (us-api/eu-api.dust.tt) " +

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -777,8 +777,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "metronome_billing_usage_page"
   | "user_settings_v2"
   | "admin_governance"
-  | "exa_search"
-  | "exa_browse"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -707,6 +707,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "databricks_tool"
   | "deepseek_feature"
   | "dev_mcp_actions"
+  | "exa_mcp"
   | "disable_formatting_prompt"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -776,6 +776,8 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "metronome_billing_usage_page"
   | "user_settings_v2"
   | "admin_governance"
+  | "exa_search"
+  | "exa_browse"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description
Adds an internal MCP server exa with two tools: search_people and search_companies.

search_people: searches Exa's people index (LinkedIn profiles, professional backgrounds) by name, role, or company
search_companies: searches Exa's company index by name, industry, or criteria

## Tests
Tested manually:
- search_people: queried known and unknown people, edge cases (ambiguous names, non-existent people)
- search_companies: queried known companies, ambiguous names, non-existent companies
- Verified the server does not appear in the capabilities picker without the feature flag

## Risk
Low. The server is behind a dust_only feature flag and only available to workspaces that explicitly enable it. Uses a Dust-managed API key with no OAuth. 

## Deploy Plan
none. DUST_MANAGED_EXA_API_KEY is already set in prod
