### PR TITLE
Fix finalization single shot

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -4841,7 +4841,7 @@ describe("updateAgentMessageWithFinalStatus", () => {
 
     const agentMessages = conversation.content
       .flat()
-      .filter((m) => m.type === "agent_message") as AgentMessageType[];
+      .filter((m): m is AgentMessageType => m.type === "agent_message");
     if (agentMessages.length === 0) {
       throw new Error("No agent message found in conversation");
     }

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -7,6 +7,7 @@ import {
   retryAgentMessage,
   softDeleteAgentMessage,
   softDeleteUserMessageAndReplies,
+  updateAgentMessageWithFinalStatus,
 } from "@app/lib/api/assistant/conversation";
 import { compactConversation } from "@app/lib/api/assistant/conversation/compaction";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
@@ -4805,5 +4806,113 @@ describe("postUserMessage no-seat gate", () => {
       expect(result.error.status_code).toBe(403);
       expect(result.error.api_error.type).toBe("no_seat");
     }
+  });
+});
+
+describe("updateAgentMessageWithFinalStatus", () => {
+  let auth: Authenticator;
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let conversation: ConversationType;
+  let agentMessage: AgentMessageType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    const conversationWithoutContent = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const fetchedConversationResult = await getConversation(
+      auth,
+      conversationWithoutContent.sId
+    );
+    if (fetchedConversationResult.isErr()) {
+      throw new Error("Failed to fetch conversation");
+    }
+    conversation = fetchedConversationResult.value;
+
+    const agentMessages = conversation.content
+      .flat()
+      .filter((m) => m.type === "agent_message") as AgentMessageType[];
+    if (agentMessages.length === 0) {
+      throw new Error("No agent message found in conversation");
+    }
+    agentMessage = agentMessages[0];
+
+    vi.clearAllMocks();
+  });
+
+  it("only applies the first terminal status (finalization is single-shot)", async () => {
+    const first = await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "interrupted",
+    });
+    expect(first.status).toBe("interrupted");
+
+    // A late terminal event from an orphaned activity (e.g. an LLM call still
+    // running after an interrupt) must not overwrite the final status.
+    const second = await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "succeeded",
+    });
+    expect(second.status).toBe("interrupted");
+
+    const agentMessageRow = await AgentMessageModel.findOne({
+      where: { id: agentMessage.agentMessageId, workspaceId: workspace.id },
+    });
+    expect(agentMessageRow?.status).toBe("interrupted");
+  });
+
+  it("does not promote pending messages nor spawn a new agent loop when already finalized", async () => {
+    await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "interrupted",
+    });
+
+    // Queue a steering message, pending at the time the late terminal event arrives. The
+    // conversation already has messages at ranks 0 and 1.
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: "steering message",
+      rank: 2,
+    });
+    await MessageModel.update(
+      { visibility: "pending" },
+      {
+        where: { id: messageRow.id, workspaceId: workspace.id },
+        // Bulk update constructs a dummy instance failing the beforeValidate hook; the row is
+        // already valid, we only update visibility.
+        validate: false,
+      }
+    );
+
+    vi.clearAllMocks();
+
+    const result = await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "succeeded",
+    });
+    expect(result.status).toBe("interrupted");
+
+    // The pending steering message must remain pending: no promotion, no new agent loop.
+    const pendingMessageRow = await MessageModel.findOne({
+      where: { id: messageRow.id, workspaceId: workspace.id },
+    });
+    expect(pendingMessageRow?.visibility).toBe("pending");
+    expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3069,10 +3069,15 @@ export async function updateAgentMessageWithFinalStatus(
     promotedAuth,
     agentMessage: newAgentMessage,
     deniedActions,
+    alreadyFinalized,
   } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    await AgentMessageModel.update(
+    // Only transition from "created": finalization is single-shot. A late terminal event from an
+    // orphaned activity (e.g. an LLM call still running after an interrupt) must not overwrite
+    // the final status nor re-run the pending-messages promotion below, which would spawn a
+    // second concurrent agent loop.
+    const [updatedCount] = await AgentMessageModel.update(
       {
         status,
         completedAt,
@@ -3088,10 +3093,29 @@ export async function updateAgentMessageWithFinalStatus(
         where: {
           id: agentMessage.agentMessageId,
           workspaceId: owner.id,
+          status: "created",
         },
         transaction: t,
       }
     );
+
+    if (updatedCount === 0) {
+      const existingAgentMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: owner.id,
+        },
+        transaction: t,
+      });
+
+      return {
+        promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
+        promotedAuth: auth,
+        agentMessage: null as AgentMessageType | null,
+        deniedActions: [],
+        alreadyFinalized: existingAgentMessage,
+      };
+    }
 
     const deniedActions = UNRESUMABLE_AGENT_MESSAGE_STATUSES.includes(status)
       ? await AgentMCPActionResource.denyBlockedActionsForAgentMessage(auth, {
@@ -3121,6 +3145,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedAuth: auth,
         agentMessage: null as AgentMessageType | null,
         deniedActions,
+        alreadyFinalized: null,
       };
     }
 
@@ -3177,6 +3202,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedAuth,
         agentMessage: null,
         deniedActions,
+        alreadyFinalized: null,
       };
     }
 
@@ -3189,6 +3215,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedAuth,
         agentMessage: null,
         deniedActions,
+        alreadyFinalized: null,
       };
     }
 
@@ -3216,8 +3243,31 @@ export async function updateAgentMessageWithFinalStatus(
       promotedAuth,
       agentMessage: agentMessages[0] ?? null,
       deniedActions,
+      alreadyFinalized: null,
     };
   });
+
+  if (alreadyFinalized) {
+    logger.warn(
+      {
+        agentMessageId: agentMessage.sId,
+        conversationId: conversation.sId,
+        currentStatus: alreadyFinalized.status,
+        requestedStatus: status,
+        workspaceId: owner.sId,
+      },
+      "updateAgentMessageWithFinalStatus: message already finalized, skipping"
+    );
+
+    return {
+      completedTs:
+        alreadyFinalized.completedAt?.getTime() ?? completedAt.getTime(),
+      status:
+        alreadyFinalized.status !== "created"
+          ? alreadyFinalized.status
+          : status,
+    };
+  }
 
   // Publish events and launch agent loop outside of the advisory lock.
   if (promotedUserMessages.length > 0) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3060,6 +3060,9 @@ export async function updateAgentMessageWithFinalStatus(
 ): Promise<{
   completedTs: number;
   status: Exclude<AgentMessageStatus, "created">;
+  // False when the message was already finalized (or deleted): callers must skip the terminal
+  // side effects (event publish, unread state, conversation flags) of a late terminal event.
+  applied: boolean;
 }> {
   const completedAt = new Date();
   const owner = auth.getNonNullableWorkspace();
@@ -3069,7 +3072,7 @@ export async function updateAgentMessageWithFinalStatus(
     promotedAuth,
     agentMessage: newAgentMessage,
     deniedActions,
-    alreadyFinalized,
+    skippedTransition,
   } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
@@ -3108,12 +3111,13 @@ export async function updateAgentMessageWithFinalStatus(
         transaction: t,
       });
 
+      // existingAgentMessage is null when the message row was deleted mid-finalize.
       return {
         promotedUserMessages: [] as UserMessageTypeWithoutMentions[],
         promotedAuth: auth,
         agentMessage: null as AgentMessageType | null,
         deniedActions: [],
-        alreadyFinalized: existingAgentMessage,
+        skippedTransition: { existingAgentMessage },
       };
     }
 
@@ -3145,7 +3149,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedAuth: auth,
         agentMessage: null as AgentMessageType | null,
         deniedActions,
-        alreadyFinalized: null,
+        skippedTransition: null,
       };
     }
 
@@ -3202,7 +3206,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedAuth,
         agentMessage: null,
         deniedActions,
-        alreadyFinalized: null,
+        skippedTransition: null,
       };
     }
 
@@ -3215,7 +3219,7 @@ export async function updateAgentMessageWithFinalStatus(
         promotedAuth,
         agentMessage: null,
         deniedActions,
-        alreadyFinalized: null,
+        skippedTransition: null,
       };
     }
 
@@ -3243,16 +3247,18 @@ export async function updateAgentMessageWithFinalStatus(
       promotedAuth,
       agentMessage: agentMessages[0] ?? null,
       deniedActions,
-      alreadyFinalized: null,
+      skippedTransition: null,
     };
   });
 
-  if (alreadyFinalized) {
+  if (skippedTransition) {
+    const { existingAgentMessage } = skippedTransition;
+
     logger.warn(
       {
         agentMessageId: agentMessage.sId,
         conversationId: conversation.sId,
-        currentStatus: alreadyFinalized.status,
+        currentStatus: existingAgentMessage?.status ?? "not_found",
         requestedStatus: status,
         workspaceId: owner.sId,
       },
@@ -3261,11 +3267,12 @@ export async function updateAgentMessageWithFinalStatus(
 
     return {
       completedTs:
-        alreadyFinalized.completedAt?.getTime() ?? completedAt.getTime(),
+        existingAgentMessage?.completedAt?.getTime() ?? completedAt.getTime(),
       status:
-        alreadyFinalized.status !== "created"
-          ? alreadyFinalized.status
+        existingAgentMessage && existingAgentMessage.status !== "created"
+          ? existingAgentMessage.status
           : status,
+      applied: false,
     };
   }
 
@@ -3330,5 +3337,6 @@ export async function updateAgentMessageWithFinalStatus(
   return {
     completedTs: completedAt.getTime(),
     status,
+    applied: true,
   };
 }

--- a/front/lib/api/cancel.ts
+++ b/front/lib/api/cancel.ts
@@ -88,11 +88,17 @@ export async function terminateMessageGeneration(
       continue;
     }
 
-    await updateAgentMessageWithFinalStatus(auth, {
+    const result = await updateAgentMessageWithFinalStatus(auth, {
       conversation,
       agentMessage,
       status,
     });
+
+    // The status check above reads a snapshot: the message may have been finalized between the
+    // render and the update. Don't publish a stale terminal event in that case.
+    if (!result.applied) {
+      continue;
+    }
 
     await publishConversationRelatedEvent({
       event: {

--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -1,9 +1,15 @@
+import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import type { AgentMessageSuccessEvent } from "@app/types/assistant/agent";
+import type {
+  AgentErrorEvent,
+  AgentMessageSuccessEvent,
+} from "@app/types/assistant/agent";
+import type { AgentMessageType } from "@app/types/assistant/conversation";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   processEventForDatabase,
@@ -1047,5 +1053,165 @@ describe("updateAgentMessageDBAndMemory", () => {
       // Assert: In-memory object should be updated
       expect(agentMessage.prunedContext).toBe(true);
     });
+  });
+});
+
+describe("late terminal events after finalization", () => {
+  let auth: Awaited<ReturnType<typeof createResourceTest>>["authenticator"];
+  let workspace: Awaited<ReturnType<typeof createResourceTest>>["workspace"];
+  let conversation: Awaited<ReturnType<typeof ConversationFactory.create>>;
+  let agentMessage: AgentMessageType;
+  let agentConfig: Awaited<
+    ReturnType<typeof AgentConfigurationFactory.createTestAgent>
+  >;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+
+    agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+    });
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    ({ agentMessage } = await ConversationFactory.createAgentMessage(auth, {
+      workspace,
+      conversation,
+      agentConfig,
+    }));
+
+    // Interrupt the message (e.g. user skipped), as finalizeInterruption would.
+    const result = await updateAgentMessageWithFinalStatus(auth, {
+      conversation,
+      agentMessage,
+      status: "interrupted",
+    });
+    expect(result.applied).toBe(true);
+
+    // Simulate the promotion having started the next agent loop.
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation,
+      isRunningAgentLoop: true,
+    });
+  });
+
+  it("drops a late success event without mutating status or conversation flags", async () => {
+    const event: AgentMessageSuccessEvent = {
+      type: "agent_message_success",
+      created: Date.now(),
+      configurationId: agentConfig.sId,
+      messageId: agentMessage.sId,
+      message: agentMessage,
+      runIds: [],
+    };
+
+    const shouldPublish = await processEventForDatabase(auth, {
+      event,
+      agentMessage,
+      step: 0,
+      conversation,
+    });
+
+    expect(shouldPublish).toBe(false);
+
+    const dbMessage = await AgentMessageModel.findOne({
+      where: { id: agentMessage.agentMessageId, workspaceId: workspace.id },
+    });
+    expect(dbMessage?.status).toBe("interrupted");
+
+    // The next loop must still be marked as running.
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        conversation.sId
+      );
+    expect(conversationRes.isOk()).toBe(true);
+    if (conversationRes.isOk()) {
+      expect(conversationRes.value.isRunningAgentLoop).toBe(true);
+    }
+  });
+
+  it("drops a late error event without failing the message or the conversation", async () => {
+    const event: AgentErrorEvent = {
+      type: "agent_error",
+      created: Date.now(),
+      configurationId: agentConfig.sId,
+      messageId: agentMessage.sId,
+      error: {
+        code: "multi_actions_error",
+        message: "Late error from an orphaned activity",
+        metadata: null,
+      },
+      runIds: [],
+    };
+
+    const shouldPublish = await processEventForDatabase(auth, {
+      event,
+      agentMessage,
+      step: 0,
+      conversation,
+    });
+
+    expect(shouldPublish).toBe(false);
+
+    const dbMessage = await AgentMessageModel.findOne({
+      where: { id: agentMessage.agentMessageId, workspaceId: workspace.id },
+    });
+    expect(dbMessage?.status).toBe("interrupted");
+    expect(dbMessage?.errorCode).toBeNull();
+
+    const conversationRes =
+      await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        conversation.sId
+      );
+    expect(conversationRes.isOk()).toBe(true);
+    if (conversationRes.isOk()) {
+      expect(conversationRes.value.hasError).toBe(false);
+      expect(conversationRes.value.isRunningAgentLoop).toBe(true);
+    }
+  });
+
+  it("still applies the first terminal event normally", async () => {
+    // Sanity check on a fresh (non-finalized) message: the pipeline continues.
+    const freshConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const { agentMessage: freshAgentMessage } =
+      await ConversationFactory.createAgentMessage(auth, {
+        workspace,
+        conversation: freshConversation,
+        agentConfig,
+      });
+
+    const event: AgentMessageSuccessEvent = {
+      type: "agent_message_success",
+      created: Date.now(),
+      configurationId: agentConfig.sId,
+      messageId: freshAgentMessage.sId,
+      message: freshAgentMessage,
+      runIds: [],
+    };
+
+    const shouldPublish = await processEventForDatabase(auth, {
+      event,
+      agentMessage: freshAgentMessage,
+      step: 0,
+      conversation: freshConversation,
+    });
+
+    expect(shouldPublish).toBe(true);
+
+    const dbMessage = await AgentMessageModel.findOne({
+      where: {
+        id: freshAgentMessage.agentMessageId,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(dbMessage?.status).toBe("succeeded");
   });
 });

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -88,7 +88,7 @@ export async function updateAgentMessageDBAndMemory(
               prunedContext: true;
             };
       }
-): Promise<void> {
+): Promise<boolean> {
   const { agentMessage } = args;
   const where: WhereOptions<InferAttributes<AgentMessageModel>> = {
     id: agentMessage.agentMessageId,
@@ -96,39 +96,40 @@ export async function updateAgentMessageDBAndMemory(
   };
 
   // Terminal status updates go through the advisory-locked updateAgentMessageWithFinalStatus.
+  // Returns false when the terminal transition was not applied (message already finalized):
+  // callers must then skip the remaining terminal side effects.
   if ("conversation" in args) {
     const { conversation, update } = args;
     switch (update.type) {
-      case "error":
-        {
-          const result = await updateAgentMessageWithFinalStatus(auth, {
-            conversation,
-            agentMessage,
-            status: "failed",
-            error: update.error,
-          });
-          agentMessage.status = result.status;
-          agentMessage.completedTs = result.completedTs;
+      case "error": {
+        const result = await updateAgentMessageWithFinalStatus(auth, {
+          conversation,
+          agentMessage,
+          status: "failed",
+          error: update.error,
+        });
+        agentMessage.status = result.status;
+        agentMessage.completedTs = result.completedTs;
+        if (result.applied) {
           agentMessage.error = update.error;
         }
-        break;
+        return result.applied;
+      }
 
-      case "status":
-        {
-          const result = await updateAgentMessageWithFinalStatus(auth, {
-            conversation,
-            agentMessage,
-            status: update.status,
-          });
-          agentMessage.status = result.status;
-          agentMessage.completedTs = result.completedTs;
-        }
-        break;
+      case "status": {
+        const result = await updateAgentMessageWithFinalStatus(auth, {
+          conversation,
+          agentMessage,
+          status: update.status,
+        });
+        agentMessage.status = result.status;
+        agentMessage.completedTs = result.completedTs;
+        return result.applied;
+      }
 
       default:
-        assertNever(update);
+        return assertNever(update);
     }
-    return;
   }
 
   // Non-terminal metadata updates — no lock needed.
@@ -189,6 +190,8 @@ export async function updateAgentMessageDBAndMemory(
     default:
       assertNever(update);
   }
+
+  return true;
 }
 
 export async function markAgentMessageAsFailed(
@@ -202,8 +205,8 @@ export async function markAgentMessageAsFailed(
     conversation: ConversationWithoutContentType;
     error: ToolErrorEvent["error"];
   }
-): Promise<void> {
-  await updateAgentMessageDBAndMemory(auth, {
+): Promise<boolean> {
+  return updateAgentMessageDBAndMemory(auth, {
     agentMessage,
     conversation,
     update: {
@@ -214,6 +217,9 @@ export async function markAgentMessageAsFailed(
 }
 
 // Process database operations for agent events before publishing to Redis.
+// Returns false when a terminal event targets an already-finalized message: the event is stale
+// (e.g. emitted by an orphaned activity after an interrupt) and must be dropped by the caller
+// instead of being published.
 export async function processEventForDatabase(
   auth: Authenticator,
   {
@@ -229,7 +235,7 @@ export async function processEventForDatabase(
     conversation: ConversationWithoutContentType;
     modelInteractionDurationMs?: number;
   }
-): Promise<void> {
+): Promise<boolean> {
   // If we have a model interaction duration, store it.
   if (modelInteractionDurationMs) {
     await updateAgentMessageDBAndMemory(auth, {
@@ -254,13 +260,17 @@ export async function processEventForDatabase(
   }
 
   switch (event.type) {
-    case "agent_error":
+    case "agent_error": {
       // Store error in database.
-      await markAgentMessageAsFailed(auth, {
+      const applied = await markAgentMessageAsFailed(auth, {
         agentMessage,
         conversation,
         error: event.error,
       });
+
+      if (!applied) {
+        return false;
+      }
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
@@ -286,24 +296,30 @@ export async function processEventForDatabase(
         },
       });
       break;
+    }
 
-    case "tool_error":
-      await markAgentMessageAsFailed(auth, {
+    case "tool_error": {
+      const applied = await markAgentMessageAsFailed(auth, {
         agentMessage,
         conversation,
         error: event.error,
       });
+
+      if (!applied) {
+        return false;
+      }
 
       // Mark the conversation as errored.
       await ConversationResource.markHasError(auth, {
         conversation,
       });
       break;
+    }
 
-    case "agent_generation_cancelled":
+    case "agent_generation_cancelled": {
       // Store cancellation in database. Also denies blocked actions of the cancelled message
       // (via updateAgentMessageWithFinalStatus).
-      await updateAgentMessageDBAndMemory(auth, {
+      const applied = await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         conversation,
         update: {
@@ -311,42 +327,50 @@ export async function processEventForDatabase(
           status: event.status,
         },
       });
+
+      if (!applied) {
+        return false;
+      }
       break;
+    }
 
     case "agent_message_gracefully_stopped":
-    case "agent_message_success":
-      await Promise.all([
-        // Store terminal status in database behind advisory lock.
-        updateAgentMessageDBAndMemory(auth, {
-          agentMessage,
-          conversation,
-          update: {
-            type: "status",
-            status:
-              event.type === "agent_message_gracefully_stopped"
-                ? "gracefully_stopped"
-                : "succeeded",
-          },
-        }),
-        // Mark the conversation as updated
-        ConversationResource.markAsUpdated(auth, { conversation }),
-      ]);
+    case "agent_message_success": {
+      // Store terminal status in database behind advisory lock.
+      const applied = await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        conversation,
+        update: {
+          type: "status",
+          status:
+            event.type === "agent_message_gracefully_stopped"
+              ? "gracefully_stopped"
+              : "succeeded",
+        },
+      });
 
+      if (!applied) {
+        return false;
+      }
+
+      // Mark the conversation as updated
+      await ConversationResource.markAsUpdated(auth, { conversation });
       break;
+    }
 
     default:
       // Ensure we handle all event types.
       break;
   }
 
-  if (!TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
-    return;
+  if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
+    await ConversationResource.setIsRunningAgentLoop(auth, {
+      conversation,
+      isRunningAgentLoop: false,
+    });
   }
 
-  await ConversationResource.setIsRunningAgentLoop(auth, {
-    conversation,
-    isRunningAgentLoop: false,
-  });
+  return true;
 }
 
 // Process unread state for agent events before publishing to Redis.
@@ -400,13 +424,29 @@ export async function updateResourceAndPublishEvent(
   // computed and persisted later, in the finalize activities (see finalize.ts), so it is
   // intentionally not carried on the terminal events here — clients read it from the messages /
   // conversation API on their next revalidation.
-  await processEventForDatabase(auth, {
+  const shouldPublish = await processEventForDatabase(auth, {
     event,
     agentMessage,
     step,
     conversation,
     modelInteractionDurationMs,
   });
+
+  if (!shouldPublish) {
+    // Stale terminal event from an orphaned activity (the message was already finalized): don't
+    // publish it nor let it mutate conversation flags. Usage metadata (runIds,
+    // modelInteractionDurationMs) was still recorded above: those runs really happened and must
+    // stay attributed for cost accounting.
+    logger.info(
+      {
+        conversationId: conversation.sId,
+        messageId: event.messageId,
+        eventType: event.type,
+      },
+      "Dropping late terminal event for already-finalized agent message"
+    );
+    return;
+  }
 
   await processEventForUnreadState(auth, {
     event,
@@ -686,6 +726,22 @@ export async function finalizeInterruption(
   const { auth, agentConfiguration, agentMessage, conversation } =
     runAgentDataRes.value;
 
+  // The message may have been finalized by another path already (e.g. an orphaned activity
+  // erroring during the kill window). Don't publish a stale interrupted event: the single-shot
+  // guard in updateAgentMessageWithFinalStatus would no-op the transition anyway, and pending
+  // messages were already promoted by the first finalization.
+  if (agentMessage.status !== "created") {
+    logger.info(
+      {
+        agentMessageId: agentMessage.sId,
+        conversationId: conversation.sId,
+        status: agentMessage.status,
+      },
+      "finalizeInterruption: message already finalized, skipping"
+    );
+    return;
+  }
+
   const step = maxBy(agentMessage.contents, "step")?.step ?? 0;
 
   const contentParser = new AgentMessageContentParser(
@@ -704,7 +760,10 @@ export async function finalizeInterruption(
   }
 
   // Published before updateAgentMessageWithFinalStatus so clients drop the old message from
-  // generatingMessages before the new agent message appears.
+  // generatingMessages before the new agent message appears. Known TOCTOU: the DB transition
+  // below may no-op if another terminal event wins after the status snapshot above. We accept
+  // the tiny window because the DB is guarded and the worst case is transient UI state,
+  // corrected on reload.
   await publishConversationRelatedEvent({
     event: {
       type: "agent_generation_cancelled",

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -173,6 +173,7 @@ export class ConversationFactory {
     conversation,
     content,
     origin = "web",
+    rank = 0,
     agenticMessageType,
     agenticOriginMessageId,
   }: {
@@ -181,6 +182,7 @@ export class ConversationFactory {
     conversation: ConversationWithoutContentType;
     content: string;
     origin?: UserMessageOrigin;
+    rank?: number;
     agenticMessageType?: "run_agent" | "agent_handover";
     agenticOriginMessageId?: string;
   }): Promise<{ messageRow: MessageModel; userMessage: UserMessageType }> {
@@ -201,7 +203,7 @@ export class ConversationFactory {
 
     const messageRow = await MessageModel.create({
       sId: generateRandomModelSId(),
-      rank: 0,
+      rank,
       conversationId: conversation.id,
       parentId: null,
       userMessageId: userMessageRow.id,


### PR DESCRIPTION
## Problem

Steering could end up with two agentic loops processing two agent messages at once, and an interrupted message could later flip back to "succeeded", with clients receiving stale success events for a message the user had skipped.

## Root cause

All terminal events (success, error, cancelled, gracefully stopped) funnel into `updateAgentMessageWithFinalStatus`, which unconditionally overwrote the message status and re-ran the pending-messages promotion. An orphaned model activity (an LLM call still running after a skip/stop, or a retried activity whose first attempt is still alive after a missed heartbeat) eventually finishes and publishes its terminal event. That late event re-entered finalization: it overwrote "interrupted" with "succeeded" and, if a steering message was pending, promoted it and spawned a second concurrent agent loop. The pipeline also re-ran the terminal side effects: stale publish to clients, unread marking, clearing `isRunningAgentLoop` while the promoted loop was running, and `hasError` on the error path.

## Fix

Invariant: once an agent message leaves `"created"`, nothing transitions it again and no terminal side effect fires for it again.

`updateAgentMessageWithFinalStatus` only transitions out of `"created"` (enforced in the `WHERE` clause inside the existing advisory-locked transaction) and returns an `applied` flag. The event pipeline honors it end to end: when the transition was not applied, `updateResourceAndPublishEvent` drops the event entirely (no Redis publish, no unread/`agent_message_done`, no `markAsUpdated`/`markHasError`/`setIsRunningAgentLoop(false)`, no error step content). Usage metadata (`runIds`, `modelInteractionDurationMs`) is still recorded before the drop: those runs happened and must stay attributed for cost accounting.

Two publishers bypass that pipeline and were aligned: the cancel fallback in `terminateMessageGeneration` skips its `agent_generation_cancelled` publish when not applied, and `finalizeInterruption` (which publishes before updating, by design, so clients drop the old message before the promoted one appears) early-returns when the message is no longer `"created"`. All other terminal event producers were audited and route through the guarded pipeline.

Two conscious behavior changes: the first terminal status now always wins (an activity erroring as the user hits stop leaves the message "failed" and drops the later "cancelled"), and a duplicate error event for an already-failed message is no longer re-published.

## Tests

Finalization applies only the first terminal status; a late terminal event neither promotes a pending steering message nor launches a new agent loop; a late success after an interrupt is dropped (status stays interrupted, `isRunningAgentLoop` stays true); a late error is dropped (no `hasError`, no `errorCode`); a first terminal event on a fresh message flows normally.