### PR TITLE
[front] default currency to usd when customer not linked to stripe

### DIFF
--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -175,12 +175,9 @@ export async function resolveCurrencyForExistingMetronomeCustomer({
 
   const stripeCustomerId = stripeCustomerIdResult.value;
   if (!stripeCustomerId) {
-    return new Err(
-      new Error(
-        "Failed to resolve billing currency for Metronome customer " +
-          `${metronomeCustomerId}: no Stripe billing config found.`
-      )
-    );
+    // So Metronome contract do not have stripeCustomerId (e.g. for Free Plans)
+    // use usd as default in this case.
+    return new Ok("usd");
   }
 
   const stripeCustomer = await getStripeCustomer(stripeCustomerId);


### PR DESCRIPTION
## Description

Now, with free plans on Metronome, customers and contracts can exist without a stripeCustomerId
=> in this case default resolveCurrencyForExistingMetronomeCustomer to "usd" instead of returning an error

## Tests

Tested locally on a free plan

## Risk

Low, specific for metronome customers/contracts without stripe (Free plan)

## Deploy Plan

Deploy front