### PR TITLE
feat(credits): show sub-agent cost in message dropdown

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -133,6 +133,8 @@ import {
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
+const RUN_AGENT_TOOL_NAME = "run_agent";
+
 function PrunedContextChip() {
   return (
     <Tooltip
@@ -175,6 +177,21 @@ function PrunedContextChip() {
         />
       }
     />
+  );
+}
+
+function hasMessageSpawnedSubAgent(
+  agentMessage: AgentMessageWithStreaming
+): boolean {
+  return (
+    agentMessage.actions.some(
+      (action) => action.internalMCPServerName === RUN_AGENT_TOOL_NAME
+    ) ||
+    agentMessage.activitySteps.some(
+      (step) =>
+        step.type === "action" &&
+        step.internalMCPServerName === RUN_AGENT_TOOL_NAME
+    )
   );
 }
 
@@ -232,22 +249,30 @@ export function AgentMessage({
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  // The streamed message carries a null cost: it is computed and persisted only
-  // after the agentic loop finishes, in the finalize activities. Re-fetch the
-  // message when the menu opens so a freshly-arrived message shows its cost
-  // without a reload. Falls back to the value already on the message otherwise.
+  // Re-fetch (on menu open) only if a cost we want to show is still missing:
+  // - Own cost: null until the agentic loop finishes; absent while streaming/listed.
+  // - Sub-agent cost: only aggregated by the single-message fetch, and only exists
+  //   when a `run_agent` action is present (it triggers both run_agent and handover).
+  // Messages with no sub-agents only fetch if their own cost is still missing.
+  const needsCostFetch =
+    agentMessage.costCredits == null ||
+    (hasMessageSpawnedSubAgent(agentMessage) &&
+      agentMessage.subAgentCostCredits == null);
   const { message: refreshedMessage } = useConversationMessage({
     conversationId,
     workspaceId: owner.sId,
     messageId: agentMessage.sId,
-    options: { disabled: !isMenuOpen || agentMessage.costCredits != null },
+    options: {
+      disabled: !isMenuOpen || !needsCostFetch,
+    },
   });
-  const refreshedCostCredits =
-    refreshedMessage?.type === "agent_message"
-      ? refreshedMessage.costCredits
-      : null;
+  const refreshedAgentMessage =
+    refreshedMessage?.type === "agent_message" ? refreshedMessage : null;
   const creditCostItem = useCreditCostMenuItem({
-    credits: refreshedCostCredits ?? agentMessage.costCredits,
+    credits: refreshedAgentMessage?.costCredits ?? agentMessage.costCredits,
+    subAgentCredits:
+      refreshedAgentMessage?.subAgentCostCredits ??
+      agentMessage.subAgentCostCredits,
   });
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);

--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -3,18 +3,20 @@ import { formatCredits } from "@app/lib/client/credits";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
 
-const CREDIT_COST_COPY = {
-  label: "Message credit cost",
-  tooltip:
-    "Credits used for this message: intelligence, tools. Sub-agent costs are tracked separately.",
-};
+const BEGINNING_AGENT_TOOLTIP =
+  "Credits used for this message (intelligence and tools).";
+
+const ITEM_CLASS_NAME =
+  "cursor-default font-normal text-muted-foreground hover:bg-transparent focus:bg-transparent dark:text-muted-foreground-night dark:hover:bg-transparent dark:focus:bg-transparent";
 
 interface UseCreditCostMenuItemProps {
   credits: number | null | undefined;
+  subAgentCredits: number | null | undefined;
 }
 
 export function useCreditCostMenuItem({
   credits,
+  subAgentCredits,
 }: UseCreditCostMenuItemProps): DropdownMenuItemProps | null {
   const { subscription } = useAuth();
 
@@ -22,18 +24,25 @@ export function useCreditCostMenuItem({
     return null;
   }
 
-  if (credits == null || credits <= 0) {
+  const ownCredits = credits ?? 0;
+  const subCredits = subAgentCredits ?? 0;
+  const totalCredits = ownCredits + subCredits;
+
+  if (totalCredits <= 0) {
     return null;
   }
 
-  const { label, tooltip } = CREDIT_COST_COPY;
+  const tooltip =
+    BEGINNING_AGENT_TOOLTIP +
+    (subCredits > 0
+      ? `\nThis message: ${formatCredits(ownCredits)} credits.\nSub-agents: ${formatCredits(subCredits)} credits.`
+      : "");
 
   return {
-    label,
-    endComponent: formatCredits(credits),
+    label: "Credit cost",
+    endComponent: formatCredits(totalCredits),
     tooltip,
-    className:
-      "cursor-default font-normal text-muted-foreground hover:bg-transparent focus:bg-transparent dark:text-muted-foreground-night dark:hover:bg-transparent dark:focus:bg-transparent",
+    className: ITEM_CLASS_NAME,
     onSelect: (e) => e.preventDefault(),
   };
 }


### PR DESCRIPTION
## Description
<img width="973" height="704" alt="Screenshot 2026-06-15 at 16 02 52" src="https://github.com/user-attachments/assets/51e886f9-cd90-4b1c-9624-5164c38afec2" />

<img width="1028" height="706" alt="Screenshot 2026-06-15 at 16 03 39" src="https://github.com/user-attachments/assets/632bf354-587e-4f8b-8687-a4dc671aa71c" />


Surfaces the sub-agent credit cost (served by the stacked backend PR #27324) in the agent message cost dropdown. The dropdown now shows the message's own cost, the aggregated sub-agent cost, and a total when both are present, instead of just the message's own cost.

- `useCreditCostMenuItem` becomes `useCreditCostMenuItems`, returning up to three muted, non-interactive lines: *Message credit cost*, *Sub-agent credit cost*, *Total credit cost*.
- `AgentMessage` re-fetches the full message when the menu opens (the sub-agent total only exists on the single-message fetch) and renders the lines.

Depends on #27324 for the `subAgentCostCredits` field.

## Tests

Manual: open the message cost dropdown on an agent message that ran sub-agents and confirm the three lines (message / sub-agent / total) render with correct values; confirm a message with no sub-agents shows only its own cost.
