### PR TITLE
Self improving skills in AWU: update the UI to display AWU in metronome billed workspaces

### DIFF
--- a/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection.tsx
@@ -6,7 +6,10 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { ConsumptionProgressBarWithNumbers } from "@app/components/pages/workspace/developers/ConsumptionProgressBar";
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import type { ReinforcementBillingUnit } from "@app/lib/reinforcement/enforcement";
 import {
+  useReinforcementBillingUnit,
   useSelfImprovingDailySpend,
   useSkillsSelfImprovingSpend,
 } from "@app/lib/swr/useSelfImprovingSkillsSettings";
@@ -42,17 +45,26 @@ const DISPLAY_MODE_OPTIONS: { value: DisplayMode; label: string }[] = [
 
 const ANIMATION_DURATION_MS = 1500;
 
+// All amounts are in the display unit: AWU credits for workspaces billed by
+// Metronome, dollars otherwise.
 type ChartDataPoint = {
   date: string;
   timestamp: number;
-  spendMicroUsd?: number;
-  predictionMicroUsd?: number;
-  capMicroUsd?: number;
+  spend?: number;
+  prediction?: number;
+  cap?: number;
 };
+
+function formatAmount(value: number, unit: ReinforcementBillingUnit): string {
+  return unit === "awu_credits"
+    ? `${formatCredits(value)} credits`
+    : `$${value.toFixed(2)}`;
+}
 
 function SpendTooltip(
   props: TooltipContentProps<number, string>,
-  displayMode: DisplayMode
+  displayMode: DisplayMode,
+  unit: ReinforcementBillingUnit
 ): JSX.Element | null {
   const { active, payload } = props;
   if (!active || !payload || payload.length === 0) {
@@ -71,26 +83,26 @@ function SpendTooltip(
 
   const rows: { label: string; value: string; colorClassName: string }[] = [];
 
-  if (data.spendMicroUsd !== undefined) {
+  if (data.spend !== undefined) {
     rows.push({
       label: displayMode === "cumulative" ? "Total spent" : "Daily spend",
-      value: `$${(data.spendMicroUsd / 1_000_000).toFixed(2)}`,
+      value: formatAmount(data.spend, unit),
       colorClassName: COST_PALETTE.costMicroUsd,
     });
   }
 
-  if (data.predictionMicroUsd !== undefined) {
+  if (data.prediction !== undefined) {
     rows.push({
       label: "Projected",
-      value: `$${(data.predictionMicroUsd / 1_000_000).toFixed(2)}`,
+      value: formatAmount(data.prediction, unit),
       colorClassName: COST_PALETTE.costMicroUsd,
     });
   }
 
-  if (data.capMicroUsd !== undefined) {
+  if (data.cap !== undefined) {
     rows.push({
       label: "Monthly cap",
-      value: `$${(data.capMicroUsd / 1_000_000).toFixed(2)}`,
+      value: formatAmount(data.cap, unit),
       colorClassName: COST_PALETTE.totalCredits,
     });
   }
@@ -104,17 +116,21 @@ function SpendTooltip(
 
 interface SelfImprovingSpendChartProps {
   owner: LightWorkspaceType;
-  capMicroUsd: number;
+  // Cap is in the display unit.
+  cap: number;
+  unit: ReinforcementBillingUnit;
 }
 
 function SelfImprovingSpendChart({
   owner,
-  capMicroUsd,
+  cap,
+  unit,
 }: SelfImprovingSpendChartProps) {
   const [displayMode, setDisplayMode] = useState<DisplayMode>("cumulative");
 
   const {
     dailySpendMicroUsd,
+    dailySpendAwuCredits,
     periodStartDate,
     periodEndDate,
     isDailySpendLoading,
@@ -131,21 +147,23 @@ function SelfImprovingSpendChart({
     const today = new Date();
     const effectiveEnd = end < today ? end : today;
 
-    // Build actual data points up to today.
+    // Build actual data points up to today, in the display unit.
     const points: ChartDataPoint[] = [];
     let cumulativeSpend = 0;
     const current = new Date(start);
 
     while (current < effectiveEnd) {
       const dateStr = current.toISOString().slice(0, 10);
-      const daySpend = dailySpendMicroUsd[dateStr] ?? 0;
+      const daySpend =
+        unit === "awu_credits"
+          ? (dailySpendAwuCredits[dateStr] ?? 0)
+          : (dailySpendMicroUsd[dateStr] ?? 0) / 1_000_000;
       cumulativeSpend += daySpend;
 
       points.push({
         date: dateStr,
         timestamp: current.getTime(),
-        spendMicroUsd:
-          displayMode === "cumulative" ? cumulativeSpend : daySpend,
+        spend: displayMode === "cumulative" ? cumulativeSpend : daySpend,
       });
 
       current.setUTCDate(current.getUTCDate() + 1);
@@ -158,7 +176,7 @@ function SelfImprovingSpendChart({
 
       if (displayMode === "cumulative") {
         // Anchor the prediction at the last actual point.
-        points[points.length - 1].predictionMicroUsd = cumulativeSpend;
+        points[points.length - 1].prediction = cumulativeSpend;
       }
 
       let projectedSpend = cumulativeSpend;
@@ -173,10 +191,10 @@ function SelfImprovingSpendChart({
         };
 
         if (displayMode === "cumulative") {
-          point.predictionMicroUsd = projectedSpend;
+          point.prediction = projectedSpend;
         } else {
           // Show future days as zero bars.
-          point.spendMicroUsd = 0;
+          point.spend = 0;
         }
 
         points.push(point);
@@ -185,26 +203,28 @@ function SelfImprovingSpendChart({
     }
 
     // In cumulative mode, add the cap as a flat reference line.
-    if (displayMode === "cumulative" && capMicroUsd > 0) {
+    if (displayMode === "cumulative" && cap > 0) {
       for (const point of points) {
-        point.capMicroUsd = capMicroUsd;
+        point.cap = cap;
       }
     }
 
     return points;
   }, [
     dailySpendMicroUsd,
+    dailySpendAwuCredits,
+    unit,
     periodStartDate,
     periodEndDate,
     displayMode,
-    capMicroUsd,
+    cap,
   ]);
 
   const ChartComponent = displayMode === "daily" ? BarChart : LineChart;
 
   const hasPrediction =
     displayMode === "cumulative" &&
-    chartData.some((p) => p.predictionMicroUsd !== undefined);
+    chartData.some((p) => p.prediction !== undefined);
 
   const legendItems: LegendItem[] = useMemo(() => {
     const items: LegendItem[] = [
@@ -216,7 +236,7 @@ function SelfImprovingSpendChart({
         isActive: true,
       },
     ];
-    if (displayMode === "cumulative" && capMicroUsd > 0) {
+    if (displayMode === "cumulative" && cap > 0) {
       items.push({
         key: "cap",
         label: "Monthly cap",
@@ -225,7 +245,7 @@ function SelfImprovingSpendChart({
       });
     }
     return items;
-  }, [displayMode, capMicroUsd]);
+  }, [displayMode, cap]);
 
   return (
     <ChartContainer
@@ -292,11 +312,15 @@ function SelfImprovingSpendChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
-          tickFormatter={(value) => `$${(value / 1_000_000).toFixed(0)}`}
+          tickFormatter={(value) =>
+            unit === "awu_credits"
+              ? formatCreditsCompact(value)
+              : `$${value.toFixed(0)}`
+          }
         />
         <Tooltip
           content={(props: TooltipContentProps<number, string>) =>
-            SpendTooltip(props, displayMode)
+            SpendTooltip(props, displayMode, unit)
           }
           cursor={false}
           wrapperStyle={{ outline: "none" }}
@@ -309,7 +333,7 @@ function SelfImprovingSpendChart({
         />
         {displayMode === "daily" ? (
           <Bar
-            dataKey="spendMicroUsd"
+            dataKey="spend"
             fill="currentColor"
             className={COST_PALETTE.costMicroUsd}
           />
@@ -317,7 +341,7 @@ function SelfImprovingSpendChart({
           <>
             <Line
               type="monotone"
-              dataKey="spendMicroUsd"
+              dataKey="spend"
               stroke="currentColor"
               strokeWidth={2}
               className={COST_PALETTE.costMicroUsd}
@@ -329,7 +353,7 @@ function SelfImprovingSpendChart({
             {hasPrediction && (
               <Line
                 type="monotone"
-                dataKey="predictionMicroUsd"
+                dataKey="prediction"
                 stroke="currentColor"
                 strokeWidth={2}
                 className={COST_PALETTE.costMicroUsd}
@@ -341,10 +365,10 @@ function SelfImprovingSpendChart({
                 animationDuration={ANIMATION_DURATION_MS / 2}
               />
             )}
-            {capMicroUsd > 0 && (
+            {cap > 0 && (
               <Line
                 type="monotone"
-                dataKey="capMicroUsd"
+                dataKey="cap"
                 stroke="currentColor"
                 strokeWidth={2}
                 className={COST_PALETTE.totalCredits}
@@ -363,20 +387,24 @@ function SelfImprovingSpendChart({
 
 interface SelfImprovingSkillsConsumptionSectionProps {
   owner: LightWorkspaceType;
-  capMicroUsd: number;
+  // In the display unit: AWU credits for workspaces billed by Metronome,
+  // dollars otherwise.
+  cap: number;
 }
 
 export function SelfImprovingSkillsConsumptionSection({
   owner,
-  capMicroUsd,
+  cap,
 }: SelfImprovingSkillsConsumptionSectionProps) {
-  const { spentMicroUsdBySkillId, isSpendLoading } =
+  const unit = useReinforcementBillingUnit({ owner });
+  const { spentMicroUsdBySkillId, spentAwuCreditsBySkillId, isSpendLoading } =
     useSkillsSelfImprovingSpend({ owner });
 
-  const totalSpentDollars =
-    Object.values(spentMicroUsdBySkillId).reduce((sum, v) => sum + v, 0) /
-    1_000_000;
-  const capDollars = capMicroUsd / 1_000_000;
+  const totalSpent =
+    unit === "awu_credits"
+      ? Object.values(spentAwuCreditsBySkillId).reduce((sum, v) => sum + v, 0)
+      : Object.values(spentMicroUsdBySkillId).reduce((sum, v) => sum + v, 0) /
+        1_000_000;
 
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -387,13 +415,18 @@ export function SelfImprovingSkillsConsumptionSection({
         </div>
       ) : (
         <ConsumptionProgressBarWithNumbers
-          consumed={totalSpentDollars}
-          total={capDollars}
-          consumedFormatted={`$${totalSpentDollars.toFixed(2)}`}
-          totalFormatted={`$${capDollars.toFixed(2)}`}
+          consumed={totalSpent}
+          total={cap}
+          // For credits, only suffix the total: "0/10,000 credits".
+          consumedFormatted={
+            unit === "awu_credits"
+              ? formatCredits(totalSpent)
+              : formatAmount(totalSpent, unit)
+          }
+          totalFormatted={formatAmount(cap, unit)}
         />
       )}
-      <SelfImprovingSpendChart owner={owner} capMicroUsd={capMicroUsd} />
+      <SelfImprovingSpendChart owner={owner} cap={cap} unit={unit} />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
@@ -7,9 +7,12 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import {
+  getReinforcementMonthlyCapAwuCredits,
   getReinforcementMonthlyCapMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits,
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
+import { useReinforcementBillingUnit } from "@app/lib/swr/useSelfImprovingSkillsSettings";
 import {
   ContentMessage,
   InfoCircle,
@@ -25,12 +28,20 @@ export function SelfImprovingSkillsPage() {
   const { featureFlags } = useFeatureFlags();
   const hasReinforcement = featureFlags.includes("reinforced_agents");
 
-  const [capMicroUsd, setCapMicroUsd] = useState(() =>
-    getReinforcementMonthlyCapMicroUsd(owner)
+  const unit = useReinforcementBillingUnit({ owner });
+
+  // Caps in the display unit: AWU credits for workspaces billed by Metronome,
+  // dollars otherwise.
+  const [cap, setCap] = useState(() =>
+    unit === "awu_credits"
+      ? getReinforcementMonthlyCapAwuCredits(owner)
+      : getReinforcementMonthlyCapMicroUsd(owner) / 1_000_000
   );
 
-  const [defaultCapPerSkillMicroUsd, setDefaultCapPerSkillMicroUsd] = useState(
-    () => getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner)
+  const [defaultCapPerSkill, setDefaultCapPerSkill] = useState(() =>
+    unit === "awu_credits"
+      ? getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(owner)
+      : getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner) / 1_000_000
   );
 
   const renderBody = () => {
@@ -68,16 +79,13 @@ export function SelfImprovingSkillsPage() {
         </ContentMessage>
         <SelfImprovingSkillsSettingsSection
           owner={owner}
-          onCapSaved={setCapMicroUsd}
-          onDefaultCapPerSkillSaved={setDefaultCapPerSkillMicroUsd}
+          onCapSaved={setCap}
+          onDefaultCapPerSkillSaved={setDefaultCapPerSkill}
         />
-        <SelfImprovingSkillsConsumptionSection
-          owner={owner}
-          capMicroUsd={capMicroUsd}
-        />
+        <SelfImprovingSkillsConsumptionSection owner={owner} cap={cap} />
         <SelfImprovingSkillsListSection
           owner={owner}
-          defaultCapPerSkillMicroUsd={defaultCapPerSkillMicroUsd}
+          defaultCapPerSkill={defaultCapPerSkill}
         />
       </>
     );

--- a/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
+++ b/front/components/workspace/settings/SelfImprovingSkillsListSection.tsx
@@ -1,9 +1,14 @@
+import { formatCredits } from "@app/lib/client/credits";
+import type { ReinforcementBillingUnit } from "@app/lib/reinforcement/enforcement";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   useSkillsWithRelations,
   useUpdateSkillReinforcement,
 } from "@app/lib/swr/skill_configurations";
-import { useSkillsSelfImprovingSpend } from "@app/lib/swr/useSelfImprovingSkillsSettings";
+import {
+  useReinforcementBillingUnit,
+  useSkillsSelfImprovingSpend,
+} from "@app/lib/swr/useSelfImprovingSkillsSettings";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 import type {
   SkillReinforcementMode,
@@ -27,7 +32,9 @@ import { useCallback, useMemo, useState } from "react";
 
 interface SelfImprovingSkillsListSectionProps {
   owner: LightWorkspaceType;
-  defaultCapPerSkillMicroUsd: number;
+  // In the display unit: AWU credits for workspaces billed by Metronome,
+  // dollars otherwise.
+  defaultCapPerSkill: number;
 }
 
 type RowData = {
@@ -42,7 +49,8 @@ type RowData = {
   lock: boolean;
   pendingLock: boolean | null;
   isLockUpdating: boolean;
-  currentSpentDollars: number;
+  currentSpent: number;
+  currentSpentFormatted: string;
   capInputValue: string;
   capPlaceholder: string;
   isCapUpdating: boolean;
@@ -60,134 +68,150 @@ function isReinforcementEnabled(
   return reinforcement !== "off";
 }
 
-const COLUMNS: ColumnDef<RowData, unknown>[] = [
-  {
-    header: "Name",
-    accessorKey: "name",
-    cell: (info: CellContext<RowData, unknown>) => {
-      const SkillAvatar = getSkillAvatarIcon(info.row.original);
-      return (
-        <DataTable.CellContent>
-          <div className="flex flex-row items-center gap-2 py-3">
-            <SkillAvatar />
-            <div className="heading-sm overflow-hidden truncate text-foreground dark:text-foreground-night">
-              {info.row.original.name}
+function getColumns(
+  unit: ReinforcementBillingUnit
+): ColumnDef<RowData, unknown>[] {
+  // "(credits)" goes on its own line: the single-line header is too wide and
+  // overlaps the neighboring columns.
+  const headerWithUnit = (label: string) =>
+    unit === "awu_credits"
+      ? () => (
+          <>
+            {label}
+            <br />
+            (credits)
+          </>
+        )
+      : `${label} ($)`;
+  return [
+    {
+      header: "Name",
+      accessorKey: "name",
+      cell: (info: CellContext<RowData, unknown>) => {
+        const SkillAvatar = getSkillAvatarIcon(info.row.original);
+        return (
+          <DataTable.CellContent>
+            <div className="flex flex-row items-center gap-2 py-3">
+              <SkillAvatar />
+              <div className="heading-sm overflow-hidden truncate text-foreground dark:text-foreground-night">
+                {info.row.original.name}
+              </div>
             </div>
-          </div>
-        </DataTable.CellContent>
-      );
+          </DataTable.CellContent>
+        );
+      },
+      meta: { className: "w-40 @lg:w-full" },
     },
-    meta: { className: "w-40 @lg:w-full" },
-  },
-  {
-    header: "Editors",
-    accessorKey: "editors",
-    cell: (info: CellContext<RowData, unknown>) => {
-      const editors = info.row.original.editors;
-      const items = editors
-        ? editors.map((editor) => ({
-            name: editor.fullName,
-            visual: editor.image,
-            isRounded: true,
-          }))
-        : [{ name: "Dust", visual: DUST_AVATAR_URL, isRounded: false }];
-      return (
-        <DataTable.CellContent avatarStack={{ items, nbVisibleItems: 4 }} />
-      );
+    {
+      header: "Editors",
+      accessorKey: "editors",
+      cell: (info: CellContext<RowData, unknown>) => {
+        const editors = info.row.original.editors;
+        const items = editors
+          ? editors.map((editor) => ({
+              name: editor.fullName,
+              visual: editor.image,
+              isRounded: true,
+            }))
+          : [{ name: "Dust", visual: DUST_AVATAR_URL, isRounded: false }];
+        return (
+          <DataTable.CellContent avatarStack={{ items, nbVisibleItems: 4 }} />
+        );
+      },
+      meta: { className: "w-32" },
     },
-    meta: { className: "w-32" },
-  },
-  {
-    header: "Enabled",
-    accessorKey: "enabled",
-    cell: (info: CellContext<RowData, unknown>) => {
-      const {
-        enabled,
-        pendingEnabled,
-        isEnabledUpdating,
-        lock,
-        pendingLock,
-        onToggleEnabled,
-      } = info.row.original;
-      const selected = pendingEnabled ?? enabled;
-      const isLocked = pendingLock ?? lock;
-      return (
-        <DataTable.CellContent>
-          <SliderToggle
-            size="xs"
-            selected={selected}
-            disabled={isEnabledUpdating || isLocked}
-            onClick={onToggleEnabled}
-          />
-        </DataTable.CellContent>
-      );
+    {
+      header: "Enabled",
+      accessorKey: "enabled",
+      cell: (info: CellContext<RowData, unknown>) => {
+        const {
+          enabled,
+          pendingEnabled,
+          isEnabledUpdating,
+          lock,
+          pendingLock,
+          onToggleEnabled,
+        } = info.row.original;
+        const selected = pendingEnabled ?? enabled;
+        const isLocked = pendingLock ?? lock;
+        return (
+          <DataTable.CellContent>
+            <SliderToggle
+              size="xs"
+              selected={selected}
+              disabled={isEnabledUpdating || isLocked}
+              onClick={onToggleEnabled}
+            />
+          </DataTable.CellContent>
+        );
+      },
+      meta: { className: "w-24" },
     },
-    meta: { className: "w-24" },
-  },
-  {
-    header: "Currently Spent ($)",
-    accessorKey: "currentSpentDollars",
-    cell: (info: CellContext<RowData, unknown>) => (
-      <DataTable.BasicCellContent
-        label={formatDollars(info.row.original.currentSpentDollars)}
-      />
-    ),
-    meta: { className: "w-32" },
-  },
-  {
-    header: "Cap ($)",
-    accessorKey: "capInputValue",
-    cell: (info: CellContext<RowData, unknown>) => {
-      const {
-        sId,
-        capInputValue,
-        capPlaceholder,
-        isCapUpdating,
-        onCapChange,
-        onCapCommit,
-      } = info.row.original;
-      return (
-        <DataTable.CellContent>
-          <Input
-            name={`cap-${sId}`}
-            value={capInputValue}
-            placeholder={capPlaceholder}
-            disabled={isCapUpdating}
-            onChange={(e) => onCapChange(e.target.value)}
-            onBlur={onCapCommit}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                onCapCommit();
-              }
-            }}
-          />
-        </DataTable.CellContent>
-      );
+    {
+      header: headerWithUnit("Currently Spent"),
+      accessorKey: "currentSpent",
+      cell: (info: CellContext<RowData, unknown>) => (
+        <DataTable.BasicCellContent
+          label={info.row.original.currentSpentFormatted}
+        />
+      ),
+      meta: { className: "w-32" },
     },
-    meta: { className: "w-32" },
-  },
-  {
-    header: "Lock State",
-    accessorKey: "lock",
-    cell: (info: CellContext<RowData, unknown>) => {
-      const { lock, pendingLock, isLockUpdating, onToggleLock } =
-        info.row.original;
-      const selected = pendingLock ?? lock;
-      return (
-        <DataTable.CellContent>
-          <SliderToggle
-            size="xs"
-            selected={selected}
-            disabled={isLockUpdating}
-            onClick={onToggleLock}
-          />
-        </DataTable.CellContent>
-      );
+    {
+      header: headerWithUnit("Cap"),
+      accessorKey: "capInputValue",
+      cell: (info: CellContext<RowData, unknown>) => {
+        const {
+          sId,
+          capInputValue,
+          capPlaceholder,
+          isCapUpdating,
+          onCapChange,
+          onCapCommit,
+        } = info.row.original;
+        return (
+          <DataTable.CellContent>
+            <Input
+              name={`cap-${sId}`}
+              value={capInputValue}
+              placeholder={capPlaceholder}
+              disabled={isCapUpdating}
+              onChange={(e) => onCapChange(e.target.value)}
+              onBlur={onCapCommit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  onCapCommit();
+                }
+              }}
+            />
+          </DataTable.CellContent>
+        );
+      },
+      meta: { className: "w-32" },
     },
-    meta: { className: "w-24" },
-  },
-];
+    {
+      header: "Lock State",
+      accessorKey: "lock",
+      cell: (info: CellContext<RowData, unknown>) => {
+        const { lock, pendingLock, isLockUpdating, onToggleLock } =
+          info.row.original;
+        const selected = pendingLock ?? lock;
+        return (
+          <DataTable.CellContent>
+            <SliderToggle
+              size="xs"
+              selected={selected}
+              disabled={isLockUpdating}
+              onClick={onToggleLock}
+            />
+          </DataTable.CellContent>
+        );
+      },
+      meta: { className: "w-24" },
+    },
+  ];
+}
 
 function formatDollars(value: number): string {
   if (value === 0) {
@@ -195,6 +219,19 @@ function formatDollars(value: number): string {
   }
   // Show up to 2 decimals, trimming trailing zeros.
   return value.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function formatSpend(value: number, unit: ReinforcementBillingUnit): string {
+  return unit === "awu_credits" ? formatCredits(value) : formatDollars(value);
+}
+
+// Plain (unformatted) value for cap inputs: thousands separators would not
+// round-trip through Number().
+function capInputValueFromSaved(
+  value: number,
+  unit: ReinforcementBillingUnit
+): string {
+  return unit === "awu_credits" ? String(value) : formatDollars(value);
 }
 
 function microUsdToDollars(microUsd: number): number {
@@ -216,15 +253,31 @@ function withoutSkill<T>(
 
 export function SelfImprovingSkillsListSection({
   owner,
-  defaultCapPerSkillMicroUsd,
+  defaultCapPerSkill,
 }: SelfImprovingSkillsListSectionProps) {
+  const unit = useReinforcementBillingUnit({ owner });
   const { skillsWithRelations, isSkillsWithRelationsLoading } =
     useSkillsWithRelations({ owner, status: "active", onlyCustom: true });
-  const { spentMicroUsdBySkillId } = useSkillsSelfImprovingSpend({ owner });
+  const { spentMicroUsdBySkillId, spentAwuCreditsBySkillId } =
+    useSkillsSelfImprovingSpend({ owner });
   const { updateSkillReinforcement } = useUpdateSkillReinforcement({
     owner,
     onlyCustom: true,
   });
+
+  // Spend per skill in the display unit.
+  const spentBySkillId = useMemo(
+    () =>
+      unit === "awu_credits"
+        ? spentAwuCreditsBySkillId
+        : Object.fromEntries(
+            Object.entries(spentMicroUsdBySkillId).map(([skillId, spent]) => [
+              skillId,
+              microUsdToDollars(spent),
+            ])
+          ),
+    [unit, spentMicroUsdBySkillId, spentAwuCreditsBySkillId]
+  );
 
   // Per-skill optimistic state during in-flight updates.
   const [pendingEnabledBySkillId, setPendingEnabledBySkillId] = useState<
@@ -289,26 +342,37 @@ export function SelfImprovingSkillsListSection({
     [updateSkillReinforcement]
   );
 
+  // `savedCap` is the skill's saved cap in the display unit (null when using
+  // the workspace default).
   const handleCapCommit = useCallback(
-    async (skillId: string, savedCapMicroUsd: number | null) => {
+    async (skillId: string, savedCap: number | null) => {
       const inputValue = capInputBySkillId[skillId];
       if (inputValue === undefined) {
         return;
       }
 
+      const capUpdate = (value: number | null) =>
+        unit === "awu_credits"
+          ? {
+              selfImprovementCostsCapAwuCredits:
+                value === null ? null : Math.round(value),
+            }
+          : {
+              selfImprovementCostsCapMicroUsd:
+                value === null ? null : dollarsToMicroUsd(value),
+            };
+
       const trimmed = inputValue.trim();
 
       // Empty input resets to default (null).
       if (trimmed === "") {
-        if (savedCapMicroUsd === null) {
+        if (savedCap === null) {
           // Already using default — just drop the local override.
           setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
           return;
         }
         setCapUpdatingBySkillId((prev) => ({ ...prev, [skillId]: true }));
-        const ok = await updateSkillReinforcement(skillId, {
-          selfImprovementCostsCapMicroUsd: null,
-        });
+        const ok = await updateSkillReinforcement(skillId, capUpdate(null));
         setCapUpdatingBySkillId((prev) => withoutSkill(prev, skillId));
         if (ok) {
           setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
@@ -318,9 +382,7 @@ export function SelfImprovingSkillsListSection({
 
       const parsed = Number(trimmed);
       const isInvalid = !Number.isFinite(parsed) || parsed < 0;
-      const isUnchanged =
-        savedCapMicroUsd !== null &&
-        parsed === microUsdToDollars(savedCapMicroUsd);
+      const isUnchanged = savedCap !== null && parsed === savedCap;
       if (isInvalid || isUnchanged) {
         // Drop the local input override so the field falls back to the server value.
         setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
@@ -328,9 +390,7 @@ export function SelfImprovingSkillsListSection({
       }
 
       setCapUpdatingBySkillId((prev) => ({ ...prev, [skillId]: true }));
-      const ok = await updateSkillReinforcement(skillId, {
-        selfImprovementCostsCapMicroUsd: dollarsToMicroUsd(parsed),
-      });
+      const ok = await updateSkillReinforcement(skillId, capUpdate(parsed));
       setCapUpdatingBySkillId((prev) => withoutSkill(prev, skillId));
 
       if (ok) {
@@ -338,7 +398,7 @@ export function SelfImprovingSkillsListSection({
         setCapInputBySkillId((prev) => withoutSkill(prev, skillId));
       }
     },
-    [capInputBySkillId, updateSkillReinforcement]
+    [capInputBySkillId, updateSkillReinforcement, unit]
   );
 
   const [filter, setFilter] = useState("");
@@ -350,18 +410,20 @@ export function SelfImprovingSkillsListSection({
   const sortedSkills = useMemo(
     () =>
       [...skillsWithRelations].sort((a, b) => {
-        const spentA = spentMicroUsdBySkillId[a.sId] ?? 0;
-        const spentB = spentMicroUsdBySkillId[b.sId] ?? 0;
+        const spentA = spentBySkillId[a.sId] ?? 0;
+        const spentB = spentBySkillId[b.sId] ?? 0;
         // Sort by currently spent descending, then by name ascending as tiebreaker.
         if (spentB !== spentA) {
           return spentB - spentA;
         }
         return a.name.localeCompare(b.name);
       }),
-    [skillsWithRelations, spentMicroUsdBySkillId]
+    [skillsWithRelations, spentBySkillId]
   );
 
-  const defaultCapPlaceholder = `${formatDollars(microUsdToDollars(defaultCapPerSkillMicroUsd))} (default)`;
+  const columns = useMemo(() => getColumns(unit), [unit]);
+
+  const defaultCapPlaceholder = `${capInputValueFromSaved(defaultCapPerSkill, unit)} (default)`;
 
   const rows: RowData[] = useMemo(
     () =>
@@ -369,12 +431,17 @@ export function SelfImprovingSkillsListSection({
         (skill: SkillWithoutInstructionsAndToolsWithRelationsType) => {
           const enabled = isReinforcementEnabled(skill.reinforcement);
           const lock = skill.selfImprovementLock;
-          const savedCapMicroUsd = skill.selfImprovementCostsCapMicroUsd;
+          // Saved cap in the display unit.
+          const savedCap =
+            unit === "awu_credits"
+              ? skill.selfImprovementCostsCapAwuCredits
+              : skill.selfImprovementCostsCapMicroUsd !== null
+                ? microUsdToDollars(skill.selfImprovementCostsCapMicroUsd)
+                : null;
           const capInput =
             capInputBySkillId[skill.sId] ??
-            (savedCapMicroUsd !== null
-              ? formatDollars(microUsdToDollars(savedCapMicroUsd))
-              : "");
+            (savedCap !== null ? capInputValueFromSaved(savedCap, unit) : "");
+          const currentSpent = spentBySkillId[skill.sId] ?? 0;
 
           return {
             sId: skill.sId,
@@ -388,9 +455,8 @@ export function SelfImprovingSkillsListSection({
             lock,
             pendingLock: pendingLockBySkillId[skill.sId] ?? null,
             isLockUpdating: lockUpdatingBySkillId[skill.sId] ?? false,
-            currentSpentDollars: microUsdToDollars(
-              spentMicroUsdBySkillId[skill.sId] ?? 0
-            ),
+            currentSpent,
+            currentSpentFormatted: formatSpend(currentSpent, unit),
             capInputValue: capInput,
             capPlaceholder: defaultCapPlaceholder,
             isCapUpdating: capUpdatingBySkillId[skill.sId] ?? false,
@@ -404,7 +470,7 @@ export function SelfImprovingSkillsListSection({
               setCapInputBySkillId((prev) => ({ ...prev, [skill.sId]: value }));
             },
             onCapCommit: () => {
-              void handleCapCommit(skill.sId, savedCapMicroUsd);
+              void handleCapCommit(skill.sId, savedCap);
             },
           };
         }
@@ -418,7 +484,8 @@ export function SelfImprovingSkillsListSection({
       lockUpdatingBySkillId,
       capInputBySkillId,
       capUpdatingBySkillId,
-      spentMicroUsdBySkillId,
+      spentBySkillId,
+      unit,
       handleToggleEnabled,
       handleToggleLock,
       handleCapCommit,
@@ -445,7 +512,7 @@ export function SelfImprovingSkillsListSection({
       ) : (
         <DataTable
           data={rows}
-          columns={COLUMNS}
+          columns={columns}
           filter={filter}
           filterColumn="name"
           pagination={pagination}

--- a/front/components/workspace/settings/SelfImprovingSkillsSettingsSection.tsx
+++ b/front/components/workspace/settings/SelfImprovingSkillsSettingsSection.tsx
@@ -1,7 +1,10 @@
 import {
+  DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS,
   DEFAULT_REINFORCEMENT_CAP_MICRO_USD,
+  DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS,
   DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD,
 } from "@app/lib/reinforcement/constants";
+import type { ReinforcementBillingUnit } from "@app/lib/reinforcement/enforcement";
 import {
   useSelfImprovementCapPerSkillSetting,
   useSelfImprovingBatchModeToggle,
@@ -18,10 +21,55 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+interface CapInputProps {
+  name: string;
+  placeholder: string;
+  value: string;
+  isInvalid: boolean;
+  disabled: boolean;
+  unit: ReinforcementBillingUnit;
+  onChange: (value: string) => void;
+}
+
+// Cap input with the unit displayed inside the field, mirroring the spend
+// limit input of the usage page (EditSpendLimitModal).
+function CapInput({
+  name,
+  placeholder,
+  value,
+  isInvalid,
+  disabled,
+  unit,
+  onChange,
+}: CapInputProps) {
+  const isCredits = unit === "awu_credits";
+  return (
+    <div className={isCredits ? "w-40" : "w-32"}>
+      <div className="relative">
+        <Input
+          name={name}
+          placeholder={placeholder}
+          value={value}
+          message={isInvalid ? "Enter a non-negative number." : undefined}
+          messageStatus={isInvalid ? "error" : undefined}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled}
+          className={isCredits ? "pr-16 text-right" : "pr-7 text-right"}
+        />
+        <span className="copy-sm pointer-events-none absolute right-3 top-0 flex h-9 items-center text-muted-foreground dark:text-muted-foreground-night">
+          {isCredits ? "credits" : "$"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 interface SelfImprovingSkillsSettingsSectionProps {
   owner: WorkspaceType;
-  onCapSaved?: (capMicroUsd: number) => void;
-  onDefaultCapPerSkillSaved?: (microUsd: number) => void;
+  // Saved cap values are in the display unit: AWU credits for workspaces
+  // billed by Metronome, dollars otherwise.
+  onCapSaved?: (cap: number) => void;
+  onDefaultCapPerSkillSaved?: (cap: number) => void;
 }
 
 export function SelfImprovingSkillsSettingsSection({
@@ -88,35 +136,36 @@ function SelfImprovingBatchModeToggle({
 
 interface SelfImprovementCapPerSkillItemProps {
   owner: WorkspaceType;
-  onSaved?: (microUsd: number) => void;
+  onSaved?: (cap: number) => void;
 }
 
 function SelfImprovementCapPerSkillItem({
   owner,
   onSaved,
 }: SelfImprovementCapPerSkillItemProps) {
-  const { capDollars, isSaving, saveCapDollars } =
-    useSelfImprovementCapPerSkillSetting({ owner });
-  const [inputValue, setInputValue] = useState<string>(() =>
-    String(capDollars)
+  const { unit, cap, isSaving, saveCap } = useSelfImprovementCapPerSkillSetting(
+    { owner }
   );
+  const [inputValue, setInputValue] = useState<string>(() => String(cap));
 
-  const parsedInputDollars = Number(inputValue);
-  const isInputDollarsValid =
+  const parsedInput = Number(inputValue);
+  const isInputValid =
     inputValue.trim() !== "" &&
-    Number.isFinite(parsedInputDollars) &&
-    parsedInputDollars >= 0;
+    Number.isFinite(parsedInput) &&
+    parsedInput >= 0;
 
-  const defaultDollars =
-    DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD / 1_000_000;
+  const defaultCap =
+    unit === "awu_credits"
+      ? DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_AWU_CREDITS
+      : DEFAULT_SELF_IMPROVEMENT_CAP_PER_SKILL_MICRO_USD / 1_000_000;
 
   const handleSave = async () => {
-    if (!isInputDollarsValid) {
+    if (!isInputValid) {
       return;
     }
-    const ok = await saveCapDollars(parsedInputDollars);
+    const ok = await saveCap(parsedInput);
     if (ok) {
-      onSaved?.(Math.round(parsedInputDollars * 1_000_000));
+      onSaved?.(parsedInput);
     }
   };
 
@@ -133,33 +182,27 @@ function SelfImprovementCapPerSkillItem({
             void handleSave();
           }}
         >
-          <div className="w-32">
-            <Input
-              name="selfImprovementCapPerSkill"
-              placeholder={String(defaultDollars)}
-              value={inputValue}
-              message={
-                !isInputDollarsValid && inputValue !== ""
-                  ? "Enter a non-negative number."
-                  : undefined
-              }
-              messageStatus={
-                !isInputDollarsValid && inputValue !== "" ? "error" : undefined
-              }
-              onChange={(event) => setInputValue(event.target.value)}
-              disabled={isSaving}
-            />
-          </div>
+          <CapInput
+            name="selfImprovementCapPerSkill"
+            placeholder={String(defaultCap)}
+            value={inputValue}
+            isInvalid={!isInputValid && inputValue !== ""}
+            disabled={isSaving}
+            unit={unit}
+            onChange={setInputValue}
+          />
           <Button
             type="submit"
             label="Save"
-            disabled={!isInputDollarsValid}
+            disabled={!isInputValid}
             isLoading={isSaving}
           />
         </form>
       }
     >
-      <ContextItem.Description description="Maximum cost per skill per self-improvement run (in USD). Once reached, no further self-improvement runs are started for that skill." />
+      <ContextItem.Description
+        description={`Maximum cost per skill per self-improvement run (in ${unit === "awu_credits" ? "AWU credits" : "USD"}). Once reached, no further self-improvement runs are started for that skill.`}
+      />
     </ContextItem>
   );
 }
@@ -168,12 +211,10 @@ function SelfImprovingCapItem({
   owner,
   onCapSaved,
 }: SelfImprovingSkillsSettingsSectionProps) {
-  const { capDollars, isSaving, saveCapDollars } = useSelfImprovingCapSetting({
+  const { unit, cap, isSaving, saveCap } = useSelfImprovingCapSetting({
     owner,
   });
-  const [inputValue, setInputValue] = useState<string>(() =>
-    String(capDollars)
-  );
+  const [inputValue, setInputValue] = useState<string>(() => String(cap));
 
   const parsedInput = Number(inputValue);
   const isInputValid =
@@ -181,15 +222,18 @@ function SelfImprovingCapItem({
     Number.isFinite(parsedInput) &&
     parsedInput >= 0;
 
-  const defaultDollars = DEFAULT_REINFORCEMENT_CAP_MICRO_USD / 1_000_000;
+  const defaultCap =
+    unit === "awu_credits"
+      ? DEFAULT_REINFORCEMENT_CAP_AWU_CREDITS
+      : DEFAULT_REINFORCEMENT_CAP_MICRO_USD / 1_000_000;
 
   const handleSave = async () => {
     if (!isInputValid) {
       return;
     }
-    const ok = await saveCapDollars(parsedInput);
+    const ok = await saveCap(parsedInput);
     if (ok) {
-      onCapSaved?.(Math.round(parsedInput * 1_000_000));
+      onCapSaved?.(parsedInput);
     }
   };
 
@@ -206,23 +250,15 @@ function SelfImprovingCapItem({
             void handleSave();
           }}
         >
-          <div className="w-32">
-            <Input
-              name="reinforcementCap"
-              placeholder={String(defaultDollars)}
-              value={inputValue}
-              message={
-                !isInputValid && inputValue !== ""
-                  ? "Enter a non-negative number."
-                  : undefined
-              }
-              messageStatus={
-                !isInputValid && inputValue !== "" ? "error" : undefined
-              }
-              onChange={(event) => setInputValue(event.target.value)}
-              disabled={isSaving}
-            />
-          </div>
+          <CapInput
+            name="reinforcementCap"
+            placeholder={String(defaultCap)}
+            value={inputValue}
+            isInvalid={!isInputValid && inputValue !== ""}
+            disabled={isSaving}
+            unit={unit}
+            onChange={setInputValue}
+          />
           <Button
             type="submit"
             label="Save"
@@ -232,7 +268,9 @@ function SelfImprovingCapItem({
         </form>
       }
     >
-      <ContextItem.Description description="Self-improving skills is priced as programmatic usage. This is the maximum cost per month (in USD) for the feature across all skills. Once reached, no new self-improving runs are started until the next billing month." />
+      <ContextItem.Description
+        description={`Self-improving skills is priced as programmatic usage. This is the maximum cost per month (in ${unit === "awu_credits" ? "AWU credits" : "USD"}) for the feature across all skills. Once reached, no new self-improving runs are started until the next billing month.`}
+      />
     </ContextItem>
   );
 }

--- a/front/lib/swr/useSelfImprovingSkillsSettings.ts
+++ b/front/lib/swr/useSelfImprovingSkillsSettings.ts
@@ -3,16 +3,38 @@ import type {
   GetReinforcementDailySpendResponseBody,
   GetSkillsSpendResponseBody,
 } from "@app/lib/api/skills";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import {
+  getReinforcementMonthlyCapAwuCredits,
   getReinforcementMonthlyCapMicroUsd,
+  getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits,
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
+import type { ReinforcementBillingUnit } from "@app/lib/reinforcement/enforcement";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { isCreditPricedPlan } from "@app/types/plan";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useState } from "react";
 import type { Fetcher } from "swr";
+
+/**
+ * Client-side mirror of getReinforcementBillingUnit
+ * (lib/reinforcement/enforcement.ts): self-improving skills spend and caps
+ * are displayed and edited in AWU credits for workspaces billed by Metronome
+ * on a credit-priced plan, and in dollars otherwise.
+ */
+export function useReinforcementBillingUnit({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}): ReinforcementBillingUnit {
+  const { subscription } = useAuth();
+  return owner.metronomeCustomerId && isCreditPricedPlan(subscription.plan)
+    ? "awu_credits"
+    : "micro_usd";
+}
 
 interface UseSelfImprovingToggleProps {
   owner: LightWorkspaceType;
@@ -119,12 +141,17 @@ interface UseSelfImprovingCapSettingProps {
 export function useSelfImprovingCapSetting({
   owner,
 }: UseSelfImprovingCapSettingProps) {
+  const unit = useReinforcementBillingUnit({ owner });
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
-  const capDollars = getReinforcementMonthlyCapMicroUsd(owner) / 1_000_000;
+  // Cap in the display unit: AWU credits, or dollars for micro-USD.
+  const cap =
+    unit === "awu_credits"
+      ? getReinforcementMonthlyCapAwuCredits(owner)
+      : getReinforcementMonthlyCapMicroUsd(owner) / 1_000_000;
 
-  const saveCapDollars = async (dollars: number): Promise<boolean> => {
+  const saveCap = async (value: number): Promise<boolean> => {
     setIsSaving(true);
     try {
       const res = await clientFetch(`/api/w/${owner.sId}`, {
@@ -132,9 +159,11 @@ export function useSelfImprovingCapSetting({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          reinforcementCapMicroUsd: Math.round(dollars * 1_000_000),
-        }),
+        body: JSON.stringify(
+          unit === "awu_credits"
+            ? { reinforcementCapAwuCredits: Math.round(value) }
+            : { reinforcementCapMicroUsd: Math.round(value * 1_000_000) }
+        ),
       });
 
       if (!res.ok) {
@@ -154,9 +183,10 @@ export function useSelfImprovingCapSetting({
   };
 
   return {
-    capDollars,
+    unit,
+    cap,
     isSaving,
-    saveCapDollars,
+    saveCap,
   };
 }
 
@@ -178,6 +208,7 @@ export function useSkillsSelfImprovingSpend({
 
   return {
     spentMicroUsdBySkillId: data?.spentMicroUsdBySkillId ?? {},
+    spentAwuCreditsBySkillId: data?.spentAwuCreditsBySkillId ?? {},
     isSpendLoading: isLoading,
     isSpendError: !!error,
     mutateSpend: mutate,
@@ -202,6 +233,7 @@ export function useSelfImprovingDailySpend({
 
   return {
     dailySpendMicroUsd: data?.dailySpendMicroUsd ?? {},
+    dailySpendAwuCredits: data?.dailySpendAwuCredits ?? {},
     periodStartDate: data?.periodStartDate ?? null,
     periodEndDate: data?.periodEndDate ?? null,
     isDailySpendLoading: isLoading,
@@ -216,13 +248,18 @@ interface UseSelfImprovementCapPerSkillSettingProps {
 export function useSelfImprovementCapPerSkillSetting({
   owner,
 }: UseSelfImprovementCapPerSkillSettingProps) {
+  const unit = useReinforcementBillingUnit({ owner });
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);
 
-  const capDollars =
-    getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner) / 1_000_000;
+  // Cap in the display unit: AWU credits, or dollars for micro-USD.
+  const cap =
+    unit === "awu_credits"
+      ? getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits(owner)
+      : getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd(owner) /
+        1_000_000;
 
-  const saveCapDollars = async (dollars: number): Promise<boolean> => {
+  const saveCap = async (value: number): Promise<boolean> => {
     setIsSaving(true);
     try {
       const res = await clientFetch(`/api/w/${owner.sId}`, {
@@ -230,9 +267,15 @@ export function useSelfImprovementCapPerSkillSetting({
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          selfImprovementCapPerSkillMicroUsd: Math.round(dollars * 1_000_000),
-        }),
+        body: JSON.stringify(
+          unit === "awu_credits"
+            ? { selfImprovementCapPerSkillAwuCredits: Math.round(value) }
+            : {
+                selfImprovementCapPerSkillMicroUsd: Math.round(
+                  value * 1_000_000
+                ),
+              }
+        ),
       });
 
       if (!res.ok) {
@@ -252,8 +295,9 @@ export function useSelfImprovementCapPerSkillSetting({
   };
 
   return {
-    capDollars,
+    unit,
+    cap,
     isSaving,
-    saveCapDollars,
+    saveCap,
   };
 }


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/8784

Update the admin apge for self improving skills to display the AWU limits and AWU consumption.

Step by step plan:
  1. [Store the AWU in the self_improving_skills_usage table (always with margins) ](https://github.com/dust-tt/dust/pull/27190) ✅ done 
  2. [Update resources and API to retrieve the value ](https://github.com/dust-tt/dust/pull/27218) ✅ done 
  3. [Store limit in AWU in db and update API to set/get them](https://github.com/dust-tt/dust/pull/27227) ✅ done 
  4. [Use AWU to enforce the limit for credit based workspaces](https://github.com/dust-tt/dust/pull/27229) ✅ done 
  5. Update UI admin apge to display AWU credits when using metronome. <-- ℹ️ You are here

## Tests

tested the UI locally 

<img width="1363" height="818" alt="Screenshot 2026-06-11 at 14 35 48" src="https://github.com/user-attachments/assets/46fab189-577d-4f27-9edb-7f968127ae57" />

<img width="1307" height="826" alt="Screenshot 2026-06-11 at 14 36 03" src="https://github.com/user-attachments/assets/06c69125-7d00-4a13-ac68-817921462871" />


## Risk

low, it's purely UI and easy to revert

## Deploy Plan

deploy front
