### PR TITLE
[front] Add get_source_breakdown tool to workspace_analytics

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -1,4 +1,9 @@
-import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import {
+  type AnalyticsVisibleOrigin,
+  SOURCE_ORIGIN_LABELS,
+} from "@app/lib/api/analytics/source_labels";
+
+export type { AnalyticsVisibleOrigin };
 
 export const OBSERVABILITY_TIME_RANGE = [7, 14, 30, 90] as const;
 export type ObservabilityTimeRangeType =
@@ -112,56 +117,99 @@ export const FEEDBACK_DISTRIBUTION_LEGEND = [
   { key: "negative", label: "Negative" },
 ] as const;
 
-export type AnalyticsVisibleOrigin = Exclude<
-  UserMessageOrigin,
-  "reinforced_skill_notification" | "branch_anchor"
->;
-
 export const USER_MESSAGE_ORIGIN_LABELS: Record<
   AnalyticsVisibleOrigin,
   { label: string; color: string }
 > = {
-  web: { label: "Conversation", color: buildColorClass("blue", 500) },
+  web: { label: SOURCE_ORIGIN_LABELS.web, color: buildColorClass("blue", 500) },
   extension: {
-    label: "Chrome extension",
+    label: SOURCE_ORIGIN_LABELS.extension,
     color: buildColorClass("orange", 500),
   },
-  slack: { label: "Slack", color: buildColorClass("green", 500) },
-  slack_workflow: { label: "Slack", color: buildColorClass("green", 500) },
-  api: { label: "API", color: buildColorClass("violet", 500) },
-  cli: { label: "CLI", color: buildColorClass("gray", 500) },
-  cli_programmatic: { label: "CLI", color: buildColorClass("gray", 500) },
-  gsheet: { label: "Google Sheets", color: buildColorClass("emerald", 500) },
-  email: { label: "Email", color: buildColorClass("pink", 500) },
-  excel: { label: "Excel", color: buildColorClass("rose", 500) },
-  teams: { label: "Teams", color: buildColorClass("blue", 300) },
-  make: { label: "Make", color: buildColorClass("gray", 700) },
-  n8n: { label: "n8n", color: buildColorClass("lime", 500) },
-  raycast: { label: "Raycast", color: buildColorClass("red", 500) },
-  zapier: { label: "Zapier", color: buildColorClass("blue", 700) },
-  zendesk: { label: "Zendesk", color: buildColorClass("golden", 700) },
-  powerpoint: { label: "PowerPoint", color: buildColorClass("violet", 300) },
+  slack: {
+    label: SOURCE_ORIGIN_LABELS.slack,
+    color: buildColorClass("green", 500),
+  },
+  slack_workflow: {
+    label: SOURCE_ORIGIN_LABELS.slack_workflow,
+    color: buildColorClass("green", 500),
+  },
+  api: {
+    label: SOURCE_ORIGIN_LABELS.api,
+    color: buildColorClass("violet", 500),
+  },
+  cli: { label: SOURCE_ORIGIN_LABELS.cli, color: buildColorClass("gray", 500) },
+  cli_programmatic: {
+    label: SOURCE_ORIGIN_LABELS.cli_programmatic,
+    color: buildColorClass("gray", 500),
+  },
+  gsheet: {
+    label: SOURCE_ORIGIN_LABELS.gsheet,
+    color: buildColorClass("emerald", 500),
+  },
+  email: {
+    label: SOURCE_ORIGIN_LABELS.email,
+    color: buildColorClass("pink", 500),
+  },
+  excel: {
+    label: SOURCE_ORIGIN_LABELS.excel,
+    color: buildColorClass("rose", 500),
+  },
+  teams: {
+    label: SOURCE_ORIGIN_LABELS.teams,
+    color: buildColorClass("blue", 300),
+  },
+  make: {
+    label: SOURCE_ORIGIN_LABELS.make,
+    color: buildColorClass("gray", 700),
+  },
+  n8n: { label: SOURCE_ORIGIN_LABELS.n8n, color: buildColorClass("lime", 500) },
+  raycast: {
+    label: SOURCE_ORIGIN_LABELS.raycast,
+    color: buildColorClass("red", 500),
+  },
+  zapier: {
+    label: SOURCE_ORIGIN_LABELS.zapier,
+    color: buildColorClass("blue", 700),
+  },
+  zendesk: {
+    label: SOURCE_ORIGIN_LABELS.zendesk,
+    color: buildColorClass("golden", 700),
+  },
+  powerpoint: {
+    label: SOURCE_ORIGIN_LABELS.powerpoint,
+    color: buildColorClass("violet", 300),
+  },
   reinforcement: {
-    label: "Self-improving skills",
+    label: SOURCE_ORIGIN_LABELS.reinforcement,
     color: buildColorClass("emerald", 700),
   },
-  transcript: { label: "Transcript", color: buildColorClass("golden", 500) },
-  triggered: { label: "Trigger", color: buildColorClass("orange", 700) },
+  transcript: {
+    label: SOURCE_ORIGIN_LABELS.transcript,
+    color: buildColorClass("golden", 500),
+  },
+  triggered: {
+    label: SOURCE_ORIGIN_LABELS.triggered,
+    color: buildColorClass("orange", 700),
+  },
   triggered_programmatic: {
-    label: "Trigger",
+    label: SOURCE_ORIGIN_LABELS.triggered_programmatic,
     color: buildColorClass("orange", 300),
   },
   wakeup: {
-    label: "Wake-up",
+    label: SOURCE_ORIGIN_LABELS.wakeup,
     color: buildColorClass("violet", 700),
   },
   onboarding_conversation: {
-    label: "Onboarding",
+    label: SOURCE_ORIGIN_LABELS.onboarding_conversation,
     color: buildColorClass("rose", 300),
   },
-  agent_sidekick: { label: "Sidekick", color: buildColorClass("emerald", 300) },
+  agent_sidekick: {
+    label: SOURCE_ORIGIN_LABELS.agent_sidekick,
+    color: buildColorClass("emerald", 300),
+  },
   project_kickoff: {
-    label: "Pod Kickoff",
+    label: SOURCE_ORIGIN_LABELS.project_kickoff,
     color: buildColorClass("lime", 300),
   },
 };

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -711,6 +711,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_agent_details": "never_ask",
     "get_credit_timeseries": "never_ask",
     "get_credit_usage": "never_ask",
+    "get_source_breakdown": "never_ask",
     "get_top_agents": "never_ask",
     "get_top_skills": "never_ask",
     "get_top_tools": "never_ask",

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -32,6 +32,12 @@ const getTopUsersSchema = topListSchema("users");
 const getTopSkillsSchema = topListSchema("skills");
 const getTopToolsSchema = topListSchema("tools");
 
+const getSourceBreakdownSchema = {
+  ...timeWindowSchemaShape,
+  agentIds: usageFilterSchema.agentIds,
+  userIds: usageFilterSchema.userIds,
+};
+
 const getAgentDetailsSchema = {
   agentId: z
     .string()
@@ -175,6 +181,25 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Retrieving top tools",
       done: "Retrieved top tools",
+    },
+  },
+  get_source_breakdown: {
+    description:
+      "Return the workspace's message volume broken down by source — where " +
+      "messages originate (Conversation, Slack, API, Trigger, extension, and " +
+      "more) — over a time window (defaults to the current calendar month), " +
+      "most used first. Sources are labeled and merged exactly as the " +
+      "workspace Usage page's source chart, so the values line up with the " +
+      "dashboard. Use this to discover and compare which channels or " +
+      "integrations drive usage (including programmatic ones like API and " +
+      "triggers) — the source filter on the other tools only narrows to one " +
+      "source, this enumerates them all. Optionally filter by agent or user. " +
+      "Admin-only.",
+    schema: getSourceBreakdownSchema,
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving source breakdown",
+      done: "Retrieved source breakdown",
     },
   },
   get_credit_usage: {

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -29,6 +29,7 @@ describe("workspace_analytics tools", () => {
     "get_agent_details",
     "get_top_skills",
     "get_top_tools",
+    "get_source_breakdown",
     "get_credit_usage",
     "get_credit_timeseries",
     "get_usage_timeseries",

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -14,6 +14,10 @@ import {
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
+  fetchContextOriginBreakdown,
+  toLabeledSources,
+} from "@app/lib/api/assistant/observability/context_origin";
+import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
   fetchCreditUsage,
@@ -361,6 +365,62 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
         type: "text" as const,
         text:
           `Most-used tools for ${label} (${tz}), most used first:\n` +
+          lines.join("\n"),
+      },
+    ]);
+  },
+
+  get_source_breakdown: async (
+    { period, startDate, endDate, timezone, agentIds, userIds },
+    { auth }
+  ) => {
+    const denied = workspaceAdminGuard(auth);
+    if (denied) {
+      return new Err(denied);
+    }
+
+    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    if (window.isErr()) {
+      return new Err(new MCPError(window.error, { tracked: false }));
+    }
+
+    const baseQuery = scopedBaseQuery(auth, window.value, {
+      agentIds,
+      userIds,
+    });
+
+    const result = await fetchContextOriginBreakdown(baseQuery);
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to retrieve source breakdown: ${result.error.message}`
+        )
+      );
+    }
+
+    const { label, timezone: tz } = window.value;
+    const sources = toLabeledSources(result.value);
+
+    if (sources.length === 0) {
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `No source activity recorded for ${label} (${tz}).`,
+        },
+      ]);
+    }
+
+    const total = sources.reduce((sum, source) => sum + source.count, 0);
+    const lines = sources.map((source, index) => {
+      const percent = total > 0 ? Math.round((source.count / total) * 100) : 0;
+      return `${index + 1}. ${source.label} — ${source.count} messages (${percent}%)`;
+    });
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text:
+          `Message sources for ${label} (${tz}), most used first:\n` +
           lines.join("\n"),
       },
     ]);

--- a/front/lib/api/analytics/source_labels.ts
+++ b/front/lib/api/analytics/source_labels.ts
@@ -33,8 +33,14 @@ export const SOURCE_ORIGIN_LABELS: Record<AnalyticsVisibleOrigin, string> = {
   project_kickoff: "Pod Kickoff",
 };
 
+export function isAnalyticsVisibleOrigin(
+  origin: string
+): origin is AnalyticsVisibleOrigin {
+  return origin in SOURCE_ORIGIN_LABELS;
+}
+
 export function sourceLabelForOrigin(origin: string): string | undefined {
-  return origin in SOURCE_ORIGIN_LABELS
-    ? SOURCE_ORIGIN_LABELS[origin as AnalyticsVisibleOrigin]
+  return isAnalyticsVisibleOrigin(origin)
+    ? SOURCE_ORIGIN_LABELS[origin]
     : undefined;
 }

--- a/front/lib/api/analytics/source_labels.ts
+++ b/front/lib/api/analytics/source_labels.ts
@@ -1,0 +1,40 @@
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+
+export type AnalyticsVisibleOrigin = Exclude<
+  UserMessageOrigin,
+  "reinforced_skill_notification" | "branch_anchor"
+>;
+
+export const SOURCE_ORIGIN_LABELS: Record<AnalyticsVisibleOrigin, string> = {
+  web: "Conversation",
+  extension: "Chrome extension",
+  slack: "Slack",
+  slack_workflow: "Slack",
+  api: "API",
+  cli: "CLI",
+  cli_programmatic: "CLI",
+  gsheet: "Google Sheets",
+  email: "Email",
+  excel: "Excel",
+  teams: "Teams",
+  make: "Make",
+  n8n: "n8n",
+  raycast: "Raycast",
+  zapier: "Zapier",
+  zendesk: "Zendesk",
+  powerpoint: "PowerPoint",
+  reinforcement: "Self-improving skills",
+  transcript: "Transcript",
+  triggered: "Trigger",
+  triggered_programmatic: "Trigger",
+  wakeup: "Wake-up",
+  onboarding_conversation: "Onboarding",
+  agent_sidekick: "Sidekick",
+  project_kickoff: "Pod Kickoff",
+};
+
+export function sourceLabelForOrigin(origin: string): string | undefined {
+  return origin in SOURCE_ORIGIN_LABELS
+    ? SOURCE_ORIGIN_LABELS[origin as AnalyticsVisibleOrigin]
+    : undefined;
+}

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -1,3 +1,4 @@
+import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import {
   bucketsToArray,
   formatDateFromMillis,
@@ -54,6 +55,31 @@ export type ContextOriginBucket = {
   origin: string;
   count: number;
 };
+
+export type LabeledSource = {
+  label: string;
+  count: number;
+};
+
+// Maps raw context_origin buckets to the dashboard's display labels, merging
+// origins that share a label (e.g. triggered + triggered_programmatic ->
+// "Trigger"). Origins outside the visible set — including the "unknown"
+// sentinel — are dropped, mirroring the usage page's source chart.
+export function toLabeledSources(
+  buckets: ContextOriginBucket[]
+): LabeledSource[] {
+  const countByLabel = new Map<string, number>();
+  for (const bucket of buckets) {
+    const label = sourceLabelForOrigin(bucket.origin);
+    if (!label) {
+      continue;
+    }
+    countByLabel.set(label, (countByLabel.get(label) ?? 0) + bucket.count);
+  }
+  return Array.from(countByLabel.entries())
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count);
+}
 
 type ContextOriginAggs = {
   by_origin?: estypes.AggregationsMultiBucketAggregateBase<{


### PR DESCRIPTION
## Description

The source filter only narrows to one origin, so the agent could not enumerate the workspace's sources (it missed origins like Trigger). Add a get_source_breakdown tool backed by the existing fetchContextOriginBreakdown, labeling and merging origins exactly as the Usage page's source chart (triggered + triggered_programmatic -> "Trigger", etc.) so values line up with the dashboard.

Single-source the origin->label map in lib/api/analytics/source_labels.ts and have the dashboard constants consume it to prevent drift.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
