### PR TITLE
[LLM] Add StreamEndpoint and BatchEndpoint base classes and constructor types

### DIFF
--- a/front/lib/model_constructors/batch/configuration.ts
+++ b/front/lib/model_constructors/batch/configuration.ts
@@ -1,0 +1,10 @@
+import type { BatchEndpoint } from "@app/lib/model_constructors/batch/endpoint";
+import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+
+export type BatchModelConfiguration = BaseModelConfiguration;
+
+export type BatchEndpointConstructor = (new (
+  credentials: Credentials
+) => BatchEndpoint<any, any>) &
+  BatchModelConfiguration;

--- a/front/lib/model_constructors/batch/endpoint.ts
+++ b/front/lib/model_constructors/batch/endpoint.ts
@@ -1,0 +1,20 @@
+import { Client } from "@app/lib/model_constructors/client";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
+
+export type BatchStatus = "ready" | "computing";
+
+export type BatchRequest = { payload: Payload; config: InputConfig };
+
+// Generic over the raw request payload `I` and per-request result `R`.
+export abstract class BatchEndpoint<I = unknown, R = unknown> extends Client {
+  abstract sendBatch(requests: Map<string, BatchRequest>): Promise<string>;
+  abstract getBatchStatus(batchId: string): Promise<BatchStatus>;
+  abstract getBatchResult(
+    batchId: string
+  ): Promise<Map<string, NonDeltaResponseEvent[]>>;
+  abstract deleteBatch(batchId: string): Promise<boolean>;
+  abstract rawBatchOutputToEvents(raw: R): NonDeltaResponseEvent[];
+  abstract buildRequestPayload(payload: Payload, config: InputConfig): I;
+}

--- a/front/lib/model_constructors/stream/configuration.ts
+++ b/front/lib/model_constructors/stream/configuration.ts
@@ -1,0 +1,13 @@
+import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
+
+export type StreamModelConfiguration = BaseModelConfiguration & {
+  supportedReasoningEfforts: ReasoningEffort[];
+};
+
+export type StreamEndpointConstructor = (new (
+  credentials: Credentials
+) => StreamEndpoint<any, any>) &
+  StreamModelConfiguration;

--- a/front/lib/model_constructors/stream/endpoint.ts
+++ b/front/lib/model_constructors/stream/endpoint.ts
@@ -1,0 +1,13 @@
+import { Client } from "@app/lib/model_constructors/client";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+
+// Generic over the raw request payload `I` and raw stream event `O`.
+export abstract class StreamEndpoint<I = unknown, O = unknown> extends Client {
+  abstract buildRequestPayload(payload: Payload, config: InputConfig): I;
+  abstract streamRaw(input: I): AsyncGenerator<O>;
+  abstract rawStreamOutputToEvents(
+    raw: AsyncGenerator<O>
+  ): AsyncGenerator<ModelResponseEvent>;
+}

--- a/front/lib/model_constructors/types/endpoint_metadata.ts
+++ b/front/lib/model_constructors/types/endpoint_metadata.ts
@@ -3,7 +3,7 @@ import type { ProviderApi } from "@app/lib/model_constructors/types/provider_api
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
 import type { Region } from "@app/lib/model_constructors/types/regions";
 
-export type AgentMetadata = {
+export type EndpointMetadata = {
   providerId: ProviderId;
   api: ProviderApi;
   region: Region;

--- a/front/lib/model_constructors/types/output/events.ts
+++ b/front/lib/model_constructors/types/output/events.ts
@@ -1,25 +1,25 @@
-import type { AgentMetadata } from "@app/lib/model_constructors/types/agent_metadata";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 
 export type ResponseIdContent = { responseId: string };
 
 export interface ResponseIdEvent {
   type: "response_id";
   content: ResponseIdContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type TextDeltaContent = { value: string };
 export interface TextDeltaEvent {
   type: "text_delta";
   content: TextDeltaContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type TextContent = { value: string };
 export interface TextEvent {
   type: "text";
   content: TextContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type ToolCallStartedContent = {
@@ -30,12 +30,12 @@ export type ToolCallStartedContent = {
 export interface ToolCallStartedEvent {
   type: "tool_call_started";
   content: ToolCallStartedContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export interface ToolCallDeltaEvent {
   type: "tool_call_delta";
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type ToolCallContent = {
@@ -46,21 +46,21 @@ export type ToolCallContent = {
 export interface ToolCallEvent {
   type: "tool_call";
   content: ToolCallContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type ReasoningDeltaContent = { value: string };
 export interface ReasoningDeltaEvent {
   type: "reasoning_delta";
   content: ReasoningDeltaContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type ReasoningContent = { value: string };
 export interface ReasoningEvent {
   type: "reasoning";
   content: ReasoningContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type TokenUsageContent = {
@@ -73,7 +73,7 @@ export type TokenUsageContent = {
 export interface TokenUsageEvent {
   type: "token_usage";
   content: TokenUsageContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type SuccessContent = {
@@ -82,7 +82,7 @@ export type SuccessContent = {
 export interface SuccessEvent {
   type: "success";
   content: SuccessContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export const ERROR_TYPES = [
@@ -112,7 +112,7 @@ export type ErrorContent = {
 export interface ErrorEvent {
   type: "error";
   content: ErrorContent;
-  metadata: AgentMetadata;
+  metadata: EndpointMetadata;
 }
 
 export type ModelResponseEvent =


### PR DESCRIPTION
## Description

Add the `StreamEndpoint` / `BatchEndpoint` abstract base classes and their constructor types to the `model_constructors` scaffolding, defining the methods concrete provider subclasses must implement.

## Tests

Not needed.

## Risk

None.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`