### PR TITLE
[LLM] Add model_constructors Client scaffolding and core types

### DIFF
--- a/front/lib/model_constructors/client.ts
+++ b/front/lib/model_constructors/client.ts
@@ -1,0 +1,31 @@
+import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
+import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
+import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+
+export abstract class Client {
+  // Re-type `this.constructor` (typed as `Function` by default) so the concrete
+  // subclass's static config is visible at the type level.
+  declare ["constructor"]: BaseModelConfiguration;
+
+  constructor(protected readonly credentials: Credentials) {}
+
+  // Generic `this` params P/A/R/M capture each concrete class's literal
+  // identity fields, so the returned `id` is an exact literal (not the wide
+  // union) and a registry keyed by it yields a precise `ModelId`.
+  static buildId<
+    P extends ProviderId,
+    A extends ProviderApi,
+    R extends Region,
+    M extends ModelId,
+  >(this: {
+    providerId: P;
+    api: A;
+    region: R;
+    modelId: M;
+  }): `${P}/${A}/${R}/${M}` {
+    return `${this.providerId}/${this.api}/${this.region}/${this.modelId}`;
+  }
+}

--- a/front/lib/model_constructors/client.ts
+++ b/front/lib/model_constructors/client.ts
@@ -1,5 +1,4 @@
 import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
-import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
@@ -9,8 +8,6 @@ export abstract class Client {
   // Re-type `this.constructor` (typed as `Function` by default) so the concrete
   // subclass's static config is visible at the type level.
   declare ["constructor"]: BaseModelConfiguration;
-
-  constructor(protected readonly credentials: Credentials) {}
 
   // Generic `this` params P/A/R/M capture each concrete class's literal
   // identity fields, so the returned `id` is an exact literal (not the wide

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -1,0 +1,24 @@
+import type { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
+import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
+import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+import type { TokenPricing } from "@app/lib/model_constructors/types/token_pricing";
+import type { z } from "zod";
+
+export type BaseModelConfiguration = {
+  // Identity
+  id: `${ProviderId}::${ProviderApi}::${Region}::${ModelId}`;
+  providerId: ProviderId;
+  api: ProviderApi;
+  modelId: ModelId;
+  region: Region;
+
+  // Capabilities
+  contextSize: number;
+  maxOutputTokens: number;
+  configSchema: z.ZodType<z.infer<typeof inputConfigSchema>>;
+
+  // Pricing
+  tokenPricing: TokenPricing;
+};

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -1,4 +1,4 @@
-import type { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
@@ -17,7 +17,7 @@ export type BaseModelConfiguration = {
   // Capabilities
   contextSize: number;
   maxOutputTokens: number;
-  configSchema: z.ZodType<z.infer<typeof inputConfigSchema>>;
+  configSchema: z.ZodType<InputConfig>;
 
   // Pricing
   tokenPricing: TokenPricing;

--- a/front/lib/model_constructors/types/agent_metadata.ts
+++ b/front/lib/model_constructors/types/agent_metadata.ts
@@ -1,0 +1,12 @@
+import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
+import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
+import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+
+export type AgentMetadata = {
+  providerId: ProviderId;
+  api: ProviderApi;
+  region: Region;
+  modelId: ModelId;
+  content?: Record<string, unknown>;
+};

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -1,0 +1,7 @@
+export type Credentials = {
+  OPENAI_API_KEY?: string;
+  OPENAI_BASE_URL?: string;
+  ANTHROPIC_API_KEY?: string;
+  GOOGLE_AI_STUDIO_API_KEY?: string;
+  AGENT_PLATFORM_PROJECT_ID?: string;
+};

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -1,0 +1,26 @@
+export const GPT_5_4_MODEL_ID = "gpt-5.4" as const;
+export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
+
+export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
+
+export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
+
+// Include a few examples for now
+export const MODEL_IDS = [
+  GPT_5_4_MODEL_ID,
+  GPT_5_2_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+  GEMINI_3_1_PRO_MODEL_ID,
+] as const;
+
+export type ModelId = (typeof MODEL_IDS)[number];
+
+export function isModelId(value: string): value is ModelId {
+  return (MODEL_IDS as readonly string[]).includes(value);
+}
+
+export const ORDERED_LARGE_MODEL_IDS = [
+  CLAUDE_SONNET_4_6_MODEL_ID,
+  GPT_5_4_MODEL_ID,
+  GEMINI_3_1_PRO_MODEL_ID,
+];

--- a/front/lib/model_constructors/types/output/events.ts
+++ b/front/lib/model_constructors/types/output/events.ts
@@ -1,0 +1,134 @@
+import type { AgentMetadata } from "@app/lib/model_constructors/types/agent_metadata";
+
+export type ResponseIdContent = { responseId: string };
+
+export interface ResponseIdEvent {
+  type: "response_id";
+  content: ResponseIdContent;
+  metadata: AgentMetadata;
+}
+
+export type TextDeltaContent = { value: string };
+export interface TextDeltaEvent {
+  type: "text_delta";
+  content: TextDeltaContent;
+  metadata: AgentMetadata;
+}
+
+export type TextContent = { value: string };
+export interface TextEvent {
+  type: "text";
+  content: TextContent;
+  metadata: AgentMetadata;
+}
+
+export type ToolCallStartedContent = {
+  id: string;
+  index: number;
+  name: string;
+};
+export interface ToolCallStartedEvent {
+  type: "tool_call_started";
+  content: ToolCallStartedContent;
+  metadata: AgentMetadata;
+}
+
+export interface ToolCallDeltaEvent {
+  type: "tool_call_delta";
+  metadata: AgentMetadata;
+}
+
+export type ToolCallContent = {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+export interface ToolCallEvent {
+  type: "tool_call";
+  content: ToolCallContent;
+  metadata: AgentMetadata;
+}
+
+export type ReasoningDeltaContent = { value: string };
+export interface ReasoningDeltaEvent {
+  type: "reasoning_delta";
+  content: ReasoningDeltaContent;
+  metadata: AgentMetadata;
+}
+
+export type ReasoningContent = { value: string };
+export interface ReasoningEvent {
+  type: "reasoning";
+  content: ReasoningContent;
+  metadata: AgentMetadata;
+}
+
+export type TokenUsageContent = {
+  cacheCreated: number;
+  cacheHit: number;
+  standardInput: number;
+  standardOutput: number;
+  reasoning: number;
+};
+export interface TokenUsageEvent {
+  type: "token_usage";
+  content: TokenUsageContent;
+  metadata: AgentMetadata;
+}
+
+export type SuccessContent = {
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[];
+};
+export interface SuccessEvent {
+  type: "success";
+  content: SuccessContent;
+  metadata: AgentMetadata;
+}
+
+export const ERROR_TYPES = [
+  "input_configuration_error",
+  "stop_error",
+  "refusal_error",
+  "model_output_error",
+  // HTTP errors
+  "rate_limit_error",
+  "overloaded_error",
+  "invalid_request_error",
+  "authentication_error",
+  "permission_error",
+  "not_found_error",
+  "network_error",
+  "timeout_error",
+  "server_error",
+  "stream_error",
+  "unknown_error",
+] as const;
+export type ErrorType = (typeof ERROR_TYPES)[number];
+export type ErrorContent = {
+  type: ErrorType;
+  message: string;
+  originalError?: unknown;
+};
+export interface ErrorEvent {
+  type: "error";
+  content: ErrorContent;
+  metadata: AgentMetadata;
+}
+
+export type ModelResponseEvent =
+  | ResponseIdEvent
+  | TextDeltaEvent
+  | TextEvent
+  | ReasoningDeltaEvent
+  | ReasoningEvent
+  | ToolCallStartedEvent
+  | ToolCallDeltaEvent
+  | ToolCallEvent
+  | TokenUsageEvent
+  | SuccessEvent
+  | ErrorEvent;
+
+export type NonDeltaResponseEvent = Exclude<
+  ModelResponseEvent,
+  TextDeltaEvent | ReasoningDeltaEvent | ToolCallDeltaEvent
+>;

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -1,0 +1,12 @@
+export const OPENAI_RESPONSES_API = "openai-responses" as const;
+export const ANTHROPIC_API = "anthropic" as const;
+export const GOOGLE_AI_STUDIO_API = "google-ai-studio" as const;
+export const AGENT_PLATFORM_API = "agent-platform" as const;
+
+const PROVIDER_APIS = [
+  OPENAI_RESPONSES_API,
+  ANTHROPIC_API,
+  GOOGLE_AI_STUDIO_API,
+  AGENT_PLATFORM_API,
+] as const;
+export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -1,0 +1,21 @@
+import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+
+export const OPENAI_PROVIDER_ID = "openai" as const;
+export const ANTHROPIC_PROVIDER_ID = "anthropic" as const;
+export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
+
+// `satisfies readonly ModelProviderIdType[]` guarantees every new-system
+// provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
+// a true subset, so narrowing helpers like `isProviderId` filter the legacy
+// union without silently dropping ids on a naming drift (e.g. the previous
+// "google-ai-studio" vs "google_ai_studio" mismatch).
+const PROVIDER_IDS = [
+  OPENAI_PROVIDER_ID,
+  ANTHROPIC_PROVIDER_ID,
+  GOOGLE_AI_STUDIO_PROVIDER_ID,
+] as const satisfies readonly ModelProviderIdType[];
+export type ProviderId = (typeof PROVIDER_IDS)[number];
+
+export function isProviderId(value: string): value is ProviderId {
+  return (PROVIDER_IDS as readonly string[]).includes(value);
+}

--- a/front/lib/model_constructors/types/regions.ts
+++ b/front/lib/model_constructors/types/regions.ts
@@ -1,0 +1,6 @@
+export const EUROPE = "eu" as const;
+export const US = "us" as const;
+export const GLOBAL = "global" as const;
+
+export const REGIONS = [EUROPE, US, GLOBAL] as const;
+export type Region = (typeof REGIONS)[number];

--- a/front/lib/model_constructors/types/token_pricing.ts
+++ b/front/lib/model_constructors/types/token_pricing.ts
@@ -1,0 +1,7 @@
+// Per M tokens
+export type TokenPricing = {
+  cacheCreated?: number;
+  cacheHit?: number;
+  standardInput: number;
+  standardOutput: number;
+};


### PR DESCRIPTION
## Description

Adds the base `Client` class with the `buildId` helper plus the supporting `model_constructors` types — model configuration, token pricing, provider/api/region/model id unions, agent metadata, and model response events.

## Tests

No - types only

## Risk

None. New unused scaffolding (no call sites yet).

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`