### PR TITLE
[front] UsagePage: hide pool, top-up, and settings sections on free plan

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -18,7 +18,11 @@ import {
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
-import { isEnterprisePlanPrefix, isUpgraded } from "@app/lib/plans/plan_codes";
+import {
+  isEnterprisePlanPrefix,
+  isFreePlan,
+  isUpgraded,
+} from "@app/lib/plans/plan_codes";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
@@ -385,6 +389,7 @@ export function UsagePage() {
 
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);
+  const isFreePlanWorkspace = isFreePlan(plan.code);
 
   const isManualInvitationsEnabled =
     owner.metadata?.disableManualInvitations !== true;
@@ -523,66 +528,69 @@ export function UsagePage() {
           </Page.P>
         </Page.Vertical>
 
-        <Page.Vertical gap="xs" align="stretch">
-          {isAwuPoolSummaryError && (
-            <ContentMessage
-              title="Failed to load Workspace Credits Pool"
-              icon={AlertCircle}
-              variant="warning"
-            >
-              An error occurred while loading your Workspace Credits Pool data.
-              Please refresh the page or contact support if the issue persists.
-            </ContentMessage>
-          )}
+        {!isFreePlanWorkspace && (
+          <Page.Vertical gap="xs" align="stretch">
+            {isAwuPoolSummaryError && (
+              <ContentMessage
+                title="Failed to load Workspace Credits Pool"
+                icon={AlertCircle}
+                variant="warning"
+              >
+                An error occurred while loading your Workspace Credits Pool
+                data. Please refresh the page or contact support if the issue
+                persists.
+              </ContentMessage>
+            )}
 
-          {isAwuPoolSummaryLoading && (
-            <div className="flex justify-center py-8">
-              <Spinner />
-            </div>
-          )}
-
-          {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
-            <>
-              <div className="flex items-baseline gap-1">
-                <span className="heading-mono-4xl text-foreground dark:text-foreground-night">
-                  {formatCredits(totalConsumedCredits)}
-                </span>
-                <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                  /{formatCredits(initialTotalCredits)}
-                </span>
+            {isAwuPoolSummaryLoading && (
+              <div className="flex justify-center py-8">
+                <Spinner />
               </div>
-              <div className="flex items-center gap-2">
-                {isReadOnly ? (
-                  <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                    {formatCredits(periodSpendCredits)} credits spent this
-                    period
+            )}
+
+            {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
+              <>
+                <div className="flex items-baseline gap-1">
+                  <span className="heading-mono-4xl text-foreground dark:text-foreground-night">
+                    {formatCredits(totalConsumedCredits)}
                   </span>
-                ) : (
-                  <>
-                    {overageCredits !== null && overageCredits > 0 && (
-                      <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                        {formatCredits(overageCredits)} overage credits
-                      </span>
-                    )}
-                    {isEnterprise ? (
-                      <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                        Contact your Dust sales representative to buy credits
-                      </span>
-                    ) : (
-                      <Button
-                        label="Top up"
-                        icon={ArrowUp}
-                        size="xs"
-                        variant="ghost"
-                        onClick={() => setShowBuyCreditDialog(true)}
-                      />
-                    )}
-                  </>
-                )}
-              </div>
-            </>
-          )}
-        </Page.Vertical>
+                  <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                    /{formatCredits(initialTotalCredits)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {isReadOnly ? (
+                    <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                      {formatCredits(periodSpendCredits)} credits spent this
+                      period
+                    </span>
+                  ) : (
+                    <>
+                      {overageCredits !== null && overageCredits > 0 && (
+                        <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                          {formatCredits(overageCredits)} overage credits
+                        </span>
+                      )}
+                      {isEnterprise ? (
+                        <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+                          Contact your Dust sales representative to buy credits
+                        </span>
+                      ) : (
+                        <Button
+                          label="Top up"
+                          icon={ArrowUp}
+                          size="xs"
+                          variant="ghost"
+                          onClick={() => setShowBuyCreditDialog(true)}
+                        />
+                      )}
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+          </Page.Vertical>
+        )}
 
         {isCreditPurchaseInfoLoading ? (
           <div className="h-64 animate-pulse rounded bg-muted-foreground/20" />
@@ -593,14 +601,21 @@ export function UsagePage() {
           />
         )}
 
-        <UsageSettingsCard workspaceId={owner.sId} readOnly={isReadOnly} />
+        {!isFreePlanWorkspace && (
+          <>
+            <UsageSettingsCard workspaceId={owner.sId} readOnly={isReadOnly} />
 
-        <UsageProgrammaticLimitCard
-          workspaceId={owner.sId}
-          readOnly={isReadOnly}
-        />
+            <UsageProgrammaticLimitCard
+              workspaceId={owner.sId}
+              readOnly={isReadOnly}
+            />
 
-        <UsageNotificationsCard workspaceId={owner.sId} readOnly={isReadOnly} />
+            <UsageNotificationsCard
+              workspaceId={owner.sId}
+              readOnly={isReadOnly}
+            />
+          </>
+        )}
 
         <Page.Vertical gap="sm" align="stretch">
           <span className="heading-2xl text-foreground dark:text-foreground-night">

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -488,6 +488,7 @@ export function UsagePage() {
       members={membersUsage}
       isLoading={isMembersUsageLoading}
       readOnly={isReadOnly}
+      showSpendLimit={!isFreePlanWorkspace}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
       seatChangePendingMemberIds={seatChangePendingMemberIds}
       seatTypeFilter={seatTypeFilter}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -445,6 +445,7 @@ interface MembersUsageTableProps {
   seatChangePendingMemberIds: ReadonlySet<string>;
   seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
+  showSpendLimit: boolean;
   readOnly: boolean;
   onChangeSeat: (member: MemberUsageType) => void;
   onRemoveSeat: (member: MemberUsageType) => void;
@@ -463,6 +464,7 @@ export function MembersUsageTable({
   seatChangePendingMemberIds,
   seatTypeFilter,
   isSeatBased,
+  showSpendLimit,
   readOnly,
   onChangeSeat,
   onRemoveSeat,
@@ -523,12 +525,16 @@ export function MembersUsageTable({
                 },
               ]
             : []),
-          {
-            kind: "item" as const,
-            label: "Edit spend limit",
-            disabled: readOnly,
-            onClick: () => onEditSpendLimit(m),
-          },
+          ...(showSpendLimit
+            ? [
+                {
+                  kind: "item" as const,
+                  label: "Edit spend limit",
+                  disabled: readOnly,
+                  onClick: () => onEditSpendLimit(m),
+                },
+              ]
+            : []),
           // Only members who currently hold a billable seat can have it removed.
           ...(isSeatBased && m.seatType && m.seatType !== "none"
             ? [
@@ -548,6 +554,7 @@ export function MembersUsageTable({
       totalAllowedUsagePendingMemberIds,
       seatChangePendingMemberIds,
       isSeatBased,
+      showSpendLimit,
       readOnly,
       onChangeSeat,
       onRemoveSeat,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8814
Keep only Usage and Members in UsagePage for Free plan (removed pool with topup and settings)

<img width="1000" height="675" alt="Screenshot 2026-06-11 at 17 33 10" src="https://github.com/user-attachments/assets/d88d7566-44d6-48e3-b8a3-c8bbe5107767" />


## Tests

Tested locally

## Risk

Low, only UI for free plan

## Deploy Plan

Deploy front