### PR TITLE
[marketing] fix: Speedup redirect

### DIFF
--- a/marketing/components/home/OpenDustButton.tsx
+++ b/marketing/components/home/OpenDustButton.tsx
@@ -1,3 +1,4 @@
+import config from "@marketing/lib/api/config";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@marketing/lib/cookies";
 import { useLandingAuthContext } from "@marketing/lib/swr/website";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
@@ -28,9 +29,10 @@ export function OpenDustButton({
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
 
-  const { user, isLoading, isAuthenticated } = useLandingAuthContext({
-    hasSessionCookie: hasSession,
-  });
+  const { user, defaultWorkspaceId, isLoading, isAuthenticated } =
+    useLandingAuthContext({
+      hasSessionCookie: hasSession,
+    });
 
   if (!hasSession) {
     return null;
@@ -52,6 +54,14 @@ export function OpenDustButton({
     return null;
   }
 
+  // When we already know the user's workspace, navigate straight to the app to
+  // skip the slow server-side `/api/login` round-trip. Fall back to `/api/login`
+  // when there is no default workspace (no-workspace / first-login / invite / SSO
+  // edge cases that need the full login flow).
+  const target = defaultWorkspaceId
+    ? appendUTMParams(`${config.getAppUrl()}/w/${defaultWorkspaceId}`)
+    : appendUTMParams("/api/login");
+
   const button = (
     <Button
       variant={variant}
@@ -60,7 +70,7 @@ export function OpenDustButton({
       icon={ArrowRight}
       onClick={withTracking(trackingArea, trackingObject, () => {
         // eslint-disable-next-line react-hooks/immutability
-        window.location.href = appendUTMParams("/api/login");
+        window.location.href = target;
       })}
     />
   );

--- a/marketing/lib/swr/website.ts
+++ b/marketing/lib/swr/website.ts
@@ -39,6 +39,7 @@ export function useLandingAuthContext({
 
   return {
     user: data?.user ?? null,
+    defaultWorkspaceId: data?.defaultWorkspaceId ?? null,
     isLoading: hasSessionCookie && !error && !data,
     isAuthenticated: !!data?.user,
   };

--- a/marketing/pages/index.tsx
+++ b/marketing/pages/index.tsx
@@ -5,10 +5,11 @@ import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
 import { extractUTMParams } from "@marketing/lib/utils/utm";
 import { Landing } from "@marketing/pages/home";
+import { normalizeError } from "@marketing/types/shared/utils/error_utils";
+import logger from "@marketing/logger/logger";
 import type { GetServerSideProps } from "next";
-import { useRouter } from "next/router";
+import type { ParsedUrlQuery } from "querystring";
 import type { ReactElement } from "react";
-import { useEffect } from "react";
 
 interface HomeProps {
   postLoginReturnToUrl: string;
@@ -17,10 +18,100 @@ interface HomeProps {
   gtmTrackingId: string | null;
 }
 
+// Cap the SSR auth-context lookup so a slow/unavailable front API never hangs
+// the marketing homepage — we render the landing instead.
+const AUTH_CONTEXT_TIMEOUT_MS = 1500;
+
+/**
+ * Resolve where an already-authenticated visitor should be sent, server-side.
+ *
+ * Mirrors the old `front` behaviour (`front/pages/index.tsx` `getServerSideProps`,
+ * which called `getSession` and redirected before rendering). Marketing has no
+ * WorkOS code of its own, so it asks `front` via `/api/auth-context`, forwarding
+ * the incoming cookies — the `workos_session` cookie is scoped to the shared
+ * `*.dust.tt` domain (`WORKOS_SESSION_COOKIE_DOMAIN`), so it reaches us here.
+ *
+ * `/api/auth-context` already returns the default workspace, so we redirect
+ * straight to the app (`/w/<id>`) rather than bouncing through `/api/login`,
+ * which re-runs the full server-side login flow (a second WorkOS
+ * `authenticate()` + invite/membership/audit work) before issuing the same
+ * redirect. We fall back to `/api/login` only when there is no default
+ * workspace (no-workspace / invite / SSO flows that need it).
+ *
+ * Returns `null` when the visitor is anonymous or the lookup fails, in which
+ * case the caller renders the landing page.
+ */
+async function resolveAuthedRedirectDestination(
+  cookieHeader: string,
+  query: ParsedUrlQuery
+): Promise<string | null> {
+  try {
+    const res = await fetch(`${config.getApiBaseUrl()}/api/auth-context`, {
+      headers: { cookie: cookieHeader },
+      signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const data = (await res.json()) as {
+      user?: { sId?: string };
+      defaultWorkspaceId?: string | null;
+    };
+    if (!data.user) {
+      return null;
+    }
+
+    // Forward only marketing/attribution params (UTM + click IDs) so the
+    // destination keeps signup attribution.
+    const utmSearchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(extractUTMParams(query))) {
+      if (value) {
+        utmSearchParams.set(key, value);
+      }
+    }
+    const utmQueryString = utmSearchParams.toString();
+    const destinationUrl = data.defaultWorkspaceId
+      ? `${config.getAppUrl()}/w/${data.defaultWorkspaceId}`
+      : `${config.getApiBaseUrl()}/api/login`;
+    return utmQueryString
+      ? `${destinationUrl}?${utmQueryString}`
+      : destinationUrl;
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err) },
+      "auth-context lookup failed during marketing root SSR; rendering landing"
+    );
+    return null;
+  }
+}
+
 export const getServerSideProps: GetServerSideProps<HomeProps> = async (
   context
 ) => {
   const { inviteToken } = context.query;
+
+  // On the marketing root, an authenticated user's intent is to open the
+  // product, not browse the homepage — so redirect them server-side, before
+  // rendering, to avoid the render + hydrate + client fetch round-trip. Gated on
+  // the session cookie so anonymous SSR stays a no-op. We do NOT forward
+  // inviteToken: an expired/invalid one makes /api/login 400, and the redirect
+  // intent doesn't depend on it.
+  const cookieHeader = context.req.headers.cookie ?? "";
+  if (cookieHeader.includes("workos_session=")) {
+    const destination = await resolveAuthedRedirectDestination(
+      cookieHeader,
+      context.query
+    );
+    if (destination) {
+      logger.info(
+        { path: "/" },
+        "Redirecting authenticated user from marketing root to the app"
+      );
+      return {
+        redirect: { permanent: false, destination },
+      };
+    }
+  }
 
   let postLoginCallbackUrl = "/api/login";
   if (inviteToken) {
@@ -39,56 +130,8 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
   };
 };
 
-/**
- * Client-side redirect for already-authenticated visitors landing on the
- * marketing root: an authed user's intent is to open the product, not browse
- * the homepage. We forward only marketing/attribution params (UTM + click IDs)
- * so /api/login keeps signup attribution.
- */
-function useRedirectAuthedToApp() {
-  const router = useRouter();
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const res = await fetch(`${config.getApiBaseUrl()}/api/auth-context`, {
-          credentials: "include",
-        });
-        if (cancelled || !res.ok) {
-          return;
-        }
-        const data = (await res.json()) as { user?: { sId?: string } };
-        if (!data.user) {
-          return;
-        }
-
-        const utmSearchParams = new URLSearchParams();
-        for (const [key, value] of Object.entries(
-          extractUTMParams(router.query)
-        )) {
-          if (value) {
-            utmSearchParams.set(key, value);
-          }
-        }
-        const utmQueryString = utmSearchParams.toString();
-        const loginUrl = `${config.getApiBaseUrl()}/api/login`;
-        window.location.replace(
-          utmQueryString ? `${loginUrl}?${utmQueryString}` : loginUrl
-        );
-      } catch {
-        // Not authenticated or fetch failed — stay on landing.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [router.query]);
-}
-
 // biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
 export default function Home({ news }: HomeProps) {
-  useRedirectAuthedToApp();
   return <Landing news={news} />;
 }
 


### PR DESCRIPTION
## Description

The redirect implementation of marketing was quite slow, doing the /api/login + redirect route, whereas the one in front was a bit smarter, just routing from / at getServerSideProps.

We now do the same as before, straight redirect.

## Tests

Tested manually

## Risk

Low

## Deploy Plan

Deploy marketing