### PR TITLE
[Skills] Remove referencedSkillIds from the skill builder client

### DIFF
--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -62,7 +62,6 @@ export const skillBuilderFormSchema = z.object({
   fileAttachments: z.array(fileAttachmentSchema),
   attachedKnowledge: z.array(attachedKnowledgeSchema).optional(),
   referencedSkills: z.array(referencedSkillSchema),
-  referencedSkillIds: z.array(z.string()),
   additionalSpaces: z.array(z.string()),
 });
 

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -49,7 +49,6 @@ const INSTRUCTIONS_FIELD_NAME = "instructions";
 const INSTRUCTIONS_HTML_FIELD_NAME = "instructionsHtml";
 const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
 const REFERENCED_SKILLS_FIELD_NAME = "referencedSkills";
-const REFERENCED_SKILL_IDS_FIELD_NAME = "referencedSkillIds";
 const BASE_ALLOWED_INSTRUCTIONS_TAGS = ["knowledge"];
 const BASE_ALLOWED_INSTRUCTIONS_ATTRS = ["space", "dsv", "hasChildren"];
 const SKILL_REFERENCE_ALLOWED_TAGS = [
@@ -194,16 +193,6 @@ function collectSkillReferenceIds(editor: Editor): Set<string> {
   return skillIds;
 }
 
-function haveSameSkillReferenceIds(
-  currentIds: readonly string[],
-  nextIds: ReadonlySet<string>
-): boolean {
-  return (
-    currentIds.length === nextIds.size &&
-    currentIds.every((skillId) => nextIds.has(skillId))
-  );
-}
-
 function toAttachedKnowledge(
   items: readonly KnowledgeItem[]
 ): SkillBuilderFormData["attachedKnowledge"] {
@@ -257,9 +246,6 @@ export function SkillBuilderInstructionsEditor({
   const referencedSkillsRef = useRef<SkillBuilderFormData["referencedSkills"]>(
     []
   );
-  const referencedSkillIdsRef = useRef<
-    SkillBuilderFormData["referencedSkillIds"]
-  >([]);
   const {
     owner,
     user,
@@ -307,15 +293,6 @@ export function SkillBuilderInstructionsEditor({
     name: REFERENCED_SKILLS_FIELD_NAME,
   });
 
-  const {
-    field: { onChange: onReferencedSkillIdsChange, value: referencedSkillIds },
-  } = useController<
-    SkillBuilderFormData,
-    typeof REFERENCED_SKILL_IDS_FIELD_NAME
-  >({
-    name: REFERENCED_SKILL_IDS_FIELD_NAME,
-  });
-
   useEffect(() => {
     toolsRef.current = tools;
   }, [tools]);
@@ -323,10 +300,6 @@ export function SkillBuilderInstructionsEditor({
   useEffect(() => {
     referencedSkillsRef.current = referencedSkills;
   }, [referencedSkills]);
-
-  useEffect(() => {
-    referencedSkillIdsRef.current = referencedSkillIds;
-  }, [referencedSkillIds]);
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
@@ -365,17 +338,6 @@ export function SkillBuilderInstructionsEditor({
       previousInlineToolIdsRef.current = currentInlineToolIds;
 
       const currentInlineSkillIds = collectSkillReferenceIds(editor);
-      if (
-        !haveSameSkillReferenceIds(
-          referencedSkillIdsRef.current,
-          currentInlineSkillIds
-        )
-      ) {
-        const nextReferencedSkillIds = [...currentInlineSkillIds];
-        referencedSkillIdsRef.current = nextReferencedSkillIds;
-        onReferencedSkillIdsChange(nextReferencedSkillIds);
-      }
-
       const removedSkillIds = [...previousInlineSkillIdsRef.current].filter(
         (skillId) => !currentInlineSkillIds.has(skillId)
       );
@@ -391,7 +353,7 @@ export function SkillBuilderInstructionsEditor({
 
       previousInlineSkillIdsRef.current = currentInlineSkillIds;
     },
-    [onReferencedSkillIdsChange, onReferencedSkillsChange, onToolsChange]
+    [onReferencedSkillsChange, onToolsChange]
   );
 
   const syncInstructionsFromEditor = useCallback(
@@ -478,17 +440,8 @@ export function SkillBuilderInstructionsEditor({
         referencedSkillsRef.current = nextReferencedSkills;
         onReferencedSkillsChange(nextReferencedSkills);
       }
-
-      if (!referencedSkillIdsRef.current.includes(skill.sId)) {
-        const nextReferencedSkillIds = [
-          ...referencedSkillIdsRef.current,
-          skill.sId,
-        ];
-        referencedSkillIdsRef.current = nextReferencedSkillIds;
-        onReferencedSkillIdsChange(nextReferencedSkillIds);
-      }
     },
-    [onReferencedSkillIdsChange, onReferencedSkillsChange]
+    [onReferencedSkillsChange]
   );
 
   const handleSkillDetails = useCallback(
@@ -696,15 +649,7 @@ export function SkillBuilderInstructionsEditor({
       keepTouched: true,
     });
     previousInlineToolIdsRef.current = collectToolReferenceIds(editor);
-    const inlineSkillIds = collectSkillReferenceIds(editor);
-    const inlineSkillIdList = [...inlineSkillIds];
-    previousInlineSkillIdsRef.current = inlineSkillIds;
-    referencedSkillIdsRef.current = inlineSkillIdList;
-    resetField(REFERENCED_SKILL_IDS_FIELD_NAME, {
-      defaultValue: inlineSkillIdList,
-      keepError: true,
-      keepTouched: true,
-    });
+    previousInlineSkillIdsRef.current = collectSkillReferenceIds(editor);
   }, [editor, isContentReady, isDiffMode, resetField]);
 
   // Apply pending instruction suggestions as inline diff decorations.

--- a/front/components/skill_builder/skillFormData.ts
+++ b/front/components/skill_builder/skillFormData.ts
@@ -1,6 +1,5 @@
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
-import { extractUniqueSkillReferenceIds } from "@app/lib/skills/format";
 import type {
   SkillRelations,
   SkillType,
@@ -35,13 +34,6 @@ export function transformSkillTypeToFormData(
         icon: childSkill.icon,
         requestedSpaceIds: childSkill.requestedSpaceIds,
       })) ?? [],
-    referencedSkillIds: [
-      ...new Set([
-        ...(skill.relations?.childSkills.map((childSkill) => childSkill.sId) ??
-          []),
-        ...extractUniqueSkillReferenceIds(skill.instructions ?? ""),
-      ]),
-    ],
   };
 }
 
@@ -70,6 +62,5 @@ export function getDefaultSkillFormData({
     reinforcement: "on",
     additionalSpaces: [],
     referencedSkills: [],
-    referencedSkillIds: [],
   };
 }

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -58,7 +58,6 @@ export async function submitSkillBuilderForm({
         })),
         attachedKnowledge: formData.attachedKnowledge ?? [],
         additionalRequestedSpaceIds: formData.additionalSpaces,
-        referencedSkillIds: formData.referencedSkillIds,
       }),
     });
 


### PR DESCRIPTION
## Description

Follow-up to #27198

Since #27198 the server derives skill references from the inline tags in the instructions and ignores the client-provided `referencedSkillIds` (the request schemas strip it). This removes the now-dead client side: the POST/PATCH payload field, the `referencedSkillIds` form field, and the editor bookkeeping that maintained it (~70 lines deleted).

`referencedSkills` (the metadata list driving the reference chips and space-blocker UI) is intentionally untouched.

## Risks

Blast radius: Skill Builder form state and save payload
Risk: low

## Deploy Plan
- pmrr
- deploy front