### PR TITLE
[marketing] fix: Migrate academy to front-api

### DIFF
--- a/front-api/middlewares/session_resolution.ts
+++ b/front-api/middlewares/session_resolution.ts
@@ -53,3 +53,37 @@ export async function resolveSession(
 
   return session;
 }
+
+/**
+ * Like {@link resolveSession} but for endpoints where a session is OPTIONAL:
+ * returns the resolved session when present, or `null` for anonymous requests
+ * (no/invalid bearer token and no session cookie). Never returns a `Response`
+ * and never logs an auth error, so callers can fall back to another identifier
+ * (e.g. an anonymous browser id) when this is `null`.
+ *
+ * Still refreshes the `workos_session` cookie via `Set-Cookie` when a cookie
+ * session is resolved, matching {@link resolveSession}.
+ */
+export async function resolveOptionalSession(
+  ctx: Context
+): Promise<SessionWithUser | null> {
+  const bearerRes = await getSessionFromBearerToken(
+    ctx.req.header("authorization")
+  );
+
+  let session: SessionWithUser | null = bearerRes.isOk()
+    ? (bearerRes.value ?? null)
+    : null;
+
+  if (!session) {
+    const result = await getWorkOSSessionWithSetCookies(
+      getCookie(ctx, "workos_session")
+    );
+    for (const cookie of result.setCookies) {
+      ctx.header("Set-Cookie", cookie, { append: true });
+    }
+    session = result.session ?? null;
+  }
+
+  return session;
+}

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -13,11 +13,13 @@
     "tsgo": "tsgo"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.100.1",
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^1.19.10",
     "@hono/zod-validator": "^0.7.6",
     "hono": "^4.12.15",
     "jose": "^6.2.3",
+    "jsonwebtoken": "^9.0.0",
     "next": "^14.2.35",
     "next-swagger-doc": "^0.4.0",
     "openai": "^6.33.0",
@@ -25,6 +27,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.2",
     "esbuild": "^0.27.3",
     "tsx": "^4.21.0"
   }

--- a/front-api/routes/marketing/academy/chat.test.ts
+++ b/front-api/routes/marketing/academy/chat.test.ts
@@ -1,0 +1,130 @@
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+// The chat route allows a request whose Origin OR Referer starts with the
+// static website URL. In this test environment the `Origin` header is stripped
+// by the fetch/cors path that `honoApp.request` runs through, but `Referer`
+// passes through to the handler — so we drive the allowed-origin checks with a
+// Referer. The static website URL resolves to "http://fake-url" (set in
+// front/vite.globalSetup.ts via NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL).
+const ALLOWED_REFERER = "http://fake-url/academy";
+
+// Issue a CSRF token through the GET endpoint (the same secret signs and
+// verifies within the service) so POST tests reuse a genuinely valid token.
+async function getCsrfToken(): Promise<string> {
+  const response = await honoApp.request("/api/marketing/academy/chat", {
+    headers: { referer: ALLOWED_REFERER },
+  });
+  const body = await response.json();
+  return body.csrfToken;
+}
+
+// The academy quiz endpoints are public (no session), so the chat route gates
+// on the request originating from the marketing website. A request without a
+// matching Origin/Referer must be rejected before any CSRF / LLM work.
+describe("GET /api/marketing/academy/chat", () => {
+  it("rejects a CSRF token request with a disallowed referer", async () => {
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      headers: { referer: "https://evil.example.com" },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("issues a CSRF token when the referer is allowed", async () => {
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      headers: { referer: ALLOWED_REFERER },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(typeof body.csrfToken).toBe("string");
+    expect(body.csrfToken.length).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /api/marketing/academy/chat", () => {
+  const validBody = {
+    messages: [],
+    contentType: "chapter",
+    title: "Intro to Dust",
+    content: "Some chapter content.",
+    correctAnswers: 0,
+    totalQuestions: 0,
+  };
+
+  it("rejects a chat request with a disallowed referer", async () => {
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      method: "POST",
+      headers: {
+        referer: "https://evil.example.com",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects an allowed-origin request without a CSRF token", async () => {
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      method: "POST",
+      headers: {
+        referer: ALLOWED_REFERER,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects an allowed-origin request with an invalid CSRF token", async () => {
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      method: "POST",
+      headers: {
+        referer: ALLOWED_REFERER,
+        "content-type": "application/json",
+        "x-csrf-token": "not-a-valid-token",
+      },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects a malformed body even with a valid CSRF token", async () => {
+    const csrfToken = await getCsrfToken();
+
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      method: "POST",
+      headers: {
+        referer: ALLOWED_REFERER,
+        "content-type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      body: JSON.stringify({ contentType: "chapter" }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 500 when the chat service is not configured", async () => {
+    // The request passes origin + CSRF + rate limit + body validation; it then
+    // fails because DUST_MANAGED_ANTHROPIC_API_KEY is unset in the test env
+    // (vite.globalSetup.ts resets process.env to a fixed allowlist).
+    const csrfToken = await getCsrfToken();
+
+    const response = await honoApp.request("/api/marketing/academy/chat", {
+      method: "POST",
+      headers: {
+        referer: ALLOWED_REFERER,
+        "content-type": "application/json",
+        "x-csrf-token": csrfToken,
+      },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/front-api/routes/marketing/academy/chat.ts
+++ b/front-api/routes/marketing/academy/chat.ts
@@ -1,0 +1,294 @@
+/** @ignoreswagger */
+import Anthropic from "@anthropic-ai/sdk";
+import config from "@app/lib/api/config";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import { streamEvents } from "@front-api/lib/api/sse/stream_events";
+import { getClientIpFromContext } from "@front-api/lib/request";
+import { unauthedApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+
+const CSRF_TOKEN_EXPIRY = "30m";
+
+const MAX_REQUESTS_PER_MINUTE = 20;
+const MAX_MESSAGE_LENGTH = 2000;
+const MAX_MESSAGES = 20;
+const MAX_CONTENT_LENGTH = 50000;
+const TOTAL_QUESTIONS = 5;
+
+const ChatMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string().max(MAX_MESSAGE_LENGTH),
+});
+
+type ChatMessage = z.infer<typeof ChatMessageSchema>;
+
+const ChatRequestBodySchema = z.object({
+  messages: z.array(ChatMessageSchema).max(MAX_MESSAGES),
+  contentType: z.enum(["course", "lesson", "chapter"]),
+  title: z.string(),
+  content: z.string(),
+  correctAnswers: z.number().int().nonnegative(),
+  totalQuestions: z.number().int().nonnegative(),
+  userName: z.string().max(100).optional(),
+});
+
+function buildSystemPrompt(
+  contentType: "course" | "lesson" | "chapter",
+  title: string,
+  content: string,
+  correctAnswers: number,
+  totalQuestions: number,
+  userName?: string
+): string {
+  const truncatedContent = content.slice(0, MAX_CONTENT_LENGTH);
+  const studentContext = userName ? `The student's name is ${userName}.` : "";
+
+  // Quiz is complete - give final assessment
+  if (totalQuestions >= TOTAL_QUESTIONS) {
+    const hasPassed = correctAnswers >= 3;
+    const isPerfect = correctAnswers === TOTAL_QUESTIONS;
+    let feedback: string;
+    if (isPerfect) {
+      feedback =
+        "Congratulate them enthusiastically on their perfect score! Encourage them to explore other Academy content.";
+    } else if (hasPassed) {
+      feedback =
+        "Congratulate them on passing! Briefly mention any areas they could review to improve further.";
+    } else {
+      feedback =
+        "Give brief constructive feedback: acknowledge their effort, note they need 3/5 to pass, suggest reviewing areas they missed, and encourage them to try again.";
+    }
+    return `You are a quiz master for Dust Academy. ${studentContext} The user completed the quiz about the ${contentType} "${title}" with ${correctAnswers}/${TOTAL_QUESTIONS} correct. They need 3/${TOTAL_QUESTIONS} to pass.
+
+${feedback}
+
+Keep your response brief.`;
+  }
+
+  const questionsRemaining = TOTAL_QUESTIONS - totalQuestions;
+  const isLastQuestion = questionsRemaining === 1;
+
+  let progressInstruction: string;
+  if (totalQuestions === 0) {
+    progressInstruction =
+      "Start by briefly introducing yourself and asking your first question.";
+  } else if (isLastQuestion) {
+    progressInstruction = `The student has answered ${totalQuestions}/${TOTAL_QUESTIONS} questions (${correctAnswers} correct). This is the LAST question. Evaluate their answer (start with ✅ or ❌), then give a brief summary of how they did. Do NOT ask another question after this.`;
+  } else {
+    progressInstruction = `The student has answered ${totalQuestions}/${TOTAL_QUESTIONS} questions (${correctAnswers} correct). Evaluate their answer, then ask question ${totalQuestions + 1} of ${TOTAL_QUESTIONS}.`;
+  }
+
+  return `You are a quiz master for Dust Academy testing the user's understanding of "${title}". ${studentContext}
+
+RULES:
+- Ask ONE question at a time testing comprehension (not memorization)
+- Be LENIENT when grading: accept answers that demonstrate understanding even if they are incomplete, use different wording, or miss minor details. Only mark an answer wrong if it shows a fundamental misunderstanding or is entirely off-topic.
+- After answering: start your evaluation with exactly "✅" if correct or "❌" if wrong (this is mandatory for every evaluation). Then briefly explain why, or give the right answer if wrong.
+- Then ask the next question
+- You MUST ask exactly ${TOTAL_QUESTIONS} questions total — no more, no less
+- Cover different aspects of the content
+- Do NOT mention question numbers or progress stats to the student
+- Use markdown when helpful
+
+${progressInstruction}
+
+---
+CONTENT:
+${truncatedContent}
+---`;
+}
+
+// The CSRF token is self-issued (GET) and self-verified (POST) within this
+// service, so the HS256 secret never leaves front-api.
+function generateCsrfToken(): string {
+  return jwt.sign({ type: "academy_chat" }, config.getAcademyJwtSecret(), {
+    algorithm: "HS256",
+    expiresIn: CSRF_TOKEN_EXPIRY,
+  });
+}
+
+function verifyCsrfToken(token: string): boolean {
+  try {
+    const payload = jwt.verify(token, config.getAcademyJwtSecret(), {
+      algorithms: ["HS256"],
+    });
+    return (
+      typeof payload === "object" &&
+      payload !== null &&
+      "type" in payload &&
+      payload.type === "academy_chat"
+    );
+  } catch {
+    // `jsonwebtoken` throws on any verification failure (bad signature,
+    // expiry, ...); treat all of these as an invalid token.
+    return false;
+  }
+}
+
+// Only requests originating from the marketing website are allowed. Mirrors the
+// origin/referer check from the former Next.js handler.
+function hasAllowedOrigin(ctx: Context): boolean {
+  const allowedOrigin = config.getStaticWebsiteUrl();
+  const origin = ctx.req.header("origin");
+  const referer = ctx.req.header("referer");
+
+  return (
+    (origin !== undefined && origin.startsWith(allowedOrigin)) ||
+    (referer !== undefined && referer.startsWith(allowedOrigin))
+  );
+}
+
+// Mounted at /api/marketing/academy/chat. No session auth — the quiz is
+// available to anonymous visitors; abuse is mitigated by origin + CSRF + IP
+// rate limiting.
+const app = unauthedApp();
+
+// GET: issue a short-lived CSRF token for the subsequent POST.
+app.get("/", async (ctx) => {
+  if (!hasAllowedOrigin(ctx)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Request origin not allowed.",
+      },
+    });
+  }
+
+  return ctx.json({ csrfToken: generateCsrfToken() });
+});
+
+// POST: stream the quiz-master response as SSE.
+app.post("/", async (ctx) => {
+  if (!hasAllowedOrigin(ctx)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Request origin not allowed.",
+      },
+    });
+  }
+
+  const csrfToken = ctx.req.header("x-csrf-token");
+  if (!csrfToken || !verifyCsrfToken(csrfToken)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid or missing CSRF token.",
+      },
+    });
+  }
+
+  const clientIp = getClientIpFromContext(ctx);
+  const remaining = await rateLimiter({
+    key: `academy_chat:${clientIp}`,
+    maxPerTimeframe: MAX_REQUESTS_PER_MINUTE,
+    timeframeSeconds: 60,
+    logger,
+  });
+
+  if (remaining <= 0) {
+    return apiError(ctx, {
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message: "Too many requests. Please wait a moment and try again.",
+      },
+    });
+  }
+
+  const rawBody = await ctx.req.json().catch(() => null);
+  const bodyValidation = ChatRequestBodySchema.safeParse(rawBody);
+  if (!bodyValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyValidation.error.message}`,
+      },
+    });
+  }
+
+  const {
+    messages,
+    contentType,
+    title,
+    content,
+    correctAnswers,
+    totalQuestions,
+    userName,
+  } = bodyValidation.data;
+
+  const anthropicApiKey = config.getDustManagedAnthropicApiKey();
+  if (!anthropicApiKey) {
+    logger.error("DUST_MANAGED_ANTHROPIC_API_KEY is not configured");
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Chat service is not configured.",
+      },
+    });
+  }
+
+  const client = new Anthropic({ apiKey: anthropicApiKey });
+  const systemPrompt = buildSystemPrompt(
+    contentType,
+    title,
+    content,
+    correctAnswers,
+    totalQuestions,
+    userName
+  );
+
+  // Anthropic requires at least one message - add initial prompt if starting.
+  const apiMessages: ChatMessage[] =
+    messages.length === 0
+      ? [{ role: "user", content: "Start the quiz." }]
+      : messages;
+
+  return streamEvents<{ text?: string; error?: string }>({
+    ctx,
+    iterator: async function* (signal) {
+      try {
+        const stream = await client.messages.create(
+          {
+            model: "claude-4-sonnet-20250514",
+            max_tokens: 1024,
+            system: systemPrompt,
+            messages: apiMessages,
+            stream: true,
+          },
+          { signal }
+        );
+
+        for await (const event of stream) {
+          if (signal.aborted) {
+            break;
+          }
+
+          if (
+            event.type === "content_block_delta" &&
+            event.delta.type === "text_delta"
+          ) {
+            yield { text: event.delta.text };
+          }
+        }
+      } catch (err) {
+        // The client's SSE reader surfaces `{ error }` frames as a thrown
+        // error; the stream then ends on EOF. The original `[DONE]` sentinel
+        // is omitted because the client treats it as a no-op skip marker.
+        logger.error({ err }, "Academy chat API error");
+        yield { error: "An error occurred while generating the response." };
+      }
+    },
+  });
+});
+
+export default app;

--- a/front-api/routes/marketing/academy/index.ts
+++ b/front-api/routes/marketing/academy/index.ts
@@ -1,0 +1,12 @@
+import { createHono } from "@front-api/lib/hono";
+
+import chat from "./chat";
+import progress from "./progress";
+
+// Mounted under /api/marketing/academy.
+const app = createHono();
+
+app.route("/chat", chat);
+app.route("/progress", progress);
+
+export default app;

--- a/front-api/routes/marketing/academy/progress.test.ts
+++ b/front-api/routes/marketing/academy/progress.test.ts
@@ -1,0 +1,214 @@
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+// The progress endpoints accept an optional session and otherwise fall back to
+// an anonymous `X-Academy-Browser-Id` (a UUID). These tests exercise the
+// anonymous path end-to-end against the real DB; each test runs in its own
+// rolled-back transaction so a fresh browser id per suite is fine.
+const BROWSER_ID = "a0000000-0000-4000-8000-000000000001";
+
+function browserHeaders(extra: Record<string, string> = {}) {
+  return { "x-academy-browser-id": BROWSER_ID, ...extra };
+}
+
+function jsonHeaders(extra: Record<string, string> = {}) {
+  return browserHeaders({ "content-type": "application/json", ...extra });
+}
+
+describe("GET /api/marketing/academy/progress", () => {
+  it("returns 401 when neither a session nor a browser id is provided", async () => {
+    const response = await honoApp.request(
+      "/api/marketing/academy/progress?contentType=chapter&contentSlug=intro"
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when query parameters are missing", async () => {
+    const response = await honoApp.request("/api/marketing/academy/progress", {
+      headers: browserHeaders(),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns null progress when the content has no attempts", async () => {
+    const response = await honoApp.request(
+      "/api/marketing/academy/progress?contentType=chapter&contentSlug=intro",
+      { headers: browserHeaders() }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.progress).toBeNull();
+  });
+});
+
+describe("POST /api/marketing/academy/progress", () => {
+  it("records a passing attempt and reports it as a new completion", async () => {
+    const response = await honoApp.request("/api/marketing/academy/progress", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        contentType: "chapter",
+        contentSlug: "intro",
+        courseSlug: "basics",
+        correctAnswers: 4,
+        totalQuestions: 5,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.attempt).toMatchObject({
+      contentType: "chapter",
+      contentSlug: "intro",
+      correctAnswers: 4,
+      totalQuestions: 5,
+      isPassed: true,
+    });
+    // The attempt is identified by its string sId, never the internal ModelId.
+    expect(typeof body.attempt.sId).toBe("string");
+    expect(body.isNewCompletion).toBe(true);
+  });
+
+  it("does not mark a failing attempt as a completion", async () => {
+    const response = await honoApp.request("/api/marketing/academy/progress", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        contentType: "chapter",
+        contentSlug: "intro",
+        correctAnswers: 1,
+        totalQuestions: 5,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.attempt.isPassed).toBe(false);
+    expect(body.isNewCompletion).toBe(false);
+  });
+
+  it("returns 400 for a malformed body", async () => {
+    const response = await honoApp.request("/api/marketing/academy/progress", {
+      method: "POST",
+      headers: jsonHeaders(),
+      // totalQuestions must be a positive integer.
+      body: JSON.stringify({
+        contentType: "chapter",
+        contentSlug: "intro",
+        correctAnswers: 0,
+        totalQuestions: 0,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("surfaces a recorded attempt through GET progress", async () => {
+    const postResponse = await honoApp.request(
+      "/api/marketing/academy/progress",
+      {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+          contentType: "lesson",
+          contentSlug: "lesson-1",
+          correctAnswers: 5,
+          totalQuestions: 5,
+        }),
+      }
+    );
+    expect(postResponse.status).toBe(201);
+
+    const getResponse = await honoApp.request(
+      "/api/marketing/academy/progress?contentType=lesson&contentSlug=lesson-1",
+      { headers: browserHeaders() }
+    );
+
+    expect(getResponse.status).toBe(200);
+    const body = await getResponse.json();
+    expect(body.progress).toMatchObject({
+      attemptCount: 1,
+      bestScore: 5,
+      isCompleted: true,
+    });
+    expect(typeof body.progress.lastAttemptAt).toBe("string");
+  });
+});
+
+describe("GET /api/marketing/academy/progress/courses", () => {
+  it("aggregates chapter attempts under their course, with no caching", async () => {
+    await honoApp.request("/api/marketing/academy/progress", {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        contentType: "chapter",
+        contentSlug: "intro",
+        courseSlug: "basics",
+        correctAnswers: 4,
+        totalQuestions: 5,
+      }),
+    });
+
+    const response = await honoApp.request(
+      "/api/marketing/academy/progress/courses",
+      { headers: browserHeaders() }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const body = await response.json();
+    expect(body.courseProgress.basics.completedChapterSlugs).toContain("intro");
+    expect(body.courseProgress.basics.attemptedChapterSlugs).toContain("intro");
+  });
+});
+
+describe("POST /api/marketing/academy/progress/visit", () => {
+  it("records a chapter visit", async () => {
+    const response = await honoApp.request(
+      "/api/marketing/academy/progress/visit",
+      {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({
+          courseSlug: "basics",
+          chapterSlug: "intro",
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 400 for a malformed visit body", async () => {
+    const response = await honoApp.request(
+      "/api/marketing/academy/progress/visit",
+      {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ courseSlug: "basics" }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("POST /api/marketing/academy/progress/backfill", () => {
+  it("requires an authenticated session", async () => {
+    const response = await honoApp.request(
+      "/api/marketing/academy/progress/backfill",
+      {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: JSON.stringify({ browserId: BROWSER_ID }),
+      }
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/front-api/routes/marketing/academy/progress.ts
+++ b/front-api/routes/marketing/academy/progress.ts
@@ -1,0 +1,279 @@
+/** @ignoreswagger */
+import type { CourseProgressData } from "@app/lib/api/academy_api";
+import { getAcademyIdentifier } from "@app/lib/api/academy_api";
+import { fetchUserFromSession } from "@app/lib/iam/users";
+import { AcademyChapterVisitResource } from "@app/lib/resources/academy_chapter_visit_resource";
+import { AcademyQuizAttemptResource } from "@app/lib/resources/academy_quiz_attempt_resource";
+import { unauthedApp } from "@front-api/middlewares/ctx";
+import {
+  resolveOptionalSession,
+  resolveSession,
+} from "@front-api/middlewares/session_resolution";
+import { apiError } from "@front-api/middlewares/utils";
+import type { Context } from "hono";
+import { z } from "zod";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const GetProgressQuerySchema = z.object({
+  contentType: z.enum(["course", "lesson", "chapter"]),
+  contentSlug: z.string().min(1),
+});
+
+const PostProgressBodySchema = z.object({
+  contentType: z.enum(["course", "lesson", "chapter"]),
+  contentSlug: z.string().min(1),
+  courseSlug: z.string().min(1).optional(),
+  correctAnswers: z.number().int().nonnegative(),
+  totalQuestions: z.number().int().positive(),
+});
+
+const PostVisitBodySchema = z.object({
+  courseSlug: z.string().min(1),
+  chapterSlug: z.string().min(1),
+});
+
+const BackfillBodySchema = z.object({
+  browserId: z.string().regex(UUID_RE),
+});
+
+// `getAcademyIdentifier` only reads `x-academy-browser-id`; forward just that
+// header in the shape it expects.
+function browserIdHeaders(ctx: Context): Record<string, string | undefined> {
+  return { "x-academy-browser-id": ctx.req.header("x-academy-browser-id") };
+}
+
+// Mounted at /api/marketing/academy/progress. Most routes accept an optional
+// session and fall back to an anonymous `X-Academy-Browser-Id`; `/backfill`
+// requires a logged-in user.
+const app = unauthedApp();
+
+// GET /: progress for a single piece of content.
+app.get("/", async (ctx) => {
+  const session = await resolveOptionalSession(ctx);
+  const identifier = await getAcademyIdentifier(browserIdHeaders(ctx), session);
+  if (!identifier) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Authentication or browser ID required.",
+      },
+    });
+  }
+
+  const queryValidation = GetProgressQuerySchema.safeParse({
+    contentType: ctx.req.query("contentType"),
+    contentSlug: ctx.req.query("contentSlug"),
+  });
+  if (!queryValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "Missing or invalid query parameters: contentType and contentSlug.",
+      },
+    });
+  }
+
+  const { contentType, contentSlug } = queryValidation.data;
+
+  const progress = await AcademyQuizAttemptResource.getProgressForContent(
+    identifier,
+    contentType,
+    contentSlug
+  );
+
+  return ctx.json({
+    progress: progress
+      ? {
+          attemptCount: progress.attemptCount,
+          bestScore: progress.bestScore,
+          isCompleted: progress.isCompleted,
+          lastAttemptAt: progress.lastAttemptAt.toISOString(),
+        }
+      : null,
+  });
+});
+
+// POST /: record a quiz attempt.
+app.post("/", async (ctx) => {
+  const session = await resolveOptionalSession(ctx);
+  const identifier = await getAcademyIdentifier(browserIdHeaders(ctx), session);
+  if (!identifier) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Authentication or browser ID required.",
+      },
+    });
+  }
+
+  const rawBody = await ctx.req.json().catch(() => null);
+  const bodyValidation = PostProgressBodySchema.safeParse(rawBody);
+  if (!bodyValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyValidation.error.message}`,
+      },
+    });
+  }
+
+  const {
+    contentType,
+    contentSlug,
+    courseSlug,
+    correctAnswers,
+    totalQuestions,
+  } = bodyValidation.data;
+
+  // Check if user already had a passing score before this attempt.
+  const hadPassingScore = await AcademyQuizAttemptResource.hasPassingScore(
+    identifier,
+    contentType,
+    contentSlug
+  );
+
+  const attempt = await AcademyQuizAttemptResource.recordAttempt(identifier, {
+    contentType,
+    contentSlug,
+    courseSlug,
+    correctAnswers,
+    totalQuestions,
+  });
+
+  const isNewCompletion = attempt.isPassed && !hadPassingScore;
+
+  return ctx.json(
+    {
+      attempt: {
+        sId: attempt.sId,
+        contentType: attempt.contentType,
+        contentSlug: attempt.contentSlug,
+        correctAnswers: attempt.correctAnswers,
+        totalQuestions: attempt.totalQuestions,
+        isPassed: attempt.isPassed,
+        createdAt: attempt.createdAt.toISOString(),
+      },
+      isNewCompletion,
+    },
+    201
+  );
+});
+
+// GET /courses: progress across all courses.
+app.get("/courses", async (ctx) => {
+  const session = await resolveOptionalSession(ctx);
+  const identifier = await getAcademyIdentifier(browserIdHeaders(ctx), session);
+  if (!identifier) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Authentication or browser ID required.",
+      },
+    });
+  }
+
+  const courseProgressMap =
+    await AcademyQuizAttemptResource.getAllCourseProgress(identifier);
+
+  const courseProgress: Record<string, CourseProgressData> = {};
+  for (const [courseSlug, data] of courseProgressMap) {
+    courseProgress[courseSlug] = {
+      completedChapterSlugs: data.completedChapterSlugs,
+      attemptedChapterSlugs: data.attemptedChapterSlugs,
+      lastAttemptAt: data.lastAttemptAt.toISOString(),
+    };
+  }
+
+  // Prevent HTTP caching — progress changes on every chapter visit.
+  ctx.header("Cache-Control", "no-store");
+
+  return ctx.json({ courseProgress });
+});
+
+// POST /backfill: attach an anonymous browser id's progress to the logged-in
+// user. Requires a session.
+app.post("/backfill", async (ctx) => {
+  const sessionResult = await resolveSession(ctx);
+  if (sessionResult instanceof Response) {
+    return sessionResult;
+  }
+
+  const user = await fetchUserFromSession(sessionResult);
+  if (!user) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_request_error",
+        message: "User not found.",
+      },
+    });
+  }
+
+  const rawBody = await ctx.req.json().catch(() => null);
+  const bodyValidation = BackfillBodySchema.safeParse(rawBody);
+  if (!bodyValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyValidation.error.message}`,
+      },
+    });
+  }
+
+  const { browserId } = bodyValidation.data;
+
+  const [backfilledVisits, backfilledAttempts] = await Promise.all([
+    AcademyChapterVisitResource.backfillBrowserId(browserId, user.id),
+    AcademyQuizAttemptResource.backfillBrowserId(browserId, user.id),
+  ]);
+
+  return ctx.json({ backfilledVisits, backfilledAttempts });
+});
+
+// POST /visit: record that a chapter was visited.
+app.post("/visit", async (ctx) => {
+  const session = await resolveOptionalSession(ctx);
+  const identifier = await getAcademyIdentifier(browserIdHeaders(ctx), session);
+  if (!identifier) {
+    return apiError(ctx, {
+      status_code: 401,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Authentication or browser ID required.",
+      },
+    });
+  }
+
+  const rawBody = await ctx.req.json().catch(() => null);
+  const bodyValidation = PostVisitBodySchema.safeParse(rawBody);
+  if (!bodyValidation.success) {
+    return apiError(ctx, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyValidation.error.message}`,
+      },
+    });
+  }
+
+  const { courseSlug, chapterSlug } = bodyValidation.data;
+
+  await AcademyChapterVisitResource.recordVisit(
+    identifier,
+    courseSlug,
+    chapterSlug
+  );
+
+  return ctx.json({ success: true });
+});
+
+export default app;

--- a/front-api/routes/marketing/index.ts
+++ b/front-api/routes/marketing/index.ts
@@ -1,10 +1,12 @@
 import { createHono } from "@front-api/lib/hono";
 
+import academy from "./academy";
 import integrations from "./integrations";
 
 // Mounted under /api/marketing.
 const app = createHono();
 
+app.route("/academy", academy);
 app.route("/integrations", integrations);
 
 export default app;

--- a/front-api/vite.setup.ts
+++ b/front-api/vite.setup.ts
@@ -9,6 +9,7 @@ vi.mock("@app/lib/api/config", async (importOriginal) => {
     "@app/tests/utils/mocks/app_config"
   );
   return createAppConfigMock(importOriginal, {
+    getAcademyJwtSecret: () => "test-academy-jwt-secret",
     getApiBaseUrl: () => "http://localhost:3000",
     getAppUrl: () => "http://localhost:3000",
     getCoreAPIConfig: () => ({

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -101,6 +101,15 @@ const config = {
       EnvironmentConfig.getOptionalEnvVariable("ANTHROPIC_EAP_API_KEY") ?? null
     );
   },
+  // Anthropic API key for Dust-managed features (e.g. the Academy quiz chat).
+  // Optional: only set in deployments that serve these features.
+  getDustManagedAnthropicApiKey: (): string | null => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable(
+        "DUST_MANAGED_ANTHROPIC_API_KEY"
+      ) ?? null
+    );
+  },
   getSupportEmailAddress: (): { name: string; email: string } => {
     return {
       name: "Dust team",

--- a/marketing/hooks/useAcademyQuiz.ts
+++ b/marketing/hooks/useAcademyQuiz.ts
@@ -2,9 +2,9 @@ import config from "@marketing/lib/api/config";
 import { clientFetch } from "@marketing/lib/egress/client";
 import { useCallback, useRef, useState } from "react";
 
-// Academy chat endpoint lives behind the API host (front-api, with front
-// behind it via the L7 proxy).
-const ACADEMY_CHAT_URL = `${config.getApiBaseUrl()}/api/academy/chat`;
+// Academy chat endpoint lives on the API host (front-api) under
+// /api/marketing/academy, alongside the other marketing endpoints.
+const ACADEMY_CHAT_URL = `${config.getApiBaseUrl()}/api/marketing/academy/chat`;
 
 interface QuizMessage {
   role: "user" | "assistant";

--- a/marketing/lib/swr/academy.ts
+++ b/marketing/lib/swr/academy.ts
@@ -9,10 +9,11 @@ import { useSWRConfig } from "swr";
 
 const BROWSER_ID_KEY = "dust_academy_browser_id";
 
-// Academy progress/chat endpoints live behind the API host (front-api, with
-// front behind it via the L7 proxy). Marketing hits them cross-origin.
+// Academy progress/chat endpoints live on the API host (front-api) under
+// /api/marketing/academy, alongside the other marketing endpoints. Marketing
+// hits them cross-origin.
 const academyApiUrl = (path: string): string =>
-  `${config.getApiBaseUrl()}/api/academy${path}`;
+  `${config.getApiBaseUrl()}/api/marketing/academy${path}`;
 
 function generateUUID(): string {
   return crypto.randomUUID();
@@ -61,7 +62,7 @@ interface GetCourseProgressResponse {
 
 interface PostProgressResponse {
   attempt: {
-    id: number;
+    sId: string;
     contentType: string;
     contentSlug: string;
     correctAnswers: number;

--- a/marketing/pages/academy/[slug]/chapter/[chapterSlug].tsx
+++ b/marketing/pages/academy/[slug]/chapter/[chapterSlug].tsx
@@ -166,7 +166,7 @@ export default function ChapterPage({
     } else if (browserId) {
       void (async () => {
         await clientFetch(
-          `${config.getApiBaseUrl()}/api/academy/progress/visit`,
+          `${config.getApiBaseUrl()}/api/marketing/academy/progress/visit`,
           {
             method: "POST",
             headers: {


### PR DESCRIPTION
## Description

Forgot to migrate academy endpoints, now they are in front-api, with tests and sId in JSON :)

And made the switch in marketing so we don't 404.

## Tests

Unit tests + locally tested

## Risk

Low

## Deploy Plan

deploy front & marketing