### PR TITLE
fix(gmail): retry get_attachment with fresh attachment ID on expired token

### DIFF
--- a/front/lib/api/actions/servers/gmail/helpers.test.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.test.ts
@@ -1,0 +1,67 @@
+import type { GmailMessagePayload } from "@app/lib/api/actions/servers/gmail/helpers";
+import {
+  findAttachmentData,
+  findAttachmentIdByPartId,
+} from "@app/lib/api/actions/servers/gmail/helpers";
+import { describe, expect, it } from "vitest";
+
+const payload: GmailMessagePayload = {
+  partId: "",
+  mimeType: "multipart/mixed",
+  parts: [
+    {
+      partId: "0",
+      mimeType: "multipart/alternative",
+      parts: [
+        {
+          partId: "0.0",
+          mimeType: "text/plain",
+          body: { data: "aGVsbG8=", size: 5 },
+        },
+        {
+          partId: "0.1",
+          mimeType: "text/html",
+          body: { data: "PGI+aGk8L2I+", size: 12 },
+        },
+      ],
+    },
+    {
+      partId: "1",
+      mimeType: "text/csv",
+      filename: "export.csv",
+      body: { attachmentId: "fresh-attachment-id", size: 17000 },
+    },
+  ],
+};
+
+describe("findAttachmentIdByPartId", () => {
+  it("returns the attachment ID of the part matching partId", () => {
+    expect(findAttachmentIdByPartId(payload, "1")).toBe("fresh-attachment-id");
+  });
+
+  it("returns null when the matching part has no attachment ID", () => {
+    expect(findAttachmentIdByPartId(payload, "0.0")).toBeNull();
+  });
+
+  it("returns null when no part matches partId", () => {
+    expect(findAttachmentIdByPartId(payload, "42")).toBeNull();
+  });
+
+  it("returns null when the payload is undefined", () => {
+    expect(findAttachmentIdByPartId(undefined, "1")).toBeNull();
+  });
+});
+
+describe("findAttachmentData", () => {
+  it("returns the inline data of a nested part matching partId", () => {
+    expect(findAttachmentData(payload, "0.1")).toBe("PGI+aGk8L2I+");
+  });
+
+  it("returns null when the matching part has no inline data", () => {
+    expect(findAttachmentData(payload, "1")).toBeNull();
+  });
+
+  it("returns null when no part matches partId", () => {
+    expect(findAttachmentData(payload, "42")).toBeNull();
+  });
+});

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -141,20 +141,20 @@ export function extractAttachments(
 }
 
 /**
- * Search payload for specific attachment data by partId
+ * Search payload for the part matching partId (partIds are unique within a
+ * message).
  */
-export function findAttachmentData(
+function findPartByPartId(
   payload: GmailMessagePayload | undefined,
   partId: string
-): string | null {
+): GmailMessagePart | null {
   if (!payload) {
     return null;
   }
 
-  const traverse = (part: GmailMessagePart): string | null => {
-    // Match by partId to find inline attachment data
-    if (part.partId === partId && part.body?.data) {
-      return part.body.data;
+  const traverse = (part: GmailMessagePart): GmailMessagePart | null => {
+    if (part.partId === partId) {
+      return part;
     }
     if (part.parts) {
       for (const nested of part.parts) {
@@ -171,6 +171,16 @@ export function findAttachmentData(
 }
 
 /**
+ * Search payload for specific inline attachment data by partId
+ */
+export function findAttachmentData(
+  payload: GmailMessagePayload | undefined,
+  partId: string
+): string | null {
+  return findPartByPartId(payload, partId)?.body?.data ?? null;
+}
+
+/**
  * Search payload for a part's attachment ID by partId. Gmail attachment IDs
  * are short-lived tokens, so this is used to get a fresh ID from a re-fetched
  * message when a previously obtained ID has expired.
@@ -179,26 +189,7 @@ export function findAttachmentIdByPartId(
   payload: GmailMessagePayload | undefined,
   partId: string
 ): string | null {
-  if (!payload) {
-    return null;
-  }
-
-  const traverse = (part: GmailMessagePart): string | null => {
-    if (part.partId === partId && part.body?.attachmentId) {
-      return part.body.attachmentId;
-    }
-    if (part.parts) {
-      for (const nested of part.parts) {
-        const found = traverse(nested);
-        if (found) {
-          return found;
-        }
-      }
-    }
-    return null;
-  };
-
-  return traverse(payload);
+  return findPartByPartId(payload, partId)?.body?.attachmentId ?? null;
 }
 
 /**

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -171,6 +171,37 @@ export function findAttachmentData(
 }
 
 /**
+ * Search payload for a part's attachment ID by partId. Gmail attachment IDs
+ * are short-lived tokens, so this is used to get a fresh ID from a re-fetched
+ * message when a previously obtained ID has expired.
+ */
+export function findAttachmentIdByPartId(
+  payload: GmailMessagePayload | undefined,
+  partId: string
+): string | null {
+  if (!payload) {
+    return null;
+  }
+
+  const traverse = (part: GmailMessagePart): string | null => {
+    if (part.partId === partId && part.body?.attachmentId) {
+      return part.body.attachmentId;
+    }
+    if (part.parts) {
+      for (const nested of part.parts) {
+        const found = traverse(nested);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return null;
+  };
+
+  return traverse(payload);
+}
+
+/**
  * Create HTML quote section for replies with original message
  */
 export function createQuoteSection(

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -841,29 +841,32 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     let base64Data: string | null = null;
 
     const fetchAttachmentFromApi = async (
-      id: string
+      gmailAttachmentId: string
     ): Promise<Result<string, string>> => {
       const response = await fetchFromGmail(
-        `/gmail/v1/users/me/messages/${encodedMessageId}/attachments/${encodeURIComponent(id)}`,
+        `/gmail/v1/users/me/messages/${encodedMessageId}/attachments/${encodeURIComponent(gmailAttachmentId)}`,
         accessToken,
         { method: "GET" }
       );
       if (!response.ok) {
         return new Err(await getErrorText(response));
       }
-      const result = await response.json();
-      return new Ok(result.data);
+      const body = await response.json();
+      if (typeof body.data !== "string") {
+        return new Err("Gmail API returned no attachment data");
+      }
+      return new Ok(body.data);
     };
 
     let attachmentApiErrorText: string | null = null;
 
     // Only try the attachments API if we have a real attachment ID
     if (hasRealAttachmentId && attachmentId) {
-      const result = await fetchAttachmentFromApi(attachmentId);
-      if (result.isOk()) {
-        base64Data = result.value;
+      const fetchResult = await fetchAttachmentFromApi(attachmentId);
+      if (fetchResult.isOk()) {
+        base64Data = fetchResult.value;
       } else {
-        attachmentApiErrorText = result.error;
+        attachmentApiErrorText = fetchResult.error;
         const lowerError = attachmentApiErrorText.toLowerCase();
 
         // Gmail attachment IDs are short-lived tokens: an ID obtained from an

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -26,6 +26,7 @@ import {
   extractAttachments,
   fetchFromGmail,
   findAttachmentData,
+  findAttachmentIdByPartId,
   getErrorText,
   getHeaderValue,
   isGmailMessage,
@@ -35,6 +36,7 @@ import {
 } from "@app/lib/api/actions/servers/gmail/helpers";
 import { GMAIL_TOOLS_METADATA } from "@app/lib/api/actions/servers/gmail/metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import { unescape } from "html-escaper";
@@ -838,29 +840,40 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
     const encodedMessageId = encodeURIComponent(messageId);
     let base64Data: string | null = null;
 
-    // Only try the attachments API if we have a real attachment ID
-    if (hasRealAttachmentId && attachmentId) {
-      const encodedAttachmentId = encodeURIComponent(attachmentId);
+    const fetchAttachmentFromApi = async (
+      id: string
+    ): Promise<Result<string, string>> => {
       const response = await fetchFromGmail(
-        `/gmail/v1/users/me/messages/${encodedMessageId}/attachments/${encodedAttachmentId}`,
+        `/gmail/v1/users/me/messages/${encodedMessageId}/attachments/${encodeURIComponent(id)}`,
         accessToken,
         { method: "GET" }
       );
+      if (!response.ok) {
+        return new Err(await getErrorText(response));
+      }
+      const result = await response.json();
+      return new Ok(result.data);
+    };
 
-      if (response.ok) {
-        const result = await response.json();
-        base64Data = result.data;
+    let attachmentApiErrorText: string | null = null;
+
+    // Only try the attachments API if we have a real attachment ID
+    if (hasRealAttachmentId && attachmentId) {
+      const result = await fetchAttachmentFromApi(attachmentId);
+      if (result.isOk()) {
+        base64Data = result.value;
       } else {
-        const attachmentErrorText = await getErrorText(response);
-        const lowerError = attachmentErrorText.toLowerCase();
+        attachmentApiErrorText = result.error;
+        const lowerError = attachmentApiErrorText.toLowerCase();
 
-        // Gmail sometimes returns attachmentIds that look valid but fail with
-        // "invalid attachment token". Fall back to fetching from the MIME body.
+        // Gmail attachment IDs are short-lived tokens: an ID obtained from an
+        // earlier get_messages call can expire and fail with "invalid
+        // attachment token". Fall back to re-fetching the message.
         if (!lowerError.includes("invalid") && !lowerError.includes("token")) {
           return new Err(
             new MCPError(
               `Failed to fetch attachment via Gmail API (messageId: ${messageId}, ` +
-                `filename: "${filename}"): ${attachmentErrorText}`,
+                `filename: "${filename}"): ${attachmentApiErrorText}`,
               { tracked: false }
             )
           );
@@ -868,9 +881,9 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       }
     }
 
-    // Fallback: fetch attachment data from the message MIME body.
-    // Used when hasRealAttachmentId is false (inline content) or when the
-    // attachments API returned an invalid token error.
+    // Fallback: re-fetch the message, then read inline data (content without a
+    // real attachment ID) or retry the attachments API with the fresh
+    // attachment ID found in the re-fetched message (expired token case).
     if (!base64Data) {
       const messageResponse = await fetchFromGmail(
         `/gmail/v1/users/me/messages/${encodedMessageId}?format=full`,
@@ -891,12 +904,31 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
       base64Data = findAttachmentData(messageData.payload, partId);
 
       if (!base64Data) {
+        // Real attachments never carry inline data in the message payload, but
+        // the re-fetched message contains a fresh attachment ID for the part.
+        // Skip the retry if the ID is unchanged: the same ID just failed above.
+        const freshAttachmentId = findAttachmentIdByPartId(
+          messageData.payload,
+          partId
+        );
+        if (freshAttachmentId && freshAttachmentId !== attachmentId) {
+          const retryResult = await fetchAttachmentFromApi(freshAttachmentId);
+          if (retryResult.isOk()) {
+            base64Data = retryResult.value;
+          } else {
+            attachmentApiErrorText = retryResult.error;
+          }
+        }
+      }
+
+      if (!base64Data) {
         return new Err(
           new MCPError(
-            `Attachment data not found in message body (messageId: ${messageId}, ` +
-              `filename: "${filename}", partId: ${partId}, mimeType: ${mimeType}). ` +
-              `This can happen when Gmail returns an invalid attachment token and ` +
-              `the attachment is too large to be included inline in the message payload.`
+            `Attachment data not found (messageId: ${messageId}, ` +
+              `filename: "${filename}", partId: ${partId}, mimeType: ${mimeType})` +
+              (attachmentApiErrorText
+                ? `. Gmail API error: ${attachmentApiErrorText}`
+                : ".")
           )
         );
       }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8830.

Gmail attachment IDs are short-lived tokens. When `attachments.get` failed with an invalid token error, `get_attachment` fell back to reading inline MIME data from the re-fetched message. Real attachments never carry inline data in the message payload (regardless of size), so the tool always failed with "Attachment data not found in message body" (631 hits in Datadog over the last 30 days).

The re-fetched message already contains a fresh attachment ID for the part: use it to retry `attachments.get` (skipped if the ID is unchanged). The original Gmail error text is now included in the final error instead of being swallowed.

## Tests

Unit tests on `findAttachmentIdByPartId` / `findAttachmentData`. The end-to-end path will be confirmed on the failing customer conversation once deployed.

## Risk

Low: at most one extra Gmail API call on a path that previously always failed. Safe to rollback.

## Deploy Plan

Standard deploy.