### PR TITLE
[front] DustFileSystem: accept Readable in write for streamed uploads

### DIFF
--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -59,9 +59,13 @@ export interface FileSystemBackend {
    */
   exists(scopedPath: string): Promise<Result<boolean, DustFileSystemError>>;
 
+  /**
+   * When `content` is a `Readable`, the data is streamed to storage without buffering it in
+   * memory; the stream is consumed (or destroyed on error) by the backend.
+   */
   write(
     scopedPath: string,
-    content: Buffer | string,
+    content: Buffer | string | Readable,
     contentType: string
   ): Promise<Result<void, DustFileSystemError>>;
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -20,6 +20,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
 import type { Readable } from "stream";
+import { pipeline } from "stream/promises";
 
 import type { FileSystemBackend } from "./file_system_backend";
 
@@ -343,7 +344,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
   async write(
     scopedPath: string,
-    content: Buffer | string,
+    content: Buffer | string | Readable,
     contentType: string
   ): Promise<Result<void, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
@@ -357,8 +358,17 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
 
     try {
-      const buf = isString(content) ? Buffer.from(content) : content;
-      await getPrivateUploadBucket().file(gcsPath).save(buf, { contentType });
+      const file = getPrivateUploadBucket().file(gcsPath);
+
+      if (isString(content) || Buffer.isBuffer(content)) {
+        const buf = isString(content) ? Buffer.from(content) : content;
+        await file.save(buf, { contentType });
+      } else {
+        await pipeline(
+          content,
+          file.createWriteStream({ contentType, resumable: false })
+        );
+      }
 
       return new Ok(undefined);
     } catch (err) {

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -689,9 +689,13 @@ export class DustFileSystem {
     return this.backend.exists(resolved.value.path);
   }
 
+  /**
+   * When `content` is a `Readable`, the data is streamed to storage without buffering it in
+   * memory; the stream is consumed (or destroyed on error) by the backend.
+   */
   async write(
     scopedPath: string,
-    content: Buffer | string,
+    content: Buffer | string | Readable,
     contentType: string
   ): Promise<Result<void, DustFileSystemError>> {
     const resolved = this.requireWriteMount(scopedPath);


### PR DESCRIPTION
## Description

`DustFileSystem.write` (and the underlying `FileSystemBackend` interface / GCS implementation) only accepted `Buffer | string`, forcing callers with stream sources to buffer the full content in memory. This adds `Readable` to the accepted content types: the GCS backend pipes the stream into `createWriteStream` via `stream/promises.pipeline`, which destroys both streams on error. Buffer/string behavior is unchanged.

## Tests

Existing functional tests for `dust_file_system` and `gcs_file_system_backend` pass (92 tests). N/A otherwise, tested locally.

## Risk

Low. Additive signature change; existing callers are unaffected.

## Deploy Plan

- deploy `front`

🤖 Generated with [Claude Code](https://claude.com/claude-code)