### PR TITLE
feat(credits): filter members usage by seat type in elasticsearch

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -54,7 +54,6 @@ import {
   toBaseSeatType,
 } from "@app/types/memberships";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { LightWorkspaceType } from "@app/types/user";
 import { z } from "zod";
 
 export type MemberUsageType = {
@@ -713,28 +712,15 @@ export async function getMemberUsage({
   };
 }
 
-// Resolve the member user sIds matching a base seat-type filter, querying the
-// memberships table directly (a base tier matches its monthly + yearly
-// variants). Seat type isn't held in the user search index, so we hand these
-// ids to Elasticsearch as an allowlist and let it own search/sort/pagination
-// over the filtered set.
-async function resolveSeatTypeFilterUserIds({
-  workspace,
-  seatType,
-}: {
-  workspace: LightWorkspaceType;
-  seatType: MembershipSeatType;
-}): Promise<string[]> {
-  const seatTypes = MEMBERSHIP_SEAT_TYPES.filter(
-    (t) => toBaseSeatType(t) === seatType
-  );
-  const { memberships } = await MembershipResource.getActiveMemberships({
-    workspace,
-    seatTypes,
-  });
-  return memberships
-    .map((m) => m.user?.sId)
-    .filter((sId): sId is string => Boolean(sId));
+// Expand a base seat-type filter to the concrete seat types it matches (a base
+// tier matches its monthly + yearly variants, e.g. `pro` → `pro` + `pro_yearly`).
+// The seat type is denormalized into the user search index, so the filter is
+// handed to Elasticsearch which owns search/sort/pagination over the filtered
+// set (a non-matching filter naturally yields an empty page).
+function expandSeatTypeFilter(
+  seatType: MembershipSeatType
+): MembershipSeatType[] {
+  return MEMBERSHIP_SEAT_TYPES.filter((t) => toBaseSeatType(t) === seatType);
 }
 
 export async function getMembersUsage({
@@ -755,19 +741,12 @@ export async function getMembersUsage({
   const { metronomeCustomerId } = workspace;
   const metronomeContractId = subscription?.metronomeContractId ?? null;
 
-  // When a seat-type filter is active, resolve the matching user sIds up front
-  // and restrict the search to them so pagination and the returned `total`
-  // reflect the filtered set. No match means an empty page.
-  let restrictToUserIds: string[] | undefined;
-  if (paginationParams.seatType) {
-    restrictToUserIds = await resolveSeatTypeFilterUserIds({
-      workspace,
-      seatType: paginationParams.seatType,
-    });
-    if (restrictToUserIds.length === 0) {
-      return { members: [], total: 0 };
-    }
-  }
+  // When a seat-type filter is active, hand the matching seat types to the
+  // search index so pagination and the returned `total` reflect the filtered
+  // set. A base tier matches its monthly + yearly variants.
+  const seatTypes = paginationParams.seatType
+    ? expandSeatTypeFilter(paginationParams.seatType)
+    : undefined;
 
   const usersResult = await UserResource.searchUsers(auth, {
     searchTerm: paginationParams.search ?? "",
@@ -777,7 +756,7 @@ export async function getMembersUsage({
       field: paginationParams.orderColumn,
       direction: paginationParams.orderDirection,
     },
-    restrictToUserIds,
+    seatTypes,
   });
 
   if (usersResult.isErr()) {

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -370,13 +370,13 @@ export class UserResource extends BaseResource<UserModel> {
       offset,
       limit,
       orderBy,
-      restrictToUserIds,
+      seatTypes,
     }: {
       searchTerm: string;
       offset: number;
       limit: number;
       orderBy?: SearchUsersOrderBy;
-      restrictToUserIds?: string[];
+      seatTypes?: MembershipSeatType[];
     }
   ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
     const owner = auth.getNonNullableWorkspace();
@@ -388,7 +388,7 @@ export class UserResource extends BaseResource<UserModel> {
       offset,
       limit,
       orderBy,
-      userIds: restrictToUserIds,
+      seatTypes,
     });
     if (searchResult.isErr()) {
       return searchResult;

--- a/front/lib/user_search/search.ts
+++ b/front/lib/user_search/search.ts
@@ -1,5 +1,6 @@
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { USER_SEARCH_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
+import type { MembershipSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { UserSearchDocument } from "@app/types/user_search/user_search";
@@ -28,14 +29,19 @@ export async function searchUsers({
   offset,
   limit,
   orderBy,
-  userIds,
+  seatTypes,
 }: {
   owner: LightWorkspaceType;
   searchTerm: string;
   offset: number;
   limit: number;
   orderBy?: SearchUsersOrderBy;
-  userIds?: string[];
+  // Optional seat-type filter. The seat type is denormalized into the index
+  // (see `UserSearchDocument.seat_type`), so the filter is owned by
+  // Elasticsearch and the returned `total`/pagination reflect the filtered set.
+  // A base tier should be expanded to its variants (e.g. `pro` + `pro_yearly`)
+  // by the caller.
+  seatTypes?: MembershipSeatType[];
 }): Promise<Result<SearchUsersResult, ElasticsearchError>> {
   return withEs(async (client) => {
     // If searchTerm is empty or only whitespace, return all users from the workspace.
@@ -45,7 +51,7 @@ export async function searchUsers({
       bool: {
         filter: [
           { term: { workspace_id: owner.sId } },
-          ...(userIds ? [{ terms: { user_id: userIds } }] : []),
+          ...(seatTypes ? [{ terms: { seat_type: seatTypes } }] : []),
         ],
         ...(hasSearchTerm && {
           should: [


### PR DESCRIPTION
## Description

Final of three PRs moving the members-usage seat-type filter into Elasticsearch (after the schema/write-path change #27306 and the backfill #27307).

Switches the members-usage seat-type filter to query the denormalized `seat_type` field directly, removing the separate Postgres pre-fetch that resolved matching user sIds and handed them to ES as a `user_id` allowlist.

- `searchUsers` (ES layer) and `UserResource.searchUsers` now take a `seatTypes` filter (translated to a `terms` filter on `seat_type`) in place of the `userIds` / `restrictToUserIds` allowlist.
- `getMembersUsage` drops `resolveSeatTypeFilterUserIds` and instead expands the base seat-type filter to its variants (`pro` → `pro` + `pro_yearly`) and passes them to the search. Elasticsearch keeps owning search, sort, pagination and the returned `total`; a non-matching filter naturally yields an empty page.

This removes one round-trip per filtered request and avoids the unbounded `terms` allowlist the interim approach built for large workspaces.

## Tests

Existing `user_resource` search tests pass. Manually verify on the members usage page: filtering by each seat type returns the correct members with an accurate total and working pagination, and yearly seats match their base-tier filter.

## Deploy Plan

Deploy only after #27306 is live (mapping applied) and #27307 has backfilled existing documents — otherwise the filter would query a field that isn't populated yet.
