### PR TITLE
feat: save file explorer state in the query params

### DIFF
--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -34,8 +34,7 @@ export function ConversationFileExplorer({
   const { closePanel, openPanel } = useConversationSidePanelContext();
   const isPod = isPodConversation(conversation);
 
-  const [currentFolderPath, setCurrentFolderPath] =
-    useFolderPathUrlState("folderPath");
+  const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
 
   const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
     conversationId: conversation.sId,

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -8,6 +8,7 @@ import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
+import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
 import { usePodFiles } from "@app/lib/swr/pods";
 import {
@@ -32,6 +33,9 @@ export function ConversationFileExplorer({
 }: ConversationFileExplorerProps) {
   const { closePanel, openPanel } = useConversationSidePanelContext();
   const isPod = isPodConversation(conversation);
+
+  const [currentFolderPath, setCurrentFolderPath] =
+    useFolderPathUrlState("folderPath");
 
   const { sandboxFiles, isSandboxFilesLoading } = useConversationSandboxFiles({
     conversationId: conversation.sId,
@@ -102,6 +106,7 @@ export function ConversationFileExplorer({
 
       <div className="flex min-h-0 flex-1 flex-col">
         <FileExplorer
+          currentFolderPath={currentFolderPath}
           defaultViewMode={isPod ? "list" : "grid"}
           files={files}
           hideBreadcrumbAtRoot={!isPod}
@@ -111,6 +116,7 @@ export function ConversationFileExplorer({
               : isSandboxFilesLoading
           }
           getFileUrl={getFileUrl}
+          onCurrentFolderChange={setCurrentFolderPath}
           onFileDownload={onFileDownload}
           onOpenInteractive={onOpenInteractive}
           onOpenInPanel={onOpenInPanel}

--- a/front/components/file_explorer/FileExplorer.test.tsx
+++ b/front/components/file_explorer/FileExplorer.test.tsx
@@ -1,6 +1,8 @@
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClientFetch = vi.fn();
@@ -34,6 +36,25 @@ function makeFile({
   };
 }
 
+type ControlledFileExplorerProps = Omit<
+  ComponentProps<typeof FileExplorer>,
+  "currentFolderPath" | "onCurrentFolderChange"
+>;
+
+// `FileExplorer` is a controlled component: folder navigation lives in the
+// parent (in the app, in the URL). Tests hold it in local state.
+function ControlledFileExplorer(props: ControlledFileExplorerProps) {
+  const [currentFolderPath, setCurrentFolderPath] = useState("");
+
+  return (
+    <FileExplorer
+      {...props}
+      currentFolderPath={currentFolderPath}
+      onCurrentFolderChange={setCurrentFolderPath}
+    />
+  );
+}
+
 describe("FileExplorer file opening", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,7 +76,7 @@ describe("FileExplorer file opening", () => {
     );
 
     render(
-      <FileExplorer
+      <ControlledFileExplorer
         defaultViewMode="list"
         files={[archive]}
         getFileUrl={(path) => `/files/${path}`}
@@ -109,7 +130,7 @@ describe("FileExplorer file opening", () => {
     });
 
     render(
-      <FileExplorer
+      <ControlledFileExplorer
         defaultViewMode="list"
         files={[first, archive, second]}
         getFileUrl={(path) => `/files/${path}`}
@@ -146,7 +167,7 @@ describe("FileExplorer navigation", () => {
     });
 
     render(
-      <FileExplorer
+      <ControlledFileExplorer
         defaultViewMode="list"
         files={[nestedFile, rootFile]}
         getFileUrl={(path) => `/files/${path}`}

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -32,7 +32,7 @@ import { Err, type Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { cn, Edit04, FolderOpen, Trash01 } from "@dust-tt/sparkle";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 interface FileExplorerProps {
   contentClassName?: string;
@@ -40,12 +40,12 @@ interface FileExplorerProps {
   defaultViewMode?: ViewMode;
   emptyState?: React.ReactNode;
   hideBreadcrumbAtRoot?: boolean;
+  currentFolderPath: string;
   files: FileExplorerPathEntry[];
   getFileUrl: (path: string) => string;
   toolbarExtraActions?: React.ReactNode;
   isLoading: boolean;
-  navigationResetKey?: number;
-  onCurrentFolderChange?: (relativePath: string) => void;
+  onCurrentFolderChange: (relativePath: string) => void;
   onDelete?: (entry: FileExplorerEntry) => Promise<void>;
   onFileDownload: (entry: FileEntry) => Promise<void>;
   onMoveFile?: (
@@ -68,12 +68,12 @@ export function FileExplorer({
   contentNodes = [],
   defaultViewMode = "grid",
   emptyState,
+  currentFolderPath,
   files,
   getFileUrl,
   toolbarExtraActions,
   hideBreadcrumbAtRoot = false,
   isLoading,
-  navigationResetKey,
   onCurrentFolderChange,
   onDelete,
   onFileDownload,
@@ -85,23 +85,6 @@ export function FileExplorer({
   getExtraFileMenuItems,
   virtualScopeRoots,
 }: FileExplorerProps) {
-  const [currentFolderPath, setCurrentFolderPath] = useState("");
-  const prevNavigationResetKey = useRef(navigationResetKey);
-
-  useEffect(() => {
-    onCurrentFolderChange?.(currentFolderPath);
-  }, [currentFolderPath, onCurrentFolderChange]);
-
-  useEffect(() => {
-    if (
-      navigationResetKey !== undefined &&
-      prevNavigationResetKey.current !== navigationResetKey
-    ) {
-      setCurrentFolderPath("");
-    }
-    prevNavigationResetKey.current = navigationResetKey;
-  }, [navigationResetKey]);
-
   const [viewMode, setViewMode] = useState<ViewMode>(defaultViewMode);
   const [searchQuery, setSearchQuery] = useState("");
   const searchFolderPath = searchQuery.trim() ? currentFolderPath : undefined;
@@ -206,18 +189,18 @@ export function FileExplorer({
 
   const handleBreadcrumbNavigate = (index: number) => {
     if (index < 0) {
-      setCurrentFolderPath("");
+      onCurrentFolderChange("");
       setActiveFilter("all");
       return;
     }
 
     const segments = getFolderBreadcrumbSegments(currentFolderPath);
-    setCurrentFolderPath(segments[index]?.path ?? "");
+    onCurrentFolderChange(segments[index]?.path ?? "");
     setActiveFilter("all");
   };
 
   const handleFolderNavigate = (node: FileSystemTreeNode) => {
-    setCurrentFolderPath(node.path);
+    onCurrentFolderChange(node.path);
     setActiveFilter("all");
   };
 

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -19,6 +19,7 @@ import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import { RenameFileDialog } from "@app/components/pod/files/RenameFileDialog";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
+import { useFolderPathUrlState } from "@app/hooks/useFolderPathUrlState";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { useAppRouter } from "@app/lib/platform";
@@ -240,8 +241,8 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     fileName: string;
   } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [currentFolderPath, setCurrentFolderPath] = useState("");
-  const [navigationResetKey, setNavigationResetKey] = useState(0);
+  const [currentFolderPath, setCurrentFolderPath] =
+    useFolderPathUrlState("folderPath");
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
   const [itemToRename, setItemToRename] = useState<
@@ -253,7 +254,6 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     "companyData" | "noCompanyData" | null
   >(null);
 
-  const podMountParentRelativePath = currentFolderPath;
   const isArchived = !!pod.archivedAt;
   const isEditor = pod.isEditor;
   const { togglePin, isPinned } = usePinPodBanner({
@@ -395,7 +395,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         return;
       }
 
-      if (podMountParentRelativePath) {
+      if (currentFolderPath) {
         for (const blob of uploadedBlobs) {
           if (!blob.path) {
             console.error(
@@ -405,7 +405,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
             continue;
           }
           const fileName = blob.path.split("/").pop() ?? blob.filename;
-          const destCanonicalPath = `pod-${pod.sId}/${joinMountRelativePath(podMountParentRelativePath, fileName)}`;
+          const destCanonicalPath = `pod-${pod.sId}/${joinMountRelativePath(currentFolderPath, fileName)}`;
           const moveResult = await movePodFile({
             srcCanonicalPath: blob.path,
             destCanonicalPath,
@@ -423,13 +423,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
 
       await refreshPodFiles();
     },
-    [
-      movePodFile,
-      pod.sId,
-      podMountParentRelativePath,
-      podFileUpload,
-      refreshPodFiles,
-    ]
+    [movePodFile, pod.sId, currentFolderPath, podFileUpload, refreshPodFiles]
   );
 
   const handleFileChange = useCallback(
@@ -667,7 +661,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
       }
 
       await refreshPodKnowledge();
-      setNavigationResetKey((key) => key + 1);
+      setCurrentFolderPath("");
       return true;
     },
     [
@@ -675,6 +669,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
       contentNodeAttachments,
       refreshPodKnowledge,
       removePodContextContentNodes,
+      setCurrentFolderPath,
     ]
   );
 
@@ -729,7 +724,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         onClose={() => setShowCreateFolderDialog(false)}
         onCreated={() => void refreshPodFiles()}
         owner={owner}
-        parentRelativePath={podMountParentRelativePath}
+        parentRelativePath={currentFolderPath}
         podId={pod.sId}
       />
 
@@ -772,7 +767,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         emptyState={hasFiles ? undefined : emptyState}
         files={podGCSFiles}
         getFileUrl={getFileUrl}
-        navigationResetKey={navigationResetKey}
+        currentFolderPath={currentFolderPath}
         onCurrentFolderChange={setCurrentFolderPath}
         onFileDownload={onFileDownload}
         onDelete={!isArchived ? onDelete : undefined}

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -241,8 +241,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
     fileName: string;
   } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [currentFolderPath, setCurrentFolderPath] =
-    useFolderPathUrlState("folderPath");
+  const [currentFolderPath, setCurrentFolderPath] = useFolderPathUrlState();
   const [showRenameDialog, setShowRenameDialog] = useState(false);
   const [showCreateFolderDialog, setShowCreateFolderDialog] = useState(false);
   const [itemToRename, setItemToRename] = useState<

--- a/front/hooks/useFolderPathUrlState.ts
+++ b/front/hooks/useFolderPathUrlState.ts
@@ -1,0 +1,15 @@
+import { useQueryParams } from "@app/hooks/useQueryParams";
+import { useMemo } from "react";
+
+export function useFolderPathUrlState(
+  paramKey: string
+): [string, (path: string) => void] {
+  const paramNames = useMemo(() => [paramKey], [paramKey]);
+  const params = useQueryParams(paramNames);
+  const param = params[paramKey];
+
+  const setPath = (path: string) =>
+    param.setParam(path === "" ? undefined : path);
+
+  return [param.value ?? "", setPath];
+}

--- a/front/hooks/useFolderPathUrlState.ts
+++ b/front/hooks/useFolderPathUrlState.ts
@@ -1,15 +1,16 @@
 import { useQueryParams } from "@app/hooks/useQueryParams";
-import { useMemo } from "react";
+import { useCallback } from "react";
 
-export function useFolderPathUrlState(
-  paramKey: string
-): [string, (path: string) => void] {
-  const paramNames = useMemo(() => [paramKey], [paramKey]);
-  const params = useQueryParams(paramNames);
-  const param = params[paramKey];
+// Module-level so the reference passed to `useQueryParams` stays stable.
+const FOLDER_PATH_PARAMS: ["folderPath"] = ["folderPath"];
 
-  const setPath = (path: string) =>
-    param.setParam(path === "" ? undefined : path);
+export function useFolderPathUrlState(): [string, (path: string) => void] {
+  const { folderPath } = useQueryParams(FOLDER_PATH_PARAMS);
 
-  return [param.value ?? "", setPath];
+  const setPath = useCallback(
+    (path: string) => folderPath.setParam(path === "" ? undefined : path),
+    [folderPath]
+  );
+
+  return [folderPath.value ?? "", setPath];
 }

--- a/front/hooks/useFolderPathUrlState.ts
+++ b/front/hooks/useFolderPathUrlState.ts
@@ -2,13 +2,14 @@ import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useCallback } from "react";
 
 // Module-level so the reference passed to `useQueryParams` stays stable.
-const FOLDER_PATH_PARAMS: ["folderPath"] = ["folderPath"];
+const FOLDER_PATH_PARAMS: ["path"] = ["path"];
 
 export function useFolderPathUrlState(): [string, (path: string) => void] {
-  const { folderPath } = useQueryParams(FOLDER_PATH_PARAMS);
+  const { path: folderPath } = useQueryParams(FOLDER_PATH_PARAMS);
 
   const setPath = useCallback(
-    (path: string) => folderPath.setParam(path === "" ? undefined : path),
+    (newPath: string) =>
+      folderPath.setParam(newPath === "" ? undefined : newPath),
     [folderPath]
   );
 


### PR DESCRIPTION
## Description

This PR persists the file explorer state (current folder path) in the URL query params.

- `FileExplorer` now accepts `currentFolderPath` and `onCurrentFolderChange` as controlled props
- The current folder is stored in a `folderPath` URL query param via a new `useFolderPathUrlState` hook
- `PodFileExplorer` and `ConversationFileExplorer` both use it, replacing their local `useState` (the `navigationResetKey` prop is gone, resetting is now `onCurrentFolderChange("")`)


https://github.com/user-attachments/assets/11b584e3-f071-4eb5-9a46-9f7f76d0ecfb



## Tests

Manually tested that
- navigating into a folder updates the URL
- opening and closing the panel keeps the state
- reloading the page opens the panel at the correct folder

Existing `FileExplorer` tests updated for the controlled props.

## Risks
Low.

## Deploy Plan
Standard deployment.
