### PR TITLE
Handle no-seat errors

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -33,6 +33,7 @@ app.get(
         poolCreditState: "active",
         programmaticCreditStatus: "active",
         balanceThresholdReached: false,
+        noSeat: false,
       });
     }
 
@@ -43,7 +44,7 @@ app.get(
       balanceThresholdReached,
     ] = await Promise.all([
       getWorkspaceCreditPoolStatus(workspace.sId),
-      isUserBlocked(workspace.sId, user.sId),
+      isUserBlocked(workspace, user),
       getWorkspaceProgrammaticCreditStatus(workspace.sId),
       isWorkspaceBalanceThresholdReached(workspace.sId),
     ]);
@@ -54,6 +55,8 @@ app.get(
     } else if (await isUserAwuWarned(workspace.sId, user.sId)) {
       awuStatus = "warned";
     }
+
+    const noSeat = blockedReason === "no_seat";
 
     let programmaticCreditStatus: ProgrammaticCreditStatus = "active";
     if (programmaticState === "depleted") {
@@ -70,6 +73,7 @@ app.get(
       poolCreditState,
       programmaticCreditStatus,
       balanceThresholdReached,
+      noSeat,
     });
   }
 );

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -2,6 +2,7 @@ import { FairUsageModal } from "@app/components/FairUsageModal";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
+import type { SubmitMessageError } from "@app/types/assistant/conversation";
 import type { SubscriptionType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -27,6 +28,31 @@ export type WorkspaceLimit =
   | "pool_credits_exhausted"
   | "user_credits_exhausted"
   | "no_seat";
+
+// Maps a message-send failure to the blocking popup it should open, or null when
+// the failure is transient and should be surfaced as a notification instead.
+export function getWorkspaceLimitForSubmitError(
+  type: SubmitMessageError["type"]
+): WorkspaceLimit | null {
+  switch (type) {
+    case "plan_limit_reached_error":
+      return "message_limit";
+    case "credits_exhausted_error":
+      return "pool_credits_exhausted";
+    case "user_cap_reached_error":
+      return "user_credits_exhausted";
+    case "no_seat_error":
+      return "no_seat";
+    case "user_not_found":
+    case "attachment_upload_error":
+    case "message_send_error":
+    case "content_too_large":
+      return null;
+    default:
+      assertNeverAndIgnore(type);
+      return null;
+  }
+}
 
 function formatLimitTimeframe(timeframe: string): string {
   switch (timeframe) {

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -1,5 +1,8 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
-import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
+import {
+  getWorkspaceLimitForSubmitError,
+  ReachedLimitPopup,
+} from "@app/components/app/ReachedLimitPopup";
 import { AgentBrowserContainer } from "@app/components/assistant/conversation/AgentBrowserContainer";
 import { ConversationViewer } from "@app/components/assistant/conversation/ConversationViewer";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
@@ -100,25 +103,15 @@ export function ConversationContainerVirtuoso({
   // is a transient error shown as a notification.
   const handleSubmitMessageError = useCallback(
     (error: SubmitMessageError) => {
-      switch (error.type) {
-        case "plan_limit_reached_error":
-          setLimitReachedCode("message_limit");
-          break;
-        case "credits_exhausted_error":
-          setLimitReachedCode("pool_credits_exhausted");
-          break;
-        case "user_cap_reached_error":
-          setLimitReachedCode("user_credits_exhausted");
-          break;
-        case "no_seat_error":
-          setLimitReachedCode("no_seat");
-          break;
-        default:
-          sendNotification({
-            title: error.title,
-            description: error.message,
-            type: "error",
-          });
+      const limitCode = getWorkspaceLimitForSubmitError(error.type);
+      if (limitCode) {
+        setLimitReachedCode(limitCode);
+      } else {
+        sendNotification({
+          title: error.title,
+          description: error.message,
+          type: "error",
+        });
       }
     },
     [sendNotification]

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -13,9 +13,13 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
+import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { ConversationListItemType } from "@app/types/assistant/conversation";
+import type {
+  ConversationListItemType,
+  SubmitMessageError,
+} from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import {
   toMentionType,
@@ -86,6 +90,40 @@ export function ConversationContainerVirtuoso({
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // A seatless member can never send a message. We surface this up-front rather
+  // than relying on the deferred background message-post failure, which lands
+  // after navigation and would otherwise leave behind an empty conversation.
+  const { noSeat } = useWorkspaceUsageStatus({ owner });
+
+  // Maps a message-send failure to the right surface: blocking limits (no seat,
+  // credits, per-user cap, plan limit) open the dedicated popup, everything else
+  // is a transient error shown as a notification.
+  const handleSubmitMessageError = useCallback(
+    (error: SubmitMessageError) => {
+      switch (error.type) {
+        case "plan_limit_reached_error":
+          setLimitReachedCode("message_limit");
+          break;
+        case "credits_exhausted_error":
+          setLimitReachedCode("pool_credits_exhausted");
+          break;
+        case "user_cap_reached_error":
+          setLimitReachedCode("user_credits_exhausted");
+          break;
+        case "no_seat_error":
+          setLimitReachedCode("no_seat");
+          break;
+        default:
+          sendNotification({
+            title: error.title,
+            description: error.message,
+            type: "error",
+          });
+      }
+    },
+    [sendNotification]
+  );
+
   const handleConversationCreation = useCallback(
     async (
       input: string,
@@ -101,6 +139,18 @@ export function ConversationContainerVirtuoso({
         });
       }
 
+      // Block seatless members before creating the conversation: the backend
+      // would reject the message anyway, and doing it here shows the popup
+      // immediately without leaving an empty conversation behind.
+      if (noSeat) {
+        setLimitReachedCode("no_seat");
+        return new Err({
+          code: "internal_error",
+          name: "NoSeat",
+          message: "You don't have a seat in this workspace.",
+        });
+      }
+
       setIsSubmitting(true);
 
       const conversationRes = await createConversationWithMessage({
@@ -113,26 +163,17 @@ export function ConversationContainerVirtuoso({
           richMentions: mentions,
         },
         // Navigate as soon as the conversation exists; the first message is posted
-        // in the background by useCreateConversationWithMessage.
+        // in the background by useCreateConversationWithMessage. Background-post
+        // failures (e.g. no seat, credits) are surfaced through `onError` so the
+        // same blocking popup shows even though the conversation already exists.
         deferMessage: true,
+        onError: handleSubmitMessageError,
       });
 
       setIsSubmitting(false);
 
       if (conversationRes.isErr()) {
-        if (conversationRes.error.type === "plan_limit_reached_error") {
-          setLimitReachedCode("message_limit");
-        } else if (conversationRes.error.type === "credits_exhausted_error") {
-          setLimitReachedCode("pool_credits_exhausted");
-        } else if (conversationRes.error.type === "user_cap_reached_error") {
-          setLimitReachedCode("user_credits_exhausted");
-        } else {
-          sendNotification({
-            title: conversationRes.error.title,
-            description: conversationRes.error.message,
-            type: "error",
-          });
-        }
+        handleSubmitMessageError(conversationRes.error);
 
         return new Err({
           code: "internal_error",
@@ -161,10 +202,11 @@ export function ConversationContainerVirtuoso({
     },
     [
       isSubmitting,
+      noSeat,
       mutateConversations,
       owner,
       router,
-      sendNotification,
+      handleSubmitMessageError,
       createConversationWithMessage,
       clientSideMCPServerIds,
     ]

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1227,6 +1227,8 @@ export const ConversationViewer = ({
             setLimitReachedCode?.("pool_credits_exhausted");
           } else if (result.error.type === "user_cap_reached_error") {
             setLimitReachedCode?.("user_credits_exhausted");
+          } else if (result.error.type === "no_seat_error") {
+            setLimitReachedCode?.("no_seat");
           } else {
             sendNotification({
               title: result.error.title,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1,4 +1,5 @@
 import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
+import { getWorkspaceLimitForSubmitError } from "@app/components/app/ReachedLimitPopup";
 import { ConversationViewerEmptyState } from "@app/components/assistant/ConversationViewerEmptyState";
 import { AgentInputBar } from "@app/components/assistant/conversation/AgentInputBar";
 import { ConversationBranchApprovalModal } from "@app/components/assistant/conversation/ConversationBranchApprovalModal";
@@ -1221,14 +1222,9 @@ export const ConversationViewer = ({
         const result = await submitMessage(messageData);
 
         if (result.isErr()) {
-          if (result.error.type === "plan_limit_reached_error") {
-            setLimitReachedCode?.("message_limit");
-          } else if (result.error.type === "credits_exhausted_error") {
-            setLimitReachedCode?.("pool_credits_exhausted");
-          } else if (result.error.type === "user_cap_reached_error") {
-            setLimitReachedCode?.("user_credits_exhausted");
-          } else if (result.error.type === "no_seat_error") {
-            setLimitReachedCode?.("no_seat");
+          const limitCode = getWorkspaceLimitForSubmitError(result.error.type);
+          if (limitCode) {
+            setLimitReachedCode?.(limitCode);
           } else {
             sendNotification({
               title: result.error.title,

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -211,6 +211,7 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
     poolCreditState,
     programmaticCreditStatus,
     balanceThresholdReached,
+    noSeat,
   } = useWorkspaceUsageStatus({ owner });
 
   // Pool balance and programmatic cap banners are only shown to admins who
@@ -262,6 +263,17 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
   );
 
   const banner = ((): StatusBannerProps | null => {
+    // A seatless member cannot run agents at all, so this takes precedence over
+    // every credit-related banner.
+    if (noSeat) {
+      return {
+        variant: "danger",
+        title: "You don't have a seat in this workspace",
+        description:
+          "You can no longer run agents. Contact your admin to be assigned a seat.",
+      };
+    }
+
     if (showPoolBanner) {
       return {
         variant: isPoolDepleted ? "danger" : "warning",

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -52,6 +52,7 @@ export function useCreateConversationWithMessage({
       title,
       visibility = "unlisted",
       deferMessage = false,
+      onError,
     }: {
       messageData: {
         input: string;
@@ -74,6 +75,10 @@ export function useCreateConversationWithMessage({
       // posted in the background so the caller can navigate as soon as the `sId`
       // is known.
       deferMessage?: boolean;
+      // Called when the deferred background message-post fails. The caller decides
+      // how to surface it (e.g. a blocking popup for limit errors). When omitted,
+      // background failures fall back to an error notification.
+      onError?: (err: SubmitMessageError) => void;
     }): Promise<Result<ConversationType, SubmitMessageError>> => {
       if (!user) {
         return new Err({
@@ -140,13 +145,15 @@ export function useCreateConversationWithMessage({
             origin,
             skipToolsValidation,
             profilePictureUrl: user.image,
-            onError: (err) => {
-              sendNotification({
-                title: err.title,
-                description: err.message,
-                type: "error",
-              });
-            },
+            onError:
+              onError ??
+              ((err) => {
+                sendNotification({
+                  title: err.title,
+                  description: err.message,
+                  type: "error",
+                });
+              }),
           }).finally(() => {
             clearPendingFirstMessage(conversationId);
           });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2472,31 +2472,22 @@ async function checkMessagesLimit(
   const plan = auth.subscription()?.plan;
   const user = auth.user();
 
-  if (user) {
-    const membership =
-      await MembershipResource.getActiveMembershipOfUserInWorkspace({
-        user,
-        workspace: owner,
-      });
-    if (membership?.seatType === "none") {
+  if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
+    const blockedReason = user
+      ? await isUserBlocked(owner, user)
+      : (await isApiBlocked(owner.sId))
+        ? ("credits_exhausted" as const)
+        : null;
+    if (blockedReason === "no_seat") {
       return new Err({
         status_code: 403,
         api_error: {
           type: "no_seat",
           message:
-            "You don't have a seat in this workspace. Ask a workspace admin " +
-            "to assign you one to start sending messages.",
+            "You don't have a seat in this workspace. Contact your admin to be assigned one.",
         },
       });
     }
-  }
-
-  if (owner.metronomeCustomerId && plan && isCreditPricedPlan(plan)) {
-    const blockedReason = user
-      ? await isUserBlocked(owner.sId, user.sId)
-      : (await isApiBlocked(owner.sId))
-        ? ("credits_exhausted" as const)
-        : null;
     if (blockedReason === "user_cap_reached") {
       return new Err({
         status_code: 403,

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -2,7 +2,12 @@ import {
   getWorkspaceCreditPoolStatus,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workspace = { sId: "ws_test" } as LightWorkspaceType;
+const user = { sId: "u_test" } as unknown as UserResource;
 
 const {
   redisValues,
@@ -72,6 +77,9 @@ vi.mock("@app/logger/logger", () => ({
 describe("isUserBlocked", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // `clearAllMocks` resets call history but not implementations, so reset the
+    // membership mock to its default (no membership) between tests.
+    mockGetActiveMembershipOfUserInWorkspace.mockReset();
     redisValues.clear();
   });
 
@@ -79,19 +87,29 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
     redisValues.set("metronome:pool_credit_status:ws_test", "active");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
     expect(mockFetchWorkspaceById).not.toHaveBeenCalled();
     expect(mockFetchUserById).not.toHaveBeenCalled();
-    expect(mockGetActiveMembershipOfUserInWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns 'no_seat' when the user has no seat in the workspace", async () => {
+    mockGetActiveMembershipOfUserInWorkspace.mockResolvedValue({
+      seatType: "none",
+    });
+
+    const blocked = await isUserBlocked(workspace, user);
+
+    expect(blocked).toBe("no_seat");
+    expect(mockRunOnRedis).not.toHaveBeenCalled();
   });
 
   it("returns 'user_cap_reached' when the user is capped, even if the pool is also depleted", async () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "capped");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
   });
@@ -100,7 +118,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
     redisValues.set("metronome:pool_credit_status:ws_test", "active");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -109,7 +127,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "user_seat");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -121,7 +139,7 @@ describe("isUserBlocked", () => {
     );
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -130,7 +148,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("credits_exhausted");
   });
@@ -142,7 +160,7 @@ describe("isUserBlocked", () => {
     );
     redisValues.set("metronome:pool_credit_status:ws_test", "active");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -154,7 +172,7 @@ describe("isUserBlocked", () => {
     );
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("credits_exhausted");
   });
@@ -167,7 +185,7 @@ describe("isUserBlocked", () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
     redisValues.set("metronome:pool_credit_status:ws_test", poolState);
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -189,7 +207,7 @@ describe("isUserBlocked", () => {
       creditState: "capped",
     });
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
     expect(mockFetchUserById).toHaveBeenCalled();
@@ -203,7 +221,7 @@ describe("isUserBlocked", () => {
       poolCreditState: "active",
     });
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
     expect(redisValues.get("metronome:pool_credit_status:ws_test")).toBe(
@@ -220,7 +238,7 @@ describe("isUserBlocked", () => {
     });
     mockGetActiveMembershipOfUserInWorkspace.mockResolvedValue(null);
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBeNull();
   });
@@ -236,7 +254,7 @@ describe("isUserBlocked", () => {
       creditState: "capped",
     });
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("user_cap_reached");
     expect(redisValues.get("metronome:user_credit_state:ws_test:u_test")).toBe(
@@ -256,7 +274,7 @@ describe("isUserBlocked", () => {
       poolCreditState: "depleted",
     });
 
-    const blocked = await isUserBlocked("ws_test", "u_test");
+    const blocked = await isUserBlocked(workspace, user);
 
     expect(blocked).toBe("credits_exhausted");
     expect(redisValues.get("metronome:user_credit_state:ws_test:u_test")).toBe(

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -7,7 +7,7 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const workspace = { sId: "ws_test" } as LightWorkspaceType;
-const user = { sId: "u_test" } as unknown as UserResource;
+const user = { sId: "u_test" } as UserResource;
 
 const {
   redisValues,

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -47,7 +47,10 @@ import {
 import type { MaxAwuCreditsTimeframeType, PlanType } from "@app/types/plan";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
-export type UserBlockedReason = "credits_exhausted" | "user_cap_reached";
+export type UserBlockedReason =
+  | "credits_exhausted"
+  | "user_cap_reached"
+  | "no_seat";
 
 export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
 
@@ -68,6 +71,9 @@ export type GetWorkspaceUsageStatusResponseBody = {
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditStatus: ProgrammaticCreditStatus;
   balanceThresholdReached: boolean;
+  // True when the current user has no billable seat in the workspace and is
+  // therefore blocked from sending messages.
+  noSeat: boolean;
 };
 
 export type GetFairUseCreditsResponseBody = {
@@ -215,9 +221,21 @@ function deriveBlockedReason({
 }
 
 export async function isUserBlocked(
-  workspaceId: string,
-  userId: string
+  workspace: LightWorkspaceType,
+  user: UserResource
 ): Promise<UserBlockedReason | null> {
+  const workspaceId = workspace.sId;
+  const userId = user.sId;
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (membership?.seatType === "none") {
+    return "no_seat";
+  }
+
   const [creditStateRaw, poolStatusRaw] = await runOnRedis(
     { origin: REDIS_ORIGIN },
     async (client) =>

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -286,6 +286,7 @@ export function useWorkspaceUsageStatus({
     poolCreditState: data?.poolCreditState ?? "active",
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
     balanceThresholdReached: data?.balanceThresholdReached ?? false,
+    noSeat: data?.noSeat ?? false,
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }


### PR DESCRIPTION
## Description

Block workspace members who have no billable seat (`seatType: "none"`) from sending messages on credit-priced workspaces, and surface it clearly in the UI.

- `isUserBlocked` now returns a `no_seat` reason when the user's active membership has no seat; `postUserMessage` rejects with a `403 no_seat` error.
- Conversation send flows map `no_seat` to a "No seat assigned" popup — proactively on new-conversation creation (so no empty conversation is left behind) and via the backend error on replies.
- `usage-status` returns a `noSeat` flag, and the sidebar shows a "You don't have a seat in this workspace" banner.

## Tests

- Added unit coverage for the `no_seat` branch in `isUserBlocked` and a functional test asserting `postUserMessage` returns `403 no_seat` for a seatless member on a credit-priced workspace.
- Manually verified the popup (new + existing conversations) and the banner.

## Risk

Low. The gate only applies to credit-priced (Metronome) workspaces; seated users are unaffected. Safe to roll back.

## Deploy Plan

Standard deploy, no migration required.
