### PR TITLE
[LLM] Input types to the models

### DIFF
--- a/front/lib/model_constructors/types/input/configuration.ts
+++ b/front/lib/model_constructors/types/input/configuration.ts
@@ -1,0 +1,45 @@
+import { ORDERED_REASONING_EFFORTS } from "@app/lib/model_constructors/types/reasoning_efforts";
+import { z } from "zod";
+
+export const reasoningEffortSchema = z.enum(ORDERED_REASONING_EFFORTS);
+
+export const reasoningSchema = z.object({
+  effort: reasoningEffortSchema,
+});
+export type Reasoning = z.infer<typeof reasoningSchema>;
+
+export const temperatureSchema = z.number().min(0).max(1);
+export const maxOutputTokensSchema = z.number().min(0);
+
+export const outputFormatSchema = z.object({
+  type: z.literal("json_schema"),
+  json_schema: z.object({
+    name: z.string(),
+    schema: z.object({
+      type: z.literal("object"),
+      properties: z.record(z.unknown()),
+      required: z.array(z.string()),
+      additionalProperties: z.boolean(),
+    }),
+    description: z.string().optional(),
+    strict: z.boolean().nullable().optional(),
+  }),
+});
+export type OutputFormat = z.infer<typeof outputFormatSchema>;
+
+export const toolSpecificationSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  inputSchema: z.record(z.unknown()),
+});
+export type ToolSpecification = z.infer<typeof toolSpecificationSchema>;
+
+export const inputConfigSchema = z.object({
+  temperature: temperatureSchema.optional(),
+  reasoning: reasoningSchema.optional(),
+  tools: z.array(toolSpecificationSchema).optional(),
+  forceTool: z.string().optional(),
+  outputFormat: outputFormatSchema.optional(),
+  cacheKey: z.string().optional(),
+});
+export type InputConfig = z.infer<typeof inputConfigSchema>;

--- a/front/lib/model_constructors/types/input/messages.ts
+++ b/front/lib/model_constructors/types/input/messages.ts
@@ -1,0 +1,85 @@
+const CACHE_OPTIONS = ["short", "long"] as const;
+export type CacheOption = (typeof CACHE_OPTIONS)[number];
+
+export type BaseUserTextMessage = {
+  role: "user";
+  type: "text";
+  content: { value: string };
+  cache?: CacheOption;
+};
+
+export type BaseUserImageMessage = {
+  role: "user";
+  type: "image_url";
+  content: { url: string };
+  cache?: CacheOption;
+};
+
+export type ToolCallResultTextPart = { type: "text"; text: string };
+export type ToolCallResultImagePart = { type: "image_url"; url: string };
+export type ToolCallResultPart =
+  | ToolCallResultTextPart
+  | ToolCallResultImagePart;
+
+export type BaseToolCallResultMessage = {
+  role: "user";
+  type: "tool_call_result";
+  content: {
+    callId: string;
+    parts: ToolCallResultPart[];
+    isError: boolean;
+  };
+  cache?: CacheOption;
+};
+
+export type BaseUserMessage =
+  | BaseUserTextMessage
+  | BaseUserImageMessage
+  | BaseToolCallResultMessage;
+
+export type BaseAssistantTextMessage = {
+  role: "assistant";
+  type: "text";
+  content: { value: string };
+};
+
+export type BaseAssistantReasoningMessage = {
+  role: "assistant";
+  type: "reasoning";
+  content: { value: string };
+  signature?: string;
+};
+
+export type BaseAssistantToolCallRequestMessage = {
+  role: "assistant";
+  type: "tool_call_request";
+  content: {
+    callId: string;
+    toolName: string;
+    arguments: string;
+  };
+  signature?: string;
+};
+
+export type BaseAssistantMessage =
+  | BaseAssistantTextMessage
+  | BaseAssistantReasoningMessage
+  | BaseAssistantToolCallRequestMessage;
+
+export type BaseMessage = BaseUserMessage | BaseAssistantMessage;
+
+export type SystemTextMessage = {
+  role: "system";
+  type: "text";
+  content: { value: string };
+  cache?: CacheOption;
+};
+
+export type BaseConversation = {
+  system: SystemTextMessage[];
+  messages: BaseMessage[];
+};
+
+export type Payload = {
+  conversation: BaseConversation;
+};

--- a/front/lib/model_constructors/types/reasoning_efforts.ts
+++ b/front/lib/model_constructors/types/reasoning_efforts.ts
@@ -1,0 +1,10 @@
+export const ORDERED_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "maximal",
+] as const;
+export type ReasoningEffort = (typeof ORDERED_REASONING_EFFORTS)[number];


### PR DESCRIPTION
## Description

Starts a larger refactor to isolate the new LLM router into a self-contained `model_constructors/` SDK with zero `@app/` dependencies: it describes *what a model can do and how to talk to it* (types, providers, converters, stream/batch surfaces, registries), while everything Dust-specific — the "LLM" abstraction, BYOK / feature-flag / enterprise filtering, the `use_new_llm_router` gating, and legacy provider-id compat — is pushed out to `lib/api/llm/`, which consumes the SDK. The dependency arrow becomes one-way (dust → model_constructors), landed incrementally over several PRs. This first PR adds the foundational provider-neutral input vocabulary (`types/input/messages.ts`, `types/input/configuration.ts`, `types/reasoning_efforts.ts`); types only, no callers yet.

## Tests

No, just types

## Risk

None. Types only, no callers.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`