### PR TITLE
Sparkle: add input with unit + save button. Use it for usage page

### DIFF
--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -2,8 +2,13 @@ import {
   useUpdateUsageNotifications,
   useUsageNotifications,
 } from "@app/lib/swr/usage_settings";
-import { Input, Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import {
+  InputWithSave,
+  Page,
+  SettingsList,
+  SliderToggle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface UsageNotificationsCardProps {
   workspaceId: string;
@@ -20,10 +25,6 @@ export function UsageNotificationsCard({
     workspaceId,
   });
 
-  const [balanceThresholdInput, setBalanceThresholdInput] =
-    useState<string>("");
-  const [isSavingBalanceThreshold, setIsSavingBalanceThreshold] =
-    useState(false);
   const [isSavingUpgradeRequestEmail, setIsSavingUpgradeRequestEmail] =
     useState(false);
 
@@ -38,37 +39,24 @@ export function UsageNotificationsCard({
     }
   };
 
-  useEffect(() => {
-    // Defaults to 0 when no threshold is configured (warning off).
-    setBalanceThresholdInput(
-      String(usageNotifications.balanceThresholdCredits ?? 0)
-    );
-  }, [usageNotifications.balanceThresholdCredits]);
+  // Defaults to 0 when no threshold is configured (warning off).
+  const currentThreshold = usageNotifications.balanceThresholdCredits ?? 0;
 
-  const handleCommitBalanceThreshold = async () => {
-    const currentThreshold = usageNotifications.balanceThresholdCredits ?? 0;
-    const trimmed = balanceThresholdInput.trim();
+  const handleSaveBalanceThreshold = async (newValue: string) => {
+    const trimmed = newValue.trim();
 
     // An empty value falls back to 0 (warning off). The input only ever holds
-    // digits (see onChange), so `next` is always a non-negative integer.
+    // digits (see normalizeValue), so `nextThreshold` is always a non-negative
+    // integer.
     const nextThreshold = trimmed === "" ? 0 : Number(trimmed);
 
     if (nextThreshold === currentThreshold) {
       return;
     }
 
-    setIsSavingBalanceThreshold(true);
-    try {
-      const ok = await doUpdateUsageNotifications({
-        balanceThresholdCredits: nextThreshold,
-      });
-      if (!ok) {
-        // reset to the current value
-        setBalanceThresholdInput(String(currentThreshold));
-      }
-    } finally {
-      setIsSavingBalanceThreshold(false);
-    }
+    await doUpdateUsageNotifications({
+      balanceThresholdCredits: nextThreshold,
+    });
   };
 
   return (
@@ -86,26 +74,16 @@ export function UsageNotificationsCard({
           title="Credit balance threshold"
           description="Email all workspace admins when your remaining credit balance drops below this amount (in credits). Set to 0 to disable."
           action={
-            <div className="relative w-32">
-              <Input
-                type="text"
+            <div className="w-40">
+              <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"
-                value={balanceThresholdInput}
-                onChange={(e) =>
-                  setBalanceThresholdInput(e.target.value.replace(/[^\d]/g, ""))
-                }
-                onBlur={() => void handleCommitBalanceThreshold()}
-                disabled={
-                  readOnly ||
-                  isSavingBalanceThreshold ||
-                  isUsageNotificationsLoading
-                }
-                className="pr-16 text-right"
+                value={String(currentThreshold)}
+                unit="credits"
+                normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                onSave={handleSaveBalanceThreshold}
+                disabled={readOnly || isUsageNotificationsLoading}
               />
-              <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                credits
-              </span>
             </div>
           }
         />

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -74,7 +74,7 @@ export function UsageNotificationsCard({
           title="Credit balance threshold"
           description="Email all workspace admins when your remaining credit balance drops below this amount (in credits). Set to 0 to disable."
           action={
-            <div className="w-40">
+            <div className="w-52">
               <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -53,7 +53,7 @@ export function UsageProgrammaticLimitCard({
           title="Programmatic monthly limit"
           description="Maximum credits allowed for programmatic usage per month"
           action={
-            <div className="w-40">
+            <div className="w-52">
               <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -2,8 +2,7 @@ import {
   useProgrammaticUsageLimit,
   useUpdateProgrammaticUsageLimit,
 } from "@app/lib/swr/usage_settings";
-import { Input, Page, SettingsList } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { InputWithSave, Page, SettingsList } from "@dust-tt/sparkle";
 
 interface UsageProgrammaticLimitCardProps {
   workspaceId: string;
@@ -20,57 +19,27 @@ export function UsageProgrammaticLimitCard({
     workspaceId,
   });
 
-  const [limitInput, setLimitInput] = useState<string>("");
-  const [isSaving, setIsSaving] = useState(false);
+  const currentLimit = programmaticUsageLimit?.monthlyCapCredits ?? null;
 
-  useEffect(() => {
-    if (programmaticUsageLimit?.monthlyCapCredits !== undefined) {
-      setLimitInput(
-        programmaticUsageLimit.monthlyCapCredits !== null
-          ? String(programmaticUsageLimit.monthlyCapCredits)
-          : ""
-      );
-    }
-  }, [programmaticUsageLimit]);
+  const handleSaveLimit = async (newValue: string) => {
+    const trimmed = newValue.trim();
 
-  const handleCommitLimit = async () => {
-    const current = programmaticUsageLimit?.monthlyCapCredits ?? null;
-
-    if (limitInput.trim() === "") {
-      if (current === null) {
+    // An empty value means no limit.
+    if (trimmed === "") {
+      if (currentLimit === null) {
         return;
       }
-      setIsSaving(true);
-      try {
-        const result = await doUpdateProgrammaticUsageLimit(null);
-        if (!result) {
-          setLimitInput(current !== null ? String(current) : "");
-        }
-      } finally {
-        setIsSaving(false);
-      }
+      await doUpdateProgrammaticUsageLimit(null);
       return;
     }
 
-    const parsed = Number(limitInput);
-    if (!Number.isInteger(parsed) || parsed < 0 || parsed === current) {
-      setLimitInput(current !== null ? String(current) : "");
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed === currentLimit) {
+      // The component reverts to the current value when nothing is persisted.
       return;
     }
-
-    setIsSaving(true);
-    try {
-      const result = await doUpdateProgrammaticUsageLimit(parsed);
-      if (!result) {
-        setLimitInput(current !== null ? String(current) : "");
-      }
-    } finally {
-      setIsSaving(false);
-    }
+    await doUpdateProgrammaticUsageLimit(parsed);
   };
-
-  const isInputDisabled =
-    readOnly || isSaving || isProgrammaticUsageLimitLoading;
 
   return (
     <Page.Vertical gap="sm" align="stretch">
@@ -84,23 +53,17 @@ export function UsageProgrammaticLimitCard({
           title="Programmatic monthly limit"
           description="Maximum credits allowed for programmatic usage per month"
           action={
-            <div className="relative w-32">
-              <Input
-                type="text"
+            <div className="w-40">
+              <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"
                 placeholder="No limit"
-                value={limitInput}
-                onChange={(e) =>
-                  setLimitInput(e.target.value.replace(/[^\d]/g, ""))
-                }
-                onBlur={() => void handleCommitLimit()}
-                disabled={isInputDisabled}
-                className="pr-16 text-right"
+                value={currentLimit !== null ? String(currentLimit) : ""}
+                unit="credits"
+                normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                onSave={handleSaveLimit}
+                disabled={readOnly || isProgrammaticUsageLimitLoading}
               />
-              <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                credits
-              </span>
             </div>
           }
         />

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -9,13 +9,12 @@ import {
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
 } from "@app/types/credits";
 import {
-  Input,
+  InputWithSave,
   Page,
   SettingsList,
   SliderToggle,
-  Spinner,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface UsageSettingsCardProps {
   workspaceId: string;
@@ -36,8 +35,6 @@ export function UsageSettingsCard({
   });
   const { doUpdateUsageSettings } = useUpdateUsageSettings({ workspaceId });
 
-  const [defaultLimitInput, setDefaultLimitInput] = useState<string>("");
-  const [isSavingLimit, setIsSavingLimit] = useState(false);
   const [isSavingAllowUpgradeRequest, setIsSavingAllowUpgradeRequest] =
     useState(false);
 
@@ -52,41 +49,21 @@ export function UsageSettingsCard({
     }
   };
 
-  useEffect(() => {
-    if (defaultUserSpendLimit?.awuCredits !== undefined) {
-      setDefaultLimitInput(
-        defaultUserSpendLimit.awuCredits !== null
-          ? String(defaultUserSpendLimit.awuCredits)
-          : ""
-      );
-    }
-  }, [defaultUserSpendLimit]);
+  const currentDefaultLimit = defaultUserSpendLimit?.awuCredits ?? null;
 
-  const handleCommitDefaultLimit = async () => {
-    const parsed = Number(defaultLimitInput);
-    const current = defaultUserSpendLimit?.awuCredits ?? null;
+  const handleSaveDefaultLimit = async (newValue: string) => {
+    const parsed = Number(newValue);
     if (
       !Number.isInteger(parsed) ||
       parsed < MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
       parsed > MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS ||
-      parsed === current
+      parsed === currentDefaultLimit
     ) {
-      setDefaultLimitInput(current !== null ? String(current) : "");
+      // The component reverts to the current value when nothing is persisted.
       return;
     }
-    setIsSavingLimit(true);
-    try {
-      const result = await doUpdateDefaultUserSpendLimit(parsed);
-      if (!result) {
-        setDefaultLimitInput(current !== null ? String(current) : "");
-      }
-    } finally {
-      setIsSavingLimit(false);
-    }
+    await doUpdateDefaultUserSpendLimit(parsed);
   };
-
-  const isDefaultLimitInputDisabled =
-    readOnly || isSavingLimit || isDefaultUserSpendLimitLoading;
 
   return (
     <Page.Vertical gap="sm" align="stretch">
@@ -98,28 +75,20 @@ export function UsageSettingsCard({
           title="Default pool credit limit"
           description="Define the pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance."
           action={
-            <div className="relative w-32">
-              <Input
-                type="text"
+            <div className="w-40">
+              <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"
-                value={defaultLimitInput}
-                onChange={(e) =>
-                  setDefaultLimitInput(e.target.value.replace(/[^\d]/g, ""))
+                value={
+                  currentDefaultLimit !== null
+                    ? String(currentDefaultLimit)
+                    : ""
                 }
-                onBlur={() => void handleCommitDefaultLimit()}
-                disabled={isDefaultLimitInputDisabled}
-                className="pr-16 text-right"
+                unit="credits"
+                normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                onSave={handleSaveDefaultLimit}
+                disabled={readOnly || isDefaultUserSpendLimitLoading}
               />
-              {isSavingLimit ? (
-                <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
-                  <Spinner size="xs" />
-                </div>
-              ) : (
-                <span className="copy-sm pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground dark:text-muted-foreground-night">
-                  credits
-                </span>
-              )}
             </div>
           }
         />

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -75,7 +75,7 @@ export function UsageSettingsCard({
           title="Default pool credit limit"
           description="Define the pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance."
           action={
-            <div className="w-40">
+            <div className="w-52">
               <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"

--- a/sparkle/src/components/InputWithSave.tsx
+++ b/sparkle/src/components/InputWithSave.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@sparkle/components/Button";
-import { Save01 } from "@sparkle/icons/v2-stroke";
 import { cn } from "@sparkle/lib/utils";
 import React, {
   forwardRef,
@@ -112,7 +111,7 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
         <input
           ref={inputRef}
           className={cn(
-            "s-h-full s-w-full s-min-w-0 s-flex-1 s-border-0 s-bg-transparent s-p-0",
+            "s-h-full s-w-full s-min-w-0 s-flex-1 s-border-0 s-bg-transparent s-p-0 s-text-right",
             // The container carries the focus styles (via focus-within); the
             // inner input must not render its own outline or ring.
             "s-outline-none focus:s-outline-none focus-visible:s-outline-none",
@@ -143,11 +142,10 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
         )}
         {showSaveButton && (
           <Button
-            icon={Save01}
+            label="Save"
             variant="highlight"
-            size="icon-xs"
+            size="xs"
             isLoading={isSaving}
-            aria-label="Save"
             // Prevent the input from blurring (which would revert the edit)
             // before the click registers.
             onMouseDown={(e) => e.preventDefault()}

--- a/sparkle/src/components/InputWithSave.tsx
+++ b/sparkle/src/components/InputWithSave.tsx
@@ -1,0 +1,165 @@
+import { Button } from "@sparkle/components/Button";
+import { Save01 } from "@sparkle/icons/v2-stroke";
+import { cn } from "@sparkle/lib/utils";
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+
+export interface InputWithSaveProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "onChange"
+  > {
+  value?: string | null;
+  unit?: string;
+  onSave: (value: string) => Promise<void> | void;
+  // Applied to the draft value on each keystroke (e.g. to strip non-digit
+  // characters for numeric inputs).
+  normalizeValue?: (value: string) => string;
+  className?: string;
+}
+
+export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
+  (
+    {
+      value,
+      unit,
+      onSave,
+      normalizeValue,
+      className,
+      disabled,
+      onFocus,
+      onBlur,
+      onKeyDown,
+      ...props
+    },
+    ref
+  ) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    useImperativeHandle(ref, () => inputRef.current!);
+
+    const [draftValue, setDraftValue] = useState("");
+    const [isEditing, setIsEditing] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const showSaveButton = isEditing || isSaving;
+
+    const handleSave = async () => {
+      if (isSaving) {
+        return;
+      }
+      setIsSaving(true);
+      try {
+        await onSave(draftValue);
+        setIsEditing(false);
+        inputRef.current?.blur();
+      } catch {
+        // Stay in editing state; error handling is the caller's responsibility.
+      } finally {
+        setIsSaving(false);
+      }
+    };
+
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (!isSaving && !isEditing) {
+        setDraftValue(value ?? "");
+        setIsEditing(true);
+      }
+      onFocus?.(e);
+    };
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+      // Revert to the value before the edit, unless a save is in flight.
+      if (!isSaving) {
+        setIsEditing(false);
+      }
+      onBlur?.(e);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        void handleSave();
+      } else if (e.key === "Escape") {
+        inputRef.current?.blur();
+      }
+      onKeyDown?.(e);
+    };
+
+    return (
+      <div
+        className={cn(
+          "s-flex s-h-9 s-w-full s-items-center s-gap-1.5 s-rounded-xl s-border s-py-1.5 s-pl-3 s-text-sm",
+          showSaveButton ? "s-pr-1.5" : "s-pr-3",
+          "s-bg-background dark:s-bg-background-night",
+          "s-border-border dark:s-border-border-night",
+          "s-ring-inset s-ring-highlight/0 dark:s-ring-highlight-night/0",
+          disabled
+            ? "s-cursor-not-allowed"
+            : cn(
+                "s-cursor-text",
+                "focus-within:s-border-border-focus dark:focus-within:s-border-border-focus-night",
+                "focus-within:s-ring-2",
+                "focus-within:s-ring-highlight/20 dark:focus-within:s-ring-highlight/50"
+              ),
+          className
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        <input
+          ref={inputRef}
+          className={cn(
+            "s-h-full s-w-full s-min-w-0 s-flex-1 s-border-0 s-bg-transparent s-p-0",
+            // The container carries the focus styles (via focus-within); the
+            // inner input must not render its own outline or ring.
+            "s-outline-none focus:s-outline-none focus-visible:s-outline-none",
+            "s-ring-0 focus:s-ring-0 focus-visible:s-ring-0 s-shadow-none",
+            "dark:s-text-primary-50",
+            "placeholder:s-text-muted-foreground dark:placeholder:s-text-muted-foreground-night",
+            disabled &&
+              "s-cursor-not-allowed s-text-muted-foreground dark:s-text-muted-foreground-night"
+          )}
+          data-1p-ignore
+          value={showSaveButton ? draftValue : (value ?? "")}
+          onChange={(e) =>
+            setDraftValue(
+              normalizeValue ? normalizeValue(e.target.value) : e.target.value
+            )
+          }
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          readOnly={isSaving}
+          {...props}
+        />
+        {unit && (
+          <span className="s-shrink-0 s-text-muted-foreground dark:s-text-muted-foreground-night">
+            {unit}
+          </span>
+        )}
+        {showSaveButton && (
+          <Button
+            icon={Save01}
+            variant="highlight"
+            size="icon-xs"
+            isLoading={isSaving}
+            aria-label="Save"
+            // Prevent the input from blurring (which would revert the edit)
+            // before the click registers.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              void handleSave();
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+);
+
+InputWithSave.displayName = "InputWithSave";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -152,6 +152,8 @@ export {
 export type { ImageZoomDialogProps } from "./ImageZoomDialog";
 export { downloadFile, ImageZoomDialog } from "./ImageZoomDialog";
 export { Input } from "./Input";
+export type { InputWithSaveProps } from "./InputWithSave";
+export { InputWithSave } from "./InputWithSave";
 export { InteractiveImageGrid } from "./InteractiveImageGrid";
 export { KeyboardShortcut } from "./KeyboardShortcut";
 export { Label } from "./Label";

--- a/sparkle/src/stories/InputWithSave.stories.tsx
+++ b/sparkle/src/stories/InputWithSave.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
     layout: "padded",
     docs: {
       description: {
-        component: `A text field with an optional right-aligned **unit** and an inline save action. At rest it shows the value and unit; while editing, a save icon button appears on the right. Clicking save (or pressing Enter) calls **onSave** and shows a spinner until the returned promise resolves; blurring without saving (or pressing Escape) reverts the edit.
+        component: `A text field with an optional right-aligned **unit** and an inline save action. At rest it shows the value and unit; while editing, a Save button appears on the right. Clicking save (or pressing Enter) calls **onSave** and shows a spinner until the returned promise resolves; blurring without saving (or pressing Escape) reverts the edit.
 
 **When to use**
 - For a single value that is persisted on its own (e.g. a quota, a price, a limit), without a surrounding form.

--- a/sparkle/src/stories/InputWithSave.stories.tsx
+++ b/sparkle/src/stories/InputWithSave.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+
+import { InputWithSave } from "../index_with_tw_base";
+
+const meta = {
+  title: "Forms & Inputs/InputWithSave",
+  component: InputWithSave,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `A text field with an optional right-aligned **unit** and an inline save action. At rest it shows the value and unit; while editing, a save icon button appears on the right. Clicking save (or pressing Enter) calls **onSave** and shows a spinner until the returned promise resolves; blurring without saving (or pressing Escape) reverts the edit.
+
+**When to use**
+- For a single value that is persisted on its own (e.g. a quota, a price, a limit), without a surrounding form.
+
+**Guidelines**
+- **onSave** receives the draft string and may return a promise; the spinner is shown until it settles.
+- The component reverts to the **value** prop when the edit is abandoned, so keep **value** in sync with the persisted state.`,
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      description: "The persisted value shown at rest",
+      control: "text",
+    },
+    unit: {
+      description: "Optional unit displayed on the right of the input",
+      control: "text",
+    },
+    placeholder: {
+      description: "Placeholder text for the input",
+      control: "text",
+    },
+    disabled: {
+      description: "Whether the input is disabled",
+      control: "boolean",
+    },
+    onSave: {
+      description: "Callback when the save button is clicked",
+      action: "saved",
+    },
+  },
+} satisfies Meta<React.ComponentProps<typeof InputWithSave>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ControlledInputWithSave({
+  initialValue,
+  unit,
+  placeholder,
+}: {
+  initialValue: string;
+  unit?: string;
+  placeholder?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <InputWithSave
+      value={value}
+      unit={unit}
+      placeholder={placeholder}
+      onSave={async (newValue) => {
+        // Simulate a network call.
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        setValue(newValue);
+      }}
+    />
+  );
+}
+
+export const ExampleInputWithSave: Story = {
+  args: {
+    value: "12,890",
+    unit: "Credits",
+    onSave: () => {},
+  },
+  render: (args) => (
+    <ControlledInputWithSave
+      initialValue={args.value ?? ""}
+      unit={args.unit}
+      placeholder={args.placeholder}
+    />
+  ),
+};
+
+export function InputWithSaveExamples() {
+  return (
+    <div className="s-flex s-max-w-md s-flex-col s-gap-4">
+      <ControlledInputWithSave initialValue="12,890" unit="Credits" />
+      <ControlledInputWithSave initialValue="49" unit="$" />
+      <ControlledInputWithSave
+        initialValue=""
+        unit="Credits"
+        placeholder="Enter an amount"
+      />
+      <ControlledInputWithSave initialValue="No unit here" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/8776

Add a new sparkle component which is input + unit + save button.
Add a story for it.
Use it for pricing usage page.



https://github.com/user-attachments/assets/31eb7000-664b-41f8-9678-ddb1b169ec8d



https://github.com/user-attachments/assets/559452be-b2f7-4a3b-8241-cbcb6ad844fc






## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front 
