### PR TITLE
[Skills] Propagate skill icon changes to inline references

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -939,6 +939,47 @@ describe("SkillResource", () => {
       expect(availableParentSkill?.instructions).toContain(skillReferenceTag);
     });
 
+    it("updates parent skill references when child icon changes", async () => {
+      const { parentSkill, childSkill, skillReferenceTag } =
+        await SkillFactory.createWithNestedSkill(testContext.authenticator, {
+          childOverrides: {
+            name: "Child Icon Skill",
+          },
+          parentOverrides: {
+            name: "Parent Icon Skill",
+          },
+        });
+
+      const newIcon = "ActionRocketIcon";
+      expect(childSkill.icon).not.toBe(newIcon);
+
+      await childSkill.updateSkill(testContext.authenticator, {
+        name: childSkill.name,
+        agentFacingDescription: childSkill.agentFacingDescription,
+        userFacingDescription: childSkill.userFacingDescription,
+        instructions: childSkill.instructions,
+        instructionsHtml: childSkill.instructionsHtml,
+        icon: newIcon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: childSkill.requestedSpaceIds,
+        referencedSkillIds: [],
+      });
+
+      const updatedParentSkill = await SkillResource.fetchById(
+        testContext.authenticator,
+        parentSkill.sId
+      );
+      expect(updatedParentSkill?.instructions).not.toContain(skillReferenceTag);
+      expect(updatedParentSkill?.instructions).toContain(
+        SkillFactory.serializeSkillReferenceTag({
+          sId: childSkill.sId,
+          icon: newIcon,
+          name: childSkill.name,
+        })
+      );
+    });
+
     it("normalizes missing nested skill references as unavailable", async () => {
       const MISSING_SKILL_MODEL_ID = 999_999;
       const missingSkillId = SkillResource.modelIdToSId({

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2464,8 +2464,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   ): Promise<void> {
     assert(this.canWrite(auth), "User is not authorized to update this skill");
 
-    // Snapshot the previous name before updating to detect a rename below.
+    // Snapshot the previous name and icon before updating to detect changes below.
     const previousName = this.name;
+    const previousIcon = this.icon;
     const previousStatus = this.status;
 
     await withTransaction(async (transaction) => {
@@ -2518,7 +2519,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
       }
 
-      if (name !== previousName || requestedSpaceIdsChanged || statusChanged) {
+      if (
+        name !== previousName ||
+        icon !== previousIcon ||
+        requestedSpaceIdsChanged ||
+        statusChanged
+      ) {
         await this.propagateReferenceUpdatesToParentSkills(
           auth,
           {


### PR DESCRIPTION
## Description

When a skill is renamed, skills referencing it inline in their instructions (`<skill id="…" name="…" icon="…" />` tags) are rewritten to show the new name (https://github.com/dust-tt/dust/pull/26470). The same was not done for icons: an icon-only change never triggered `propagateReferenceUpdatesToParentSkills`, so referencing skills kept showing the stale icon in their instruction chips.

The propagation path already rewrites the full tag (including the `icon` attribute) from the target skill — the only gap was the trigger condition in `updateSkill`, which checked name, requested spaces, and status but not icon. This PR adds the icon to the snapshot/trigger, plus a test mirroring the existing spaces/status propagation tests.

Context: discussion on https://github.com/dust-tt/dust/pull/26470 ("Do we need the same mechanic for icon?").

## Risks

Blast radius: skill updates that change the icon now rewrite inline references in parent skills (same code path as renames).
Risk: low

## Deploy Plan

- deploy front