### PR TITLE
[front] Stop biasing the analytics source filter to a few origins

### DIFF
--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -66,8 +66,10 @@ export const usageFilterSchema = {
     .string()
     .optional()
     .describe(
-      "Filter to a single message origin (context_origin), e.g. web, slack, " +
-        "api, extension, cli, or 'unknown' for messages with no recorded origin."
+      "Filter to a single message origin (context_origin) — the source a " +
+        "message came from. Many origins exist (channels, integrations, " +
+        "triggers, and more); do not assume a fixed short list. Use 'unknown' " +
+        "to match messages with no recorded origin."
     ),
   agentIds: z
     .array(z.string())


### PR DESCRIPTION
## Description

The shared source filter enumerated only "web, slack, api, extension, cli", which led the agent to assume those were the only message origins and miss others (e.g. Trigger). Drop the partial example list, signal that many origins exist, and keep the 'unknown' special-value note.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
