### PR TITLE
[LLM] Add Anthropic input converters for the new LLM router

### DIFF
--- a/front/lib/model_constructors/batch/configuration.ts
+++ b/front/lib/model_constructors/batch/configuration.ts
@@ -6,5 +6,5 @@ export type BatchModelConfiguration = BaseModelConfiguration;
 
 export type BatchEndpointConstructor = (new (
   credentials: Credentials
-) => BatchEndpoint<any, any>) &
+) => BatchEndpoint) &
   BatchModelConfiguration;

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -7,6 +7,7 @@ import type { Client } from "@app/lib/model_constructors/client";
 import {
   assistantReasoningMessageToThinkingBlocks,
   assistantTextMessageToTextBlock,
+  assistantToolCallRequestToToolUseBlock,
   conversationToMessages,
   type MessageBlockConverters,
   reasoningToThinkingConfig,
@@ -42,6 +43,8 @@ export function WithAnthropicInputConverter<
     assistantTextMessageToTextBlock = assistantTextMessageToTextBlock;
     assistantReasoningMessageToThinkingBlocks =
       assistantReasoningMessageToThinkingBlocks;
+    assistantToolCallRequestToToolUseBlock =
+      assistantToolCallRequestToToolUseBlock;
 
     conversationToMessages(
       conversation: Payload["conversation"]

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -1,0 +1,51 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  MessageParam,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  conversationToMessages,
+  type MessageBlockConverters,
+  userTextMessageToTextBlock,
+} from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the Anthropic Messages
+// API request shape. Leaf converters are bound as class fields and composites
+// route through `this`, so an endpoint can override a single leaf.
+export function WithAnthropicInputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithAnthropicInputConverter
+    extends Base
+    implements MessageBlockConverters
+  {
+    userTextMessageToTextBlock = userTextMessageToTextBlock;
+
+    conversationToMessages(
+      conversation: Payload["conversation"]
+    ): MessageParam[] {
+      return conversationToMessages(conversation, this);
+    }
+
+    buildRequestPayload(
+      payload: Payload,
+      config: InputConfig
+    ): MessageCreateParamsNonStreaming {
+      const { conversation } = payload;
+      const { temperature } = config;
+
+      return {
+        model: this.constructor.modelId,
+        max_tokens: this.constructor.maxOutputTokens,
+        messages: this.conversationToMessages(conversation),
+        ...(temperature !== undefined ? { temperature } : {}),
+      };
+    }
+  }
+
+  return WithAnthropicInputConverter;
+}

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -11,6 +11,7 @@ import {
   reasoningToThinkingConfig,
   systemMessagesToSystemParam,
   systemMessageToTextBlock,
+  userImageMessageToImageBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
@@ -33,6 +34,7 @@ export function WithAnthropicInputConverter<
   {
     systemMessageToTextBlock = systemMessageToTextBlock;
     userTextMessageToTextBlock = userTextMessageToTextBlock;
+    userImageMessageToImageBlock = userImageMessageToImageBlock;
     assistantReasoningMessageToThinkingBlocks =
       assistantReasoningMessageToThinkingBlocks;
 

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -1,15 +1,21 @@
 import type {
   MessageCreateParamsNonStreaming,
   MessageParam,
+  TextBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { Client } from "@app/lib/model_constructors/client";
 import {
   conversationToMessages,
   type MessageBlockConverters,
+  systemMessagesToSystemParam,
+  systemMessageToTextBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
-import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type {
+  Payload,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
 
 type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 
@@ -23,12 +29,17 @@ export function WithAnthropicInputConverter<
     extends Base
     implements MessageBlockConverters
   {
+    systemMessageToTextBlock = systemMessageToTextBlock;
     userTextMessageToTextBlock = userTextMessageToTextBlock;
 
     conversationToMessages(
       conversation: Payload["conversation"]
     ): MessageParam[] {
       return conversationToMessages(conversation, this);
+    }
+
+    systemMessagesToSystemParam(system: SystemTextMessage[]): TextBlockParam[] {
+      return systemMessagesToSystemParam(system, this);
     }
 
     buildRequestPayload(
@@ -42,6 +53,7 @@ export function WithAnthropicInputConverter<
         model: this.constructor.modelId,
         max_tokens: this.constructor.maxOutputTokens,
         messages: this.conversationToMessages(conversation),
+        system: this.systemMessagesToSystemParam(conversation.system),
         ...(temperature !== undefined ? { temperature } : {}),
       };
     }

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -88,7 +88,7 @@ export function WithAnthropicInputConverter<
         thinking: thinkingConfig.thinking,
         tools: tools.map((tool) => toolSpecToAnthropicTool(tool)),
         tool_choice: forceToolNameToToolChoice(tools, forceTool),
-        ...(temperature !== undefined ? { temperature } : {}),
+        temperature,
         ...(Object.keys(outputConfig).length > 0
           ? { output_config: outputConfig }
           : {}),

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -5,8 +5,10 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { Client } from "@app/lib/model_constructors/client";
 import {
+  assistantReasoningMessageToThinkingBlocks,
   conversationToMessages,
   type MessageBlockConverters,
+  reasoningToThinkingConfig,
   systemMessagesToSystemParam,
   systemMessageToTextBlock,
   userTextMessageToTextBlock,
@@ -31,6 +33,8 @@ export function WithAnthropicInputConverter<
   {
     systemMessageToTextBlock = systemMessageToTextBlock;
     userTextMessageToTextBlock = userTextMessageToTextBlock;
+    assistantReasoningMessageToThinkingBlocks =
+      assistantReasoningMessageToThinkingBlocks;
 
     conversationToMessages(
       conversation: Payload["conversation"]
@@ -47,14 +51,25 @@ export function WithAnthropicInputConverter<
       config: InputConfig
     ): MessageCreateParamsNonStreaming {
       const { conversation } = payload;
-      const { temperature } = config;
+      const { temperature, reasoning } = config;
+
+      const thinkingConfig = reasoningToThinkingConfig(reasoning);
+      const outputConfig = {
+        ...("output_config" in thinkingConfig
+          ? thinkingConfig.output_config
+          : {}),
+      };
 
       return {
         model: this.constructor.modelId,
         max_tokens: this.constructor.maxOutputTokens,
         messages: this.conversationToMessages(conversation),
         system: this.systemMessagesToSystemParam(conversation.system),
+        thinking: thinkingConfig.thinking,
         ...(temperature !== undefined ? { temperature } : {}),
+        ...(Object.keys(outputConfig).length > 0
+          ? { output_config: outputConfig }
+          : {}),
       };
     }
   }

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -11,6 +11,7 @@ import {
   reasoningToThinkingConfig,
   systemMessagesToSystemParam,
   systemMessageToTextBlock,
+  toolCallResultMessageToToolResultBlock,
   userImageMessageToImageBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
@@ -35,6 +36,8 @@ export function WithAnthropicInputConverter<
     systemMessageToTextBlock = systemMessageToTextBlock;
     userTextMessageToTextBlock = userTextMessageToTextBlock;
     userImageMessageToImageBlock = userImageMessageToImageBlock;
+    toolCallResultMessageToToolResultBlock =
+      toolCallResultMessageToToolResultBlock;
     assistantReasoningMessageToThinkingBlocks =
       assistantReasoningMessageToThinkingBlocks;
 

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -6,6 +6,7 @@ import type {
 import type { Client } from "@app/lib/model_constructors/client";
 import {
   assistantReasoningMessageToThinkingBlocks,
+  assistantTextMessageToTextBlock,
   conversationToMessages,
   type MessageBlockConverters,
   reasoningToThinkingConfig,
@@ -38,6 +39,7 @@ export function WithAnthropicInputConverter<
     userImageMessageToImageBlock = userImageMessageToImageBlock;
     toolCallResultMessageToToolResultBlock =
       toolCallResultMessageToToolResultBlock;
+    assistantTextMessageToTextBlock = assistantTextMessageToTextBlock;
     assistantReasoningMessageToThinkingBlocks =
       assistantReasoningMessageToThinkingBlocks;
 

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -9,11 +9,14 @@ import {
   assistantTextMessageToTextBlock,
   assistantToolCallRequestToToolUseBlock,
   conversationToMessages,
+  forceToolNameToToolChoice,
   type MessageBlockConverters,
+  outputFormatToOutputConfig,
   reasoningToThinkingConfig,
   systemMessagesToSystemParam,
   systemMessageToTextBlock,
   toolCallResultMessageToToolResultBlock,
+  toolSpecToAnthropicTool,
   userImageMessageToImageBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
@@ -61,10 +64,17 @@ export function WithAnthropicInputConverter<
       config: InputConfig
     ): MessageCreateParamsNonStreaming {
       const { conversation } = payload;
-      const { temperature, reasoning } = config;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        forceTool,
+        outputFormat,
+      } = config;
 
       const thinkingConfig = reasoningToThinkingConfig(reasoning);
       const outputConfig = {
+        ...(outputFormat ? outputFormatToOutputConfig(outputFormat) : {}),
         ...("output_config" in thinkingConfig
           ? thinkingConfig.output_config
           : {}),
@@ -76,6 +86,8 @@ export function WithAnthropicInputConverter<
         messages: this.conversationToMessages(conversation),
         system: this.systemMessagesToSystemParam(conversation.system),
         thinking: thinkingConfig.thinking,
+        tools: tools.map((tool) => toolSpecToAnthropicTool(tool)),
+        tool_choice: forceToolNameToToolChoice(tools, forceTool),
         ...(temperature !== undefined ? { temperature } : {}),
         ...(Object.keys(outputConfig).length > 0
           ? { output_config: outputConfig }

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
@@ -1,0 +1,705 @@
+import type {
+  ImageBlockParam,
+  TextBlockParam,
+  ToolResultBlockParam,
+  ToolUseBlockParam,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type { MessageBlockConverters } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
+import {
+  assistantMessageToContentBlocks,
+  assistantReasoningMessageToThinkingBlocks,
+  assistantTextMessageToTextBlock,
+  assistantToolCallRequestToToolUseBlock,
+  cacheControlFor,
+  conversationToMessages,
+  forceToolNameToToolChoice,
+  outputFormatToOutputConfig,
+  parseToolArguments,
+  reasoningToThinkingConfig,
+  systemMessagesToSystemParam,
+  systemMessageToTextBlock,
+  toolCallResultMessageToToolResultBlock,
+  toolSpecToAnthropicTool,
+  userImageMessageToImageBlock,
+  userMessageToContentBlocks,
+  userTextMessageToTextBlock,
+} from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
+import type {
+  OutputFormat,
+  Reasoning,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import { describe, expect, it, vi } from "vitest";
+
+// The real leaf converters, bundled into the interface the composites consume.
+// Used wherever a test wants the genuine end-to-end conversion.
+const realConverters: MessageBlockConverters = {
+  systemMessageToTextBlock,
+  userTextMessageToTextBlock,
+  userImageMessageToImageBlock,
+  toolCallResultMessageToToolResultBlock,
+  assistantTextMessageToTextBlock,
+  assistantReasoningMessageToThinkingBlocks,
+  assistantToolCallRequestToToolUseBlock,
+};
+
+// A fully stubbed converters object, so composites can be checked for pure
+// delegation independently of the leaf converters' real behavior.
+function makeStubConverters(): MessageBlockConverters {
+  return {
+    systemMessageToTextBlock: vi.fn(
+      () => ({ type: "text", text: "stub-system" }) as TextBlockParam
+    ),
+    userTextMessageToTextBlock: vi.fn(
+      () => ({ type: "text", text: "stub-user-text" }) as TextBlockParam
+    ),
+    userImageMessageToImageBlock: vi.fn(
+      () =>
+        ({
+          type: "image",
+          source: { type: "url", url: "stub-url" },
+        }) as ImageBlockParam
+    ),
+    toolCallResultMessageToToolResultBlock: vi.fn(
+      () =>
+        ({
+          type: "tool_result",
+          tool_use_id: "stub-call",
+          content: [],
+        }) as ToolResultBlockParam
+    ),
+    assistantTextMessageToTextBlock: vi.fn(
+      () => ({ type: "text", text: "stub-assistant-text" }) as TextBlockParam
+    ),
+    assistantReasoningMessageToThinkingBlocks: vi.fn(() => []),
+    assistantToolCallRequestToToolUseBlock: vi.fn(
+      () =>
+        ({
+          type: "tool_use",
+          id: "stub-id",
+          name: "stub-name",
+          input: {},
+        }) as ToolUseBlockParam
+    ),
+  };
+}
+
+describe("cacheControlFor", () => {
+  it("returns a 5m ephemeral cache control for 'short'", () => {
+    expect(cacheControlFor("short")).toEqual({
+      cache_control: { type: "ephemeral", ttl: "5m" },
+    });
+  });
+
+  it("returns a 1h ephemeral cache control for 'long'", () => {
+    expect(cacheControlFor("long")).toEqual({
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    });
+  });
+
+  it("returns an empty fragment for undefined", () => {
+    expect(cacheControlFor(undefined)).toEqual({});
+  });
+
+  it("returns a spreadable object that does not inject keys when empty", () => {
+    expect({ type: "text", ...cacheControlFor(undefined) }).toEqual({
+      type: "text",
+    });
+  });
+});
+
+describe("parseToolArguments", () => {
+  it("parses a well-formed JSON object", () => {
+    expect(parseToolArguments('{"a":1,"b":"two"}')).toEqual({ a: 1, b: "two" });
+  });
+
+  it("returns {} for malformed JSON", () => {
+    expect(parseToolArguments("{not valid json")).toEqual({});
+  });
+
+  it("returns {} for valid JSON that is an array", () => {
+    expect(parseToolArguments("[1,2,3]")).toEqual({});
+  });
+
+  it("returns {} for the JSON literal null", () => {
+    expect(parseToolArguments("null")).toEqual({});
+  });
+
+  // NOTE: this documents a latent gap rather than the desired contract. The
+  // helper's comment promises `{}` for "non-object JSON", but `isRecord` only
+  // rejects arrays, so primitive JSON (numbers, strings, booleans) flows
+  // through unchanged even though the declared return type is a record. If the
+  // intent is to also coerce primitives to `{}`, `isRecord` / this helper needs
+  // tightening; these tests pin the current behavior.
+  it("passes a primitive number through unchanged (latent gap)", () => {
+    expect(parseToolArguments("42")).toBe(42);
+  });
+
+  it("passes a primitive string through unchanged (latent gap)", () => {
+    expect(parseToolArguments('"hello"')).toBe("hello");
+  });
+
+  it("returns {} for an empty string", () => {
+    expect(parseToolArguments("")).toEqual({});
+  });
+
+  it("preserves nested structures", () => {
+    expect(parseToolArguments('{"nested":{"k":[1,2]}}')).toEqual({
+      nested: { k: [1, 2] },
+    });
+  });
+});
+
+describe("systemMessageToTextBlock", () => {
+  const base: SystemTextMessage = {
+    role: "system",
+    type: "text",
+    content: { value: "system prompt" },
+  };
+
+  it("converts to a text block without cache control by default", () => {
+    expect(systemMessageToTextBlock(base)).toEqual({
+      type: "text",
+      text: "system prompt",
+    });
+  });
+
+  it("includes cache control when cache is set", () => {
+    expect(systemMessageToTextBlock({ ...base, cache: "long" })).toEqual({
+      type: "text",
+      text: "system prompt",
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    });
+  });
+});
+
+describe("userTextMessageToTextBlock", () => {
+  const base: BaseUserTextMessage = {
+    role: "user",
+    type: "text",
+    content: { value: "hi there" },
+  };
+
+  it("converts to a text block", () => {
+    expect(userTextMessageToTextBlock(base)).toEqual({
+      type: "text",
+      text: "hi there",
+    });
+  });
+
+  it("includes cache control when cache is 'short'", () => {
+    expect(userTextMessageToTextBlock({ ...base, cache: "short" })).toEqual({
+      type: "text",
+      text: "hi there",
+      cache_control: { type: "ephemeral", ttl: "5m" },
+    });
+  });
+});
+
+describe("userImageMessageToImageBlock", () => {
+  const base: BaseUserImageMessage = {
+    role: "user",
+    type: "image_url",
+    content: { url: "https://example.com/cat.png" },
+  };
+
+  it("converts to a url image block", () => {
+    expect(userImageMessageToImageBlock(base)).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://example.com/cat.png" },
+    });
+  });
+
+  it("includes cache control when set", () => {
+    expect(userImageMessageToImageBlock({ ...base, cache: "long" })).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://example.com/cat.png" },
+      cache_control: { type: "ephemeral", ttl: "1h" },
+    });
+  });
+});
+
+describe("toolCallResultMessageToToolResultBlock", () => {
+  it("converts text and image parts in order", () => {
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: {
+        callId: "call_1",
+        parts: [
+          { type: "text", text: "result text" },
+          { type: "image_url", url: "https://example.com/img.png" },
+        ],
+        isError: false,
+      },
+    };
+    expect(toolCallResultMessageToToolResultBlock(message)).toEqual({
+      type: "tool_result",
+      tool_use_id: "call_1",
+      content: [
+        { type: "text", text: "result text" },
+        {
+          type: "image",
+          source: { type: "url", url: "https://example.com/img.png" },
+        },
+      ],
+    });
+  });
+
+  it("sets is_error only when isError is true", () => {
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: { callId: "call_err", parts: [], isError: true },
+    };
+    expect(toolCallResultMessageToToolResultBlock(message)).toEqual({
+      type: "tool_result",
+      tool_use_id: "call_err",
+      content: [],
+      is_error: true,
+    });
+  });
+
+  it("omits is_error when isError is false", () => {
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: { callId: "call_ok", parts: [], isError: false },
+    };
+    expect(toolCallResultMessageToToolResultBlock(message)).not.toHaveProperty(
+      "is_error"
+    );
+  });
+
+  it("includes cache control when set", () => {
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: { callId: "call_c", parts: [], isError: false },
+      cache: "short",
+    };
+    expect(toolCallResultMessageToToolResultBlock(message)).toMatchObject({
+      cache_control: { type: "ephemeral", ttl: "5m" },
+    });
+  });
+
+  it("produces empty content for no parts", () => {
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: { callId: "call_empty", parts: [], isError: false },
+    };
+    expect(toolCallResultMessageToToolResultBlock(message).content).toEqual([]);
+  });
+});
+
+describe("assistantTextMessageToTextBlock", () => {
+  it("converts to a text block and never attaches cache control", () => {
+    const message: BaseAssistantTextMessage = {
+      role: "assistant",
+      type: "text",
+      content: { value: "assistant says hi" },
+    };
+    const result = assistantTextMessageToTextBlock(message);
+    expect(result).toEqual({ type: "text", text: "assistant says hi" });
+    expect(result).not.toHaveProperty("cache_control");
+  });
+});
+
+describe("assistantReasoningMessageToThinkingBlocks", () => {
+  it("returns an empty array when there is no signature", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "let me think" },
+    };
+    expect(assistantReasoningMessageToThinkingBlocks(message)).toEqual([]);
+  });
+
+  it("returns an empty array for an empty-string signature", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "let me think" },
+      signature: "",
+    };
+    expect(assistantReasoningMessageToThinkingBlocks(message)).toEqual([]);
+  });
+
+  it("returns a thinking block when a signature is present", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "deep thoughts" },
+      signature: "sig-123",
+    };
+    expect(assistantReasoningMessageToThinkingBlocks(message)).toEqual([
+      { type: "thinking", thinking: "deep thoughts", signature: "sig-123" },
+    ]);
+  });
+});
+
+describe("assistantToolCallRequestToToolUseBlock", () => {
+  it("converts to a tool_use block with parsed arguments", () => {
+    const message: BaseAssistantToolCallRequestMessage = {
+      role: "assistant",
+      type: "tool_call_request",
+      content: {
+        callId: "tc_1",
+        toolName: "get_weather",
+        arguments: '{"city":"Paris"}',
+      },
+    };
+    expect(assistantToolCallRequestToToolUseBlock(message)).toEqual({
+      type: "tool_use",
+      id: "tc_1",
+      name: "get_weather",
+      input: { city: "Paris" },
+    });
+  });
+
+  it("falls back to empty input for malformed arguments", () => {
+    const message: BaseAssistantToolCallRequestMessage = {
+      role: "assistant",
+      type: "tool_call_request",
+      content: { callId: "tc_2", toolName: "noop", arguments: "not json" },
+    };
+    expect(assistantToolCallRequestToToolUseBlock(message).input).toEqual({});
+  });
+});
+
+describe("userMessageToContentBlocks", () => {
+  it("delegates text messages to userTextMessageToTextBlock", () => {
+    const stub = makeStubConverters();
+    const message: BaseUserTextMessage = {
+      role: "user",
+      type: "text",
+      content: { value: "hello" },
+    };
+    const result = userMessageToContentBlocks(message, stub);
+    expect(stub.userTextMessageToTextBlock).toHaveBeenCalledWith(message);
+    expect(result).toEqual([{ type: "text", text: "stub-user-text" }]);
+  });
+
+  it("delegates image messages to userImageMessageToImageBlock", () => {
+    const stub = makeStubConverters();
+    const message: BaseUserImageMessage = {
+      role: "user",
+      type: "image_url",
+      content: { url: "u" },
+    };
+    userMessageToContentBlocks(message, stub);
+    expect(stub.userImageMessageToImageBlock).toHaveBeenCalledWith(message);
+  });
+
+  it("delegates tool_call_result messages to toolCallResultMessageToToolResultBlock", () => {
+    const stub = makeStubConverters();
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: { callId: "c", parts: [], isError: false },
+    };
+    userMessageToContentBlocks(message, stub);
+    expect(stub.toolCallResultMessageToToolResultBlock).toHaveBeenCalledWith(
+      message
+    );
+  });
+
+  it("wraps the leaf result in a single-element array (real converters)", () => {
+    const message: BaseUserTextMessage = {
+      role: "user",
+      type: "text",
+      content: { value: "hi" },
+    };
+    expect(userMessageToContentBlocks(message, realConverters)).toEqual([
+      { type: "text", text: "hi" },
+    ]);
+  });
+});
+
+describe("assistantMessageToContentBlocks", () => {
+  it("delegates text messages to assistantTextMessageToTextBlock", () => {
+    const stub = makeStubConverters();
+    const message: BaseAssistantTextMessage = {
+      role: "assistant",
+      type: "text",
+      content: { value: "v" },
+    };
+    const result = assistantMessageToContentBlocks(message, stub);
+    expect(stub.assistantTextMessageToTextBlock).toHaveBeenCalledWith(message);
+    expect(result).toEqual([{ type: "text", text: "stub-assistant-text" }]);
+  });
+
+  it("delegates reasoning messages and returns the blocks directly (not re-wrapped)", () => {
+    const stub = makeStubConverters();
+    stub.assistantReasoningMessageToThinkingBlocks = vi.fn(() => [
+      { type: "thinking" as const, thinking: "t", signature: "s" },
+    ]);
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "v" },
+      signature: "s",
+    };
+    const result = assistantMessageToContentBlocks(message, stub);
+    expect(stub.assistantReasoningMessageToThinkingBlocks).toHaveBeenCalledWith(
+      message
+    );
+    expect(result).toEqual([
+      { type: "thinking", thinking: "t", signature: "s" },
+    ]);
+  });
+
+  it("returns an empty array for unsigned reasoning (real converters)", () => {
+    const message: BaseAssistantReasoningMessage = {
+      role: "assistant",
+      type: "reasoning",
+      content: { value: "v" },
+    };
+    expect(assistantMessageToContentBlocks(message, realConverters)).toEqual(
+      []
+    );
+  });
+
+  it("delegates tool_call_request messages to assistantToolCallRequestToToolUseBlock", () => {
+    const stub = makeStubConverters();
+    const message: BaseAssistantToolCallRequestMessage = {
+      role: "assistant",
+      type: "tool_call_request",
+      content: { callId: "c", toolName: "t", arguments: "{}" },
+    };
+    const result = assistantMessageToContentBlocks(message, stub);
+    expect(stub.assistantToolCallRequestToToolUseBlock).toHaveBeenCalledWith(
+      message
+    );
+    expect(result).toEqual([
+      { type: "tool_use", id: "stub-id", name: "stub-name", input: {} },
+    ]);
+  });
+});
+
+describe("conversationToMessages", () => {
+  it("maps user and assistant messages to role-tagged MessageParams in order", () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        { role: "user", type: "text", content: { value: "hello" } },
+        { role: "assistant", type: "text", content: { value: "hi back" } },
+      ],
+    };
+    expect(conversationToMessages(conversation, realConverters)).toEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "hi back" }] },
+    ]);
+  });
+
+  it("returns an empty array for an empty conversation", () => {
+    const conversation: BaseConversation = { system: [], messages: [] };
+    expect(conversationToMessages(conversation, realConverters)).toEqual([]);
+  });
+
+  it("preserves message ordering across mixed roles", () => {
+    const conversation: BaseConversation = {
+      system: [],
+      messages: [
+        { role: "assistant", type: "text", content: { value: "a" } },
+        { role: "user", type: "text", content: { value: "b" } },
+        { role: "assistant", type: "text", content: { value: "c" } },
+      ],
+    };
+    const result = conversationToMessages(conversation, realConverters);
+    expect(result.map((m) => m.role)).toEqual([
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+  });
+});
+
+describe("systemMessagesToSystemParam", () => {
+  it("converts each system message via the converter", () => {
+    const system: SystemTextMessage[] = [
+      { role: "system", type: "text", content: { value: "rule 1" } },
+      {
+        role: "system",
+        type: "text",
+        content: { value: "rule 2" },
+        cache: "long",
+      },
+    ];
+    expect(systemMessagesToSystemParam(system, realConverters)).toEqual([
+      { type: "text", text: "rule 1" },
+      {
+        type: "text",
+        text: "rule 2",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+  });
+
+  it("returns an empty array for no system messages", () => {
+    expect(systemMessagesToSystemParam([], realConverters)).toEqual([]);
+  });
+});
+
+describe("outputFormatToOutputConfig", () => {
+  it("maps the json schema into a json_schema output config", () => {
+    const outputFormat: OutputFormat = {
+      type: "json_schema",
+      json_schema: {
+        name: "my_schema",
+        schema: {
+          type: "object",
+          properties: { foo: { type: "string" } },
+          required: ["foo"],
+          additionalProperties: false,
+        },
+      },
+    };
+    expect(outputFormatToOutputConfig(outputFormat)).toEqual({
+      format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { foo: { type: "string" } },
+          required: ["foo"],
+          additionalProperties: false,
+        },
+      },
+    });
+  });
+});
+
+describe("toolSpecToAnthropicTool", () => {
+  it("converts a tool spec, merging the object type into the input schema", () => {
+    const tool: ToolSpecification = {
+      name: "search",
+      description: "Search things",
+      inputSchema: {
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      },
+    };
+    expect(toolSpecToAnthropicTool(tool)).toEqual({
+      name: "search",
+      description: "Search things",
+      eager_input_streaming: true,
+      input_schema: {
+        type: "object",
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      },
+    });
+  });
+
+  it("always sets type 'object' even when inputSchema has its own type", () => {
+    const tool: ToolSpecification = {
+      name: "t",
+      description: "d",
+      inputSchema: { type: "string" },
+    };
+    // The spread places inputSchema.type after the literal, so it wins; this
+    // documents the merge order rather than asserting a guarantee.
+    expect(toolSpecToAnthropicTool(tool).input_schema.type).toBe("string");
+  });
+});
+
+describe("forceToolNameToToolChoice", () => {
+  const tools: ToolSpecification[] = [
+    { name: "alpha", description: "", inputSchema: {} },
+    { name: "beta", description: "", inputSchema: {} },
+  ];
+
+  it("forces the named tool when it exists", () => {
+    expect(forceToolNameToToolChoice(tools, "beta")).toEqual({
+      type: "tool",
+      name: "beta",
+    });
+  });
+
+  it("falls back to auto when the forced tool does not exist", () => {
+    expect(forceToolNameToToolChoice(tools, "gamma")).toEqual({
+      type: "auto",
+    });
+  });
+
+  it("falls back to auto when no tool is forced", () => {
+    expect(forceToolNameToToolChoice(tools, undefined)).toEqual({
+      type: "auto",
+    });
+  });
+
+  it("falls back to auto when forceTool is an empty string", () => {
+    expect(forceToolNameToToolChoice(tools, "")).toEqual({ type: "auto" });
+  });
+
+  it("falls back to auto when the tools list is empty", () => {
+    expect(forceToolNameToToolChoice([], "alpha")).toEqual({ type: "auto" });
+  });
+});
+
+describe("reasoningToThinkingConfig", () => {
+  it("disables thinking when reasoning is undefined", () => {
+    expect(reasoningToThinkingConfig(undefined)).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("disables thinking when effort is 'none'", () => {
+    expect(reasoningToThinkingConfig({ effort: "none" })).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("disables thinking for an unsupported effort (e.g. 'minimal')", () => {
+    const reasoning = { effort: "minimal" } as Reasoning;
+    expect(reasoningToThinkingConfig(reasoning)).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("disables thinking for an unsupported effort (e.g. 'xhigh')", () => {
+    const reasoning = { effort: "xhigh" } as Reasoning;
+    expect(reasoningToThinkingConfig(reasoning)).toEqual({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("enables adaptive thinking for 'low'", () => {
+    expect(reasoningToThinkingConfig({ effort: "low" })).toEqual({
+      output_config: { effort: "low" },
+      thinking: { type: "adaptive" },
+    });
+  });
+
+  it("enables adaptive thinking for 'medium'", () => {
+    expect(reasoningToThinkingConfig({ effort: "medium" })).toEqual({
+      output_config: { effort: "medium" },
+      thinking: { type: "adaptive" },
+    });
+  });
+
+  it("enables adaptive thinking for 'high'", () => {
+    expect(reasoningToThinkingConfig({ effort: "high" })).toEqual({
+      output_config: { effort: "high" },
+      thinking: { type: "adaptive" },
+    });
+  });
+
+  it("maps 'maximal' effort to Anthropic's 'max'", () => {
+    expect(reasoningToThinkingConfig({ effort: "maximal" })).toEqual({
+      output_config: { effort: "max" },
+      thinking: { type: "adaptive" },
+    });
+  });
+});

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -17,6 +17,7 @@ import type { Reasoning } from "@app/lib/model_constructors/types/input/configur
 import type {
   BaseAssistantMessage,
   BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
   BaseConversation,
   BaseToolCallResultMessage,
   BaseUserImageMessage,
@@ -37,6 +38,9 @@ export interface MessageBlockConverters {
   toolCallResultMessageToToolResultBlock(
     message: BaseToolCallResultMessage
   ): ToolResultBlockParam;
+  assistantTextMessageToTextBlock(
+    message: BaseAssistantTextMessage
+  ): TextBlockParam;
   assistantReasoningMessageToThinkingBlocks(
     message: BaseAssistantReasoningMessage
   ): ThinkingBlockParam[];
@@ -110,6 +114,12 @@ export function toolCallResultMessageToToolResultBlock(
   };
 }
 
+export function assistantTextMessageToTextBlock(
+  message: BaseAssistantTextMessage
+): TextBlockParam {
+  return { type: "text", text: message.content.value };
+}
+
 export function assistantReasoningMessageToThinkingBlocks(
   message: BaseAssistantReasoningMessage
 ): ThinkingBlockParam[] {
@@ -149,6 +159,8 @@ export function assistantMessageToContentBlocks(
   converters: MessageBlockConverters
 ): MessageParam["content"] {
   switch (message.type) {
+    case "text":
+      return [converters.assistantTextMessageToTextBlock(message)];
     case "reasoning":
       return converters.assistantReasoningMessageToThinkingBlocks(message);
     default:

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -1,0 +1,84 @@
+import type {
+  CacheControlEphemeral,
+  MessageParam,
+  TextBlockParam,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type {
+  BaseConversation,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  CacheOption,
+} from "@app/lib/model_constructors/types/input/messages";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+// The per-message leaf converters. Composites below take an object satisfying
+// this interface (`this`), so overriding one leaf on an endpoint changes how
+// every composite uses it.
+export interface MessageBlockConverters {
+  userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;
+}
+
+// -- Small, reusable building blocks --
+
+// Spreadable fragment adding `cache_control` only when the message opts in.
+export function cacheControlFor(
+  cache: CacheOption | undefined
+): { cache_control: CacheControlEphemeral } | Record<string, never> {
+  switch (cache) {
+    case "short":
+      return { cache_control: { type: "ephemeral", ttl: "5m" } };
+    case "long":
+      return { cache_control: { type: "ephemeral", ttl: "1h" } };
+    case undefined:
+      return {};
+    default:
+      assertNever(cache);
+  }
+}
+
+// -- Leaf converters: one Anthropic block per message --
+
+export function userTextMessageToTextBlock(
+  message: BaseUserTextMessage
+): TextBlockParam {
+  return {
+    type: "text",
+    text: message.content.value,
+    ...cacheControlFor(message.cache),
+  };
+}
+
+// -- Composite message converters (depend on the leaf converters) --
+
+export function userMessageToContentBlocks(
+  message: BaseUserMessage,
+  converters: MessageBlockConverters
+): MessageParam["content"] {
+  switch (message.type) {
+    case "text":
+      return [converters.userTextMessageToTextBlock(message)];
+    default:
+      // Other user message types are wired in in subsequent commits.
+      return [];
+  }
+}
+
+export function conversationToMessages(
+  conversation: BaseConversation,
+  converters: MessageBlockConverters
+): MessageParam[] {
+  return conversation.messages.map((message) => {
+    switch (message.role) {
+      case "user":
+        return {
+          role: "user",
+          content: userMessageToContentBlocks(message, converters),
+        };
+      case "assistant":
+        // Assistant content blocks are wired in in subsequent commits.
+        return { role: "assistant", content: [] };
+      default:
+        assertNever(message);
+    }
+  });
+}

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -7,6 +7,9 @@ import type {
   ThinkingBlockParam,
   ThinkingConfigAdaptive,
   ThinkingConfigDisabled,
+  Tool,
+  ToolChoiceAuto,
+  ToolChoiceTool,
   ToolResultBlockParam,
   ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
@@ -14,7 +17,11 @@ import {
   type ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
   isAnthropicSupportedNonNullReasoningEffort,
 } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
-import type { Reasoning } from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  OutputFormat,
+  Reasoning,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
 import type {
   BaseAssistantMessage,
   BaseAssistantReasoningMessage,
@@ -230,6 +237,38 @@ export function systemMessagesToSystemParam(
 }
 
 // -- Config converters (pure) --
+
+export function outputFormatToOutputConfig(outputFormat: OutputFormat): {
+  format: NonNullable<OutputConfig["format"]>;
+} {
+  return {
+    format: {
+      type: "json_schema",
+      schema: outputFormat.json_schema.schema,
+    },
+  };
+}
+
+export function toolSpecToAnthropicTool(tool: ToolSpecification): Tool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    // Stream tool-call arguments eagerly to avoid hangs on long arguments.
+    // Anthropic no longer validates the JSON, so callers validate at content_block_stop.
+    // https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming
+    eager_input_streaming: true,
+    input_schema: { type: "object", ...tool.inputSchema },
+  };
+}
+
+export function forceToolNameToToolChoice(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ToolChoiceAuto | ToolChoiceTool {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? { type: "tool", name: forceTool }
+    : { type: "auto" };
+}
 
 function effortToAnthropicEffort(
   effort: (typeof ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number]

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -8,6 +8,7 @@ import type {
   ThinkingConfigAdaptive,
   ThinkingConfigDisabled,
   ToolResultBlockParam,
+  ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import {
   type ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
@@ -18,6 +19,7 @@ import type {
   BaseAssistantMessage,
   BaseAssistantReasoningMessage,
   BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
   BaseConversation,
   BaseToolCallResultMessage,
   BaseUserImageMessage,
@@ -27,6 +29,8 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isRecord } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 
 // The per-message leaf converters. Composites below take an object satisfying
 // this interface (`this`), so overriding one leaf on an endpoint changes how
@@ -44,6 +48,9 @@ export interface MessageBlockConverters {
   assistantReasoningMessageToThinkingBlocks(
     message: BaseAssistantReasoningMessage
   ): ThinkingBlockParam[];
+  assistantToolCallRequestToToolUseBlock(
+    message: BaseAssistantToolCallRequestMessage
+  ): ToolUseBlockParam;
 }
 
 // -- Small, reusable building blocks --
@@ -62,6 +69,18 @@ export function cacheControlFor(
     default:
       assertNever(cache);
   }
+}
+
+// Parses tool-call arguments into an object, falling back to `{}` for malformed
+// or non-object JSON.
+export function parseToolArguments(
+  argumentsJson: string
+): Record<string, unknown> {
+  const parsed = safeParseJSON(argumentsJson);
+  if (parsed.isErr() || parsed.value === null || !isRecord(parsed.value)) {
+    return {};
+  }
+  return parsed.value;
 }
 
 // -- Leaf converters: one Anthropic block per message --
@@ -136,6 +155,17 @@ export function assistantReasoningMessageToThinkingBlocks(
   ];
 }
 
+export function assistantToolCallRequestToToolUseBlock(
+  message: BaseAssistantToolCallRequestMessage
+): ToolUseBlockParam {
+  return {
+    type: "tool_use",
+    id: message.content.callId,
+    name: message.content.toolName,
+    input: parseToolArguments(message.content.arguments),
+  };
+}
+
 // -- Composite message converters (depend on the leaf converters) --
 
 export function userMessageToContentBlocks(
@@ -163,9 +193,10 @@ export function assistantMessageToContentBlocks(
       return [converters.assistantTextMessageToTextBlock(message)];
     case "reasoning":
       return converters.assistantReasoningMessageToThinkingBlocks(message);
+    case "tool_call_request":
+      return [converters.assistantToolCallRequestToToolUseBlock(message)];
     default:
-      // Other assistant message types are wired in in subsequent commits.
-      return [];
+      assertNever(message);
   }
 }
 

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -8,6 +8,7 @@ import type {
   BaseUserMessage,
   BaseUserTextMessage,
   CacheOption,
+  SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
@@ -15,6 +16,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 // this interface (`this`), so overriding one leaf on an endpoint changes how
 // every composite uses it.
 export interface MessageBlockConverters {
+  systemMessageToTextBlock(message: SystemTextMessage): TextBlockParam;
   userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;
 }
 
@@ -37,6 +39,16 @@ export function cacheControlFor(
 }
 
 // -- Leaf converters: one Anthropic block per message --
+
+export function systemMessageToTextBlock(
+  message: SystemTextMessage
+): TextBlockParam {
+  return {
+    type: "text",
+    text: message.content.value,
+    ...cacheControlFor(message.cache),
+  };
+}
 
 export function userTextMessageToTextBlock(
   message: BaseUserTextMessage
@@ -81,4 +93,11 @@ export function conversationToMessages(
         assertNever(message);
     }
   });
+}
+
+export function systemMessagesToSystemParam(
+  system: SystemTextMessage[],
+  converters: MessageBlockConverters
+): TextBlockParam[] {
+  return system.map((message) => converters.systemMessageToTextBlock(message));
 }

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -1,5 +1,6 @@
 import type {
   CacheControlEphemeral,
+  ImageBlockParam,
   MessageParam,
   OutputConfig,
   TextBlockParam,
@@ -16,6 +17,7 @@ import type {
   BaseAssistantMessage,
   BaseAssistantReasoningMessage,
   BaseConversation,
+  BaseUserImageMessage,
   BaseUserMessage,
   BaseUserTextMessage,
   CacheOption,
@@ -29,6 +31,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 export interface MessageBlockConverters {
   systemMessageToTextBlock(message: SystemTextMessage): TextBlockParam;
   userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;
+  userImageMessageToImageBlock(message: BaseUserImageMessage): ImageBlockParam;
   assistantReasoningMessageToThinkingBlocks(
     message: BaseAssistantReasoningMessage
   ): ThinkingBlockParam[];
@@ -74,6 +77,16 @@ export function userTextMessageToTextBlock(
   };
 }
 
+export function userImageMessageToImageBlock(
+  message: BaseUserImageMessage
+): ImageBlockParam {
+  return {
+    type: "image",
+    source: { type: "url", url: message.content.url },
+    ...cacheControlFor(message.cache),
+  };
+}
+
 export function assistantReasoningMessageToThinkingBlocks(
   message: BaseAssistantReasoningMessage
 ): ThinkingBlockParam[] {
@@ -99,6 +112,8 @@ export function userMessageToContentBlocks(
   switch (message.type) {
     case "text":
       return [converters.userTextMessageToTextBlock(message)];
+    case "image_url":
+      return [converters.userImageMessageToImageBlock(message)];
     default:
       // Other user message types are wired in in subsequent commits.
       return [];

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -7,6 +7,7 @@ import type {
   ThinkingBlockParam,
   ThinkingConfigAdaptive,
   ThinkingConfigDisabled,
+  ToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import {
   type ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
@@ -17,6 +18,7 @@ import type {
   BaseAssistantMessage,
   BaseAssistantReasoningMessage,
   BaseConversation,
+  BaseToolCallResultMessage,
   BaseUserImageMessage,
   BaseUserMessage,
   BaseUserTextMessage,
@@ -32,6 +34,9 @@ export interface MessageBlockConverters {
   systemMessageToTextBlock(message: SystemTextMessage): TextBlockParam;
   userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;
   userImageMessageToImageBlock(message: BaseUserImageMessage): ImageBlockParam;
+  toolCallResultMessageToToolResultBlock(
+    message: BaseToolCallResultMessage
+  ): ToolResultBlockParam;
   assistantReasoningMessageToThinkingBlocks(
     message: BaseAssistantReasoningMessage
   ): ThinkingBlockParam[];
@@ -87,6 +92,24 @@ export function userImageMessageToImageBlock(
   };
 }
 
+export function toolCallResultMessageToToolResultBlock(
+  message: BaseToolCallResultMessage
+): ToolResultBlockParam {
+  const content: Array<TextBlockParam | ImageBlockParam> =
+    message.content.parts.map((part) =>
+      part.type === "text"
+        ? { type: "text", text: part.text }
+        : { type: "image", source: { type: "url", url: part.url } }
+    );
+  return {
+    type: "tool_result",
+    tool_use_id: message.content.callId,
+    content,
+    ...(message.content.isError ? { is_error: true } : {}),
+    ...cacheControlFor(message.cache),
+  };
+}
+
 export function assistantReasoningMessageToThinkingBlocks(
   message: BaseAssistantReasoningMessage
 ): ThinkingBlockParam[] {
@@ -114,9 +137,10 @@ export function userMessageToContentBlocks(
       return [converters.userTextMessageToTextBlock(message)];
     case "image_url":
       return [converters.userImageMessageToImageBlock(message)];
+    case "tool_call_result":
+      return [converters.toolCallResultMessageToToolResultBlock(message)];
     default:
-      // Other user message types are wired in in subsequent commits.
-      return [];
+      assertNever(message);
   }
 }
 

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -126,11 +126,16 @@ export function toolCallResultMessageToToolResultBlock(
   message: BaseToolCallResultMessage
 ): ToolResultBlockParam {
   const content: Array<TextBlockParam | ImageBlockParam> =
-    message.content.parts.map((part) =>
-      part.type === "text"
-        ? { type: "text", text: part.text }
-        : { type: "image", source: { type: "url", url: part.url } }
-    );
+    message.content.parts.map((part) => {
+      switch (part.type) {
+        case "text":
+          return { type: "text", text: part.text };
+        case "image_url":
+          return { type: "image", source: { type: "url", url: part.url } };
+        default:
+          return assertNever(part);
+      }
+    });
   return {
     type: "tool_result",
     tool_use_id: message.content.callId,

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -1,9 +1,20 @@
 import type {
   CacheControlEphemeral,
   MessageParam,
+  OutputConfig,
   TextBlockParam,
+  ThinkingBlockParam,
+  ThinkingConfigAdaptive,
+  ThinkingConfigDisabled,
 } from "@anthropic-ai/sdk/resources/messages/messages";
+import {
+  type ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+  isAnthropicSupportedNonNullReasoningEffort,
+} from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import type { Reasoning } from "@app/lib/model_constructors/types/input/configuration";
 import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
   BaseConversation,
   BaseUserMessage,
   BaseUserTextMessage,
@@ -18,6 +29,9 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 export interface MessageBlockConverters {
   systemMessageToTextBlock(message: SystemTextMessage): TextBlockParam;
   userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;
+  assistantReasoningMessageToThinkingBlocks(
+    message: BaseAssistantReasoningMessage
+  ): ThinkingBlockParam[];
 }
 
 // -- Small, reusable building blocks --
@@ -60,6 +74,22 @@ export function userTextMessageToTextBlock(
   };
 }
 
+export function assistantReasoningMessageToThinkingBlocks(
+  message: BaseAssistantReasoningMessage
+): ThinkingBlockParam[] {
+  // Anthropic rejects thinking blocks without a signature, so drop unsigned ones.
+  if (!message.signature) {
+    return [];
+  }
+  return [
+    {
+      type: "thinking",
+      thinking: message.content.value,
+      signature: message.signature,
+    },
+  ];
+}
+
 // -- Composite message converters (depend on the leaf converters) --
 
 export function userMessageToContentBlocks(
@@ -71,6 +101,19 @@ export function userMessageToContentBlocks(
       return [converters.userTextMessageToTextBlock(message)];
     default:
       // Other user message types are wired in in subsequent commits.
+      return [];
+  }
+}
+
+export function assistantMessageToContentBlocks(
+  message: BaseAssistantMessage,
+  converters: MessageBlockConverters
+): MessageParam["content"] {
+  switch (message.type) {
+    case "reasoning":
+      return converters.assistantReasoningMessageToThinkingBlocks(message);
+    default:
+      // Other assistant message types are wired in in subsequent commits.
       return [];
   }
 }
@@ -87,8 +130,10 @@ export function conversationToMessages(
           content: userMessageToContentBlocks(message, converters),
         };
       case "assistant":
-        // Assistant content blocks are wired in in subsequent commits.
-        return { role: "assistant", content: [] };
+        return {
+          role: "assistant",
+          content: assistantMessageToContentBlocks(message, converters),
+        };
       default:
         assertNever(message);
     }
@@ -100,4 +145,45 @@ export function systemMessagesToSystemParam(
   converters: MessageBlockConverters
 ): TextBlockParam[] {
   return system.map((message) => converters.systemMessageToTextBlock(message));
+}
+
+// -- Config converters (pure) --
+
+function effortToAnthropicEffort(
+  effort: (typeof ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number]
+): NonNullable<OutputConfig["effort"]> {
+  switch (effort) {
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "maximal":
+      return "max";
+    default:
+      assertNever(effort);
+  }
+}
+
+export function reasoningToThinkingConfig(reasoning: Reasoning | undefined):
+  | {
+      output_config: { effort: NonNullable<OutputConfig["effort"]> };
+      thinking: ThinkingConfigAdaptive;
+    }
+  | {
+      thinking: ThinkingConfigDisabled;
+    } {
+  if (
+    !reasoning ||
+    reasoning.effort === "none" ||
+    !isAnthropicSupportedNonNullReasoningEffort(reasoning.effort)
+  ) {
+    return { thinking: { type: "disabled" } };
+  }
+
+  return {
+    output_config: { effort: effortToAnthropicEffort(reasoning.effort) },
+    thinking: { type: "adaptive" },
+  };
 }

--- a/front/lib/model_constructors/providers/anthropic/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/anthropic/reasoning_efforts.ts
@@ -1,0 +1,17 @@
+export const ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "maximal",
+] as const;
+
+export type AnthropicSupportedNonNullReasoningEffort =
+  (typeof ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number];
+
+export function isAnthropicSupportedNonNullReasoningEffort(
+  effort: string
+): effort is AnthropicSupportedNonNullReasoningEffort {
+  return ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS.some(
+    (supported) => supported === effort
+  );
+}


### PR DESCRIPTION
## Description

Add the `WithAnthropicInputConverter` mixin that turns the new LLM router's provider-agnostic conversation and config into an Anthropic Messages API request, built up event by event (user text → system → reasoning → user image → tool result → assistant text → assistant tool-call → tools/tool-choice/output format) with per-message leaf converters that an endpoint can override individually.

## Tests

Not needed — pure, type-driven converters that are not yet wired into a live endpoint. Each commit type-checks (`tsgo`) and lints (`biome`) on its own.

## Risk

None — not yet called from any live path.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`
