### PR TITLE
feat: do not notify on slack when added to a pod

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -2,8 +2,8 @@ import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/a
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
+import { podAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
-import { projectAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/project-added-as-member";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
@@ -28,7 +28,7 @@ const options: ServeHandlerOptions = {
     agentMessageFeedbackWorkflow,
     agentSuggestionsReadyWorkflow,
     skillSuggestionsReadyWorkflow,
-    projectAddedAsMemberWorkflow,
+    podAddedAsMemberWorkflow,
     providerCredentialsHealthUpdatedWorkflow,
     userAwuCapReachedWorkflow,
     balanceThresholdReachedWorkflow,

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -1,4 +1,4 @@
-import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
+import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -189,8 +189,8 @@ app.post(
 
     // Trigger notifications for newly added members (projects only).
     if (space.isProject()) {
-      notifyProjectMembersAdded(auth, {
-        project: space.toJSON(),
+      notifyPodMembersAdded(auth, {
+        pod: space.toJSON(),
         addedUserIds: userIds,
       });
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -4,7 +4,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { PatchSpaceMembersRequestBodySchema } from "@app/lib/api/spaces/members";
-import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
+import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
 import { auditLog } from "@app/logger/logger";
@@ -204,8 +204,8 @@ app.patch(
         (id) => !currentMemberIds.has(id)
       );
       if (newlyAddedUserIds.length > 0) {
-        notifyProjectMembersAdded(auth, {
-          project: space.toJSON(),
+        notifyPodMembersAdded(auth, {
+          pod: space.toJSON(),
           addedUserIds: newlyAddedUserIds,
         });
       }

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -48,7 +48,7 @@ import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/l
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
-import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
+import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { seedInitialPodTasks } from "@app/lib/project_task/seed_initial_pod_tasks";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -365,8 +365,8 @@ export function createProjectManagerTools(
             );
           }
           added.push(...addMembersRes.value.map((user) => user.sId));
-          notifyProjectMembersAdded(auth, {
-            project: pod.toJSON(),
+          notifyPodMembersAdded(auth, {
+            pod: pod.toJSON(),
             addedUserIds: uniqueAddIds,
           });
         }

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -17,7 +17,7 @@ import { extractFromString } from "@app/lib/mentions/format";
 import type { MentionStatusType } from "@app/lib/models/agent/conversation";
 import { MentionModel } from "@app/lib/models/agent/conversation";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
-import { notifyProjectMembersAdded } from "@app/lib/notifications/workflows/project-added-as-member";
+import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -293,8 +293,8 @@ export async function validateUserMention(
     }
 
     // Notify the user they were added to the project.
-    notifyProjectMembersAdded(auth, {
-      project: space.toJSON(),
+    notifyPodMembersAdded(auth, {
+      pod: space.toJSON(),
       addedUserIds: [userId],
     });
   }

--- a/front/lib/notifications/workflows/pod-added-as-member.ts
+++ b/front/lib/notifications/workflows/pod-added-as-member.ts
@@ -2,16 +2,13 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import {
-  ensureSlackNotificationsReady,
-  getNovuClient,
-} from "@app/lib/notifications";
+import { getNovuClient } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { getPodRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
-import { PROJECT_ADDED_AS_MEMBER_TRIGGER_ID } from "@app/types/notification_preferences";
+import { POD_ADDED_AS_MEMBER_TRIGGER_ID } from "@app/types/notification_preferences";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -19,32 +16,32 @@ import type { SpaceType } from "@app/types/space";
 import { workflow } from "@novu/framework";
 import z from "zod";
 
-const ProjectAddedAsMemberPayloadSchema = z.object({
+const PodAddedAsMemberPayloadSchema = z.object({
   workspaceId: z.string(),
-  projectId: z.string(),
+  podId: z.string(),
   userThatAddedYouId: z.string(),
 });
 
-type ProjectAddedAsMemberPayloadType = z.infer<
-  typeof ProjectAddedAsMemberPayloadSchema
+type PodAddedAsMemberPayloadType = z.infer<
+  typeof PodAddedAsMemberPayloadSchema
 >;
 
-const ProjectDetailsSchema = z.object({
-  projectName: z.string(),
+const PodDetailsSchema = z.object({
+  podName: z.string(),
   userThatAddedYouFullname: z.string(),
   workspaceName: z.string(),
 });
 
-type ProjectDetailsType = z.infer<typeof ProjectDetailsSchema>;
+type PodDetailsType = z.infer<typeof PodDetailsSchema>;
 
-const getProjectDetails = async ({
+const getPodDetails = async ({
   subscriberId,
   payload,
 }: {
   subscriberId?: string | null;
-  payload: ProjectAddedAsMemberPayloadType;
-}): Promise<ProjectDetailsType> => {
-  let projectName: string = "A Pod";
+  payload: PodAddedAsMemberPayloadType;
+}): Promise<PodDetailsType> => {
+  let podName: string = "A Pod";
   let userThatAddedYouFullname: string = "Someone";
   let workspaceName: string = "A workspace";
 
@@ -54,11 +51,11 @@ const getProjectDetails = async ({
       payload.workspaceId
     );
 
-    const project = await SpaceResource.fetchById(auth, payload.projectId);
+    const pod = await SpaceResource.fetchById(auth, payload.podId);
 
-    if (project) {
+    if (pod) {
       workspaceName = auth.getNonNullableWorkspace().name;
-      projectName = project.name;
+      podName = pod.name;
 
       const userThatAddedYou = await UserResource.fetchById(
         payload.userThatAddedYouId
@@ -70,18 +67,18 @@ const getProjectDetails = async ({
     }
   }
   return {
-    projectName,
+    podName,
     userThatAddedYouFullname,
     workspaceName,
   };
 };
 
-const shouldSkipProject = async ({
+const shouldSkipPod = async ({
   subscriberId,
   payload,
 }: {
   subscriberId?: string | null;
-  payload: ProjectAddedAsMemberPayloadType;
+  payload: PodAddedAsMemberPayloadType;
 }): Promise<boolean> => {
   if (subscriberId) {
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -89,9 +86,9 @@ const shouldSkipProject = async ({
       payload.workspaceId
     );
 
-    const project = await SpaceResource.fetchById(auth, payload.projectId);
+    const pod = await SpaceResource.fetchById(auth, payload.podId);
 
-    if (!project) {
+    if (!pod) {
       return true;
     }
   }
@@ -99,19 +96,19 @@ const shouldSkipProject = async ({
   return false;
 };
 
-export const projectAddedAsMemberWorkflow = workflow(
-  PROJECT_ADDED_AS_MEMBER_TRIGGER_ID,
+export const podAddedAsMemberWorkflow = workflow(
+  POD_ADDED_AS_MEMBER_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
     const details = await step.custom(
       "get-project-details",
       async () => {
-        return getProjectDetails({
+        return getPodDetails({
           subscriberId: subscriber.subscriberId,
           payload,
         });
       },
       {
-        outputSchema: ProjectDetailsSchema,
+        outputSchema: PodDetailsSchema,
       }
     );
 
@@ -119,55 +116,21 @@ export const projectAddedAsMemberWorkflow = workflow(
       "send-in-app",
       async () => {
         return {
-          subject: details.projectName,
-          body: `${details.userThatAddedYouFullname} added you to Pod "${details.projectName}".`,
+          subject: details.podName,
+          body: `${details.userThatAddedYouFullname} added you to Pod "${details.podName}".`,
           primaryAction: {
             label: "View",
             redirect: {
-              url: getPodRoute(payload.workspaceId, payload.projectId),
+              url: getPodRoute(payload.workspaceId, payload.podId),
             },
           },
           data: {
             autoDelete: true,
-            projectId: payload.projectId,
           },
         };
       },
       {
-        skip: async () => shouldSkipProject({ payload }),
-      }
-    );
-
-    await step.chat(
-      "slack-notification",
-      async () => {
-        const projectUrl =
-          config.getAppUrl() +
-          getPodRoute(payload.workspaceId, payload.projectId);
-
-        const baseMessage = `${details.userThatAddedYouFullname} added you to Pod "${details.projectName}"`;
-
-        const message = `${baseMessage}\n<${projectUrl}|View Pod>`;
-
-        return {
-          body: message,
-        };
-      },
-      {
-        skip: async () => {
-          const shouldSkip = await shouldSkipProject({ payload });
-          if (shouldSkip) {
-            return true;
-          }
-          const { isReady } = await ensureSlackNotificationsReady(
-            subscriber.subscriberId,
-            payload.workspaceId
-          );
-          if (!isReady) {
-            return true;
-          }
-          return false;
-        },
+        skip: async () => shouldSkipPod({ payload }),
       }
     );
 
@@ -180,48 +143,48 @@ export const projectAddedAsMemberWorkflow = workflow(
             id: payload.workspaceId,
             name: details.workspaceName,
           },
-          content: `${details.userThatAddedYouFullname} added you to Pod "${details.projectName}".`,
+          content: `${details.userThatAddedYouFullname} added you to Pod "${details.podName}".`,
           action: {
             label: "View Pod",
             url:
               config.getAppUrl() +
-              getPodRoute(payload.workspaceId, payload.projectId),
+              getPodRoute(payload.workspaceId, payload.podId),
           },
         });
         return {
-          subject: `[Dust] You were added to Pod '${details.projectName}'`,
+          subject: `[Dust] You were added to Pod '${details.podName}'`,
           body,
         };
       },
       {
         skip: async () => {
-          return shouldSkipProject({ payload });
+          return shouldSkipPod({ payload });
         },
       }
     );
   },
   {
-    payloadSchema: ProjectAddedAsMemberPayloadSchema,
+    payloadSchema: PodAddedAsMemberPayloadSchema,
     tags: ["admin"] as NotificationAllowedTags,
   }
 );
 
 /**
- * Trigger notifications for users added to a project.
+ * Trigger notifications for users added to a pod.
  * Should be called from API endpoints after successfully adding members.
  */
-export const triggerProjectAddedAsMemberNotifications = async (
+export const triggerPodAddedAsMemberNotifications = async (
   auth: Authenticator,
   {
-    project,
+    pod,
     addedUserIds,
   }: {
-    project: SpaceType;
+    pod: SpaceType;
     addedUserIds: string[];
   }
 ): Promise<Result<void, DustError<"internal_error">>> => {
   // Only notify for project spaces.
-  if (project.kind !== "project") {
+  if (pod.kind !== "project") {
     return new Ok(undefined);
   }
 
@@ -249,15 +212,15 @@ export const triggerProjectAddedAsMemberNotifications = async (
   try {
     const novuClient = await getNovuClient();
 
-    const payload: ProjectAddedAsMemberPayloadType = {
+    const payload: PodAddedAsMemberPayloadType = {
       workspaceId: auth.getNonNullableWorkspace().sId,
-      projectId: project.sId,
+      podId: pod.sId,
       userThatAddedYouId: userThatAddedYou.sId,
     };
 
     const r = await novuClient.triggerBulk({
       events: addedUsers.map((user: UserResource) => ({
-        workflowId: PROJECT_ADDED_AS_MEMBER_TRIGGER_ID,
+        workflowId: POD_ADDED_AS_MEMBER_TRIGGER_ID,
         to: {
           subscriberId: user.sId,
           email: user.email,
@@ -276,14 +239,14 @@ export const triggerProjectAddedAsMemberNotifications = async (
       return new Err({
         name: "dust_error",
         code: "internal_error",
-        message: `Failed to trigger project added as member notification: ${eventErrors}`,
+        message: `Failed to trigger pod added as member notification: ${eventErrors}`,
       });
     }
   } catch (err) {
     return new Err({
       name: "dust_error",
       code: "internal_error",
-      message: "Failed to trigger project added as member notification",
+      message: "Failed to trigger pod added as member notification",
       cause: normalizeError(err),
     });
   }
@@ -292,27 +255,27 @@ export const triggerProjectAddedAsMemberNotifications = async (
 };
 
 /**
- * Fire-and-forget helper to trigger project member notifications.
+ * Fire-and-forget helper to trigger pod member notifications.
  * The notification is sent asynchronously and errors are logged but don't block the caller.
  */
-export function notifyProjectMembersAdded(
+export function notifyPodMembersAdded(
   auth: Authenticator,
   {
-    project,
+    pod,
     addedUserIds,
   }: {
-    project: SpaceType;
+    pod: SpaceType;
     addedUserIds: string[];
   }
 ): void {
-  void triggerProjectAddedAsMemberNotifications(auth, {
-    project,
+  void triggerPodAddedAsMemberNotifications(auth, {
+    pod: pod,
     addedUserIds,
   }).then((notifRes) => {
     if (notifRes.isErr()) {
       logger.error(
-        { error: notifRes.error, projectId: project.sId },
-        "Failed to trigger project added as member notification"
+        { error: notifRes.error, podId: pod.sId },
+        "Failed to trigger pod added as member notification"
       );
     }
   });

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -95,7 +95,7 @@ export const CONVERSATION_NOTIFICATION_METADATA_KEYS = {
 } as const;
 
 export const CONVERSATION_UNREAD_TRIGGER_ID = "conversation-unread" as const;
-export const PROJECT_ADDED_AS_MEMBER_TRIGGER_ID =
+export const POD_ADDED_AS_MEMBER_TRIGGER_ID =
   "project-added-as-member" as const;
 export const AGENT_SUGGESTIONS_READY_TRIGGER_ID =
   "agent-suggestions-ready" as const;
@@ -120,7 +120,7 @@ export const PROGRAMMATIC_CAP_REACHED_TAG = "programmatic-cap-reached" as const;
 
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
-  | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID
+  | typeof POD_ADDED_AS_MEMBER_TRIGGER_ID
   | typeof AGENT_SUGGESTIONS_READY_TRIGGER_ID
   | typeof SKILL_SUGGESTIONS_READY_TRIGGER_ID
   | typeof PROVIDER_CREDENTIALS_HEALTH_UPDATED_TRIGGER_ID


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8717

This PR removes the slack notification that we send when a user is added to a Pod.
Since we do not expose the preferences for this notification in the UI, we remove the slack notification to make it consistent with the other notification not manageable from the UI.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Standard deployment.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
