### PR TITLE
[marketing] fix: Put back models pricing

### DIFF
--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -30,6 +30,7 @@ jobs:
           # Define monitored paths
           MONITORED_PATHS=(
             'front/lib/'
+            'front/types/assistant/models/'
             'front-api/'
             'connectors/src/lib/models/'
             'connectors/src/resources/storage/models/'

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -9,6 +9,7 @@ const sparkleVersionAckLabel = "sparkle-version-ack";
 const sseAckLabel = "sse-ack";
 const sandboxImageAckLabel = "sandbox-image-ack";
 const auditLogAckLabel = "audit-log-ack";
+const marketingSnapshotAckLabel = "marketing-snapshot-ack";
 
 const REMOVE_INDEX_WARNING =
   "\n\nBefore deleting an index, make sure it is actually not used by running:" +
@@ -455,6 +456,87 @@ async function checkAuditSchemaVersions(changedActions: string[]) {
   }
 }
 
+// The `/home/api-pricing` page is served by the `marketing` workspace, which
+// cannot import front's model/pricing modules (they pull in a deep dependency
+// graph: io-ts, zod, GCS-generated custom models, ...). Instead, marketing keeps
+// hand-maintained snapshots of the data the page needs. When the front sources
+// of truth change, those snapshots must be re-synced or the page silently
+// renders stale/incomplete prices.
+const MARKETING_SNAPSHOT_FILES = [
+  "marketing/lib/api/assistant/token_pricing.ts",
+  "marketing/types/assistant/models/models.ts",
+  "marketing/types/assistant/models/providers.ts",
+  "marketing/types/assistant/models/types.ts",
+];
+
+// Front files mirrored into the marketing snapshots above. We watch the pricing
+// data and the model-config/provider source files, but skip front-only files
+// under `front/types/assistant/models/` that the snapshot doesn't reflect.
+function isWatchedMarketingSourceFile(path: string) {
+  if (path === "front/lib/api/assistant/token_pricing.ts") {
+    return true;
+  }
+  if (
+    !path.startsWith("front/types/assistant/models/") ||
+    !path.endsWith(".ts") ||
+    path.endsWith(".test.ts")
+  ) {
+    return false;
+  }
+  const frontOnlyFiles = [
+    "custom_models.generated.ts",
+    "embedding.ts",
+    "reasoning.ts",
+    "utils.ts",
+  ];
+  return !frontOnlyFiles.some((f) => path.endsWith(`/${f}`));
+}
+
+function failMarketingSnapshotAck(frontFiles: string[]) {
+  fail(
+    "Model/pricing source files in `front` changed but the hand-maintained " +
+      "`marketing` snapshots were not updated:\n" +
+      frontFiles.map((f) => `- ${f}`).join("\n") +
+      "\n\nThe `/home/api-pricing` page is served by `marketing`, which keeps " +
+      "its own copies of the model configs and token pricing. Re-sync:\n" +
+      MARKETING_SNAPSHOT_FILES.map((f) => `- \`${f}\``).join("\n") +
+      "\n\nso the pricing table stays correct, or add the " +
+      `\`${marketingSnapshotAckLabel}\` label if this change does not affect ` +
+      "the marketing snapshots (e.g. it only touches fields the snapshot " +
+      "ignores, such as `contextSize` or descriptions)."
+  );
+}
+
+function warnMarketingSnapshotAck() {
+  warn(
+    "Model/pricing source files in `front` changed and the " +
+      `\`${marketingSnapshotAckLabel}\` label is set. Confirm the marketing ` +
+      "snapshots under `marketing/lib/api/assistant/token_pricing.ts` and " +
+      "`marketing/types/assistant/models/` genuinely don't need updating."
+  );
+}
+
+function warnMarketingSnapshotUpdated() {
+  warn(
+    "Both `front` model/pricing sources and the `marketing` snapshots changed. " +
+      "Double-check the marketing copies match front (model ids, display names, " +
+      "providers, prices) — they are mirrored by hand."
+  );
+}
+
+function checkMarketingSnapshotSync(
+  changedFrontFiles: string[],
+  changedMarketingFiles: string[]
+) {
+  if (changedMarketingFiles.length > 0) {
+    warnMarketingSnapshotUpdated();
+  } else if (hasLabel(marketingSnapshotAckLabel)) {
+    warnMarketingSnapshotAck();
+  } else {
+    failMarketingSnapshotAck(changedFrontFiles);
+  }
+}
+
 async function checkDiffFiles() {
   const diffFiles = danger.git.modified_files
     .concat(danger.git.created_files)
@@ -508,6 +590,21 @@ async function checkDiffFiles() {
   });
   if (modifiedFrontFiles.length > 0) {
     await checkRawSqlRegistry(modifiedFrontFiles);
+  }
+
+  // Model/pricing sources mirrored into the marketing snapshots that back the
+  // `/home/api-pricing` page.
+  const modifiedMarketingSourceFiles = diffFiles.filter(
+    isWatchedMarketingSourceFile
+  );
+  if (modifiedMarketingSourceFiles.length > 0) {
+    const modifiedMarketingSnapshotFiles = diffFiles.filter((path) =>
+      MARKETING_SNAPSHOT_FILES.includes(path)
+    );
+    checkMarketingSnapshotSync(
+      modifiedMarketingSourceFiles,
+      modifiedMarketingSnapshotFiles
+    );
   }
 
   // Sparkle version consistency check

--- a/marketing/lib/api/assistant/token_pricing.ts
+++ b/marketing/lib/api/assistant/token_pricing.ts
@@ -38,6 +38,18 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 15.0,
     cache_read_input_tokens: 0.25,
   },
+  // https://openai.com/api/pricing/
+  "gpt-5.4-mini": {
+    input: 0.75,
+    output: 4.5,
+    cache_read_input_tokens: 0.075,
+  },
+  // https://openai.com/api/pricing/
+  "gpt-5.4-nano": {
+    input: 0.2,
+    output: 1.25,
+    cache_read_input_tokens: 0.02,
+  },
   "gpt-5.2": {
     input: 1.75,
     output: 14.0,
@@ -154,6 +166,13 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 25.0,
     cache_creation_input_tokens: 6.25,
     cache_read_input_tokens: 0.5,
+  },
+  // https://platform.claude.com/docs/en/about-claude/models/overview
+  "claude-fable-5": {
+    input: 10.0,
+    output: 50.0,
+    cache_creation_input_tokens: 12.5,
+    cache_read_input_tokens: 1.0,
   },
   "claude-sonnet-4-6": {
     input: 3.0,
@@ -290,23 +309,9 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     input: 0.27,
     output: 1.1,
   },
-  "deepseek-ai/DeepSeek-R1": {
-    input: 0.55,
-    output: 2.19,
-  },
   "deepseek-chat": {
     input: 0.14,
     output: 0.28,
-  },
-  "deepseek-reasoner": {
-    input: 0.55,
-    output: 2.19,
-  },
-  // https://app.fireworks.ai/models/fireworks/deepseek-r1-0528
-  "accounts/fireworks/models/deepseek-r1-0528": {
-    input: 1.35,
-    output: 5.4,
-    cache_read_input_tokens: 0.68,
   },
   // https://fireworks.ai/models/fireworks/deepseek-v3p2
   "accounts/fireworks/models/deepseek-v3p2": {

--- a/marketing/types/assistant/models/models.ts
+++ b/marketing/types/assistant/models/models.ts
@@ -1,8 +1,12 @@
-// Marketing static copy of the model list. The real SUPPORTED_MODEL_CONFIGS is a
-// giant data table that lives in front (with imports from many provider sub-files).
-// This file mirrors only the fields the /home/api-pricing page needs (modelId,
-// displayName, providerId). Until a build-time snapshot exists, marketing ships
-// this static copy. A follow-up will bake in the snapshot.
+// Baked snapshot of the model configs the /home/api-pricing page needs.
+//
+// The full SUPPORTED_MODEL_CONFIGS in front is assembled from many provider
+// sub-files behind a deep dependency chain (io-ts, zod, GCS-generated custom
+// models, ...). Marketing only needs (modelId, displayName, providerId) to render
+// the pricing table, so we keep a flat snapshot here instead of importing front.
+//
+// Keep in sync with front/types/assistant/models (SUPPORTED_MODEL_CONFIGS) and
+// front/lib/api/assistant/token_pricing.ts when models are added or removed.
 import type { ModelConfig } from "@marketing/types/assistant/models/types";
 
 export type StaticModelIdType = string;


### PR DESCRIPTION
## Description

Add API pricing page to marketing, with a dangerjs to catch when we update front models without reflecting the change in markenting


## Tests

Tested locally


## Risk

Low

## Deploy Plan

Deploy