### PR TITLE
feat(credits): filter members usage by seat type server-side

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -47,6 +47,11 @@ import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  SEAT_TYPE_ORDER,
+  toBaseSeatType,
+} from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { isAdmin } from "@app/types/user";
 import {
@@ -102,6 +107,10 @@ function memberFromUpgradeRequest(
 
 const DEFAULT_PAGE_SIZE = 25;
 
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
@@ -129,6 +138,23 @@ export function UsagePage() {
   // changes so the user lands on the start of the new ordering.
   const handleSetSorting = useCallback((next: SortingState) => {
     setSorting(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  // The seat-type filter is applied server-side before pagination, so reset to
+  // the first page whenever it changes to land on the start of the new set.
+  const handleSetSeatTypeFilter = useCallback(
+    (next: MembershipSeatType | "none" | null) => {
+      setSeatTypeFilter(next);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
+
+  // Name/email search is also applied server-side before pagination, so reset
+  // to the first page whenever the search term changes.
+  const handleSetSearchTerm = useCallback((next: string) => {
+    setSearchTerm(next);
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
@@ -371,6 +397,7 @@ export function UsagePage() {
       pageSize: pagination.pageSize,
       orderColumn: membersOrderColumn,
       orderDirection: membersOrderDirection,
+      seatType: seatTypeFilter ?? undefined,
     });
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
@@ -386,6 +413,21 @@ export function UsagePage() {
   });
 
   const isSeatBased = Object.keys(seatPlans).length > 1;
+
+  // Seat-type filter options derived from the seats available to this
+  // workspace, collapsed to base tiers (monthly/yearly share one entry) and
+  // ordered by tier.
+  const seatFilterOptions = useMemo(() => {
+    const currentBaseSeatTypes = new Set<MembershipSeatType>();
+    for (const key of Object.keys(seatPlans)) {
+      if (isMembershipSeatType(key)) {
+        currentBaseSeatTypes.add(toBaseSeatType(key));
+      }
+    }
+    return [...currentBaseSeatTypes].sort(
+      (a, b) => SEAT_TYPE_ORDER[a] - SEAT_TYPE_ORDER[b]
+    );
+  }, [seatPlans]);
 
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);
@@ -426,7 +468,7 @@ export function UsagePage() {
         placeholder="Search members"
         value={searchTerm}
         name="search"
-        onChange={setSearchTerm}
+        onChange={handleSetSearchTerm}
         className="w-full"
       />
       {isManualInvitationsEnabled && (
@@ -450,8 +492,7 @@ export function UsagePage() {
             seatTypeFilter === "none"
               ? "No seat"
               : seatTypeFilter
-                ? seatTypeFilter.charAt(0).toUpperCase() +
-                  seatTypeFilter.slice(1)
+                ? capitalize(seatTypeFilter)
                 : "All seats"
           }
           size="sm"
@@ -461,24 +502,19 @@ export function UsagePage() {
       <DropdownMenuContent align="end">
         <DropdownMenuItem
           label="All seats"
-          onClick={() => setSeatTypeFilter(null)}
+          onClick={() => handleSetSeatTypeFilter(null)}
         />
         <DropdownMenuItem
           label="No seat"
-          onClick={() => setSeatTypeFilter("none")}
+          onClick={() => handleSetSeatTypeFilter("none")}
         />
-        <DropdownMenuItem
-          label="Free"
-          onClick={() => setSeatTypeFilter("free")}
-        />
-        <DropdownMenuItem
-          label="Pro"
-          onClick={() => setSeatTypeFilter("pro")}
-        />
-        <DropdownMenuItem
-          label="Max"
-          onClick={() => setSeatTypeFilter("max")}
-        />
+        {seatFilterOptions.map((seatType) => (
+          <DropdownMenuItem
+            key={seatType}
+            label={capitalize(seatType)}
+            onClick={() => handleSetSeatTypeFilter(seatType)}
+          />
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -491,7 +527,6 @@ export function UsagePage() {
       showSpendLimit={!isFreePlanWorkspace}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
       seatChangePendingMemberIds={seatChangePendingMemberIds}
-      seatTypeFilter={seatTypeFilter}
       isSeatBased={isSeatBased}
       onChangeSeat={handleChangeSeatFromTable}
       onRemoveSeat={onRemoveSeat}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -74,6 +74,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
+import capitalize from "lodash/capitalize";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 // Build a minimal member from an upgrade request to feed the reused seat / spend
@@ -106,10 +107,6 @@ function memberFromUpgradeRequest(
 }
 
 const DEFAULT_PAGE_SIZE = 25;
-
-function capitalize(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
 
 export function UsagePage() {
   const owner = useWorkspace();

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -11,9 +11,9 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { useDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import {
-  isMembershipSeatType,
   type MembershipSeatType,
   SEAT_TYPE_ORDER,
+  toBaseSeatType,
 } from "@app/types/memberships";
 import {
   Clock,
@@ -52,16 +52,6 @@ type RowData = {
 
 type Info = CellContext<RowData, string>;
 
-// Yearly seat types are billed yearly but render in the table identically to
-// their monthly counterpart. Strip the suffix for icon lookup and display.
-function getDisplaySeatType(seatType: MembershipSeatType): MembershipSeatType {
-  if (seatType.endsWith("_yearly")) {
-    const stripped = seatType.slice(0, -"_yearly".length);
-    return isMembershipSeatType(stripped) ? stripped : seatType;
-  }
-  return seatType;
-}
-
 // Builds the tooltip explaining a scheduled seat change, e.g.
 // "This user will be downgraded to Free at the end of the billing period (July 1)".
 function getScheduledSeatChangeLabel(
@@ -77,7 +67,7 @@ function getScheduledSeatChangeLabel(
       : scheduledRank < currentRank
         ? "downgraded"
         : "changed";
-  const target = getDisplaySeatType(scheduledSeatType);
+  const target = toBaseSeatType(scheduledSeatType);
   const targetLabel = target.charAt(0).toUpperCase() + target.slice(1);
   const dateSuffix = scheduledSeatChangeAt
     ? ` (${new Date(scheduledSeatChangeAt).toLocaleDateString("en-US", {
@@ -97,7 +87,7 @@ function SeatTypeIcon({ seatType }: SeatTypeIconProps) {
   if (!seatType) {
     return null;
   }
-  const displaySeatType = getDisplaySeatType(seatType);
+  const displaySeatType = toBaseSeatType(seatType);
   const visual = SEAT_TYPE_ICONS[displaySeatType];
   if (!visual) {
     return null;
@@ -341,7 +331,7 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
       <DataTable.CellContent>
         <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
           <SeatTypeIcon seatType={seatType} />
-          {seatType ? getDisplaySeatType(seatType) : "—"}
+          {seatType ? toBaseSeatType(seatType) : "—"}
           {scheduledSeatType && (
             <Tooltip
               label={getScheduledSeatChangeLabel(
@@ -430,7 +420,6 @@ interface MembersUsageTableProps {
   isLoading: boolean;
   totalAllowedUsagePendingMemberIds: ReadonlySet<string>;
   seatChangePendingMemberIds: ReadonlySet<string>;
-  seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
   showSpendLimit: boolean;
   readOnly: boolean;
@@ -449,7 +438,6 @@ export function MembersUsageTable({
   isLoading,
   totalAllowedUsagePendingMemberIds,
   seatChangePendingMemberIds,
-  seatTypeFilter,
   isSeatBased,
   showSpendLimit,
   readOnly,
@@ -462,29 +450,9 @@ export function MembersUsageTable({
   sorting,
   setSorting,
 }: MembersUsageTableProps) {
-  // Name/email search is handled server-side; only filter by seat type here.
-  const filtered = useMemo(
-    () =>
-      members.filter((m) => {
-        if (seatTypeFilter === "none" && m.seatType !== null) {
-          return false;
-        }
-        if (
-          seatTypeFilter !== null &&
-          seatTypeFilter !== "none" &&
-          m.seatType &&
-          !m.seatType.startsWith(seatTypeFilter)
-        ) {
-          return false;
-        }
-        return true;
-      }),
-    [members, seatTypeFilter]
-  );
-
   const rows: RowData[] = useMemo(
     () =>
-      filtered.map((m) => ({
+      members.map((m) => ({
         sId: m.sId,
         name: m.name,
         email: m.email,
@@ -537,7 +505,7 @@ export function MembersUsageTable({
         ],
       })),
     [
-      filtered,
+      members,
       totalAllowedUsagePendingMemberIds,
       seatChangePendingMemberIds,
       isSeatBased,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -717,7 +717,8 @@ export async function getMemberUsage({
 // memberships table directly (a base tier matches its monthly + yearly
 // variants). Seat type isn't held in the user search index, so we hand these
 // ids to Elasticsearch as an allowlist and let it own search/sort/pagination
-// over the filtered set.
+// over the filtered set. We don't do it in ES because seats can be effective
+// at the end of the billing period so it would require bigger plumbing.
 async function resolveSeatTypeFilterUserIds({
   workspace,
   seatType,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -48,10 +48,13 @@ import type {
   UserCreditState,
 } from "@app/types/memberships";
 import {
+  MEMBERSHIP_SEAT_TYPES,
   NORMALIZED_POOL_LIMIT_SEAT_TYPES,
   normalizeToPoolLimitSeatType,
+  toBaseSeatType,
 } from "@app/types/memberships";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 import { z } from "zod";
 
 export type MemberUsageType = {
@@ -148,6 +151,9 @@ export const MembersUsagePaginationSchema = z.object({
   // for pagination instead of relevance ranking.
   orderColumn: z.enum(["name", "email"]).catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
+  // Optional seat-type filter. A base seat type (e.g. "pro") matches its
+  // monthly and yearly variants; "none" matches members with no seat.
+  seatType: z.enum(MEMBERSHIP_SEAT_TYPES).optional().catch(undefined),
 });
 
 export type MembersUsagePaginationInput = z.infer<
@@ -707,6 +713,30 @@ export async function getMemberUsage({
   };
 }
 
+// Resolve the member user sIds matching a base seat-type filter, querying the
+// memberships table directly (a base tier matches its monthly + yearly
+// variants). Seat type isn't held in the user search index, so we hand these
+// ids to Elasticsearch as an allowlist and let it own search/sort/pagination
+// over the filtered set.
+async function resolveSeatTypeFilterUserIds({
+  workspace,
+  seatType,
+}: {
+  workspace: LightWorkspaceType;
+  seatType: MembershipSeatType;
+}): Promise<string[]> {
+  const seatTypes = MEMBERSHIP_SEAT_TYPES.filter(
+    (t) => toBaseSeatType(t) === seatType
+  );
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+    seatTypes,
+  });
+  return memberships
+    .map((m) => m.user?.sId)
+    .filter((sId): sId is string => Boolean(sId));
+}
+
 export async function getMembersUsage({
   auth,
   paginationParams,
@@ -725,6 +755,20 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
+  // When a seat-type filter is active, resolve the matching user sIds up front
+  // and restrict the search to them so pagination and the returned `total`
+  // reflect the filtered set. No match means an empty page.
+  let restrictToUserIds: string[] | undefined;
+  if (paginationParams.seatType) {
+    restrictToUserIds = await resolveSeatTypeFilterUserIds({
+      workspace,
+      seatType: paginationParams.seatType,
+    });
+    if (restrictToUserIds.length === 0) {
+      return { members: [], total: 0 };
+    }
+  }
+
   const usersResult = await UserResource.searchUsers(auth, {
     searchTerm: paginationParams.search ?? "",
     offset: paginationParams.offset,
@@ -733,6 +777,7 @@ export async function getMembersUsage({
       field: paginationParams.orderColumn,
       direction: paginationParams.orderDirection,
     },
+    restrictToUserIds,
   });
 
   if (usersResult.isErr()) {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -718,7 +718,8 @@ export async function getMemberUsage({
 // variants). Seat type isn't held in the user search index, so we hand these
 // ids to Elasticsearch as an allowlist and let it own search/sort/pagination
 // over the filtered set. We don't do it in ES because seats can be effective
-// at the end of the billing period so it would require bigger plumbing.
+// at the end of the billing period so it would add a lot of complexity to
+// keep the index up to date with the effective seat type for each user.
 async function resolveSeatTypeFilterUserIds({
   workspace,
   seatType,
@@ -733,9 +734,14 @@ async function resolveSeatTypeFilterUserIds({
     workspace,
     seatTypes,
   });
-  return memberships
-    .map((m) => m.user?.sId)
-    .filter((sId): sId is string => Boolean(sId));
+  return (
+    memberships
+      .map((m) => m.user?.sId)
+      // defensive typecheck: in practice this should never happen because the
+      // memberships are inner-joined to users, but the type system doesn't
+      // know that.
+      .filter((sId): sId is string => Boolean(sId))
+  );
 }
 
 export async function getMembersUsage({

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -48,6 +48,7 @@ type GetMembershipsOptions = RequireAtLeastOne<{
   workspace: LightWorkspaceType;
 }> & {
   roles?: MembershipRoleType[];
+  seatTypes?: MembershipSeatType[];
   transaction?: Transaction;
 };
 
@@ -136,6 +137,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     users,
     workspace,
     roles,
+    seatTypes,
     transaction,
     paginationParams,
   }: GetMembershipsOptions & {
@@ -175,6 +177,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     if (roles) {
       whereClause.role = {
         [Op.in]: roles,
+      };
+    }
+    if (seatTypes) {
+      whereClause.seatType = {
+        [Op.in]: seatTypes,
       };
     }
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -369,11 +369,13 @@ export class UserResource extends BaseResource<UserModel> {
       offset,
       limit,
       orderBy,
+      restrictToUserIds,
     }: {
       searchTerm: string;
       offset: number;
       limit: number;
       orderBy?: SearchUsersOrderBy;
+      restrictToUserIds?: string[];
     }
   ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
     const owner = auth.getNonNullableWorkspace();
@@ -385,6 +387,7 @@ export class UserResource extends BaseResource<UserModel> {
       offset,
       limit,
       orderBy,
+      userIds: restrictToUserIds,
     });
     if (searchResult.isErr()) {
       return searchResult;

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -240,6 +240,7 @@ export function useMembersUsage({
   pageSize,
   orderColumn,
   orderDirection,
+  seatType,
   disabled,
 }: {
   workspaceId: string;
@@ -248,6 +249,7 @@ export function useMembersUsage({
   pageSize: number;
   orderColumn?: "name" | "email";
   orderDirection?: "asc" | "desc";
+  seatType?: MembershipSeatType | "none";
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -271,6 +273,9 @@ export function useMembersUsage({
   }
   if (orderDirection) {
     searchParams.set("orderDirection", orderDirection);
+  }
+  if (seatType) {
+    searchParams.set("seatType", seatType);
   }
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/user_search/search.ts
+++ b/front/lib/user_search/search.ts
@@ -28,12 +28,14 @@ export async function searchUsers({
   offset,
   limit,
   orderBy,
+  userIds,
 }: {
   owner: LightWorkspaceType;
   searchTerm: string;
   offset: number;
   limit: number;
   orderBy?: SearchUsersOrderBy;
+  userIds?: string[];
 }): Promise<Result<SearchUsersResult, ElasticsearchError>> {
   return withEs(async (client) => {
     // If searchTerm is empty or only whitespace, return all users from the workspace.
@@ -41,7 +43,10 @@ export async function searchUsers({
 
     const query: estypes.QueryDslQueryContainer = {
       bool: {
-        filter: [{ term: { workspace_id: owner.sId } }],
+        filter: [
+          { term: { workspace_id: owner.sId } },
+          ...(userIds ? [{ terms: { user_id: userIds } }] : []),
+        ],
         ...(hasSearchTerm && {
           should: [
             // Prefix matching on full_name using edge n-grams

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -94,6 +94,24 @@ export function isNormalizedPoolLimitSeatType(
 }
 
 /**
+ * Collapse a seat type's `_yearly` variant onto its base tier (e.g.
+ * `pro_yearly` → `pro`). Yearly and monthly variants share a tier, icon and
+ * label, so this is used both for display and for matching a base seat-type
+ * filter against either cadence.
+ */
+export function toBaseSeatType(
+  seatType: MembershipSeatType
+): MembershipSeatType {
+  if (seatType.endsWith("_yearly")) {
+    const base = seatType.slice(0, -"_yearly".length);
+    if (isMembershipSeatType(base)) {
+      return base;
+    }
+  }
+  return seatType;
+}
+
+/**
  * Map a membership seat type to its normalized pool-limit seat type.
  * Returns null for `free` seats (they have a fixed lifetime allocation with
  * no pool access).


### PR DESCRIPTION
## Description

Moves the members-usage seat-type filter from client-side to server-side, so pagination and the returned `total` reflect the filtered set instead of only re-filtering the current page.

- The seat-type filter is now passed to the API. Matching user `sId`s are resolved up front from the `memberships` table (a base tier like `pro` matches both its monthly and yearly variants), then handed to Elasticsearch as a `terms` allowlist so ES still owns search, sort and pagination over the filtered set.
- `MembershipResource.getActiveMemberships` gains an optional `seatTypes` filter; `UserResource.searchUsers` / the ES `searchUsers` query gain an optional `restrictToUserIds` / `userIds` allowlist.
- The filter dropdown is now derived from the seats actually available to the workspace (collapsed to base tiers, ordered by tier) rather than a hardcoded Free/Pro/Max list.
- Extracted the yearly→base seat-type collapsing into a shared `toBaseSeatType` helper in `types/memberships` (previously a local `getDisplaySeatType` in the table), reused for both display and filter matching.
- Changing the search term or seat-type filter now resets pagination to the first page, since both are applied server-side before pagination.

## Tests

Manually verified the members usage page: filtering by each seat type returns the correct members with an accurate total and working pagination, the dropdown only lists seat types available to the workspace, and yearly seats match their base-tier filter.
