### PR TITLE
Add: refactoring mcp auth, add method to fetch a workos application.

### DIFF
--- a/front/lib/api/mcp_server/auth.ts
+++ b/front/lib/api/mcp_server/auth.ts
@@ -142,7 +142,7 @@ export const mcpServerAuthMiddleware = createMiddleware<{
       });
     }
 
-    c.set("mcpAuth", authResult.value);
+    c.set("mcpAuth", authResult.value.authenticator);
     await next();
   } catch (err) {
     let decoded: JWTPayload | undefined;

--- a/front/lib/api/workos.ts
+++ b/front/lib/api/workos.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { getWorkOS } from "@app/lib/api/workos/client";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -7,6 +8,47 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import jwt from "jsonwebtoken";
 import jwksClient from "jwks-rsa";
 import { z } from "zod";
+
+const WorkOSConnectApplicationRedirectUriSchema = z.object({
+  uri: z.string(),
+  default: z.boolean(),
+});
+
+const WorkOSConnectApplicationBaseSchema = z.object({
+  object: z.literal("connect_application"),
+  id: z.string(),
+  client_id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  scopes: z.array(z.string()),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+const WorkOSConnectOAuthApplicationSchema =
+  WorkOSConnectApplicationBaseSchema.extend({
+    application_type: z.literal("oauth"),
+    redirect_uris: z.array(WorkOSConnectApplicationRedirectUriSchema),
+    uses_pkce: z.boolean(),
+    is_first_party: z.boolean(),
+    was_dynamically_registered: z.boolean().optional(),
+    organization_id: z.string().optional(),
+  });
+
+const WorkOSConnectM2MApplicationSchema =
+  WorkOSConnectApplicationBaseSchema.extend({
+    application_type: z.literal("m2m"),
+    organization_id: z.string(),
+  });
+
+export const WorkOSConnectApplicationSchema = z.discriminatedUnion(
+  "application_type",
+  [WorkOSConnectOAuthApplicationSchema, WorkOSConnectM2MApplicationSchema]
+);
+
+export type WorkOSConnectApplication = z.infer<
+  typeof WorkOSConnectApplicationSchema
+>;
 
 const WorkOSJwtClaimValueSchema = z.union([
   z.string(),
@@ -116,4 +158,32 @@ export async function getUserFromWorkOSToken(
   accessToken: WorkOSJwtPayload
 ): Promise<UserResource | null> {
   return UserResource.fetchByWorkOSUserId(accessToken.sub);
+}
+
+/**
+ * Retrieve a WorkOS Connect application by application ID or client ID.
+ *
+ * @see https://workos.com/docs/reference/workos-connect/applications#get-a-connect-application
+ */
+export async function getWorkOSConnectApplication(
+  clientId: string
+): Promise<Result<WorkOSConnectApplication, Error>> {
+  try {
+    const { data } = await getWorkOS().get(
+      `/connect/applications/${encodeURIComponent(clientId)}`
+    );
+
+    const validation = WorkOSConnectApplicationSchema.safeParse(data);
+    if (!validation.success) {
+      logger.error(
+        { err: validation.error },
+        "Invalid WorkOS Connect application response."
+      );
+      return new Err(new Error("Invalid WorkOS Connect application response."));
+    }
+
+    return new Ok(validation.data);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
 }

--- a/front/lib/api/workos_authenticator.test.ts
+++ b/front/lib/api/workos_authenticator.test.ts
@@ -96,9 +96,9 @@ describe("getAuthenticatorFromWorkOSClaims", () => {
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value.user().sId).toBe(user.sId);
-      expect(result.value.workspace().sId).toBe(workspace.sId);
-      expect(result.value.role()).toBe("user");
+      expect(result.value.authenticator.user().sId).toBe(user.sId);
+      expect(result.value.authenticator.workspace().sId).toBe(workspace.sId);
+      expect(result.value.authenticator.role()).toBe("user");
     }
   });
 });

--- a/front/lib/api/workos_authenticator.ts
+++ b/front/lib/api/workos_authenticator.ts
@@ -29,7 +29,13 @@ function getOrganizationId(payload: WorkOSJwtPayload): string | null {
 export async function getAuthenticatorFromWorkOSClaims(
   payload: unknown
 ): Promise<
-  Result<WorkOSWorkspaceAuthenticator, WorkOSWorkspaceAuthenticatorError>
+  Result<
+    {
+      authenticator: WorkOSWorkspaceAuthenticator;
+      workOSJWTPayload: WorkOSJwtPayload;
+    },
+    WorkOSWorkspaceAuthenticatorError
+  >
 > {
   const workOSTokenResult = parseWorkOSJwtPayload(payload);
   if (workOSTokenResult.isErr()) {
@@ -69,5 +75,8 @@ export async function getAuthenticatorFromWorkOSClaims(
     return new Err("not_a_member");
   }
 
-  return new Ok(auth as WorkOSWorkspaceAuthenticator);
+  return new Ok({
+    authenticator: auth as WorkOSWorkspaceAuthenticator,
+    workOSJWTPayload: workOSToken,
+  });
 }


### PR DESCRIPTION
## Description

Two related changes to the WorkOS/MCP auth layer:

- `getAuthenticatorFromWorkOSClaims` now returns `{ authenticator: WorkOSWorkspaceAuthenticator, workOSJWTPayload: WorkOSJwtPayload }` instead of the bare authenticator. This exposes raw JWT claims (e.g., `client_id`, `organization_id`) to callers without requiring a second parse. `mcpServerAuthMiddleware` updated to set `mcpAuth` from `.authenticator`.
- Added `getWorkOSConnectApplication(clientId)` in `workos.ts` — fetches a WorkOS Connect application by ID or client ID via the WorkOS HTTP client, with Zod-validated discriminated union schemas for `oauth` and `m2m` app types.

## Tests

Updated `workos_authenticator.test.ts` assertions to match the new return shape (`result.value.authenticator.*`). Tested locally.

## Risk

Low. `getAuthenticatorFromWorkOSClaims` return type change is additive — the only required callsite update is `mcpServerAuthMiddleware`, which is the sole consumer. `getWorkOSConnectApplication` is net-new with no existing callers.

## Deploy Plan

Deploy front.
