### PR TITLE
Simplify token handling code and move to zod.

### DIFF
--- a/front-api/routes/mcp/index.ts
+++ b/front-api/routes/mcp/index.ts
@@ -16,10 +16,9 @@ mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
     await dustMcpServer.connect(transport);
   }
 
-  const user = c.get("mcpUser");
   const auth = c.get("mcpAuth");
   logger.info(
-    { userId: user.sub, workspaceId: auth.workspace().sId },
+    { userId: auth.user().sId, workspaceId: auth.workspace().sId },
     "[dust-mcp-server] Inbound request"
   );
 

--- a/front/lib/api/mcp_server/auth.ts
+++ b/front/lib/api/mcp_server/auth.ts
@@ -1,13 +1,14 @@
 import {
-  getAuthenticatorFromWorkOSClaims,
-  type McpAuthenticator,
-} from "@app/lib/api/mcp_server/authenticator";
-import {
   getMcpResourceMetadataUrl,
   getMcpResourceServerUrl,
   getWorkOSAuthKitDomain,
   normalizeOAuthUrl,
 } from "@app/lib/api/mcp_server/urls";
+import type { WorkOSJwtPayload } from "@app/lib/api/workos";
+import {
+  getAuthenticatorFromWorkOSClaims,
+  type WorkOSWorkspaceAuthenticator,
+} from "@app/lib/api/workos_authenticator";
 import logger from "@app/logger/logger";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { Context } from "hono";
@@ -19,31 +20,11 @@ import {
   jwtVerify,
 } from "jose";
 
-export type McpServerAuthUser = JWTPayload & { sub: string };
-
 export type McpServerAuthVariables = {
-  mcpUser: McpServerAuthUser;
+  mcpUser: WorkOSJwtPayload;
   mcpAuthInfo: AuthInfo;
-  mcpAuth: McpAuthenticator;
+  mcpAuth: WorkOSWorkspaceAuthenticator;
 };
-
-function tokenScopes(payload: JWTPayload): string[] {
-  const { scope } = payload;
-  if (typeof scope === "string" && scope.trim()) {
-    return scope.split(" ").filter(Boolean);
-  }
-  return [];
-}
-
-function toMcpAuthInfo(token: string, payload: McpServerAuthUser): AuthInfo {
-  return {
-    token,
-    clientId: payload.sub,
-    scopes: tokenScopes(payload),
-    expiresAt: typeof payload.exp === "number" ? payload.exp : undefined,
-    extra: { user: payload },
-  };
-}
 
 const WORKOS_AUTHKIT_DOMAIN = getWorkOSAuthKitDomain();
 const DUST_MCP_SERVER_URL = getMcpResourceServerUrl();
@@ -132,8 +113,7 @@ export const mcpServerAuthMiddleware = createMiddleware<{
       throw new Error("Token audience does not match MCP resource URL");
     }
 
-    const mcpUser = payload as McpServerAuthUser;
-    const authResult = await getAuthenticatorFromWorkOSClaims(mcpUser);
+    const authResult = await getAuthenticatorFromWorkOSClaims(payload);
     if (authResult.isErr()) {
       const descriptions: Record<typeof authResult.error, string> = {
         organization_missing:
@@ -149,8 +129,8 @@ export const mcpServerAuthMiddleware = createMiddleware<{
         {
           error: authResult.error,
           tokenClaims: {
-            sub: mcpUser.sub,
-            org_id: mcpUser.org_id,
+            sub: payload.sub,
+            org_id: payload.org_id,
           },
         },
         "[dust-mcp-server] Failed to build workspace-scoped authenticator"
@@ -162,8 +142,6 @@ export const mcpServerAuthMiddleware = createMiddleware<{
       });
     }
 
-    c.set("mcpUser", mcpUser);
-    c.set("mcpAuthInfo", toMcpAuthInfo(token, mcpUser));
     c.set("mcpAuth", authResult.value);
     await next();
   } catch (err) {

--- a/front/lib/api/mcp_server/context.ts
+++ b/front/lib/api/mcp_server/context.ts
@@ -1,17 +1,17 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-import type { McpAuthenticator } from "@app/lib/api/mcp_server/authenticator";
+import type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
 
-export type { McpAuthenticator } from "@app/lib/api/mcp_server/authenticator";
+export type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
 
 type McpContext = {
-  auth: McpAuthenticator;
+  auth: WorkOSWorkspaceAuthenticator;
 };
 
 const mcpContext = new AsyncLocalStorage<McpContext>();
 
 export function runWithMcpContext<T>(
-  context: { auth: McpAuthenticator },
+  context: { auth: WorkOSWorkspaceAuthenticator },
   fn: () => T
 ): T {
   return mcpContext.run(context, fn);
@@ -21,7 +21,7 @@ export function getMcpContext(): McpContext | undefined {
   return mcpContext.getStore();
 }
 
-export function getAuthenticatorFromMcpContext(): McpAuthenticator {
+export function getAuthenticatorFromMcpContext(): WorkOSWorkspaceAuthenticator {
   const auth = getMcpContext()?.auth;
   if (!auth) {
     throw new Error(

--- a/front/lib/api/mcp_server/urls.ts
+++ b/front/lib/api/mcp_server/urls.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { isDevelopment } from "@app/types/shared/env";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
 /**
@@ -27,6 +28,12 @@ export function normalizeOAuthUrl(url: string): string {
 }
 
 export function getMcpResourceServerUrl(): string {
+  // In dev, we do not have the magical ingress redirect so we need to use the API url.
+  if (isDevelopment()) {
+    return normalizeOAuthUrl(
+      EnvironmentConfig.getEnvVariable("DUST_FRONT_API").trim() + "/mcp"
+    );
+  }
   return normalizeOAuthUrl(
     EnvironmentConfig.getEnvVariable("DUST_CLIENT_FACING_URL").trim() + "/mcp"
   );

--- a/front/lib/api/workos.test.ts
+++ b/front/lib/api/workos.test.ts
@@ -1,0 +1,65 @@
+import { parseWorkOSJwtPayload } from "@app/lib/api/workos";
+import { describe, expect, it } from "vitest";
+
+describe("parseWorkOSJwtPayload", () => {
+  it("accepts a valid payload with required fields", () => {
+    const payload = {
+      sub: "user_123",
+      exp: 1_700_000_000,
+    };
+
+    const result = parseWorkOSJwtPayload(payload);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sub).toBe("user_123");
+      expect(result.value.exp).toBe(1_700_000_000);
+    }
+  });
+
+  it("accepts optional string and number claims", () => {
+    const payload = {
+      sub: "user_123",
+      exp: 1_700_000_000,
+      org_id: "org_abc",
+      iat: 1_699_999_000,
+    };
+
+    const result = parseWorkOSJwtPayload(payload);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.org_id).toBe("org_abc");
+      expect(result.value.iat).toBe(1_699_999_000);
+    }
+  });
+
+  it("rejects a payload missing sub", () => {
+    const result = parseWorkOSJwtPayload({
+      exp: 1_700_000_000,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Invalid token payload.");
+    }
+  });
+
+  it("rejects a payload missing exp", () => {
+    const result = parseWorkOSJwtPayload({
+      sub: "user_123",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("rejects a payload with invalid claim types", () => {
+    const result = parseWorkOSJwtPayload({
+      sub: "user_123",
+      exp: 1_700_000_000,
+      org_id: { nested: "object" },
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/workos.ts
+++ b/front/lib/api/workos.ts
@@ -4,24 +4,36 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isLeft } from "fp-ts/lib/Either";
-import * as t from "io-ts";
 import jwt from "jsonwebtoken";
 import jwksClient from "jwks-rsa";
+import { z } from "zod";
 
-export const WorkOSJwtPayloadSchema = t.intersection([
-  t.type({
-    exp: t.number,
-    sub: t.string,
-  }),
-  t.record(
-    t.string,
-    t.union([t.string, t.number, t.undefined, t.array(t.string)])
-  ),
+const WorkOSJwtClaimValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.undefined(),
+  z.array(z.string()),
 ]);
 
-export type WorkOSJwtPayload = t.TypeOf<typeof WorkOSJwtPayloadSchema> &
+export const WorkOSJwtPayloadSchema = z
+  .object({
+    exp: z.number(),
+    sub: z.string(),
+  })
+  .catchall(WorkOSJwtClaimValueSchema);
+
+export type WorkOSJwtPayload = z.infer<typeof WorkOSJwtPayloadSchema> &
   jwt.JwtPayload;
+
+export function parseWorkOSJwtPayload(
+  payload: unknown
+): Result<WorkOSJwtPayload, Error> {
+  const validation = WorkOSJwtPayloadSchema.safeParse(payload);
+  if (!validation.success) {
+    return new Err(new Error("Invalid token payload."));
+  }
+  return new Ok(validation.data);
+}
 
 /**
  * Get the public key to verify a WorkOS token.
@@ -84,13 +96,13 @@ export async function verifyWorkOSToken(
           return resolve(new Err(Error("No token payload")));
         }
 
-        const payloadValidation = WorkOSJwtPayloadSchema.decode(decoded);
-        if (isLeft(payloadValidation)) {
+        const payloadValidation = parseWorkOSJwtPayload(decoded);
+        if (payloadValidation.isErr()) {
           logger.error("Invalid token payload.");
-          return resolve(new Err(Error("Invalid token payload.")));
+          return resolve(payloadValidation);
         }
 
-        return resolve(new Ok(payloadValidation.right));
+        return resolve(new Ok(payloadValidation.value));
       }
     );
   });

--- a/front/lib/api/workos_authenticator.test.ts
+++ b/front/lib/api/workos_authenticator.test.ts
@@ -1,0 +1,104 @@
+import { getAuthenticatorFromWorkOSClaims } from "@app/lib/api/workos_authenticator";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+function makeClaims({
+  sub,
+  orgId,
+  exp = 1_700_000_000,
+}: {
+  sub: string;
+  orgId?: string;
+  exp?: number;
+}) {
+  return orgId === undefined ? { sub, exp } : { sub, exp, org_id: orgId };
+}
+
+describe("getAuthenticatorFromWorkOSClaims", () => {
+  it("returns invalid_token_payload for malformed claims", async () => {
+    const result = await getAuthenticatorFromWorkOSClaims({ sub: "user_123" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe("invalid_token_payload");
+    }
+  });
+
+  it("returns organization_missing when org_id is absent", async () => {
+    const result = await getAuthenticatorFromWorkOSClaims(
+      makeClaims({ sub: "user_123" })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe("organization_missing");
+    }
+  });
+
+  it("returns workspace_not_found when org_id is unknown", async () => {
+    const result = await getAuthenticatorFromWorkOSClaims(
+      makeClaims({ sub: "user_123", orgId: "org_does_not_exist" })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe("workspace_not_found");
+    }
+  });
+
+  it("returns user_not_found when the user does not exist", async () => {
+    const workspace = await WorkspaceFactory.basic();
+
+    const result = await getAuthenticatorFromWorkOSClaims(
+      makeClaims({
+        sub: "user_unknown",
+        orgId: workspace.workOSOrganizationId!,
+      })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe("user_not_found");
+    }
+  });
+
+  it("returns not_a_member when the user is not in the workspace", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const user = await UserFactory.withWorkOSId("user_not_member");
+
+    const result = await getAuthenticatorFromWorkOSClaims(
+      makeClaims({
+        sub: user.workOSUserId!,
+        orgId: workspace.workOSOrganizationId!,
+      })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBe("not_a_member");
+    }
+  });
+
+  it("returns a workspace-scoped authenticator for valid claims", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const workOSUserId = "user_member_123";
+    const user = await UserFactory.withWorkOSId(workOSUserId);
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+
+    const result = await getAuthenticatorFromWorkOSClaims(
+      makeClaims({
+        sub: workOSUserId,
+        orgId: workspace.workOSOrganizationId!,
+      })
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.user().sId).toBe(user.sId);
+      expect(result.value.workspace().sId).toBe(workspace.sId);
+      expect(result.value.role()).toBe("user");
+    }
+  });
+});

--- a/front/lib/api/workos_authenticator.ts
+++ b/front/lib/api/workos_authenticator.ts
@@ -1,7 +1,6 @@
-import type { McpServerAuthUser } from "@app/lib/api/mcp_server/auth";
 import {
+  parseWorkOSJwtPayload,
   type WorkOSJwtPayload,
-  WorkOSJwtPayloadSchema,
 } from "@app/lib/api/workos";
 import { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -9,29 +8,18 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
-import { isLeft } from "fp-ts/lib/Either";
 
-export interface McpAuthenticator extends Authenticator {
+export interface WorkOSWorkspaceAuthenticator extends Authenticator {
   workspace(): WorkspaceType;
   user(): UserResource;
 }
 
-export type McpAuthenticatorError =
+export type WorkOSWorkspaceAuthenticatorError =
   | "organization_missing"
   | "workspace_not_found"
   | "user_not_found"
   | "not_a_member"
   | "invalid_token_payload";
-
-function parseWorkOSJwtPayload(
-  payload: McpServerAuthUser
-): WorkOSJwtPayload | null {
-  const validation = WorkOSJwtPayloadSchema.decode(payload);
-  if (isLeft(validation)) {
-    return null;
-  }
-  return validation.right;
-}
 
 function getOrganizationId(payload: WorkOSJwtPayload): string | null {
   const orgId = payload.org_id;
@@ -39,12 +27,15 @@ function getOrganizationId(payload: WorkOSJwtPayload): string | null {
 }
 
 export async function getAuthenticatorFromWorkOSClaims(
-  payload: McpServerAuthUser
-): Promise<Result<McpAuthenticator, McpAuthenticatorError>> {
-  const workOSToken = parseWorkOSJwtPayload(payload);
-  if (!workOSToken) {
+  payload: unknown
+): Promise<
+  Result<WorkOSWorkspaceAuthenticator, WorkOSWorkspaceAuthenticatorError>
+> {
+  const workOSTokenResult = parseWorkOSJwtPayload(payload);
+  if (workOSTokenResult.isErr()) {
     return new Err("invalid_token_payload");
   }
+  const workOSToken = workOSTokenResult.value;
 
   const organizationId = getOrganizationId(workOSToken);
   if (!organizationId) {
@@ -78,5 +69,5 @@ export async function getAuthenticatorFromWorkOSClaims(
     return new Err("not_a_member");
   }
 
-  return new Ok(auth as McpAuthenticator);
+  return new Ok(auth as WorkOSWorkspaceAuthenticator);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -738,11 +738,13 @@
       "name": "@dust-tt/front-api",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.100.1",
         "@hono/mcp": "^0.3.0",
         "@hono/node-server": "^1.19.10",
         "@hono/zod-validator": "^0.7.6",
         "hono": "^4.12.15",
         "jose": "^6.2.3",
+        "jsonwebtoken": "^9.0.0",
         "next": "^14.2.35",
         "next-swagger-doc": "^0.4.0",
         "openai": "^6.33.0",
@@ -750,6 +752,7 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.2",
         "esbuild": "^0.27.3",
         "tsx": "^4.21.0"
       }


### PR DESCRIPTION
## Description

Replaces `io-ts`/`fp-ts` with `zod` for WorkOS JWT payload validation in `workos.ts`, extracting a standalone `parseWorkOSJwtPayload(payload: unknown): Result<WorkOSJwtPayload, Error>` helper. Renames `McpAuthenticator` → `WorkOSWorkspaceAuthenticator` and moves `mcp_server/authenticator.ts` → `workos_authenticator.ts` to decouple the authenticator from MCP-specific namespacing. The MCP auth middleware (`mcp_server/auth.ts`) is simplified by removing the now-redundant `mcpUser` context variable, `tokenScopes`, and `toMcpAuthInfo` helpers. Also fixes `getMcpResourceServerUrl` in dev to use `DUST_FRONT_API` instead of `DUST_CLIENT_FACING_URL`.

## Tests

Added unit tests for `parseWorkOSJwtPayload` in `workos.test.ts` (valid payloads, missing `sub`/`exp`, invalid claim types) and for `getAuthenticatorFromWorkOSClaims` in `workos_authenticator.test.ts` (malformed claims, missing org, unknown workspace, user not found, not a member, happy path).

## Risk

Low. Pure refactor — behavior of `verifyWorkOSToken` and `getAuthenticatorFromWorkOSClaims` is unchanged. Zod and io-ts agree on all accepted/rejected claim shapes. The interface rename and file move are internal to the auth path; no external API surface changed.

## Deploy Plan

Deploy front. No migrations, no infrastructure changes.
