### PR TITLE
Adjust creditState on deferred assignemnts

### DIFF
--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -1,4 +1,5 @@
 import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import type { Transaction } from "sequelize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
@@ -660,9 +661,15 @@ describe("MembershipResource", () => {
   describe("scheduleSeatChange", () => {
     let workspace: WorkspaceType;
     let lightWorkspace: LightWorkspaceType;
+    let outerTransaction: Transaction;
     const scheduledAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
-    beforeEach(async () => {
+    beforeEach(async (ctx) => {
+      // Capture the outer CLS transaction so scheduleSeatChange can use it as
+      // a parent (SAVEPOINT). Without this, scheduleSeatChange opens a second
+      // DB connection that deadlocks waiting for the lock held by the test
+      // isolation transaction on the membership row.
+      outerTransaction = (ctx as any)["transaction"] as Transaction;
       workspace = await WorkspaceFactory.basic();
       lightWorkspace = renderLightWorkspaceType({ workspace });
     });
@@ -691,6 +698,7 @@ describe("MembershipResource", () => {
         newSeatType: "max",
         scheduledAt,
         author: "no-author",
+        transaction: outerTransaction,
       });
 
       const future = await MembershipResource.getScheduledFutureMemberships({
@@ -725,6 +733,7 @@ describe("MembershipResource", () => {
         newSeatType: "workspace",
         scheduledAt,
         author: "no-author",
+        transaction: outerTransaction,
       });
 
       const future = await MembershipResource.getScheduledFutureMemberships({

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -656,4 +656,83 @@ describe("MembershipResource", () => {
       });
     });
   });
+
+  describe("scheduleSeatChange", () => {
+    let workspace: WorkspaceType;
+    let lightWorkspace: LightWorkspaceType;
+    const scheduledAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      lightWorkspace = renderLightWorkspaceType({ workspace });
+    });
+
+    it("initializes the scheduled row's creditState to user_seat for an allowance seat", async () => {
+      const user = await UserFactory.basic();
+      await MembershipResource.createMembership({
+        user,
+        workspace: lightWorkspace,
+        role: "user",
+        origin: "invited",
+        seatType: "workspace",
+      });
+      const active =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user,
+          workspace: lightWorkspace,
+        });
+      if (!active) {
+        throw new Error("Expected an active membership");
+      }
+
+      await active.scheduleSeatChange({
+        user,
+        workspace: lightWorkspace,
+        newSeatType: "max",
+        scheduledAt,
+        author: "no-author",
+      });
+
+      const future = await MembershipResource.getScheduledFutureMemberships({
+        workspace: lightWorkspace,
+      });
+      expect(future).toHaveLength(1);
+      expect(future[0].seatType).toBe("max");
+      expect(future[0].creditState).toBe("user_seat");
+    });
+
+    it("initializes the scheduled row's creditState to on_pool for a pool seat", async () => {
+      const user = await UserFactory.basic();
+      await MembershipResource.createMembership({
+        user,
+        workspace: lightWorkspace,
+        role: "user",
+        origin: "invited",
+        seatType: "max",
+      });
+      const active =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user,
+          workspace: lightWorkspace,
+        });
+      if (!active) {
+        throw new Error("Expected an active membership");
+      }
+
+      await active.scheduleSeatChange({
+        user,
+        workspace: lightWorkspace,
+        newSeatType: "workspace",
+        scheduledAt,
+        author: "no-author",
+      });
+
+      const future = await MembershipResource.getScheduledFutureMemberships({
+        workspace: lightWorkspace,
+      });
+      expect(future).toHaveLength(1);
+      expect(future[0].seatType).toBe("workspace");
+      expect(future[0].creditState).toBe("on_pool");
+    });
+  });
 });

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1503,15 +1503,20 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     newSeatType,
     scheduledAt,
     author,
+    transaction: parentTransaction,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     newSeatType: MembershipSeatType;
     scheduledAt: Date;
     author: UserType | "no-author";
+    transaction?: Transaction;
   }): Promise<void> {
     const previousSeatType = this.seatType;
-    await frontSequelize.transaction(async (transaction) => {
+    const txOptions = parentTransaction
+      ? { transaction: parentTransaction }
+      : {};
+    await frontSequelize.transaction(txOptions, async (transaction) => {
       // Replace any existing future row (re-scheduling is idempotent).
       await MembershipModel.destroy({
         where: {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1531,6 +1531,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
           origin: this.origin,
           seatType: newSeatType,
           firstUsedAt: this.firstUsedAt,
+          creditState: initialCreditStateForSeatType(newSeatType),
           // The pool cap override survives the seat change: it's the
           // pool-only portion, independent of the seat allowance.
           poolCapOverrideAwuCredits: this.poolCapOverrideAwuCredits,


### PR DESCRIPTION
## Description

Stacked on #27294.

When a seat change is deferred to the next period (`scheduleSeatChange`), the future membership row was created without an explicit `creditState`, so it took the column default (`on_pool`). For a seat **with an allowance** (pro/max) that's wrong: when the row activates at the period boundary its balance has renewed, so it should be `user_seat`.

This initializes the scheduled row's `creditState` from the new seat type via `initialCreditStateForSeatType` — mirroring `createMembership` — so the row is consistent for the new period (`user_seat` for an allowance seat, `on_pool` for a pool seat) rather than relying solely on a later reconcile.

Note: this fixes the *persisted* value. The enforcement read path (the no-TTL per-user `creditState` Redis cache) is refreshed at the period boundary by `reconcileWorkspaceUserCreditStates` (see #26877) — the two are complementary.

## Tests

Added `scheduleSeatChange` cases in `membership_resource.test.ts`: the scheduled row initializes to `user_seat` for an allowance seat (→ `max`) and `on_pool` for a pool seat (→ `workspace`).

## Risk

Low. Only sets the initial `creditState` on a newly-created future row; the authoritative reconcile still refines it from live balances at activation.

## Deploy Plan

Standard. No migration. Merge after #27294.
