### PR TITLE
Choose initial seat on join

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -50,21 +50,22 @@ import type {
 import type { Transaction } from "sequelize";
 
 /**
- * Resolve the seat type for a brand-new membership. For seat-billed
- * contracts, picks the lowest-allowance seat tier billed on the contract,
- * gated by the active plan's free-seat caps:
+ * Resolve the seat type for a brand-new membership on a Metronome-billed
+ * workspace. The assignment follows three phases:
  *
- *  - Returning member (already had a row in this workspace) → `free` is
- *    skipped (one-shot starter tier).
- *  - `useFreeSeat` is false → caller opted out of `free` directly.
- *  - `plan.limits.users.maxFreeUsers` reached → `free` is skipped.
- *  - `plan.limits.users.maxLifetimeFreeUsers` reached → `free` is skipped.
+ *  1. **Committed seats** — the cheapest seat tier whose committed allocation
+ *     (`workspace_seat_limits.minSeats`) still has unassigned slots is picked.
+ *  2. **Free seat** — if no committed slot is available and `free` is on the
+ *     contract, it is assigned unless any of the following are true:
+ *       - `isReturningMember` (one-shot: `free` cannot be re-granted).
+ *       - `useFreeSeat` is false (caller opted out).
+ *       - `plan.limits.users.maxFreeUsers` reached.
+ *       - `plan.limits.users.maxLifetimeFreeUsers` reached.
+ *  3. **None** — if both phases are exhausted the member is assigned `"none"`
+ *     (no-seat tier; cannot send messages).
  *
- * In all three skip cases the resolver advances to the next billed tier
- * and only fails when no tier is assignable.
- *
- * The workspace-wide active-member cap (`plan.limits.users.maxUsers`) is
- * NOT checked here — it's enforced upstream by
+ * The workspace-wide active-member cap (`plan.limits.users.maxUsers`) is NOT
+ * checked here — it is enforced upstream by
  * `evaluateWorkspaceSeatAvailability` (signup) and `invitation.ts` (invite
  * creation).
  *
@@ -108,38 +109,28 @@ async function resolveSeatTypeForNewMembership(
       WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
     ]);
 
-  // Only fetch per-seat-type counts when at least one tier has a maxSeats cap
-  // configured
-  const hasAnyCap = [...seatLimits.values()].some(
-    (l) => l.maxSeats !== null && l.maxSeats !== undefined
+  // Seat counts are needed to check whether committed slots (minSeats) are
+  // still available.
+  const hasCommittedSeats = [...seatLimits.values()].some(
+    (l) => l.minSeats > 0
   );
-  const seatCounts = hasAnyCap
+  const seatCounts = hasCommittedSeats
     ? await MembershipResource.getActiveSeatTypeCountsForWorkspace({
         workspace,
       })
     : undefined;
 
-  const defaultSeatType = getDefaultSeatTypeForContract(
-    contract,
-    productSeatTypes,
-    {
-      isReturningMember,
-      useFreeSeat,
-      freeSeatCounts,
-      freeSeatLimits: {
-        maxActiveFreeUsers: planLimits.maxFreeUsers,
-        maxLifetimeFreeUsers: planLimits.maxLifetimeFreeUsers,
-      },
-      seatLimits,
-      seatCounts,
-    }
-  );
-  if (!defaultSeatType) {
-    throw new Error(
-      `Cannot resolve a seat type for user ${user.sId} in workspace ${workspace.sId}: contract has seat subscriptions but no tier is assignable${isReturningMember ? " (returning user; `free` is one-shot)" : ""}.`
-    );
-  }
-  return defaultSeatType;
+  return getDefaultSeatTypeForContract(contract, productSeatTypes, {
+    isReturningMember,
+    useFreeSeat,
+    freeSeatCounts,
+    freeSeatLimits: {
+      maxActiveFreeUsers: planLimits.maxFreeUsers,
+      maxLifetimeFreeUsers: planLimits.maxLifetimeFreeUsers,
+    },
+    seatLimits,
+    seatCounts,
+  });
 }
 
 /**

--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -40,23 +40,34 @@ describe("getDefaultSeatTypeForContract — entitlement", () => {
     ],
   } as unknown as CachedContract;
 
-  it("assigns the entitled seat, not a dormant lower-name subscription", () => {
+  it("assigns the entitled committed seat, not a dormant lower-name subscription", () => {
     // Both seats are 0 AWU; without entitlement filtering the tie-break would
-    // pick "workspace" (< "workspace_yearly"). Entitlement must win.
-    expect(getDefaultSeatTypeForContract(contract, productSeatTypes)).toBe(
-      "workspace_yearly"
-    );
+    // pick "workspace" (< "workspace_yearly"). Entitlement must win: only
+    // workspace_yearly is in onContract, so its committed slot is assigned.
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["workspace_yearly", { minSeats: 10, maxSeats: null }],
+    ]);
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
+      workspace_yearly: 0,
+    };
+    expect(
+      getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("workspace_yearly");
   });
 });
 
-// maxSeats cap: skips tiers at capacity; returns "none" when all capped.
-describe("getDefaultSeatTypeForContract — maxSeats cap", () => {
+// Committed-seat assignment: fills minSeats slots first, then falls through to
+// free, then none.
+describe("getDefaultSeatTypeForContract — committed seats", () => {
   const productSeatTypes = new Map<string, MembershipSeatType>([
     ["pro-product", "pro"],
-    ["max-product", "max"],
+    ["free-product", "free"],
   ]);
 
-  // Contract with two entitled seat types: pro (lower AWU) and max.
+  // Contract bills both `pro` and `free`.
   const contract = {
     subscriptions: [
       {
@@ -64,85 +75,95 @@ describe("getDefaultSeatTypeForContract — maxSeats cap", () => {
         subscription_rate: { product: { id: "pro-product", name: "Pro" } },
       },
       {
-        id: "sub_max",
-        subscription_rate: { product: { id: "max-product", name: "Max" } },
+        id: "sub_free",
+        subscription_rate: { product: { id: "free-product", name: "Free" } },
       },
     ],
     recurring_credits: [],
     overrides: [
       { entitled: true, product: { id: "pro-product" } },
-      { entitled: true, product: { id: "max-product" } },
+      { entitled: true, product: { id: "free-product" } },
     ],
   } as unknown as CachedContract;
 
-  it("skips a capped tier and falls through to the next", () => {
+  it("assigns a committed seat when slots remain", () => {
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
-      ["pro", { minSeats: 0, maxSeats: 2 }],
+      ["pro", { minSeats: 5, maxSeats: null }],
     ]);
-    // Pro is at cap (2 assigned, maxSeats=2); should fall through to max.
-    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
-      pro: 2,
-    };
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = { pro: 3 };
     expect(
       getDefaultSeatTypeForContract(contract, productSeatTypes, {
         seatLimits,
         seatCounts,
       })
-    ).toBe("max");
+    ).toBe("pro");
   });
 
-  it("returns none when all tiers are at their maxSeats cap", () => {
+  it("falls through to free when all committed slots are taken", () => {
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
-      ["pro", { minSeats: 0, maxSeats: 2 }],
-      ["max", { minSeats: 0, maxSeats: 1 }],
+      ["pro", { minSeats: 5, maxSeats: null }],
     ]);
-    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
-      pro: 2,
-      max: 1,
-    };
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = { pro: 5 };
     expect(
       getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("free");
+  });
+
+  it("returns none when committed exhausted and free blocked (returning member)", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 5, maxSeats: null }],
+    ]);
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = { pro: 5 };
+    expect(
+      getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        isReturningMember: true,
         seatLimits,
         seatCounts,
       })
     ).toBe("none");
   });
 
-  it("assigns normally when no tiers are at cap", () => {
+  it("returns none when committed exhausted and free blocked (useFreeSeat=false)", () => {
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
-      ["pro", { minSeats: 0, maxSeats: 10 }],
+      ["pro", { minSeats: 5, maxSeats: null }],
     ]);
-    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
-      pro: 5,
-    };
-    // Both tiers have 0 AWU; tie-break is alphabetical, so "max" < "pro".
-    // Neither is capped, so the first sorted tier ("max") is assigned.
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = { pro: 5 };
     expect(
       getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        useFreeSeat: false,
         seatLimits,
         seatCounts,
       })
-    ).toBe("max");
+    ).toBe("none");
   });
 
-  it("legacy: no-seat-subscription contract returns workspace regardless of caps", () => {
+  it("returns none when no committed seats configured and free not available", () => {
+    // No seatLimits — committed phase skipped entirely → free → none (returning)
+    expect(
+      getDefaultSeatTypeForContract(contract, productSeatTypes, {
+        isReturningMember: true,
+      })
+    ).toBe("none");
+  });
+
+  it("assigns free (no committed seats, new member)", () => {
+    // No committed seat configured; free is the only option and the member is new.
+    expect(getDefaultSeatTypeForContract(contract, productSeatTypes)).toBe(
+      "free"
+    );
+  });
+
+  it("legacy: no-seat-subscription contract returns workspace regardless", () => {
     const legacyContract = {
       subscriptions: [],
       recurring_credits: [],
       overrides: [],
     } as unknown as CachedContract;
-    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
-      ["workspace", { minSeats: 0, maxSeats: 0 }],
-    ]);
-    const seatCounts: Partial<Record<MembershipSeatType, number>> = {
-      workspace: 99,
-    };
-    // The early-return for no subscriptions runs before cap logic.
     expect(
-      getDefaultSeatTypeForContract(legacyContract, productSeatTypes, {
-        seatLimits,
-        seatCounts,
-      })
+      getDefaultSeatTypeForContract(legacyContract, productSeatTypes)
     ).toBe("workspace");
   });
 });

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -131,35 +131,30 @@ export type FreeSeatCounts = {
 /**
  * Returns the seat type to assign to a new membership on this contract.
  *
- * The default is derived from the contract itself — no rate-card custom
- * field. We order the seat tiers actually billed on the contract by AWU
- * allowance (ascending — the cheapest first) and pick the lowest tier.
+ * The seat is chosen in three phases:
  *
- * Legacy contracts carrying only untagged subscriptions (e.g. the legacy
- * MAU plan products) fall back to `"workspace"` — those subscriptions are
- * quantity-managed by `syncMauCount`, so the seat type is informational
- * only and `"workspace"` matches what new-tier enterprise contracts use.
+ *  1. **Committed seats** — iterate the contract's non-`free` seat types
+ *     ordered by AWU allowance ascending (cheapest first). For each type that
+ *     has a committed allocation (`seatLimits.minSeats > 0`) with remaining
+ *     slots (`assignedCount < minSeats`), assign it.
  *
- * `free` is a one-shot starter tier (its lifetime AWU credit cannot be
- * re-granted). It is skipped, and the next tier in the ordering is
- * tried, when any of the following are true:
+ *  2. **Free seat** — if `free` is on the contract and all of the following
+ *     hold, assign `free`:
+ *       - `isReturningMember` is false (`free` is a one-shot starter tier).
+ *       - `useFreeSeat` is true (caller has not opted out).
+ *       - Active free-seat cap not exceeded.
+ *       - Lifetime free-seat cap not exceeded.
  *
- *   - `isReturningMember` is true (the user already had a membership row
- *     in this workspace at some point).
- *   - `useFreeSeat` is false (caller opted out, e.g. an admin invitation
- *     that should land on a paid tier directly).
- *   - `freeSeatCounts.active >= freeSeatLimits.maxActiveFreeUsers` (and
- *     the limit is not `-1`).
- *   - `freeSeatCounts.lifetime >= freeSeatLimits.maxLifetimeFreeUsers`
- *     (and the limit is not `-1`).
+ *  3. **None** — all committed slots are taken and `free` is unavailable:
+ *     return `"none"` (no-seat tier).
  *
- * Returns `undefined` when no remaining tier is assignable (e.g. a
- * free-only contract that has exhausted its lifetime cap).
+ * Legacy contracts that carry no seat subscriptions return `"workspace"` early
+ * and never reach the three phases.
  *
- * The workspace-wide active-member cap (`plan.limits.users.maxUsers`) is
- * NOT enforced here — it's already enforced upstream by
- * `evaluateWorkspaceSeatAvailability` (signup) and `invitation.ts` (invite
- * creation).
+ * The workspace-wide active-member cap (`plan.limits.users.maxUsers`) is NOT
+ * enforced here — it is already enforced upstream by
+ * `evaluateWorkspaceSeatAvailability` (signup) and `invitation.ts`
+ * (invite creation).
  */
 export function getDefaultSeatTypeForContract(
   contract: CachedContract,
@@ -179,7 +174,7 @@ export function getDefaultSeatTypeForContract(
     seatLimits?: Map<MembershipSeatType, SeatLimit>;
     seatCounts?: Partial<Record<MembershipSeatType, number>>;
   } = {}
-): MembershipSeatType | undefined {
+): MembershipSeatType {
   const seatTypesOnContract = [
     ...getSeatSubscriptionsFromContract(contract, productSeatTypes).keys(),
   ];
@@ -196,53 +191,45 @@ export function getDefaultSeatTypeForContract(
     // and free = 0 on a hybrid contract).
     .sort((a, b) => a.awu - b.awu || a.seatType.localeCompare(b.seatType));
 
-  // Track whether any tier was skipped because it hit its maxSeats cap.
-  // If every tier is capped (and none was skippable for another reason), we
-  // return "none" instead of undefined so callers assign the member to the
-  // "no seat" tier rather than throwing.
-  let anyTierAtMaxCap = false;
-
+  // Phase 1: assign to the cheapest committed seat type with remaining slots.
+  // A seat type is committed if seatLimits.minSeats > 0. The commitment is
+  // exhausted once assignedCount >= minSeats.
   for (const { seatType } of ordered) {
     if (seatType === "free") {
-      if (isReturningMember || !useFreeSeat) {
-        continue;
-      }
-      if (
-        freeSeatLimits &&
-        freeSeatCounts &&
-        freeSeatLimits.maxActiveFreeUsers !== -1 &&
-        freeSeatCounts.active >= freeSeatLimits.maxActiveFreeUsers
-      ) {
-        continue;
-      }
-      if (
-        freeSeatLimits &&
-        freeSeatCounts &&
-        freeSeatLimits.maxLifetimeFreeUsers !== -1 &&
-        freeSeatCounts.lifetime >= freeSeatLimits.maxLifetimeFreeUsers
-      ) {
-        continue;
-      }
+      continue;
     }
-
-    // Skip this tier if it has a maxSeats cap and is at capacity.
     const limit = seatLimits?.get(seatType);
-    if (limit?.maxSeats !== null && limit?.maxSeats !== undefined) {
-      const assignedCount = seatCounts?.[seatType] ?? 0;
-      if (assignedCount >= limit.maxSeats) {
-        anyTierAtMaxCap = true;
-        continue;
-      }
+    if (!limit || limit.minSeats <= 0) {
+      continue;
     }
-
-    return seatType;
+    const assignedCount = seatCounts?.[seatType] ?? 0;
+    if (assignedCount < limit.minSeats) {
+      return seatType;
+    }
   }
 
-  // All tiers were skipped: if at least one was capped by maxSeats, signal
-  // "no seat" so the caller assigns the member to the none tier. Otherwise
-  // (e.g. only the free tier exists and it is exhausted) return undefined so
-  // the caller can surface the appropriate error.
-  return anyTierAtMaxCap ? "none" : undefined;
+  // Phase 2: committed seats exhausted — try "free" if on the contract and
+  // the caller/workspace conditions allow it.
+  if (seatTypesOnContract.includes("free")) {
+    if (!isReturningMember && useFreeSeat) {
+      const activeCapHit =
+        freeSeatLimits !== undefined &&
+        freeSeatCounts !== undefined &&
+        freeSeatLimits.maxActiveFreeUsers !== -1 &&
+        freeSeatCounts.active >= freeSeatLimits.maxActiveFreeUsers;
+      const lifetimeCapHit =
+        freeSeatLimits !== undefined &&
+        freeSeatCounts !== undefined &&
+        freeSeatLimits.maxLifetimeFreeUsers !== -1 &&
+        freeSeatCounts.lifetime >= freeSeatLimits.maxLifetimeFreeUsers;
+      if (!activeCapHit && !lifetimeCapHit) {
+        return "free";
+      }
+    }
+  }
+
+  // Phase 3: no committed seat or free available.
+  return "none";
 }
 
 /**

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -24,7 +24,6 @@ import {
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
-  getDefaultSeatTypeForContract,
   getNextSeatCreditRenewalDate,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
@@ -243,7 +242,8 @@ export function classifySeatChange({
  *  - keep the current type if the contract still bills it;
  *  - if the current type is monthly and the contract bills its yearly
  *    equivalent (`<type>_yearly`), convert to yearly;
- *  - otherwise fall back to the contract's default tier (no `free`).
+ *  - otherwise fall back to the cheapest seat type on the contract, skipping
+ *    `free` when `useFreeSeat` is false.
  *
  * Returns `undefined` when no target is resolvable (caller leaves the
  * membership untouched).
@@ -266,9 +266,21 @@ export function resolveRemappedSeatType(
       return yearly;
     }
   }
-  return getDefaultSeatTypeForContract(contract, productSeatTypes, {
-    useFreeSeat,
-  });
+  // Fallback: assign the cheapest seat type billed on the contract (by AWU
+  // allowance), skipping "free" when the caller opted out.
+  const ordered = [...onContract]
+    .map((seatType) => ({
+      seatType,
+      awu: getAwuAllocationForSeatType(contract, seatType, productSeatTypes),
+    }))
+    .sort((a, b) => a.awu - b.awu || a.seatType.localeCompare(b.seatType));
+  for (const { seatType } of ordered) {
+    if (seatType === "free" && !useFreeSeat) {
+      continue;
+    }
+    return seatType;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Description

Changes the seat assignment logic for new workspace members (in `resolveSeatTypeForNewMembership` / `getDefaultSeatTypeForContract`).

**New three-phase algorithm:**

1. **Committed seats** — iterate non-`free` seat types by AWU allowance (cheapest first). Pick the first type whose committed allocation (`workspace_seat_limits.minSeats > 0`) still has unassigned slots (`assignedCount < minSeats`).
2. **Free seat** — if no committed slot is available and `free` is on the contract, assign it (subject to existing conditions: not a returning member, `useFreeSeat` not opted out, caps not hit).
3. **None** — assign `"none"` (no-seat tier) when both phases are exhausted.

**Previously**, any seat type on the contract was eligible and the cheapest tier was picked unconditionally (with `maxSeats` as the only cap). Now only seats with a configured `minSeats` commitment are auto-assigned to new members; once the commitment is full, members spill over to `free` or `none`.

Contract remapping (`resolveRemappedSeatType`, used on contract switches) keeps the old "cheapest seat on contract" fallback, since committed-seat counting doesn't apply there.

## Tests

- Rewrote `seat_types.test.ts` to cover the new three-phase algorithm: committed slot available → assign; commitment exhausted → free; free blocked (returning member / `useFreeSeat=false`) → none; no committed config → free or none; legacy contract → workspace.
- All existing `seats.test.ts` tests (including `resolveRemappedSeatType`) continue to pass unchanged.

## Risk

Low. The change only affects new member creation on Metronome-billed workspaces. Workspaces without any `workspace_seat_limits.minSeats` configured will assign `free` or `none` to new members (instead of the cheapest paid tier), which matches the intended product behaviour — committed seats must be explicitly configured.

## Deploy Plan

No migration needed. The change is purely in seat-assignment logic and takes effect immediately on deploy.