### PR TITLE
Do not redirect when step=done in verification flow

### DIFF
--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -307,8 +307,11 @@ export function VerifyPage() {
     );
   }
 
-  // Redirect to subscribe if not eligible for trial.
-  if (!isEligibleForTrial) {
+  // Redirect to subscribe if not eligible for trial. Skipped once the trial
+  // has been activated in this session ("done" step): activation makes the
+  // workspace ineligible by definition, and a focus-triggered revalidation of
+  // useVerifyData would otherwise yank the success screen to /subscribe.
+  if (!isEligibleForTrial && step !== "done") {
     void router.replace(`/w/${workspace.sId}/subscribe`);
     return (
       <div className="flex h-screen items-center justify-center">


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/8813

When refocusing, we re-trigger the whole component rendering.
When the phone activation is done, the workspace is no longer `isEligibleForTrial`, so it redirects to the suscribe page.
This PR prevents from doing this when we are in the step=done: just after phone verification but still on the /verify page

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
