### PR TITLE
[connectors] chore: Remove front-internal references

### DIFF
--- a/connectors/src/connectors/dust_project/temporal/activities.ts
+++ b/connectors/src/connectors/dust_project/temporal/activities.ts
@@ -70,7 +70,7 @@ export async function dustProjectConversationsFullSyncActivity({
     );
 
     // Fetch all conversations for the project from Front API
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+    const dustAPI = getDustAPI(dataSourceConfig);
     const conversationsResult =
       await dustAPI.getSpaceConversationsForDataSource({
         spaceId: configuration.projectId,
@@ -213,7 +213,7 @@ export async function dustProjectConversationsIncrementalSyncActivity({
     const maxSourceUpdatedAt =
       await DustProjectConversationResource.getMaxSourceUpdatedAt(connectorId);
 
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+    const dustAPI = getDustAPI(dataSourceConfig);
     const conversationsResult =
       await dustAPI.getSpaceConversationsForDataSource({
         spaceId: configuration.projectId,
@@ -307,7 +307,7 @@ async function dustProjectConversationsGarbageCollectActivity({
 
     // Fetch all visible conversation IDs from Front API
     // This endpoint only returns conversations that still exist (not hard-deleted)
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+    const dustAPI = getDustAPI(dataSourceConfig);
     const conversationIdsResult = await dustAPI.getSpaceConversationIds({
       spaceId: configuration.projectId,
     });
@@ -428,7 +428,7 @@ export async function dustProjectMountFilesFullSyncActivity({
     "Starting full sync for dust_project mount files"
   );
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+  const dustAPI = getDustAPI(dataSourceConfig);
   const listRes = await dustAPI.getSpaceProjectFiles({
     spaceId: configuration.projectId,
   });
@@ -531,7 +531,7 @@ export async function dustProjectMountFilesIncrementalSyncActivity({
   const maxSourceUpdatedAt =
     await DustProjectMountFileResource.getMaxSourceUpdatedAt(connectorId);
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+  const dustAPI = getDustAPI(dataSourceConfig);
   const listRes = await dustAPI.getSpaceProjectFiles({
     spaceId: configuration.projectId,
     updatedSince:
@@ -621,7 +621,7 @@ export async function dustProjectMountFilesGarbageCollectActivity({
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
   try {
-    const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+    const dustAPI = getDustAPI(dataSourceConfig);
     const listRes = await dustAPI.getSpaceProjectFiles({
       spaceId: configuration.projectId,
     });
@@ -711,7 +711,7 @@ export async function dustProjectSyncMetadataActivity({
     "Fetching and syncing project metadata"
   );
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+  const dustAPI = getDustAPI(dataSourceConfig);
   const metadataResult = await dustAPI.getSpaceMetadata({
     spaceId: configuration.projectId,
   });

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -22,7 +22,7 @@ async function getVerifiedDomainsForWorkspace(
 ): Promise<WorkspaceDomainType[]> {
   const ds = dataSourceConfigFromConnector(connector);
 
-  const dustAPI = getDustAPI(ds, { useInternalAPI: false });
+  const dustAPI = getDustAPI(ds);
 
   const workspaceVerifiedDomainsRes =
     await dustAPI.getWorkspaceVerifiedDomains();

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -7,9 +7,6 @@ export const apiConfig = {
       apiKey: EnvironmentConfig.getOptionalEnvVariable("OAUTH_API_KEY") ?? null,
     };
   },
-  getDustFrontInternalAPIUrl: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_FRONT_INTERNAL_API");
-  },
   getDustFrontAPIUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_FRONT_API");
   },

--- a/connectors/src/lib/api/dust_api.ts
+++ b/connectors/src/lib/api/dust_api.ts
@@ -4,22 +4,16 @@ import type { DataSourceConfig } from "@connectors/types";
 import { DustAPI } from "@dust-tt/client";
 
 /**
- * Creates a DustAPI instance for the given data source configuration.
- * Uses the public Front API URL by default.
+ * Creates a DustAPI instance for the given data source configuration,
+ * targeting the front API URL.
  *
  * @param dataSourceConfig - The data source configuration
- * @param useInternalAPI - If true, uses the internal API URL instead of the public one
  * @returns A configured DustAPI instance
  */
-export function getDustAPI(
-  dataSourceConfig: DataSourceConfig,
-  { useInternalAPI }: { useInternalAPI?: boolean } = { useInternalAPI: false }
-): DustAPI {
+export function getDustAPI(dataSourceConfig: DataSourceConfig): DustAPI {
   return new DustAPI(
     {
-      url: useInternalAPI
-        ? apiConfig.getDustFrontInternalAPIUrl()
-        : apiConfig.getDustFrontAPIUrl(),
+      url: apiConfig.getDustFrontAPIUrl(),
     },
     {
       apiKey: dataSourceConfig.workspaceAPIKey,

--- a/connectors/src/lib/bot/user_validation.ts
+++ b/connectors/src/lib/bot/user_validation.ts
@@ -10,7 +10,7 @@ async function getActiveMemberEmails(
   const ds = dataSourceConfigFromConnector(connector);
 
   // List the emails of all active members in the workspace.
-  const dustAPI = getDustAPI(ds, { useInternalAPI: false });
+  const dustAPI = getDustAPI(ds);
 
   const activeMemberEmailsRes =
     await dustAPI.getActiveMemberEmailsInWorkspace();

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -119,7 +119,7 @@ async function _upsertDataSourceDocument({
       });
 
       const endpoint =
-        `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+        `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
         `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
 
       const localLogger = logger.child({
@@ -257,7 +257,7 @@ export async function getDataSourceDocument({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/documents?document_ids=${documentId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -292,7 +292,7 @@ export async function getDataSourceDocumentBlob({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}/blob`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -325,7 +325,7 @@ export async function deleteDataSourceDocument(
   const localLogger = logger.child({ ...loggerArgs, documentId });
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/documents/${documentId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -424,7 +424,7 @@ async function _updateDocumentOrTableParentsField({
       ? logger.child({ ...loggerArgs, documentId: id })
       : logger.child({ ...loggerArgs, tableId: id });
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/${tableOrDocument}s/${id}/parents`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -535,7 +535,7 @@ async function tokenize(text: string, ds: DataSourceConfig) {
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), TOKENIZE_TIMEOUT_MS);
-  const tokensRes = await getDustAPI(ds, { useInternalAPI: true }).tokenize(
+  const tokensRes = await getDustAPI(ds).tokenize(
     sanitizedText,
     ds.dataSourceId,
     { signal: controller.signal }
@@ -870,7 +870,7 @@ export async function upsertDataSourceRemoteTable({
   const now = new Date();
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables`;
   const dustRequestPayload: UpsertDatabaseTableRequestType = {
     name: tableName,
@@ -1074,7 +1074,7 @@ export async function upsertDataSourceTableFromCsv({
     );
   }
 
-  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
+  const dustAPI = getDustAPI(dataSourceConfig);
 
   const fileRes = await dustAPI.uploadFile({
     contentType: "text/csv",
@@ -1088,7 +1088,7 @@ export async function upsertDataSourceTableFromCsv({
   }
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/csv`;
   const dustRequestPayload: UpsertTableFromCsvRequestType = {
     name: tableName,
@@ -1265,7 +1265,7 @@ export async function deleteDataSourceTableRow({
   const now = new Date();
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}/rows/${rowId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1349,7 +1349,7 @@ async function _getDataSourceTable({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1404,7 +1404,7 @@ export async function deleteDataSourceTable({
   const now = new Date();
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/tables/${tableId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1488,7 +1488,7 @@ export async function _getDataSourceFolder({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/folders/${folderId}`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {
@@ -1543,9 +1543,7 @@ export async function _upsertDataSourceFolder({
 }) {
   const now = new Date();
 
-  const r = await getDustAPI(dataSourceConfig, {
-    useInternalAPI: true,
-  }).upsertFolder({
+  const r = await getDustAPI(dataSourceConfig).upsertFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
     timestamp: timestampMs ? timestampMs : now.getTime(),
@@ -1570,9 +1568,7 @@ export async function deleteDataSourceFolder({
   folderId: string;
   loggerArgs?: Record<string, string | number>;
 }) {
-  const r = await getDustAPI(dataSourceConfig, {
-    useInternalAPI: true,
-  }).deleteFolder({
+  const r = await getDustAPI(dataSourceConfig).deleteFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
   });
@@ -1600,7 +1596,7 @@ export async function checkDataSourceUpsertQueueStatus({
   });
 
   const endpoint =
-    `${apiConfig.getDustFrontInternalAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
+    `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${dataSourceConfig.workspaceId}` +
     `/data_sources/${dataSourceConfig.dataSourceId}/check_upsert_queue`;
   const dustRequestConfig: AxiosRequestConfig = {
     headers: {


### PR DESCRIPTION
## Description

Now that front-internal is gone, it makes sense to remove references to it to not induce people & agents into error.

## Tests

Unit tests

## Risk

Low
Blast radius includes slack bot afaik, so not small.

## Deploy Plan

- deploy connector
- remove the secret