### PR TITLE
[front] improve input bar placement + subscription banner

### DIFF
--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -6,7 +6,8 @@ import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Button, cn, LinkWrapper } from "@dust-tt/sparkle";
-import { useMemo, useRef } from "react";
+import { Link } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
 
 const SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
 const THRESHOLD_MS =
@@ -39,6 +40,22 @@ export function SubscriptionEndBanner({
   const ctaHref = isCreditPricedPlan(subscription.plan)
     ? `/w/${owner.sId}/billing`
     : `/w/${owner.sId}/subscription`;
+
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = bannerRef.current;
+    if (node) {
+      document.documentElement.style.setProperty(
+        "--banner-height",
+        `${node.offsetHeight}px`
+      );
+    }
+
+    return () => {
+      document.documentElement.style.setProperty("--banner-height", "0px");
+    };
+  });
 
   // Capture initial timestamp in a ref to avoid re-computation on re-renders.
   // This is intentionally not reactive - the banner state is stable for the session.
@@ -97,36 +114,33 @@ export function SubscriptionEndBanner({
 
   return (
     <div
+      ref={bannerRef}
       className={cn(
-        "flex items-center justify-between gap-4 px-4 py-3",
-        "bg-sky-50 dark:bg-sky-50-night"
+        "flex items-center justify-between gap-4 px-4 py-1",
+        "bg-sky-50 dark:bg-sky-50-night",
       )}
     >
-      <div className="flex flex-col text-sm">
-        <span
+      <div className="text-sm flex gap-2">
+        <p
           className={cn(
             "font-semibold",
             "text-sky-900 dark:text-sky-900-night"
           )}
         >
           {title}
-        </span>
-        <span className="text-sky-800 dark:text-sky-800-night">
+        </p>
+        <p className="text-sky-800 dark:text-sky-800-night hidden md:inline-block">
           {description}
-        </span>
+        </p>
       </div>
       {isAdmin && !isEnterprise && (
-        <LinkWrapper href={ctaHref} className="shrink-0 no-underline">
           <Button
+            href={ctaHref}
             label={isTrial ? "Subscribe to Dust" : "Resume subscription"}
-            className={cn(
-              "bg-sky-600 dark:bg-sky-600-night",
-              "dark:text-white-night text-white",
-              "hover:bg-sky-700 dark:hover:bg-sky-700-night"
-            )}
+            className="hover:opacity-90 hover:bg-transparent"
+            variant="ghost-secondary"
             size="sm"
           />
-        </LinkWrapper>
       )}
     </div>
   );

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -5,8 +5,7 @@ import {
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
-import { Button, cn, LinkWrapper } from "@dust-tt/sparkle";
-import { Link } from "lucide-react";
+import { Button, cn } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 const SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
@@ -117,7 +116,7 @@ export function SubscriptionEndBanner({
       ref={bannerRef}
       className={cn(
         "flex items-center justify-between gap-4 px-4 py-1",
-        "bg-sky-50 dark:bg-sky-50-night",
+        "bg-sky-50 dark:bg-sky-50-night"
       )}
     >
       <div className="text-sm flex gap-2">
@@ -134,13 +133,13 @@ export function SubscriptionEndBanner({
         </p>
       </div>
       {isAdmin && !isEnterprise && (
-          <Button
-            href={ctaHref}
-            label={isTrial ? "Subscribe to Dust" : "Resume subscription"}
-            className="hover:opacity-90 hover:bg-transparent"
-            variant="ghost-secondary"
-            size="sm"
-          />
+        <Button
+          href={ctaHref}
+          label={isTrial ? "Subscribe to Dust" : "Resume subscription"}
+          className="hover:opacity-90 hover:bg-transparent"
+          variant="ghost-secondary"
+          size="sm"
+        />
       )}
     </div>
   );

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -54,7 +54,7 @@ export function SubscriptionEndBanner({
     return () => {
       document.documentElement.style.setProperty("--banner-height", "0px");
     };
-  });
+  }, []);
 
   // Capture initial timestamp in a ref to avoid re-computation on re-renders.
   // This is intentionally not reactive - the banner state is stable for the session.

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -98,10 +98,10 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
   return (
     <div className="flex h-dvh flex-col">
       <SubscriptionEndBanner
-              isAdmin={isAdmin(owner)}
-              owner={owner}
-              subscription={subscription}
-            />
+        isAdmin={isAdmin(owner)}
+        owner={owner}
+        subscription={subscription}
+      />
       <div className="flex min-h-0 flex-1 flex-row">
         <Navigation
           hideSidebar={hideSidebar}

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -97,6 +97,11 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
 
   return (
     <div className="flex h-dvh flex-col">
+      <SubscriptionEndBanner
+              isAdmin={isAdmin(owner)}
+              owner={owner}
+              subscription={subscription}
+            />
       <div className="flex min-h-0 flex-1 flex-row">
         <Navigation
           hideSidebar={hideSidebar}
@@ -109,7 +114,6 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
           isFullScreen={isFullScreen}
           isMobile={isMobile}
         />
-
         <div
           className={cn(
             "relative flex h-full w-full flex-1 flex-col overflow-x-hidden",
@@ -122,11 +126,6 @@ export function AppContentLayout({ children }: AppContentLayoutProps) {
             isMobile={isMobile}
             isFullScreen={isFullScreen}
           >
-            <SubscriptionEndBanner
-              isAdmin={isAdmin(owner)}
-              owner={owner}
-              subscription={subscription}
-            />
             {/* Temporary measure to preserve title existence on smaller screens.
              * Page has no title, prepend empty AppLayoutTitle. */}
             {!hasTitleBar && (

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -24,7 +24,8 @@
 
   :root {
     --dev-bar-height: 0px;
-    --panel-height: 100dvh;
+    --banner-height: 0px;
+    --panel-height: calc(100dvh - var(--banner-height));
 
     /* Chart tokens (light): exact shadcn palette */
     --chart-1: 211 100% 78%;
@@ -46,7 +47,7 @@
 
 @media (min-width: 768px) {
   :root {
-    --panel-height: calc(100dvh - 1rem - var(--dev-bar-height));
+    --panel-height: calc(100dvh - 1rem - var(--dev-bar-height) - var(--banner-height));
   }
 }
 


### PR DESCRIPTION
## Description
This PR is to fix https://github.com/dust-tt/tasks/issues/8785. The subscription banner will be shown on top of the app like these: 

<img width="3828" height="1918" alt="CleanShot 2026-06-12 at 12 36 53@2x" src="https://github.com/user-attachments/assets/b974ecb4-e8ff-4fdd-b9a0-00114629819c" />


<img width="872" height="1410" alt="CleanShot 2026-06-12 at 12 36 34@2x" src="https://github.com/user-attachments/assets/245a80b7-b47d-4c71-b552-c0add2821435" />

On mobile the menu button is shown on top but this is existing, I will fix it later 

 
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
