### PR TITLE
feat(user-search): index membership seat type in elasticsearch

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -47,6 +47,11 @@ import type {
   MembershipSeatType,
   MembershipUpgradeRequestType,
 } from "@app/types/memberships";
+import {
+  isMembershipSeatType,
+  SEAT_TYPE_ORDER,
+  toBaseSeatType,
+} from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { isAdmin } from "@app/types/user";
 import {
@@ -102,6 +107,10 @@ function memberFromUpgradeRequest(
 
 const DEFAULT_PAGE_SIZE = 25;
 
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
@@ -129,6 +138,23 @@ export function UsagePage() {
   // changes so the user lands on the start of the new ordering.
   const handleSetSorting = useCallback((next: SortingState) => {
     setSorting(next);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  // The seat-type filter is applied server-side before pagination, so reset to
+  // the first page whenever it changes to land on the start of the new set.
+  const handleSetSeatTypeFilter = useCallback(
+    (next: MembershipSeatType | "none" | null) => {
+      setSeatTypeFilter(next);
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
+
+  // Name/email search is also applied server-side before pagination, so reset
+  // to the first page whenever the search term changes.
+  const handleSetSearchTerm = useCallback((next: string) => {
+    setSearchTerm(next);
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
   }, []);
 
@@ -371,6 +397,7 @@ export function UsagePage() {
       pageSize: pagination.pageSize,
       orderColumn: membersOrderColumn,
       orderDirection: membersOrderDirection,
+      seatType: seatTypeFilter ?? undefined,
     });
 
   const { hasAvailableSeats } = useWorkspaceSeatAvailability({
@@ -386,6 +413,21 @@ export function UsagePage() {
   });
 
   const isSeatBased = Object.keys(seatPlans).length > 1;
+
+  // Seat-type filter options derived from the seats available to this
+  // workspace, collapsed to base tiers (monthly/yearly share one entry) and
+  // ordered by tier.
+  const seatFilterOptions = useMemo(() => {
+    const currentBaseSeatTypes = new Set<MembershipSeatType>();
+    for (const key of Object.keys(seatPlans)) {
+      if (isMembershipSeatType(key)) {
+        currentBaseSeatTypes.add(toBaseSeatType(key));
+      }
+    }
+    return [...currentBaseSeatTypes].sort(
+      (a, b) => SEAT_TYPE_ORDER[a] - SEAT_TYPE_ORDER[b]
+    );
+  }, [seatPlans]);
 
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);
@@ -426,7 +468,7 @@ export function UsagePage() {
         placeholder="Search members"
         value={searchTerm}
         name="search"
-        onChange={setSearchTerm}
+        onChange={handleSetSearchTerm}
         className="w-full"
       />
       {isManualInvitationsEnabled && (
@@ -450,8 +492,7 @@ export function UsagePage() {
             seatTypeFilter === "none"
               ? "No seat"
               : seatTypeFilter
-                ? seatTypeFilter.charAt(0).toUpperCase() +
-                  seatTypeFilter.slice(1)
+                ? capitalize(seatTypeFilter)
                 : "All seats"
           }
           size="sm"
@@ -461,24 +502,19 @@ export function UsagePage() {
       <DropdownMenuContent align="end">
         <DropdownMenuItem
           label="All seats"
-          onClick={() => setSeatTypeFilter(null)}
+          onClick={() => handleSetSeatTypeFilter(null)}
         />
         <DropdownMenuItem
           label="No seat"
-          onClick={() => setSeatTypeFilter("none")}
+          onClick={() => handleSetSeatTypeFilter("none")}
         />
-        <DropdownMenuItem
-          label="Free"
-          onClick={() => setSeatTypeFilter("free")}
-        />
-        <DropdownMenuItem
-          label="Pro"
-          onClick={() => setSeatTypeFilter("pro")}
-        />
-        <DropdownMenuItem
-          label="Max"
-          onClick={() => setSeatTypeFilter("max")}
-        />
+        {seatFilterOptions.map((seatType) => (
+          <DropdownMenuItem
+            key={seatType}
+            label={capitalize(seatType)}
+            onClick={() => handleSetSeatTypeFilter(seatType)}
+          />
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -491,7 +527,6 @@ export function UsagePage() {
       showSpendLimit={!isFreePlanWorkspace}
       totalAllowedUsagePendingMemberIds={totalAllowedUsagePendingMemberIds}
       seatChangePendingMemberIds={seatChangePendingMemberIds}
-      seatTypeFilter={seatTypeFilter}
       isSeatBased={isSeatBased}
       onChangeSeat={handleChangeSeatFromTable}
       onRemoveSeat={onRemoveSeat}

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -11,9 +11,9 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { useDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import {
-  isMembershipSeatType,
   type MembershipSeatType,
   SEAT_TYPE_ORDER,
+  toBaseSeatType,
 } from "@app/types/memberships";
 import {
   Clock,
@@ -52,16 +52,6 @@ type RowData = {
 
 type Info = CellContext<RowData, string>;
 
-// Yearly seat types are billed yearly but render in the table identically to
-// their monthly counterpart. Strip the suffix for icon lookup and display.
-function getDisplaySeatType(seatType: MembershipSeatType): MembershipSeatType {
-  if (seatType.endsWith("_yearly")) {
-    const stripped = seatType.slice(0, -"_yearly".length);
-    return isMembershipSeatType(stripped) ? stripped : seatType;
-  }
-  return seatType;
-}
-
 // Builds the tooltip explaining a scheduled seat change, e.g.
 // "This user will be downgraded to Free at the end of the billing period (July 1)".
 function getScheduledSeatChangeLabel(
@@ -77,7 +67,7 @@ function getScheduledSeatChangeLabel(
       : scheduledRank < currentRank
         ? "downgraded"
         : "changed";
-  const target = getDisplaySeatType(scheduledSeatType);
+  const target = toBaseSeatType(scheduledSeatType);
   const targetLabel = target.charAt(0).toUpperCase() + target.slice(1);
   const dateSuffix = scheduledSeatChangeAt
     ? ` (${new Date(scheduledSeatChangeAt).toLocaleDateString("en-US", {
@@ -97,7 +87,7 @@ function SeatTypeIcon({ seatType }: SeatTypeIconProps) {
   if (!seatType) {
     return null;
   }
-  const displaySeatType = getDisplaySeatType(seatType);
+  const displaySeatType = toBaseSeatType(seatType);
   const visual = SEAT_TYPE_ICONS[displaySeatType];
   if (!visual) {
     return null;
@@ -341,7 +331,7 @@ const seatTypeColumn: ColumnDef<RowData, string> = {
       <DataTable.CellContent>
         <span className="flex items-center gap-1.5 text-sm font-semibold capitalize text-muted-foreground dark:text-muted-foreground-night">
           <SeatTypeIcon seatType={seatType} />
-          {seatType ? getDisplaySeatType(seatType) : "—"}
+          {seatType ? toBaseSeatType(seatType) : "—"}
           {scheduledSeatType && (
             <Tooltip
               label={getScheduledSeatChangeLabel(
@@ -430,7 +420,6 @@ interface MembersUsageTableProps {
   isLoading: boolean;
   totalAllowedUsagePendingMemberIds: ReadonlySet<string>;
   seatChangePendingMemberIds: ReadonlySet<string>;
-  seatTypeFilter: MembershipSeatType | "none" | null;
   isSeatBased: boolean;
   showSpendLimit: boolean;
   readOnly: boolean;
@@ -449,7 +438,6 @@ export function MembersUsageTable({
   isLoading,
   totalAllowedUsagePendingMemberIds,
   seatChangePendingMemberIds,
-  seatTypeFilter,
   isSeatBased,
   showSpendLimit,
   readOnly,
@@ -462,29 +450,9 @@ export function MembersUsageTable({
   sorting,
   setSorting,
 }: MembersUsageTableProps) {
-  // Name/email search is handled server-side; only filter by seat type here.
-  const filtered = useMemo(
-    () =>
-      members.filter((m) => {
-        if (seatTypeFilter === "none" && m.seatType !== null) {
-          return false;
-        }
-        if (
-          seatTypeFilter !== null &&
-          seatTypeFilter !== "none" &&
-          m.seatType &&
-          !m.seatType.startsWith(seatTypeFilter)
-        ) {
-          return false;
-        }
-        return true;
-      }),
-    [members, seatTypeFilter]
-  );
-
   const rows: RowData[] = useMemo(
     () =>
-      filtered.map((m) => ({
+      members.map((m) => ({
         sId: m.sId,
         name: m.name,
         email: m.email,
@@ -537,7 +505,7 @@ export function MembersUsageTable({
         ],
       })),
     [
-      filtered,
+      members,
       totalAllowedUsagePendingMemberIds,
       seatChangePendingMemberIds,
       isSeatBased,

--- a/front/lib/analytics/migrations/20260612_add_seat_type_to_user_search_1.http
+++ b/front/lib/analytics/migrations/20260612_add_seat_type_to_user_search_1.http
@@ -1,0 +1,8 @@
+PUT /front.user_search_1/_mapping
+{
+  "properties": {
+    "seat_type": {
+      "type": "keyword"
+    }
+  }
+}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -48,10 +48,13 @@ import type {
   UserCreditState,
 } from "@app/types/memberships";
 import {
+  MEMBERSHIP_SEAT_TYPES,
   NORMALIZED_POOL_LIMIT_SEAT_TYPES,
   normalizeToPoolLimitSeatType,
+  toBaseSeatType,
 } from "@app/types/memberships";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
 import { z } from "zod";
 
 export type MemberUsageType = {
@@ -148,6 +151,9 @@ export const MembersUsagePaginationSchema = z.object({
   // for pagination instead of relevance ranking.
   orderColumn: z.enum(["name", "email"]).catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
+  // Optional seat-type filter. A base seat type (e.g. "pro") matches its
+  // monthly and yearly variants; "none" matches members with no seat.
+  seatType: z.enum(MEMBERSHIP_SEAT_TYPES).optional().catch(undefined),
 });
 
 export type MembersUsagePaginationInput = z.infer<
@@ -707,6 +713,30 @@ export async function getMemberUsage({
   };
 }
 
+// Resolve the member user sIds matching a base seat-type filter, querying the
+// memberships table directly (a base tier matches its monthly + yearly
+// variants). Seat type isn't held in the user search index, so we hand these
+// ids to Elasticsearch as an allowlist and let it own search/sort/pagination
+// over the filtered set.
+async function resolveSeatTypeFilterUserIds({
+  workspace,
+  seatType,
+}: {
+  workspace: LightWorkspaceType;
+  seatType: MembershipSeatType;
+}): Promise<string[]> {
+  const seatTypes = MEMBERSHIP_SEAT_TYPES.filter(
+    (t) => toBaseSeatType(t) === seatType
+  );
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace,
+    seatTypes,
+  });
+  return memberships
+    .map((m) => m.user?.sId)
+    .filter((sId): sId is string => Boolean(sId));
+}
+
 export async function getMembersUsage({
   auth,
   paginationParams,
@@ -725,6 +755,20 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
+  // When a seat-type filter is active, resolve the matching user sIds up front
+  // and restrict the search to them so pagination and the returned `total`
+  // reflect the filtered set. No match means an empty page.
+  let restrictToUserIds: string[] | undefined;
+  if (paginationParams.seatType) {
+    restrictToUserIds = await resolveSeatTypeFilterUserIds({
+      workspace,
+      seatType: paginationParams.seatType,
+    });
+    if (restrictToUserIds.length === 0) {
+      return { members: [], total: 0 };
+    }
+  }
+
   const usersResult = await UserResource.searchUsers(auth, {
     searchTerm: paginationParams.search ?? "",
     offset: paginationParams.offset,
@@ -733,6 +777,7 @@ export async function getMembersUsage({
       field: paginationParams.orderColumn,
       direction: paginationParams.orderDirection,
     },
+    restrictToUserIds,
   });
 
   if (usersResult.isErr()) {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -48,6 +48,7 @@ type GetMembershipsOptions = RequireAtLeastOne<{
   workspace: LightWorkspaceType;
 }> & {
   roles?: MembershipRoleType[];
+  seatTypes?: MembershipSeatType[];
   transaction?: Transaction;
 };
 
@@ -136,6 +137,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     users,
     workspace,
     roles,
+    seatTypes,
     transaction,
     paginationParams,
   }: GetMembershipsOptions & {
@@ -175,6 +177,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     if (roles) {
       whereClause.role = {
         [Op.in]: roles,
+      };
+    }
+    if (seatTypes) {
+      whereClause.seatType = {
+        [Op.in]: seatTypes,
       };
     }
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1481,6 +1481,19 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       "Membership seat type updated"
     );
 
+    // Seat type is denormalized into the user search index, so re-index to keep
+    // the seat-type filter in sync. Scheduled (future-dated) seat changes go
+    // through `scheduleSeatChange` and don't touch the active row, so they don't
+    // re-index here; their new seat is picked up on the next re-index after the
+    // change takes effect.
+    const workflowResult = await launchIndexUserSearchWorkflow({
+      userId: user.sId,
+    });
+    if (workflowResult.isErr()) {
+      // Throw if it fails to launch (unexpected).
+      throw workflowResult.error;
+    }
+
     return { previousSeatType, newSeatType };
   }
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -369,11 +369,13 @@ export class UserResource extends BaseResource<UserModel> {
       offset,
       limit,
       orderBy,
+      restrictToUserIds,
     }: {
       searchTerm: string;
       offset: number;
       limit: number;
       orderBy?: SearchUsersOrderBy;
+      restrictToUserIds?: string[];
     }
   ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
     const owner = auth.getNonNullableWorkspace();
@@ -385,6 +387,7 @@ export class UserResource extends BaseResource<UserModel> {
       offset,
       limit,
       orderBy,
+      userIds: restrictToUserIds,
     });
     if (searchResult.isErr()) {
       return searchResult;

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -20,6 +20,7 @@ import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 
 import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+import type { MembershipSeatType } from "@app/types/memberships";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -837,12 +838,16 @@ export class UserResource extends BaseResource<UserModel> {
     return [this.firstName, this.lastName].filter(Boolean).join(" ");
   }
 
-  toUserSearchDocument(workspace: LightWorkspaceType): UserSearchDocument {
+  toUserSearchDocument(
+    workspace: LightWorkspaceType,
+    seatType: MembershipSeatType
+  ): UserSearchDocument {
     return {
       workspace_id: workspace.sId,
       user_id: this.sId,
       email: this.email,
       full_name: this.fullName(),
+      seat_type: seatType,
       updated_at: this.updatedAt,
     };
   }

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -240,6 +240,7 @@ export function useMembersUsage({
   pageSize,
   orderColumn,
   orderDirection,
+  seatType,
   disabled,
 }: {
   workspaceId: string;
@@ -248,6 +249,7 @@ export function useMembersUsage({
   pageSize: number;
   orderColumn?: "name" | "email";
   orderDirection?: "asc" | "desc";
+  seatType?: MembershipSeatType | "none";
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -271,6 +273,9 @@ export function useMembersUsage({
   }
   if (orderDirection) {
     searchParams.set("orderDirection", orderDirection);
+  }
+  if (seatType) {
+    searchParams.set("seatType", seatType);
   }
 
   const { data, error } = useSWRWithDefaults(

--- a/front/lib/user_search/indices/user_search_1.mappings.json
+++ b/front/lib/user_search/indices/user_search_1.mappings.json
@@ -29,6 +29,9 @@
         }
       }
     },
+    "seat_type": {
+      "type": "keyword"
+    },
     "updated_at": {
       "type": "date"
     }

--- a/front/lib/user_search/search.ts
+++ b/front/lib/user_search/search.ts
@@ -28,12 +28,14 @@ export async function searchUsers({
   offset,
   limit,
   orderBy,
+  userIds,
 }: {
   owner: LightWorkspaceType;
   searchTerm: string;
   offset: number;
   limit: number;
   orderBy?: SearchUsersOrderBy;
+  userIds?: string[];
 }): Promise<Result<SearchUsersResult, ElasticsearchError>> {
   return withEs(async (client) => {
     // If searchTerm is empty or only whitespace, return all users from the workspace.
@@ -41,7 +43,10 @@ export async function searchUsers({
 
     const query: estypes.QueryDslQueryContainer = {
       bool: {
-        filter: [{ term: { workspace_id: owner.sId } }],
+        filter: [
+          { term: { workspace_id: owner.sId } },
+          ...(userIds ? [{ terms: { user_id: userIds } }] : []),
+        ],
         ...(hasSearchTerm && {
           should: [
             // Prefix matching on full_name using edge n-grams

--- a/front/migrations/20251126_backfill_user_search.ts
+++ b/front/migrations/20251126_backfill_user_search.ts
@@ -30,6 +30,15 @@ async function backfillUserSearch(
   const activeMemberships = memberships.filter((m) => !m.isRevoked());
   const revokedMemberships = memberships.filter((m) => m.isRevoked());
 
+  // Seat type indexed alongside each user mirrors the currently-active
+  // membership, so a member with a scheduled future seat change is indexed
+  // under their current seat rather than the upcoming one.
+  const { memberships: currentMemberships } =
+    await MembershipResource.getActiveMemberships({ workspace });
+  const activeSeatTypeByUserModelId = new Map(
+    currentMemberships.map((m) => [m.userId, m.seatType])
+  );
+
   logger.info(
     {
       workspaceId: workspace.sId,
@@ -65,7 +74,10 @@ async function backfillUserSearch(
           }
 
           // Create the user search document
-          const document = user.toUserSearchDocument(workspace);
+          const seatType =
+            activeSeatTypeByUserModelId.get(membership.userId) ??
+            membership.seatType;
+          const document = user.toUserSearchDocument(workspace, seatType);
 
           // Index the document
           const result = await indexUserDocument(document);

--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -35,6 +35,17 @@ export async function indexUserSearchActivity({
     workspaces.map((workspace) => [workspace.id, workspace])
   );
 
+  // The indexed seat type mirrors the currently-active membership (what the
+  // members table shows), not the latest row: a scheduled future seat change
+  // creates a future-dated membership that `getLatestMemberships` would return,
+  // and indexing it would filter the user under their upcoming seat before the
+  // change actually takes effect.
+  const { memberships: activeMemberships } =
+    await MembershipResource.getActiveMemberships({ users: [user] });
+  const activeSeatTypeByWorkspaceModelId = new Map(
+    activeMemberships.map((m) => [m.workspaceId, m.seatType])
+  );
+
   // Process each membership
   for (const membership of memberships) {
     const workspace = workspaceByModelId.get(membership.workspaceId);
@@ -65,8 +76,12 @@ export async function indexUserSearchActivity({
       }
     } else {
       // Membership is active, index user in this workspace
+      const seatType =
+        activeSeatTypeByWorkspaceModelId.get(membership.workspaceId) ??
+        membership.seatType;
       const document = user.toUserSearchDocument(
-        renderLightWorkspaceType({ workspace, role: membership.role })
+        renderLightWorkspaceType({ workspace, role: membership.role }),
+        seatType
       );
       const indexResult = await indexUserDocument(document);
       if (indexResult.isErr()) {

--- a/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
+++ b/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
@@ -32,6 +32,18 @@ export async function recreateUserSearchIndex({
   // Filter out revoked memberships - only index active members.
   const activeMemberships = memberships.filter((m) => !m.isRevoked());
 
+  // Seat type indexed alongside each user mirrors the currently-active
+  // membership (what the members table shows), so a member with a scheduled
+  // future seat change is indexed under their current seat, not the upcoming
+  // one.
+  const { memberships: currentMemberships } =
+    await MembershipResource.getActiveMemberships({
+      workspace: lightWorkspace,
+    });
+  const activeSeatTypeByUserModelId = new Map(
+    currentMemberships.map((m) => [m.userId, m.seatType])
+  );
+
   localLogger.info(
     {
       totalMemberships: memberships.length,
@@ -63,7 +75,10 @@ export async function recreateUserSearchIndex({
         return;
       }
 
-      const document = user.toUserSearchDocument(lightWorkspace);
+      const seatType =
+        activeSeatTypeByUserModelId.get(membership.userId) ??
+        membership.seatType;
+      const document = user.toUserSearchDocument(lightWorkspace, seatType);
       const result = await indexUserDocument(document);
 
       if (result.isErr()) {

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -94,6 +94,24 @@ export function isNormalizedPoolLimitSeatType(
 }
 
 /**
+ * Collapse a seat type's `_yearly` variant onto its base tier (e.g.
+ * `pro_yearly` → `pro`). Yearly and monthly variants share a tier, icon and
+ * label, so this is used both for display and for matching a base seat-type
+ * filter against either cadence.
+ */
+export function toBaseSeatType(
+  seatType: MembershipSeatType
+): MembershipSeatType {
+  if (seatType.endsWith("_yearly")) {
+    const base = seatType.slice(0, -"_yearly".length);
+    if (isMembershipSeatType(base)) {
+      return base;
+    }
+  }
+  return seatType;
+}
+
+/**
  * Map a membership seat type to its normalized pool-limit seat type.
  * Returns null for `free` seats (they have a fixed lifetime allocation with
  * no pool access).

--- a/front/types/user_search/user_search.ts
+++ b/front/types/user_search/user_search.ts
@@ -1,4 +1,5 @@
 import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import type { MembershipSeatType } from "@app/types/memberships";
 
 /**
  * Elasticsearch document for user search.
@@ -8,5 +9,9 @@ export interface UserSearchDocument extends ElasticsearchBaseDocument {
   user_id: string; // User's unique identifier (sId)
   email: string; // User's email address
   full_name: string; // User's full name
+  // The user's currently-active seat type in this workspace (denormalized from
+  // the memberships table) so seat-type filtering can be owned by the search
+  // index. Mirrors the active membership shown in the members table.
+  seat_type: MembershipSeatType;
   updated_at: Date; // Date when document was created/updated
 }


### PR DESCRIPTION
## Description

First of three PRs moving the members-usage seat-type filter into Elasticsearch (so the filter no longer needs a separate Postgres pre-fetch handed to ES as a `user_id` allowlist). This PR adds the `seat_type` field to the user search index and keeps it populated going forward; the backfill (#27307) and the read-side switch (#27308) follow.

- Adds a `seat_type` keyword to the `user_search` mapping (`user_search_1.mappings.json`) and a `PUT _mapping` migration (`lib/analytics/migrations/20260612_add_seat_type_to_user_search_1.http`) to apply the additive field to the live index — no version bump needed for a new field.
- `UserSearchDocument` gains `seat_type`, and `UserResource.toUserSearchDocument` now takes the seat type.
- The seat type indexed mirrors the user's **currently-active** membership (what the members table shows), not the latest membership row: a scheduled future seat change creates a future-dated membership, and indexing that would filter the user under their upcoming seat before it takes effect. The indexer, the relocation re-index activity, and the existing user-search backfill all resolve the active seat accordingly.
- Adds a re-index trigger on in-place seat changes (`MembershipResource.updateMembershipSeat`), alongside the existing create/role-update/revoke triggers, so the denormalized field stays in sync. Scheduled (future-dated) changes don't touch the active row, so their new seat is picked up on the next re-index after the change takes effect.

## Deploy Plan

Deploy this first, then run the live-index mapping migration:
`npx tsx front/scripts/execute_elasticsearch_http.ts -f lib/analytics/migrations/20260612_add_seat_type_to_user_search_1.http --execute`
Then run the backfill (#27307) before the read-side switch (#27308) is relied upon.
