### PR TITLE
fix(confluence): create placeholder ConfluencePageModel when skipping unseen page

### DIFF
--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -132,10 +132,11 @@ export const confluence = async ({
         }
         await existingPage.update({ skipReason });
       } else {
-        const confluencePage = await confluenceClient.getPageById(
-          pageId.toString()
-        );
-        if (!confluencePage) {
+        const confluencePage =
+          args.skipFetch !== "true"
+            ? await confluenceClient.getPageById(pageId.toString())
+            : null;
+        if (!args.skipFetch && !confluencePage) {
           return {
             skipped: false,
             reason: `Confluence Page id ${pageId} doesn't exist in confluence API`,
@@ -145,10 +146,10 @@ export const confluence = async ({
           connectorId,
           pageId: pageId.toString(),
           skipReason,
-          spaceId: confluencePage.spaceId,
-          title: confluencePage.title ?? "",
-          version: confluencePage.version.number,
-          externalUrl: confluencePage._links.tinyui,
+          spaceId: confluencePage?.spaceId ?? args.spaceId?.toString() ?? "",
+          title: confluencePage?.title ?? "",
+          version: confluencePage?.version.number ?? 0,
+          externalUrl: confluencePage?._links.tinyui ?? "",
         });
       }
 

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -61,6 +61,7 @@ export const ConfluenceCommandSchema = z.object({
     keyInFile: z.string().optional(),
     url: z.string().optional(),
     forceUpsert: z.literal("true").optional(),
+    skipFetch: z.literal("true").optional(),
     skipReason: z.string().optional(),
   }),
 });


### PR DESCRIPTION
## Description

Follow-up to #27276. Adds a `--skipFetch=true` flag to the Confluence `skip-page` CLI command for cases where the page can't be fetched from the API (e.g. it returns a 504). When set, the API call is skipped and a placeholder `ConfluencePageModel` is created with empty metadata — still enough for the sync to honour the skip reason. Without the flag the existing behaviour is preserved: the page is fetched from the API and the real title/version/externalUrl are stored.
