### PR TITLE
[front] Carry over non-recurring contract balances on renewal

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -21,7 +21,9 @@ import {
 } from "@app/lib/metronome/client";
 import {
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  CARRY_ON_RENEWAL_FOREVER_VALUE,
   CURRENCY_TO_CREDIT_TYPE_ID,
+  FOREVER_ENDING_BEFORE,
   getProductSeatSubscriptionCommitId,
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
   PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
@@ -293,9 +295,6 @@ export async function createPaymentGatedBusinessActivation({
   const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[currency];
   const amountNative = metronomeAmount(effectiveAmountCents, currency);
 
-  const accessEndingBefore = new Date(now);
-  accessEndingBefore.setUTCFullYear(accessEndingBefore.getUTCFullYear() + 1);
-
   const commitResult = await addPaymentGatedCommitToContract({
     metronomeCustomerId,
     metronomeContractId,
@@ -303,7 +302,7 @@ export async function createPaymentGatedBusinessActivation({
     accessAmount: amountNative,
     accessCreditTypeId: fiatCreditTypeId,
     accessStartingAt: now,
-    accessEndingBefore,
+    accessEndingBefore: FOREVER_ENDING_BEFORE,
     invoiceUnitPrice: amountNative,
     invoiceQuantity: 1,
     invoiceCreditTypeId: fiatCreditTypeId,
@@ -313,7 +312,7 @@ export async function createPaymentGatedBusinessActivation({
     name: `Business subscription activation (${seatType} ${billingPeriod})`,
     uniquenessKey,
     customFields: {
-      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: accessEndingBefore.toISOString(),
+      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
     },
     stripeInvoiceMetadata: {
       subscription_activation: "true",

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -20,6 +20,7 @@ import {
   scheduleMetronomeContractEnd,
 } from "@app/lib/metronome/client";
 import {
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getProductSeatSubscriptionCommitId,
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
@@ -311,6 +312,9 @@ export async function createPaymentGatedBusinessActivation({
     applicableProducTags: [SEAT_TAG],
     name: `Business subscription activation (${seatType} ${billingPeriod})`,
     uniquenessKey,
+    customFields: {
+      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: accessEndingBefore.toISOString(),
+    },
     stripeInvoiceMetadata: {
       subscription_activation: "true",
       workspace_id: workspace.sId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -76,6 +76,7 @@ import {
 } from "@app/lib/metronome/constants";
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
+import { carryOverContractBalancesOnRenewal } from "@app/lib/metronome/renewal_carry_over";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
@@ -1417,6 +1418,69 @@ export async function processMetronomeWebhook({
     case "contract.start": {
       const { contract_id: contractId, customer_id: customerId } = event;
 
+      // Read the PLAN_CODE custom field to know which plan to swap the
+      // workspace subscription onto. The actual swap is gated below on
+      // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
+      // Stripe) handle their own state transitions, and contracts whose
+      // start aligns with a synchronous DB flip get caught by the
+      // idempotency check. Fetched up-front because the carry-over below also
+      // needs the contract's transition lineage and start.
+      const contractResult = await getMetronomeContractById({
+        metronomeCustomerId: customerId,
+        metronomeContractId: contractId,
+      });
+      if (contractResult.isErr()) {
+        logger.error(
+          {
+            contractId,
+            customerId,
+            error: contractResult.error,
+            workspaceId: workspace.sId,
+          },
+          "[Metronome Webhook] contract.start: failed to fetch contract"
+        );
+        return new Err(
+          new ProcessMetronomeWebhookError(
+            "processing_failed",
+            `Error fetching contract: ${contractResult.error.message}`
+          )
+        );
+      }
+
+      const renewalTransition = contractResult.value.transitions?.find(
+        (t) => t.to_contract_id === contractId
+      );
+      logger.info(
+        {
+          contractId,
+          customerId,
+          workspaceId: workspace.sId,
+          transitions: contractResult.value.transitions,
+          renewalFromContractId: renewalTransition?.from_contract_id ?? null,
+        },
+        "[Metronome Webhook] contract.start: renewal transition lookup"
+      );
+      if (renewalTransition) {
+        const carryResult = await carryOverContractBalancesOnRenewal({
+          metronomeCustomerId: customerId,
+          fromContractId: renewalTransition.from_contract_id,
+          toContractId: contractId,
+          toContractStart: new Date(contractResult.value.starting_at),
+        });
+        if (carryResult.isErr()) {
+          logger.error(
+            {
+              contractId,
+              customerId,
+              fromContractId: renewalTransition.from_contract_id,
+              error: carryResult.error,
+              workspaceId: workspace.sId,
+            },
+            "[Metronome Webhook] contract.start: failed to carry over balances"
+          );
+        }
+      }
+
       // Reconcile the workspace pool credit state against the new contract's
       // live AWU balance. Replaces the in-process call we previously made
       // from `provisionMetronomeContract` (removed to break a dependency
@@ -1442,34 +1506,6 @@ export async function processMetronomeWebhook({
         metronomeCustomerId: customerId,
         metronomeContractId: contractId,
       });
-
-      // Read the PLAN_CODE custom field to know which plan to swap the
-      // workspace subscription onto. The actual swap is gated below on
-      // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
-      // Stripe) handle their own state transitions, and contracts whose
-      // start aligns with a synchronous DB flip get caught by the
-      // idempotency check.
-      const contractResult = await getMetronomeContractById({
-        metronomeCustomerId: customerId,
-        metronomeContractId: contractId,
-      });
-      if (contractResult.isErr()) {
-        logger.error(
-          {
-            contractId,
-            customerId,
-            error: contractResult.error,
-            workspaceId: workspace.sId,
-          },
-          "[Metronome Webhook] contract.start: failed to fetch contract"
-        );
-        return new Err(
-          new ProcessMetronomeWebhookError(
-            "processing_failed",
-            `Error fetching contract: ${contractResult.error.message}`
-          )
-        );
-      }
 
       const targetPlanCode =
         contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -16,7 +16,9 @@ import {
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  CARRY_ON_RENEWAL_FOREVER_VALUE,
   CURRENCY_TO_CREDIT_TYPE_ID,
+  FOREVER_ENDING_BEFORE,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
   getProductSeatSubscriptionCommitId,
@@ -525,13 +527,10 @@ export async function switchContract({
   );
 
   // Optional one-off initial credits: a contract-level prepaid AWU commit
-  // starting with the contract and lasting one year. `invoiceAmount` is in the
-  // customer's currency major units; convert to Metronome fiat units (cents
-  // for USD, whole units for EUR) for the invoice unit price.
+  // starting with the contract. `invoiceAmount` is in the customer's currency
+  // major units; convert to Metronome fiat units (cents for USD, whole units
+  // for EUR) for the invoice unit price.
   if (body.initialCredits && resolvedCurrency) {
-    const oneYearAfterStart = new Date(alignedStart);
-    oneYearAfterStart.setUTCFullYear(oneYearAfterStart.getUTCFullYear() + 1);
-
     const invoiceAmountCents = Math.round(
       body.initialCredits.invoiceAmount * 100
     );
@@ -547,7 +546,7 @@ export async function switchContract({
       accessAmount: body.initialCredits.amountCredits,
       accessCreditTypeId: getCreditTypeAwuId(),
       accessStartingAt: alignedStart,
-      accessEndingBefore: oneYearAfterStart,
+      accessEndingBefore: FOREVER_ENDING_BEFORE,
       invoiceUnitPrice,
       invoiceQuantity: 1,
       invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
@@ -560,7 +559,7 @@ export async function switchContract({
       // workspace, start moment, and amount.
       uniquenessKey: `initial-credits-${metronomeContractId}-${body.initialCredits.amountCredits}`,
       customFields: {
-        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: oneYearAfterStart.toISOString(),
+        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
       },
     });
     if (commitResult.isErr()) {

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
@@ -558,6 +559,9 @@ export async function switchContract({
       // start can otherwise collide with a prior switch that shared the same
       // workspace, start moment, and amount.
       uniquenessKey: `initial-credits-${metronomeContractId}-${body.initialCredits.amountCredits}`,
+      customFields: {
+        [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: oneYearAfterStart.toISOString(),
+      },
     });
     if (commitResult.isErr()) {
       return new Err(

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/metronome/client";
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   CURRENCY_TO_CREDIT_TYPE_ID,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
@@ -348,6 +349,9 @@ export async function purchaseAwuCredits(
         ? `Credit top-up: ${amountCredits.toLocaleString()} credits (${discountPercent}% discount)`
         : `Credit top-up: ${amountCredits.toLocaleString()} credits`,
     uniquenessKey,
+    customFields: {
+      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: oneYearFromNow.toISOString(),
+    },
     // Stamped on the Stripe invoice Metronome pushes downstream so the
     // existing eligibility check (`isAwuPurchaseInvoice`) still recognises
     // pending AWU purchases.

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -16,7 +16,9 @@ import {
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  CARRY_ON_RENEWAL_FOREVER_VALUE,
   CURRENCY_TO_CREDIT_TYPE_ID,
+  FOREVER_ENDING_BEFORE,
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
 } from "@app/lib/metronome/constants";
@@ -315,8 +317,6 @@ export async function purchaseAwuCredits(
   });
 
   const now = new Date();
-  const oneYearFromNow = new Date(now);
-  oneYearFromNow.setUTCFullYear(oneYearFromNow.getUTCFullYear() + 1);
 
   const uniquenessKey = `awuPurchase-${workspace.sId}-${now.getTime()}`;
 
@@ -337,7 +337,7 @@ export async function purchaseAwuCredits(
     accessAmount: amountCredits,
     accessCreditTypeId: getCreditTypeAwuId(),
     accessStartingAt: now,
-    accessEndingBefore: oneYearFromNow,
+    accessEndingBefore: FOREVER_ENDING_BEFORE,
     invoiceUnitPrice,
     invoiceQuantity: 1,
     invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[currency],
@@ -350,7 +350,7 @@ export async function purchaseAwuCredits(
         : `Credit top-up: ${amountCredits.toLocaleString()} credits`,
     uniquenessKey,
     customFields: {
-      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: oneYearFromNow.toISOString(),
+      [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: CARRY_ON_RENEWAL_FOREVER_VALUE,
     },
     // Stamped on the Stripe invoice Metronome pushes downstream so the
     // existing eligibility check (`isAwuPurchaseInvoice`) still recognises

--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -1,4 +1,7 @@
 import {
+  addComplimentaryCommitToContract,
+  addPaymentGatedCommitToContract,
+  addPrepaidCommitToContract,
   adjustSeatCreditBalances,
   createMetronomeContract,
   createMetronomeCredit,
@@ -32,6 +35,7 @@ const {
   mockList,
   mockAddManualBalanceEntry,
   mockContractsCreate,
+  mockContractsEdit,
   mockSetCustomFieldValues,
   MockConflictError,
 } = vi.hoisted(() => {
@@ -43,6 +47,7 @@ const {
     mockList: vi.fn(),
     mockAddManualBalanceEntry: vi.fn(),
     mockContractsCreate: vi.fn(),
+    mockContractsEdit: vi.fn(),
     mockSetCustomFieldValues: vi.fn(),
     MockConflictError,
   };
@@ -61,6 +66,9 @@ vi.mock("@metronome/sdk", () => {
           create: mockContractsCreate,
         },
         customFields: { setValues: mockSetCustomFieldValues },
+      },
+      v2: {
+        contracts: { edit: mockContractsEdit },
       },
     };
   }
@@ -99,6 +107,8 @@ beforeEach(() => {
 
   mockContractsCreate.mockReset();
   mockContractsCreate.mockResolvedValue({ data: { id: "contract-id-1" } });
+  mockContractsEdit.mockReset();
+  mockContractsEdit.mockResolvedValue({ data: { id: "edit-id-1" } });
   mockSetCustomFieldValues.mockReset();
   mockSetCustomFieldValues.mockResolvedValue(undefined);
 });
@@ -359,5 +369,104 @@ describe("createMetronomeContract", () => {
         transition: { type: "RENEWAL", from_contract_id: "prior-contract" },
       })
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// add*CommitToContract — custom_fields (carry-on-renewal flag)
+// ---------------------------------------------------------------------------
+
+const BASE_PREPAID_COMMIT_PARAMS = {
+  metronomeCustomerId: "cust-1",
+  metronomeContractId: "contract-1",
+  productId: "prod-1",
+  accessAmount: 10_000,
+  accessCreditTypeId: "credit-type-awu",
+  accessStartingAt: new Date("2026-04-01T00:00:00.000Z"),
+  accessEndingBefore: new Date("2027-04-01T00:00:00.000Z"),
+  invoiceUnitPrice: 5_000,
+  invoiceQuantity: 1,
+  invoiceCreditTypeId: "credit-type-usd",
+  invoiceTimestamp: new Date("2026-04-01T00:00:00.000Z"),
+  priority: 2,
+  name: "Test commit",
+  uniquenessKey: "commit-key-1",
+};
+
+function firstAddedCommit() {
+  return mockContractsEdit.mock.calls[0][0].add_commits[0];
+}
+
+describe("addPrepaidCommitToContract", () => {
+  it("forwards custom_fields when provided", async () => {
+    await addPrepaidCommitToContract({
+      ...BASE_PREPAID_COMMIT_PARAMS,
+      customFields: { DUST_CARRY_ON_RENEWAL: "true" },
+    });
+
+    expect(firstAddedCommit()).toMatchObject({
+      custom_fields: { DUST_CARRY_ON_RENEWAL: "true" },
+    });
+  });
+
+  it("omits custom_fields when not provided", async () => {
+    await addPrepaidCommitToContract(BASE_PREPAID_COMMIT_PARAMS);
+
+    expect(firstAddedCommit()).not.toHaveProperty("custom_fields");
+  });
+});
+
+describe("addPaymentGatedCommitToContract", () => {
+  const BASE_PAYMENT_GATED_PARAMS = {
+    ...BASE_PREPAID_COMMIT_PARAMS,
+    applicableProducTags: ["usage"],
+    stripeInvoiceMetadata: { workspace_id: "ws-1" },
+  };
+
+  it("forwards custom_fields when provided", async () => {
+    await addPaymentGatedCommitToContract({
+      ...BASE_PAYMENT_GATED_PARAMS,
+      customFields: { DUST_CARRY_ON_RENEWAL: "true" },
+    });
+
+    expect(firstAddedCommit()).toMatchObject({
+      custom_fields: { DUST_CARRY_ON_RENEWAL: "true" },
+    });
+  });
+
+  it("omits custom_fields when not provided", async () => {
+    await addPaymentGatedCommitToContract(BASE_PAYMENT_GATED_PARAMS);
+
+    expect(firstAddedCommit()).not.toHaveProperty("custom_fields");
+  });
+});
+
+describe("addComplimentaryCommitToContract", () => {
+  const BASE_COMPLIMENTARY_PARAMS = {
+    metronomeCustomerId: "cust-1",
+    metronomeContractId: "contract-2",
+    productId: "prod-1",
+    accessAmount: 4_200,
+    accessCreditTypeId: "credit-type-awu",
+    accessStartingAt: new Date("2026-04-01T00:00:00.000Z"),
+    accessEndingBefore: new Date("2027-04-01T00:00:00.000Z"),
+    priority: 300,
+    name: "Carried-over balance",
+    uniquenessKey: "carry:contract-2:commit-1",
+  };
+
+  it("adds a PREPAID commit with no invoice schedule", async () => {
+    await addComplimentaryCommitToContract({
+      ...BASE_COMPLIMENTARY_PARAMS,
+      customFields: { DUST_CARRY_ON_RENEWAL: "true" },
+    });
+
+    const commit = firstAddedCommit();
+    expect(commit).toMatchObject({
+      type: "PREPAID",
+      custom_fields: { DUST_CARRY_ON_RENEWAL: "true" },
+    });
+    expect(commit.access_schedule.schedule_items[0].amount).toBe(4_200);
+    expect(commit).not.toHaveProperty("invoice_schedule");
   });
 });

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -789,9 +789,11 @@ export async function createMetronomeContract({
   // automatic subscription swap.
   additionalCustomFields?: Record<string, string>;
   // When set, the contract is created as a RENEWAL transition from this prior
-  // contract: Metronome records the lineage and automatically ends the prior
-  // contract at `startingAt`. Unused commit balance only carries over for
-  // commits that were created with a `rollover_fraction`
+  // contract: Metronome records the lineage (exposed on the successor's
+  // `transitions`) and automatically ends the prior contract at `startingAt`.
+  // Unused balance does NOT roll over automatically — the `contract.start`
+  // webhook carries flagged non-recurring balances forward (see
+  // `carryOverContractBalancesOnRenewal` / `CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY`).
   fromContractId?: string;
 }): Promise<Result<{ contractId: string }, Error>> {
   if (!packageAlias === !packageId) {
@@ -1789,6 +1791,7 @@ export async function addPaymentGatedCommitToContract({
   name,
   uniquenessKey,
   stripeInvoiceMetadata,
+  customFields,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
@@ -1806,6 +1809,10 @@ export async function addPaymentGatedCommitToContract({
   name: string;
   uniquenessKey: string;
   stripeInvoiceMetadata: Record<string, string>;
+  // Custom fields stamped on the commit (e.g. CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY
+  // so its balance is carried into the successor contract on renewal). Keys must
+  // be registered for the `commit` entity in `scripts/metronome_setup.ts`.
+  customFields?: Record<string, string>;
 }): Promise<Result<{ editId: string }, Error>> {
   try {
     const response = await getMetronomeClient().v2.contracts.edit({
@@ -1819,6 +1826,7 @@ export async function addPaymentGatedCommitToContract({
           name,
           priority,
           applicable_product_tags: applicableProducTags,
+          ...(customFields ? { custom_fields: customFields } : {}),
           access_schedule: {
             credit_type_id: accessCreditTypeId,
             schedule_items: [
@@ -1918,6 +1926,7 @@ export async function addPrepaidCommitToContract({
   uniquenessKey,
   applicableProductIds,
   applicableProductTags,
+  customFields,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
@@ -1935,6 +1944,7 @@ export async function addPrepaidCommitToContract({
   uniquenessKey: string;
   applicableProductIds?: string[];
   applicableProductTags?: string[];
+  customFields?: Record<string, string>;
 }): Promise<Result<{ editId: string }, Error>> {
   try {
     const response = await getMetronomeClient().v2.contracts.edit({
@@ -1953,6 +1963,7 @@ export async function addPrepaidCommitToContract({
           ...(applicableProductTags && applicableProductTags.length > 0
             ? { applicable_product_tags: applicableProductTags }
             : {}),
+          ...(customFields ? { custom_fields: customFields } : {}),
           access_schedule: {
             credit_type_id: accessCreditTypeId,
             schedule_items: [
@@ -2010,6 +2021,107 @@ export async function addPrepaidCommitToContract({
         invoiceQuantity,
       },
       "[Metronome] Failed to add prepaid commit to contract"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * Add a complimentary PREPAID commit (access only, no invoice) to a contract.
+ *
+ * Used to carry a non-recurring commit/credit's leftover balance into a renewed
+ * contract: the customer already paid for it on the prior contract, so the
+ * carried grant must not re-charge. Omitting `invoice_schedule` makes Metronome
+ * treat it as a complimentary commit. It stays a PREPAID commit (not a rollover
+ * commit), so it lands in the prepaid burn tier ordered by `priority` (after
+ * the seat allocation) instead of jumping ahead of seat-based commits the way a
+ * rollover commit would (see `CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY`).
+ */
+export async function addComplimentaryCommitToContract({
+  metronomeCustomerId,
+  metronomeContractId,
+  productId,
+  accessAmount,
+  accessCreditTypeId,
+  accessStartingAt,
+  accessEndingBefore,
+  priority,
+  name,
+  uniquenessKey,
+  applicableProductIds,
+  applicableProductTags,
+  customFields,
+}: {
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+  productId: string;
+  accessAmount: number;
+  accessCreditTypeId: string;
+  accessStartingAt: Date;
+  accessEndingBefore: Date;
+  priority: number;
+  name: string;
+  uniquenessKey: string;
+  applicableProductIds?: string[];
+  applicableProductTags?: string[];
+  customFields?: Record<string, string>;
+}): Promise<Result<{ editId: string }, Error>> {
+  try {
+    const response = await getMetronomeClient().v2.contracts.edit({
+      customer_id: metronomeCustomerId,
+      contract_id: metronomeContractId,
+      uniqueness_key: uniquenessKey,
+      add_commits: [
+        {
+          product_id: productId,
+          type: "PREPAID",
+          name,
+          priority,
+          ...(applicableProductIds && applicableProductIds.length > 0
+            ? { applicable_product_ids: applicableProductIds }
+            : {}),
+          ...(applicableProductTags && applicableProductTags.length > 0
+            ? { applicable_product_tags: applicableProductTags }
+            : {}),
+          ...(customFields ? { custom_fields: customFields } : {}),
+          access_schedule: {
+            credit_type_id: accessCreditTypeId,
+            schedule_items: [
+              {
+                amount: accessAmount,
+                starting_at: floorToHourISO(accessStartingAt),
+                ending_before: floorToHourISO(accessEndingBefore),
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    logger.info(
+      {
+        metronomeCustomerId,
+        metronomeContractId,
+        editId: response.data.id,
+        accessAmount,
+      },
+      "[Metronome] Complimentary commit added to contract"
+    );
+
+    return new Ok({ editId: response.data.id });
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      logger.info(
+        { metronomeCustomerId, metronomeContractId, uniquenessKey },
+        "[Metronome] Complimentary commit edit already exists (idempotent)"
+      );
+      return new Ok({ editId: "" });
+    }
+
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, metronomeContractId, accessAmount },
+      "[Metronome] Failed to add complimentary commit to contract"
     );
     return new Err(error);
   }
@@ -2813,6 +2925,7 @@ export async function addCreditToContract({
   uniquenessKey,
   applicableProductTags,
   priority,
+  customFields,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
@@ -2825,6 +2938,7 @@ export async function addCreditToContract({
   uniquenessKey: string;
   applicableProductTags?: string[];
   priority: number;
+  customFields?: Record<string, string>;
 }): Promise<Result<{ creditId: string } | null, Error>> {
   const roundedStartingAt = floorToHourISO(new Date(startingAt));
   const roundedEndingBefore = floorToHourISO(new Date(endingBefore));
@@ -2842,6 +2956,7 @@ export async function addCreditToContract({
           ...(applicableProductTags && applicableProductTags.length > 0
             ? { applicable_product_tags: applicableProductTags }
             : {}),
+          ...(customFields ? { custom_fields: customFields } : {}),
           access_schedule: {
             credit_type_id: creditTypeId,
             schedule_items: [
@@ -3040,6 +3155,85 @@ export async function listMetronomeCustomerCommits({
     logger.error(
       { error, metronomeCustomerId, commitId },
       "[Metronome] Failed to list customer commits"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * List a contract's commits with their ledgers and balances, for renewal
+ * carry-over.
+ *
+ * No `covering_date` filter: by the time the `contract.start` webhook runs, the
+ * source contract has ended, and the carried entry may have started arbitrarily
+ * close to the switch — a point-in-time filter can miss it. We list across the
+ * customer (`include_archived` covers ended/archived contracts) and filter to
+ * the source contract here. `include_ledgers` surfaces the
+ * `PREPAID_COMMIT_EXPIRATION` entry that records the balance left at expiry;
+ * `include_balance` is a fallback for entries not yet expired.
+ */
+export async function listContractCommitsWithLedger({
+  metronomeCustomerId,
+  contractId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+}): Promise<Result<Commit[], Error>> {
+  try {
+    const commits: Commit[] = [];
+    for await (const entry of getMetronomeClient().v1.customers.commits.list({
+      customer_id: metronomeCustomerId,
+      include_contract_commits: true,
+      include_ledgers: true,
+      include_balance: true,
+      include_archived: true,
+    })) {
+      if (entry.contract?.id === contractId) {
+        commits.push(entry);
+      }
+    }
+    return new Ok(commits);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId },
+      "[Metronome] Failed to list contract commits with ledger"
+    );
+    return new Err(error);
+  }
+}
+
+/**
+ * List a contract's credits with their ledgers and balances, for renewal
+ * carry-over. Mirrors `listContractCommitsWithLedger`; the relevant ledger
+ * entry is `CREDIT_EXPIRATION`.
+ */
+export async function listContractCreditsWithLedger({
+  metronomeCustomerId,
+  contractId,
+}: {
+  metronomeCustomerId: string;
+  contractId: string;
+}): Promise<Result<Credit[], Error>> {
+  try {
+    const credits: Credit[] = [];
+    for await (const entry of getMetronomeClient().v1.customers.credits.list({
+      customer_id: metronomeCustomerId,
+      include_contract_credits: true,
+      include_ledgers: true,
+      include_balance: true,
+      include_archived: true,
+    })) {
+      if (entry.contract?.id === contractId) {
+        credits.push(entry);
+      }
+    }
+    return new Ok(credits);
+  } catch (err) {
+    const error = normalizeError(err);
+    logger.error(
+      { error, metronomeCustomerId, contractId },
+      "[Metronome] Failed to list contract credits with ledger"
     );
     return new Err(error);
   }

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -132,6 +132,28 @@ export type ContractCreditType =
   | typeof CONTRACT_CREDIT_TYPE_POOL
   | typeof CONTRACT_CREDIT_TYPE_FREE_SEAT;
 
+// Custom field stamped on the non-recurring, contract-level commits/credits
+// whose unused balance must survive a RENEWAL transition (initial credits,
+// AWU top-ups, business-activation seat prepayment). On renewal the
+// `contract.start` webhook reads the source contract's flagged entries, derives
+// the balance left at the transition from their expiration ledger entry, and
+// re-grants it on the successor contract (see `carryOverContractBalancesOnRenewal`).
+//
+// The field VALUE is the entry's original access expiry as an ISO timestamp.
+// Metronome clamps a commit's live access window to the contract end when a
+// RENEWAL ends the source, so by the time the webhook runs the original expiry
+// is gone — we stamp it here so it survives. The carried grant re-stamps the
+// same value, preserving the absolute expiry across any number of renewals.
+//
+// This replaces Metronome's `rollover_fraction`: a rolled-over commit becomes a
+// "rollover" commit, and Metronome consumes rollover commits before all prepaid
+// commits regardless of priority ("commit type takes precedence over priority").
+// Since these are non-seat-based, that ordering trips our client-level rule that
+// a non-seat-based commit may not be prioritized over a seat-based one, so the
+// transition is rejected. Re-granting as a plain prepaid commit keeps it in the
+// prepaid tier, ordered after the seat allocation by priority.
+export const CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY = "DUST_CARRY_ON_RENEWAL";
+
 // Custom field stamped on a per-user (free) seat credit, carrying the seat's
 // user sId. Metronome alerts can filter on custom fields but not on a credit's
 // presentation specifier, so this is what lets a per-user

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -139,11 +139,12 @@ export type ContractCreditType =
 // the balance left at the transition from their expiration ledger entry, and
 // re-grants it on the successor contract (see `carryOverContractBalancesOnRenewal`).
 //
-// The field VALUE is the entry's original access expiry as an ISO timestamp.
+// The field VALUE is either `CARRY_ON_RENEWAL_FOREVER_VALUE` (the entry never
+// expires and carries indefinitely) or an ISO timestamp (a finite expiry).
 // Metronome clamps a commit's live access window to the contract end when a
 // RENEWAL ends the source, so by the time the webhook runs the original expiry
 // is gone — we stamp it here so it survives. The carried grant re-stamps the
-// same value, preserving the absolute expiry across any number of renewals.
+// same value, preserving the policy across any number of renewals.
 //
 // This replaces Metronome's `rollover_fraction`: a rolled-over commit becomes a
 // "rollover" commit, and Metronome consumes rollover commits before all prepaid
@@ -153,6 +154,10 @@ export type ContractCreditType =
 // transition is rejected. Re-granting as a plain prepaid commit keeps it in the
 // prepaid tier, ordered after the seat allocation by priority.
 export const CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY = "DUST_CARRY_ON_RENEWAL";
+
+export const CARRY_ON_RENEWAL_FOREVER_VALUE = "forever";
+
+export const FOREVER_ENDING_BEFORE = new Date("2999-01-01T00:00:00.000Z");
 
 // Custom field stamped on a per-user (free) seat credit, carrying the seat's
 // user sId. Metronome alerts can filter on custom fields but not on a credit's

--- a/front/lib/metronome/renewal_carry_over.test.ts
+++ b/front/lib/metronome/renewal_carry_over.test.ts
@@ -1,7 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { carryOverContractBalancesOnRenewal } from "@app/lib/metronome/renewal_carry_over";
 import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockListCommits,
@@ -115,7 +114,9 @@ describe("carryOverContractBalancesOnRenewal", () => {
 
     await run();
 
-    expect(mockAddComplimentaryCommit.mock.calls[0][0].accessAmount).toBe(7_500);
+    expect(mockAddComplimentaryCommit.mock.calls[0][0].accessAmount).toBe(
+      7_500
+    );
   });
 
   it("skips commits that are not flagged", async () => {

--- a/front/lib/metronome/renewal_carry_over.test.ts
+++ b/front/lib/metronome/renewal_carry_over.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { carryOverContractBalancesOnRenewal } from "@app/lib/metronome/renewal_carry_over";
+import { Err, Ok } from "@app/types/shared/result";
+
+const {
+  mockListCommits,
+  mockListCredits,
+  mockAddComplimentaryCommit,
+  mockAddCredit,
+} = vi.hoisted(() => ({
+  mockListCommits: vi.fn(),
+  mockListCredits: vi.fn(),
+  mockAddComplimentaryCommit: vi.fn(),
+  mockAddCredit: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/client", () => ({
+  listContractCommitsWithLedger: mockListCommits,
+  listContractCreditsWithLedger: mockListCredits,
+  addComplimentaryCommitToContract: mockAddComplimentaryCommit,
+  addCreditToContract: mockAddCredit,
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+const CARRY_KEY = "DUST_CARRY_ON_RENEWAL";
+
+const TO_CONTRACT_START = new Date("2026-05-01T00:00:00.000Z");
+const ORIGINAL_ENDING = "2027-04-01T00:00:00.000Z";
+
+function flaggedCommit(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "commit-1",
+    type: "PREPAID",
+    product: { id: "prod-awu", name: "Prepaid" },
+    priority: 300,
+    name: "Credit top-up: 10,000 credits",
+    balance: 0,
+    // ISO value = finite expiry; the carry uses this, not the (clamped) window.
+    custom_fields: { [CARRY_KEY]: ORIGINAL_ENDING },
+    applicable_product_tags: ["usage"],
+    access_schedule: {
+      credit_type: { id: "credit-awu" },
+      schedule_items: [
+        {
+          id: "seg-1",
+          amount: 10_000,
+          starting_at: "2026-04-01T00:00:00.000Z",
+          ending_before: ORIGINAL_ENDING,
+        },
+      ],
+    },
+    ledger: [
+      { type: "PREPAID_COMMIT_SEGMENT_START", amount: 10_000 },
+      { type: "PREPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION", amount: -6_000 },
+      { type: "PREPAID_COMMIT_EXPIRATION", amount: -4_000 },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockListCommits.mockReset();
+  mockListCredits.mockReset();
+  mockAddComplimentaryCommit.mockReset();
+  mockAddCredit.mockReset();
+  mockListCommits.mockResolvedValue(new Ok([]));
+  mockListCredits.mockResolvedValue(new Ok([]));
+  mockAddComplimentaryCommit.mockResolvedValue(new Ok({ editId: "edit-1" }));
+  mockAddCredit.mockResolvedValue(new Ok({ creditId: "credit-1" }));
+});
+
+async function run() {
+  return carryOverContractBalancesOnRenewal({
+    metronomeCustomerId: "cust-1",
+    fromContractId: "from-1",
+    toContractId: "to-1",
+    toContractStart: TO_CONTRACT_START,
+  });
+}
+
+describe("carryOverContractBalancesOnRenewal", () => {
+  it("carries the unused balance from the expiration ledger entry, not the granted amount", async () => {
+    mockListCommits.mockResolvedValue(new Ok([flaggedCommit()]));
+
+    const result = await run();
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddComplimentaryCommit).toHaveBeenCalledTimes(1);
+    const call = mockAddComplimentaryCommit.mock.calls[0][0];
+    // 10,000 granted − 6,000 used = 4,000 left (from the -4,000 expiration entry).
+    expect(call.accessAmount).toBe(4_000);
+    expect(call.metronomeContractId).toBe("to-1");
+    expect(call.productId).toBe("prod-awu");
+    expect(call.priority).toBe(300);
+    expect(call.accessStartingAt).toEqual(TO_CONTRACT_START);
+    // Expiry comes from the custom field, and is re-stamped verbatim.
+    expect(call.accessEndingBefore).toEqual(new Date(ORIGINAL_ENDING));
+    expect(call.uniquenessKey).toBe("carry:to-1:commit-1");
+    expect(call.customFields).toEqual({ [CARRY_KEY]: ORIGINAL_ENDING });
+  });
+
+  it("falls back to the live balance when no expiration entry is present", async () => {
+    mockListCommits.mockResolvedValue(
+      new Ok([
+        flaggedCommit({
+          balance: 7_500,
+          ledger: [{ type: "PREPAID_COMMIT_SEGMENT_START", amount: 10_000 }],
+        }),
+      ])
+    );
+
+    await run();
+
+    expect(mockAddComplimentaryCommit.mock.calls[0][0].accessAmount).toBe(7_500);
+  });
+
+  it("skips commits that are not flagged", async () => {
+    mockListCommits.mockResolvedValue(
+      new Ok([flaggedCommit({ custom_fields: {} })])
+    );
+
+    await run();
+
+    expect(mockAddComplimentaryCommit).not.toHaveBeenCalled();
+  });
+
+  it("carries forever (far-future sentinel) when the flag has no ISO date", async () => {
+    mockListCommits.mockResolvedValue(
+      new Ok([flaggedCommit({ custom_fields: { [CARRY_KEY]: "forever" } })])
+    );
+
+    await run();
+
+    expect(mockAddComplimentaryCommit).toHaveBeenCalledTimes(1);
+    const call = mockAddComplimentaryCommit.mock.calls[0][0];
+    expect(call.accessAmount).toBe(4_000);
+    expect(call.accessEndingBefore).toEqual(
+      new Date("2999-01-01T00:00:00.000Z")
+    );
+    // The forever marker is re-stamped so it stays forever on the next renewal.
+    expect(call.customFields).toEqual({ [CARRY_KEY]: "forever" });
+  });
+
+  it("skips when the stored expiry is already in the past", async () => {
+    mockListCommits.mockResolvedValue(
+      new Ok([
+        flaggedCommit({
+          // Earlier than the new contract start (2026-05-01) → lapsed.
+          custom_fields: { [CARRY_KEY]: "2026-04-01T00:00:00.000Z" },
+        }),
+      ])
+    );
+
+    await run();
+
+    expect(mockAddComplimentaryCommit).not.toHaveBeenCalled();
+  });
+
+  it("skips commits with no remaining balance", async () => {
+    mockListCommits.mockResolvedValue(
+      new Ok([
+        flaggedCommit({
+          balance: 0,
+          ledger: [
+            { type: "PREPAID_COMMIT_SEGMENT_START", amount: 10_000 },
+            {
+              type: "PREPAID_COMMIT_AUTOMATED_INVOICE_DEDUCTION",
+              amount: -10_000,
+            },
+            { type: "PREPAID_COMMIT_EXPIRATION", amount: 0 },
+          ],
+        }),
+      ])
+    );
+
+    await run();
+
+    expect(mockAddComplimentaryCommit).not.toHaveBeenCalled();
+  });
+
+  it("re-grants a flagged credit as a credit with the carry flag", async () => {
+    mockListCredits.mockResolvedValue(
+      new Ok([
+        {
+          id: "credit-9",
+          type: "CREDIT",
+          product: { id: "prod-awu", name: "Credit" },
+          priority: 300,
+          name: "Negotiated credit",
+          balance: 0,
+          custom_fields: { [CARRY_KEY]: ORIGINAL_ENDING },
+          applicable_product_tags: ["usage"],
+          access_schedule: {
+            credit_type: { id: "credit-awu" },
+            schedule_items: [
+              {
+                id: "seg-1",
+                amount: 5_000,
+                starting_at: "2026-04-01T00:00:00.000Z",
+                ending_before: ORIGINAL_ENDING,
+              },
+            ],
+          },
+          ledger: [{ type: "CREDIT_EXPIRATION", amount: -1_250 }],
+        },
+      ])
+    );
+
+    await run();
+
+    expect(mockAddComplimentaryCommit).not.toHaveBeenCalled();
+    expect(mockAddCredit).toHaveBeenCalledTimes(1);
+    const call = mockAddCredit.mock.calls[0][0];
+    expect(call.amount).toBe(1_250);
+    expect(call.creditTypeId).toBe("credit-awu");
+    expect(call.uniquenessKey).toBe("carry:to-1:credit-9");
+    expect(call.customFields).toEqual({ [CARRY_KEY]: ORIGINAL_ENDING });
+  });
+
+  it("propagates a re-grant failure", async () => {
+    mockListCommits.mockResolvedValue(new Ok([flaggedCommit()]));
+    mockAddComplimentaryCommit.mockResolvedValue(new Err(new Error("boom")));
+
+    const result = await run();
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/metronome/renewal_carry_over.ts
+++ b/front/lib/metronome/renewal_carry_over.ts
@@ -1,0 +1,235 @@
+import {
+  addComplimentaryCommitToContract,
+  addCreditToContract,
+  listContractCommitsWithLedger,
+  listContractCreditsWithLedger,
+} from "@app/lib/metronome/client";
+import {
+  AWU_PRIORITY_PURCHASED_COMMIT,
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+} from "@app/lib/metronome/constants";
+import type {
+  MetronomeCommit,
+  MetronomeCredit,
+} from "@app/lib/metronome/types";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type CarryEntry = MetronomeCommit | MetronomeCredit;
+
+/**
+ * The balance left when the source entry expired at the transition.
+ *
+ * When a contract ends, Metronome zeroes each commit/credit with an expiration
+ * ledger entry whose (negative) amount is exactly the unused balance — that's
+ * the value to carry, not the live `balance` (which reads 0 once expired) nor
+ * the granted access amount (which would hand back consumed credit). If no
+ * expiration entry is present yet (the source hasn't expired — e.g. a webhook
+ * re-delivery race), fall back to the live `balance`.
+ */
+function carriedAmount(entry: CarryEntry): number {
+  // Both commit and credit ledger entries share `{ type, amount }`; normalize to
+  // that shape to side-step calling `.filter` on a union of array types.
+  const ledger: Array<{ type: string; amount: number }> = entry.ledger ?? [];
+  const expirationEntries = ledger.filter(
+    (l) =>
+      l.type === "PREPAID_COMMIT_EXPIRATION" || l.type === "CREDIT_EXPIRATION"
+  );
+  if (expirationEntries.length > 0) {
+    return -expirationEntries.reduce((sum, l) => sum + l.amount, 0);
+  }
+  return entry.balance ?? 0;
+}
+
+// Metronome commit/credit access schedules require an `ending_before` — there
+// is no true open-ended window — so "forever" (a carry flag with no ISO expiry)
+// is represented with this far-future sentinel.
+const FOREVER_ENDING_BEFORE = new Date("2999-01-01T00:00:00.000Z");
+
+type CarryPlan = {
+  amount: number;
+  // Access expiry for the re-granted entry. Read from the custom field stamped
+  // at grant time (the live window has been clamped to the source contract end
+  // by the time we run). A flag with no ISO date carries forever.
+  expiry: Date;
+  rawExpiry: string;
+  creditTypeId: string;
+};
+
+// Decide whether and how to carry an entry. Returns a plan, or a reason to skip.
+// The expiry comes from `CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY` (stamped at grant
+// time) so it survives Metronome clamping the live window at the transition.
+// The field is forever-by-default: a non-date value (or a bare marker) carries
+// forever; an ISO date carries until then, and is skipped once it's in the past.
+function resolveCarryPlan(
+  entry: CarryEntry,
+  toContractStart: Date
+): { plan: CarryPlan } | { skipReason: string } {
+  const rawExpiry = entry.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY];
+  if (rawExpiry === undefined) {
+    return { skipReason: "not flagged" };
+  }
+  const expiryMs = Date.parse(rawExpiry);
+  let expiry: Date;
+  if (Number.isNaN(expiryMs)) {
+    // No explicit expiry → forever.
+    expiry = FOREVER_ENDING_BEFORE;
+  } else if (expiryMs <= toContractStart.getTime()) {
+    return { skipReason: "expired before transition" };
+  } else {
+    expiry = new Date(expiryMs);
+  }
+  const amount = carriedAmount(entry);
+  if (amount <= 0) {
+    return { skipReason: "no remaining balance" };
+  }
+  const creditTypeId = entry.access_schedule?.credit_type?.id;
+  if (!creditTypeId) {
+    return { skipReason: "no access credit type" };
+  }
+  return { plan: { amount, expiry, rawExpiry, creditTypeId } };
+}
+
+/**
+ * Carry the unused balance of the source contract's non-recurring commits and
+ * credits onto the renewed contract.
+ *
+ * Invoked from the `contract.start` webhook once a RENEWAL transition has ended
+ * the source contract. Only entries stamped `CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY`
+ * are carried (initial credits, AWU top-ups, business-activation seat
+ * prepayment). Each is re-granted on the successor as a complimentary
+ * (no-invoice) commit / credit at its original priority, products, credit type
+ * and expiry, and re-stamped so it carries again on the next renewal.
+ *
+ * Idempotent: each re-grant uses a uniqueness key scoped to the source entry and
+ * the successor contract, so webhook re-deliveries do not double-grant.
+ */
+export async function carryOverContractBalancesOnRenewal({
+  metronomeCustomerId,
+  fromContractId,
+  toContractId,
+  toContractStart,
+}: {
+  metronomeCustomerId: string;
+  fromContractId: string;
+  toContractId: string;
+  toContractStart: Date;
+}): Promise<Result<{ carriedCount: number }, Error>> {
+  const commitsResult = await listContractCommitsWithLedger({
+    metronomeCustomerId,
+    contractId: fromContractId,
+  });
+  if (commitsResult.isErr()) {
+    return new Err(commitsResult.error);
+  }
+  const creditsResult = await listContractCreditsWithLedger({
+    metronomeCustomerId,
+    contractId: fromContractId,
+  });
+  if (creditsResult.isErr()) {
+    return new Err(creditsResult.error);
+  }
+
+  const commits = commitsResult.value.filter((c) =>
+    c.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY] !== undefined
+  );
+  const credits = creditsResult.value.filter((c) =>
+    c.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY] !== undefined
+  );
+
+  logger.info(
+    {
+      metronomeCustomerId,
+      fromContractId,
+      toContractId,
+      sourceCommits: commitsResult.value.length,
+      sourceCredits: creditsResult.value.length,
+      flaggedCommits: commits.length,
+      flaggedCredits: credits.length,
+    },
+    "[Metronome] Renewal carry-over: source entries"
+  );
+
+  let carriedCount = 0;
+
+  for (const commit of commits) {
+    const resolved = resolveCarryPlan(commit, toContractStart);
+    if ("skipReason" in resolved) {
+      logger.info(
+        {
+          metronomeCustomerId,
+          fromContractId,
+          toContractId,
+          commitId: commit.id,
+          reason: resolved.skipReason,
+        },
+        "[Metronome] Renewal carry-over: skipping commit"
+      );
+      continue;
+    }
+    const { amount, expiry, rawExpiry, creditTypeId } = resolved.plan;
+    const regrant = await addComplimentaryCommitToContract({
+      metronomeCustomerId,
+      metronomeContractId: toContractId,
+      productId: commit.product.id,
+      accessAmount: amount,
+      accessCreditTypeId: creditTypeId,
+      accessStartingAt: toContractStart,
+      accessEndingBefore: expiry,
+      priority: commit.priority ?? AWU_PRIORITY_PURCHASED_COMMIT,
+      name: commit.name ?? "Carried-over balance",
+      uniquenessKey: `carry:${toContractId}:${commit.id}`,
+      applicableProductIds: commit.applicable_product_ids,
+      applicableProductTags: commit.applicable_product_tags,
+      customFields: { [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: rawExpiry },
+    });
+    if (regrant.isErr()) {
+      return new Err(regrant.error);
+    }
+    carriedCount += 1;
+  }
+
+  for (const credit of credits) {
+    const resolved = resolveCarryPlan(credit, toContractStart);
+    if ("skipReason" in resolved) {
+      logger.info(
+        {
+          metronomeCustomerId,
+          fromContractId,
+          toContractId,
+          creditId: credit.id,
+          reason: resolved.skipReason,
+        },
+        "[Metronome] Renewal carry-over: skipping credit"
+      );
+      continue;
+    }
+    const { amount, expiry, rawExpiry, creditTypeId } = resolved.plan;
+    const regrant = await addCreditToContract({
+      metronomeCustomerId,
+      metronomeContractId: toContractId,
+      productId: credit.product.id,
+      creditTypeId,
+      amount,
+      startingAt: toContractStart.toISOString(),
+      endingBefore: expiry.toISOString(),
+      priority: credit.priority ?? AWU_PRIORITY_PURCHASED_COMMIT,
+      name: credit.name ?? "Carried-over balance",
+      uniquenessKey: `carry:${toContractId}:${credit.id}`,
+      applicableProductTags: credit.applicable_product_tags,
+      customFields: { [CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY]: rawExpiry },
+    });
+    if (regrant.isErr()) {
+      return new Err(regrant.error);
+    }
+    carriedCount += 1;
+  }
+
+  logger.info(
+    { metronomeCustomerId, fromContractId, toContractId, carriedCount },
+    "[Metronome] Renewal carry-over complete"
+  );
+
+  return new Ok({ carriedCount });
+}

--- a/front/lib/metronome/renewal_carry_over.ts
+++ b/front/lib/metronome/renewal_carry_over.ts
@@ -131,11 +131,11 @@ export async function carryOverContractBalancesOnRenewal({
     return new Err(creditsResult.error);
   }
 
-  const commits = commitsResult.value.filter((c) =>
-    c.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY] !== undefined
+  const commits = commitsResult.value.filter(
+    (c) => c.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY] !== undefined
   );
-  const credits = creditsResult.value.filter((c) =>
-    c.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY] !== undefined
+  const credits = creditsResult.value.filter(
+    (c) => c.custom_fields?.[CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY] !== undefined
   );
 
   logger.info(

--- a/front/lib/metronome/renewal_carry_over.ts
+++ b/front/lib/metronome/renewal_carry_over.ts
@@ -7,6 +7,7 @@ import {
 import {
   AWU_PRIORITY_PURCHASED_COMMIT,
   CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  FOREVER_ENDING_BEFORE,
 } from "@app/lib/metronome/constants";
 import type {
   MetronomeCommit,
@@ -41,11 +42,6 @@ function carriedAmount(entry: CarryEntry): number {
   }
   return entry.balance ?? 0;
 }
-
-// Metronome commit/credit access schedules require an `ending_before` — there
-// is no true open-ended window — so "forever" (a carry flag with no ISO expiry)
-// is represented with this far-future sentinel.
-const FOREVER_ENDING_BEFORE = new Date("2999-01-01T00:00:00.000Z");
 
 type CarryPlan = {
   amount: number;

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -16,6 +16,7 @@ import { baseUniquenessKey } from "@app/lib/metronome/alerts";
 import { DEFAULT_ALERT_UNIQUENESS_KEYS } from "@app/lib/metronome/alerts/default_alerts";
 import { getMetronomeClient } from "@app/lib/metronome/client";
 import {
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_POOL,
   CREDIT_TYPE_USD_ID,
@@ -1479,6 +1480,18 @@ const CUSTOM_FIELD_KEYS: Array<{
   {
     entity: "contract_credit",
     key: PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
+  },
+  // Stamped on the non-recurring contract-level commits/credits whose unused
+  // balance is carried into the successor contract on a RENEWAL transition (see
+  // `CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY`). Registered on both entities so the
+  // `contract.start` webhook can filter source commits and credits alike.
+  {
+    entity: "commit",
+    key: CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
+  },
+  {
+    entity: "contract_credit",
+    key: CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY,
   },
   // Stamped on each seat-style product (Workspace / Pro / Max / Free).
   // Runtime code reads `product.custom_fields.DUST_SEAT_TYPE` (cached in


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/8737

Carry the unused balance of non-recurring, contract-level commits/credits
(switch_contract initial credits, awu_purchase top-ups, business_activation
seat prepayment) into the successor contract when a RENEWAL transition ends
the prior one.

Do NOT use Metronome's rollover_fraction: a rolled-over commit becomes a
"rollover" commit, which Metronome burns down before all prepaid commits
regardless of priority ("commit type takes precedence over priority"). Since
these are non-seat-based, that ordering trips the client-level rule that a
non-seat-based commit may not be prioritized over a seat-based one, and the
RENEWAL transition is rejected with a 400.

Instead, carry the balance in the contract.start webhook:
- Flag carry-eligible grants with the DUST_CARRY_ON_RENEWAL custom field. Its
  value is the grant's original access expiry (ISO). A non-date marker means
  "forever". Storing it on the field is necessary because Metronome clamps the
  live access window to the contract end at the transition, destroying the
  original expiry.
- On contract.start, resolve the RENEWAL transition's source contract, read its
  flagged commits/credits, derive the unused balance from their expiration
  ledger entry, and re-grant each on the successor as a complimentary
  (no-invoice) commit / credit at its original priority, products and expiry,
  re-stamping the flag so it carries again on the next renewal. A plain prepaid
  commit stays in the prepaid burn tier, ordered after the seat allocation by
  priority. Expiry rules: in the past -> skip (lapsed); future -> keep it;
  non-date marker -> forever.

Register DUST_CARRY_ON_RENEWAL for the commit and contract_credit entities in
metronome_setup.ts.

Note: seat commitents, coupon credits, free-seat per-user credits, recurring credits ARE NOT rolled over.

Customer-level commits/credits are out of scope since they are not coupled to a contract and hence survive contract transitions without custom logic.

## Tests

Unit + local

## Risk

Low

## Deploy Plan

Run `npx tsx scripts/metronome_setup.ts --execute`
