### PR TITLE
[front] business_activation: schedule business contract end on failure

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -17,6 +17,7 @@ import {
   addPaymentGatedCommitToContract,
   floorToHourISO,
   getMetronomeClient,
+  scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import {
   CURRENCY_TO_CREDIT_TYPE_ID,
@@ -249,6 +250,7 @@ export async function createPaymentGatedBusinessActivation({
   // handler can update it even if it races ahead of this function returning.
   await setCheckoutPaymentPending({
     workspaceId: workspace.sId,
+    metronomeCustomerId,
     contractId: metronomeContractId,
     userId,
     targetUserId,
@@ -606,6 +608,24 @@ export async function handleSubscriptionActivationFailure({
     errorMessage,
     invoiceId,
   });
+
+  // Ending the contract created for business activation
+  const sunsetResult = await scheduleMetronomeContractEnd({
+    metronomeCustomerId: checkoutPayment.metronomeCustomerId,
+    contractId,
+    endingBefore: new Date(floorToHourISO(new Date())),
+  });
+  if (sunsetResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        metronomeCustomerId: checkoutPayment.metronomeCustomerId,
+        contractId,
+        error: sunsetResult.error.message,
+      },
+      "[Business Activation] Failed to schedule temporary business plan on activation failure."
+    );
+  }
 
   logger.warn(
     {

--- a/front/lib/credits/checkout_payment_status.test.ts
+++ b/front/lib/credits/checkout_payment_status.test.ts
@@ -28,6 +28,7 @@ import { BUSINESS_USD_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 
 const BASE_INPUT = {
   workspaceId: "ws_test",
+  metronomeCustomerId: "cst_abc",
   contractId: "contract_abc",
   userId: "user_1",
   targetUserId: "user_2",

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -13,6 +13,7 @@ export type CheckoutPaymentStatus = "pending" | "succeeded" | "failed";
 export const CheckoutPaymentSchema = z.object({
   status: z.enum(["pending", "succeeded", "failed"]),
   workspaceId: z.string(),
+  metronomeCustomerId: z.string(),
   contractId: z.string(),
   userId: z.string(),
   targetUserId: z.string(),


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8821
Make sure to end the business contract created during checkout when the payment gated commit fails

## Tests

Tested locally

## Risk

Low, only on failure in checkout for new metronome plans

## Deploy Plan

Deploy front
