### PR TITLE
[Skills] Fix tsgo on main: drop removed referencedSkillIds param in test

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -975,7 +975,6 @@ describe("SkillResource", () => {
         mcpServerViews: [],
         attachedKnowledge: [],
         requestedSpaceIds: childSkill.requestedSpaceIds,
-        referencedSkillIds: [],
       });
 
       const updatedParentSkill = await SkillResource.fetchById(


### PR DESCRIPTION
## Description

Fixes a semantic conflict breaking `tsgo` on main: #27198 removed the `referencedSkillIds` parameter from `updateSkill`, while #27237 (merged in between) added a test passing it. Both PRs were green independently.

The test passes without the parameter since references are now derived from instructions.

## Risks

Blast radius: one test file
Risk: none

## Deploy Plan
- pmrr
- none (test-only)