### PR TITLE
[CODEOWNERS] add llm-router-owners for front/lib/api/llm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,5 @@
 /front/lib/models/                    @dust-tt/data-model-owners
 /front/lib/resources/storage/models/  @dust-tt/data-model-owners
 /front/migrations/db/                 @dust-tt/data-model-owners
+
+/front/lib/api/llm/                   @dust-tt/llm-router-owners


### PR DESCRIPTION
## Description

Add a CODEOWNERS rule assigning `@dust-tt/llm-router-owners` as owners of `/front/lib/api/llm/`.

## Tests

No.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed
- No deploy required (CODEOWNERS only)