### PR TITLE
fix: retry sub-8MB file uploads to GCS and time out stalled uploads

### DIFF
--- a/front/lib/api/files/utils.test.ts
+++ b/front/lib/api/files/utils.test.ts
@@ -1,0 +1,141 @@
+import {
+  FILE_UPLOAD_TIMEOUT_MS,
+  parseUploadRequest,
+} from "@app/lib/api/files/utils";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import type { IncomingMessage } from "http";
+import { Readable } from "stream";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
+
+const BOUNDARY = "----vitestboundary";
+
+function makeMultipartBody(content: Buffer, contentType: string): Buffer {
+  return Buffer.concat([
+    Buffer.from(
+      `--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="upload.bin"\r\n` +
+        `Content-Type: ${contentType}\r\n\r\n`
+    ),
+    content,
+    Buffer.from(`\r\n--${BOUNDARY}--\r\n`),
+  ]);
+}
+
+function makeUploadRequest(stream: Readable, contentLength: number) {
+  return Object.assign(stream, {
+    headers: {
+      "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+      "content-length": String(contentLength),
+    },
+    // parseUploadRequest only reads the stream, the headers, and destroy();
+    // a full IncomingMessage is not needed.
+  }) as unknown as IncomingMessage;
+}
+
+describe("parseUploadRequest", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("buffers sub-threshold uploads and writes them with a replayable save", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const file = await FileFactory.create(auth, null, {
+      contentType: "application/pdf",
+      fileName: "document.pdf",
+      fileSize: 1000,
+      status: "created",
+      useCase: "conversation",
+    });
+
+    const content = Buffer.from("fake pdf bytes");
+    const body = makeMultipartBody(content, "application/pdf");
+
+    const result = await parseUploadRequest(
+      auth,
+      file,
+      makeUploadRequest(Readable.from([body]), body.length)
+    );
+
+    assert(
+      result.isOk(),
+      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+    );
+
+    // The payload is written via the buffered (replayable) save, not streamed.
+    expect(fileStorageMock.writeStreamCalls).toHaveLength(0);
+    const saves = fileStorageMock.saveFileCalls;
+    expect(saves).toHaveLength(1);
+    expect(saves[0].contentType).toBe("application/pdf");
+    expect(Buffer.from(saves[0].content).equals(content)).toBe(true);
+  });
+
+  it("streams uploads at or above the resumable threshold", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const file = await FileFactory.create(auth, null, {
+      contentType: "application/pdf",
+      fileName: "large.pdf",
+      fileSize: 9 * 1024 * 1024,
+      status: "created",
+      useCase: "conversation",
+    });
+
+    const body = makeMultipartBody(
+      Buffer.from("fake large pdf bytes"),
+      "application/pdf"
+    );
+
+    const result = await parseUploadRequest(
+      auth,
+      file,
+      makeUploadRequest(Readable.from([body]), body.length)
+    );
+
+    assert(
+      result.isOk(),
+      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+    );
+
+    // The payload is streamed straight to GCS (resumable upload).
+    expect(fileStorageMock.writeStreamCalls).toHaveLength(1);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(0);
+  });
+
+  it("fails with an explicit error when the upload stalls", async () => {
+    const { authenticator: auth } = await createResourceTest({
+      role: "admin",
+    });
+
+    const file = await FileFactory.create(auth, null, {
+      contentType: "application/pdf",
+      fileName: "stalled.pdf",
+      fileSize: 1000,
+      status: "created",
+      useCase: "conversation",
+    });
+
+    vi.useFakeTimers();
+
+    // A request stream that never sends any data and never ends.
+    const stalledStream = new Readable({ read() {} });
+    const resultPromise = parseUploadRequest(
+      auth,
+      file,
+      makeUploadRequest(stalledStream, 1000)
+    );
+
+    await vi.advanceTimersByTimeAsync(FILE_UPLOAD_TIMEOUT_MS + 1);
+
+    const result = await resultPromise;
+    assert(result.isErr(), "Expected Err, got Ok");
+    expect(result.error.code).toBe("internal_server_error");
+    expect(result.error.message).toBe("File upload timed out.");
+  });
+});

--- a/front/lib/api/files/utils.test.ts
+++ b/front/lib/api/files/utils.test.ts
@@ -2,6 +2,7 @@ import {
   FILE_UPLOAD_TIMEOUT_MS,
   parseUploadRequest,
 } from "@app/lib/api/files/utils";
+import { GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES } from "@app/lib/file_storage";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -82,7 +83,7 @@ describe("parseUploadRequest", () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "application/pdf",
       fileName: "large.pdf",
-      fileSize: 9 * 1024 * 1024,
+      fileSize: GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES,
       status: "created",
       useCase: "conversation",
     });

--- a/front/lib/api/files/utils.test.ts
+++ b/front/lib/api/files/utils.test.ts
@@ -1,13 +1,13 @@
 import {
-  FILE_UPLOAD_TIMEOUT_MS,
+  getFileUploadTimeoutMs,
   parseUploadRequest,
 } from "@app/lib/api/files/utils";
 import { GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES } from "@app/lib/file_storage";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import type { IncomingMessage } from "http";
-import { Readable } from "stream";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
 import { afterEach, assert, describe, expect, it, vi } from "vitest";
 
 const BOUNDARY = "----vitestboundary";
@@ -24,15 +24,26 @@ function makeMultipartBody(content: Buffer, contentType: string): Buffer {
   ]);
 }
 
-function makeUploadRequest(stream: Readable, contentLength: number) {
-  return Object.assign(stream, {
-    headers: {
-      "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
-      "content-length": String(contentLength),
-    },
-    // parseUploadRequest only reads the stream, the headers, and destroy();
-    // a full IncomingMessage is not needed.
-  }) as unknown as IncomingMessage;
+function makeUploadRequest(
+  body: Buffer | null,
+  contentLength: number
+): IncomingMessage {
+  // A real IncomingMessage backed by an unconnected socket: pushed chunks are
+  // what formidable reads. A null body leaves the stream open and empty,
+  // simulating a stalled client.
+  const req = new IncomingMessage(new Socket());
+  req.headers = {
+    "content-type": `multipart/form-data; boundary=${BOUNDARY}`,
+    "content-length": String(contentLength),
+  };
+  if (body) {
+    req.push(body);
+    req.push(null);
+    // Normally set by the HTTP parser. Without it, the stream's auto-destroy
+    // after "end" emits "aborted" and formidable fails the parse.
+    req.complete = true;
+  }
+  return req;
 }
 
 describe("parseUploadRequest", () => {
@@ -59,7 +70,7 @@ describe("parseUploadRequest", () => {
     const result = await parseUploadRequest(
       auth,
       file,
-      makeUploadRequest(Readable.from([body]), body.length)
+      makeUploadRequest(body, body.length)
     );
 
     assert(
@@ -96,7 +107,7 @@ describe("parseUploadRequest", () => {
     const result = await parseUploadRequest(
       auth,
       file,
-      makeUploadRequest(Readable.from([body]), body.length)
+      makeUploadRequest(body, body.length)
     );
 
     assert(
@@ -124,15 +135,14 @@ describe("parseUploadRequest", () => {
 
     vi.useFakeTimers();
 
-    // A request stream that never sends any data and never ends.
-    const stalledStream = new Readable({ read() {} });
+    // A request that never sends any data and never ends.
     const resultPromise = parseUploadRequest(
       auth,
       file,
-      makeUploadRequest(stalledStream, 1000)
+      makeUploadRequest(null, 1000)
     );
 
-    await vi.advanceTimersByTimeAsync(FILE_UPLOAD_TIMEOUT_MS + 1);
+    await vi.advanceTimersByTimeAsync(getFileUploadTimeoutMs(1000) + 1);
 
     const result = await resultPromise;
     assert(result.isErr(), "Expected Err, got Ok");

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -20,6 +20,8 @@ import { Writable } from "stream";
 // hanging forever with no error ever surfaced to the user.
 export const FILE_UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes.
 
+const FILE_UPLOAD_TIMED_OUT_MESSAGE = "File upload timed out.";
+
 export const parseUploadRequest = async (
   auth: Authenticator,
   file: FileResource,
@@ -101,22 +103,31 @@ export const parseUploadRequest = async (
       );
     });
 
-    const raced = await Promise.race([uploadPromise, timeoutPromise]);
-    clearTimeout(timeoutHandle);
+    let raced;
+    try {
+      raced = await Promise.race([uploadPromise, timeoutPromise]);
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
 
     if (raced === "timeout") {
-      // Tear down both ends: the GCS write stream (stalled upstream
-      // connection) and the request (stalled client).
-      writeStream?.destroy(new Error("File upload timed out."));
-      req.destroy();
-      // The abandoned promise rejects after the destroy; swallow it to avoid
+      // Tear down the GCS write stream (stalled upstream connection), and the
+      // request when the client is the stalled side. If the body was fully
+      // received, keep the socket alive so the error response can reach the
+      // client.
+      writeStream?.destroy(new Error(FILE_UPLOAD_TIMED_OUT_MESSAGE));
+      if (!req.readableEnded) {
+        req.destroy();
+      }
+      // The abandoned promise settles later (a pending buffered GCS write is
+      // not cancelled and may still land); swallow a late rejection to avoid
       // an unhandled rejection.
       uploadPromise.catch(() => {});
 
       return new Err({
         name: "dust_error",
         code: "internal_server_error",
-        message: "File upload timed out.",
+        message: FILE_UPLOAD_TIMED_OUT_MESSAGE,
       });
     }
 

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
+import { GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES } from "@app/lib/file_storage";
 import type {
   FileResource,
   FileVersion,
@@ -12,7 +13,12 @@ import type { File } from "formidable";
 import { IncomingForm } from "formidable";
 import type { IncomingMessage } from "http";
 import * as iconv from "iconv-lite";
-import type { Writable } from "stream";
+import { Writable } from "stream";
+
+// Overall budget for receiving the request body and writing it to GCS. Without
+// it, a stalled GCS connection (or a stalled client) leaves the request
+// hanging forever with no error ever surfaced to the user.
+export const FILE_UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes.
 
 export const parseUploadRequest = async (
   auth: Authenticator,
@@ -35,11 +41,27 @@ export const parseUploadRequest = async (
   // destroy it if formidable throws mid-upload after opening the stream.
   let writeStream: Writable | undefined;
 
+  // Below the resumable threshold, buffer the payload in memory and write it
+  // to GCS once fully received: a buffered write is replayable, so transient
+  // GCS errors ("socket hang up") are retried instead of failing the upload.
+  // Streamed writes piped straight from the request cannot be retried (the
+  // request stream is not replayable); above the threshold the resumable
+  // upload in getWriteStream provides per-chunk retry instead.
+  const isBufferedUpload = file.fileSize < GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES;
+  const chunks: Buffer[] = [];
+
   try {
     const form = new IncomingForm({
       // Stream the uploaded document to the cloud storage.
       fileWriteStreamHandler: () => {
-        writeStream = file.getWriteStream({ auth, version: "original" });
+        writeStream = isBufferedUpload
+          ? new Writable({
+              write(chunk: Buffer, _encoding, callback) {
+                chunks.push(chunk);
+                callback();
+              },
+            })
+          : file.getWriteStream({ auth, version: "original" });
         return writeStream;
       },
 
@@ -61,9 +83,44 @@ export const parseUploadRequest = async (
           file.contentType,
     });
 
-    const [, files] = await form.parse(req);
+    const uploadPromise = (async () => {
+      const [, files] = await form.parse(req);
 
-    const maybeFiles = files.file;
+      if (isBufferedUpload && files.file && files.file.length > 0) {
+        await file.uploadOriginalFromBuffer(auth, Buffer.concat(chunks));
+      }
+
+      return files;
+    })();
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(
+        () => resolve("timeout"),
+        FILE_UPLOAD_TIMEOUT_MS
+      );
+    });
+
+    const raced = await Promise.race([uploadPromise, timeoutPromise]);
+    clearTimeout(timeoutHandle);
+
+    if (raced === "timeout") {
+      // Tear down both ends: the GCS write stream (stalled upstream
+      // connection) and the request (stalled client).
+      writeStream?.destroy(new Error("File upload timed out."));
+      req.destroy();
+      // The abandoned promise rejects after the destroy; swallow it to avoid
+      // an unhandled rejection.
+      uploadPromise.catch(() => {});
+
+      return new Err({
+        name: "dust_error",
+        code: "internal_server_error",
+        message: "File upload timed out.",
+      });
+    }
+
+    const maybeFiles = raced.file;
 
     if (!maybeFiles || maybeFiles.length === 0) {
       return new Err({

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -20,7 +20,7 @@ import { Writable } from "stream";
 // (up to 350MB for large delimited files) is not cut off while a small one
 // fails fast. Without it, a stalled GCS connection (or a stalled client)
 // leaves the request hanging forever with no error ever surfaced to the user.
-const FILE_UPLOAD_BASE_TIMEOUT_MS = 60 * 1000; // 1 minute.
+const FILE_UPLOAD_BASE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes.
 // Slow-link allowance: ~2 Mbit/s sustained.
 const FILE_UPLOAD_MIN_THROUGHPUT_BYTES_PER_SECOND = 250 * 1024;
 

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -15,10 +15,21 @@ import type { IncomingMessage } from "http";
 import * as iconv from "iconv-lite";
 import { Writable } from "stream";
 
-// Overall budget for receiving the request body and writing it to GCS. Without
-// it, a stalled GCS connection (or a stalled client) leaves the request
-// hanging forever with no error ever surfaced to the user.
-export const FILE_UPLOAD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes.
+// Overall budget for receiving the request body and writing it to GCS,
+// scaled with the declared file size so a slow-but-progressing large upload
+// (up to 350MB for large delimited files) is not cut off while a small one
+// fails fast. Without it, a stalled GCS connection (or a stalled client)
+// leaves the request hanging forever with no error ever surfaced to the user.
+const FILE_UPLOAD_BASE_TIMEOUT_MS = 60 * 1000; // 1 minute.
+// Slow-link allowance: ~2 Mbit/s sustained.
+const FILE_UPLOAD_MIN_THROUGHPUT_BYTES_PER_SECOND = 250 * 1024;
+
+export function getFileUploadTimeoutMs(fileSizeBytes: number): number {
+  return (
+    FILE_UPLOAD_BASE_TIMEOUT_MS +
+    (fileSizeBytes / FILE_UPLOAD_MIN_THROUGHPUT_BYTES_PER_SECOND) * 1000
+  );
+}
 
 const FILE_UPLOAD_TIMED_OUT_MESSAGE = "File upload timed out.";
 
@@ -99,7 +110,7 @@ export const parseUploadRequest = async (
     const timeoutPromise = new Promise<"timeout">((resolve) => {
       timeoutHandle = setTimeout(
         () => resolve("timeout"),
-        FILE_UPLOAD_TIMEOUT_MS
+        getFileUploadTimeoutMs(file.fileSize)
       );
     });
 

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -31,6 +31,14 @@ const GCS_OBJECT_DOES_NOT_EXIST_GENERATION_MATCH = 0;
 
 const DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000; // 5 minutes.
 
+// Threshold above which file uploads switch from a single multipart POST to a
+// resumable upload (see FileResource.getWriteStream). Below it, uploads are
+// buffered in memory and written with retry (see parseUploadRequest). Chunk
+// size must be a multiple of 256 KiB; GCS recommends at least 8 MiB for
+// performance.
+export const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
+export const GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024;
+
 interface FileStorageOptions {
   useServiceAccount?: boolean;
 }
@@ -146,6 +154,27 @@ export class FileStorage {
       {
         operationName: "file upload (stream)",
         logContext: { destPath },
+      }
+    );
+  }
+
+  async uploadBufferToBucket({
+    buffer,
+    contentType,
+    filePath,
+  }: {
+    buffer: Buffer;
+    contentType: AllSupportedFileContentType;
+    filePath: string;
+  }) {
+    // A single-request upload without preconditions is not retried by the
+    // SDK (conditional idempotency), so retry transient errors at the
+    // application level: the buffer is replayable.
+    await withRetryOnTransientGCSError(
+      () => this.file(filePath).save(buffer, { contentType, resumable: false }),
+      {
+        operationName: "file upload (buffer)",
+        logContext: { filePath },
       }
     );
   }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -41,6 +41,8 @@ import type { ShareFrameViewerFile } from "@app/lib/api/viz/share_frame_viewer_f
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
+  GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES,
+  GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES,
   getPrivateUploadBucket,
   getPublicUploadBucket,
   getUpsertQueueBucket,
@@ -110,12 +112,6 @@ import { validate } from "uuid";
 import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
 
 export type FileVersion = "processed" | "original" | "public";
-
-// Threshold above which file uploads switch from a single multipart POST to a
-// resumable upload (see getWriteStream). Chunk size must be a multiple of
-// 256 KiB; GCS recommends at least 8 MiB for performance.
-const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
-const GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES = 8 * 1024 * 1024;
 
 const FRAME_CONTENT_TYPES = new Set([
   frameContentType,
@@ -988,6 +984,23 @@ export class FileResource extends BaseResource<FileModel> {
   }
 
   // Direct upload logic.
+
+  /**
+   * Upload the original version from an in-memory buffer. Unlike a streamed
+   * write (getWriteStream), the buffer can be re-sent, so transient GCS errors
+   * ("socket hang up") are retried instead of failing the upload. Only use for
+   * payloads below GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES.
+   */
+  async uploadOriginalFromBuffer(
+    auth: Authenticator,
+    buffer: Buffer
+  ): Promise<void> {
+    await this.getBucketForVersion("original").uploadBufferToBucket({
+      buffer,
+      contentType: this.contentType,
+      filePath: this.getCloudStoragePath(auth, "original"),
+    });
+  }
 
   async uploadContent(auth: Authenticator, content: string): Promise<void> {
     // Update the file size.

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -57,9 +57,6 @@ class FileStorageMock {
     const createStorage = () => this.createMockStorage();
 
     return {
-      // Constants re-exported as-is (the real module is fully replaced).
-      GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES: 8 * 1024 * 1024,
-      GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES: 8 * 1024 * 1024,
       FileStorage: vi.fn().mockImplementation(createStorage),
       // Passthrough: run the operation once, without retry or backoff.
       withRetryOnTransientGCSError: vi.fn(

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -57,6 +57,9 @@ class FileStorageMock {
     const createStorage = () => this.createMockStorage();
 
     return {
+      // Constants re-exported as-is (the real module is fully replaced).
+      GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES: 8 * 1024 * 1024,
+      GCS_RESUMABLE_UPLOAD_CHUNK_SIZE_BYTES: 8 * 1024 * 1024,
       FileStorage: vi.fn().mockImplementation(createStorage),
       // Passthrough: run the operation once, without retry or backoff.
       withRetryOnTransientGCSError: vi.fn(
@@ -118,6 +121,16 @@ class FileStorageMock {
         .mockResolvedValue({ isOk: () => false, isErr: () => true }),
       getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
       uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
+      uploadBufferToBucket: vi.fn(
+        (args: { buffer: Buffer; contentType: string; filePath: string }) => {
+          this._saveFileCalls.push({
+            filePath: args.filePath,
+            content: args.buffer,
+            contentType: args.contentType,
+          });
+          return Promise.resolve(undefined);
+        }
+      ),
       uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
       uploadSmallRawContentToBucketAsNewFile: vi
         .fn()

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -166,7 +166,13 @@ vi.mock("@app/lib/file_storage", async () => {
   const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
-  return fileStorageMock.mock();
+  // Spread the actual module so plain re-exports (constants) keep their real
+  // values; the mock only replaces the GCS-backed functions. Safe because the
+  // real module only reads SERVICE_ACCOUNT inside the FileStorage constructor.
+  const actual = await vi.importActual<typeof import("@app/lib/file_storage")>(
+    "@app/lib/file_storage"
+  );
+  return { ...actual, ...fileStorageMock.mock() };
 });
 
 // Mock TextExtraction (Tika) - must be at module level to avoid connecting to Tika.


### PR DESCRIPTION
## Description

Conversation file uploads fail intermittently with GCS "socket hang up" (~600/day, mostly 4-7MB PDFs, see dust-tt/tasks#8865). Files below the 8MB resumable threshold are streamed straight from the request to GCS as a single multipart POST: the request stream is not replayable, so one transient reset fails the upload with no retry possible. #27142 fixed the >=8MB path; this covers the rest.

- Buffer sub-threshold payloads in memory in parseUploadRequest and write them after parsing, wrapped in withRetryOnTransientGCSError (a buffer is replayable). Larger files keep the resumable streamed path which retries per chunk.
- Add an overall timeout on receive + write, scaled with the declared file size (2 minute floor plus a ~2 Mbit/s slow-link allowance, so a 7MB PDF gets ~2.5min and a 350MB delimited file ~25min). A stalled GCS connection (or client) used to hang the request forever: no response, no log line, user stuck on a spinner. On timeout, the request socket is only destroyed if the client is the stalled side, so the 500 can reach the client when the stall is GCS-side.
- Move the resumable threshold constants to lib/file_storage (importing them from file_resource in lib/api created an import cycle).

## Tests

Added parseUploadRequest tests: sub-threshold upload goes through the buffered replayable save, at-threshold goes through the streamed path, stalled request returns "File upload timed out." instead of hanging (fake timers).

## Risk

Low. Memory: buffered payloads are capped at 8MB by formidable's maxFileSize (set to the declared fileSize). Behavior for >=8MB files is unchanged. Safe to rollback.

## Deploy Plan

Standard deploy.
