### PR TITLE
feat: show all readable pods in popover

### DIFF
--- a/front/components/assistant/conversation/sidebar/PodsBrowsePopover.tsx
+++ b/front/components/assistant/conversation/sidebar/PodsBrowsePopover.tsx
@@ -18,7 +18,7 @@ import {
   Spinner,
   Tooltip,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 interface PodsBrowsePopoverProps {
   owner: WorkspaceType;
@@ -88,12 +88,6 @@ export function PodsBrowsePopover({ owner }: PodsBrowsePopoverProps) {
     }
   );
 
-  const filteredPods = useMemo(() => {
-    return pods.filter(
-      ({ isMember, archivedAt }) => (!isMember && !archivedAt) || archivedAt
-    );
-  }, [pods]);
-
   return (
     <div>
       <PopoverRoot open={isOpen} onOpenChange={setIsOpen} modal>
@@ -114,15 +108,15 @@ export function PodsBrowsePopover({ owner }: PodsBrowsePopoverProps) {
             />
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
-            {isSearching && filteredPods.length === 0 ? (
+            {isSearching && pods.length === 0 ? (
               <PodBrowseItemSkeleton count={5} />
-            ) : filteredPods.length === 0 ? (
+            ) : pods.length === 0 ? (
               <div className="px-2 py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
                 No Pods found
               </div>
             ) : (
               <>
-                {filteredPods.map((pod) => (
+                {pods.map((pod) => (
                   <PodBrowseItem
                     key={pod.sId}
                     pod={pod}


### PR DESCRIPTION



## Description

Fixes https://github.com/dust-tt/tasks/issues/8732

This PR updates the pods browse popover to show all readable pods instead of filtering out pods where the user is already a member.

## Tests

Manually.

## Risks

Low.

<!-- Discuss potential risks and how they will be mitigated. -->

## Deploy Plan

Standard deployment.

<!-- Outline the deployment steps. -->

