### PR TITLE
feat(credits): move per-user usage banner above the input bar + chores

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -6,6 +6,7 @@ import { podAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/pod-a
 import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
+import { upgradeRequestCreatedWorkflow } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { createHono } from "@front-api/lib/hono";
 import type { ServeHandlerOptions } from "@novu/framework";
@@ -33,6 +34,7 @@ const options: ServeHandlerOptions = {
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,
     programmaticCapReachedWorkflow,
+    upgradeRequestCreatedWorkflow,
   ],
 };
 

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -1,3 +1,4 @@
+import { RequestUpgradeButton } from "@app/components/credits/RequestUpgradeButton";
 import type { NotificationPreferencesRefProps } from "@app/components/me/NotificationPreferences";
 import { NotificationPreferences } from "@app/components/me/NotificationPreferences";
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
@@ -14,7 +15,11 @@ import {
   useMyUsage,
   useSeatPlan,
 } from "@app/lib/swr/credits";
-import { usePatchUser, useUser } from "@app/lib/swr/user";
+import {
+  usePatchUser,
+  useUser,
+  useWorkspaceUsageStatus,
+} from "@app/lib/swr/user";
 import type { WorkspaceType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
@@ -127,7 +132,12 @@ function ordinalDay(day: number): string {
   return `${day}${suffix}`;
 }
 
-function UsageSection({ owner }: { owner: WorkspaceType }) {
+interface UsageSectionProps {
+  owner: WorkspaceType;
+  onClose: () => void;
+}
+
+function UsageSection({ owner, onClose }: UsageSectionProps) {
   const { isAdmin, subscription } = useAuth();
   const { isCreditPurchaseInfoLoading, billingCycleStartDay } =
     useCreditPurchaseInfo({
@@ -142,6 +152,11 @@ function UsageSection({ owner }: { owner: WorkspaceType }) {
   } = useAwuPoolSummary({ workspaceId: owner.sId });
   const { myUsage, isMyUsageLoading } = useMyUsage({ workspaceId: owner.sId });
   const { seatPlans } = useSeatPlan({ workspaceId: owner.sId });
+
+  const { hasPendingUpgradeRequest } = useWorkspaceUsageStatus({
+    owner,
+    disabled: isAdmin,
+  });
 
   const seatName =
     (myUsage?.seatType ? seatPlans[myUsage.seatType]?.name : null) ??
@@ -173,12 +188,19 @@ function UsageSection({ owner }: { owner: WorkspaceType }) {
               {seatName}
             </span>
           </span>
-          {isAdmin && (
+          {isAdmin ? (
             <Button
               variant="primary"
               size="xs"
-              label="Request for upgrade"
+              label="Go to workspace usage"
               href={`/w/${owner.sId}/usage`}
+              onClick={onClose}
+            />
+          ) : (
+            <RequestUpgradeButton
+              owner={owner}
+              hasPendingUpgradeRequest={hasPendingUpgradeRequest}
+              variant="button"
             />
           )}
         </div>
@@ -729,7 +751,9 @@ export function UserSettingsPopover({
             {activeSection === "personal" && (
               <PersonalInfoSection owner={owner} />
             )}
-            {activeSection === "usage" && <UsageSection owner={owner} />}
+            {activeSection === "usage" && (
+              <UsageSection owner={owner} onClose={() => onOpenChange(false)} />
+            )}
             {activeSection === "customization" && <CustomizationSection />}
             {activeSection === "notifications" && (
               <NotificationsSection owner={owner} />

--- a/front/components/assistant/conversation/ContextUsageWarningBanner.tsx
+++ b/front/components/assistant/conversation/ContextUsageWarningBanner.tsx
@@ -1,11 +1,7 @@
 import { useCompactConversation } from "@app/hooks/conversations";
 import type { GetConversationContextUsageResponse } from "@app/lib/api/assistant/conversation/context_usage";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  ContentMessageAction,
-  ContentMessageInline,
-  InfoCircle,
-} from "@dust-tt/sparkle";
+import { ContentMessageInline, Hoverable, InfoCircle } from "@dust-tt/sparkle";
 
 interface ContextUsageWarningBannerProps {
   owner: LightWorkspaceType;
@@ -27,24 +23,30 @@ export const ContextUsageWarningBanner = ({
     <ContentMessageInline
       icon={InfoCircle}
       variant="info"
-      className="mb-5 flex max-h-dvh w-full"
+      className="mb-2 flex w-full"
     >
-      <div className="flex min-w-0 items-center gap-2">
-        <span className="min-w-0 truncate text-foreground dark:text-foreground-night">
-          Conversation context is almost full.
+      <div className="flex w-full items-center justify-between gap-2">
+        <span className="min-w-0 truncate">
+          Conversation context is almost full
         </span>
+        {isCompacting ? (
+          <span className="copy-sm shrink-0 text-muted-foreground dark:text-muted-foreground-night">
+            Compacting
+          </span>
+        ) : (
+          <Hoverable
+            variant="primary"
+            className="copy-sm shrink-0 underline underline-offset-2"
+            onClick={() => {
+              if (contextUsage.model) {
+                void compact(contextUsage.model);
+              }
+            }}
+          >
+            Compact now
+          </Hoverable>
+        )}
       </div>
-      <ContentMessageAction
-        label={isCompacting ? "Compacting" : "Compact now"}
-        variant="outline"
-        size="xs"
-        disabled={isCompacting}
-        onClick={() => {
-          if (contextUsage.model) {
-            void compact(contextUsage.model);
-          }
-        }}
-      />
     </ContentMessageInline>
   );
 };

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -7,6 +7,7 @@ import InputBarContainer, {
   INPUT_BAR_ACTIONS,
 } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { InputBarUsageBanner } from "@app/components/assistant/conversation/input_bar/InputBarUsageBanner";
 import {
   INPUT_BAR_COMPACT_ENTER_ANIMATION_CLASSES,
   INPUT_BAR_COMPACT_MORPH_TRANSITION_CLASSES,
@@ -407,6 +408,7 @@ export const InputBar = React.memo(function InputBar({
         effectiveIsCompact && "min-w-0 flex-1"
       )}
     >
+      <InputBarUsageBanner owner={owner} />
       <PlanCard
         conversationId={conversation?.sId ?? null}
         workspaceId={owner.sId}

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -1,0 +1,151 @@
+import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
+import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  cn,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Hoverable,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface RequestUpgradeButtonProps {
+  owner: LightWorkspaceType;
+  hasPendingUpgradeRequest: boolean;
+}
+function RequestUpgradeButton({
+  owner,
+  hasPendingUpgradeRequest,
+}: RequestUpgradeButtonProps) {
+  const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [requested, setRequested] = useState(false);
+
+  const alreadyRequested = hasPendingUpgradeRequest || requested;
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    try {
+      const ok = await doRequestUpgrade();
+      if (ok) {
+        setRequested(true);
+        setIsDialogOpen(false);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (alreadyRequested) {
+    return (
+      <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+        Request sent
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <Hoverable
+        variant="primary"
+        className="copy-sm underline underline-offset-2"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Request an upgrade
+      </Hoverable>
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => !open && setIsDialogOpen(false)}
+      >
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Request a usage limit upgrade</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Your workspace admins will be notified that you'd like your usage
+              limit increased. They'll review your request and get back to you.
+            </p>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setIsDialogOpen(false),
+            }}
+            rightButtonProps={{
+              label: "Send request",
+              variant: "primary",
+              isLoading: isSubmitting,
+              disabled: isSubmitting,
+              onClick: () => void handleConfirm(),
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+interface InputBarUsageBannerProps {
+  owner: LightWorkspaceType;
+}
+
+export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
+  const { awuStatus, noSeat, canRequestUpgrade, hasPendingUpgradeRequest } =
+    useWorkspaceUsageStatus({
+      owner,
+    });
+
+  const showAwuBanner = awuStatus !== "normal";
+
+  // A seatless member cannot run agents at all, so this takes precedence over
+  // the usage-limit banner.
+  if (!noSeat && !showAwuBanner) {
+    return null;
+  }
+
+  // noSeat is a hard block, treated like the "blocked" AWU state. The upgrade
+  // CTA only addresses the usage limit, so it is not offered when seatless.
+  const isBlocked = noSeat || awuStatus === "blocked";
+  const message = noSeat
+    ? "You don't have a seat in this workspace. Contact your admin to be assigned a seat."
+    : awuStatus === "blocked"
+      ? "You've reached your usage limit"
+      : "You've used 80% of your usage limit";
+  const showUpgradeCta = !noSeat && canRequestUpgrade;
+
+  return (
+    <div
+      className={cn(
+        "mb-2 flex w-full items-center gap-2 rounded-2xl border px-4 py-3",
+        "border-border-dark/50 bg-background",
+        "dark:border-border-dark-night/30 dark:bg-background-night"
+      )}
+    >
+      <span
+        className={cn(
+          "copy-sm grow truncate",
+          isBlocked
+            ? "text-warning-500 dark:text-warning-500-night"
+            : "text-foreground dark:text-foreground-night"
+        )}
+      >
+        {message}
+      </span>
+      {showUpgradeCta && (
+        <div className="shrink-0">
+          <RequestUpgradeButton
+            owner={owner}
+            hasPendingUpgradeRequest={hasPendingUpgradeRequest}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -1,124 +1,26 @@
-import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
+import { RequestUpgradeButton } from "@app/components/credits/RequestUpgradeButton";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import type { LightWorkspaceType } from "@app/types/user";
-import {
-  cn,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  Hoverable,
-} from "@dust-tt/sparkle";
-import { useState } from "react";
-
-interface RequestUpgradeButtonProps {
-  owner: LightWorkspaceType;
-  hasPendingUpgradeRequest: boolean;
-}
-function RequestUpgradeButton({
-  owner,
-  hasPendingUpgradeRequest,
-}: RequestUpgradeButtonProps) {
-  const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [requested, setRequested] = useState(false);
-
-  const alreadyRequested = hasPendingUpgradeRequest || requested;
-
-  async function handleConfirm() {
-    setIsSubmitting(true);
-    try {
-      const ok = await doRequestUpgrade();
-      if (ok) {
-        setRequested(true);
-        setIsDialogOpen(false);
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  if (alreadyRequested) {
-    return (
-      <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-        Request sent
-      </span>
-    );
-  }
-
-  return (
-    <>
-      <Hoverable
-        variant="primary"
-        className="copy-sm underline underline-offset-2"
-        onClick={() => setIsDialogOpen(true)}
-      >
-        Request an upgrade
-      </Hoverable>
-      <Dialog
-        open={isDialogOpen}
-        onOpenChange={(open) => !open && setIsDialogOpen(false)}
-      >
-        <DialogContent size="md">
-          <DialogHeader>
-            <DialogTitle>Request a usage limit upgrade</DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Your workspace admins will be notified that you'd like your usage
-              limit increased. They'll review your request and get back to you.
-            </p>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => setIsDialogOpen(false),
-            }}
-            rightButtonProps={{
-              label: "Send request",
-              variant: "primary",
-              isLoading: isSubmitting,
-              disabled: isSubmitting,
-              onClick: () => void handleConfirm(),
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
+import { cn } from "@dust-tt/sparkle";
 
 interface InputBarUsageBannerProps {
   owner: LightWorkspaceType;
 }
 
 export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
-  const { awuStatus, noSeat, canRequestUpgrade, hasPendingUpgradeRequest } =
+  const { awuStatus, canRequestUpgrade, hasPendingUpgradeRequest } =
     useWorkspaceUsageStatus({
       owner,
     });
 
   const showAwuBanner = awuStatus !== "normal";
+  const showUpgradeCta = canRequestUpgrade;
 
-  // A seatless member cannot run agents at all, so this takes precedence over
-  // the usage-limit banner.
-  if (!noSeat && !showAwuBanner) {
+  if (!showAwuBanner) {
     return null;
   }
 
-  // noSeat is a hard block, treated like the "blocked" AWU state. The upgrade
-  // CTA only addresses the usage limit, so it is not offered when seatless.
-  const isBlocked = noSeat || awuStatus === "blocked";
-  const message = noSeat
-    ? "You don't have a seat in this workspace. Contact your admin to be assigned a seat."
-    : awuStatus === "blocked"
-      ? "You've reached your usage limit"
-      : "You've used 80% of your usage limit";
-  const showUpgradeCta = !noSeat && canRequestUpgrade;
+  const isBlocked = awuStatus === "blocked";
 
   return (
     <div
@@ -136,7 +38,9 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
             : "text-foreground dark:text-foreground-night"
         )}
       >
-        {message}
+        {isBlocked
+          ? "You've reached your usage limit"
+          : "You've used 80% of your usage limit"}
       </span>
       {showUpgradeCta && (
         <div className="shrink-0">

--- a/front/components/credits/RequestUpgradeButton.tsx
+++ b/front/components/credits/RequestUpgradeButton.tsx
@@ -1,0 +1,118 @@
+import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Hoverable,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+type RequestUpgradeButtonVariant = "link" | "button";
+
+interface RequestUpgradeButtonProps {
+  owner: LightWorkspaceType;
+  hasPendingUpgradeRequest: boolean;
+  variant?: RequestUpgradeButtonVariant;
+}
+
+// Member-initiated upgrade-request CTA. Opens a confirmation dialog and posts
+// the request via `useRequestUpgrade`. Rendered either as an inline link (usage
+// banner) or as a primary button (personal settings) through `variant`.
+export function RequestUpgradeButton({
+  owner,
+  hasPendingUpgradeRequest,
+  variant = "link",
+}: RequestUpgradeButtonProps) {
+  const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [requested, setRequested] = useState(false);
+
+  const alreadyRequested = hasPendingUpgradeRequest || requested;
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    try {
+      const ok = await doRequestUpgrade();
+      if (ok) {
+        setRequested(true);
+        setIsDialogOpen(false);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function renderTrigger() {
+    if (variant === "button") {
+      return (
+        <Button
+          variant="primary"
+          size="xs"
+          label={alreadyRequested ? "Requested" : "Request for upgrade"}
+          disabled={alreadyRequested}
+          onClick={() => setIsDialogOpen(true)}
+        />
+      );
+    }
+
+    if (alreadyRequested) {
+      return (
+        <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+          Request sent
+        </span>
+      );
+    }
+
+    return (
+      <Hoverable
+        variant="primary"
+        className="copy-sm underline underline-offset-2"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        Request an upgrade
+      </Hoverable>
+    );
+  }
+
+  return (
+    <>
+      {renderTrigger()}
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => !open && setIsDialogOpen(false)}
+      >
+        <DialogContent size="md">
+          <DialogHeader>
+            <DialogTitle>Request a usage limit upgrade</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Your workspace admins will be notified that you'd like your usage
+              limit increased. They'll review your request and get back to you.
+            </p>
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setIsDialogOpen(false),
+            }}
+            rightButtonProps={{
+              label: "Send request",
+              variant: "primary",
+              isLoading: isSubmitting,
+              disabled: isSubmitting,
+              onClick: () => void handleConfirm(),
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -5,7 +5,6 @@ import {
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
-import { useRequestUpgrade } from "@app/lib/swr/upgrade_requests";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { useMetronomeContract } from "@app/lib/swr/workspaces";
@@ -15,19 +14,8 @@ import type { SubscriptionType } from "@app/types/plan";
 import { PRETTIFIED_PROVIDER_NAMES } from "@app/types/provider_selection";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
-import {
-  Button,
-  cn,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  LinkWrapper,
-} from "@dust-tt/sparkle";
+import { cn, LinkWrapper } from "@dust-tt/sparkle";
 import { cva, type VariantProps } from "class-variance-authority";
-import { useState } from "react";
 
 const statusBannerVariants = cva("space-y-2 border-y px-3 py-3 text-xs", {
   variants: {
@@ -213,104 +201,16 @@ function SubscriptionPastDueBanner() {
   );
 }
 
-interface RequestUpgradeButtonProps {
+interface WorkspaceUsageStatusBannerProps {
   owner: LightWorkspaceType;
-  hasPendingUpgradeRequest: boolean;
 }
 
-// Footer CTA on the per-user AWU usage banner: lets a warned/capped non-admin
-// member ask their admins to raise their spend limit, behind a single
-// confirmation. Once a request is pending the action is disabled.
-function RequestUpgradeButton({
+function WorkspaceUsageStatusBanner({
   owner,
-  hasPendingUpgradeRequest,
-}: RequestUpgradeButtonProps) {
-  const { doRequestUpgrade } = useRequestUpgrade({ workspaceId: owner.sId });
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [requested, setRequested] = useState(false);
+}: WorkspaceUsageStatusBannerProps) {
+  const { poolCreditState, programmaticCreditStatus, balanceThresholdReached } =
+    useWorkspaceUsageStatus({ owner });
 
-  const alreadyRequested = hasPendingUpgradeRequest || requested;
-
-  async function handleConfirm() {
-    setIsSubmitting(true);
-    try {
-      const ok = await doRequestUpgrade();
-      if (ok) {
-        setRequested(true);
-        setIsDialogOpen(false);
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  if (alreadyRequested) {
-    return <Button size="xs" variant="outline" label="Request sent" disabled />;
-  }
-
-  return (
-    <>
-      <Button
-        size="xs"
-        variant="outline"
-        label="Request an upgrade"
-        onClick={() => setIsDialogOpen(true)}
-      />
-      <Dialog
-        open={isDialogOpen}
-        onOpenChange={(open) => !open && setIsDialogOpen(false)}
-      >
-        <DialogContent size="md">
-          <DialogHeader>
-            <DialogTitle>Request a usage limit upgrade</DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Your workspace admins will be notified that you'd like your usage
-              limit increased. They'll review your request and get back to you.
-            </p>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              variant: "outline",
-              onClick: () => setIsDialogOpen(false),
-            }}
-            rightButtonProps={{
-              label: "Send request",
-              variant: "primary",
-              isLoading: isSubmitting,
-              disabled: isSubmitting,
-              onClick: () => void handleConfirm(),
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
-interface UsageStatusBannerProps {
-  owner: LightWorkspaceType;
-}
-
-function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
-  const {
-    awuStatus,
-    poolCreditState,
-    programmaticCreditStatus,
-    balanceThresholdReached,
-    noSeat,
-    canRequestUpgrade,
-    hasPendingUpgradeRequest,
-  } = useWorkspaceUsageStatus({ owner });
-
-  // Pool balance and programmatic cap banners are only shown to admins who
-  // manage workspace credits. The AWU cap banner is shown to any user subject
-  // to a per-user usage cap. At most one banner is shown at a time (see the
-  // priority selection below).
-  //
   // The low/critical pool states are internal throttling signals and are not
   // surfaced. Admins are alerted when the pool is fully depleted (agents
   // blocked) or when it has run into pay-as-you-go overage.
@@ -333,8 +233,6 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
     poolStateWouldBanner &&
     !isMetronomeContractLoading &&
     !contract?.hasPersonalCreditSeats;
-  const showAwuBanner = awuStatus !== "normal";
-  const showUpgradeCta = canRequestUpgrade;
   const showProgrammaticBanner =
     isAdmin(owner) && programmaticCreditStatus !== "active";
   // The admin-configured balance-threshold warning is only relevant before the
@@ -356,17 +254,6 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
   );
 
   const banner = ((): StatusBannerProps | null => {
-    // A seatless member cannot run agents at all, so this takes precedence over
-    // every credit-related banner.
-    if (noSeat) {
-      return {
-        variant: "danger",
-        title: "You don't have a seat in this workspace",
-        description:
-          "You can no longer run agents. Contact your admin to be assigned a seat.",
-      };
-    }
-
     if (showPoolBanner) {
       return {
         variant: isPoolDepleted ? "danger" : "warning",
@@ -377,26 +264,6 @@ function UsageStatusBanner({ owner }: UsageStatusBannerProps) {
           ? "Your workspace has run out of credits. Agents are blocked until you top up."
           : "Your workspace has used all of its included credits and is now billed pay-as-you-go. Top up to avoid overage charges.",
         footer: manageCreditsFooter,
-      };
-    }
-
-    if (showAwuBanner) {
-      return {
-        variant: awuStatus === "blocked" ? "danger" : "warning",
-        title:
-          awuStatus === "blocked"
-            ? "You've reached your usage limit"
-            : "You've used 80% of your usage limit",
-        description:
-          awuStatus === "blocked"
-            ? "You can no longer run agents. Contact your admin to increase your limit."
-            : "Contact your admin to increase your limit before you are blocked.",
-        footer: showUpgradeCta ? (
-          <RequestUpgradeButton
-            owner={owner}
-            hasPendingUpgradeRequest={hasPendingUpgradeRequest}
-          />
-        ) : undefined,
       };
     }
 
@@ -445,7 +312,7 @@ export function SidebarBanners() {
 
   return (
     <>
-      <UsageStatusBanner owner={owner} />
+      <WorkspaceUsageStatusBanner owner={owner} />
       <UnhealthyCredentialsBanner owner={owner} subscription={subscription} />
       {appStatus && <AppStatusBanner appStatus={appStatus} />}
       {subscription.paymentFailingSince &&

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -208,8 +208,12 @@ interface WorkspaceUsageStatusBannerProps {
 function WorkspaceUsageStatusBanner({
   owner,
 }: WorkspaceUsageStatusBannerProps) {
-  const { poolCreditState, programmaticCreditStatus, balanceThresholdReached } =
-    useWorkspaceUsageStatus({ owner });
+  const {
+    poolCreditState,
+    programmaticCreditStatus,
+    balanceThresholdReached,
+    noSeat,
+  } = useWorkspaceUsageStatus({ owner });
 
   // The low/critical pool states are internal throttling signals and are not
   // surfaced. Admins are alerted when the pool is fully depleted (agents
@@ -254,6 +258,17 @@ function WorkspaceUsageStatusBanner({
   );
 
   const banner = ((): StatusBannerProps | null => {
+    // A seatless member cannot run agents at all, so this takes precedence over
+    // every credit-related banner.
+    if (noSeat) {
+      return {
+        variant: "danger",
+        title: "You don't have a seat in this workspace",
+        description:
+          "You can no longer run agents. Contact your admin to be assigned a seat.",
+      };
+    }
+
     if (showPoolBanner) {
       return {
         variant: isPoolDepleted ? "danger" : "warning",

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -3,10 +3,13 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { notifyAdminsUpgradeRequested } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
+import logger from "@app/logger/logger";
 import type {
   MembershipUpgradeRequestStatus,
   MembershipUpgradeRequestType,
@@ -36,6 +39,52 @@ async function isMemberUpgradeRequestAllowed(
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
   return config?.allowMemberUpgradeRequests ?? true;
+}
+
+async function isUpgradeRequestEmailEnabled(
+  auth: Authenticator
+): Promise<boolean> {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  return config?.upgradeRequestEmailEnabled ?? true;
+}
+
+async function notifyAdminsOfUpgradeRequest(
+  auth: Authenticator,
+  { request }: { request: MembershipUpgradeRequestResource }
+): Promise<void> {
+  //swallow errors
+  try {
+    if (!(await isUpgradeRequestEmailEnabled(auth))) {
+      return;
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+
+    const requester = request.requester;
+    notifyAdminsUpgradeRequested({
+      admins: admins.map((admin) => ({
+        sId: admin.sId,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+      })),
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      requestId: request.sId,
+      requesterName: requester.fullName() ?? requester.name,
+      requesterEmail: requester.email ?? null,
+    });
+  } catch (err) {
+    logger.error(
+      { err, requestId: request.sId },
+      "Failed to notify admins of upgrade request"
+    );
+  }
 }
 
 export type GetUpgradeRequestsResponseBody = {
@@ -121,8 +170,7 @@ export async function createUpgradeRequest(
     metadata: { request_sid: request.sId },
   });
 
-  // TODO(upgrade-requests PR5): notify workspace admins by email (gated on the
-  // `upgradeRequestEmail` notification toggle).
+  void notifyAdminsOfUpgradeRequest(auth, { request });
 
   return new Ok(request.toJSON());
 }

--- a/front/lib/notifications/workflows/upgrade-request-created.ts
+++ b/front/lib/notifications/workflows/upgrade-request-created.ts
@@ -1,0 +1,176 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  UPGRADE_REQUEST_CREATED_TAG,
+  UPGRADE_REQUEST_CREATED_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { isDevelopment } from "@app/types/shared/env";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const UpgradeRequestCreatedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  requesterName: z.string(),
+  requesterEmail: z.string().nullable(),
+});
+
+type UpgradeRequestCreatedPayloadType = z.infer<
+  typeof UpgradeRequestCreatedPayloadSchema
+>;
+
+const isUpgradeRequestCreatedPayload = (
+  payload: unknown
+): payload is UpgradeRequestCreatedPayloadType =>
+  UpgradeRequestCreatedPayloadSchema.safeParse(payload).success;
+
+function formatRequester(payload: UpgradeRequestCreatedPayloadType): string {
+  return payload.requesterEmail
+    ? `${payload.requesterName} (${payload.requesterEmail})`
+    : payload.requesterName;
+}
+
+export const upgradeRequestCreatedWorkflow = workflow(
+  UPGRADE_REQUEST_CREATED_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    const { events } = await step.digest("digest", async () => {
+      const digestKey = `${subscriber.subscriberId}-workspace-${payload.workspaceId}-upgrade-requests`;
+      return isDevelopment()
+        ? { amount: 2, unit: "minutes", digestKey }
+        : { amount: 15, unit: "minutes", digestKey };
+    });
+
+    await step.email(
+      "upgrade-request-created-email",
+      async () => {
+        // Dedupe by requester (a member could re-request across the window) and
+        // keep insertion order so the email lists distinct people once.
+        const requesterByKey = new Map<string, string>();
+        for (const event of events) {
+          if (!isUpgradeRequestCreatedPayload(event.payload)) {
+            continue;
+          }
+          const key =
+            event.payload.requesterEmail ?? event.payload.requesterName;
+          if (!requesterByKey.has(key)) {
+            requesterByKey.set(key, formatRequester(event.payload));
+          }
+        }
+        const requesters = Array.from(requesterByKey.values());
+        const count = requesters.length;
+
+        const subject =
+          count > 1
+            ? `[Dust] ${count} members requested a spend-limit upgrade`
+            : `[Dust] ${requesters[0]} requested a spend-limit upgrade`;
+
+        const intro =
+          count > 1
+            ? `${count} members have reached their per-user spend limit and are requesting an upgrade:`
+            : `${requesters[0]} has reached their per-user spend limit and is requesting an upgrade.`;
+        const list =
+          count > 1 ? requesters.map((r) => `• ${r}`).join("\n") : "";
+        const outro =
+          count > 1
+            ? `Review the requests and adjust their limits from your workspace usage page.`
+            : `Review the request and adjust their limit from your workspace usage page.`;
+        const content = [intro, list, outro].filter(Boolean).join("\n");
+
+        const body = await renderEmail({
+          name: subscriber.firstName ?? "there",
+          workspace: {
+            id: payload.workspaceId,
+            name: payload.workspaceName,
+          },
+          content,
+          action: {
+            label: count > 1 ? "Review requests" : "Review request",
+            url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+          },
+        });
+        return { subject, body };
+      },
+      {
+        skip: async () =>
+          !events.some((event) =>
+            isUpgradeRequestCreatedPayload(event.payload)
+          ),
+      }
+    );
+  },
+  {
+    payloadSchema: UpgradeRequestCreatedPayloadSchema,
+    tags: [UPGRADE_REQUEST_CREATED_TAG],
+  }
+);
+
+/**
+ * Email a workspace's admins that a member requested a spend-limit upgrade. One
+ * Novu event is triggered per admin (subscribed by their Dust user sId), deduped
+ * via a `transactionId` keyed on the upgrade-request sId so redeliveries don't
+ * re-send. Fire-and-forget — errors are logged but don't block the caller.
+ */
+export function notifyAdminsUpgradeRequested({
+  admins,
+  workspaceId,
+  workspaceName,
+  requestId,
+  requesterName,
+  requesterEmail,
+}: {
+  admins: Array<{
+    sId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  workspaceId: string;
+  workspaceName: string;
+  requestId: string;
+  requesterName: string;
+  requesterEmail: string | null;
+}): void {
+  if (admins.length === 0) {
+    return;
+  }
+
+  const payload: UpgradeRequestCreatedPayloadType = {
+    workspaceId,
+    workspaceName,
+    requesterName,
+    requesterEmail,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: admins.map((admin) => ({
+          workflowId: UPGRADE_REQUEST_CREATED_TRIGGER_ID,
+          to: {
+            subscriberId: admin.sId,
+            email: admin.email,
+            firstName: admin.firstName ?? undefined,
+            lastName: admin.lastName ?? undefined,
+          },
+          payload,
+          transactionId: `${UPGRADE_REQUEST_CREATED_TRIGGER_ID}-${requestId}-${admin.sId}`,
+        })),
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, requestId },
+          "Failed to trigger upgrade request created notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, requestId },
+        "Failed to trigger upgrade request created notification"
+      );
+    });
+}

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -118,6 +118,10 @@ export const PROGRAMMATIC_CAP_REACHED_TRIGGER_ID =
   "programmatic-cap-reached" as const;
 export const PROGRAMMATIC_CAP_REACHED_TAG = "programmatic-cap-reached" as const;
 
+export const UPGRADE_REQUEST_CREATED_TRIGGER_ID =
+  "upgrade-request-created" as const;
+export const UPGRADE_REQUEST_CREATED_TAG = "upgrade-request-created" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof POD_ADDED_AS_MEMBER_TRIGGER_ID
@@ -126,4 +130,5 @@ export type WorkflowTriggerId =
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID
   | typeof USER_AWU_CAP_REACHED_TRIGGER_ID
   | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID
-  | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID;
+  | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID
+  | typeof UPGRADE_REQUEST_CREATED_TRIGGER_ID;


### PR DESCRIPTION
## Description

Relocates the per-user usage (AWU cap) banner out of the sidebar `AppStatusBanner` and into a new `InputBarUsageBanner` rendered directly above the conversation input, so the "near/at usage limit" warning and its "Request an upgrade" CTA sit next to where the user is composing messages. 
<img height="300" alt="Screenshot 2026-06-11 at 19 23 34" src="https://github.com/user-attachments/assets/deb7343a-0591-4844-b983-6825b0cd390b" />


Secondary: plugs the button on the new personal settings to the right call: ask my admin or go to usage 
<img height="300" alt="image" src="https://github.com/user-attachments/assets/d080ed8d-b5b8-4644-9f70-4c2aa36ea00c" />

Chore : UI of compaction banner so that it blends well with the usage banner.
<img height="300" alt="Screenshot 2026-06-11 at 19 25 13" src="https://github.com/user-attachments/assets/861c9206-0d10-4251-8e5a-d5f04be7c287" />



Details:

- New `InputBarUsageBanner` shows the per-user AWU warning ("You've used 80% of your usage limit" / "You've reached your usage limit") with the "Request an upgrade" CTA as an underlined link, and the confirmation dialog.
- `AppStatusBanner` no longer renders the AWU banner or the upgrade CTA; `UsageStatusBanner` is renamed to `WorkspaceUsageStatusBanner` and now only handles workspace-level credit alerts (pool depletion, programmatic cap, balance threshold).
- `ContextUsageWarningBanner` (the "compact now" prompt) is restyled to read consistently with the new usage banner: underlined link CTA instead of a button, and trailing period removed.
- Extracts the upgrade-request dialog flow into a shared `RequestUpgradeButton` (`front/components/credits/`) reused by both surfaces, with a `link` variant (usage banner) and a `button` variant (personal settings).
- Wires the button in personal settings (Usage tab): members get the request-upgrade dialog (posting the request, reflecting the pending "Requested" state); admins instead get a "Go to workspace usage" button that links to the workspace usage page and closes the settings modal.

No backend or API changes.

## Tests

Manual: as a non-admin member near/at the per-user usage limit, confirm the banner appears above the input with the "Request an upgrade" link, the confirmation dialog sends the request, and the CTA shows "Request sent" once pending. Confirm the sidebar no longer shows the duplicate AWU banner while workspace-level credit banners still appear for admins. In personal settings → Usage, confirm a member sees the request-upgrade dialog and an admin is navigated to the workspace usage page with the modal closing.
