### PR TITLE
User credit usage limit is displayed as infinity when "Default pool credit limit" is set

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -5,7 +5,9 @@ import {
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
+import { useDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import {
   isMembershipSeatType,
   type MembershipSeatType,
@@ -144,8 +146,19 @@ function AwuUsageBar({
   seatType,
   isTotalAllowedUsagePending: isPending,
 }: AwuUsageBarProps) {
+  const { sId: workspaceId } = useWorkspace();
+  const { defaultUserSpendLimit } = useDefaultUserSpendLimit({ workspaceId });
+
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
+
+  // When no Metronome cap alert exists for this user (`limit` is null), fall
+  // back to displaying the workspace default: seat allowance + default pool.
+  const effectiveLimit =
+    limit ??
+    (defaultUserSpendLimit?.awuCredits != null
+      ? allowance + defaultUserSpendLimit.awuCredits
+      : null);
 
   // The bar splits consumption into seat → pool → overage:
   //   seat consumed · seat remaining · pool consumed · pool remaining · overage
@@ -155,7 +168,8 @@ function AwuUsageBar({
   // skipped. `pool remaining` is omitted when uncapped (no finite headroom).
   const seatConsumed = consumedFromAllowance;
   const seatRemaining = Math.max(0, allowance - seatConsumed);
-  const poolLimit = limit !== null ? Math.max(0, limit - allowance) : null;
+  const poolLimit =
+    effectiveLimit !== null ? Math.max(0, effectiveLimit - allowance) : null;
   // Of the pool consumption, the part within the pool limit vs. the overage
   // beyond it (only capped seats can have overage).
   const poolConsumed =
@@ -304,7 +318,9 @@ function AwuUsageBar({
         {isPending ? (
           <Spinner size="xs" />
         ) : (
-          <span>{limit === null ? "∞" : formatCredits(limit)}</span>
+          <span>
+            {effectiveLimit === null ? "∞" : formatCredits(effectiveLimit)}
+          </span>
         )}
       </div>
       {tooltipContent ? (


### PR DESCRIPTION
## Description

Fixes a display bug in the Members Usage Table where the per-user credit limit was shown as "∞" (infinity) even when a workspace-level "Default pool credit limit" had been configured. This happened because the `AwuUsageBar` component relied solely on the user-level Metronome cap alert (`limit` prop) to determine the displayed ceiling. When no per-user alert existed (e.g. on a freshly created Business plan), `limit` was `null` and the UI fell back to "∞". 

The fix computes an `effectiveLimit`: if `limit` is null, it falls back to `seat allowance + defaultUserSpendLimit.awuCredits` fetched from the workspace default spend limit API.

## Tests

Manually verify: on a workspace with "Default pool credit limit" set to 0 and no per-user overrides, the usage bar should now display `seat allowance + 0` (i.e. the seat allowance) instead of "∞".

## Risk

Low — display-only change; no data or business logic is altered. The new SWR hook call adds a lightweight fetch but has no side effects.

## Deploy Plan

Deploy `front`.