### PR TITLE
[Skills] Add more padding around Dust logo badge on skill avatars

### DIFF
--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -117,14 +117,14 @@ const AVATAR_BADGE_CLASSES: Record<
   ResourceAvatarSize,
   { badge: string; icon: string }
 > = {
-  xxs: { badge: "h-2.5 w-2.5 rounded-[2px]", icon: "h-2 w-2" },
-  xs: { badge: "h-3 w-3 rounded-[3px]", icon: "h-2.5 w-2.5" },
-  sm: { badge: "h-3.5 w-3.5 rounded-[3px]", icon: "h-3 w-3" },
-  md: { badge: "h-4 w-4 rounded", icon: "h-3.5 w-3.5" },
-  lg: { badge: "h-5 w-5 rounded-md", icon: "h-4 w-4" },
-  xl: { badge: "h-6 w-6 rounded-md", icon: "h-5 w-5" },
-  "2xl": { badge: "h-8 w-8 rounded-lg", icon: "h-7 w-7" },
-  auto: { badge: "h-6 w-6 rounded-md", icon: "h-5 w-5" },
+  xxs: { badge: "h-2.5 w-2.5 rounded-[2px]", icon: "h-1.5 w-1.5" },
+  xs: { badge: "h-3 w-3 rounded-[3px]", icon: "h-2 w-2" },
+  sm: { badge: "h-3.5 w-3.5 rounded-[3px]", icon: "h-2.5 w-2.5" },
+  md: { badge: "h-4 w-4 rounded", icon: "h-3 w-3" },
+  lg: { badge: "h-5 w-5 rounded-md", icon: "h-3.5 w-3.5" },
+  xl: { badge: "h-6 w-6 rounded-md", icon: "h-4 w-4" },
+  "2xl": { badge: "h-8 w-8 rounded-lg", icon: "h-6 w-6" },
+  auto: { badge: "h-6 w-6 rounded-md", icon: "h-4 w-4" },
 };
 
 interface ResourceAvatarWithBadgeProps extends ResourceAvatarProps {

--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -117,14 +117,14 @@ const AVATAR_BADGE_CLASSES: Record<
   ResourceAvatarSize,
   { badge: string; icon: string }
 > = {
-  xxs: { badge: "h-2.5 w-2.5 rounded-[2px]", icon: "h-1.5 w-1.5" },
-  xs: { badge: "h-3 w-3 rounded-[3px]", icon: "h-2 w-2" },
-  sm: { badge: "h-3.5 w-3.5 rounded-[3px]", icon: "h-2.5 w-2.5" },
-  md: { badge: "h-4 w-4 rounded", icon: "h-3 w-3" },
-  lg: { badge: "h-5 w-5 rounded-md", icon: "h-3.5 w-3.5" },
-  xl: { badge: "h-6 w-6 rounded-md", icon: "h-4 w-4" },
-  "2xl": { badge: "h-8 w-8 rounded-lg", icon: "h-6 w-6" },
-  auto: { badge: "h-6 w-6 rounded-md", icon: "h-4 w-4" },
+  xxs: { badge: "h-3 w-3 rounded-[2px]", icon: "h-2 w-2" },
+  xs: { badge: "h-3.5 w-3.5 rounded-[3px]", icon: "h-2.5 w-2.5" },
+  sm: { badge: "h-4 w-4 rounded-[3px]", icon: "h-3 w-3" },
+  md: { badge: "h-5 w-5 rounded", icon: "h-3.5 w-3.5" },
+  lg: { badge: "h-6 w-6 rounded-md", icon: "h-4 w-4" },
+  xl: { badge: "h-7 w-7 rounded-md", icon: "h-5 w-5" },
+  "2xl": { badge: "h-9 w-9 rounded-lg", icon: "h-7 w-7" },
+  auto: { badge: "h-7 w-7 rounded-md", icon: "h-5 w-5" },
 };
 
 interface ResourceAvatarWithBadgeProps extends ResourceAvatarProps {


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/27122. Addresses [this comment](https://github.com/dust-tt/dust/pull/27122#issuecomment-4669982663): the Dust logo badge on skill avatars almost fills its white background (only ~1px of padding at small sizes), which looks cramped.

This widens the badge by one size step at every badge size while keeping the logo at its current size, giving it more breathing room inside the badge.

<img width="506" height="275" alt="image" src="https://github.com/user-attachments/assets/75dff01d-a8b3-4330-b8da-b52803ee7206" />

### Before
<img width="506" height="275" alt="image" src="https://github.com/user-attachments/assets/e54db493-33c7-425d-8f65-3b6fe618010e" />


## Risks

Blast radius: Dust logo badge rendering on skill avatars (dropdowns, inline chips).
Risk: none

## Deploy Plan

- deploy front