### PR TITLE
[connectors] Gate microsoft sensitivity-labels reconciliation workflow on non-empty labels + FF

### DIFF
--- a/connectors/scripts/microsoft_terminate_sensitivity_labels_workflows.ts
+++ b/connectors/scripts/microsoft_terminate_sensitivity_labels_workflows.ts
@@ -6,9 +6,7 @@
  *   npx ts-node scripts/microsoft_terminate_sensitivity_labels_workflows.ts [--execute]
  */
 
-import {
-  microsoftSensitivityLabelsReconciliationWorkflowId,
-} from "@connectors/connectors/microsoft/temporal/workflows";
+import { microsoftSensitivityLabelsReconciliationWorkflowId } from "@connectors/connectors/microsoft/temporal/workflows";
 import { terminateWorkflow } from "@connectors/lib/temporal";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { MicrosoftConfigurationResource } from "@connectors/resources/microsoft_resource";
@@ -43,7 +41,10 @@ makeScript({}, async ({ execute }, logger) => {
     );
     if (execute) {
       await terminateWorkflow(workflowId);
-      logger.info({ connectorId: connector.id, workflowId }, "Terminated workflow");
+      logger.info(
+        { connectorId: connector.id, workflowId },
+        "Terminated workflow"
+      );
     } else {
       logger.info(
         { connectorId: connector.id, workflowId },

--- a/connectors/scripts/microsoft_terminate_sensitivity_labels_workflows.ts
+++ b/connectors/scripts/microsoft_terminate_sensitivity_labels_workflows.ts
@@ -1,0 +1,54 @@
+/**
+ * Terminates microsoft-sensitivityLabelsReconciliation-* workflows for connectors
+ * where allowedSensitivityLabels is null or empty (i.e. should not be running).
+ *
+ * Usage:
+ *   npx ts-node scripts/microsoft_terminate_sensitivity_labels_workflows.ts [--execute]
+ */
+
+import {
+  microsoftSensitivityLabelsReconciliationWorkflowId,
+} from "@connectors/connectors/microsoft/temporal/workflows";
+import { terminateWorkflow } from "@connectors/lib/temporal";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { MicrosoftConfigurationResource } from "@connectors/resources/microsoft_resource";
+
+import { makeScript } from "./helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const connectors = await ConnectorResource.listByType("microsoft", {});
+  logger.info({ count: connectors.length }, "Fetched Microsoft connectors");
+
+  const configs = await MicrosoftConfigurationResource.fetchByConnectorIds(
+    connectors.map((c) => c.id)
+  );
+
+  const toTerminate = connectors.filter((connector) => {
+    const config = configs[connector.id];
+    return (
+      !config ||
+      !config.allowedSensitivityLabels ||
+      config.allowedSensitivityLabels.length === 0
+    );
+  });
+
+  logger.info(
+    { count: toTerminate.length },
+    "Connectors with no allowed sensitivity labels (workflow should not be running)"
+  );
+
+  for (const connector of toTerminate) {
+    const workflowId = microsoftSensitivityLabelsReconciliationWorkflowId(
+      connector.id
+    );
+    if (execute) {
+      await terminateWorkflow(workflowId);
+      logger.info({ connectorId: connector.id, workflowId }, "Terminated workflow");
+    } else {
+      logger.info(
+        { connectorId: connector.id, workflowId },
+        "DRY RUN: Would terminate workflow"
+      );
+    }
+  }
+});

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -45,7 +45,6 @@ import {
   microsoftIncrementalSyncWorkflowId,
   microsoftSensitivityLabelsReconciliationWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
-import { getDustAPI } from "@connectors/lib/api/dust_api";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { SelectedSiteMetadata } from "@connectors/lib/models/microsoft";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
@@ -68,7 +67,6 @@ import type {
   DataSourceConfig,
 } from "@connectors/types";
 import { concurrentExecutor } from "@connectors/types/shared/utils/async_utils";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { isString } from "@connectors/types/shared/utils/general";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
 import {
@@ -82,28 +80,13 @@ import { Client } from "@microsoft/microsoft-graph-client";
 import type { Site } from "@microsoft/microsoft-graph-types";
 import { decodeJwt } from "jose";
 
-async function shouldStartSensitivityLabelsWorkflow(
-  connector: ConnectorResource,
+function shouldStartSensitivityLabelsWorkflow(
   config: MicrosoftConfigurationResource
-): Promise<boolean> {
-  if (
-    !config.allowedSensitivityLabels ||
-    config.allowedSensitivityLabels.length === 0
-  ) {
-    return false;
-  }
-  const dustAPI = getDustAPI(dataSourceConfigFromConnector(connector), {
-    useInternalAPI: true,
-  });
-  const featureFlagsRes = await dustAPI.getWorkspaceFeatureFlags();
-  if (featureFlagsRes.isErr()) {
-    logger.warn(
-      { connectorId: connector.id, error: featureFlagsRes.error },
-      "Failed to fetch feature flags for sensitivity labels workflow gate, skipping launch."
-    );
-    return false;
-  }
-  return featureFlagsRes.value.includes("sensitivity_labels");
+): boolean {
+  return (
+    !!config.allowedSensitivityLabels &&
+    config.allowedSensitivityLabels.length > 0
+  );
 }
 
 export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
@@ -180,7 +163,7 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     const config = await MicrosoftConfigurationResource.fetchByConnectorId(
       connector.id
     );
-    if (config && (await shouldStartSensitivityLabelsWorkflow(connector, config))) {
+    if (config && shouldStartSensitivityLabelsWorkflow(config)) {
       const sensitivityLabelsReconciliationRes =
         await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
           connector.id
@@ -650,17 +633,10 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       return gcRes;
     }
 
-    const connector = await ConnectorResource.fetchById(this.connectorId);
-    if (!connector) {
-      return new Err(new Error(`Connector ${this.connectorId} not found`));
-    }
     const config = await MicrosoftConfigurationResource.fetchByConnectorId(
       this.connectorId
     );
-    if (
-      config &&
-      (await shouldStartSensitivityLabelsWorkflow(connector, config))
-    ) {
+    if (config && shouldStartSensitivityLabelsWorkflow(config)) {
       const sensitivityLabelsReconciliationRes =
         await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
           this.connectorId
@@ -737,23 +713,12 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           );
           return new Ok(undefined);
         }
-        // labels is non-empty — check FF before launching the workflow.
-        const dustAPI = getDustAPI(
-          dataSourceConfigFromConnector(connector),
-          { useInternalAPI: true }
-        );
-        const featureFlagsRes = await dustAPI.getWorkspaceFeatureFlags();
-        if (
-          featureFlagsRes.isOk() &&
-          featureFlagsRes.value.includes("sensitivity_labels")
-        ) {
-          const workflowRes =
-            await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
-              this.connectorId
-            );
-          if (workflowRes.isErr()) {
-            return workflowRes;
-          }
+        const workflowRes =
+          await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+            this.connectorId
+          );
+        if (workflowRes.isErr()) {
+          return workflowRes;
         }
         return new Ok(undefined);
       }

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -45,6 +45,7 @@ import {
   microsoftIncrementalSyncWorkflowId,
   microsoftSensitivityLabelsReconciliationWorkflowId,
 } from "@connectors/connectors/microsoft/temporal/workflows";
+import { getDustAPI } from "@connectors/lib/api/dust_api";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { SelectedSiteMetadata } from "@connectors/lib/models/microsoft";
 import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
@@ -67,6 +68,7 @@ import type {
   DataSourceConfig,
 } from "@connectors/types";
 import { concurrentExecutor } from "@connectors/types/shared/utils/async_utils";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { isString } from "@connectors/types/shared/utils/general";
 import type { ConnectorProvider, Result } from "@dust-tt/client";
 import {
@@ -79,6 +81,30 @@ import {
 import { Client } from "@microsoft/microsoft-graph-client";
 import type { Site } from "@microsoft/microsoft-graph-types";
 import { decodeJwt } from "jose";
+
+async function shouldStartSensitivityLabelsWorkflow(
+  connector: ConnectorResource,
+  config: MicrosoftConfigurationResource
+): Promise<boolean> {
+  if (
+    !config.allowedSensitivityLabels ||
+    config.allowedSensitivityLabels.length === 0
+  ) {
+    return false;
+  }
+  const dustAPI = getDustAPI(dataSourceConfigFromConnector(connector), {
+    useInternalAPI: true,
+  });
+  const featureFlagsRes = await dustAPI.getWorkspaceFeatureFlags();
+  if (featureFlagsRes.isErr()) {
+    logger.warn(
+      { connectorId: connector.id, error: featureFlagsRes.error },
+      "Failed to fetch feature flags for sensitivity labels workflow gate, skipping launch."
+    );
+    return false;
+  }
+  return featureFlagsRes.value.includes("sensitivity_labels");
+}
 
 export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   readonly provider: ConnectorProvider = "microsoft";
@@ -151,12 +177,17 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       throw gcRes.error;
     }
 
-    const sensitivityLabelsReconciliationRes =
-      await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
-        connector.id
-      );
-    if (sensitivityLabelsReconciliationRes.isErr()) {
-      throw sensitivityLabelsReconciliationRes.error;
+    const config = await MicrosoftConfigurationResource.fetchByConnectorId(
+      connector.id
+    );
+    if (config && (await shouldStartSensitivityLabelsWorkflow(connector, config))) {
+      const sensitivityLabelsReconciliationRes =
+        await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+          connector.id
+        );
+      if (sensitivityLabelsReconciliationRes.isErr()) {
+        throw sensitivityLabelsReconciliationRes.error;
+      }
     }
 
     return new Ok(connector.id.toString());
@@ -619,12 +650,24 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
       return gcRes;
     }
 
-    const sensitivityLabelsReconciliationRes =
-      await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
-        this.connectorId
-      );
-    if (sensitivityLabelsReconciliationRes.isErr()) {
-      return sensitivityLabelsReconciliationRes;
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(new Error(`Connector ${this.connectorId} not found`));
+    }
+    const config = await MicrosoftConfigurationResource.fetchByConnectorId(
+      this.connectorId
+    );
+    if (
+      config &&
+      (await shouldStartSensitivityLabelsWorkflow(connector, config))
+    ) {
+      const sensitivityLabelsReconciliationRes =
+        await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+          this.connectorId
+        );
+      if (sensitivityLabelsReconciliationRes.isErr()) {
+        return sensitivityLabelsReconciliationRes;
+      }
     }
 
     return new Ok(undefined);
@@ -688,12 +731,29 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           );
         }
         await config.update({ allowedSensitivityLabels: labels });
-        const workflowRes =
-          await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
-            this.connectorId
+        if (!labels || labels.length === 0) {
+          await terminateWorkflow(
+            microsoftSensitivityLabelsReconciliationWorkflowId(this.connectorId)
           );
-        if (workflowRes.isErr()) {
-          return workflowRes;
+          return new Ok(undefined);
+        }
+        // labels is non-empty — check FF before launching the workflow.
+        const dustAPI = getDustAPI(
+          dataSourceConfigFromConnector(connector),
+          { useInternalAPI: true }
+        );
+        const featureFlagsRes = await dustAPI.getWorkspaceFeatureFlags();
+        if (
+          featureFlagsRes.isOk() &&
+          featureFlagsRes.value.includes("sensitivity_labels")
+        ) {
+          const workflowRes =
+            await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+              this.connectorId
+            );
+          if (workflowRes.isErr()) {
+            return workflowRes;
+          }
         }
         return new Ok(undefined);
       }


### PR DESCRIPTION
## Summary

- Gate `microsoft-sensitivityLabelsReconciliation-*` workflows so they only start when `allowedSensitivityLabels` is non-empty **and** the `sensitivity_labels` feature flag is enabled for the workspace
- Fixed three launch points: connector creation, resume/unpause, and config update (`setConfigurationKey` for `microsoftSensitivityLabelsToInclude`)
- Config update now **terminates** the running workflow when labels are cleared (set to empty/null)
- Adds one-off script `connectors/scripts/microsoft_terminate_sensitivity_labels_workflows.ts` to terminate stale workflows already running for connectors with no allowed labels

## Changes

**`connectors/src/connectors/microsoft/index.ts`**
- New `shouldStartSensitivityLabelsWorkflow(connector, config)` helper: checks labels non-empty + FF via internal DustAPI
- `create`: gates launch behind the helper (labels are always null at creation, so this is a no-op today but future-proof)
- `resume`: fetches connector + config then gates via helper
- `setConfigurationKey` for `microsoftSensitivityLabelsToInclude`: terminates on clear; checks FF inline before launch (avoids using stale in-memory config state after `config.update`)

**`connectors/scripts/microsoft_terminate_sensitivity_labels_workflows.ts`**
- Lists all Microsoft connectors, filters those with no allowed labels, terminates their reconciliation workflow
- Supports `--execute` flag (dry-run by default)
