### PR TITLE
Show workspace branding on public shared frames

### DIFF
--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -2,6 +2,7 @@ import config from "@app/lib/api/config";
 import type { GetShareFrameMetadataResponseBody } from "@app/lib/api/files/share";
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { lookupShareToken } from "@app/lib/api/regions/lookup";
+import { getWorkspaceBrandingPublicUrls } from "@app/lib/api/workspace_branding";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -112,7 +113,12 @@ app.get(
       : false;
     const requiresEmailVerification = isEmailScope && hasActiveGrants;
 
+    const { faviconUrl, logoUrl } =
+      await getWorkspaceBrandingPublicUrls(workspace);
+
     return ctx.json({
+      faviconUrl,
+      logoUrl,
       requiresEmailVerification,
       shareUrl,
       title: file.fileName,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -14,6 +14,7 @@ interface PublicFrameRendererProps {
   fileId: string;
   fileName?: string;
   hideHeader?: boolean;
+  logoUrl?: string | null;
   shareToken: string;
   workspaceId: string;
   vizUrl: string;
@@ -23,6 +24,7 @@ export function PublicFrameRenderer({
   fileId,
   fileName,
   hideHeader = false,
+  logoUrl,
   shareToken,
   workspaceId,
   vizUrl,
@@ -66,6 +68,7 @@ export function PublicFrameRenderer({
           user={user}
           conversationUrl={conversationUrl}
           projectUrl={projectUrl}
+          logoUrl={logoUrl}
         />
       )}
 

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -10,6 +10,7 @@ interface PublicInteractiveContentContainerProps {
   shareToken: string;
   workspaceId: string;
   vizUrl: string;
+  logoUrl?: string | null;
   hideHeader?: boolean;
 }
 
@@ -21,6 +22,7 @@ export function PublicInteractiveContentContainer({
   shareToken,
   workspaceId,
   vizUrl,
+  logoUrl,
   hideHeader = false,
 }: PublicInteractiveContentContainerProps) {
   const { frameMetadata, isFrameLoading, error } = usePublicFrame({
@@ -51,6 +53,7 @@ export function PublicInteractiveContentContainer({
             shareToken={shareToken}
             workspaceId={workspaceId}
             vizUrl={vizUrl}
+            logoUrl={logoUrl}
             hideHeader={hideHeader}
           />
         );

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
@@ -17,6 +17,7 @@ interface PublicInteractiveContentHeaderProps {
   user: UserTypeWithWorkspaces | null;
   conversationUrl: string | null;
   projectUrl: string | null;
+  logoUrl?: string | null;
 }
 
 const UTM_PARAM = `utm_source=public-frames`;
@@ -30,17 +31,26 @@ export function PublicInteractiveContentHeader({
   user,
   conversationUrl,
   projectUrl,
+  logoUrl,
 }: PublicInteractiveContentHeaderProps) {
   const staticWebsiteUrl = config.getStaticWebsiteUrl();
   return (
     <AppLayoutTitle className="h-12 bg-gray-50 px-4 @container dark:bg-gray-900">
       <div className="flex h-full min-w-0 max-w-full items-center">
         <div className="grow-1 flex shrink-0 basis-12 items-center md:basis-60">
-          <LinkWrapper
-            href={`${staticWebsiteUrl}/home${user ? "" : `?${UTM_PARAM}`}`}
-          >
-            <DustLogo className="h-[20px] w-[80px]" />
-          </LinkWrapper>
+          {logoUrl ? (
+            <img
+              src={logoUrl}
+              alt="Workspace logo"
+              className="h-[32px] max-w-[120px] object-contain"
+            />
+          ) : (
+            <LinkWrapper
+              href={`${staticWebsiteUrl}/home${user ? "" : `?${UTM_PARAM}`}`}
+            >
+              <DustLogo className="h-[20px] w-[80px]" />
+            </LinkWrapper>
+          )}
         </div>
 
         <div className="flex flex-1 justify-center">

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -78,7 +78,7 @@ export function SharedFramePage() {
     }
 
     const description = `Discover what ${shareMetadata.workspaceName} built with AI. Explore now.`;
-    const faviconPath = getFaviconPath();
+    const faviconPath = shareMetadata.faviconUrl ?? getFaviconPath();
     const elements: HTMLElement[] = [];
 
     const addMeta = (attrs: Record<string, string>) => {
@@ -168,6 +168,7 @@ export function SharedFramePage() {
         shareToken={token}
         workspaceId={shareMetadata.workspaceId}
         vizUrl={shareMetadata.vizUrl}
+        logoUrl={shareMetadata.logoUrl}
         hideHeader={hideHeader}
       />
     </div>

--- a/front/components/workspace/settings/BrandingSection.tsx
+++ b/front/components/workspace/settings/BrandingSection.tsx
@@ -107,7 +107,7 @@ function BrandingAssetUploader({
 
       <input
         ref={fileInputRef}
-        accept=".jpg,.jpeg,.png,.svg,.webp"
+        accept=".jpg,.jpeg,.png,.svg,.webp,.ico"
         className="hidden"
         onChange={handleFileChange}
         type="file"
@@ -141,7 +141,11 @@ function BrandingAssetUploader({
         </div>
       ) : (
         <EmptyCTA
-          message="SVG, PNG or WebP - Transparent background"
+          message={
+            asset === "favicon"
+              ? "SVG, PNG, WebP or ICO — Square format"
+              : "SVG, PNG or WebP — Transparent background"
+          }
           action={
             busy ? (
               <Spinner size="md" />

--- a/front/lib/api/files/processing/index.ts
+++ b/front/lib/api/files/processing/index.ts
@@ -222,9 +222,13 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
   ["image/gif", { process: processImage, processedContentType: "image/gif" }],
   ["image/webp", { process: processImage, processedContentType: "image/webp" }],
   ["image/bmp", { process: processImage, processedContentType: "image/bmp" }],
-  // SVG: rasterized to PNG to ensure consistent rendering across clients.
+  // SVG/ICO: rasterized to PNG to ensure consistent rendering across clients.
   [
     "image/svg+xml",
+    { process: processImage, processedContentType: "image/png" },
+  ],
+  [
+    "image/x-icon",
     { process: processImage, processedContentType: "image/png" },
   ],
 

--- a/front/lib/api/files/share.ts
+++ b/front/lib/api/files/share.ts
@@ -1,4 +1,6 @@
 export interface GetShareFrameMetadataResponseBody {
+  faviconUrl: string | null;
+  logoUrl: string | null;
   requiresEmailVerification: boolean;
   shareUrl: string;
   title: string;

--- a/front/lib/api/files/use_cases/workspace_branding.ts
+++ b/front/lib/api/files/use_cases/workspace_branding.ts
@@ -1,11 +1,12 @@
 import type { AllSupportedFileContentType } from "@app/types/files";
 
-// SVG is accepted but rasterized to PNG during processing to neutralize XSS risk.
+// SVG and ICO are accepted but rasterized to PNG during processing.
 const SUPPORTED_CONTENT_TYPES: Set<AllSupportedFileContentType> = new Set([
   "image/jpeg",
   "image/png",
   "image/svg+xml",
   "image/webp",
+  "image/x-icon",
 ]);
 
 export function isSupportedForWorkspaceBranding(

--- a/front/lib/api/workspace_branding.ts
+++ b/front/lib/api/workspace_branding.ts
@@ -9,10 +9,13 @@
  * Keys are extensionless; content type lives in GCS object metadata.
  */
 
+import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import type { FileResource } from "@app/lib/resources/file_resource";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -77,6 +80,45 @@ export async function getBrandingAssetState(
 
     return new Err(normalizeError(err));
   }
+}
+
+function buildBrandingAssetPublicUrl(
+  workspace: WorkspaceResource,
+  asset: UserUploadableBrandingAssetName,
+  { version }: { version: string }
+): string {
+  return `${config.getApiBaseUrl()}/api/v1/public/branding/${workspace.sId}/${asset}?v=${version}`;
+}
+
+export async function getWorkspaceBrandingPublicUrls(
+  workspace: WorkspaceResource
+): Promise<{ faviconUrl: string | null; logoUrl: string | null }> {
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
+  if (!subscription?.getPlan().isBrandedFramesAllowed) {
+    return { faviconUrl: null, logoUrl: null };
+  }
+
+  const [logoState, faviconState] = await Promise.all([
+    getBrandingAssetState({ wId: workspace.sId }, "logo"),
+    getBrandingAssetState({ wId: workspace.sId }, "favicon"),
+  ]);
+
+  return {
+    faviconUrl:
+      faviconState.isOk() && faviconState.value
+        ? buildBrandingAssetPublicUrl(workspace, "favicon", {
+            version: faviconState.value.version,
+          })
+        : null,
+    logoUrl:
+      logoState.isOk() && logoState.value
+        ? buildBrandingAssetPublicUrl(workspace, "logo", {
+            version: logoState.value.version,
+          })
+        : null,
+  };
 }
 
 export async function promoteBrandingAsset(

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -419,6 +419,12 @@ export const FILE_FORMATS = {
   "image/webp": { cat: "image", exts: [".webp"], isSafeToDisplay: true },
   "image/svg+xml": { cat: "image", exts: [".svg"], isSafeToDisplay: false },
   "image/bmp": { cat: "image", exts: [".bmp"], isSafeToDisplay: true },
+  "image/x-icon": {
+    cat: "image",
+    exts: [".ico"],
+    isSafeToDisplay: true,
+    allowedFileUploadUseCases: ["workspace_branding"],
+  },
 
   // Structured.
   "text/csv": { cat: "delimited", exts: [".csv"], isSafeToDisplay: true },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -225,6 +225,7 @@ export const supportedImageFileFormats = {
   "image/webp": [".webp"],
   "image/svg+xml": [".svg"],
   "image/bmp": [".bmp"],
+  "image/x-icon": [".ico"],
 } as const;
 
 export const supportedAudioFileFormats = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a workspace has branded Frames enabled and has uploaded a logo or favicon, these now appear on the public frame view. The workspace logo replaces the Dust logo in the frame header, and the workspace favicon replaces the Dust favicon in the browser tab. Non-entitled workspaces or those without custom assets fall back to the Dust defaults silently.

The share metadata endpoint now resolves both branding URLs at request time, including a version token for cache-busting. This means the browser can cache the asset aggressively. Same version token always returns the same bytes, while still picking up new uploads after a page refresh.

ICO files are now accepted as a branding upload format and rasterized to PNG during processing, consistent with how SVG is handled. This is particularly useful for favicon uploads where .ico is the native format.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
