### PR TITLE
Fix agent messages stuck on a blank placeholder when the conversation SSE misses `agent_message_new`

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.test.ts
+++ b/front/components/assistant/conversation/ConversationViewer.test.ts
@@ -1,5 +1,11 @@
-import { getBranchedInsertIndex } from "@app/components/assistant/conversation/ConversationViewer";
-import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import {
+  getBranchedInsertIndex,
+  upsertMessageInList,
+} from "@app/components/assistant/conversation/ConversationViewer";
+import type {
+  AgentMessageWithStreaming,
+  VirtuosoMessage,
+} from "@app/components/assistant/conversation/types";
 import { describe, expect, it } from "vitest";
 
 describe("getBranchedInsertIndex", () => {
@@ -165,5 +171,172 @@ describe("getBranchedInsertIndex", () => {
     const index = getBranchedInsertIndex(data, newMessage);
     // Pure rank-based behavior: before first rank > 2 (i.e. before rank 3)
     expect(index).toBe(2);
+  });
+});
+
+describe("upsertMessageInList", () => {
+  const makeAgentMessage = ({
+    rank,
+    branchId = null,
+    sId,
+    agentState = "thinking",
+    content = null,
+  }: {
+    rank: number;
+    branchId?: string | null;
+    sId: string;
+    agentState?: AgentMessageWithStreaming["streaming"]["agentState"];
+    content?: string | null;
+  }): AgentMessageWithStreaming =>
+    ({
+      sId,
+      rank,
+      branchId,
+      type: "agent_message",
+      status: "created",
+      content,
+      chainOfThought: null,
+      streaming: {
+        agentState,
+        isRetrying: false,
+        lastUpdated: new Date(),
+        actionProgress: new Map(),
+        pendingToolCalls: [],
+        inlineActivitySteps: [],
+      },
+    }) as unknown as AgentMessageWithStreaming;
+
+  const makeFakeListData = (initial: VirtuosoMessage[]) => {
+    let items = [...initial];
+    const data = {
+      get: () => items,
+      find: (predicate: (m: VirtuosoMessage) => boolean) =>
+        items.find(predicate),
+      map: (fn: (m: VirtuosoMessage) => VirtuosoMessage) => {
+        items = items.map(fn);
+      },
+      insert: (msgs: VirtuosoMessage[], index: number) => {
+        items = [...items.slice(0, index), ...msgs, ...items.slice(index)];
+      },
+      append: (msgs: VirtuosoMessage[]) => {
+        items = [...items, ...msgs];
+      },
+    };
+    return data as unknown as Parameters<typeof upsertMessageInList>[0];
+  };
+
+  it("replaces the optimistic placeholder at the same rank/branch", () => {
+    const placeholder = makeAgentMessage({
+      rank: 2,
+      sId: "placeholder-agent-message-123",
+      agentState: "placeholder",
+    });
+    const data = makeFakeListData([placeholder]);
+
+    const real = makeAgentMessage({ rank: 2, sId: "real-sid" });
+    upsertMessageInList(data, real);
+
+    const items = data.get();
+    expect(items).toHaveLength(1);
+    expect(items[0].sId).toBe("real-sid");
+    expect((items[0] as AgentMessageWithStreaming).streaming.agentState).toBe(
+      "thinking"
+    );
+  });
+
+  it("does not overwrite a message that already progressed past its initial state", () => {
+    const progressed = makeAgentMessage({
+      rank: 2,
+      sId: "real-sid",
+      agentState: "writing",
+      content: "already streamed content",
+    });
+    const data = makeFakeListData([progressed]);
+
+    // Replay of agent_message_new with the original "created" payload.
+    const replay = makeAgentMessage({ rank: 2, sId: "real-sid" });
+    upsertMessageInList(data, replay);
+
+    const items = data.get();
+    expect(items).toHaveLength(1);
+    expect((items[0] as AgentMessageWithStreaming).content).toBe(
+      "already streamed content"
+    );
+  });
+
+  it("replaces the same message when it is still at its initial state", () => {
+    const initial = makeAgentMessage({ rank: 2, sId: "real-sid" });
+    const data = makeFakeListData([initial]);
+
+    const replay = makeAgentMessage({ rank: 2, sId: "real-sid" });
+    upsertMessageInList(data, replay);
+
+    const items = data.get();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toBe(replay);
+  });
+
+  it("inserts the message when no entry matches its rank/branch", () => {
+    const existing = makeAgentMessage({ rank: 1, sId: "old-sid" });
+    const data = makeFakeListData([existing]);
+
+    const real = makeAgentMessage({ rank: 3, sId: "real-sid" });
+    upsertMessageInList(data, real);
+
+    const items = data.get();
+    expect(items.map((m) => m.sId)).toEqual(["old-sid", "real-sid"]);
+  });
+
+  it("retry with a new sId at the same rank/branch replaces the previous message", () => {
+    const previous = makeAgentMessage({
+      rank: 2,
+      sId: "v1-sid",
+      agentState: "writing",
+      content: "v1 content",
+    });
+    const data = makeFakeListData([previous]);
+
+    const retry = makeAgentMessage({ rank: 2, sId: "v2-sid" });
+    upsertMessageInList(data, retry);
+
+    const items = data.get();
+    expect(items).toHaveLength(1);
+    expect(items[0].sId).toBe("v2-sid");
+  });
+
+  it("inserts a user message in its branch when no entry matches (branch reconciliation)", () => {
+    const makeUserMessage = (
+      rank: number,
+      branchId: string | null,
+      sId: string
+    ): VirtuosoMessage =>
+      ({
+        sId,
+        rank,
+        branchId,
+        type: "user_message",
+        contentFragments: [],
+        context: { origin: "web" },
+      }) as unknown as VirtuosoMessage;
+
+    const mainThread = [
+      makeUserMessage(0, null, "user-0"),
+      makeAgentMessage({ rank: 1, sId: "agent-1" }),
+    ];
+    const data = makeFakeListData(mainThread);
+
+    const branchUserMessage = makeUserMessage(2, "branch-a", "branch-user");
+    upsertMessageInList(data, branchUserMessage);
+
+    expect(data.get().map((m) => m.sId)).toEqual([
+      "user-0",
+      "agent-1",
+      "branch-user",
+    ]);
+
+    // A second upsert (e.g. the SSE arriving after the POST response) is
+    // idempotent: it replaces the entry instead of duplicating it.
+    upsertMessageInList(data, branchUserMessage);
+    expect(data.get()).toHaveLength(3);
   });
 });

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -205,6 +205,58 @@ export function getBranchedInsertIndex(
   return rankOffset === -1 ? data.length : rankOffset;
 }
 
+// Upserts a message into the Virtuoso list: replaces the entry at the same
+// rank/branch (typically an optimistic placeholder), or inserts it at the
+// right position. Used by both the conversation SSE handlers and the
+// post-message response reconciliation in `handleSubmit`, so that whichever
+// path runs second is a no-op.
+//
+// For agent messages, guard against overwriting a message that the
+// message-level SSE has already partially or fully streamed: two independent
+// paths feed each message:
+//   1. Conversation stream / POST response — structural events (this function)
+//   2. Message stream — generation_tokens, tool_* (content events)
+// When the conversation stream drops and reconnects, the server replays
+// agent_message_new with the message's original "created" payload: null
+// content, agentState = "thinking", empty steps. Replacing the Virtuoso entry
+// with that stale payload would wipe whatever the message stream already
+// delivered, so we skip the replace when the existing entry is the same
+// logical message (same sId) and has already progressed past its initial
+// state.
+//
+// Retries carry a new sId at the same rank/branch, so they always fall
+// through to the replace path.
+export function upsertMessageInList(
+  data: VirtuosoMessageListMethods<
+    VirtuosoMessage,
+    VirtuosoMessageListContext
+  >["data"],
+  message: VirtuosoMessage
+): void {
+  const predicate = getPredicateForRankAndBranch(message);
+  const exists = data.find(predicate);
+
+  if (exists) {
+    const shouldSkipReplace =
+      isAgentMessageWithStreaming(exists) &&
+      exists.sId === message.sId &&
+      !isAtInitialStreamState(exists);
+
+    if (!shouldSkipReplace) {
+      data.map((m) => (predicate(m) ? message : m));
+    }
+  } else {
+    const currentData = data.get();
+    const offset = getBranchedInsertIndex(currentData, message);
+
+    if (offset < currentData.length) {
+      data.insert([message], offset);
+    } else {
+      data.append([message]);
+    }
+  }
+}
+
 function makeConversationForkNoticeMessage(
   sourceMessage: VirtuosoMessage,
   forkedChild: ConversationForkedChildType
@@ -815,56 +867,10 @@ export const ConversationViewer = ({
                 getLightAgentMessageFromAgentMessage(event.message)
               );
 
-              // Replace the message in the exist list data, or append.
-              const predicate = getPredicateForRankAndBranch(agentMessage);
-              const exists =
-                virtuosoMessageListRef.current.data.find(predicate);
-
-              if (exists) {
-                // Guard against conversation SSE replays overwriting a message
-                // that the message-level SSE has already partially or fully
-                // streamed.
-                //
-                // Two independent SSE streams feed each message:
-                //   1. Conversation stream — carries agent_message_new (structural events)
-                //   2. Message stream      — carries generation_tokens, tool_* (content events)
-                //
-                // When the conversation stream drops and reconnects, the server
-                // replays agent_message_new with the message's original "created"
-                // payload: null content, agentState = "thinking", empty steps.
-                // Replacing the Virtuoso entry with that stale payload would wipe
-                // whatever the message stream already delivered, so we skip the
-                // replace when the existing entry is the same logical message
-                // (same sId) and has already progressed past its initial state.
-                //
-                // Retries carry a new sId at the same rank/branch, so they
-                // always fall through to the replace path.
-                const shouldSkipReplace =
-                  isAgentMessageWithStreaming(exists) &&
-                  exists.sId === agentMessage.sId &&
-                  !isAtInitialStreamState(exists);
-
-                if (!shouldSkipReplace) {
-                  virtuosoMessageListRef.current.data.map((m) =>
-                    predicate(m) ? agentMessage : m
-                  );
-                }
-              } else {
-                const currentData = virtuosoMessageListRef.current.data.get();
-                const offset = getBranchedInsertIndex(
-                  currentData,
-                  agentMessage
-                );
-
-                if (offset < currentData.length) {
-                  virtuosoMessageListRef.current.data.insert(
-                    [agentMessage],
-                    offset
-                  );
-                } else {
-                  virtuosoMessageListRef.current.data.append([agentMessage]);
-                }
-              }
+              upsertMessageInList(
+                virtuosoMessageListRef.current.data,
+                agentMessage
+              );
 
               if (agentMessage.branchId) {
                 setBranchIdToApprove(agentMessage.branchId);
@@ -1255,6 +1261,7 @@ export const ConversationViewer = ({
         const {
           message: messageFromBackend,
           contentFragments: contentFragmentsFromBackend,
+          agentMessages: agentMessagesFromBackend,
         } = result.value;
 
         // If the message was created in a branch, we remove the placeholder user message and the placeholder agent messages from the list.
@@ -1268,15 +1275,67 @@ export const ConversationViewer = ({
           );
         }
 
-        // map() is how we update the state of virtuoso messages.
-        virtuosoMessageListRef.current.data.map((m) =>
-          areSameRankAndBranch(m, placeholderUserMsg)
-            ? {
-                ...messageFromBackend,
-                contentFragments: contentFragmentsFromBackend,
-              }
-            : m
+        const userMessageFromBackend = {
+          ...messageFromBackend,
+          contentFragments: contentFragmentsFromBackend,
+        };
+
+        if (messageFromBackend.branchId) {
+          // Branch case: the placeholders were just deleted, so there is no
+          // entry left to map. The user message normally arrives through the
+          // conversation SSE (user_message_new), but that event can be lost
+          // while the stream is reconnecting — upsert it from the POST
+          // response.
+          upsertMessageInList(
+            virtuosoMessageListRef.current.data,
+            userMessageFromBackend
+          );
+        } else {
+          // map() is how we update the state of virtuoso messages.
+          virtuosoMessageListRef.current.data.map((m) =>
+            areSameRankAndBranch(m, placeholderUserMsg)
+              ? userMessageFromBackend
+              : m
+          );
+        }
+
+        // The conversation SSE (agent_message_new) is the fast path for
+        // swapping the optimistic agent placeholders with the real messages,
+        // but events published while the stream is reconnecting can be lost
+        // (their Redis history has a short TTL), which would leave a
+        // placeholder stuck blank forever: its "placeholder" agentState
+        // renders nothing and blocks the message-level stream. The POST
+        // response carries the created agent messages, so reconcile from it
+        // as the guaranteed path. upsertMessageInList is a no-op for
+        // messages the SSE already swapped and progressed.
+        for (const agentMessageFromBackend of agentMessagesFromBackend) {
+          const agentMessage = makeInitialMessageStreamState(
+            getLightAgentMessageFromAgentMessage(agentMessageFromBackend)
+          );
+          upsertMessageInList(
+            virtuosoMessageListRef.current.data,
+            agentMessage
+          );
+          if (agentMessage.branchId) {
+            setBranchIdToApprove(agentMessage.branchId);
+          }
+        }
+
+        // Placeholders whose predicted rank didn't match any real agent
+        // message (e.g. the loaded page was stale so the predicted rank
+        // drifted) were not swapped above: remove the orphans.
+        const placeholderAgentSids = new Set(
+          placeholderAgentMessages.map((m) => m.sId)
         );
+        while (
+          virtuosoMessageListRef.current.data
+            .get()
+            .some((m) => placeholderAgentSids.has(m.sId))
+        ) {
+          virtuosoMessageListRef.current.data.findAndDelete((m) =>
+            placeholderAgentSids.has(m.sId)
+          );
+        }
 
         // When there are pending user mentions, MentionValidationRequired
         // renders below the user message — scroll to the bottom so the action


### PR DESCRIPTION
## Problem

Sending a message in an existing conversation sometimes leaves the agent reply permanently blank: no "Thinking…", no spinner, nothing. The agent actually completes server-side (status `succeeded` in DB), but the UI never shows it until a full reload.

## Root cause

On submit, `handleSubmit` appends an optimistic agent placeholder (`agentState: "placeholder"`) at a predicted rank. That placeholder is swapped for the real agent message by **exactly one delivery path**: the conversation-level SSE event `agent_message_new`.

That single path is lossy: conversation events have a **5-second** Redis replay TTL, while `useEventSource` reconnects after an error with a **3-8s jittered delay** (longer for backgrounded tabs and during deploys or local rebuilds). Any event published inside that gap is gone before the reconnect can replay it.

Meanwhile the POST `/messages` response already returns the created `agentMessages`, but the client discarded them.

Once the event is lost, nothing repairs the placeholder: `agentState === "placeholder"` renders nothing (`InlineActivitySteps` returns `null`) **and** blocks `shouldStream`, so the message-level event stream is never opened. Bonus damage: the stuck placeholder has `status: "created"`, so the next submit takes the steering path.

Reproduced deterministically by simulating a reconnect gap: the sent message stayed blank forever, the network log showed no `/messages/<sId>/events` request at all, while the DB showed the message as `succeeded`.

Note: this defect dates back to the introduction of optimistic agent placeholders (#16707). The inline activity timeline (#23239) only changed the symptom, from "stuck on Thinking…" to fully blank.

## Fix

`handleSubmit` now reconciles the Virtuoso list from the POST response, making it the guaranteed path while the SSE remains the fast path:

- The upsert logic of the `agent_message_new` handler is extracted into `upsertMessageInList` (generalized to any `VirtuosoMessage`). It keeps the same skip-replace guard, so whichever of SSE / POST response runs second is a no-op, and a message already progressed by the message-level stream is never wiped.
- Agent messages from the response are upserted; placeholders whose predicted rank didn't match any real message (stale page, rank drift) are removed as orphans.
- Branch submissions also reconcile the **user message** from the POST response (the branch path deletes the optimistic placeholders, so the user message previously depended solely on the `user_message_new` SSE event; a missed event could leave an agent reply without its question).

## Tests / verification

- 6 unit tests on `upsertMessageInList`: placeholder swap, replay no-op on a progressed message, same-sId replay at initial state, insert on rank mismatch, retry (new sId, same rank) replace, branch user-message insert + idempotency.
- E2E verified locally under the exact failure conditions (short TTL + delayed SSE subscribe): without the fix the message stays blank forever; with the fix the reply streams and completes. Happy path re-tested normally.