### PR TITLE
[poke] Show Usage tab for any Metronome-backed workspace

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -34,7 +34,6 @@ import { usePokeRegion } from "@app/lib/swr/poke";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeDataRetention } from "@app/poke/swr/data_retention";
 import { usePokeWorkspaceInfo } from "@app/poke/swr/workspace_info";
-import { isCreditPricedPlan } from "@app/types/plan";
 import { isString } from "@app/types/shared/utils/general";
 import type { WorkspaceSegmentationType } from "@app/types/user";
 import {
@@ -154,9 +153,13 @@ export function WorkspacePage() {
     temporalFrontNamespace,
   } = workspaceInfo;
 
-  // The Usage tab (AWU usage chart + credit pool) only applies to credit-based
-  // (CP_) pricing workspaces.
-  const isCreditPriced = isCreditPricedPlan(activeSubscription.plan);
+  // The Usage tab (AWU usage chart + credit pool) is backed by Metronome usage
+  // data, so it applies to any workspace with a Metronome contract — both
+  // credit-priced and legacy shadow contracts. There's no need to gate it on a
+  // feature flag in poke: it's staff tooling, not customer-facing exposure.
+  const hasMetronomeUsage =
+    metronomeCustomerId !== null &&
+    activeSubscription.metronomeContractId !== null;
 
   return (
     <div className="ml-8 p-6">
@@ -285,7 +288,7 @@ export function WorkspacePage() {
               <TabsTrigger value="triggers" label="Triggers" />
               <TabsTrigger value="webhooksources" label="Webhook Sources" />
               <TabsTrigger value="credits" label="API Usage" />
-              {isCreditPriced && <TabsTrigger value="usage" label="Usage" />}
+              {hasMetronomeUsage && <TabsTrigger value="usage" label="Usage" />}
               <TabsTrigger value="analytics" label="Analytics" />
             </TabsList>
 
@@ -346,7 +349,7 @@ export function WorkspacePage() {
                 loadOnInit
               />
             </TabsContent>
-            {isCreditPriced && (
+            {hasMetronomeUsage && (
               <TabsContent value="usage">
                 <PokeUsageTab
                   owner={owner}


### PR DESCRIPTION
## Description

Followup https://github.com/dust-tt/dust/pull/27202 - enable in poke for all, if metronome is present


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
