### PR TITLE
[LLM] Add Vertex model ID mapping for Claude Opus 4.8

### DIFF
--- a/front/lib/api/llm/clients/anthropic/types.ts
+++ b/front/lib/api/llm/clients/anthropic/types.ts
@@ -116,6 +116,7 @@ export const VERTEX_MODEL_ID_MAP: Partial<Record<ModelIdType, string>> = {
   [CLAUDE_SONNET_4_6_MODEL_ID]: "claude-sonnet-4-6",
   [CLAUDE_OPUS_4_6_MODEL_ID]: "claude-opus-4-6",
   [CLAUDE_OPUS_4_7_MODEL_ID]: "claude-opus-4-7",
+  [CLAUDE_OPUS_4_8_MODEL_ID]: "claude-opus-4-8",
   [CLAUDE_4_5_OPUS_20251101_MODEL_ID]: "claude-opus-4-5@20251101",
   [CLAUDE_4_5_HAIKU_20251001_MODEL_ID]: "claude-haiku-4-5@20251001",
 };


### PR DESCRIPTION
## Description

Add the `claude-opus-4-8` entry to `VERTEX_MODEL_ID_MAP` so Claude Opus 4.8 resolves correctly when served via Vertex.

## Tests

Tested in front-edge.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`