### PR TITLE
fix(front-api): handle GCS network errors in project_files listing

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,6 +1,6 @@
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -97,6 +97,28 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     });
   });
 
+  it("returns 500 when GCS listing fails", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    listGCSMountFilesMock.mockResolvedValue(
+      new Err(new Error("socket hang up"))
+    );
+
+    const response = await getProjectFiles(workspace, key, space.sId);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "internal_server_error",
+        message: "Failed to list project files.",
+      },
+    });
+  });
+
   it("returns files for a project space and filters by updatedSince", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,
@@ -120,19 +142,21 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
       signedDownloadUrl: "https://signed.example/read",
     };
 
-    listGCSMountFilesMock.mockResolvedValue([
-      mockFile,
-      {
-        isDirectory: false as const,
-        fileName: "old.txt",
-        path: "pod/old.txt",
-        sizeBytes: 1,
-        lastModifiedMs: 500,
-        contentType: "text/plain",
-        fileId: null,
-        thumbnailUrl: null,
-      },
-    ]);
+    listGCSMountFilesMock.mockResolvedValue(
+      new Ok([
+        mockFile,
+        {
+          isDirectory: false as const,
+          fileName: "old.txt",
+          path: "pod/old.txt",
+          sizeBytes: 1,
+          lastModifiedMs: 500,
+          contentType: "text/plain",
+          fileId: null,
+          thumbnailUrl: null,
+        },
+      ])
+    );
 
     const response = await getProjectFiles(
       workspace,

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -73,10 +73,22 @@ app.get(
         ? updatedSinceMs
         : null;
 
-    let files = await listGCSMountFiles(auth, {
+    const filesResult = await listGCSMountFiles(auth, {
       useCase: "pod",
       podId: space.sId,
     });
+
+    if (filesResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to list project files.",
+        },
+      });
+    }
+
+    let files = filesResult.value;
 
     if (updatedSinceFilter !== null) {
       files = files.filter((e) => e.lastModifiedMs >= updatedSinceFilter);

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -343,12 +343,13 @@ describe("listGCSMountFiles", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await listGCSMountFiles(auth, {
+    const result = await listGCSMountFiles(auth, {
       useCase: "conversation",
       conversationId,
     });
 
-    const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
+    assert(result.isOk());
+    const paths = result.value.filter((e) => !e.isDirectory).map((e) => e.path);
     expect(paths).toEqual(
       expect.arrayContaining([
         "conversation/report.pdf",
@@ -376,13 +377,14 @@ describe("listGCSMountFiles", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await listGCSMountFiles(
+    const result = await listGCSMountFiles(
       auth,
       { useCase: "conversation", conversationId },
       { includeProcessed: true }
     );
 
-    const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
+    assert(result.isOk());
+    const paths = result.value.filter((e) => !e.isDirectory).map((e) => e.path);
     expect(paths).toEqual(
       expect.arrayContaining([
         "conversation/report.pdf",

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -226,117 +226,122 @@ export async function listGCSMountFiles(
   auth: Authenticator,
   scope: GCSMountPoint,
   { includeProcessed = false }: { includeProcessed?: boolean } = {}
-): Promise<GCSMountEntry[]> {
+): Promise<Result<GCSMountEntry[], Error>> {
   const owner = auth.getNonNullableWorkspace();
   const prefix = resolvePrefix(owner, scope);
 
-  const bucket = getPrivateUploadBucket();
-  const { files: gcsFiles, pageFetchCount } = await bucket.getAllFilesByPrefix({
-    prefix,
-    pageSize: 200,
-  });
-
-  if (pageFetchCount > 1) {
-    logger.warn(
-      {
-        workspaceId: owner.sId,
+  try {
+    const bucket = getPrivateUploadBucket();
+    const { files: gcsFiles, pageFetchCount } =
+      await bucket.getAllFilesByPrefix({
         prefix,
-        scope,
-        pageFetchCount,
-        objectCount: gcsFiles.length,
-      },
-      "GCS mount file listing required multiple list requests; prefix has many objects."
-    );
-  }
+        pageSize: 200,
+      });
 
-  // GCS folder placeholders are zero-byte objects whose path ends with "/".
-  const folderPlaceholders = gcsFiles.filter((f) => f.name.endsWith("/"));
-  const regularFiles = gcsFiles.filter((f) => {
-    if (f.name.endsWith("/")) {
-      return false;
-    }
-
-    if (includeProcessed) {
-      return true;
-    }
-
-    const name = f.name.split("/").pop() ?? "";
-    return !name.includes(".processed.");
-  });
-
-  // GCS files are listed under `pods/` but some FileResource rows still store the
-  // `projects/` form. Query both shapes so old rows still resolve.
-  const mountPaths = regularFiles.map((f) => f.name);
-  const legacyMountPaths = mountPaths.map((p) =>
-    p.replace("/pods/", "/projects/")
-  );
-  const fileResources = await FileResource.fetchByMountFilePaths(auth, [
-    ...mountPaths,
-    ...legacyMountPaths,
-  ]);
-  const fileResourceByMountPath = new Map<string, FileResource>();
-  for (const r of fileResources) {
-    if (r.mountFilePath) {
-      fileResourceByMountPath.set(
-        r.mountFilePath.replace("/projects/", "/pods/"),
-        r
+    if (pageFetchCount > 1) {
+      logger.warn(
+        {
+          workspaceId: owner.sId,
+          prefix,
+          scope,
+          pageFetchCount,
+          objectCount: gcsFiles.length,
+        },
+        "GCS mount file listing required multiple list requests; prefix has many objects."
       );
     }
-  }
 
-  const folderEntries: GCSMountDirectoryEntry[] = folderPlaceholders.flatMap(
-    (f) => {
-      const trimmed = f.name.replace(/\/$/, "");
-      const name = trimmed.split("/").pop() ?? "";
-      // Skip hidden folders (name starting with "."), except the tool outputs folder which is
-      // surfaced to users despite its dot prefix.
-      if (
-        !name ||
-        (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)
-      ) {
-        return [];
+    // GCS folder placeholders are zero-byte objects whose path ends with "/".
+    const folderPlaceholders = gcsFiles.filter((f) => f.name.endsWith("/"));
+    const regularFiles = gcsFiles.filter((f) => {
+      if (f.name.endsWith("/")) {
+        return false;
       }
 
-      return [
-        makeDirectoryEntry(
-          {
-            fileName: name,
-            relativeFilePath: trimmed.slice(prefix.length),
-            sizeBytes: 0,
-            lastModifiedMs: isString(f.metadata.updated)
-              ? new Date(f.metadata.updated).getTime()
-              : 0,
-          },
-          scope
-        ),
-      ];
-    }
-  );
+      if (includeProcessed) {
+        return true;
+      }
 
-  const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
-    const metadata = gcsFile.metadata;
-    const contentType = isString(metadata.contentType)
-      ? metadata.contentType
-      : "application/octet-stream";
-    const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
+      const name = f.name.split("/").pop() ?? "";
+      return !name.includes(".processed.");
+    });
 
-    return makeFileEntry(
-      {
-        fileName: gcsFile.name.split("/").pop() ?? gcsFile.name,
-        relativeFilePath: gcsFile.name.slice(prefix.length),
-        sizeBytes: Number(metadata.size ?? 0),
-        contentType,
-        lastModifiedMs: isString(metadata.updated)
-          ? new Date(metadata.updated).getTime()
-          : 0,
-        fileId: fileResource?.sId ?? null,
-      },
-      scope,
-      owner.sId
+    // GCS files are listed under `pods/` but some FileResource rows still store the
+    // `projects/` form. Query both shapes so old rows still resolve.
+    const mountPaths = regularFiles.map((f) => f.name);
+    const legacyMountPaths = mountPaths.map((p) =>
+      p.replace("/pods/", "/projects/")
     );
-  });
+    const fileResources = await FileResource.fetchByMountFilePaths(auth, [
+      ...mountPaths,
+      ...legacyMountPaths,
+    ]);
+    const fileResourceByMountPath = new Map<string, FileResource>();
+    for (const r of fileResources) {
+      if (r.mountFilePath) {
+        fileResourceByMountPath.set(
+          r.mountFilePath.replace("/projects/", "/pods/"),
+          r
+        );
+      }
+    }
 
-  return [...folderEntries, ...fileEntries];
+    const folderEntries: GCSMountDirectoryEntry[] = folderPlaceholders.flatMap(
+      (f) => {
+        const trimmed = f.name.replace(/\/$/, "");
+        const name = trimmed.split("/").pop() ?? "";
+        // Skip hidden folders (name starting with "."), except the tool outputs folder which is
+        // surfaced to users despite its dot prefix.
+        if (
+          !name ||
+          (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)
+        ) {
+          return [];
+        }
+
+        return [
+          makeDirectoryEntry(
+            {
+              fileName: name,
+              relativeFilePath: trimmed.slice(prefix.length),
+              sizeBytes: 0,
+              lastModifiedMs: isString(f.metadata.updated)
+                ? new Date(f.metadata.updated).getTime()
+                : 0,
+            },
+            scope
+          ),
+        ];
+      }
+    );
+
+    const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
+      const metadata = gcsFile.metadata;
+      const contentType = isString(metadata.contentType)
+        ? metadata.contentType
+        : "application/octet-stream";
+      const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
+
+      return makeFileEntry(
+        {
+          fileName: gcsFile.name.split("/").pop() ?? gcsFile.name,
+          relativeFilePath: gcsFile.name.slice(prefix.length),
+          sizeBytes: Number(metadata.size ?? 0),
+          contentType,
+          lastModifiedMs: isString(metadata.updated)
+            ? new Date(metadata.updated).getTime()
+            : 0,
+          fileId: fileResource?.sId ?? null,
+        },
+        scope,
+        owner.sId
+      );
+    });
+
+    return new Ok([...folderEntries, ...fileEntries]);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

`listGCSMountFiles` called `bucket.getAllFilesByPrefix` without error handling. A transient GCS network error ("socket hang up") propagated as an unhandled exception, logging as "Unhandled API Error" on the `GET /api/v1/w/:wId/spaces/:spaceId/project_files` route.

Changed `listGCSMountFiles` return type from `Promise<GCSMountEntry[]>` to `Promise<Result<GCSMountEntry[], Error>>` (consistent with all other functions in the same file), and added proper error handling in the route handler (returns 500 instead of crashing).

## Tests

Added a test case covering the GCS error path (500 response). Updated existing tests to unwrap the `Result` type.
