### PR TITLE
Adjust seat ledgers when switching seat

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1540,8 +1540,8 @@ export async function processMetronomeWebhook({
         pendingSubscription.status === "created_backend_only"
       ) {
         const previousPlanCode = activeSubscription.getPlan().code;
+        // `activatePending` flushes the contract cache itself.
         await pendingSubscription.activatePending();
-        await invalidateContractCache(workspace.sId);
         const auth = await Authenticator.internalAdminForWorkspace(
           workspace.sId
         );
@@ -1590,12 +1590,11 @@ export async function processMetronomeWebhook({
       // End the current subscription as `ended_backend_only` and create
       // a new active subscription on the target plan + new contract.
       const legacyPreviousPlanCode = activeSubscription.getPlan().code;
+      // `swapMetronomeContract` flushes the contract cache itself.
       await activeSubscription.swapMetronomeContract({
         metronomeContractId: contractId,
         planCode: targetPlan.code,
       });
-
-      await invalidateContractCache(workspace.sId);
 
       // Cancel any scheduled scrub workflow, unpause connectors, re-enable
       // triggers. Idempotent — safe to call regardless of prior state.

--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -1,4 +1,8 @@
-import { createMetronomeCredit } from "@app/lib/metronome/client";
+import {
+  adjustSeatCreditBalances,
+  createMetronomeCredit,
+  findSeatCreditSegmentForPeriod,
+} from "@app/lib/metronome/client";
 import type { Result } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -22,16 +26,18 @@ function unwrapErr<T>(result: Result<T, Error>): Error {
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockCreate, mockList, MockConflictError } = vi.hoisted(() => {
-  class MockConflictError extends Error {
-    status = 409;
-  }
-  return {
-    mockCreate: vi.fn(),
-    mockList: vi.fn(),
-    MockConflictError,
-  };
-});
+const { mockCreate, mockList, mockAddManualBalanceEntry, MockConflictError } =
+  vi.hoisted(() => {
+    class MockConflictError extends Error {
+      status = 409;
+    }
+    return {
+      mockCreate: vi.fn(),
+      mockList: vi.fn(),
+      mockAddManualBalanceEntry: vi.fn(),
+      MockConflictError,
+    };
+  });
 
 vi.mock("@metronome/sdk", () => {
   // Must use a regular function (not an arrow) so it can be called with `new`.
@@ -41,6 +47,7 @@ vi.mock("@metronome/sdk", () => {
         customers: {
           credits: { create: mockCreate, list: mockList },
         },
+        contracts: { addManualBalanceEntry: mockAddManualBalanceEntry },
       },
     };
   }
@@ -74,6 +81,7 @@ const BASE_PARAMS = {
 beforeEach(() => {
   mockCreate.mockReset();
   mockList.mockReset();
+  mockAddManualBalanceEntry.mockReset();
   mockCreate.mockResolvedValue({ data: { id: "credit-id-1" } });
 });
 
@@ -133,5 +141,167 @@ describe("createMetronomeCredit", () => {
     const result = await createMetronomeCredit(BASE_PARAMS);
 
     expect(unwrapErr(result).message).toMatch(/network error/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSeatCreditSegmentForPeriod
+// ---------------------------------------------------------------------------
+
+const SEAT_CREDIT_PARAMS = {
+  metronomeCustomerId: "cust-1",
+  metronomeContractId: "contract-1",
+  recurringCreditId: "recurring-1",
+  coveringDate: new Date("2026-06-15T12:00:00.000Z"),
+};
+
+function makeSeatCredit(
+  opts: {
+    id?: string;
+    contractId?: string;
+    name?: string;
+    recurringCreditId?: string | undefined;
+    scheduleItems?: Array<{
+      id: string;
+      amount: number;
+      starting_at: string;
+      ending_before: string;
+    }>;
+  } = {}
+) {
+  const {
+    id = "credit-1",
+    contractId = "contract-1",
+    name = "Max Seat Credits",
+    scheduleItems = [
+      {
+        id: "segment-1",
+        amount: 80_000,
+        starting_at: "2026-06-10T00:00:00.000Z",
+        ending_before: "2026-07-10T00:00:00.000Z",
+      },
+    ],
+  } = opts;
+  // Use `in` so an explicit `recurringCreditId: undefined` is honored (a
+  // destructuring default would replace it with the fallback).
+  const recurringCreditId =
+    "recurringCreditId" in opts ? opts.recurringCreditId : "recurring-1";
+  return {
+    id,
+    name,
+    recurring_credit_id: recurringCreditId,
+    contract: { id: contractId },
+    access_schedule: { schedule_items: scheduleItems },
+  };
+}
+
+describe("findSeatCreditSegmentForPeriod", () => {
+  it("returns the credit and segment covering the date", async () => {
+    mockList.mockReturnValue([makeSeatCredit()]);
+
+    const result = await findSeatCreditSegmentForPeriod(SEAT_CREDIT_PARAMS);
+
+    expect(unwrapOk(result)).toEqual({
+      creditId: "credit-1",
+      segmentId: "segment-1",
+      segmentStartingAt: "2026-06-10T00:00:00.000Z",
+    });
+  });
+
+  it("matches by recurring credit id, skipping a same-named credit with a different id", async () => {
+    mockList.mockReturnValue([
+      // Same name ("Max Seat Credits") but a different recurring credit (e.g.
+      // the yearly product's pool) — must NOT be picked.
+      makeSeatCredit({
+        id: "other-recurring",
+        recurringCreditId: "recurring-2",
+      }),
+      makeSeatCredit({ id: "no-recurring", recurringCreditId: undefined }),
+      makeSeatCredit({ id: "credit-match", recurringCreditId: "recurring-1" }),
+    ]);
+
+    const result = await findSeatCreditSegmentForPeriod(SEAT_CREDIT_PARAMS);
+
+    expect(unwrapOk(result)).toEqual({
+      creditId: "credit-match",
+      segmentId: "segment-1",
+      segmentStartingAt: "2026-06-10T00:00:00.000Z",
+    });
+  });
+
+  it("returns null when no segment covers the date", async () => {
+    mockList.mockReturnValue([
+      makeSeatCredit({
+        scheduleItems: [
+          {
+            id: "stale-segment",
+            amount: 80_000,
+            starting_at: "2026-05-10T00:00:00.000Z",
+            ending_before: "2026-06-10T00:00:00.000Z",
+          },
+        ],
+      }),
+    ]);
+
+    const result = await findSeatCreditSegmentForPeriod(SEAT_CREDIT_PARAMS);
+
+    expect(unwrapOk(result)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adjustSeatCreditBalances
+// ---------------------------------------------------------------------------
+
+const ADJUST_PARAMS = {
+  metronomeCustomerId: "cust-1",
+  metronomeContractId: "contract-1",
+  creditId: "credit-1",
+  segmentId: "segment-1",
+  reason: "test adjustment",
+};
+
+describe("adjustSeatCreditBalances", () => {
+  it("sums per-seat amounts into the total and floors the timestamp to the hour", async () => {
+    mockAddManualBalanceEntry.mockResolvedValue(undefined);
+
+    const result = await adjustSeatCreditBalances({
+      ...ADJUST_PARAMS,
+      perSeatAmounts: { seatA: -1000, seatB: -500 },
+      timestamp: new Date("2026-06-11T15:30:45.000Z"),
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddManualBalanceEntry).toHaveBeenCalledWith({
+      id: "credit-1",
+      customer_id: "cust-1",
+      contract_id: "contract-1",
+      segment_id: "segment-1",
+      amount: -1500,
+      per_group_amounts: { seatA: -1000, seatB: -500 },
+      reason: "test adjustment",
+      timestamp: "2026-06-11T15:00:00.000Z",
+    });
+  });
+
+  it("is a no-op when no per-seat amounts are provided", async () => {
+    const result = await adjustSeatCreditBalances({
+      ...ADJUST_PARAMS,
+      perSeatAmounts: {},
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddManualBalanceEntry).not.toHaveBeenCalled();
+  });
+
+  it("returns Err when the API call fails", async () => {
+    mockAddManualBalanceEntry.mockRejectedValueOnce(new Error("api boom"));
+
+    const result = await adjustSeatCreditBalances({
+      ...ADJUST_PARAMS,
+      perSeatAmounts: { seatA: -1000 },
+    });
+
+    expect(unwrapErr(result).message).toMatch(/api boom/);
   });
 });

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1360,6 +1360,82 @@ export async function getMetronomeSubscriptionSeatState({
 }
 
 /**
+ * The hour-aligned `starting_at` of the seat-history segment in which `seatId`
+ * is assigned — i.e. when the seat's current (or next upcoming) active window
+ * begins. This is the timestamp a per-seat manual ledger entry must fall in:
+ * Metronome rejects adjustments on a seat not active at the entry time, and
+ * seat changes are applied on hour boundaries (a seat requested "now" only
+ * becomes active at the next boundary).
+ *
+ * Prefers the segment covering `coveringDate`; if the seat is only assigned in
+ * a future segment (e.g. just assigned, effective next hour), returns that
+ * segment's start. Returns `null` when the seat is not assigned in any segment
+ * at/after `coveringDate` (no valid window to adjust in).
+ */
+export async function getMetronomeSeatActiveSince({
+  metronomeCustomerId,
+  contractId,
+  subscriptionId,
+  seatId,
+  coveringDate = new Date(),
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subscriptionId: string;
+  seatId: string;
+  coveringDate?: Date;
+}): Promise<Result<Date | null, Error>> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok(null);
+  }
+  try {
+    const response =
+      await getMetronomeClient().post<SubscriptionSeatsHistoryResponse>(
+        "/v1/contracts/getSubscriptionSeatsHistory",
+        {
+          body: {
+            customer_id: metronomeCustomerId,
+            contract_id: contractId,
+            subscription_id: subscriptionId,
+            covering_date: coveringDate.toISOString(),
+          },
+        }
+      );
+    const coveringMs = coveringDate.getTime();
+    // Segments are ascending by `starting_at`. Among those that assign the
+    // seat, prefer the one covering `coveringDate`; otherwise the earliest one
+    // starting at/after it (a future activation).
+    let covering: string | null = null;
+    let earliestUpcoming: string | null = null;
+    for (const seg of response.data) {
+      if (!seg.assigned_seat_ids.includes(seatId)) {
+        continue;
+      }
+      const startMs = new Date(seg.starting_at).getTime();
+      const endMs = seg.ending_before
+        ? new Date(seg.ending_before).getTime()
+        : Number.POSITIVE_INFINITY;
+      if (startMs <= coveringMs && coveringMs < endMs) {
+        covering = seg.starting_at;
+        break;
+      }
+      if (startMs >= coveringMs && earliestUpcoming === null) {
+        earliestUpcoming = seg.starting_at;
+      }
+    }
+    const activeSince = covering ?? earliestUpcoming;
+    return new Ok(activeSince ? new Date(activeSince) : null);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId, subscriptionId, seatId },
+      "[Metronome] Failed to read seat active-since"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * Fetch the assigned seat IDs on a SEAT_BASED subscription at `coveringDate`
  * (defaults to now), via the (untyped) getSubscriptionSeatsHistory endpoint.
  */
@@ -3090,6 +3166,170 @@ export async function deductMetronomeCreditBalance({
 }
 
 /**
+ * Resolve a seat-based recurring credit pool (e.g. "Max Seat Credits") on a
+ * contract and the access-schedule segment active at `coveringDate`. This is
+ * the `{ creditId, segmentId }` pair required to make per-seat ledger
+ * adjustments via `adjustSeatCreditBalances`.
+ *
+ * Matches on the credit `name`: Metronome materializes the recurring credit
+ * template into a concrete credit that carries a `recurring_credit_id`, so we
+ * also require that field to avoid matching a one-off credit of the same name.
+ * `covering_date` scopes the listing to the credit active now, and we then pick
+ * the schedule item covering `coveringDate`. Returns `null` when none matches.
+ */
+export async function findSeatCreditSegmentForPeriod({
+  metronomeCustomerId,
+  metronomeContractId,
+  recurringCreditId,
+  coveringDate = new Date(),
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  recurringCreditId: string;
+  coveringDate?: Date;
+}): Promise<
+  Result<
+    { creditId: string; segmentId: string; segmentStartingAt: string } | null,
+    Error
+  >
+> {
+  if (!config.getMetronomeApiKey()) {
+    return new Ok(null);
+  }
+
+  const client = getMetronomeClient();
+  const coveringMs = coveringDate.getTime();
+
+  try {
+    for await (const entry of client.v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      include_contract_credits: true,
+      covering_date: coveringDate.toISOString(),
+    })) {
+      if (entry.recurring_credit_id !== recurringCreditId) {
+        continue;
+      }
+      const segment = (entry.access_schedule?.schedule_items ?? []).find(
+        (item) => {
+          const startMs = new Date(item.starting_at).getTime();
+          const endMs = new Date(item.ending_before).getTime();
+          return startMs <= coveringMs && coveringMs < endMs;
+        }
+      );
+      if (segment) {
+        return new Ok({
+          creditId: entry.id,
+          segmentId: segment.id,
+          segmentStartingAt: segment.starting_at,
+        });
+      }
+    }
+    logger.warn(
+      { metronomeCustomerId, metronomeContractId, recurringCreditId },
+      "[Metronome] No active seat credit segment found for period"
+    );
+    return new Ok(null);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId, recurringCreditId },
+      "[Metronome] Failed to find seat credit segment"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Apply per-seat manual ledger entries to a seat-based recurring credit pool
+ * (e.g. "Max Seat Credits"). Each entry adjusts a single seat's slice of the
+ * shared pool: a negative amount draws that seat's balance down, a positive one
+ * tops it up. This is the API equivalent of the per-seat "Add a manual ledger
+ * entry" action in the Metronome "Seat balances" UI.
+ *
+ * `perSeatAmounts` maps a seat id (the `user_id` presentation value) to its
+ * signed delta. Metronome requires the top-level `amount` to equal the sum of
+ * the per-seat deltas, which we compute here. `timestamp` must fall within the
+ * segment window AND after the seat was assigned — Metronome rejects
+ * adjustments on seats not active at that time — so it defaults to now (floored
+ * to the hour as Metronome requires) rather than the segment start.
+ */
+export async function adjustSeatCreditBalances({
+  metronomeCustomerId,
+  metronomeContractId,
+  creditId,
+  segmentId,
+  perSeatAmounts,
+  reason,
+  timestamp = new Date(),
+  alignToHour = true,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  creditId: string;
+  segmentId: string;
+  perSeatAmounts: Record<string, number>;
+  reason: string;
+  timestamp?: Date;
+  // When false, the timestamp is used as-is. A seat is NOT considered active at
+  // the exact hour boundary it was assigned on, so an adjustment for a
+  // just-changed seat must use a time strictly inside its active window (not
+  // floored back onto the boundary).
+  alignToHour?: boolean;
+}): Promise<Result<void, Error>> {
+  const seatIds = Object.keys(perSeatAmounts);
+  if (seatIds.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const totalAmount = seatIds.reduce(
+    (sum, seatId) => sum + perSeatAmounts[seatId],
+    0
+  );
+
+  try {
+    await getMetronomeClient().v1.contracts.addManualBalanceEntry({
+      id: creditId,
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      segment_id: segmentId,
+      amount: totalAmount,
+      per_group_amounts: perSeatAmounts,
+      reason,
+      timestamp: alignToHour
+        ? floorToHourISO(timestamp)
+        : timestamp.toISOString(),
+    });
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        creditId,
+        segmentId,
+        seatIds,
+        totalAmount,
+      },
+      "[Metronome] Per-seat manual ledger entries applied"
+    );
+    return new Ok(undefined);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      {
+        error,
+        metronomeCustomerId,
+        metronomeContractId,
+        creditId,
+        segmentId,
+        seatIds,
+        totalAmount,
+      },
+      "[Metronome] Failed to apply per-seat manual ledger entries"
+    );
+    return new Err(error);
+  }
+}
+
+/**
  * List per-seat balances for a SEAT_BASED contract.
  * Uses a raw fetch because the Metronome SDK does not yet expose this endpoint.
  * Returns one entry per seat_id (user sId), with balance (remaining) and
@@ -3098,9 +3338,11 @@ export async function deductMetronomeCreditBalance({
 export async function listMetronomeSeatBalances({
   metronomeCustomerId,
   metronomeContractId,
+  coveringDate = new Date(),
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
+  coveringDate?: Date;
 }): Promise<Result<MetronomeSeatBalance[], Error>> {
   if (!config.getMetronomeApiKey()) {
     return new Ok([]);
@@ -3114,7 +3356,7 @@ export async function listMetronomeSeatBalances({
           customer_id: metronomeCustomerId,
           contract_id: metronomeContractId,
           include_credits_and_commits: true,
-          covering_date: new Date().toISOString(),
+          covering_date: coveringDate.toISOString(),
         },
       }
     );

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1,9 +1,15 @@
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   classifySeatChange,
+  computeSeatCreditTransfers,
+  getSeatCreditNameForSeatType,
   hasContractSeatSubscription,
   resolveRemappedSeatType,
 } from "@app/lib/metronome/seats";
+import {
+  MAX_SEAT_CREDIT_NAME,
+  PRO_SEAT_CREDIT_NAME,
+} from "@app/lib/metronome/setup_common";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -400,5 +406,166 @@ describe("classifySeatChange", () => {
         change: { userId: "u1", previousSeatType: "max", newSeatType: "pro" },
       })
     ).toBeUndefined();
+  });
+});
+
+describe("getSeatCreditNameForSeatType", () => {
+  it("maps pro tiers to the Pro seat credit", () => {
+    expect(getSeatCreditNameForSeatType("pro")).toBe(PRO_SEAT_CREDIT_NAME);
+    expect(getSeatCreditNameForSeatType("pro_yearly")).toBe(
+      PRO_SEAT_CREDIT_NAME
+    );
+  });
+
+  it("maps max tiers to the Max seat credit", () => {
+    expect(getSeatCreditNameForSeatType("max")).toBe(MAX_SEAT_CREDIT_NAME);
+    expect(getSeatCreditNameForSeatType("max_yearly")).toBe(
+      MAX_SEAT_CREDIT_NAME
+    );
+  });
+
+  it("returns null for seats with no recurring seat credit", () => {
+    // `free` is a one-shot per-user credit, not a recurring seat credit.
+    expect(getSeatCreditNameForSeatType("free")).toBeNull();
+    expect(getSeatCreditNameForSeatType("workspace")).toBeNull();
+    expect(getSeatCreditNameForSeatType("workspace_yearly")).toBeNull();
+    expect(getSeatCreditNameForSeatType("none")).toBeNull();
+  });
+});
+
+describe("computeSeatCreditTransfers", () => {
+  const ALLOCATIONS = new Map<MembershipSeatType, number>([
+    ["pro", 8000],
+    ["pro_yearly", 8000],
+    ["max", 40000],
+    ["max_yearly", 40000],
+  ]);
+
+  it("transfers consumption for an upgrade between allowance seats (pro → max)", () => {
+    // 2000/8000 consumed on pro → carry over: empty 6000 from pro, debit 2000
+    // from max (40000 → 38000).
+    const transfers = computeSeatCreditTransfers({
+      metronomeSeatByUser: new Map([["u1", "pro"]]),
+      desiredSeatByUser: new Map([["u1", "max"]]),
+      balanceByUser: new Map([["u1", 6000]]),
+      allocationBySeatType: ALLOCATIONS,
+    });
+    expect(transfers).toEqual([
+      {
+        userSId: "u1",
+        oldSeatType: "pro",
+        newSeatType: "max",
+        oldCreditName: PRO_SEAT_CREDIT_NAME,
+        newCreditName: MAX_SEAT_CREDIT_NAME,
+        remaining: 6000,
+        consumed: 2000,
+      },
+    ]);
+  });
+
+  it("ignores users whose Metronome seat already matches the DB", () => {
+    expect(
+      computeSeatCreditTransfers({
+        metronomeSeatByUser: new Map([["u1", "max"]]),
+        desiredSeatByUser: new Map([["u1", "max"]]),
+        balanceByUser: new Map([["u1", 30000]]),
+        allocationBySeatType: ALLOCATIONS,
+      })
+    ).toEqual([]);
+  });
+
+  it("is idempotent: skips an already-emptied origin credit", () => {
+    // After a prior transfer the old credit is at 0 → nothing to carry over.
+    expect(
+      computeSeatCreditTransfers({
+        metronomeSeatByUser: new Map([["u1", "pro"]]),
+        desiredSeatByUser: new Map([["u1", "max"]]),
+        balanceByUser: new Map([["u1", 0]]),
+        allocationBySeatType: ALLOCATIONS,
+      })
+    ).toEqual([]);
+  });
+
+  it("transfers across billing frequencies of the same tier (max → max_yearly)", () => {
+    // Same allowance/credit name but distinct recurring credits — consumption
+    // still carries over.
+    const transfers = computeSeatCreditTransfers({
+      metronomeSeatByUser: new Map([["u1", "max"]]),
+      desiredSeatByUser: new Map([["u1", "max_yearly"]]),
+      balanceByUser: new Map([["u1", 30000]]),
+      allocationBySeatType: ALLOCATIONS,
+    });
+    expect(transfers).toEqual([
+      {
+        userSId: "u1",
+        oldSeatType: "max",
+        newSeatType: "max_yearly",
+        oldCreditName: MAX_SEAT_CREDIT_NAME,
+        newCreditName: MAX_SEAT_CREDIT_NAME,
+        remaining: 30000,
+        consumed: 10000,
+      },
+    ]);
+  });
+
+  it("derives consumption from the origin allocation, not the aggregate balance", () => {
+    // After a prior pro→max transfer the max seat shows 39994/40000 used 6. The
+    // consumed amount must be 6 (40000 − 39994), NOT inflated by an emptied
+    // prior tier's starting balance.
+    const transfers = computeSeatCreditTransfers({
+      metronomeSeatByUser: new Map([["u1", "max"]]),
+      desiredSeatByUser: new Map([["u1", "max_yearly"]]),
+      balanceByUser: new Map([["u1", 39994]]),
+      allocationBySeatType: ALLOCATIONS,
+    });
+    expect(transfers[0]).toMatchObject({ remaining: 39994, consumed: 6 });
+  });
+
+  it("skips moves involving non-recurring-credit seats (workspace, free, none)", () => {
+    const balanceByUser = new Map([["u1", 6000]]);
+    // workspace → pro: origin has no recurring seat credit.
+    expect(
+      computeSeatCreditTransfers({
+        metronomeSeatByUser: new Map([["u1", "workspace"]]),
+        desiredSeatByUser: new Map([["u1", "pro"]]),
+        balanceByUser,
+        allocationBySeatType: ALLOCATIONS,
+      })
+    ).toEqual([]);
+    // pro → none: destination has no recurring seat credit (downgrade anyway).
+    expect(
+      computeSeatCreditTransfers({
+        metronomeSeatByUser: new Map([["u1", "pro"]]),
+        desiredSeatByUser: new Map([["u1", "none"]]),
+        balanceByUser,
+        allocationBySeatType: ALLOCATIONS,
+      })
+    ).toEqual([]);
+  });
+
+  it("handles multiple users moving in one sync", () => {
+    const transfers = computeSeatCreditTransfers({
+      metronomeSeatByUser: new Map([
+        ["u1", "pro"],
+        ["u2", "max"],
+        ["u3", "pro"],
+      ]),
+      desiredSeatByUser: new Map([
+        ["u1", "max"],
+        ["u2", "max"], // unchanged
+        ["u3", "max"],
+      ]),
+      balanceByUser: new Map([
+        ["u1", 6000],
+        ["u2", 30000],
+        ["u3", 8000],
+      ]),
+      allocationBySeatType: ALLOCATIONS,
+    });
+    expect(transfers.map((t) => t.userSId).sort()).toEqual(["u1", "u3"]);
+    expect(transfers.find((t) => t.userSId === "u3")).toMatchObject({
+      remaining: 8000,
+      consumed: 0,
+    });
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -4,12 +4,16 @@ import {
 } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import {
   addPerUserCreditToContract,
+  adjustSeatCreditBalances,
   archiveContractCredit,
+  findSeatCreditSegmentForPeriod,
   getMetronomeContractById,
+  getMetronomeSeatActiveSince,
   getMetronomeSubscriptionAssignedSeatIds,
   getMetronomeSubscriptionSeatState,
   listContractPerUserCreditBalances,
   listContractPerUserCreditUserIds,
+  listMetronomeSeatBalances,
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
@@ -33,6 +37,8 @@ import {
 } from "@app/lib/metronome/seat_types";
 import {
   FREE_SEAT_CREDIT_NAME,
+  MAX_SEAT_CREDIT_NAME,
+  PRO_SEAT_CREDIT_NAME,
   USAGE_TAG,
 } from "@app/lib/metronome/setup_common";
 import type { BillingFrequency } from "@app/lib/metronome/types";
@@ -51,6 +57,7 @@ import type { MembershipSeatType } from "@app/types/memberships";
 import { isMembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { addYears } from "date-fns";
 
@@ -660,6 +667,485 @@ async function revokeFreeSeatCreditsForExFreeUsers({
   );
 }
 
+/**
+ * The recurring per-seat AWU credit name for a seat type, or `null` when the
+ * seat type has no recurring seat credit to transfer between:
+ *  - `workspace`/`workspace_yearly`/`none`: no per-seat allowance;
+ *  - `free`: its allowance is a one-shot per-user credit (archived on upgrade,
+ *    see `revokeFreeSeatCreditsForExFreeUsers`), not a recurring seat credit.
+ *
+ * Monthly and yearly variants of a tier share the same credit name (they share
+ * the recurring-credit definition — see `buildPerSeatCredits`).
+ */
+export function getSeatCreditNameForSeatType(
+  seatType: MembershipSeatType
+): string | null {
+  switch (seatType) {
+    case "pro":
+    case "pro_yearly":
+      return PRO_SEAT_CREDIT_NAME;
+    case "max":
+    case "max_yearly":
+      return MAX_SEAT_CREDIT_NAME;
+    case "free":
+    case "workspace":
+    case "workspace_yearly":
+    case "none":
+      return null;
+    default:
+      assertNever(seatType);
+  }
+}
+
+export type SeatCreditTransfer = {
+  userSId: string;
+  oldSeatType: MembershipSeatType;
+  newSeatType: MembershipSeatType;
+  oldCreditName: string;
+  newCreditName: string;
+  // Remaining (unconsumed) balance on the old seat credit — emptied from it.
+  remaining: number;
+  // Amount already consumed on the old seat credit — carried onto the new one.
+  consumed: number;
+};
+
+/**
+ * Pure detection of seat-credit transfers needed to align ledgers after
+ * immediate moves between two recurring-credit seats (e.g. `pro` → `max`).
+ *
+ * A transfer is needed when a user is still assigned to one allowance seat in
+ * Metronome but the DB has already moved them to a different allowance seat,
+ * and the old seat credit still has a positive balance. The caller then empties
+ * the old credit (by `remaining`) and debits the new one (by `consumed`), so
+ * the move carries usage over instead of resetting it — e.g. 2000/8000 used on
+ * `pro` becomes 2000/40000 used on `max` (remaining 6000 → 38000).
+ *
+ * Keying the trigger on "old credit still has a balance" makes the whole thing
+ * idempotent: once the old credit is emptied, a re-run finds nothing to do.
+ *
+ * Also covers same-allowance moves between billing frequencies (e.g. `max` →
+ * `max_yearly`): they share a credit name but are distinct recurring credits,
+ * so the consumed amount still carries from one pool to the other.
+ */
+export function computeSeatCreditTransfers({
+  metronomeSeatByUser,
+  desiredSeatByUser,
+  balanceByUser,
+  allocationBySeatType,
+}: {
+  metronomeSeatByUser: Map<string, MembershipSeatType>;
+  desiredSeatByUser: Map<string, MembershipSeatType>;
+  // The seat's remaining AWU balance (aggregate across its credit pools; after
+  // prior origins are emptied this equals the current tier's balance).
+  balanceByUser: Map<string, number>;
+  // The origin tier's per-seat AWU allocation. Consumption is derived from this
+  // (allocation − remaining), NOT from the seat's aggregate starting balance —
+  // that aggregate includes prior tiers we emptied to zero, which would be
+  // mis-counted as consumption (e.g. emptied pro's 8000 inflating a max→yearly
+  // transfer).
+  allocationBySeatType: Map<MembershipSeatType, number>;
+}): SeatCreditTransfer[] {
+  const transfers: SeatCreditTransfer[] = [];
+  for (const [userSId, oldSeatType] of metronomeSeatByUser) {
+    const newSeatType = desiredSeatByUser.get(userSId);
+    if (!newSeatType || newSeatType === oldSeatType) {
+      continue;
+    }
+    const oldCreditName = getSeatCreditNameForSeatType(oldSeatType);
+    const newCreditName = getSeatCreditNameForSeatType(newSeatType);
+    // Both ends must be recurring-credit seats. (Distinct seat types always map
+    // to distinct recurring credits, even when they share a credit name — the
+    // transfer targets credits by id, not name.)
+    if (!oldCreditName || !newCreditName) {
+      continue;
+    }
+    const remaining = balanceByUser.get(userSId);
+    // No balance left → nothing to carry over (fresh seat, or already
+    // transferred on a prior run).
+    if (remaining === undefined || remaining <= 0) {
+      continue;
+    }
+    const allocation = allocationBySeatType.get(oldSeatType);
+    if (allocation === undefined) {
+      continue;
+    }
+    transfers.push({
+      userSId,
+      oldSeatType,
+      newSeatType,
+      oldCreditName,
+      newCreditName,
+      remaining,
+      consumed: Math.max(0, allocation - remaining),
+    });
+  }
+  return transfers;
+}
+
+async function findSeatCreditSegmentCached(
+  cache: Map<
+    string,
+    { creditId: string; segmentId: string; segmentStartingAt: string } | null
+  >,
+  args: {
+    metronomeCustomerId: string;
+    metronomeContractId: string;
+    recurringCreditId: string;
+  }
+): Promise<{
+  creditId: string;
+  segmentId: string;
+  segmentStartingAt: string;
+} | null> {
+  const cached = cache.get(args.recurringCreditId);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const res = await findSeatCreditSegmentForPeriod(args);
+  const seg = res.isOk() ? res.value : null;
+  cache.set(args.recurringCreditId, seg);
+  return seg;
+}
+
+/**
+ * The timestamp at which a per-seat manual ledger entry must be made: a time
+ * the seat is provably active AND within the credit segment. Reads the seat's
+ * active-segment start from Metronome (seats become active on hour boundaries,
+ * a "now" change only from the next boundary) and clamps it up to the credit
+ * segment start (the entry must also fall inside the segment). Returns `null`
+ * when the seat has no active window to adjust in (caller skips).
+ */
+async function resolveSeatAdjustmentTimestamp({
+  metronomeCustomerId,
+  contractId,
+  subscriptionId,
+  seatId,
+  creditSegmentStartingAt,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  subscriptionId: string;
+  seatId: string;
+  creditSegmentStartingAt: string;
+}): Promise<Date | null> {
+  const activeSinceRes = await getMetronomeSeatActiveSince({
+    metronomeCustomerId,
+    contractId,
+    subscriptionId,
+    seatId,
+  });
+  if (activeSinceRes.isErr() || !activeSinceRes.value) {
+    return null;
+  }
+  // Metronome requires the entry timestamp to be on an hour boundary. Use the
+  // later of the seat's active-since and the credit segment start (both already
+  // hour-aligned) — the seat is active from there, so it's a valid entry time
+  // (matches what the Metronome UI accepts: e.g. 08:00 for a seat whose segment
+  // started at 08:00).
+  const startMs = Math.max(
+    activeSinceRes.value.getTime(),
+    new Date(creditSegmentStartingAt).getTime()
+  );
+  return new Date(startMs);
+}
+
+/**
+ * Detect users who moved between two recurring-credit seats (Metronome still
+ * has them on the old seat, the DB on the new one) and empty their old seat
+ * credit. Returns the transfers whose old credit was successfully emptied, so
+ * the caller can credit the new seat once it's been assigned.
+ *
+ * Runs BEFORE seat reconciliation while the old seat is still assigned: a
+ * manual ledger entry requires the seat to be active at the adjustment
+ * timestamp. Best-effort: a failure to read or empty one user's credit is
+ * logged and that user is left out of the returned list (their new credit is
+ * then not debited — the move stays usage-fresh rather than double-charged).
+ */
+async function emptyOriginSeatCreditsForTransfers({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+  subscriptionIdBySeatType,
+  recurringCreditIdBySeatType,
+  allocationBySeatType,
+  desiredSeatByUser,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+  subscriptionIdBySeatType: Map<MembershipSeatType, string>;
+  recurringCreditIdBySeatType: Map<MembershipSeatType, string>;
+  allocationBySeatType: Map<MembershipSeatType, number>;
+  desiredSeatByUser: Map<string, MembershipSeatType>;
+}): Promise<SeatCreditTransfer[]> {
+  const balancesRes = await listMetronomeSeatBalances({
+    metronomeCustomerId,
+    metronomeContractId: contractId,
+  });
+  if (balancesRes.isErr()) {
+    logger.error(
+      { workspaceId, contractId, error: balancesRes.error },
+      "[Metronome] Failed to read seat balances for credit transfer — skipping"
+    );
+    return [];
+  }
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const balanceByUser = new Map<string, number>();
+  for (const seat of balancesRes.value) {
+    const awu = seat.balances.find((b) => b.credit_type_id === awuCreditTypeId);
+    if (awu) {
+      balanceByUser.set(seat.seat_id, awu.balance);
+    }
+  }
+
+  // Metronome's current seat assignment per user (old state, before sync).
+  const metronomeSeatByUser = new Map<string, MembershipSeatType>();
+  for (const [seatType, subscriptionId] of subscriptionIdBySeatType) {
+    const assignedRes = await getMetronomeSubscriptionAssignedSeatIds({
+      metronomeCustomerId,
+      contractId,
+      subscriptionId,
+    });
+    if (assignedRes.isErr()) {
+      logger.error(
+        { workspaceId, contractId, seatType, error: assignedRes.error },
+        "[Metronome] Failed to read assigned seats for credit transfer — skipping tier"
+      );
+      continue;
+    }
+    for (const userSId of assignedRes.value) {
+      metronomeSeatByUser.set(userSId, seatType);
+    }
+  }
+
+  const transfers = computeSeatCreditTransfers({
+    metronomeSeatByUser,
+    desiredSeatByUser,
+    balanceByUser,
+    allocationBySeatType,
+  });
+
+  const segmentCache = new Map<
+    string,
+    { creditId: string; segmentId: string; segmentStartingAt: string } | null
+  >();
+  const emptied: SeatCreditTransfer[] = [];
+  for (const t of transfers) {
+    const recurringCreditId = recurringCreditIdBySeatType.get(t.oldSeatType);
+    if (!recurringCreditId) {
+      logger.warn(
+        { workspaceId, contractId, userId: t.userSId, credit: t.oldCreditName },
+        "[Metronome] No recurring credit id for origin seat — skipping transfer"
+      );
+      continue;
+    }
+    const seg = await findSeatCreditSegmentCached(segmentCache, {
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      recurringCreditId,
+    });
+    if (!seg) {
+      logger.error(
+        { workspaceId, contractId, userId: t.userSId, credit: t.oldCreditName },
+        "[Metronome] No origin seat credit segment for transfer — skipping"
+      );
+      continue;
+    }
+    const subscriptionId = subscriptionIdBySeatType.get(t.oldSeatType);
+    const timestamp = subscriptionId
+      ? await resolveSeatAdjustmentTimestamp({
+          metronomeCustomerId,
+          contractId,
+          subscriptionId,
+          seatId: t.userSId,
+          creditSegmentStartingAt: seg.segmentStartingAt,
+        })
+      : null;
+    if (!timestamp) {
+      logger.warn(
+        { workspaceId, contractId, userId: t.userSId, credit: t.oldCreditName },
+        "[Metronome] No active window for origin seat — skipping transfer"
+      );
+      continue;
+    }
+    logger.info(
+      {
+        workspaceId,
+        contractId,
+        userId: t.userSId,
+        credit: t.oldCreditName,
+        segmentStartingAt: seg.segmentStartingAt,
+        adjustmentTimestamp: timestamp.toISOString(),
+        amount: -t.remaining,
+      },
+      "[Metronome] Emptying origin seat credit for transfer"
+    );
+    const adjustRes = await adjustSeatCreditBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      creditId: seg.creditId,
+      segmentId: seg.segmentId,
+      perSeatAmounts: { [t.userSId]: -t.remaining },
+      reason: `Seat change ${t.oldSeatType}→${t.newSeatType}: empty origin credit`,
+      timestamp,
+      alignToHour: false,
+    });
+    if (adjustRes.isErr()) {
+      logger.error(
+        { workspaceId, contractId, userId: t.userSId, error: adjustRes.error },
+        "[Metronome] Failed to empty origin seat credit — skipping transfer"
+      );
+      continue;
+    }
+    emptied.push(t);
+  }
+  return emptied;
+}
+
+/**
+ * Set the new seat credit to its carried balance for each transfer whose origin
+ * credit was emptied. Runs AFTER seat reconciliation, once the new seat is
+ * assigned (the adjustment requires the seat to be active).
+ *
+ * The target balance is reconciled to an absolute value — `allocation −
+ * consumed` — rather than blindly debited by `consumed`. A manual ledger entry
+ * is a delta, so we read the seat's current balance on the new credit (at the
+ * adjustment time) and apply the difference. This makes the move idempotent and
+ * correctly restores the balance when returning to a credit that was emptied on
+ * a previous move (e.g. `max → max_yearly → max`): the destination always ends
+ * at `allocation − consumed`, whatever state it was left in. Best-effort.
+ */
+async function carryConsumptionToNewSeatCredits({
+  metronomeCustomerId,
+  contractId,
+  workspaceId,
+  transfers,
+  subscriptionIdBySeatType,
+  recurringCreditIdBySeatType,
+  allocationBySeatType,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+  workspaceId: string;
+  transfers: SeatCreditTransfer[];
+  subscriptionIdBySeatType: Map<MembershipSeatType, string>;
+  recurringCreditIdBySeatType: Map<MembershipSeatType, string>;
+  allocationBySeatType: Map<MembershipSeatType, number>;
+}): Promise<void> {
+  const awuCreditTypeId = getCreditTypeAwuId();
+  const segmentCache = new Map<
+    string,
+    { creditId: string; segmentId: string; segmentStartingAt: string } | null
+  >();
+  for (const t of transfers) {
+    const recurringCreditId = recurringCreditIdBySeatType.get(t.newSeatType);
+    const targetAllocation = allocationBySeatType.get(t.newSeatType);
+    if (!recurringCreditId || targetAllocation === undefined) {
+      logger.warn(
+        { workspaceId, contractId, userId: t.userSId, credit: t.newCreditName },
+        "[Metronome] No recurring credit / allocation for new seat — origin already emptied"
+      );
+      continue;
+    }
+    const seg = await findSeatCreditSegmentCached(segmentCache, {
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      recurringCreditId,
+    });
+    if (!seg) {
+      logger.error(
+        { workspaceId, contractId, userId: t.userSId, credit: t.newCreditName },
+        "[Metronome] No destination seat credit segment for transfer — origin already emptied"
+      );
+      continue;
+    }
+    // The new seat was just assigned (active from the next hour boundary), so
+    // adjust at its actual active-window start rather than the current hour.
+    const subscriptionId = subscriptionIdBySeatType.get(t.newSeatType);
+    const timestamp = subscriptionId
+      ? await resolveSeatAdjustmentTimestamp({
+          metronomeCustomerId,
+          contractId,
+          subscriptionId,
+          seatId: t.userSId,
+          creditSegmentStartingAt: seg.segmentStartingAt,
+        })
+      : null;
+    if (!timestamp) {
+      logger.warn(
+        { workspaceId, contractId, userId: t.userSId, credit: t.newCreditName },
+        "[Metronome] No active window for new seat — origin already emptied"
+      );
+      continue;
+    }
+
+    // Read the seat's current balance on the new credit at the adjustment time,
+    // then compute the delta to reach `allocation − consumed`.
+    const balancesRes = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      coveringDate: timestamp,
+    });
+    if (balancesRes.isErr()) {
+      logger.error(
+        {
+          workspaceId,
+          contractId,
+          userId: t.userSId,
+          error: balancesRes.error,
+        },
+        "[Metronome] Failed to read new seat balance for transfer — origin already emptied"
+      );
+      continue;
+    }
+    const currentBalance = balancesRes.value
+      .find((s) => s.seat_id === t.userSId)
+      ?.balances.find((b) => b.credit_type_id === awuCreditTypeId)?.balance;
+    if (currentBalance === undefined) {
+      logger.warn(
+        { workspaceId, contractId, userId: t.userSId, credit: t.newCreditName },
+        "[Metronome] New seat balance not found at adjustment time — origin already emptied"
+      );
+      continue;
+    }
+
+    const desiredBalance = Math.max(0, targetAllocation - t.consumed);
+    const delta = desiredBalance - currentBalance;
+    if (delta === 0) {
+      continue;
+    }
+    logger.info(
+      {
+        workspaceId,
+        contractId,
+        userId: t.userSId,
+        credit: t.newCreditName,
+        adjustmentTimestamp: timestamp.toISOString(),
+        currentBalance,
+        desiredBalance,
+        delta,
+      },
+      "[Metronome] Setting new seat credit to carried balance"
+    );
+    const adjustRes = await adjustSeatCreditBalances({
+      metronomeCustomerId,
+      metronomeContractId: contractId,
+      creditId: seg.creditId,
+      segmentId: seg.segmentId,
+      perSeatAmounts: { [t.userSId]: delta },
+      reason: `Seat change ${t.oldSeatType}→${t.newSeatType}: carry over consumed AWU`,
+      timestamp,
+      alignToHour: false,
+    });
+    if (adjustRes.isErr()) {
+      logger.error(
+        { workspaceId, contractId, userId: t.userSId, error: adjustRes.error },
+        "[Metronome] Failed to set new seat credit to carried balance"
+      );
+    }
+  }
+}
+
 export async function syncSeatCount({
   metronomeCustomerId,
   contractId,
@@ -831,6 +1317,65 @@ export async function syncSeatCount({
       return sIds;
     };
 
+    // Align seat-credit ledgers for immediate moves between two recurring-credit
+    // seats (e.g. `pro` → `max`): carry the consumed AWU onto the new seat's
+    // credit instead of resetting it. Only for the immediate "now" sync — a
+    // forced `startingAt` is a contract switch / future remap, where seat
+    // credits are reconciled by the new contract rather than transferred.
+    //
+    // Split around the seat loop because a manual ledger entry requires the
+    // seat to be active at the adjustment timestamp: the old seat is emptied
+    // here (still assigned), the new one credited after it's been assigned.
+    // subscriptionId per recurring-credit seat type (pro/max families), used by
+    // the credit-transfer steps below to resolve each seat's active window.
+    const subscriptionIdBySeatType = new Map<MembershipSeatType, string>(
+      seatSubscriptions.flatMap(({ sub, seatType }) =>
+        sub.id && getSeatCreditNameForSeatType(seatType)
+          ? [[seatType, sub.id] as const]
+          : []
+      )
+    );
+    // The recurring credit backing each seat type, resolved via the credit's
+    // `subscription_config.subscription_id`. Two seat tiers can share a credit
+    // NAME across the monthly and yearly products (e.g. two "Pro Seat
+    // Credits"), so the ledger adjustment must target the credit by id, not by
+    // name, or it can hit the wrong pool (where the seat isn't active).
+    const recurringCreditIdBySeatType = new Map<MembershipSeatType, string>();
+    const allocationBySeatType = new Map<MembershipSeatType, number>();
+    for (const { sub, seatType } of seatSubscriptions) {
+      if (!sub.id || !getSeatCreditNameForSeatType(seatType)) {
+        continue;
+      }
+      const recurringCredit = (resolvedContract.recurring_credits ?? []).find(
+        (c) => c.subscription_config?.subscription_id === sub.id
+      );
+      if (recurringCredit?.id) {
+        recurringCreditIdBySeatType.set(seatType, recurringCredit.id);
+      }
+      allocationBySeatType.set(
+        seatType,
+        getAwuAllocationForSeatType(
+          resolvedContract,
+          seatType,
+          productSeatTypes
+        )
+      );
+    }
+    let pendingCreditTransfers: SeatCreditTransfer[] = [];
+    if (!startingAt) {
+      pendingCreditTransfers = await emptyOriginSeatCreditsForTransfers({
+        metronomeCustomerId,
+        contractId,
+        workspaceId: workspace.sId,
+        subscriptionIdBySeatType,
+        recurringCreditIdBySeatType,
+        allocationBySeatType,
+        desiredSeatByUser: currentSeatByUserSId,
+      });
+      didMutateSeatData =
+        didMutateSeatData || pendingCreditTransfers.length > 0;
+    }
+
     for (const { sub, seatType } of seatSubscriptions) {
       const subscriptionId = sub.id!;
       const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
@@ -902,6 +1447,20 @@ export async function syncSeatCount({
         }
         didMutateSeatData = true;
       }
+    }
+
+    // New seats are now assigned, so their credits exist: carry the consumed
+    // AWU emptied from the origin seats onto them (see above).
+    if (pendingCreditTransfers.length > 0) {
+      await carryConsumptionToNewSeatCredits({
+        metronomeCustomerId,
+        contractId,
+        workspaceId: workspace.sId,
+        transfers: pendingCreditTransfers,
+        subscriptionIdBySeatType,
+        recurringCreditIdBySeatType,
+        allocationBySeatType,
+      });
     }
 
     // Per-user AWU grant/revoke for free members. Driven off DB membership

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -19,6 +19,8 @@ const {
   mockArchiveContractCredit,
   mockUpsertPerUserCreditAlerts,
   mockClearPerUserCreditAlerts,
+  mockListSeatBalances,
+  mockGetAssignedSeatIds,
 } = vi.hoisted(() => ({
   mockGetProductSeatTypes: vi.fn(),
   mockUpdateSubscriptionQuantity: vi.fn(),
@@ -33,6 +35,8 @@ const {
   mockArchiveContractCredit: vi.fn(),
   mockUpsertPerUserCreditAlerts: vi.fn(),
   mockClearPerUserCreditAlerts: vi.fn(),
+  mockListSeatBalances: vi.fn(),
+  mockGetAssignedSeatIds: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/client", () => ({
@@ -40,11 +44,17 @@ vi.mock("@app/lib/metronome/client", () => ({
   updateSubscriptionQuantity: mockUpdateSubscriptionQuantity,
   updateSubscriptionSeats: mockUpdateSubscriptionSeats,
   getMetronomeSubscriptionSeatState: mockGetSeatState,
-  getMetronomeSubscriptionAssignedSeatIds: vi.fn(),
+  getMetronomeSubscriptionAssignedSeatIds: mockGetAssignedSeatIds,
   listContractPerUserCreditUserIds: mockListPerUserCreditUserIds,
   listContractPerUserCreditBalances: mockListPerUserCreditBalances,
   addPerUserCreditToContract: mockAddPerUserCredit,
   archiveContractCredit: mockArchiveContractCredit,
+  // Seat-credit transfer path (no-op in these tests: empty balances ⇒ no
+  // transfers ⇒ the segment-find / adjust helpers are never reached).
+  listMetronomeSeatBalances: mockListSeatBalances,
+  findSeatCreditSegmentForPeriod: vi.fn(),
+  getMetronomeSeatActiveSince: vi.fn(),
+  adjustSeatCreditBalances: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/alerts/per_user_credit_balance", () => ({
@@ -110,6 +120,10 @@ describe("syncSeatCount min clamping", () => {
     mockArchiveContractCredit.mockResolvedValue(new Ok(undefined));
     mockUpsertPerUserCreditAlerts.mockResolvedValue(new Ok(undefined));
     mockClearPerUserCreditAlerts.mockResolvedValue(new Ok(undefined));
+    // No seat balances / assignments ⇒ the credit-transfer reconciliation
+    // finds nothing to move (the focus of these tests is seat-count sync).
+    mockListSeatBalances.mockResolvedValue(new Ok([]));
+    mockGetAssignedSeatIds.mockResolvedValue(new Ok([]));
   });
 
   it("clamps a QUANTITY_ONLY count up to the configured minSeats", async () => {

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -291,6 +291,22 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     return SubscriptionResource._invalidateSubscriptionCache(workspaceModelId);
   };
 
+  // The Metronome contract cache (`getActiveContract`) is keyed by workspace
+  // `sId` with no TTL, so it must be flushed whenever the active subscription's
+  // contract changes. We only hold the workspace model id here, so resolve the
+  // `sId` first.
+  private static async invalidateContractCacheByWorkspaceModelId(
+    workspaceModelId: ModelId
+  ): Promise<void> {
+    const workspace = await WorkspaceModel.findOne({
+      attributes: ["sId"],
+      where: { id: workspaceModelId },
+    });
+    if (workspace) {
+      await invalidateContractCache(workspace.sId);
+    }
+  }
+
   /**
    * Invalidate subscription caches for all workspaces on a given plan.
    * Should be called when plan attributes are updated (e.g., via Poke).
@@ -1292,6 +1308,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         renderPlanFromModel({ plan: newPlan }),
         t
       );
+      // The active contract changed → flush the Metronome contract cache too
+      // (no TTL), otherwise `getActiveContract` keeps serving the old contract.
+      invalidateCacheAfterCommit(t, () =>
+        SubscriptionResource.invalidateContractCacheByWorkspaceModelId(
+          this.workspaceId
+        )
+      );
     });
   }
 
@@ -1323,6 +1346,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       const workspaceId = this.workspaceId;
       invalidateCacheAfterCommit(t, () =>
         SubscriptionResource.invalidateSubscriptionCache(workspaceId)
+      );
+      // The active contract changed → flush the Metronome contract cache too
+      // (no TTL), otherwise `getActiveContract` keeps serving the old contract.
+      invalidateCacheAfterCommit(t, () =>
+        SubscriptionResource.invalidateContractCacheByWorkspaceModelId(
+          workspaceId
+        )
       );
     });
   }


### PR DESCRIPTION
## Description

Stacked on #27269.

When a member moves between two allowance-bearing seats, the seat-count sync now aligns the per-seat AWU credit ledgers so consumption carries over instead of resetting. Without this, switching seats (e.g. `pro → max`) would hand the member a fresh full allowance, letting usage be reset by re-picking a seat.

On each immediate seat change, `syncSeatCount` reconciles the ledgers (sync-side, idempotent — no new `classifySeatChange` outcome needed):

- **Empties** the origin seat's credit (sets it to `0`).
- **Sets** the destination seat's credit to `allocation − consumed` (so `2000/8000` used on pro becomes `2000/40000` used on max; remaining `6000 → 38000`).

Works for upgrades (`pro → max`), same-tier billing-frequency switches (`max → max_yearly`), and round-trips (`max → max_yearly → max` restores the original balance).

Key implementation details (the subtle bits this went through):

- **Match credits by recurring-credit id, never by name.** `pro`/`pro_yearly` (and `max`/`max_yearly`) share a credit name across the monthly/yearly products; matching by name targets the wrong pool. `findSeatCreditSegmentForPeriod` now matches `recurring_credit_id`, resolved per seat type via `subscription_config.subscription_id`.
- **Adjust at the seat's active-window start.** Metronome requires the ledger-entry timestamp on an hour boundary and rejects adjustments on a seat not active at that time. We read each seat's active-segment start (`getMetronomeSeatActiveSince`) and adjust there; `adjustSeatCreditBalances` gained `alignToHour` to pass the timestamp verbatim.
- **Derive `consumed` from the origin tier's allocation**, not the seat's aggregate AWU balance — the aggregate includes prior tiers we emptied to `0`, which would be mis-counted as consumption.
- **Reconcile the destination to an absolute target via a delta** (read current balance, apply `desired − current`) rather than blindly debiting — this restores the balance when returning to a previously-emptied credit and is idempotent.
- **Contract-cache fix:** `activatePending` / `swapMetronomeContract` now flush the Metronome active-contract cache themselves (no-TTL, was only flushed by the webhook caller), so the seats/plan UI reflects the new contract after a switch.

## Tests

- Unit tests for `computeSeatCreditTransfers` (transfer math, idempotent skip on already-emptied origin, allocation-based `consumed`, same-tier frequency switch, multi-user, non-credit seats), `getSeatCreditNameForSeatType`, and `findSeatCreditSegmentForPeriod` (matches by recurring-credit id, skips a same-named credit with a different id).
- Manually verified end-to-end against Metronome: `pro → max`, `max → max_yearly`, and the `max → max_yearly → max` round-trip all land at `allocation − consumed`.

## Risk

Manual ledger entries are irreversible, so correctness matters. Mitigations:

- Delta-to-absolute reconciliation → a rate-limit/retry of the activity **never double-applies** (re-running converges).
- Best-effort / fail-open: any read or adjust failure is logged and skipped; the seat change itself still proceeds.

Known limitation (not yet hardened): a crash *between* emptying the origin and carrying to the destination (e.g. a rate limit mid seat-loop) can drop that one transfer — the destination is left at full allowance (an over-grant bounded to one seat's `consumed`, **not** a double-charge), and it doesn't self-heal. New-pricing seat AWU credits are test-only today, so blast radius is limited.

## Deploy Plan

Standard. No migration. Merge after #27269.
