### PR TITLE
Fixes in seat changes

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -668,6 +668,7 @@ export async function updateMembershipSeatAndTrack({
   const outcome = classifySeatChange({
     contract,
     productSeatTypes,
+    now: new Date(),
     change: {
       userId: user.sId,
       previousSeatType,

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -16,6 +16,7 @@ import {
   NORMALIZED_POOL_LIMIT_SEAT_TYPES,
   normalizeToPoolLimitSeatType,
 } from "@app/types/memberships";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { Subscription } from "@metronome/sdk/resources";
 
 /**
@@ -441,6 +442,112 @@ export function getAwuAllocationForSeatType(
 ): number {
   return getAwuAllocationInfoForSeatType(contract, seatType, productSeatTypes)
     .credits;
+}
+
+/**
+ * The next time the per-seat AWU credit for `seatType` recurs (renews),
+ * strictly after `now`.
+ *
+ * This is the credit *recurrence*, which is deliberately independent of the
+ * subscription's billing period: in new pricing every per-seat AWU credit
+ * recurs MONTHLY (see `getPerSeatIndividualAwuCredits` /
+ * `buildPerSeatCredits` in `setup_new_pricing.ts`, which set
+ * `recurrence_frequency: "MONTHLY"` for both the monthly and the annual
+ * subscription of each seat pair). So a `pro_yearly` seat is billed once a
+ * year but its allowance refreshes every month. We therefore step the
+ * credit's recurrence anchor (the subscription's current billing-period
+ * start) forward by its `recurrence_frequency` rather than reading
+ * `billing_periods.next.starting_at`, which on an annual seat would point up
+ * to a year out.
+ *
+ * Returns `undefined` when the seat carries no recurring credit (e.g. `free`,
+ * whose AWU grant is a one-shot lifetime contract credit created at
+ * assignment time — see `grantFreeSeatCredits` — or `none`), when the credit
+ * never recurs (`lifetime`), or when the subscription exposes no
+ * billing-period anchor. Callers decide the fallback.
+ */
+export function getNextSeatCreditRenewalDate({
+  contract,
+  seatType,
+  productSeatTypes,
+  now,
+}: {
+  contract: CachedContract;
+  seatType: MembershipSeatType;
+  productSeatTypes: Map<string, MembershipSeatType>;
+  now: Date;
+}): Date | undefined {
+  const subscription = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  ).get(seatType);
+  if (!subscription?.id) {
+    return undefined;
+  }
+
+  const credit = (contract.recurring_credits ?? []).find(
+    (c) => c.subscription_config?.subscription_id === subscription.id
+  );
+  if (!credit) {
+    return undefined;
+  }
+
+  const period = getSeatAwuCreditsPeriod(credit);
+  if (period === "lifetime") {
+    return undefined;
+  }
+
+  // Recurrences are anchored at the subscription start and refresh every
+  // `period`; the current billing-period start sits on that grid (one period
+  // back for monthly seats, up to a year back for annual seats whose credit
+  // still recurs monthly).
+  const anchorIso =
+    subscription.billing_periods?.current?.starting_at ??
+    subscription.billing_periods?.next?.starting_at;
+  if (!anchorIso) {
+    return undefined;
+  }
+
+  // Step in UTC: `date-fns` add* operate in local time and would shift the
+  // recurrence date across timezones. Month overflow is handled by `Date.UTC`
+  // (e.g. month 13 → next January).
+  const anchor = new Date(anchorIso);
+  const addMonthsUtc = (months: number): Date =>
+    new Date(
+      Date.UTC(
+        anchor.getUTCFullYear(),
+        anchor.getUTCMonth() + months,
+        anchor.getUTCDate(),
+        anchor.getUTCHours(),
+        anchor.getUTCMinutes(),
+        anchor.getUTCSeconds(),
+        anchor.getUTCMilliseconds()
+      )
+    );
+  const step = (n: number): Date => {
+    switch (period) {
+      case "weekly":
+        return new Date(anchor.getTime() + n * 7 * 24 * 60 * 60 * 1000);
+      case "monthly":
+        return addMonthsUtc(n);
+      case "quarterly":
+        return addMonthsUtc(3 * n);
+      case "annual":
+        return addMonthsUtc(12 * n);
+      default:
+        // `lifetime` already returned above; this guards new period values.
+        return assertNever(period);
+    }
+  };
+
+  // Step forward until the first occurrence strictly after `now`. Bounded:
+  // the anchor is at most one period before `now`, except an annual seat with
+  // a monthly credit, where it's at most ~12 months back.
+  let next = anchor;
+  for (let n = 1; next.getTime() <= now.getTime(); n++) {
+    next = step(n);
+  }
+  return next;
 }
 
 /**

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1,5 +1,6 @@
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
+  classifySeatChange,
   hasContractSeatSubscription,
   resolveRemappedSeatType,
 } from "@app/lib/metronome/seats";
@@ -45,9 +46,17 @@ type SeatFixture = {
 function makeContract({
   seats = [],
   isMau = false,
+  currentBillingPeriodStartingAt,
+  nextBillingPeriodStartingAt,
 }: {
   seats?: SeatFixture[];
   isMau?: boolean;
+  // ISO timestamp for `subscriptions[].billing_periods.current.starting_at`,
+  // the recurrence anchor `getNextSeatCreditRenewalDate` steps from.
+  currentBillingPeriodStartingAt?: string;
+  // ISO timestamp for `subscriptions[].billing_periods.next.starting_at`, the
+  // fallback anchor used when a seat has no recurring credit.
+  nextBillingPeriodStartingAt?: string;
 } = {}): {
   contract: CachedContract;
   productSeatTypes: Map<string, MembershipSeatType>;
@@ -57,6 +66,18 @@ function makeContract({
   const recurringCredits = [];
   const overrides = [];
 
+  const billingPeriods =
+    currentBillingPeriodStartingAt || nextBillingPeriodStartingAt
+      ? {
+          ...(currentBillingPeriodStartingAt
+            ? { current: { starting_at: currentBillingPeriodStartingAt } }
+            : {}),
+          ...(nextBillingPeriodStartingAt
+            ? { next: { starting_at: nextBillingPeriodStartingAt } }
+            : {}),
+        }
+      : undefined;
+
   for (const seat of seats) {
     const productId = `${seat.seatType}-product`;
     const subscriptionId = `sub_${seat.seatType}`;
@@ -64,6 +85,7 @@ function makeContract({
     subscriptions.push({
       id: subscriptionId,
       subscription_rate: { product: { id: productId, name: seat.seatType } },
+      ...(billingPeriods ? { billing_periods: billingPeriods } : {}),
     });
     if (seat.awu != null) {
       recurringCredits.push({
@@ -221,5 +243,162 @@ describe("resolveRemappedSeatType (entitlement-aware)", () => {
     expect(
       resolveRemappedSeatType("pro", contract, productSeatTypes, false)
     ).toBe("workspace_yearly");
+  });
+});
+
+describe("classifySeatChange", () => {
+  const NOW = new Date("2026-06-11T12:00:00Z");
+  // Current monthly credit period started mid-month; recurrences land on the
+  // 15th. The next one after NOW (Jun 11) is Jun 15.
+  const CURRENT_PERIOD = "2026-01-15T00:00:00Z";
+  const NEXT_RENEWAL = new Date("2026-06-15T00:00:00Z");
+
+  // `workspace` carries no AWU allocation, `pro`/`max` recur MONTHLY. The
+  // current period started months ago to show the renewal is the next monthly
+  // recurrence — not the billing-period boundary a year out.
+  const { contract, productSeatTypes } = makeContract({
+    seats: [
+      { seatType: "workspace" },
+      { seatType: "pro", awu: 100 },
+      { seatType: "max", awu: 500 },
+    ],
+    currentBillingPeriodStartingAt: CURRENT_PERIOD,
+    nextBillingPeriodStartingAt: "2027-01-15T00:00:00Z",
+  });
+
+  const classify = (
+    previousSeatType: MembershipSeatType,
+    newSeatType: MembershipSeatType,
+    pendingScheduledChange?: { seatType: MembershipSeatType; at: Date }
+  ) =>
+    classifySeatChange({
+      contract,
+      productSeatTypes,
+      now: NOW,
+      change: {
+        userId: "u1",
+        previousSeatType,
+        newSeatType,
+        pendingScheduledChange,
+      },
+    });
+
+  it("removes a zero-allowance seat (workspace → none) immediately", () => {
+    expect(classify("workspace", "none")).toEqual({ kind: "immediate" });
+  });
+
+  it("defers removal of a seat that carried allowance (pro → none) to the next credit renewal", () => {
+    // Anchored on the monthly credit recurrence, NOT the (year-out) billing
+    // period.
+    expect(classify("pro", "none")).toEqual({
+      kind: "deferred",
+      at: NEXT_RENEWAL,
+    });
+  });
+
+  it("defers a downgrade between allowance tiers (max → pro) to the next credit renewal", () => {
+    expect(classify("max", "pro")).toEqual({
+      kind: "deferred",
+      at: NEXT_RENEWAL,
+    });
+  });
+
+  it("defers an annually-billed downgrade (max_yearly → pro_yearly) to the next MONTHLY renewal, not next year", () => {
+    // The seats are billed annually (current → next billing period a year
+    // apart) but their AWU credit recurs monthly, so the downgrade lands on
+    // the next monthly recurrence (Jun 15), not the year-out billing boundary
+    // (Jan 15 2027).
+    const { contract: yearly, productSeatTypes: types } = makeContract({
+      seats: [
+        { seatType: "pro_yearly", awu: 100, frequency: "MONTHLY" },
+        { seatType: "max_yearly", awu: 500, frequency: "MONTHLY" },
+      ],
+      currentBillingPeriodStartingAt: CURRENT_PERIOD,
+      nextBillingPeriodStartingAt: "2027-01-15T00:00:00Z",
+    });
+    expect(
+      classifySeatChange({
+        contract: yearly,
+        productSeatTypes: types,
+        now: NOW,
+        change: {
+          userId: "u1",
+          previousSeatType: "max_yearly",
+          newSeatType: "pro_yearly",
+        },
+      })
+    ).toEqual({ kind: "deferred", at: NEXT_RENEWAL });
+  });
+
+  it("applies an upgrade immediately (pro → max)", () => {
+    expect(classify("pro", "max")).toEqual({ kind: "immediate" });
+  });
+
+  it("is a noop when selecting the current seat with no pending change", () => {
+    expect(classify("pro", "pro")).toEqual({ kind: "noop" });
+  });
+
+  it("cancels a pending change when re-selecting the current seat", () => {
+    expect(
+      classify("pro", "pro", { seatType: "none", at: NEXT_RENEWAL })
+    ).toEqual({ kind: "cancelled" });
+  });
+
+  it("anchors an annually-recurring credit on its yearly recurrence", () => {
+    // A seat whose credit recurs ANNUALLY renews on the yearly anniversary of
+    // the period start, not monthly.
+    const { contract: annual, productSeatTypes: types } = makeContract({
+      seats: [
+        { seatType: "pro", awu: 100, frequency: "ANNUAL" },
+        { seatType: "max", awu: 500, frequency: "ANNUAL" },
+      ],
+      currentBillingPeriodStartingAt: CURRENT_PERIOD,
+    });
+    expect(
+      classifySeatChange({
+        contract: annual,
+        productSeatTypes: types,
+        now: NOW,
+        change: { userId: "u1", previousSeatType: "max", newSeatType: "pro" },
+      })
+    ).toEqual({ kind: "deferred", at: new Date("2027-01-15T00:00:00Z") });
+  });
+
+  it("uses the next billing period as the anchor when there is no current one", () => {
+    // With no `current` period to step from, the recurrence anchor falls back
+    // to `next.starting_at` (which is already in the future).
+    const { contract: c, productSeatTypes: types } = makeContract({
+      seats: [{ seatType: "pro", awu: 100 }],
+      nextBillingPeriodStartingAt: "2026-07-01T00:00:00Z",
+    });
+    expect(
+      classifySeatChange({
+        contract: c,
+        productSeatTypes: types,
+        now: NOW,
+        change: { userId: "u1", previousSeatType: "pro", newSeatType: "none" },
+      })
+    ).toEqual({ kind: "deferred", at: new Date("2026-07-01T00:00:00Z") });
+  });
+
+  it("treats free → none as a no-op (free is a one-shot tier)", () => {
+    expect(classify("free", "none")).toEqual({ kind: "noop" });
+  });
+
+  it("returns undefined for a deferral when no anchor date exists", () => {
+    const { contract: noPeriod, productSeatTypes: types } = makeContract({
+      seats: [
+        { seatType: "pro", awu: 100 },
+        { seatType: "max", awu: 500 },
+      ],
+    });
+    expect(
+      classifySeatChange({
+        contract: noPeriod,
+        productSeatTypes: types,
+        now: NOW,
+        change: { userId: "u1", previousSeatType: "max", newSeatType: "pro" },
+      })
+    ).toBeUndefined();
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -25,6 +25,7 @@ import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
   getDefaultSeatTypeForContract,
+  getNextSeatCreditRenewalDate,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
   getSeatTypeForSubscription,
@@ -151,21 +152,25 @@ export type SeatChangeOutcome =
  * Branches:
  * - Same seat as current: `cancelled` if a pending future change exists,
  *   else `noop`.
+ * - `free` → `none`: `noop`. A `free` seat is a one-shot tier that cannot be
+ *   downgraded to no seat.
  * - New allocation ≥ previous: `immediate` (the user gains/keeps access
  *   right away).
- * - New allocation < previous: `deferred` at the next billing-period start
- *   so the user keeps the richer access through the period they already
- *   paid for. Returns `undefined` when the contract has no next billing
- *   period to anchor the deferred transition to.
+ * - New allocation < previous: `deferred` to the next time the previous
+ *   seat's AWU allowance renews, so the user keeps the richer access through
+ *   the allowance they already paid for. Returns `undefined` when no renewal
+ *   (or billing-period) date can be resolved to anchor the deferral.
  */
 export function classifySeatChange({
   contract,
   productSeatTypes,
   change,
+  now,
 }: {
   contract: CachedContract;
   productSeatTypes: Map<string, MembershipSeatType>;
   change: SeatChangeRequest;
+  now: Date;
 }): SeatChangeOutcome | undefined {
   const { previousSeatType, newSeatType, pendingScheduledChange } = change;
 
@@ -173,6 +178,13 @@ export function classifySeatChange({
   // future change — a cancellation of that pending change.
   if (previousSeatType === newSeatType) {
     return pendingScheduledChange ? { kind: "cancelled" } : { kind: "noop" };
+  }
+
+  // `free` is a one-shot tier that can't be given back: downgrading a free
+  // seat to no seat is not allowed, so treat it as a no-op (the caller leaves
+  // the membership untouched).
+  if (previousSeatType === "free" && newSeatType === "none") {
+    return { kind: "noop" };
   }
 
   const previousAllocation = getAwuAllocationForSeatType(
@@ -185,33 +197,44 @@ export function classifySeatChange({
     newSeatType,
     productSeatTypes
   );
-  // Removing a seat (`none`) always defers, even when the previous tier had
-  // zero AWU allocation (e.g. workspace seats): 0 >= 0 would otherwise
-  // classify as immediate. Any genuine upgrade takes effect right away.
-  if (newSeatType !== "none" && newAllocation >= previousAllocation) {
+  // Keep or gain allowance — takes effect right away. This also covers
+  // removing a seat that carried no allowance (e.g. workspace seats:
+  // 0 >= 0): there's nothing already paid for to preserve, so the removal
+  // is immediate.
+  if (newAllocation >= previousAllocation) {
     return { kind: "immediate" };
   }
 
-  // Downgrade (or seat removal) — defer to the start of the next billing
-  // period so the user keeps the richer access they've already paid for.
-  // Billing-period
-  // boundaries aren't anchored to midnight on the contract, so ceil to
-  // midnight UTC to match how the invoice timestamp is displayed.
-  const nextStartingAt = (contract.subscriptions ?? [])
+  // Losing allowance (downgrade, or removal of a seat that had allowance) —
+  // defer until the previous seat's AWU allowance next renews, so the user
+  // keeps the richer allowance they've already paid for until it would have
+  // refreshed anyway. The renewal cadence is the credit's `recurrence_frequency`
+  // (MONTHLY in new pricing, even for annually-billed seats — see
+  // `getNextSeatCreditRenewalDate`), which is independent of the billing period.
+  //
+  // Defensive: a downgrade is always from a credit-bearing seat (`free` →
+  // `none` is handled above as a no-op), but if the credit's recurrence can't
+  // be resolved, fall back to the next billing-period start rather than
+  // failing the change.
+  const creditRenewalAt = getNextSeatCreditRenewalDate({
+    contract,
+    seatType: previousSeatType,
+    productSeatTypes,
+    now,
+  });
+  const fallbackNextStartingAt = (contract.subscriptions ?? [])
     .map((s) => s.billing_periods?.next?.starting_at)
     .find((d) => d !== undefined);
-  if (!nextStartingAt) {
+  const renewalAt =
+    creditRenewalAt ??
+    (fallbackNextStartingAt ? new Date(fallbackNextStartingAt) : undefined);
+  if (!renewalAt) {
     return undefined;
   }
-  const date = new Date(nextStartingAt);
-  const floored = new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
-  );
-  const at =
-    floored.getTime() < date.getTime()
-      ? new Date(floored.getTime() + 24 * 60 * 60 * 1000)
-      : floored;
-  return { kind: "deferred", at };
+
+  // `renewalAt` is already the exact instant the allowance refreshes — no
+  // rounding needed.
+  return { kind: "deferred", at: renewalAt };
 }
 
 /**


### PR DESCRIPTION
## Description

Three fixes to how seat changes are classified (`classifySeatChange`) and when they take effect:

1. **Removing a zero-allowance seat is now immediate.** Previously *any* seat removal was deferred to the next period. A seat with no AWU allowance (e.g. a workspace seat) has nothing already-paid-for to preserve, so its removal now applies immediately. Only losing allowance defers.

2. **Deferred downgrades anchor on the credit's recurrence, not the billing period.** A downgrade (or removal of a seat that carries allowance) defers to the next time the previous seat's AWU credit *renews*. The credit recurs monthly even for annually-billed seats, so e.g. `max_yearly → pro_yearly` now defers to next month instead of up to a year out. Recurrence dates are stepped in UTC (`getNextSeatCreditRenewalDate`); the scheduled date is the exact renewal instant (no midnight rounding).

3. **`free → none` is a no-op.** `free` is a one-shot, non-reassignable tier and cannot be downgraded to no seat.

## Tests

Added unit coverage for `classifySeatChange` in `seats.test.ts`: immediate zero-allowance removal, deferral on allowance loss, the annual-billing/monthly-credit case (`max_yearly → pro_yearly` → next month), `free → none` no-op, upgrade/noop/cancelled, and the credit-less billing-period fallback.

## Risk

Low. Pure classification logic; new-pricing seat AWU contracts are test-only so far.
