### PR TITLE
[Email Agents] Continue existing conversation when replying to an agent email

### DIFF
--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -226,18 +226,13 @@ describe("buildReplyThreadingHeaders", () => {
 });
 
 describe("splitThreadContent", () => {
-  it("extracts the conversation id from the current agent reply footer link", async () => {
+  it("extracts the conversation id from a forwarded agent reply", async () => {
     const { conversationId } = await splitThreadContent(
-      "Thanks!\n\nAnswered by agent · View full conversation " +
-        "<https://dust.tt/w/workspace1/conversation/abc123XYZ0>"
-    );
-
-    expect(conversationId).toBe("abc123XYZ0");
-  });
-
-  it("extracts the conversation id from a bare URL", async () => {
-    const { conversationId } = await splitThreadContent(
-      "See https://dust.tt/w/workspace1/conversation/abc123XYZ0 for details."
+      "Follow up on this please.\n" +
+        "\n" +
+        "---------- Forwarded message ----------\n" +
+        "Answered by agent · View full conversation\n" +
+        "https://dust.tt/w/workspace1/conversation/abc123XYZ0\n"
     );
 
     expect(conversationId).toBe("abc123XYZ0");
@@ -245,10 +240,21 @@ describe("splitThreadContent", () => {
 
   it("extracts the conversation id from legacy assistant links", async () => {
     const { conversationId } = await splitThreadContent(
-      "Open in Dust <https://dust.tt/w/workspace1/assistant/abc123XYZ0>"
+      "Thanks!\n" +
+        "\n" +
+        "---------- Forwarded message ----------\n" +
+        "Open in Dust <https://dust.tt/w/workspace1/assistant/abc123XYZ0>\n"
     );
 
     expect(conversationId).toBe("abc123XYZ0");
+  });
+
+  it("ignores conversation links outside the quoted thread", async () => {
+    const { conversationId } = await splitThreadContent(
+      "Can you summarize https://dust.tt/w/workspace1/conversation/abc123XYZ0?"
+    );
+
+    expect(conversationId).toBeNull();
   });
 
   it("returns null when no conversation link is present", async () => {

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -4,8 +4,10 @@ import {
   ASSISTANT_EMAIL_SUBDOMAIN,
   buildEmailUserMessage,
   buildReplyThreadingHeaders,
+  getThreadingLookupMessageIds,
   parseEmailReplyContext,
   sendToolValidationEmail,
+  splitThreadContent,
 } from "@app/lib/api/assistant/email/email_trigger";
 import { sendEmail } from "@app/lib/api/email";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
@@ -220,6 +222,108 @@ describe("buildReplyThreadingHeaders", () => {
       inReplyTo: "<incoming-message-id@dust.tt>",
       references: "<older-message-id@dust.tt> <incoming-message-id@dust.tt>",
     });
+  });
+});
+
+describe("splitThreadContent", () => {
+  it("extracts the conversation id from the current agent reply footer link", async () => {
+    const { conversationId } = await splitThreadContent(
+      "Thanks!\n\nAnswered by agent · View full conversation " +
+        "<https://dust.tt/w/workspace1/conversation/abc123XYZ0>"
+    );
+
+    expect(conversationId).toBe("abc123XYZ0");
+  });
+
+  it("extracts the conversation id from a bare URL", async () => {
+    const { conversationId } = await splitThreadContent(
+      "See https://dust.tt/w/workspace1/conversation/abc123XYZ0 for details."
+    );
+
+    expect(conversationId).toBe("abc123XYZ0");
+  });
+
+  it("extracts the conversation id from legacy assistant links", async () => {
+    const { conversationId } = await splitThreadContent(
+      "Open in Dust <https://dust.tt/w/workspace1/assistant/abc123XYZ0>"
+    );
+
+    expect(conversationId).toBe("abc123XYZ0");
+  });
+
+  it("returns null when no conversation link is present", async () => {
+    const { conversationId } = await splitThreadContent(
+      "Hello, can you help with https://example.com/w/foo?"
+    );
+
+    expect(conversationId).toBeNull();
+  });
+
+  it("splits a reply from the quoted thread and finds the link in the quote", async () => {
+    const { userMessage, restOfThread, conversationId } =
+      await splitThreadContent(
+        "Can you go deeper on point 2?\n" +
+          "\n" +
+          "On Mon, Jun 8, 2026 at 10:12 AM agent (Dust agent)\n" +
+          "<agent@dust.team> wrote:\n" +
+          "> Here is my answer.\n" +
+          "> Answered by agent · View full conversation\n" +
+          "> <https://dust.tt/w/workspace1/conversation/abc123XYZ0>\n"
+      );
+
+    expect(userMessage).toBe("Can you go deeper on point 2?");
+    expect(restOfThread).toContain("Here is my answer.");
+    expect(conversationId).toBe("abc123XYZ0");
+  });
+});
+
+describe("getThreadingLookupMessageIds", () => {
+  it("orders message-ids most recent first: in-reply-to, then references reversed", () => {
+    const messageIds = getThreadingLookupMessageIds({
+      messageId: "<reply@mail.gmail.com>",
+      inReplyTo: "<agent-reply@sendgrid.net>",
+      references: "<original@mail.gmail.com> <agent-reply@sendgrid.net>",
+    });
+
+    expect(messageIds).toEqual([
+      "agent-reply@sendgrid.net",
+      "original@mail.gmail.com",
+    ]);
+  });
+
+  it("normalizes brackets and whitespace and deduplicates", () => {
+    const messageIds = getThreadingLookupMessageIds({
+      messageId: null,
+      inReplyTo: " <a@x.com> ",
+      references: "<a@x.com>   b@x.com\n <c@x.com>",
+    });
+
+    expect(messageIds).toEqual(["a@x.com", "c@x.com", "b@x.com"]);
+  });
+
+  it("caps the number of lookup candidates", () => {
+    const references = Array.from(
+      { length: 20 },
+      (_, i) => `<ref-${i}@x.com>`
+    ).join(" ");
+    const messageIds = getThreadingLookupMessageIds({
+      messageId: null,
+      inReplyTo: null,
+      references,
+    });
+
+    expect(messageIds).toHaveLength(10);
+    expect(messageIds[0]).toBe("ref-19@x.com");
+  });
+
+  it("returns an empty array when no threading headers are set", () => {
+    const messageIds = getThreadingLookupMessageIds({
+      messageId: null,
+      inReplyTo: null,
+      references: null,
+    });
+
+    expect(messageIds).toEqual([]);
   });
 });
 

--- a/front/lib/api/assistant/email/email_trigger.test.ts
+++ b/front/lib/api/assistant/email/email_trigger.test.ts
@@ -226,60 +226,17 @@ describe("buildReplyThreadingHeaders", () => {
 });
 
 describe("splitThreadContent", () => {
-  it("extracts the conversation id from a forwarded agent reply", async () => {
-    const { conversationId } = await splitThreadContent(
-      "Follow up on this please.\n" +
+  it("splits the fresh reply from the quoted thread", async () => {
+    const { userMessage, restOfThread } = await splitThreadContent(
+      "Can you go deeper on point 2?\n" +
         "\n" +
-        "---------- Forwarded message ----------\n" +
-        "Answered by agent · View full conversation\n" +
-        "https://dust.tt/w/workspace1/conversation/abc123XYZ0\n"
+        "On Mon, Jun 8, 2026 at 10:12 AM agent (Dust agent)\n" +
+        "<agent@dust.team> wrote:\n" +
+        "> Here is my answer.\n"
     );
-
-    expect(conversationId).toBe("abc123XYZ0");
-  });
-
-  it("extracts the conversation id from legacy assistant links", async () => {
-    const { conversationId } = await splitThreadContent(
-      "Thanks!\n" +
-        "\n" +
-        "---------- Forwarded message ----------\n" +
-        "Open in Dust <https://dust.tt/w/workspace1/assistant/abc123XYZ0>\n"
-    );
-
-    expect(conversationId).toBe("abc123XYZ0");
-  });
-
-  it("ignores conversation links outside the quoted thread", async () => {
-    const { conversationId } = await splitThreadContent(
-      "Can you summarize https://dust.tt/w/workspace1/conversation/abc123XYZ0?"
-    );
-
-    expect(conversationId).toBeNull();
-  });
-
-  it("returns null when no conversation link is present", async () => {
-    const { conversationId } = await splitThreadContent(
-      "Hello, can you help with https://example.com/w/foo?"
-    );
-
-    expect(conversationId).toBeNull();
-  });
-
-  it("splits a reply from the quoted thread and finds the link in the quote", async () => {
-    const { userMessage, restOfThread, conversationId } =
-      await splitThreadContent(
-        "Can you go deeper on point 2?\n" +
-          "\n" +
-          "On Mon, Jun 8, 2026 at 10:12 AM agent (Dust agent)\n" +
-          "<agent@dust.team> wrote:\n" +
-          "> Here is my answer.\n" +
-          "> Answered by agent · View full conversation\n" +
-          "> <https://dust.tt/w/workspace1/conversation/abc123XYZ0>\n"
-      );
 
     expect(userMessage).toBe("Can you go deeper on point 2?");
     expect(restOfThread).toContain("Here is my answer.");
-    expect(conversationId).toBe("abc123XYZ0");
   });
 });
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -247,11 +247,6 @@ export async function storeEmailThreadConversation({
   await redis.set(key, conversationId, {
     EX: EMAIL_THREAD_CONVERSATION_TTL_SECONDS,
   });
-
-  logger.info(
-    { conversationId, key },
-    "[email] Stored email thread conversation mapping in Redis"
-  );
 }
 
 /**
@@ -739,12 +734,6 @@ export function emailAssistantMatcher({
   });
 }
 
-// Matches a Dust conversation URL anywhere in the email body, independent of the surrounding
-// anchor text (email clients render the agent reply footer link in varying plain-text forms).
-// Also matches the legacy `/assistant/` path present in older agent reply emails.
-const DUST_CONVERSATION_URL_REGEX =
-  /https?:\/\/[^\s<>"]+\/w\/[a-zA-Z0-9]+\/(?:conversation|assistant)\/([a-zA-Z0-9]+)/;
-
 export async function splitThreadContent(content: string) {
   const separators = [
     /\n\s*On\s+[A-Za-z]{3},\s+[A-Za-z]{3}\s+\d{1,2},\s+\d{4}\s+at\s+\d{1,2}:\d{2}\s+[AP]M/,
@@ -770,12 +759,7 @@ export async function splitThreadContent(content: string) {
   const thread =
     firstSeparatorIndex > -1 ? content.slice(firstSeparatorIndex).trim() : "";
 
-  // Only look for a conversation link in the quoted thread: a link in the fresh part of the
-  // message is a reference the user is making, not a sign this email continues a conversation.
-  const conversationIdMatch = thread.match(DUST_CONVERSATION_URL_REGEX);
-  const conversationId = conversationIdMatch ? conversationIdMatch[1] : null;
-
-  return { userMessage: newMessage, restOfThread: thread, conversationId };
+  return { userMessage: newMessage, restOfThread: thread };
 }
 
 /**
@@ -811,34 +795,27 @@ export async function triggerFromEmail(
     });
   }
 
-  const {
-    userMessage,
-    restOfThread,
-    conversationId: bodyConversationId,
-  } = await splitThreadContent(email.text);
+  const { userMessage, restOfThread } = await splitThreadContent(email.text);
 
-  // Prefer the thread mapping over the body link: threading headers are set mechanically by
-  // the email client, while a quoted body can carry conversation links from forwarded content.
   const threadConversationId = await findConversationIdFromThreadingHeaders(
     workspace.sId,
     email.threadingHeaders
   );
 
-  const candidateConversationIds = [
-    ...new Set([threadConversationId, bodyConversationId].filter(isString)),
-  ];
-
   let conversation: ConversationType | null = null;
-  for (const candidateId of candidateConversationIds) {
-    const conversationRes = await getConversation(auth, candidateId);
+  if (threadConversationId) {
+    const conversationRes = await getConversation(auth, threadConversationId);
     if (conversationRes.isOk()) {
       conversation = conversationRes.value;
-      break;
+    } else {
+      localLogger.warn(
+        {
+          conversationId: threadConversationId,
+          errorType: conversationRes.error.type,
+        },
+        "[email] Cannot access conversation matching inbound email, creating a new one."
+      );
     }
-    localLogger.warn(
-      { conversationId: candidateId, errorType: conversationRes.error.type },
-      "[email] Cannot access conversation matching inbound email, ignoring candidate."
-    );
   }
   if (!conversation) {
     conversation = await createConversation(auth, {

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -45,6 +45,11 @@ import type { InboundEmailDkimResult } from "./inbound_auth";
 const REDIS_ORIGIN: RedisUsageTagsType = "email_context";
 const EMAIL_REPLY_CONTEXT_PREFIX = "email-reply-context";
 const EMAIL_REPLY_CONTEXT_TTL_SECONDS = 3 * 60 * 60; // 3 hours
+// Maps inbound email Message-IDs to conversation sIds so that replies in the same email thread
+// continue the existing conversation. Long TTL: users may reply to an agent email days later.
+const EMAIL_THREAD_CONVERSATION_PREFIX = "email-thread-conversation";
+const EMAIL_THREAD_CONVERSATION_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const EMAIL_THREAD_LOOKUP_MAX_MESSAGE_IDS = 10;
 // Same-email multi-workspace routing is rare and mostly specific to Dust, so a
 // single hardcoded priority workspace is enough for now.
 const EMAIL_PRIORITY_WORKSPACE_IDS = ["0ec9852c2f"] as const;
@@ -194,6 +199,113 @@ export async function deleteEmailReplyContext(
   const redis = await getRedisStreamClient({ origin: REDIS_ORIGIN });
   const key = makeEmailReplyContextKey(workspaceId, agentMessageId);
   await redis.del(key);
+}
+
+/**
+ * Normalize an RFC 5322 Message-ID to a canonical form (no angle brackets) used for both
+ * storing and looking up thread-to-conversation mappings.
+ */
+function normalizeMessageId(rawMessageId: string): string | null {
+  let messageId = rawMessageId.trim();
+  if (messageId.startsWith("<")) {
+    messageId = messageId.slice(1);
+  }
+  if (messageId.endsWith(">")) {
+    messageId = messageId.slice(0, -1);
+  }
+  return messageId.length > 0 ? messageId : null;
+}
+
+function makeEmailThreadConversationKey(
+  workspaceId: string,
+  messageId: string
+): string {
+  return `${EMAIL_THREAD_CONVERSATION_PREFIX}:${workspaceId}:${messageId}`;
+}
+
+/**
+ * Map an inbound email Message-ID to a conversation sId so later replies in the same email
+ * thread can continue the conversation.
+ */
+export async function storeEmailThreadConversation({
+  workspaceId,
+  messageId,
+  conversationId,
+}: {
+  workspaceId: string;
+  messageId: string;
+  conversationId: string;
+}): Promise<void> {
+  const normalizedMessageId = normalizeMessageId(messageId);
+  if (!normalizedMessageId) {
+    return;
+  }
+
+  const redis = await getRedisStreamClient({ origin: REDIS_ORIGIN });
+  const key = makeEmailThreadConversationKey(workspaceId, normalizedMessageId);
+
+  await redis.set(key, conversationId, {
+    EX: EMAIL_THREAD_CONVERSATION_TTL_SECONDS,
+  });
+
+  logger.info(
+    { conversationId, key },
+    "[email] Stored email thread conversation mapping in Redis"
+  );
+}
+
+/**
+ * Message-IDs to look up when matching an inbound email to an existing conversation, most
+ * recent first: In-Reply-To, then References reversed (References is oldest-first per RFC 5322).
+ */
+export function getThreadingLookupMessageIds(
+  threadingHeaders: EmailThreadingHeaders
+): string[] {
+  const referenceTokens = (threadingHeaders.references ?? "")
+    .split(/\s+/)
+    .reverse();
+  const candidates = [threadingHeaders.inReplyTo ?? "", ...referenceTokens];
+
+  const seen = new Set<string>();
+  const messageIds: string[] = [];
+  for (const candidate of candidates) {
+    const messageId = normalizeMessageId(candidate);
+    if (!messageId || seen.has(messageId)) {
+      continue;
+    }
+    seen.add(messageId);
+    messageIds.push(messageId);
+    if (messageIds.length >= EMAIL_THREAD_LOOKUP_MAX_MESSAGE_IDS) {
+      break;
+    }
+  }
+
+  return messageIds;
+}
+
+/**
+ * Find the conversation associated with the email thread an inbound email belongs to, if any.
+ */
+export async function findConversationIdFromThreadingHeaders(
+  workspaceId: string,
+  threadingHeaders: EmailThreadingHeaders
+): Promise<string | null> {
+  const messageIds = getThreadingLookupMessageIds(threadingHeaders);
+  if (messageIds.length === 0) {
+    return null;
+  }
+
+  const redis = await getRedisStreamClient({ origin: REDIS_ORIGIN });
+  for (const messageId of messageIds) {
+    const conversationId = await redis.get(
+      makeEmailThreadConversationKey(workspaceId, messageId)
+    );
+    if (conversationId) {
+      return conversationId;
+    }
+  }
+
+  return null;
 }
 
 export { ASSISTANT_EMAIL_SUBDOMAIN } from "@app/lib/api/assistant/email/constants";
@@ -627,6 +739,12 @@ export function emailAssistantMatcher({
   });
 }
 
+// Matches a Dust conversation URL anywhere in the email body, independent of the surrounding
+// anchor text (email clients render the agent reply footer link in varying plain-text forms).
+// Also matches the legacy `/assistant/` path present in older agent reply emails.
+const DUST_CONVERSATION_URL_REGEX =
+  /https?:\/\/[^\s<>"]+\/w\/[a-zA-Z0-9]+\/(?:conversation|assistant)\/([a-zA-Z0-9]+)/;
+
 export async function splitThreadContent(content: string) {
   const separators = [
     /\n\s*On\s+[A-Za-z]{3},\s+[A-Za-z]{3}\s+\d{1,2},\s+\d{4}\s+at\s+\d{1,2}:\d{2}\s+[AP]M/,
@@ -645,9 +763,7 @@ export async function splitThreadContent(content: string) {
       firstSeparatorIndex = match.index;
     }
   }
-  const conversationIdRegex =
-    /Open in Dust <https?:\/\/[^/]+\/w\/[^/]+\/assistant\/([^>]+)>/;
-  const conversationIdMatch = content.match(conversationIdRegex);
+  const conversationIdMatch = content.match(DUST_CONVERSATION_URL_REGEX);
   const conversationId = conversationIdMatch ? conversationIdMatch[1] : null;
 
   const newMessage =
@@ -692,24 +808,50 @@ export async function triggerFromEmail(
     });
   }
 
-  const { userMessage, restOfThread, conversationId } =
-    await splitThreadContent(email.text);
+  const {
+    userMessage,
+    restOfThread,
+    conversationId: bodyConversationId,
+  } = await splitThreadContent(email.text);
 
-  let conversation;
-  if (conversationId) {
-    const conversationRes = await getConversation(auth, conversationId);
-    if (conversationRes.isErr()) {
-      return new Err({
-        type: "unexpected_error",
-        message: "Failed to find conversation with given id.",
-      });
+  // Prefer the thread mapping over the body link: threading headers are set mechanically by
+  // the email client, while a quoted body can carry conversation links from forwarded content.
+  const threadConversationId = await findConversationIdFromThreadingHeaders(
+    workspace.sId,
+    email.threadingHeaders
+  );
+
+  const candidateConversationIds = [
+    ...new Set([threadConversationId, bodyConversationId].filter(isString)),
+  ];
+
+  let conversation: ConversationType | null = null;
+  for (const candidateId of candidateConversationIds) {
+    const conversationRes = await getConversation(auth, candidateId);
+    if (conversationRes.isOk()) {
+      conversation = conversationRes.value;
+      break;
     }
-    conversation = conversationRes.value;
-  } else {
+    localLogger.warn(
+      { conversationId: candidateId, errorType: conversationRes.error.type },
+      "[email] Cannot access conversation matching inbound email, ignoring candidate."
+    );
+  }
+  if (!conversation) {
     conversation = await createConversation(auth, {
       title: `Email: ${email.subject}`,
       visibility: "unlisted",
       spaceId: null,
+    });
+  }
+
+  // Map this email's Message-ID to the conversation (on create and on continue) so any later
+  // reply in the thread keeps routing to it.
+  if (email.threadingHeaders.messageId) {
+    await storeEmailThreadConversation({
+      workspaceId: workspace.sId,
+      messageId: email.threadingHeaders.messageId,
+      conversationId: conversation.sId,
     });
   }
 

--- a/front/lib/api/assistant/email/email_trigger.ts
+++ b/front/lib/api/assistant/email/email_trigger.ts
@@ -763,15 +763,18 @@ export async function splitThreadContent(content: string) {
       firstSeparatorIndex = match.index;
     }
   }
-  const conversationIdMatch = content.match(DUST_CONVERSATION_URL_REGEX);
-  const conversationId = conversationIdMatch ? conversationIdMatch[1] : null;
-
   const newMessage =
     firstSeparatorIndex > -1
       ? content.slice(0, firstSeparatorIndex).trim()
       : content.trim();
   const thread =
     firstSeparatorIndex > -1 ? content.slice(firstSeparatorIndex).trim() : "";
+
+  // Only look for a conversation link in the quoted thread: a link in the fresh part of the
+  // message is a reference the user is making, not a sign this email continues a conversation.
+  const conversationIdMatch = thread.match(DUST_CONVERSATION_URL_REGEX);
+  const conversationId = conversationIdMatch ? conversationIdMatch[1] : null;
+
   return { userMessage: newMessage, restOfThread: thread, conversationId };
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8123

When a user emailed an agent and then replied to the agent's answer, a new Dust conversation was opened instead of continuing the existing one.

Root cause: continuity relied on finding a conversation link in the quoted email body via a regex that was doubly stale — it expected the anchor text `Open in Dust` (the footer now says "View full conversation") and the URL path `/assistant/` (conversation URLs are now `/w/{wId}/conversation/{cId}`). So it never matched, and every reply forked a new conversation.

Fix: a **Redis thread mapping** in `triggerFromEmail`. Each inbound email's `Message-ID` is mapped to the conversation sId (workspace-scoped key, 30-day TTL), stored on create and on continue. Inbound emails look up their `In-Reply-To`/`References` tokens (newest first, capped at 10) to find the conversation. This works because our outgoing reply sets `References` to the inbound Message-ID and clients propagate it — it also routes reply-all messages in group threads where the agent is cc'd.

The legacy body-link regex was **removed** (rather than fixed) during review: the quoted thread can contain conversation links shared by users unrelated to our footer, which could route an email into the wrong conversation and leak its context into the email reply.

Behavior change worth noting: when a thread mapping points to a conversation but `getConversation` fails (deleted conversation, or a thread participant without access), we log a warning and fall back to creating a new conversation instead of emailing an error back to the sender.

Known remaining gaps (accepted):
- Replies arriving after the 30-day TTL (or after a Redis flush) start a new conversation — same as the previous behavior.
- Rare clients that strip `References` fork too: their `In-Reply-To` points at our SendGrid-generated outgoing Message-ID, which we never learn.

## Risks

Blast radius: inbound email-agents processing (conversation routing for emailed agents)
Risk: low

## Deploy Plan

- deploy front-api (webhook ingestion path)
- deploy front

## Tests

- [x] Unit tests for thread splitting (`splitThreadContent`) and lookup ordering (`getThreadingLookupMessageIds`)
- [x] End-to-end in local dev: emailed a dev agent, replied within the thread, verified the reply continued the existing conversation (2 user + 2 agent messages) and the agent's answer was emailed back