### PR TITLE
[front] Add get_credit_timeseries tool to workspace_analytics

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -705,6 +705,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "workspace_analytics": {
     "get_agent_details": "never_ask",
+    "get_credit_timeseries": "never_ask",
     "get_credit_usage": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_skills": "never_ask",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -1,7 +1,9 @@
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
+  MAX_CREDIT_GROUPS,
   MAX_RESULTS,
   timeWindowSchemaShape,
   usageFilterSchema,
@@ -67,6 +69,24 @@ const getCreditTimeseriesSchema = {
     .enum(["day", "week", "month"])
     .optional()
     .describe("Bucket granularity for the credit trend (default day)."),
+  breakdownBy: z
+    .enum(["agent", "user"])
+    .optional()
+    .describe(
+      "Split each bucket into the top agents or users by credits, plus an " +
+        "'other' series for the rest. Omit for a single total-credits trend."
+    ),
+  breakdownLimit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_CREDIT_GROUPS)
+    .optional()
+    .describe(
+      `Number of top groups to break out when breakdownBy is set ` +
+        `(default ${DEFAULT_CREDIT_GROUPS}, max ${MAX_CREDIT_GROUPS}); the ` +
+        `remainder is folded into 'other'.`
+    ),
 };
 
 const getUsageTimeseriesSchema = {
@@ -181,12 +201,14 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     description:
       "Return estimated AWU credit consumption as a time series over a window " +
       "(defaults to the last 30 days), bucketed by day, week, or month. Each " +
-      "point splits model and tool credits. Use this for credit/spend TRENDS " +
-      "over time; use get_credit_usage for totals and top agent/user " +
-      "attribution. IMPORTANT: these figures are ESTIMATES — always tell the " +
-      "user they are approximate and point them to the workspace Usage page " +
-      "for exact, billed credit amounts. Chart the result. Optionally filter " +
-      "by source (context_origin), agent, or user. Admin-only.",
+      "point splits model and tool credits. Set breakdownBy to split each " +
+      "bucket into the top agents or users plus an 'other' series (a stacked " +
+      "trend). Use this for credit/spend TRENDS over time; use get_credit_usage " +
+      "for a single window's totals and top agent/user attribution. IMPORTANT: " +
+      "these figures are ESTIMATES — always tell the user they are approximate " +
+      "and point them to the workspace Usage page for exact, billed credit " +
+      "amounts. Chart the result. Optionally filter by source (context_origin), " +
+      "agent, or user. Admin-only.",
     schema: getCreditTimeseriesSchema,
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -60,6 +60,15 @@ const getCreditUsageSchema = {
     ),
 };
 
+const getCreditTimeseriesSchema = {
+  ...timeWindowSchemaShape,
+  ...usageFilterSchema,
+  granularity: z
+    .enum(["day", "week", "month"])
+    .optional()
+    .describe("Bucket granularity for the credit trend (default day)."),
+};
+
 const getUsageTimeseriesSchema = {
   ...timeWindowSchemaShape,
   ...usageFilterSchema,
@@ -166,6 +175,23 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Estimating credit usage",
       done: "Estimated credit usage",
+    },
+  },
+  get_credit_timeseries: {
+    description:
+      "Return estimated AWU credit consumption as a time series over a window " +
+      "(defaults to the last 30 days), bucketed by day, week, or month. Each " +
+      "point splits model and tool credits. Use this for credit/spend TRENDS " +
+      "over time; use get_credit_usage for totals and top agent/user " +
+      "attribution. IMPORTANT: these figures are ESTIMATES — always tell the " +
+      "user they are approximate and point them to the workspace Usage page " +
+      "for exact, billed credit amounts. Chart the result. Optionally filter " +
+      "by source (context_origin), agent, or user. Admin-only.",
+    schema: getCreditTimeseriesSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Estimating credit trend",
+      done: "Estimated credit trend",
     },
   },
   get_usage_timeseries: {

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -15,6 +15,11 @@ export const MAX_QUERY_WINDOW_DAYS = 100;
 export const DEFAULT_RESULTS = 25;
 export const MAX_RESULTS = 100;
 
+// Credit timeseries breakdowns keep a small number of series and fold the
+// remainder into an "other" group, so a stacked chart stays readable.
+export const DEFAULT_CREDIT_GROUPS = 5;
+export const MAX_CREDIT_GROUPS = 10;
+
 export const ANALYTICS_PERIODS = [
   "this_month",
   "last_7_days",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -30,6 +30,7 @@ describe("workspace_analytics tools", () => {
     "get_top_skills",
     "get_top_tools",
     "get_credit_usage",
+    "get_credit_timeseries",
     "get_usage_timeseries",
   ])("%s refuses non-admin callers", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -12,7 +12,10 @@ import {
   resolveTimeWindow,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { fetchCreditUsage } from "@app/lib/api/assistant/observability/credit_usage";
+import {
+  fetchCreditTimeseries,
+  fetchCreditUsage,
+} from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   fetchAvailableSkills,
@@ -435,6 +438,79 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `${header}\nTop ${selectedGroupBy}s by estimated credits:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_credit_timeseries: async (
+    {
+      granularity,
+      period,
+      startDate,
+      endDate,
+      timezone,
+      source,
+      agentIds,
+      userIds,
+    },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      "last_30_days"
+    );
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const interval = granularity ?? "day";
+    const result = await fetchCreditTimeseries(auth, {
+      startDate: window.value.startDate,
+      endDate: window.value.endDate,
+      granularity: interval,
+      timezone: window.value.timezone,
+      contextOrigin: source,
+      agentIds,
+      userIds,
+    });
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to estimate credit trend: ${result.error.message}`)
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+    const points = result.value;
+
+    if (points.every((point) => point.totalCredits === 0)) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No credit usage recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const lines = points.map(
+      (point) =>
+        `${point.date}: ${point.totalCredits} credits ` +
+        `(${point.llmCredits} model + ${point.toolCredits} tools)`
+    );
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Estimated credit usage per ${interval} for ${label} (${tz}). ` +
+          "These are estimates — point the user to the workspace Usage page " +
+          "for exact billed credits:\n" +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -8,12 +8,14 @@ import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import {
+  DEFAULT_CREDIT_GROUPS,
   DEFAULT_RESULTS,
   resolveTimeWindow,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
   fetchCreditTimeseries,
+  fetchCreditTimeseriesBreakdown,
   fetchCreditUsage,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
@@ -446,6 +448,8 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   get_credit_timeseries: async (
     {
       granularity,
+      breakdownBy,
+      breakdownLimit,
       period,
       startDate,
       endDate,
@@ -469,7 +473,67 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
 
+    const { label, timezone: tz } = window.value;
     const interval = granularity ?? "day";
+    const estimateNote =
+      "These are estimates — point the user to the workspace Usage page for " +
+      "exact billed credits";
+
+    if (breakdownBy) {
+      const result = await fetchCreditTimeseriesBreakdown(auth, {
+        startDate: window.value.startDate,
+        endDate: window.value.endDate,
+        granularity: interval,
+        timezone: window.value.timezone,
+        breakdownBy,
+        limit: breakdownLimit ?? DEFAULT_CREDIT_GROUPS,
+        contextOrigin: source,
+        agentIds,
+        userIds,
+      });
+
+      if (result.isErr()) {
+        return new Err(
+          new MCPError(
+            `Failed to estimate credit trend: ${result.error.message}`
+          )
+        );
+      }
+
+      const { groups, points } = result.value;
+      if (
+        groups.length === 0 ||
+        points.every((point) => point.totalCredits === 0)
+      ) {
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `No credit usage recorded for ${label} (${tz}).`,
+          },
+        ]);
+      }
+
+      const series = [...groups.map((group) => group.name), "Other"].join(", ");
+      const lines = points.map((point) => {
+        const parts = groups.map(
+          (group, index) => `${group.name} ${point.groupCredits[index]}`
+        );
+        parts.push(`Other ${point.otherCredits}`);
+        return `${point.date}: ${parts.join(", ")} (total ${point.totalCredits})`;
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text:
+            `Estimated credit usage per ${interval} for ${label} (${tz}), top ` +
+            `${groups.length} ${breakdownBy}s plus 'other'. ${estimateNote}.\n` +
+            `Series: ${series}\n` +
+            lines.join("\n"),
+        },
+      ]);
+    }
+
     const result = await fetchCreditTimeseries(auth, {
       startDate: window.value.startDate,
       endDate: window.value.endDate,
@@ -486,7 +550,6 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       );
     }
 
-    const { label, timezone: tz } = window.value;
     const points = result.value;
 
     if (points.every((point) => point.totalCredits === 0)) {
@@ -509,8 +572,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Estimated credit usage per ${interval} for ${label} (${tz}). ` +
-          "These are estimates — point the user to the workspace Usage page " +
-          "for exact billed credits:\n" +
+          `${estimateNote}:\n` +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -71,6 +71,30 @@ type CreditTimeseriesAggs = {
   by_date?: estypes.AggregationsMultiBucketAggregateBase<DateCreditBucket>;
 };
 
+type BreakdownGroupBucket = CreditSlice & { key: string };
+
+type BreakdownDateBucket = CreditSlice & {
+  key: number;
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<BreakdownGroupBucket>;
+};
+
+type CreditTimeseriesBreakdownAggs = {
+  by_date?: estypes.AggregationsMultiBucketAggregateBase<BreakdownDateBucket>;
+};
+
+export type CreditTimeseriesBreakdownPoint = {
+  timestamp: number;
+  date: string;
+  totalCredits: number;
+  otherCredits: number;
+  groupCredits: number[];
+};
+
+export type CreditTimeseriesBreakdown = {
+  groups: { groupKey: string; name: string }[];
+  points: CreditTimeseriesBreakdownPoint[];
+};
+
 // Total credits (LLM + tool) cannot be ordered on inside a single ES terms
 // aggregation, so we overfetch the most active groups, compute credits for each,
 // then rank in JS. This caps how many groups we pull before ranking; workspaces
@@ -342,4 +366,124 @@ export async function fetchCreditTimeseries(
       ...creditsFromSlice(bucket),
     }))
   );
+}
+
+// Estimated credits over time, split into the top-N agents/users plus an
+// "other" bucket holding everything else. Ranks groups once (by total credits),
+// then fetches the per-bucket series for just those groups; "other" is the
+// per-bucket total minus the shown groups so the series reconciles.
+export async function fetchCreditTimeseriesBreakdown(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    granularity,
+    timezone,
+    breakdownBy,
+    limit,
+    contextOrigin,
+    agentIds,
+    userIds,
+  }: {
+    startDate: string;
+    endDate: string;
+    granularity: "day" | "week" | "month";
+    timezone: string;
+    breakdownBy: "agent" | "user";
+    limit: number;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+  }
+): Promise<Result<CreditTimeseriesBreakdown, ElasticsearchError>> {
+  const ranking = await fetchCreditUsage(auth, {
+    startDate,
+    endDate,
+    limit,
+    groupBy: breakdownBy,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+  if (ranking.isErr()) {
+    return ranking;
+  }
+
+  const groups = ranking.value.rows.map((row) => ({
+    groupKey: row.groupKey,
+    name: row.name,
+  }));
+  if (groups.length === 0) {
+    return new Ok({ groups: [], points: [] });
+  }
+
+  const groupKeys = groups.map((group) => group.groupKey);
+  const query = buildCreditQuery(auth, {
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+
+  const result = await searchAnalytics<never, CreditTimeseriesBreakdownAggs>(
+    query,
+    {
+      aggregations: {
+        by_date: {
+          date_histogram: {
+            field: "timestamp",
+            calendar_interval: granularity,
+            time_zone: timezone,
+          },
+          aggs: {
+            ...creditSubAggs,
+            by_group: {
+              terms: {
+                field: groupFieldFor(breakdownBy),
+                include: groupKeys,
+                size: groupKeys.length,
+              },
+              aggs: { ...creditSubAggs },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<BreakdownDateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  const points = buckets.map((bucket) => {
+    const totalCredits = creditsFromSlice(bucket).totalCredits;
+    const creditsByKey = new Map(
+      bucketsToArray<BreakdownGroupBucket>(bucket.by_group?.buckets).map(
+        (groupBucket) => [
+          String(groupBucket.key),
+          creditsFromSlice(groupBucket).totalCredits,
+        ]
+      )
+    );
+    const groupCredits = groupKeys.map((key) => creditsByKey.get(key) ?? 0);
+    const otherCredits = Math.max(
+      0,
+      totalCredits - groupCredits.reduce((sum, credits) => sum + credits, 0)
+    );
+    return {
+      timestamp: bucket.key,
+      date: formatDateFromMillis(bucket.key, timezone),
+      totalCredits,
+      otherCredits,
+      groupCredits,
+    };
+  });
+
+  return new Ok({ groups, points });
 }

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -1,7 +1,11 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  formatDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import {
   awuFromMicroUsd,
@@ -33,22 +37,38 @@ export type CreditUsageResult = {
   rows: CreditUsageRow[];
 };
 
+export type CreditTimeseriesPoint = {
+  timestamp: number;
+  date: string;
+  llmCredits: number;
+  toolCredits: number;
+  totalCredits: number;
+};
+
 type ServerBucket = { key: string; doc_count: number };
 
 type ToolsNestedAgg = {
   by_server?: estypes.AggregationsMultiBucketAggregateBase<ServerBucket>;
 };
 
-type GroupBucket = {
-  key: string;
+// The LLM-cost + tool-usage aggregations from which one slice's credits are
+// computed. Shared by the workspace totals, the per-group buckets, and the
+// per-date histogram buckets so all of them convert credits identically.
+type CreditSlice = {
   llm_cost?: estypes.AggregationsSumAggregate;
   tools?: ToolsNestedAgg;
 };
 
-type CreditUsageAggs = {
-  total_llm_cost?: estypes.AggregationsSumAggregate;
-  total_tools?: ToolsNestedAgg;
+type GroupBucket = CreditSlice & { key: string };
+
+type DateCreditBucket = CreditSlice & { key: number };
+
+type CreditUsageAggs = CreditSlice & {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
+};
+
+type CreditTimeseriesAggs = {
+  by_date?: estypes.AggregationsMultiBucketAggregateBase<DateCreditBucket>;
 };
 
 // Total credits (LLM + tool) cannot be ordered on inside a single ES terms
@@ -76,6 +96,59 @@ function toolCreditsFromServerBuckets(buckets: ServerBucket[]): number {
       TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(bucket.key)] * bucket.doc_count
     );
   }, 0);
+}
+
+const creditSubAggs = {
+  llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
+  tools: toolsNestedAgg,
+} satisfies Record<string, estypes.AggregationsAggregationContainer>;
+
+function creditsFromSlice(slice: CreditSlice): {
+  llmCredits: number;
+  toolCredits: number;
+  totalCredits: number;
+} {
+  const llmCredits = awuFromMicroUsd(slice.llm_cost?.value ?? 0);
+  const toolCredits = toolCreditsFromServerBuckets(
+    bucketsToArray<ServerBucket>(slice.tools?.by_server?.buckets)
+  );
+  return { llmCredits, toolCredits, totalCredits: llmCredits + toolCredits };
+}
+
+// Workspace query scoped to the window/filters, with free origins excluded to
+// mirror the non-free billed scope. Shared by both credit fetchers so the scope
+// stays identical.
+function buildCreditQuery(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  }: {
+    startDate: string;
+    endDate: string;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+  },
+  extraFilters: estypes.QueryDslQueryContainer[] = []
+): estypes.QueryDslQueryContainer {
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+  return {
+    bool: {
+      filter: [baseQuery, ...extraFilters],
+      must_not: [{ terms: { context_origin: [...FREE_ORIGINS] } }],
+    },
+  };
 }
 
 function groupFieldFor(groupBy: "agent" | "user"): "agent_id" | "user_id" {
@@ -145,22 +218,8 @@ export async function fetchCreditUsage(
     userIds?: string[];
   }
 ): Promise<Result<CreditUsageResult, ElasticsearchError>> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    startDate,
-    endDate,
-    contextOrigin,
-    agentIds,
-    userIds,
-  });
-
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
-    {
-      total_llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
-      total_tools: toolsNestedAgg,
-    };
+    { ...creditSubAggs };
   if (groupBy !== "none") {
     aggregations.by_group = {
       terms: {
@@ -168,23 +227,15 @@ export async function fetchCreditUsage(
         size: Math.max(limit, CREDIT_RANKING_FETCH),
         order: { _count: "desc" },
       },
-      aggs: {
-        llm_cost: { sum: { field: "tokens.cost_micro_usd" } },
-        tools: toolsNestedAgg,
-      },
+      aggs: { ...creditSubAggs },
     };
   }
 
-  const filter: estypes.QueryDslQueryContainer[] = [baseQuery];
-  if (groupBy !== "none") {
-    filter.push({ exists: { field: groupFieldFor(groupBy) } });
-  }
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter,
-      must_not: [{ terms: { context_origin: [...FREE_ORIGINS] } }],
-    },
-  };
+  const query = buildCreditQuery(
+    auth,
+    { startDate, endDate, contextOrigin, agentIds, userIds },
+    groupBy === "none" ? [] : [{ exists: { field: groupFieldFor(groupBy) } }]
+  );
 
   const result = await searchAnalytics<never, CreditUsageAggs>(query, {
     aggregations,
@@ -197,11 +248,9 @@ export async function fetchCreditUsage(
 
   const aggs = result.value.aggregations;
 
-  const llmCredits = awuFromMicroUsd(aggs?.total_llm_cost?.value ?? 0);
-  const toolCredits = toolCreditsFromServerBuckets(
-    bucketsToArray<ServerBucket>(aggs?.total_tools?.by_server?.buckets)
+  const { llmCredits, toolCredits, totalCredits } = creditsFromSlice(
+    aggs ?? {}
   );
-  const totalCredits = llmCredits + toolCredits;
 
   if (groupBy === "none") {
     return new Ok({ llmCredits, toolCredits, totalCredits, rows: [] });
@@ -210,19 +259,10 @@ export async function fetchCreditUsage(
   const buckets = bucketsToArray<GroupBucket>(aggs?.by_group?.buckets);
 
   const ranked = buckets
-    .map((bucket) => {
-      const groupKey = String(bucket.key);
-      const rowLlmCredits = awuFromMicroUsd(bucket.llm_cost?.value ?? 0);
-      const rowToolCredits = toolCreditsFromServerBuckets(
-        bucketsToArray<ServerBucket>(bucket.tools?.by_server?.buckets)
-      );
-      return {
-        groupKey,
-        llmCredits: rowLlmCredits,
-        toolCredits: rowToolCredits,
-        totalCredits: rowLlmCredits + rowToolCredits,
-      };
-    })
+    .map((bucket) => ({
+      groupKey: String(bucket.key),
+      ...creditsFromSlice(bucket),
+    }))
     .sort((a, b) => b.totalCredits - a.totalCredits)
     .slice(0, limit);
 
@@ -240,4 +280,66 @@ export async function fetchCreditUsage(
   }));
 
   return new Ok({ llmCredits, toolCredits, totalCredits, rows });
+}
+
+// Estimated AWU credits bucketed over time (the trend behind get_credit_usage's
+// totals). Same conversion and non-free scope as fetchCreditUsage; per-bucket
+// values are rounded independently so they need not sum to a window total.
+export async function fetchCreditTimeseries(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    granularity,
+    timezone,
+    contextOrigin,
+    agentIds,
+    userIds,
+  }: {
+    startDate: string;
+    endDate: string;
+    granularity: "day" | "week" | "month";
+    timezone: string;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+  }
+): Promise<Result<CreditTimeseriesPoint[], ElasticsearchError>> {
+  const query = buildCreditQuery(auth, {
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+
+  const result = await searchAnalytics<never, CreditTimeseriesAggs>(query, {
+    aggregations: {
+      by_date: {
+        date_histogram: {
+          field: "timestamp",
+          calendar_interval: granularity,
+          time_zone: timezone,
+        },
+        aggs: { ...creditSubAggs },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<DateCreditBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  return new Ok(
+    buckets.map((bucket) => ({
+      timestamp: bucket.key,
+      date: formatDateFromMillis(bucket.key, timezone),
+      ...creditsFromSlice(bucket),
+    }))
+  );
 }

--- a/front/lib/resources/skill/code_defined/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/workspace_analytics.ts
@@ -29,6 +29,10 @@ export const workspaceAnalyticsSkill = {
     "unnecessary, the timeseries tools already bucket over time.\n" +
     "- Use get_credit_usage for a single window's total credits or to " +
     "attribute spend to the top agents or users, not for per-day trends.\n" +
+    "- For a credit trend split by agent or user (e.g. 'how did each agent's " +
+    "spend evolve'), set breakdownBy on get_credit_timeseries — one call " +
+    "returns the top groups plus an 'other' series. Do not make one filtered " +
+    "call per agent or user.\n" +
     "- Chart timeseries results so the admin can see the trend.\n" +
     "- Credit figures are estimates; when reporting them, tell the admin they " +
     "are approximate and point to the workspace Usage page for exact billed " +

--- a/front/lib/resources/skill/code_defined/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/workspace_analytics.ts
@@ -17,9 +17,24 @@ export const workspaceAnalyticsSkill = {
     "question and present the results clearly. Only report figures returned " +
     "by the tools — never fabricate numbers. If a tool reports an " +
     "authorization error, explain that workspace analytics is restricted to " +
-    "workspace admins.",
+    "workspace admins.\n\n" +
+    "Choosing a tool:\n" +
+    "- For trends over time — anything spanning multiple days or phrased as " +
+    "'over time', 'per day', 'evolution', 'trend' — make a single timeseries " +
+    "call: get_credit_timeseries for credit/spend trends, or " +
+    "get_usage_timeseries for activity, skill, or tool trends. They return the " +
+    "whole series bucketed by day/week/month in one call.\n" +
+    "- Never build a trend by calling a snapshot tool (get_credit_usage, " +
+    "get_top_*) once per day or in parallel per period — it is slower and " +
+    "unnecessary, the timeseries tools already bucket over time.\n" +
+    "- Use get_credit_usage for a single window's total credits or to " +
+    "attribute spend to the top agents or users, not for per-day trends.\n" +
+    "- Chart timeseries results so the admin can see the trend.\n" +
+    "- Credit figures are estimates; when reporting them, tell the admin they " +
+    "are approximate and point to the workspace Usage page for exact billed " +
+    "amounts.",
   mcpServers: [{ name: "workspace_analytics" }],
-  version: 1,
+  version: 2,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isAdmin()) {


### PR DESCRIPTION
## Description

Estimated AWU credits bucketed over time (day/week/month), the trend behind
get_credit_usage's totals. Extracts the shared per-slice credit conversion
(creditsFromSlice) and the free-origin-excluded query (buildCreditQuery) so the
snapshot, ranking, and timeseries all compute credits identically.

Agents were building trends by firing many parallel get_credit_usage snapshot
calls (one per period). Update the workspace-analytics skill instructions to
direct over-time/multi-day questions to a single get_credit_timeseries or
get_usage_timeseries call, and reserve get_credit_usage for single-window
totals and top agent/user attribution. Bump skill version to 2.

Add an optional breakdownBy (agent|user) that turns the credit trend into a
stacked series: the top-N groups by credits plus an "other" series for the
rest. Ranks groups once via fetchCreditUsage, then fetches the per-bucket
series for just those groups; "other" is each bucket's total minus the shown
groups so the series reconciles. Defaults to top 5 (max 10). Steer the skill
prompt to use breakdownBy for "credit trend by agent/user" rather than one
filtered call per group.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
