### PR TITLE
fix exa MCP name and feature flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -97,7 +97,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "databricks": {
     "list_warehouses": "never_ask",
   },
-  "exa": {
+  "exa_people_and_company": {
     "search_companies": "never_ask",
     "search_people": "never_ask",
   },

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -157,7 +157,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "data_sources_file_system",
   DATA_WAREHOUSE_SERVER_NAME,
   "extract_data",
-  "exa",
+  "exa_people_and_company",
   "file_generation",
   "fathom",
   "freshservice",
@@ -1154,12 +1154,13 @@ export const INTERNAL_MCP_SERVERS = {
     timeoutMs: undefined,
     metadata: WORKSPACE_ANALYTICS_SERVER,
   },
-  exa: {
+  exa_people_and_company: {
     id: 1036,
     availability: "manual",
     allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) => !featureFlags.includes("exa_mcp"),
+    isRestricted: ({ featureFlags }) =>
+      !featureFlags.includes("exa_people_and_company"),
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -77,6 +77,6 @@
     { "name": "front", "id": 1018 },
     { "name": "poke", "id": 1027 },
     { "name": "clari_copilot", "id": 1030 },
-    { "name": "exa", "id": 1036 }
+    { "name": "exa_people_and_company", "id": 1036 }
   ]
 }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -226,7 +226,7 @@ export async function getInternalMCPServer(
       return agentSidekickAgentStateServer(auth, agentLoopContext);
     case "agent_sidekick_context":
       return agentSidekickContextServer(auth, agentLoopContext);
-    case "exa":
+    case "exa_people_and_company":
       return exaServer(auth, agentLoopContext);
     case "fathom":
       return fathomServer(auth, agentLoopContext);

--- a/front/lib/actions/tool_display_labels.ts
+++ b/front/lib/actions/tool_display_labels.ts
@@ -996,7 +996,7 @@ function getDynamicToolDisplayLabels({
     case "agent_router":
     case "ashby":
     case "databricks":
-    case "exa":
+    case "exa_people_and_company":
     case "fathom":
     case "freshservice":
     case "gong":

--- a/front/lib/api/actions/servers/exa/index.ts
+++ b/front/lib/api/actions/servers/exa/index.ts
@@ -9,11 +9,11 @@ function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer("exa");
+  const server = makeInternalMCPServer("exa_people_and_company");
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: "exa",
+      monitoringName: "exa_people_and_company",
     });
   }
 

--- a/front/lib/api/actions/servers/exa/metadata.ts
+++ b/front/lib/api/actions/servers/exa/metadata.ts
@@ -77,7 +77,7 @@ export const EXA_TOOLS_METADATA = createToolsRecord({
   },
 });
 
-export const EXA_SERVER_NAME = "exa" as const;
+export const EXA_SERVER_NAME = "exa_people_and_company" as const;
 
 export const EXA_SERVER = {
   serverInfo: {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -113,7 +113,7 @@ const TOOL_CATEGORY_MAP: Record<InternalMCPServerNameType, ToolCategory> = {
   interactive_content: "advanced",
   confluence: "advanced",
   databricks: "advanced",
-  exa: "advanced",
+  exa_people_and_company: "advanced",
   fathom: "advanced",
   freshservice: "advanced",
   github: "advanced",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -61,7 +61,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "MCP tools currently in development",
     stage: "dust_only",
   },
-  exa_mcp: {
+  exa_people_and_company: {
     description: "Access to Exa MCP server (search_people, search_companies)",
     stage: "dust_only",
   },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -707,7 +707,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "databricks_tool"
   | "deepseek_feature"
   | "dev_mcp_actions"
-  | "exa_mcp"
+  | "exa_people_and_company"
   | "disable_formatting_prompt"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"


### PR DESCRIPTION
## Description
Renames the Exa MCP server from exa to exa_people_and_company and the feature flag from exa_mcp to exa_people_and_company to better reflect its purpose and avoid confusion with the web search/browse server.

## Tests
tested manually.

## Risk
low. Just a rename

## Deploy Plan

