### PR TITLE
Skills: fix attachment when no sandbox is present

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -739,14 +739,12 @@ describe("PATCH /api/w/:wId/skills/:sId - Suggested skill activation", () => {
 });
 
 describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
-  it("should update file attachments when sandbox_tools is enabled", async () => {
+  it("should update file attachments", async () => {
     const { auth, workspace, skill, requestUser, requestUserAuth } =
       await setupTest({
         skillOwnerRole: "builder",
         requestUserRole: "builder",
       });
-
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     const file = await FileFactory.create(auth, requestUser, {
       contentType: "text/plain",
@@ -784,26 +782,6 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
     );
   });
 
-  it("should succeed without file attachments when sandbox_tools is not enabled", async () => {
-    const { workspace, skill } = await setupTest({
-      skillOwnerRole: "builder",
-      requestUserRole: "builder",
-    });
-
-    const response = await patchSkill(workspace, skill.sId, {
-      name: skill.name,
-      agentFacingDescription: "Updated description",
-      userFacingDescription: skill.userFacingDescription,
-      instructions: skill.instructions,
-      icon: null,
-      tools: [],
-      attachedKnowledge: [],
-      instructionsHtml: null,
-    });
-
-    expect(response.status).toBe(200);
-  });
-
   it("should succeed without file attachments", async () => {
     const { workspace, skill } = await setupTest({
       skillOwnerRole: "builder",
@@ -830,8 +808,6 @@ describe("PATCH /api/w/:wId/skills/:sId - file attachments", () => {
         skillOwnerRole: "builder",
         requestUserRole: "builder",
       });
-
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     const file = await FileFactory.create(auth, requestUser, {
       contentType: "text/plain",

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -6,7 +6,6 @@ import {
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -6,7 +6,6 @@ import type {
 } from "@app/lib/api/skills";
 import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
-import { getFeatureFlags } from "@app/lib/auth";
 import { pruneOutdatedSkillEditSuggestions } from "@app/lib/reinforcement/skill_suggestion_pruning";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -316,24 +315,9 @@ app.patch(
       ...additionalRequestedSpaceIds,
     ]);
 
-    const featureFlags = await getFeatureFlags(auth);
-
-    // Validate file attachments if provided (gated behind sandbox_tools).
+    // Validate file attachments if provided.
     let files: FileResource[] | undefined;
     if (fileAttachments) {
-      if (
-        !featureFlags.includes("sandbox_tools") &&
-        fileAttachments.length > 0
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "File attachments are not supported.",
-          },
-        });
-      }
-
       const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
       files = await FileResource.fetchByIds(auth, fileAttachmentIds);
       if (files.length !== fileAttachmentIds.length) {

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -5,7 +5,6 @@ import { discoverToolsSkill } from "@app/lib/resources/skill/code_defined/discov
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -971,10 +971,8 @@ describe("POST /api/w/:wId/skills", () => {
 });
 
 describe("POST /api/w/:wId/skills - file attachments", () => {
-  it("creates a skill with file attachments when sandbox_tools is enabled", async () => {
+  it("creates a skill with file attachments", async () => {
     const { auth, workspace, user } = await setupTest("builder");
-
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     const file1 = await FileFactory.create(auth, user, {
       contentType: "text/plain",
@@ -1020,37 +1018,7 @@ describe("POST /api/w/:wId/skills - file attachments", () => {
     expect(createdSkill!.toJSON(auth).fileAttachments).toHaveLength(2);
   });
 
-  it("rejects file attachments when sandbox_tools is not enabled", async () => {
-    const { auth, workspace, user } = await setupTest("admin");
-
-    const file = await FileFactory.create(auth, user, {
-      contentType: "text/plain",
-      fileName: "template.txt",
-      fileSize: 100,
-      status: "ready",
-      useCase: "skill_attachment",
-    });
-
-    const response = await postSkill(workspace, {
-      name: "Skill With Files",
-      agentFacingDescription: "A skill with file attachments",
-      userFacingDescription: "User description",
-      instructions: "Instructions",
-      icon: "PuzzleIcon",
-      tools: [],
-      extendedSkillId: null,
-      attachedKnowledge: [],
-      instructionsHtml: null,
-      fileAttachments: [{ fileId: file.sId }],
-    });
-
-    expect(response.status).toBe(403);
-    expect((await response.json()).error.message).toContain(
-      "File attachments are not supported"
-    );
-  });
-
-  it("succeeds without file attachments when sandbox_tools is not enabled", async () => {
+  it("succeeds without file attachments", async () => {
     const { workspace } = await setupTest("admin");
 
     const response = await postSkill(workspace, {
@@ -1071,8 +1039,6 @@ describe("POST /api/w/:wId/skills - file attachments", () => {
 
   it("rejects file attachments with wrong use case", async () => {
     const { auth, workspace, user } = await setupTest("admin");
-
-    await FeatureFlagFactory.basic(auth, "sandbox_tools");
 
     const file = await FileFactory.create(auth, user, {
       contentType: "text/plain",

--- a/front-api/routes/w/[wId]/skills/index.ts
+++ b/front-api/routes/w/[wId]/skills/index.ts
@@ -6,7 +6,6 @@ import type {
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { AttachedKnowledgeSchema } from "@app/lib/api/skills/schemas";
 import { resolveAdditionalRequestedSpaceModelIds } from "@app/lib/api/skills/space_requirements";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -342,24 +341,9 @@ app.post(
       });
     }
 
-    const featureFlags = await getFeatureFlags(auth);
-
-    // Validate file attachments if provided (gated behind sandbox_tools).
+    // Validate file attachments if provided.
     let files: FileResource[] | undefined;
     if (fileAttachments) {
-      if (
-        !featureFlags.includes("sandbox_tools") &&
-        fileAttachments.length > 0
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "invalid_request_error",
-            message: "File attachments are not supported.",
-          },
-        });
-      }
-
       const fileAttachmentIds = uniq(fileAttachments.map((f) => f.fileId));
       files = await FileResource.fetchByIds(auth, fileAttachmentIds);
       if (files.length !== fileAttachmentIds.length) {

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -232,7 +232,7 @@ export default function SkillBuilder({
           <SkillBuilderRequestedSpacesSection
             initialRequestedSpaceIds={skill?.requestedSpaceIds}
           />
-          {hasFeature("sandbox_tools") && <SkillBuilderFilesSection />}
+          <SkillBuilderFilesSection />
           <SkillBuilderSettingsOrComparisonFooter
             skill={skill}
             hasSelfImprovingSkills={hasSelfImprovingSkills}

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -8,7 +8,6 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSkills } from "@app/lib/swr/skill_configurations";
@@ -44,7 +43,6 @@ export function SkillInfoTab({
   showDescription = true,
 }: SkillInfoTabProps) {
   const [knowledgeItems, setKnowledgeItems] = useState<KnowledgeItem[]>([]);
-  const { hasFeature } = useFeatureFlags();
 
   const showDiscoverableSkills = skill.sId === "discover_skills";
 
@@ -101,7 +99,7 @@ export function SkillInfoTab({
   const showSeparator =
     !!skill.instructions ||
     knowledgeItems.length > 0 ||
-    (hasFeature("sandbox_tools") && skill.fileAttachments.length > 0) ||
+    skill.fileAttachments.length > 0 ||
     sortedMCPServerViews.length > 0 ||
     showChildSkills ||
     showDiscoverableSkills ||
@@ -148,7 +146,7 @@ export function SkillInfoTab({
           </div>
         </div>
       )}
-      {hasFeature("sandbox_tools") && skill.fileAttachments.length > 0 && (
+      {skill.fileAttachments.length > 0 && (
         <div className="flex flex-col gap-4">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Files

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -1,27 +1,22 @@
 import { ENABLE_SKILL_TOOL_NAME } from "@app/lib/actions/constants";
+import { isEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockEnableForAgent,
-  mockEnsureSandboxReady,
   mockFetchActiveByName,
-  mockGetFeatureFlags,
-  mockLoadSkillFiles,
+  mockGetFileAttachments,
+  mockLoadSkillFilesToConversation,
 } = vi.hoisted(() => ({
   mockEnableForAgent: vi.fn(),
-  mockEnsureSandboxReady: vi.fn(),
   mockFetchActiveByName: vi.fn(),
-  mockGetFeatureFlags: vi.fn(),
-  mockLoadSkillFiles: vi.fn(),
+  mockGetFileAttachments: vi.fn(),
+  mockLoadSkillFilesToConversation: vi.fn(),
 }));
 
-vi.mock("@app/lib/auth", () => ({
-  getFeatureFlags: mockGetFeatureFlags,
-}));
-
-vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
-  ensureSandboxReady: mockEnsureSandboxReady,
+vi.mock("@app/lib/api/skills/conversation_files", () => ({
+  loadSkillFilesToConversation: mockLoadSkillFilesToConversation,
 }));
 
 vi.mock("@app/lib/resources/skill/skill_resource", () => ({
@@ -38,7 +33,7 @@ describe("skill_management enable_skill tool", () => {
   const conversation = { sId: "conversation-id" };
   const skill = {
     enableForAgent: mockEnableForAgent,
-    getFileAttachments: () => [{ fileId: "file-id" }],
+    getFileAttachments: mockGetFileAttachments,
     name: "commit",
     sId: "skill-id",
   };
@@ -47,18 +42,12 @@ describe("skill_management enable_skill tool", () => {
     vi.clearAllMocks();
 
     mockFetchActiveByName.mockResolvedValue(skill);
-    mockEnableForAgent.mockResolvedValue(new Ok({ alreadyEnabled: false }));
-    mockGetFeatureFlags.mockResolvedValue(["sandbox_tools"]);
-    mockEnsureSandboxReady.mockResolvedValue(
+    mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: false });
+    mockGetFileAttachments.mockReturnValue([{ fileName: "SKILL.md" }]);
+    mockLoadSkillFilesToConversation.mockResolvedValue(
       new Ok({
-        sandbox: {
-          loadSkillFiles: mockLoadSkillFiles,
-        },
-        freshlyCreated: false,
+        loadedPaths: ["conversation-conversation-id/skills/commit/SKILL.md"],
       })
-    );
-    mockLoadSkillFiles.mockResolvedValue(
-      new Ok({ loadedPaths: ["/home/agent/.skills/commit/SKILL.md"] })
     );
   });
 
@@ -75,35 +64,65 @@ describe("skill_management enable_skill tool", () => {
     } as never;
   }
 
-  it("ensures the sandbox lifecycle has run before loading skill files", async () => {
+  function getTool() {
     const tool = TOOLS.find((tool) => tool.name === ENABLE_SKILL_TOOL_NAME);
     if (!tool) {
       throw new Error("enable_skill tool not found");
     }
+    return tool;
+  }
 
-    const result = await tool.handler({ skillName: "commit" }, makeExtra());
+  it("loads skill files into the conversation and surfaces their paths", async () => {
+    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
 
     expect(result.isOk()).toBe(true);
-    expect(mockEnsureSandboxReady).toHaveBeenCalledWith(auth, conversation);
-    expect(mockLoadSkillFiles).toHaveBeenCalledWith(auth, skill);
-    expect(mockEnsureSandboxReady.mock.invocationCallOrder[0]).toBeLessThan(
-      mockLoadSkillFiles.mock.invocationCallOrder[0]
-    );
+    expect(mockLoadSkillFilesToConversation).toHaveBeenCalledWith(auth, {
+      skill,
+      conversation,
+    });
+    if (result.isOk()) {
+      const [output] = result.value;
+      if (!isEnableSkillResultOutput(output)) {
+        throw new Error("Expected an enable_skill resource output");
+      }
+      expect(output.resource.text).toContain(
+        "conversation-conversation-id/skills/commit/SKILL.md"
+      );
+    }
   });
 
-  it("surfaces sandbox lifecycle errors", async () => {
-    mockEnsureSandboxReady.mockResolvedValue(
-      new Err(new Error("sandbox setup failed"))
+  it("skips file loading when the skill has no attachments", async () => {
+    mockGetFileAttachments.mockReturnValue([]);
+
+    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+
+    expect(result.isOk()).toBe(true);
+    expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
+  });
+
+  it("reports file load failures without failing the tool", async () => {
+    mockLoadSkillFilesToConversation.mockResolvedValue(
+      new Err(new Error("GCS copy failed"))
     );
 
-    const tool = TOOLS.find((tool) => tool.name === ENABLE_SKILL_TOOL_NAME);
-    if (!tool) {
-      throw new Error("enable_skill tool not found");
+    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [output] = result.value;
+      if (!isEnableSkillResultOutput(output)) {
+        throw new Error("Expected an enable_skill resource output");
+      }
+      expect(output.resource.text).toContain("Failed to load skill files");
     }
+  });
 
-    const result = await tool.handler({ skillName: "commit" }, makeExtra());
+  it("does not load files when the skill was already enabled", async () => {
+    mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: true });
 
-    expect(result.isErr()).toBe(true);
-    expect(mockLoadSkillFiles).not.toHaveBeenCalled();
+    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+
+    expect(result.isOk()).toBe(true);
+    expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -73,7 +73,10 @@ describe("skill_management enable_skill tool", () => {
   }
 
   it("loads skill files into the conversation and surfaces their paths", async () => {
-    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
 
     expect(result.isOk()).toBe(true);
     expect(mockLoadSkillFilesToConversation).toHaveBeenCalledWith(auth, {
@@ -94,7 +97,10 @@ describe("skill_management enable_skill tool", () => {
   it("skips file loading when the skill has no attachments", async () => {
     mockGetFileAttachments.mockReturnValue([]);
 
-    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
 
     expect(result.isOk()).toBe(true);
     expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
@@ -105,7 +111,10 @@ describe("skill_management enable_skill tool", () => {
       new Err(new Error("GCS copy failed"))
     );
 
-    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -120,7 +129,10 @@ describe("skill_management enable_skill tool", () => {
   it("does not load files when the skill was already enabled", async () => {
     mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: true });
 
-    const result = await getTool().handler({ skillName: "commit" }, makeExtra());
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
 
     expect(result.isOk()).toBe(true);
     expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -4,8 +4,7 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/skill_management/metadata";
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
-import { ensureSandboxReady } from "@app/lib/api/sandbox/lifecycle";
-import { getFeatureFlags } from "@app/lib/auth";
+import { loadSkillFilesToConversation } from "@app/lib/api/skills/conversation_files";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -43,36 +42,22 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       ]);
     }
 
-    const featureFlags = await getFeatureFlags(auth);
-    // Load skill file attachments to the sandbox (behind feature flag).
-    if (
-      !featureFlags.includes("sandbox_tools") ||
-      skill.getFileAttachments().length === 0
-    ) {
-      const text = `Skill "${skill.name}" has been enabled.`;
-
-      return new Ok([
-        makeEnableSkillResultOutput({ skillId: skill.sId, text }),
-      ]);
-    }
-
-    const ensureResult = await ensureSandboxReady(auth, conversation);
-    if (ensureResult.isErr()) {
-      return new Err(new MCPError(ensureResult.error.message));
-    }
-
-    const { sandbox } = ensureResult.value;
-
+    // Copy the skill's file attachments into the conversation GCS mount so they are visible to
+    // both the files tools and the sandbox (when one exists).
     let fileMessage: string | null = null;
-    const fileLoadResult = await sandbox.loadSkillFiles(auth, skill);
+    if (skill.getFileAttachments().length > 0) {
+      const fileLoadResult = await loadSkillFilesToConversation(auth, {
+        skill,
+        conversation,
+      });
 
-    // We don't say anything if there are no files to load.
-    if (fileLoadResult.isOk() && fileLoadResult.value.loadedPaths.length > 0) {
-      fileMessage =
-        "Skill files successfully loaded:\n" +
-        fileLoadResult.value.loadedPaths.map((p) => `  - ${p}`).join("\n");
-    } else if (fileLoadResult.isErr()) {
-      fileMessage = `Failed to load skill files: ${fileLoadResult.error.message}`;
+      if (fileLoadResult.isOk()) {
+        fileMessage =
+          "Skill files successfully loaded:\n" +
+          fileLoadResult.value.loadedPaths.map((p) => `  - ${p}`).join("\n");
+      } else {
+        fileMessage = `Failed to load skill files: ${fileLoadResult.error.message}`;
+      }
     }
 
     const text =

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -42,7 +42,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       ]);
     }
 
-    // Copy the skill's file attachments into the conversation GCS mount so they are visible to
+    // Copy the skill's file attachments into the conversation file system so they are visible to
     // both the files tools and the sandbox (when one exists).
     let fileMessage: string | null = null;
     if (skill.getFileAttachments().length > 0) {

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -1,5 +1,4 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -38,12 +37,18 @@ export async function loadSkillFilesToConversation(
   }
   const fileSystem = fsResult.value;
 
+  const conversationMount = fileSystem
+    .getMounts()
+    .find((m) => m.kind === "conversation" && m.id === conversation.sId);
+  // `forConversation` always creates the conversation mount.
+  if (!conversationMount) {
+    throw new Error("Conversation mount not found.");
+  }
+
   const loadedPaths: string[] = [];
 
   for (const file of fileAttachments) {
-    const scopedPath =
-      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/` +
-      `skills/${skill.name}/${file.fileName}`;
+    const scopedPath = `${conversationMount.scopedPrefix}/skills/${skill.name}/${file.fileName}`;
 
     const writeResult = await fileSystem.write(
       scopedPath,

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -1,0 +1,64 @@
+import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
+import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Copy a skill's file attachments into the conversation's GCS file mount under
+ * `skills/{skillName}/{fileName}` (skill names are unique per workspace).
+ *
+ * Writing to the conversation GCS mount (rather than the sandbox filesystem) makes the files
+ * visible everywhere the conversation files are: the `files__*` tools, the sandbox gcsfuse mount
+ * (`/files/conversation-{cId}/skills/...`), the conversation files panel, and conversation
+ * branching copies. The copy is a server-side GCS copy (attachments and conversation files live
+ * in the same private bucket) and is idempotent: re-enabling a skill overwrites the same paths.
+ *
+ * Returns the canonical scoped paths (`conversation-{cId}/skills/...`) of the loaded files, as
+ * surfaced by the `files__list` tool.
+ */
+export async function loadSkillFilesToConversation(
+  auth: Authenticator,
+  {
+    skill,
+    conversation,
+  }: {
+    skill: SkillResource;
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<Result<{ loadedPaths: string[] }, Error>> {
+  const fileAttachments = skill.getFileAttachments();
+  if (fileAttachments.length === 0) {
+    return new Ok({ loadedPaths: [] });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const basePath = getConversationFilesBasePath({
+    workspaceId: owner.sId,
+    conversationId: conversation.sId,
+  });
+  const skillFolder = `skills/${skill.name}`;
+
+  const bucket = getPrivateUploadBucket();
+  const loadedPaths: string[] = [];
+
+  for (const file of fileAttachments) {
+    const sourcePath = file.getCloudStoragePath(auth, "original");
+    const destPath = `${basePath}${skillFolder}/${file.fileName}`;
+
+    try {
+      await bucket.copyFile(sourcePath, destPath);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+
+    loadedPaths.push(
+      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${skillFolder}/${file.fileName}`
+    );
+  }
+
+  return new Ok({ loadedPaths });
+}

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -1,21 +1,20 @@
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
-import { getConversationFilesBasePath } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import streamConsumers from "stream/consumers";
 
 /**
- * Copy a skill's file attachments into the conversation's GCS file mount under
+ * Copy a skill's file attachments into the conversation's file system under
  * `skills/{skillName}/{fileName}` (skill names are unique per workspace).
  *
- * Writing to the conversation GCS mount (rather than the sandbox filesystem) makes the files
- * visible everywhere the conversation files are: the `files__*` tools, the sandbox gcsfuse mount
+ * Writing through DustFileSystem (rather than the sandbox filesystem) makes the files visible
+ * everywhere the conversation files are: the `files__*` tools, the sandbox gcsfuse mount
  * (`/files/conversation-{cId}/skills/...`), the conversation files panel, and conversation
- * branching copies. The copy is a server-side GCS copy (attachments and conversation files live
- * in the same private bucket) and is idempotent: re-enabling a skill overwrites the same paths.
+ * branching copies. The write is idempotent: re-enabling a skill overwrites the same paths.
  *
  * Returns the canonical scoped paths (`conversation-{cId}/skills/...`) of the loaded files, as
  * surfaced by the `files__list` tool.
@@ -35,29 +34,38 @@ export async function loadSkillFilesToConversation(
     return new Ok({ loadedPaths: [] });
   }
 
-  const owner = auth.getNonNullableWorkspace();
-  const basePath = getConversationFilesBasePath({
-    workspaceId: owner.sId,
-    conversationId: conversation.sId,
-  });
-  const skillFolder = `skills/${skill.name}`;
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+  const fileSystem = fsResult.value;
 
-  const bucket = getPrivateUploadBucket();
   const loadedPaths: string[] = [];
 
   for (const file of fileAttachments) {
-    const sourcePath = file.getCloudStoragePath(auth, "original");
-    const destPath = `${basePath}${skillFolder}/${file.fileName}`;
+    const scopedPath =
+      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/` +
+      `skills/${skill.name}/${file.fileName}`;
 
+    let content: Buffer;
     try {
-      await bucket.copyFile(sourcePath, destPath);
+      content = await streamConsumers.buffer(
+        file.getReadStream({ auth, version: "original" })
+      );
     } catch (err) {
       return new Err(normalizeError(err));
     }
 
-    loadedPaths.push(
-      `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${skillFolder}/${file.fileName}`
+    const writeResult = await fileSystem.write(
+      scopedPath,
+      content,
+      file.contentType
     );
+    if (writeResult.isErr()) {
+      return writeResult;
+    }
+
+    loadedPaths.push(scopedPath);
   }
 
   return new Ok({ loadedPaths });

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -3,9 +3,7 @@ import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
 import type { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { Err, Ok, type Result } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import streamConsumers from "stream/consumers";
+import { Ok, type Result } from "@app/types/shared/result";
 
 /**
  * Copy a skill's file attachments into the conversation's file system under
@@ -47,18 +45,9 @@ export async function loadSkillFilesToConversation(
       `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/` +
       `skills/${skill.name}/${file.fileName}`;
 
-    let content: Buffer;
-    try {
-      content = await streamConsumers.buffer(
-        file.getReadStream({ auth, version: "original" })
-      );
-    } catch (err) {
-      return new Err(normalizeError(err));
-    }
-
     const writeResult = await fileSystem.write(
       scopedPath,
-      content,
+      file.getReadStream({ auth, version: "original" }),
       file.contentType
     );
     if (writeResult.isErr()) {

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -7,7 +7,7 @@ import {
 } from "@app/lib/api/skills/detection/zip/detect_skills";
 import type { ZipDetectedSkill } from "@app/lib/api/skills/detection/zip/types";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -68,8 +68,6 @@ export async function importSkillsFromFiles(
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const allSkills: ZipDetectedSkill[] = [];
-  const featureFlags = await getFeatureFlags(auth);
-  const allowFileAttachments = featureFlags.includes("sandbox_tools");
 
   // Readers are keyed by skill to avoid re-opening the same zip for each
   // attachment. Each zip buffer produces one reader shared across its skills.
@@ -88,23 +86,16 @@ export async function importSkillsFromFiles(
       return new Err(new Error(detectResult.error.message));
     }
 
-    let reader:
-      | ((originalEntryName: string) => Result<Buffer, Error>)
-      | undefined;
-    if (allowFileAttachments) {
-      const readerResult = createZipAttachmentReader(buffer);
-      if (readerResult.isErr()) {
-        await cleanupTempFiles(uploadedFiles);
-        return new Err(readerResult.error);
-      }
-      reader = readerResult.value;
+    const readerResult = createZipAttachmentReader(buffer);
+    if (readerResult.isErr()) {
+      await cleanupTempFiles(uploadedFiles);
+      return new Err(readerResult.error);
     }
+    const reader = readerResult.value;
 
     for (const skill of detectResult.value) {
       allSkills.push(skill);
-      if (reader) {
-        readerBySkill.set(skill, reader);
-      }
+      readerBySkill.set(skill, reader);
     }
   }
 
@@ -153,32 +144,29 @@ export async function importSkillsFromFiles(
       continue;
     }
 
-    let fileAttachments: FileResource[] = [];
-    if (allowFileAttachments) {
-      const readEntry = readerBySkill.get(skill);
-      if (!readEntry) {
-        skipped.push({
-          name: skill.name,
-          message: "Internal error: no zip reader for skill.",
-        });
-        continue;
-      }
-
-      const skillDirPath = path.dirname(skill.skillMdPath);
-      const uploadResults = await concurrentExecutor(
-        skill.attachments,
-        (attachment) =>
-          uploadAttachment(auth, {
-            originalEntryName: attachment.originalEntryName,
-            contentType: attachment.contentType,
-            fileName: path.relative(skillDirPath, attachment.path),
-            readEntry,
-          }),
-        { concurrency: FILE_IMPORT_CONCURRENCY }
-      );
-
-      fileAttachments = removeNulls(uploadResults);
+    const readEntry = readerBySkill.get(skill);
+    if (!readEntry) {
+      skipped.push({
+        name: skill.name,
+        message: "Internal error: no zip reader for skill.",
+      });
+      continue;
     }
+
+    const skillDirPath = path.dirname(skill.skillMdPath);
+    const uploadResults = await concurrentExecutor(
+      skill.attachments,
+      (attachment) =>
+        uploadAttachment(auth, {
+          originalEntryName: attachment.originalEntryName,
+          contentType: attachment.contentType,
+          fileName: path.relative(skillDirPath, attachment.path),
+          readEntry,
+        }),
+      { concurrency: FILE_IMPORT_CONCURRENCY }
+    );
+
+    const fileAttachments = removeNulls(uploadResults);
 
     if (existing) {
       const attachedKnowledge = await existing.getAttachedKnowledge(auth);
@@ -193,16 +181,14 @@ export async function importSkillsFromFiles(
         mcpServerViews: existing.mcpServerViews,
         attachedKnowledge,
         requestedSpaceIds: existing.requestedSpaceIds,
-        ...(allowFileAttachments ? { fileAttachments } : {}),
+        fileAttachments,
         source,
         sourceMetadata: { filePath: skill.skillMdPath },
       });
 
-      if (allowFileAttachments) {
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: existing.sId,
-        });
-      }
+      await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+        skillId: existing.sId,
+      });
 
       updated.push(existing);
     } else {
@@ -245,16 +231,14 @@ export async function importSkillsFromFiles(
         },
         {
           mcpServerViews: suggestedMCPServerViews,
-          ...(allowFileAttachments ? { fileAttachments } : {}),
+          fileAttachments,
           addCurrentUserAsEditor: auth.user() !== null,
         }
       );
 
-      if (allowFileAttachments) {
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: skillResource.sId,
-        });
-      }
+      await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+        skillId: skillResource.sId,
+      });
 
       imported.push(skillResource);
     }

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -15,7 +15,7 @@ import type {
 import { suggestMCPServersForDetectedSkill } from "@app/lib/api/skills/detection/suggest_mcp_servers";
 import { validateSkillsForImport } from "@app/lib/api/skills/detection/validate_skills";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
-import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -68,8 +68,6 @@ export async function importSkillsFromGitHub(
     onConflict?: "error" | "skip";
   }
 ): Promise<Result<ImportSkillsResult, GitHubSkillDetectionError>> {
-  const featureFlags = await getFeatureFlags(auth);
-  const allowFileAttachments = featureFlags.includes("sandbox_tools");
   const accessToken = await getWorkspaceLevelGitHubAccessToken(auth);
   const clientResult = initGitHubRepoClient({ repoUrl, accessToken });
   if (clientResult.isErr()) {
@@ -133,24 +131,21 @@ export async function importSkillsFromGitHub(
       continue;
     }
 
-    let fileAttachments: FileResource[] = [];
-    if (allowFileAttachments) {
-      const skillDirPath = path.dirname(skill.skillMdPath);
-      const uploadResults = await concurrentExecutor(
-        skill.attachments,
-        (attachment) =>
-          uploadAttachment(auth, {
-            octokit,
-            owner,
-            repo,
-            attachment,
-            skillDirPath,
-          }),
-        { concurrency: FILE_IMPORT_CONCURRENCY }
-      );
+    const skillDirPath = path.dirname(skill.skillMdPath);
+    const uploadResults = await concurrentExecutor(
+      skill.attachments,
+      (attachment) =>
+        uploadAttachment(auth, {
+          octokit,
+          owner,
+          repo,
+          attachment,
+          skillDirPath,
+        }),
+      { concurrency: FILE_IMPORT_CONCURRENCY }
+    );
 
-      fileAttachments = removeNulls(uploadResults);
-    }
+    const fileAttachments = removeNulls(uploadResults);
 
     if (existing) {
       const attachedKnowledge = await existing.getAttachedKnowledge(auth);
@@ -164,7 +159,7 @@ export async function importSkillsFromGitHub(
         mcpServerViews: existing.mcpServerViews,
         attachedKnowledge,
         requestedSpaceIds: existing.requestedSpaceIds,
-        ...(allowFileAttachments ? { fileAttachments } : {}),
+        fileAttachments,
         source: "github",
         sourceMetadata: {
           repoUrl,
@@ -172,11 +167,9 @@ export async function importSkillsFromGitHub(
         },
       });
 
-      if (allowFileAttachments) {
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: existing.sId,
-        });
-      }
+      await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+        skillId: existing.sId,
+      });
 
       updated.push(existing);
     } else {
@@ -222,15 +215,13 @@ export async function importSkillsFromGitHub(
         },
         {
           mcpServerViews: detectedMCPServerViews,
-          ...(allowFileAttachments ? { fileAttachments } : {}),
+          fileAttachments,
         }
       );
 
-      if (allowFileAttachments) {
-        await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
-          skillId: skillResource.sId,
-        });
-      }
+      await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
+        skillId: skillResource.sId,
+      });
 
       imported.push(skillResource);
     }

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -20,7 +20,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -38,7 +37,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { Op } from "sequelize";
-import streamConsumers from "stream/consumers";
 
 interface EnsureSandboxResult {
   freshlyCreated: boolean;
@@ -1040,38 +1038,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     }
 
     return result;
-  }
-
-  /**
-   * Load a skill's file attachments onto this sandbox.
-   * Files are written under /skills/{skillName}/{fileName}.
-   */
-  async loadSkillFiles(
-    auth: Authenticator,
-    skill: SkillResource
-  ): Promise<Result<{ loadedPaths: string[] }, Error>> {
-    const fileAttachments = skill.getFileAttachments();
-    if (fileAttachments.length === 0) {
-      return new Ok({ loadedPaths: [] });
-    }
-
-    const loadedPaths: string[] = [];
-
-    for (const file of fileAttachments) {
-      const targetPath = `/skills/${skill.name}/${file.fileName}`;
-
-      const readStream = file.getReadStream({ auth, version: "original" });
-      const data = await streamConsumers.arrayBuffer(readStream);
-
-      const writeResult = await this.writeFile(auth, targetPath, data);
-      if (writeResult.isErr()) {
-        return writeResult;
-      }
-
-      loadedPaths.push(targetPath);
-    }
-
-    return new Ok({ loadedPaths });
   }
 
   toLogJSON() {


### PR DESCRIPTION
## Description

- Copy files to the conversation bucket instead of solely copy them to the sandbox so that they are accessible to the files tools as well.
- Ungate the capabilty (was previously gated by sandbox tools which is broadly

<img width="575" height="159" alt="Screenshot 2026-06-12 at 14 36 02" src="https://github.com/user-attachments/assets/26748aff-743f-4600-a20a-3032306f6217" />
<img width="567" height="423" alt="Screenshot 2026-06-12 at 14 36 10" src="https://github.com/user-attachments/assets/3c877591-d7f9-4db4-b55d-a0d11dc44b97" />


## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`