### PR TITLE
feat: per-region pricing with EU override for Vertex AI inference

### DIFF
--- a/front/lib/api/assistant/token_pricing/eu.ts
+++ b/front/lib/api/assistant/token_pricing/eu.ts
@@ -1,12 +1,11 @@
 import type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
 
-// EU-hosted pricing overrides (models served via Google Vertex AI in EU).
-// Vertex AI EU incurs a 10% surcharge over global provider pricing.
+// EU-hosted pricing overrides for Anthropic models served via Google Vertex AI in EU.
+// Anthropic charges a 10% surcharge on Vertex AI EU inference.
 // Only models currently routable via Vertex in EU are listed here.
-// https://cloud.google.com/vertex-ai/pricing
+// https://www.anthropic.com/pricing
 
 export const EU_MODEL_PRICING: Partial<Record<string, PricingEntry>> = {
-  // Anthropic models via Vertex AI EU.
   "claude-sonnet-4-5-20250929": {
     input: 3.3,
     output: 16.5,
@@ -48,20 +47,5 @@ export const EU_MODEL_PRICING: Partial<Record<string, PricingEntry>> = {
     output: 5.5,
     cache_creation_input_tokens: 1.375,
     cache_read_input_tokens: 0.11,
-  },
-  // Google models via Vertex AI EU.
-  "gemini-3.1-flash-lite": {
-    input: 0.275,
-    output: 1.65,
-    cache_read_input_tokens: 0.0275,
-  },
-  "gemini-3.1-pro-preview": {
-    input: 4.4,
-    output: 19.8,
-  },
-  "gemini-3.5-flash": {
-    input: 1.65,
-    output: 9.9,
-    cache_read_input_tokens: 0.165,
   },
 };

--- a/front/lib/api/assistant/token_pricing/eu.ts
+++ b/front/lib/api/assistant/token_pricing/eu.ts
@@ -1,0 +1,67 @@
+import type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
+
+// EU-hosted pricing overrides (models served via Google Vertex AI in EU).
+// Vertex AI EU incurs a 10% surcharge over global provider pricing.
+// Only models currently routable via Vertex in EU are listed here.
+// https://cloud.google.com/vertex-ai/pricing
+
+export const EU_MODEL_PRICING: Partial<Record<string, PricingEntry>> = {
+  // Anthropic models via Vertex AI EU.
+  "claude-sonnet-4-5-20250929": {
+    input: 3.3,
+    output: 16.5,
+    cache_creation_input_tokens: 4.125,
+    cache_read_input_tokens: 0.33,
+  },
+  "claude-sonnet-4-6": {
+    input: 3.3,
+    output: 16.5,
+    cache_creation_input_tokens: 4.125,
+    cache_read_input_tokens: 0.33,
+  },
+  "claude-opus-4-5-20251101": {
+    input: 5.5,
+    output: 27.5,
+    cache_creation_input_tokens: 6.875,
+    cache_read_input_tokens: 0.55,
+  },
+  "claude-opus-4-6": {
+    input: 5.5,
+    output: 27.5,
+    cache_creation_input_tokens: 6.875,
+    cache_read_input_tokens: 0.55,
+  },
+  "claude-opus-4-7": {
+    input: 5.5,
+    output: 27.5,
+    cache_creation_input_tokens: 6.875,
+    cache_read_input_tokens: 0.55,
+  },
+  "claude-opus-4-8": {
+    input: 5.5,
+    output: 27.5,
+    cache_creation_input_tokens: 6.875,
+    cache_read_input_tokens: 0.55,
+  },
+  "claude-haiku-4-5-20251001": {
+    input: 1.1,
+    output: 5.5,
+    cache_creation_input_tokens: 1.375,
+    cache_read_input_tokens: 0.11,
+  },
+  // Google models via Vertex AI EU.
+  "gemini-3.1-flash-lite": {
+    input: 0.275,
+    output: 1.65,
+    cache_read_input_tokens: 0.0275,
+  },
+  "gemini-3.1-pro-preview": {
+    input: 4.4,
+    output: 19.8,
+  },
+  "gemini-3.5-flash": {
+    input: 1.65,
+    output: 9.9,
+    cache_read_input_tokens: 0.165,
+  },
+};

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -1,7 +1,4 @@
-import type {
-  ImageModelIdType,
-  StaticModelIdType,
-} from "@app/types/assistant/models/models";
+import type { StaticModelIdType } from "@app/types/assistant/models/models";
 
 // All pricing are in USD per million tokens (equivalent to micro-USD per token).
 export type PricingEntry = {

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -2,26 +2,14 @@ import type {
   ImageModelIdType,
   StaticModelIdType,
 } from "@app/types/assistant/models/models";
-import type { ModelIdType } from "@app/types/assistant/models/types";
 
 // All pricing are in USD per million tokens (equivalent to micro-USD per token).
-type PricingEntry = {
+export type PricingEntry = {
   input: number;
   output: number;
-  // Optional cached-token pricing.
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
 };
-
-export const DUST_MARKUP_PERCENT = 30;
-
-// Maximum discount percent that can be applied to credit purchases.
-// A discount above this threshold would result in selling below cost.
-// Formula: (1 - 1 / (1 + MARKUP/100)) * 100
-// With 30% markup: (1 - 1/1.30) * 100 ≈ 23.08%
-export const MAX_DISCOUNT_PERCENT = Math.ceil(
-  (1 - 1 / (1 + DUST_MARKUP_PERCENT / 100)) * 100
-);
 
 // Pricing for current models (USD per million tokens - equivalent to micro-USD per token)
 // This record contains all static model IDs. Custom models use default pricing.
@@ -318,7 +306,7 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 1.68,
     cache_read_input_tokens: 0.28,
   },
-  // https://fireworks.ai/models/deepseek-ai/deepseek-v4-pro
+  // https://fireworks.ai/models/fireworks/deepseek-v4-pro
   "accounts/fireworks/models/deepseek-v4-pro": {
     input: 1.74,
     output: 3.48,
@@ -551,55 +539,8 @@ const LEGACY_MODEL_PRICING: Record<string, PricingEntry> = {
 };
 
 // Combined pricing record for all models (current + legacy + image).
-// This is the exported record used throughout the codebase.
 export const MODEL_PRICING: Record<string, PricingEntry> = {
   ...CURRENT_MODEL_PRICING,
   ...IMAGE_MODEL_PRICING,
   ...LEGACY_MODEL_PRICING,
 };
-
-// If model is not found in the MODEL_PRICING, use the default pricing.
-const DEFAULT_PRICING_MODEL_ID: StaticModelIdType = "gpt-4o";
-
-const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
-
-// This discount factor applies to OpenAi, Anthropic, Google and Mistral
-const BATCH_DISCOUNT_FACTOR = 0.5;
-
-/**
- * Calculate the cost in micro USD for token usage.
- * Note: promptTokens currently includes cached read and cache write tokens for some providers.
- * To avoid double counting, price all promptTokens at base input rate, then adjust with deltas.
- */
-export function computeTokensCostForUsageInMicroUsd({
-  modelId,
-  promptTokens,
-  completionTokens,
-  cachedTokens,
-  cacheCreationTokens,
-  isBatch = false,
-}: {
-  modelId: ModelIdType | ImageModelIdType;
-  promptTokens: number;
-  completionTokens: number;
-  cachedTokens: number | null;
-  cacheCreationTokens?: number | null;
-  isBatch?: boolean;
-}): number {
-  const pricing = MODEL_PRICING[modelId] ?? DEFAULT_PRICING;
-
-  const cachedReadTokens = cachedTokens ?? 0;
-  const cacheWriteTokens = cacheCreationTokens ?? 0;
-
-  const cachedReadRate = pricing.cache_read_input_tokens ?? pricing.input;
-  const cacheWriteRate = pricing.cache_creation_input_tokens ?? pricing.input;
-
-  const basePromptCost = promptTokens * pricing.input;
-  const cachedReadDelta = cachedReadTokens * (cachedReadRate - pricing.input);
-  const cacheWriteDelta = cacheWriteTokens * (cacheWriteRate - pricing.input);
-  const outputCost = completionTokens * pricing.output;
-
-  const cost = basePromptCost + cachedReadDelta + cacheWriteDelta + outputCost;
-
-  return isBatch ? Math.round(cost * BATCH_DISCOUNT_FACTOR) : cost;
-}

--- a/front/lib/api/assistant/token_pricing/index.ts
+++ b/front/lib/api/assistant/token_pricing/index.ts
@@ -1,0 +1,80 @@
+import type { ImageModelIdType } from "@app/types/assistant/models/models";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+import { EU_MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/eu";
+import type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
+import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/global";
+
+export type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
+export { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/global";
+
+export type InferenceRegionType = "global" | "eu";
+
+// Pricing overrides keyed by region. Only non-global regions need entries here.
+const REGIONAL_MODEL_PRICING: Record<
+  Exclude<InferenceRegionType, "global">,
+  Partial<Record<string, PricingEntry>>
+> = {
+  eu: EU_MODEL_PRICING,
+};
+
+export const DUST_MARKUP_PERCENT = 30;
+
+// Maximum discount percent that can be applied to credit purchases.
+// A discount above this threshold would result in selling below cost.
+// Formula: (1 - 1 / (1 + MARKUP/100)) * 100
+// With 30% markup: (1 - 1/1.30) * 100 ≈ 23.08%
+export const MAX_DISCOUNT_PERCENT = Math.ceil(
+  (1 - 1 / (1 + DUST_MARKUP_PERCENT / 100)) * 100
+);
+
+// If model is not found in MODEL_PRICING, use the default pricing.
+const DEFAULT_PRICING_MODEL_ID = "gpt-4o";
+const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
+
+// This discount factor applies to OpenAi, Anthropic, Google and Mistral
+const BATCH_DISCOUNT_FACTOR = 0.5;
+
+/**
+ * Calculate the cost in micro USD for token usage.
+ * Note: promptTokens currently includes cached read and cache write tokens for some providers.
+ * To avoid double counting, price all promptTokens at base input rate, then adjust with deltas.
+ */
+export function computeTokensCostForUsageInMicroUsd({
+  modelId,
+  promptTokens,
+  completionTokens,
+  cachedTokens,
+  cacheCreationTokens,
+  isBatch = false,
+  inferenceRegion = "global",
+}: {
+  modelId: ModelIdType | ImageModelIdType;
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number | null;
+  cacheCreationTokens?: number | null;
+  isBatch?: boolean;
+  inferenceRegion?: InferenceRegionType;
+}): number {
+  const regionalPricing =
+    inferenceRegion !== "global"
+      ? REGIONAL_MODEL_PRICING[inferenceRegion][modelId]
+      : undefined;
+  const pricing = regionalPricing ?? MODEL_PRICING[modelId] ?? DEFAULT_PRICING;
+
+  const cachedReadTokens = cachedTokens ?? 0;
+  const cacheWriteTokens = cacheCreationTokens ?? 0;
+
+  const cachedReadRate = pricing.cache_read_input_tokens ?? pricing.input;
+  const cacheWriteRate = pricing.cache_creation_input_tokens ?? pricing.input;
+
+  const basePromptCost = promptTokens * pricing.input;
+  const cachedReadDelta = cachedReadTokens * (cachedReadRate - pricing.input);
+  const cacheWriteDelta = cacheWriteTokens * (cacheWriteRate - pricing.input);
+  const outputCost = completionTokens * pricing.output;
+
+  const cost = basePromptCost + cachedReadDelta + cacheWriteDelta + outputCost;
+
+  return isBatch ? Math.round(cost * BATCH_DISCOUNT_FACTOR) : cost;
+}

--- a/front/lib/api/assistant/token_pricing/index.ts
+++ b/front/lib/api/assistant/token_pricing/index.ts
@@ -1,12 +1,11 @@
+import { EU_MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/eu";
+import type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
+import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/global";
 import type {
   ImageModelIdType,
   StaticModelIdType,
 } from "@app/types/assistant/models/models";
 import type { ModelIdType } from "@app/types/assistant/models/types";
-
-import { EU_MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/eu";
-import type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
-import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/global";
 
 export type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
 export { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/global";

--- a/front/lib/api/assistant/token_pricing/index.ts
+++ b/front/lib/api/assistant/token_pricing/index.ts
@@ -1,4 +1,7 @@
-import type { ImageModelIdType } from "@app/types/assistant/models/models";
+import type {
+  ImageModelIdType,
+  StaticModelIdType,
+} from "@app/types/assistant/models/models";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 
 import { EU_MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/eu";
@@ -29,7 +32,7 @@ export const MAX_DISCOUNT_PERCENT = Math.ceil(
 );
 
 // If model is not found in MODEL_PRICING, use the default pricing.
-const DEFAULT_PRICING_MODEL_ID = "gpt-4o";
+const DEFAULT_PRICING_MODEL_ID: StaticModelIdType = "gpt-5.5";
 const DEFAULT_PRICING = MODEL_PRICING[DEFAULT_PRICING_MODEL_ID];
 
 // This discount factor applies to OpenAi, Anthropic, Google and Mistral
@@ -69,12 +72,20 @@ export function computeTokensCostForUsageInMicroUsd({
   const cachedReadRate = pricing.cache_read_input_tokens ?? pricing.input;
   const cacheWriteRate = pricing.cache_creation_input_tokens ?? pricing.input;
 
-  const basePromptCost = promptTokens * pricing.input;
-  const cachedReadDelta = cachedReadTokens * (cachedReadRate - pricing.input);
-  const cacheWriteDelta = cacheWriteTokens * (cacheWriteRate - pricing.input);
-  const outputCost = completionTokens * pricing.output;
+  const basePromptCostMicroUsd = promptTokens * pricing.input;
+  const cachedReadDeltaMicroUsd =
+    cachedReadTokens * (cachedReadRate - pricing.input);
+  const cacheWriteDeltaMicroUsd =
+    cacheWriteTokens * (cacheWriteRate - pricing.input);
+  const outputCostMicroUsd = completionTokens * pricing.output;
 
-  const cost = basePromptCost + cachedReadDelta + cacheWriteDelta + outputCost;
+  const costMicroUsd =
+    basePromptCostMicroUsd +
+    cachedReadDeltaMicroUsd +
+    cacheWriteDeltaMicroUsd +
+    outputCostMicroUsd;
 
-  return isBatch ? Math.round(cost * BATCH_DISCOUNT_FACTOR) : cost;
+  return isBatch
+    ? Math.round(costMicroUsd * BATCH_DISCOUNT_FACTOR)
+    : costMicroUsd;
 }

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -153,6 +153,7 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       this.metadata = {
         ...this.metadata,
         inferenceProvider: "google_vertex_ai",
+        inferenceRegion: "eu",
       };
     }
     this.client = new Anthropic({

--- a/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/anthropic_to_events.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 const metadata: LLMClientMetadata = {
   clientId: "anthropic" as const,
   inferenceProvider: "anthropic",
+  inferenceRegion: "global",
   modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/errors.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 const metadata: LLMClientMetadata = {
   clientId: "anthropic" as const,
   inferenceProvider: "anthropic",
+  inferenceRegion: "global",
   modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -8,6 +8,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -21,6 +22,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -29,6 +31,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -42,6 +45,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -59,6 +63,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -75,6 +80,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -92,6 +98,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -99,6 +106,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
@@ -8,6 +8,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -19,6 +20,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -30,6 +32,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -41,6 +44,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
       encrypted_content: "",
     },
@@ -53,6 +57,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -64,6 +69,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -75,6 +81,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -92,6 +99,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -106,6 +114,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
           encrypted_content: "",
         },
@@ -118,6 +127,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -130,6 +140,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       metadata: {
         clientId: "anthropic" as const,
         inferenceProvider: "anthropic",
+        inferenceRegion: "global",
         modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
       },
     },
@@ -141,6 +152,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       metadata: {
         clientId: "anthropic" as const,
         inferenceProvider: "anthropic",
+        inferenceRegion: "global",
         modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         encrypted_content: "",
       },
@@ -149,6 +161,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -8,6 +8,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -19,6 +20,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -30,6 +32,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -41,6 +44,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -54,6 +58,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -62,6 +67,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -75,6 +81,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -92,6 +99,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },
@@ -106,6 +114,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -119,6 +128,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -131,6 +141,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
       metadata: {
         clientId: "anthropic" as const,
         inferenceProvider: "anthropic",
+        inferenceRegion: "global",
         modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
       },
     },
@@ -145,6 +156,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "anthropic" as const,
           inferenceProvider: "anthropic",
+          inferenceRegion: "global",
           modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
         },
       },
@@ -152,6 +164,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "anthropic" as const,
       inferenceProvider: "anthropic",
+      inferenceRegion: "global",
       modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
     },
   },

--- a/front/lib/api/llm/clients/google/index.ts
+++ b/front/lib/api/llm/clients/google/index.ts
@@ -63,6 +63,7 @@ export class GoogleLLM extends LLM<GoogleGenerateContentRequestParams> {
       this.metadata = {
         ...this.metadata,
         inferenceProvider: "google_vertex_ai",
+        inferenceRegion: "eu",
       };
       this.client = new GoogleGenAI({
         vertexai: true,

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -65,6 +65,7 @@ async function contentToPart(
           {
             clientId: "google_ai_studio",
             inferenceProvider: "google_ai_studio",
+            inferenceRegion: "global" as const,
             modelId,
           }
         );

--- a/front/lib/api/llm/clients/google/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/errors.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 const metadata: LLMClientMetadata = {
   clientId: "google_ai_studio" as const,
   inferenceProvider: "google_ai_studio",
+  inferenceRegion: "global",
   modelId: GEMINI_2_5_PRO_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
+++ b/front/lib/api/llm/clients/google/utils/test/google_to_events.test.ts
@@ -167,6 +167,7 @@ const modelOutputFunctionCallEvents: PartialGenerateContentResponse[] = [
 const metadata = {
   clientId: "google_ai_studio",
   inferenceProvider: "google_ai_studio",
+  inferenceRegion: "global",
   modelId: "gemini-2.5-pro",
 } as const;
 

--- a/front/lib/api/llm/clients/mistral/utils/test/errors.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/errors.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 const metadata: LLMClientMetadata = {
   clientId: "mistral" as const,
   inferenceProvider: "mistral",
+  inferenceRegion: "global",
   modelId: MISTRAL_LARGE_MODEL_ID,
 };
 

--- a/front/lib/api/llm/clients/mistral/utils/test/mistral_to_events.test.ts
+++ b/front/lib/api/llm/clients/mistral/utils/test/mistral_to_events.test.ts
@@ -143,6 +143,7 @@ const modelOutputFinishToolCallEvents: CompletionEvent[] = [
 const metadata = {
   clientId: "mistral",
   inferenceProvider: "mistral",
+  inferenceRegion: "global",
   modelId: "mistral-large-latest",
 } as const;
 

--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -14,6 +14,7 @@ import { isTextContent } from "@app/types/assistant/generation";
 const metadata = {
   clientId: "noop" as const,
   inferenceProvider: "noop",
+  inferenceRegion: "global" as const,
   modelId: "noop" as const,
 };
 

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -84,6 +84,7 @@ export abstract class LLM<TPayload = unknown> {
     this.metadata = {
       clientId: providerId,
       inferenceProvider: providerId,
+      inferenceRegion: "global",
       modelId: this.modelId,
     };
 
@@ -332,7 +333,8 @@ export abstract class LLM<TPayload = unknown> {
           await run.recordTokenUsage(
             this.authenticator,
             buffer.runTokenUsage,
-            this.modelId
+            this.modelId,
+            { inferenceRegion: this.metadata.inferenceRegion }
           );
         }
 
@@ -517,7 +519,7 @@ export abstract class LLM<TPayload = unknown> {
             this.authenticator,
             event.content,
             this.modelId,
-            { isBatch: true }
+            { isBatch: true, inferenceRegion: this.metadata.inferenceRegion }
           );
         }
       }

--- a/front/lib/api/llm/test/errors.test.ts
+++ b/front/lib/api/llm/test/errors.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 const metadata: LLMClientMetadata = {
   clientId: "anthropic" as const,
   inferenceProvider: "anthropic",
+  inferenceRegion: "global",
   modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
 };
 

--- a/front/lib/api/llm/traces/buffer.test.ts
+++ b/front/lib/api/llm/traces/buffer.test.ts
@@ -22,6 +22,7 @@ class LLMEventFactory {
       metadata: {
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-4-turbo",
       },
     };
@@ -36,6 +37,7 @@ class LLMEventFactory {
       metadata: {
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-4-turbo",
       },
     };
@@ -52,6 +54,7 @@ class LLMEventFactory {
       metadata: {
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-4-turbo",
       },
     };
@@ -68,6 +71,7 @@ class LLMEventFactory {
       metadata: {
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-4-turbo",
       },
     };
@@ -83,6 +87,7 @@ class LLMEventFactory {
       {
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-4-turbo",
       }
     );

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -1,4 +1,5 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type { InferenceRegionType } from "@app/lib/api/assistant/token_pricing";
 import type {
   LLMTraceContext,
   LLMTraceCustomization,
@@ -11,6 +12,8 @@ import type {
 } from "@app/types/assistant/models/types";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
 import { isString } from "@app/types/shared/utils/general";
+
+export type { InferenceRegionType };
 
 export interface SystemPromptInstruction {
   role: "instruction";
@@ -115,6 +118,7 @@ export type LLMParameterOverwrites = Partial<
 export type LLMClientMetadata = {
   clientId: ModelProviderIdType;
   inferenceProvider: string;
+  inferenceRegion: InferenceRegionType;
   modelId: ModelIdType;
 };
 

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 const metadata = {
   clientId: "openai",
   inferenceProvider: "openai",
+  inferenceRegion: "global",
   modelId: "gpt-5",
 } as const;
 

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/function_call.ts
@@ -11,6 +11,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -19,6 +20,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -27,6 +29,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -40,6 +43,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -48,6 +52,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -56,6 +61,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -69,6 +75,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -82,6 +89,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -97,6 +105,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -113,6 +122,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "openai",
           inferenceProvider: "openai",
+          inferenceRegion: "global",
           modelId: "gpt-5",
         },
       },
@@ -129,6 +139,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "openai",
           inferenceProvider: "openai",
+          inferenceRegion: "global",
           modelId: "gpt-5",
         },
       },
@@ -144,6 +155,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "openai",
           inferenceProvider: "openai",
+          inferenceRegion: "global",
           modelId: "gpt-5",
         },
       },
@@ -160,6 +172,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
         metadata: {
           clientId: "openai",
           inferenceProvider: "openai",
+          inferenceRegion: "global",
           modelId: "gpt-5",
         },
       },
@@ -167,6 +180,7 @@ export const functionCallLLMEvents: LLMEvent[] = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },

--- a/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/fixtures/llm_events/reasoning.ts
@@ -7,6 +7,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -18,6 +19,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -29,6 +31,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -40,6 +43,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -51,6 +55,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -62,6 +67,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -73,6 +79,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -86,6 +93,7 @@ export const reasoningLLMEvents = [
       encrypted_content: undefined,
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -97,6 +105,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -112,6 +121,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },
@@ -127,6 +137,7 @@ export const reasoningLLMEvents = [
           id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
           clientId: "openai",
           inferenceProvider: "openai",
+          inferenceRegion: "global",
           modelId: "gpt-5",
           encrypted_content: undefined,
         },
@@ -139,6 +150,7 @@ export const reasoningLLMEvents = [
         metadata: {
           clientId: "openai",
           inferenceProvider: "openai",
+          inferenceRegion: "global",
           modelId: "gpt-5",
         },
       },
@@ -151,6 +163,7 @@ export const reasoningLLMEvents = [
       metadata: {
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-5",
       },
     },
@@ -163,6 +176,7 @@ export const reasoningLLMEvents = [
         id: "rs_06e2b572b276da09016901d7350ae08198ba76145524efe4b2",
         clientId: "openai",
         inferenceProvider: "openai",
+        inferenceRegion: "global",
         modelId: "gpt-5",
         encrypted_content: undefined,
       },
@@ -171,6 +185,7 @@ export const reasoningLLMEvents = [
     metadata: {
       clientId: "openai",
       inferenceProvider: "openai",
+      inferenceRegion: "global",
       modelId: "gpt-5",
     },
   },

--- a/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/test/openai_to_events.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 const metadata = {
   clientId: "openai",
   inferenceProvider: "openai",
+  inferenceRegion: "global",
   modelId: "gpt-5",
 } as const;
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -1,4 +1,7 @@
-import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import {
+  computeTokensCostForUsageInMicroUsd,
+  type InferenceRegionType,
+} from "@app/lib/api/assistant/token_pricing";
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
@@ -380,7 +383,10 @@ export class RunResource extends BaseResource<RunModel> {
     auth: Authenticator,
     usage: TokenUsage,
     modelId: ModelIdType,
-    { isBatch = false }: { isBatch?: boolean } = {}
+    {
+      isBatch = false,
+      inferenceRegion = "global",
+    }: { isBatch?: boolean; inferenceRegion?: InferenceRegionType } = {}
   ) {
     const modelConfig = getModelConfigByModelId(modelId);
 
@@ -396,6 +402,7 @@ export class RunResource extends BaseResource<RunModel> {
       cachedTokens: usage.cachedTokens ?? null,
       cacheCreationTokens: usage.cacheCreationTokens ?? null,
       isBatch,
+      inferenceRegion,
     });
 
     return this.recordRunUsage(auth, [


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The pricing system previously computed token costs based on model ID alone, with no awareness of where inference actually ran. This made it impossible to reflect regional cost differences, specifically, the 10% surcharge Anthropic charges for EU-hosted Vertex AI inference.

The solution restructures the flat token pricing  into a directory with one file per region:
- global holds the baseline pricing for all models
- eu holds overrides for the models currently routable through Vertex AI in EU (Anthropic Sonnet/Opus/Haiku 4.x)

Adding a new region in the future means creating one file and registering it in the index.

InferenceRegionType is introduced as a first-class field on LLMClientMetadata. Both the Anthropic and Google LLM clients set it to "eu" when routing through Vertex, defaulting to "global" otherwise. The region flows through to `recordTokenUsage` and into the cost calculation, where the regional pricing table is consulted first before falling back to global.

> [!WARNING] This will likely be reworked by @pmilliotte but currently needed to release EU-hosted Anthropic. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
