### PR TITLE
feat(credits): aggregate sub-agent cost on agent messages

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -10404,6 +10404,11 @@
             "type": "integer",
             "nullable": true,
             "description": "Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
+          },
+          "subAgentCostCredits": {
+            "type": "number",
+            "nullable": true,
+            "description": "Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
           }
         }
       },
@@ -10550,6 +10555,11 @@
             "type": "integer",
             "nullable": true,
             "description": "Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
+          },
+          "subAgentCostCredits": {
+            "type": "number",
+            "nullable": true,
+            "description": "Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
           },
           "activitySteps": {
             "type": "array",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -404,6 +404,10 @@
  *           type: integer
  *           nullable: true
  *           description: Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
+ *         subAgentCostCredits:
+ *           type: number
+ *           nullable: true
+ *           description: Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
  *     PrivateLightAgentMessage:
  *       type: object
  *       description: A lighter agent message used in paginated message list responses.
@@ -500,6 +504,10 @@
  *           type: integer
  *           nullable: true
  *           description: Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
+ *         subAgentCostCredits:
+ *           type: number
+ *           nullable: true
+ *           description: Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
  *         activitySteps:
  *           type: array
  *           items:

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -161,7 +161,9 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
     auth,
     conversation,
     [messageRes.value],
-    viewType
+    viewType,
+    null,
+    { includeSubAgentCostCredits: true }
   );
 
   if (renderedMessages.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -175,26 +175,13 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
-  // Sub-agent cost credits are aggregated lazily, only on this single-message
-  // fetch (never in bulk conversation rendering). Attach it to the agent
-  // message before returning.
-  const renderedMessage = renderedMessages.value[0];
-  const isAgentMessage = renderedMessage.type === "agent_message";
-  const message = isAgentMessage
-    ? {
-        ...renderedMessage,
-        subAgentCostCredits:
-          await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
-            agentMessageId: renderedMessage.sId,
-          }),
-      }
-    : renderedMessage;
-
   switch (viewType) {
     case "light":
-      return ctx.json({ message: message as LightMessageType });
+      return ctx.json({
+        message: renderedMessages.value[0] as LightMessageType,
+      });
     case "full":
-      return ctx.json({ message: message as MessageType });
+      return ctx.json({ message: renderedMessages.value[0] as MessageType });
     default:
       assertNever(viewType);
   }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -162,8 +162,7 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
     conversation,
     [messageRes.value],
     viewType,
-    null,
-    { includeSubAgentCostCredits: true }
+    null
   );
 
   if (renderedMessages.isErr()) {
@@ -176,13 +175,26 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
     });
   }
 
+  // Sub-agent cost credits are aggregated lazily, only on this single-message
+  // fetch (never in bulk conversation rendering). Attach it to the agent
+  // message before returning.
+  const renderedMessage = renderedMessages.value[0];
+  const isAgentMessage = renderedMessage.type === "agent_message";
+  const message = isAgentMessage
+    ? {
+        ...renderedMessage,
+        subAgentCostCredits:
+          await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
+            agentMessageId: renderedMessage.sId,
+          }),
+      }
+    : renderedMessage;
+
   switch (viewType) {
     case "light":
-      return ctx.json({
-        message: renderedMessages.value[0] as LightMessageType,
-      });
+      return ctx.json({ message: message as LightMessageType });
     case "full":
-      return ctx.json({ message: renderedMessages.value[0] as MessageType });
+      return ctx.json({ message: message as MessageType });
     default:
       assertNever(viewType);
   }

--- a/front/components/credits/RequestUpgradeButton.tsx
+++ b/front/components/credits/RequestUpgradeButton.tsx
@@ -20,6 +20,9 @@ interface RequestUpgradeButtonProps {
   variant?: RequestUpgradeButtonVariant;
 }
 
+// Member-initiated upgrade-request CTA. Opens a confirmation dialog and posts
+// the request via `useRequestUpgrade`. Rendered either as an inline link (usage
+// banner) or as a primary button (personal settings) through `variant`.
 export function RequestUpgradeButton({
   owner,
   hasPendingUpgradeRequest,

--- a/front/components/credits/RequestUpgradeButton.tsx
+++ b/front/components/credits/RequestUpgradeButton.tsx
@@ -20,9 +20,6 @@ interface RequestUpgradeButtonProps {
   variant?: RequestUpgradeButtonVariant;
 }
 
-// Member-initiated upgrade-request CTA. Opens a confirmation dialog and posts
-// the request via `useRequestUpgrade`. Rendered either as an inline link (usage
-// banner) or as a primary button (personal settings) through `variant`.
 export function RequestUpgradeButton({
   owner,
   hasPendingUpgradeRequest,

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -198,6 +198,7 @@ export function getLightAgentMessageFromAgentMessage(
     reactions: agentMessage.reactions,
     prunedContext: agentMessage.prunedContext,
     costCredits: agentMessage.costCredits,
+    subAgentCostCredits: agentMessage.subAgentCostCredits,
     activitySteps: [],
   };
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -342,17 +342,12 @@ export async function batchRenderUserMessagesWithoutMentions(
   );
 }
 
-interface BatchRenderOptions {
-  includeSubAgentCostCredits?: boolean;
-}
-
 export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
   messages: MessageModel[],
   viewType: V,
   messagesWithToolOutputContent: Set<ModelId> | null = null,
-  mentionsByMessageId: Map<ModelId, MentionModel[]>,
-  { includeSubAgentCostCredits = false }: BatchRenderOptions = {}
+  mentionsByMessageId: Map<ModelId, MentionModel[]>
 ): Promise<
   Result<
     V extends "full" ? AgentMessageType[] : LightAgentMessageType[],
@@ -605,12 +600,6 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       );
     }
   }
-  const subAgentCostCreditsByMessageId = includeSubAgentCostCredits
-    ? await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
-        agentMessageIds: agentMessages.map((m) => m.sId),
-      })
-    : null;
-
   const renderedMessages: Array<
     Result<RenderedAgentMessage, ConversationError>
   > = [];
@@ -627,7 +616,6 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         mentionsByMessageId,
         reactionsByMessageId,
         stepContentsByMessageId,
-        subAgentCostCreditsByMessageId,
         usersById,
         viewType,
       })
@@ -658,7 +646,6 @@ type RenderSingleAgentMessageContext = {
   mentionsByMessageId: Map<ModelId, MentionModel[]>;
   reactionsByMessageId: Record<ModelId, MessageReactionType[]>;
   stepContentsByMessageId: Record<string, AgentStepContentResource[]>;
-  subAgentCostCreditsByMessageId: Map<string, number> | null;
   usersById: Map<ModelId, UserType>;
   viewType: RenderMessageVariant;
 };
@@ -675,7 +662,6 @@ async function renderSingleAgentMessage(
     mentionsByMessageId,
     reactionsByMessageId,
     stepContentsByMessageId,
-    subAgentCostCreditsByMessageId,
     usersById,
     viewType,
   }: RenderSingleAgentMessageContext
@@ -810,9 +796,9 @@ async function renderSingleAgentMessage(
     reactions: reactionsByMessageId[message.id] ?? [],
     prunedContext: agentMessage.prunedContext ?? false,
     costCredits: agentMessage.costCredits ?? null,
-    subAgentCostCredits: subAgentCostCreditsByMessageId
-      ? (subAgentCostCreditsByMessageId.get(message.sId) ?? 0)
-      : null,
+    // Aggregated lazily on single-message fetches only (see the single-message
+    // endpoint), so it is `null` everywhere bulk rendering is used.
+    subAgentCostCredits: null,
   } satisfies AgentMessageType;
 
   if (viewType === "full") {
@@ -875,8 +861,7 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
   conversation: ConversationResource,
   messages: MessageModel[],
   viewType: V,
-  messagesWithToolOutputContent: Set<ModelId> | null = null,
-  options: BatchRenderOptions = {}
+  messagesWithToolOutputContent: Set<ModelId> | null = null
 ): Promise<
   Result<
     V extends "full"
@@ -920,8 +905,7 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     messages,
     viewType,
     messagesWithToolOutputContent,
-    mentionsByMessageId,
-    options
+    mentionsByMessageId
   );
 
   if (agentMessagesRes.isErr()) {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -600,6 +600,16 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       );
     }
   }
+  // Sub-agent cost credits are only aggregated when rendering a single agent
+  // message (e.g. the single-message endpoint), never in bulk conversation
+  // rendering, to avoid fanning out into an N+1 of recursive queries.
+  const subAgentCostCredits =
+    agentMessages.length === 1
+      ? await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
+          agentMessageId: agentMessages[0].sId,
+        })
+      : null;
+
   const renderedMessages: Array<
     Result<RenderedAgentMessage, ConversationError>
   > = [];
@@ -616,6 +626,7 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         mentionsByMessageId,
         reactionsByMessageId,
         stepContentsByMessageId,
+        subAgentCostCredits,
         usersById,
         viewType,
       })
@@ -646,6 +657,7 @@ type RenderSingleAgentMessageContext = {
   mentionsByMessageId: Map<ModelId, MentionModel[]>;
   reactionsByMessageId: Record<ModelId, MessageReactionType[]>;
   stepContentsByMessageId: Record<string, AgentStepContentResource[]>;
+  subAgentCostCredits: number | null;
   usersById: Map<ModelId, UserType>;
   viewType: RenderMessageVariant;
 };
@@ -662,6 +674,7 @@ async function renderSingleAgentMessage(
     mentionsByMessageId,
     reactionsByMessageId,
     stepContentsByMessageId,
+    subAgentCostCredits,
     usersById,
     viewType,
   }: RenderSingleAgentMessageContext
@@ -796,9 +809,9 @@ async function renderSingleAgentMessage(
     reactions: reactionsByMessageId[message.id] ?? [],
     prunedContext: agentMessage.prunedContext ?? false,
     costCredits: agentMessage.costCredits ?? null,
-    // Aggregated lazily on single-message fetches only (see the single-message
-    // endpoint), so it is `null` everywhere bulk rendering is used.
-    subAgentCostCredits: null,
+    // Aggregated only when rendering a single agent message (see
+    // batchRenderAgentMessages), so it is `null` for bulk conversation rendering.
+    subAgentCostCredits,
   } satisfies AgentMessageType;
 
   if (viewType === "full") {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -342,12 +342,17 @@ export async function batchRenderUserMessagesWithoutMentions(
   );
 }
 
+interface BatchRenderOptions {
+  includeSubAgentCostCredits?: boolean;
+}
+
 export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   auth: Authenticator,
   messages: MessageModel[],
   viewType: V,
   messagesWithToolOutputContent: Set<ModelId> | null = null,
-  mentionsByMessageId: Map<ModelId, MentionModel[]>
+  mentionsByMessageId: Map<ModelId, MentionModel[]>,
+  { includeSubAgentCostCredits = false }: BatchRenderOptions = {}
 ): Promise<
   Result<
     V extends "full" ? AgentMessageType[] : LightAgentMessageType[],
@@ -600,6 +605,12 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       );
     }
   }
+  const subAgentCostCreditsByMessageId = includeSubAgentCostCredits
+    ? await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
+        agentMessageIds: agentMessages.map((m) => m.sId),
+      })
+    : null;
+
   const renderedMessages: Array<
     Result<RenderedAgentMessage, ConversationError>
   > = [];
@@ -616,6 +627,7 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         mentionsByMessageId,
         reactionsByMessageId,
         stepContentsByMessageId,
+        subAgentCostCreditsByMessageId,
         usersById,
         viewType,
       })
@@ -646,6 +658,7 @@ type RenderSingleAgentMessageContext = {
   mentionsByMessageId: Map<ModelId, MentionModel[]>;
   reactionsByMessageId: Record<ModelId, MessageReactionType[]>;
   stepContentsByMessageId: Record<string, AgentStepContentResource[]>;
+  subAgentCostCreditsByMessageId: Map<string, number> | null;
   usersById: Map<ModelId, UserType>;
   viewType: RenderMessageVariant;
 };
@@ -662,6 +675,7 @@ async function renderSingleAgentMessage(
     mentionsByMessageId,
     reactionsByMessageId,
     stepContentsByMessageId,
+    subAgentCostCreditsByMessageId,
     usersById,
     viewType,
   }: RenderSingleAgentMessageContext
@@ -796,6 +810,9 @@ async function renderSingleAgentMessage(
     reactions: reactionsByMessageId[message.id] ?? [],
     prunedContext: agentMessage.prunedContext ?? false,
     costCredits: agentMessage.costCredits ?? null,
+    subAgentCostCredits: subAgentCostCreditsByMessageId
+      ? (subAgentCostCreditsByMessageId.get(message.sId) ?? 0)
+      : null,
   } satisfies AgentMessageType;
 
   if (viewType === "full") {
@@ -858,7 +875,8 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
   conversation: ConversationResource,
   messages: MessageModel[],
   viewType: V,
-  messagesWithToolOutputContent: Set<ModelId> | null = null
+  messagesWithToolOutputContent: Set<ModelId> | null = null,
+  options: BatchRenderOptions = {}
 ): Promise<
   Result<
     V extends "full"
@@ -902,7 +920,8 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     messages,
     viewType,
     messagesWithToolOutputContent,
-    mentionsByMessageId
+    mentionsByMessageId,
+    options
   );
 
   if (agentMessagesRes.isErr()) {

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -90,6 +90,152 @@ const dateFromDaysAgo = (days: number) => {
 };
 
 describe("ConversationResource", () => {
+  describe("sumSubAgentCostCreditsByMessageId", () => {
+    // Creates a sub-agent: a user message in `conversation` whose
+    // agenticOriginMessageId points at `originSid`, plus its agent reply with
+    // the given costCredits. Returns the reply's sId (the origin for any deeper
+    // sub-agents).
+    async function createSubAgent({
+      auth,
+      conversation,
+      agentConfigurationId,
+      originSid,
+      costCredits,
+    }: {
+      auth: Authenticator;
+      conversation: ConversationWithoutContentType;
+      agentConfigurationId: string;
+      originSid: string;
+      costCredits: number;
+    }): Promise<string> {
+      const workspace = auth.getNonNullableWorkspace();
+      const { messageRow: userMessageRow } =
+        await ConversationFactory.createUserMessage({
+          auth,
+          workspace,
+          conversation,
+          content: "sub-agent trigger",
+          agenticMessageType: "run_agent",
+          agenticOriginMessageId: originSid,
+        });
+
+      const replyRow = await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId,
+        parentId: userMessageRow.id,
+      });
+
+      assert(replyRow.agentMessageId, "Reply must have an agent message");
+      await ConversationResource.updateAgentMessageCostCredits(auth, {
+        agentMessageModelId: replyRow.agentMessageId,
+        costCredits,
+      });
+
+      return replyRow.sId;
+    }
+
+    it("sums sub-agent costs recursively and ignores unrelated messages", async () => {
+      const { workspace, authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Sub Agent Cost",
+        description: "agent",
+      });
+
+      // Origin agent message lives in a parent conversation.
+      const parentConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date("2026-01-01T00:00:00.000Z")],
+      });
+      const originMessage = await MessageModel.findOne({
+        where: {
+          conversationId: parentConversation.id,
+          workspaceId: workspace.id,
+          rank: 1,
+        },
+      });
+      assert(originMessage, "Origin agent message not found");
+
+      // Direct sub-agent (cost 100) in a child conversation, then a nested
+      // sub-agent (cost 50) spawned by that sub-agent in a grandchild.
+      const childConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+      const childReplySid = await createSubAgent({
+        auth,
+        conversation: childConversation,
+        agentConfigurationId: agent.sId,
+        originSid: originMessage.sId,
+        costCredits: 100,
+      });
+
+      const grandChildConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+      await createSubAgent({
+        auth,
+        conversation: grandChildConversation,
+        agentConfigurationId: agent.sId,
+        originSid: childReplySid,
+        costCredits: 50,
+      });
+
+      // An unrelated sub-agent of a different origin must not be counted.
+      const unrelatedConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [],
+      });
+      await createSubAgent({
+        auth,
+        conversation: unrelatedConversation,
+        agentConfigurationId: agent.sId,
+        originSid: "msg_unrelated_origin",
+        costCredits: 999,
+      });
+
+      const result =
+        await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
+          agentMessageIds: [originMessage.sId],
+        });
+
+      expect(result.get(originMessage.sId)).toBe(150);
+    });
+
+    it("returns an empty map when the message has no sub-agents", async () => {
+      const { workspace, authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "No Sub Agent",
+        description: "agent",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date("2026-01-01T00:00:00.000Z")],
+      });
+      const originMessage = await MessageModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+          rank: 1,
+        },
+      });
+      assert(originMessage, "Origin agent message not found");
+
+      const result =
+        await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
+          agentMessageIds: [originMessage.sId],
+        });
+
+      expect(result.size).toBe(0);
+    });
+  });
+
   describe("fetchByModelIds", () => {
     it("should fetch by model ids within workspace", async () => {
       const workspace = await WorkspaceFactory.basic();

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -200,13 +200,13 @@ describe("ConversationResource", () => {
 
       const result =
         await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
-          agentMessageIds: [originMessage.sId],
+          agentMessageId: originMessage.sId,
         });
 
-      expect(result.get(originMessage.sId)).toBe(150);
+      expect(result).toBe(150);
     });
 
-    it("returns an empty map when the message has no sub-agents", async () => {
+    it("returns 0 when the message has no sub-agents", async () => {
       const { workspace, authenticator: auth } = await createResourceTest({
         role: "admin",
       });
@@ -229,10 +229,10 @@ describe("ConversationResource", () => {
 
       const result =
         await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
-          agentMessageIds: [originMessage.sId],
+          agentMessageId: originMessage.sId,
         });
 
-      expect(result.size).toBe(0);
+      expect(result).toBe(0);
     });
   });
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -736,45 +736,26 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   }
 
   /**
-   * For each given (origin) agent message, sum the `costCredits` of every
-   * sub-agent message it spawned, recursively. A sub-agent is linked to its
-   * origin through the triggering user message's `agenticOriginMessageId`
-   * (set for both `run_agent` and `agent_handover`), which holds the origin
-   * agent message's `sId`. The sub-agent's own reply is the agent message that
-   * replies to that user message; its `sId` is in turn the origin for any
-   * deeper sub-agents.
-   *
-   * Walks the tree top-down in a single recursive query (no per-level N+1). The
-   * `maxDepth` guard both bounds runtime and protects against unexpected cycles
-   * (the graph is acyclic by construction, since an origin always predates its
-   * children). We `logger.warn` if the cap is hit so a truncated total does not
-   * silently under-report cost.
-   *
-   * Returns a map keyed by origin agent message `sId`. Origins with no
-   * sub-agents are absent from the map.
+   * Recursively sums the `costCredits` of every sub-agent spawned by a single
+   * origin agent message (one recursive query, `maxDepth`-bounded). Single-message
+   * by design (and avoids an N+1); returns `0` when there are no sub-agents.
    */
   static async sumSubAgentCostCreditsByMessageId(
     auth: Authenticator,
     {
-      agentMessageIds,
+      agentMessageId,
       maxDepth = 10,
-    }: { agentMessageIds: string[]; maxDepth?: number }
-  ): Promise<Map<string, number>> {
-    const result = new Map<string, number>();
-    if (agentMessageIds.length === 0) {
-      return result;
-    }
-
+    }: { agentMessageId: string; maxDepth?: number }
+  ): Promise<number> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
     const query = `
       WITH RECURSIVE sub_agents AS (
-        -- Direct sub-agent replies of each requested origin agent message.
+        -- Direct sub-agent replies of the origin agent message.
         SELECT
-          um."agenticOriginMessageId" AS root_sid,
-          reply."sId"                 AS agent_message_sid,
-          am."costCredits"            AS cost_credits,
-          1                           AS depth
+          reply."sId"      AS agent_message_sid,
+          am."costCredits" AS cost_credits,
+          1                AS depth
         FROM user_messages um
         JOIN messages user_msg
           ON user_msg."userMessageId" = um.id
@@ -787,13 +768,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           ON am.id = reply."agentMessageId"
          AND am."workspaceId" = um."workspaceId"
         WHERE um."workspaceId" = :workspaceId
-          AND um."agenticOriginMessageId" IN (:agentMessageIds)
+          AND um."agenticOriginMessageId" = :agentMessageId
 
         UNION ALL
 
         -- Sub-agents spawned (recursively) by previously found sub-agent replies.
         SELECT
-          s.root_sid,
           reply."sId",
           am."costCredits",
           s.depth + 1
@@ -814,38 +794,38 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         WHERE s.depth < :maxDepth
       )
       SELECT
-        root_sid,
         SUM(COALESCE(cost_credits, 0))::float AS total_credits,
         MAX(depth)::int                       AS max_depth
       FROM sub_agents
-      GROUP BY root_sid
     `;
 
     // biome-ignore lint/plugin/noRawSql: recursive CTE has no Sequelize equivalent.
     const rows = await frontSequelize.query<{
-      root_sid: string;
-      total_credits: number;
-      max_depth: number;
+      total_credits: number | null;
+      max_depth: number | null;
     }>(query, {
       type: QueryTypes.SELECT,
-      replacements: { workspaceId, agentMessageIds, maxDepth },
+      replacements: { workspaceId, agentMessageId, maxDepth },
     });
 
-    for (const row of rows) {
-      result.set(row.root_sid, row.total_credits);
-      if (row.max_depth >= maxDepth) {
-        logger.warn(
-          {
-            workspaceId: auth.getNonNullableWorkspace().sId,
-            agentMessageId: row.root_sid,
-            maxDepth,
-          },
-          "[Credits] Sub-agent cost aggregation hit the depth cap; total may be truncated."
-        );
-      }
+    // No sub-agents: the CTE is empty and SUM/MAX over zero rows return NULL.
+    const row = rows[0];
+    if (!row || row.total_credits === null) {
+      return 0;
     }
 
-    return result;
+    if (row.max_depth !== null && row.max_depth >= maxDepth) {
+      logger.warn(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          agentMessageId,
+          maxDepth,
+        },
+        "[Credits] Sub-agent cost aggregation hit the depth cap; total may be truncated."
+      );
+    }
+
+    return row.total_credits;
   }
 
   private static getOptions(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -735,6 +735,119 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     );
   }
 
+  /**
+   * For each given (origin) agent message, sum the `costCredits` of every
+   * sub-agent message it spawned, recursively. A sub-agent is linked to its
+   * origin through the triggering user message's `agenticOriginMessageId`
+   * (set for both `run_agent` and `agent_handover`), which holds the origin
+   * agent message's `sId`. The sub-agent's own reply is the agent message that
+   * replies to that user message; its `sId` is in turn the origin for any
+   * deeper sub-agents.
+   *
+   * Walks the tree top-down in a single recursive query (no per-level N+1). The
+   * `maxDepth` guard both bounds runtime and protects against unexpected cycles
+   * (the graph is acyclic by construction, since an origin always predates its
+   * children). We `logger.warn` if the cap is hit so a truncated total does not
+   * silently under-report cost.
+   *
+   * Returns a map keyed by origin agent message `sId`. Origins with no
+   * sub-agents are absent from the map.
+   */
+  static async sumSubAgentCostCreditsByMessageId(
+    auth: Authenticator,
+    {
+      agentMessageIds,
+      maxDepth = 10,
+    }: { agentMessageIds: string[]; maxDepth?: number }
+  ): Promise<Map<string, number>> {
+    const result = new Map<string, number>();
+    if (agentMessageIds.length === 0) {
+      return result;
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const query = `
+      WITH RECURSIVE sub_agents AS (
+        -- Direct sub-agent replies of each requested origin agent message.
+        SELECT
+          um."agenticOriginMessageId" AS root_sid,
+          reply."sId"                 AS agent_message_sid,
+          am."costCredits"            AS cost_credits,
+          1                           AS depth
+        FROM user_messages um
+        JOIN messages user_msg
+          ON user_msg."userMessageId" = um.id
+         AND user_msg."workspaceId" = um."workspaceId"
+        JOIN messages reply
+          ON reply."parentId" = user_msg.id
+         AND reply."workspaceId" = um."workspaceId"
+         AND reply."agentMessageId" IS NOT NULL
+        JOIN agent_messages am
+          ON am.id = reply."agentMessageId"
+         AND am."workspaceId" = um."workspaceId"
+        WHERE um."workspaceId" = :workspaceId
+          AND um."agenticOriginMessageId" IN (:agentMessageIds)
+
+        UNION ALL
+
+        -- Sub-agents spawned (recursively) by previously found sub-agent replies.
+        SELECT
+          s.root_sid,
+          reply."sId",
+          am."costCredits",
+          s.depth + 1
+        FROM sub_agents s
+        JOIN user_messages um
+          ON um."agenticOriginMessageId" = s.agent_message_sid
+         AND um."workspaceId" = :workspaceId
+        JOIN messages user_msg
+          ON user_msg."userMessageId" = um.id
+         AND user_msg."workspaceId" = :workspaceId
+        JOIN messages reply
+          ON reply."parentId" = user_msg.id
+         AND reply."workspaceId" = :workspaceId
+         AND reply."agentMessageId" IS NOT NULL
+        JOIN agent_messages am
+          ON am.id = reply."agentMessageId"
+         AND am."workspaceId" = :workspaceId
+        WHERE s.depth < :maxDepth
+      )
+      SELECT
+        root_sid,
+        SUM(COALESCE(cost_credits, 0))::float AS total_credits,
+        MAX(depth)::int                       AS max_depth
+      FROM sub_agents
+      GROUP BY root_sid
+    `;
+
+    // biome-ignore lint/plugin/noRawSql: recursive CTE has no Sequelize equivalent.
+    const rows = await frontSequelize.query<{
+      root_sid: string;
+      total_credits: number;
+      max_depth: number;
+    }>(query, {
+      type: QueryTypes.SELECT,
+      replacements: { workspaceId, agentMessageIds, maxDepth },
+    });
+
+    for (const row of rows) {
+      result.set(row.root_sid, row.total_credits);
+      if (row.max_depth >= maxDepth) {
+        logger.warn(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            agentMessageId: row.root_sid,
+            maxDepth,
+          },
+          "[Credits] Sub-agent cost aggregation hit the depth cap; total may be truncated."
+        );
+      }
+    }
+
+    return result;
+  }
+
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -737,8 +737,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   /**
    * Recursively sums the `costCredits` of every sub-agent spawned by a single
-   * origin agent message (one recursive query, `maxDepth`-bounded). Single-message
-   * by design (and avoids an N+1); returns `0` when there are no sub-agents.
+   * origin agent message (one recursive query, `maxDepth`-bounded). Only counts
+   * sub-agents whose triggering user message is a `run_agent` agentic origin
+   * (`agent_handover` and non-agentic origins are excluded). Single-message by
+   * design (and avoids an N+1); returns `0` when there are no sub-agents.
    */
   static async sumSubAgentCostCreditsByMessageId(
     auth: Authenticator,
@@ -769,6 +771,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
          AND am."workspaceId" = um."workspaceId"
         WHERE um."workspaceId" = :workspaceId
           AND um."agenticOriginMessageId" = :agentMessageId
+          AND um."agenticMessageType" = 'run_agent'
 
         UNION ALL
 
@@ -781,6 +784,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         JOIN user_messages um
           ON um."agenticOriginMessageId" = s.agent_message_sid
          AND um."workspaceId" = :workspaceId
+         AND um."agenticMessageType" = 'run_agent'
         JOIN messages user_msg
           ON user_msg."userMessageId" = um.id
          AND user_msg."workspaceId" = :workspaceId

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -195,6 +195,8 @@ export class ConversationFactory {
       userContextProfilePictureUrl: null,
       userContextOrigin: origin,
       clientSideMCPServerIds: [],
+      agenticMessageType: agenticMessageType ?? null,
+      agenticOriginMessageId: agenticOriginMessageId ?? null,
     });
 
     const messageRow = await MessageModel.create({

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -312,11 +312,13 @@ export type BaseAgentMessageType = {
   completionDurationMs: number | null;
   reactions: MessageReactionType[];
   prunedContext?: boolean;
-  // Optional during rollout: serialized from the API, so an old API server can
-  // return agent messages without this field (`undefined`) to a newer client
-  // during the credit-cost stack rollout. Tighten to `number | null` once the API
-  // change is fully deployed. See [BACK12].
-  costCredits?: number | null;
+  costCredits: number | null;
+  // Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned
+  // (recursively) by this message, separate from `costCredits` (this message's own
+  // intelligence + tools). Computed lazily on single-message fetches only, so it is
+  // `null` everywhere else (e.g. conversation list rendering). Optional during
+  // rollout. See [BACK12].
+  subAgentCostCredits?: number | null;
 };
 
 export type InlineActivityStep =


### PR DESCRIPTION
## Description

Next PR will do the UI!

Agent messages already expose their own credit cost (`costCredits` = intelligence + tools). When an agent spawns sub-agents (`run_agent` or `agent_handover`), those sub-agents' costs were tracked separately and not attributed back to the parent. This PR computes and serves the aggregated sub-agent cost on a message.

- Adds `ConversationResource.sumSubAgentCostCreditsByMessageId`, a single recursive CTE that walks the sub-agent tree top-down: `user_messages.agenticOriginMessageId → agent reply → costCredits`, recursing through nested sub-agents. Depth-capped at 10 (the graph is acyclic by construction; the cap bounds runtime and guards against unexpected cycles) with a `logger.warn` if the cap truncates a total.
- Adds an optional `subAgentCostCredits` field to the agent message type, populated only on the single-message fetch via a new opt-in `includeSubAgentCostCredits` option on `batchRenderMessages` / `batchRenderAgentMessages`. Conversation-list and SSE rendering do not pay for the extra query.
- The private single-message `GET` endpoint opts in, so the cost is computed only when the message cost dropdown re-fetches.
- Swagger schemas updated for the new field.

No user-visible change yet — the UI consuming this field ships in the stacked follow-up (#27325).

Also fixes a test-infra gap: `ConversationFactory.createUserMessage` accepted `agenticOriginMessageId` / `agenticMessageType` but never persisted them.

## Tests

Added `sumSubAgentCostCreditsByMessageId` resource tests covering recursive aggregation (direct + nested sub-agents sum correctly), isolation from unrelated origins, and the empty-map case when a message has no sub-agents.

## Risk

Low. The new field is optional and append-only ([BACK12]); the aggregation runs only on the single-message fetch path. `front` and `front-api` deploy independently, but since the field is optional, ordering does not break clients.
