### PR TITLE
feat(credits): email admins on member upgrade request

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -6,6 +6,7 @@ import { podAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/pod-a
 import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { upgradeRequestCreatedWorkflow } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { createHono } from "@front-api/lib/hono";
 import type { ServeHandlerOptions } from "@novu/framework";
@@ -33,6 +34,7 @@ const options: ServeHandlerOptions = {
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,
     programmaticCapReachedWorkflow,
+    upgradeRequestCreatedWorkflow,
   ],
 };
 

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -3,10 +3,13 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { notifyAdminsUpgradeRequested } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
+import logger from "@app/logger/logger";
 import type {
   MembershipUpgradeRequestStatus,
   MembershipUpgradeRequestType,
@@ -36,6 +39,52 @@ async function isMemberUpgradeRequestAllowed(
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
   return config?.allowMemberUpgradeRequests ?? true;
+}
+
+async function isUpgradeRequestEmailEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  return config?.upgradeRequestEmailEnabled ?? true;
+}
+
+async function notifyAdminsOfUpgradeRequest(
+  auth: Authenticator,
+  { request }: { request: MembershipUpgradeRequestResource }
+): Promise<void> {
+  //swallow errors
+  try {
+    if (!(await isUpgradeRequestEmailEnabled(auth))) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+
+    const requester = request.requester;
+    notifyAdminsUpgradeRequested({
+      admins: admins.map((admin) => ({
+        sId: admin.sId,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+      })),
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      requestId: request.sId,
+      requesterName: requester.fullName() ?? requester.name,
+      requesterEmail: requester.email ?? null,
+    });
+  } catch (err) {
+    logger.error(
+      { err, requestId: request.sId },
+      "Failed to notify admins of upgrade request"
+    );
+  }
 }
 
 export type GetUpgradeRequestsResponseBody = {
@@ -121,8 +170,7 @@ export async function createUpgradeRequest(
     metadata: { request_sid: request.sId },
   });
 
-  // TODO(upgrade-requests PR5): notify workspace admins by email (gated on the
-  // `upgradeRequestEmail` notification toggle).
+  void notifyAdminsOfUpgradeRequest(auth, { request });
 
   return new Ok(request.toJSON());
 }

--- a/front/lib/notifications/workflows/upgrade-request-created.ts
+++ b/front/lib/notifications/workflows/upgrade-request-created.ts
@@ -1,0 +1,176 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  UPGRADE_REQUEST_CREATED_TAG,
+  UPGRADE_REQUEST_CREATED_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { isDevelopment } from "@app/types/shared/env";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const UpgradeRequestCreatedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  requesterName: z.string(),
+  requesterEmail: z.string().nullable(),
+});
+
+type UpgradeRequestCreatedPayloadType = z.infer<
+  typeof UpgradeRequestCreatedPayloadSchema
+>;
+
+const isUpgradeRequestCreatedPayload = (
+  payload: unknown
+): payload is UpgradeRequestCreatedPayloadType =>
+  UpgradeRequestCreatedPayloadSchema.safeParse(payload).success;
+
+function formatRequester(payload: UpgradeRequestCreatedPayloadType): string {
+  return payload.requesterEmail
+    ? `${payload.requesterName} (${payload.requesterEmail})`
+    : payload.requesterName;
+}
+
+export const upgradeRequestCreatedWorkflow = workflow(
+  UPGRADE_REQUEST_CREATED_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    const { events } = await step.digest("digest", async () => {
+      const digestKey = `${subscriber.subscriberId}-workspace-${payload.workspaceId}-upgrade-requests`;
+      return isDevelopment()
+        ? { amount: 2, unit: "minutes", digestKey }
+        : { amount: 15, unit: "minutes", digestKey };
+    });
+
+    await step.email(
+      "upgrade-request-created-email",
+      async () => {
+        // Dedupe by requester (a member could re-request across the window) and
+        // keep insertion order so the email lists distinct people once.
+        const requesterByKey = new Map<string, string>();
+        for (const event of events) {
+          if (!isUpgradeRequestCreatedPayload(event.payload)) {
+            continue;
+          }
+          const key =
+            event.payload.requesterEmail ?? event.payload.requesterName;
+          if (!requesterByKey.has(key)) {
+            requesterByKey.set(key, formatRequester(event.payload));
+          }
+        }
+        const requesters = Array.from(requesterByKey.values());
+        const count = requesters.length;
+
+        const subject =
+          count > 1
+            ? `[Dust] ${count} members requested a spend-limit upgrade`
+            : `[Dust] ${requesters[0]} requested a spend-limit upgrade`;
+
+        const intro =
+          count > 1
+            ? `${count} members have reached their per-user spend limit and are requesting an upgrade:`
+            : `${requesters[0]} has reached their per-user spend limit and is requesting an upgrade.`;
+        const list =
+          count > 1 ? requesters.map((r) => `• ${r}`).join("\n") : "";
+        const outro =
+          count > 1
+            ? `Review the requests and adjust their limits from your workspace usage page.`
+            : `Review the request and adjust their limit from your workspace usage page.`;
+        const content = [intro, list, outro].filter(Boolean).join("\n");
+
+        const body = await renderEmail({
+          name: subscriber.firstName ?? "there",
+          workspace: {
+            id: payload.workspaceId,
+            name: payload.workspaceName,
+          },
+          content,
+          action: {
+            label: count > 1 ? "Review requests" : "Review request",
+            url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+          },
+        });
+        return { subject, body };
+      },
+      {
+        skip: async () =>
+          !events.some((event) =>
+            isUpgradeRequestCreatedPayload(event.payload)
+          ),
+      }
+    );
+  },
+  {
+    payloadSchema: UpgradeRequestCreatedPayloadSchema,
+    tags: [UPGRADE_REQUEST_CREATED_TAG],
+  }
+);
+
+/**
+ * Email a workspace's admins that a member requested a spend-limit upgrade. One
+ * Novu event is triggered per admin (subscribed by their Dust user sId), deduped
+ * via a `transactionId` keyed on the upgrade-request sId so redeliveries don't
+ * re-send. Fire-and-forget — errors are logged but don't block the caller.
+ */
+export function notifyAdminsUpgradeRequested({
+  admins,
+  workspaceId,
+  workspaceName,
+  requestId,
+  requesterName,
+  requesterEmail,
+}: {
+  admins: Array<{
+    sId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  workspaceId: string;
+  workspaceName: string;
+  requestId: string;
+  requesterName: string;
+  requesterEmail: string | null;
+}): void {
+  if (admins.length === 0) {
+    return;
+  }
+
+  const payload: UpgradeRequestCreatedPayloadType = {
+    workspaceId,
+    workspaceName,
+    requesterName,
+    requesterEmail,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: admins.map((admin) => ({
+          workflowId: UPGRADE_REQUEST_CREATED_TRIGGER_ID,
+          to: {
+            subscriberId: admin.sId,
+            email: admin.email,
+            firstName: admin.firstName ?? undefined,
+            lastName: admin.lastName ?? undefined,
+          },
+          payload,
+          transactionId: `${UPGRADE_REQUEST_CREATED_TRIGGER_ID}-${requestId}-${admin.sId}`,
+        })),
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, requestId },
+          "Failed to trigger upgrade request created notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, requestId },
+        "Failed to trigger upgrade request created notification"
+      );
+    });
+}

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -118,6 +118,10 @@ export const PROGRAMMATIC_CAP_REACHED_TRIGGER_ID =
   "programmatic-cap-reached" as const;
 export const PROGRAMMATIC_CAP_REACHED_TAG = "programmatic-cap-reached" as const;
 
+export const UPGRADE_REQUEST_CREATED_TRIGGER_ID =
+  "upgrade-request-created" as const;
+export const UPGRADE_REQUEST_CREATED_TAG = "upgrade-request-created" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof POD_ADDED_AS_MEMBER_TRIGGER_ID
@@ -126,4 +130,5 @@ export type WorkflowTriggerId =
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
   | typeof USER_AWU_CAP_REACHED_TRIGGER_ID
   | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID
-  | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID;
+  | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID
+  | typeof UPGRADE_REQUEST_CREATED_TRIGGER_ID;


### PR DESCRIPTION
## Description

Adds a Novu workflow that emails a workspace's admins when a member requests a spend-limit upgrade, completing the member-initiated upgrade-request flow (the `TODO` left in `createUpgradeRequest`).

- New `upgrade-request-created` workflow (`front/lib/notifications/workflows/upgrade-request-created.ts`) registered with the Novu endpoint, plus its trigger id / tag in `notification_preferences.ts`.
- `createUpgradeRequest` now notifies active workspace admins after a request is created, **gated on the existing `upgradeRequestEmailEnabled` admin toggle** ("Upgrade request" in Usage settings). The notification is fire-and-forget (wrapped + logged like `emitAuditLogEvent`) so it never blocks or fails request creation.
- Emails are **digested per admin** (keyed by subscriber + workspace) so a burst of members hitting their limit collapses into a single email instead of flooding the inbox: 2-minute window in development, 1-hour window in production. The digest email dedupes requesters and pluralizes the subject/body, linking admins to the workspace usage page to review.

## Tests

Manual: with a credit-priced workspace and the "Upgrade request" toggle on, a member at/near their limit requesting an upgrade results in admins receiving an email; toggling the setting off suppresses it. Multiple requests within the digest window arrive as one email.
