### PR TITLE
[front] Add Commands section to input bar slash dropdown with /compact

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -525,7 +525,7 @@ const InputBarContainer = ({
         })();
         break;
       default:
-        assertNever(command.id);
+        assertNeverAndIgnore(command.id);
     }
   };
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -525,7 +525,7 @@ const InputBarContainer = ({
         })();
         break;
       default:
-        assertNeverAndIgnore(command.id);
+        assertNever(command.id);
     }
   };
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -12,13 +12,20 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { useInputBarOverlayTracker } from "@app/components/assistant/conversation/input_bar/useInputBarOverlayTracker";
-import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import type {
+  InputBarSlashCommand,
+  InputBarSlashSuggestionCapability,
+} from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
 import useUrlHandler from "@app/components/editor/input_bar/useUrlHandler";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
+import {
+  useCompactConversation,
+  useConversationContextUsage,
+} from "@app/hooks/conversations";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
@@ -263,6 +270,10 @@ const InputBarContainer = ({
   );
   const selectedMCPServerViewIdsRef = useRef(selectedMCPServerViewIds);
   const shouldEnableSlashSuggestionRef = useRef(shouldEnableSlashSuggestion);
+  // The slash suggestion extension captures its options at editor initialization, while the
+  // conversation may only be created after the first message; the ref keeps it current.
+  const conversationIdRef = useRef<string | null>(conversation?.sId ?? null);
+  conversationIdRef.current = conversation?.sId ?? null;
   const onSelectRef = useRef<
     ((capability: InputBarSlashSuggestionCapability) => void) | undefined
   >(undefined);
@@ -378,6 +389,18 @@ const InputBarContainer = ({
 
   const sendNotification = useSendNotification();
 
+  // Context usage provides the model required by the compaction endpoint; both back the /compact
+  // slash command. SWR dedupes these with the ContextUsageIndicator calls.
+  const { contextUsage, mutateContextUsage } = useConversationContextUsage({
+    conversationId: conversation?.sId,
+    workspaceId: owner.sId,
+    options: { disabled: !conversation?.sId },
+  });
+  const { compact, isCompacting } = useCompactConversation({
+    owner,
+    conversationId: conversation?.sId,
+  });
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const handleInlineText = useCallback(
     async (fileId: string, textContent: string) => {
@@ -477,8 +500,40 @@ const InputBarContainer = ({
       .run();
   };
 
+  const handleSlashCommandSelect = (command: InputBarSlashCommand) => {
+    switch (command.id) {
+      case "compact":
+        if (isCompacting) {
+          break;
+        }
+        // The cached context usage may be missing or stale (the endpoint reports a null model
+        // until the latest agent run has usage rows); revalidate on demand before giving up.
+        void (async () => {
+          const usage = contextUsage?.model
+            ? contextUsage
+            : await mutateContextUsage();
+          if (usage?.model) {
+            void compact(usage.model);
+          } else {
+            sendNotification({
+              type: "error",
+              title: "Cannot compact conversation",
+              description:
+                "Compaction requires a completed agent message in the conversation.",
+            });
+          }
+        })();
+        break;
+      default:
+        assertNeverAndIgnore(command.id);
+    }
+  };
+
   onSelectRef.current = (capability: InputBarSlashSuggestionCapability) => {
     switch (capability.kind) {
+      case "command":
+        handleSlashCommandSelect(capability.command);
+        break;
       case "skill":
         handleSkillSelect(capability.skill);
         break;
@@ -494,6 +549,9 @@ const InputBarContainer = ({
 
   onDetailsRef.current = (capability: InputBarSlashSuggestionCapability) => {
     switch (capability.kind) {
+      case "command":
+        // Static commands have no details sheet.
+        break;
       case "skill":
         setSelectedSkillIdForDetails(capability.skill.sId);
         break;
@@ -520,6 +578,7 @@ const InputBarContainer = ({
     onInlineText: handleInlineText,
     onFirstAgentMentionPasteRef,
     slashSuggestion: {
+      conversationIdRef,
       enabledRef: shouldEnableSlashSuggestionRef,
       onSelectRef,
       onDetailsRef,

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -5,6 +5,7 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { describe, expect, it } from "vitest";
 
 import { filterInputBarSlashSuggestions } from "./InputBarSlashSuggestionDropdown";
+import { INPUT_BAR_SLASH_COMMANDS } from "./InputBarSlashSuggestionTypes";
 
 describe("filterInputBarSlashSuggestions", () => {
   it("filters capabilities by name only", async () => {
@@ -25,6 +26,7 @@ describe("filterInputBarSlashSuggestions", () => {
     );
 
     const result = filterInputBarSlashSuggestions({
+      commands: [],
       query: "spreadsheet",
       selectedMCPServerViewIds: new Set(),
       serverViews: [calendarServerView.toJSON()],
@@ -46,6 +48,7 @@ describe("filterInputBarSlashSuggestions", () => {
     });
 
     const result = filterInputBarSlashSuggestions({
+      commands: [],
       query: "gd",
       selectedMCPServerViewIds: new Set(),
       serverViews: [],
@@ -60,5 +63,52 @@ describe("filterInputBarSlashSuggestions", () => {
         capability.kind === "skill" ? capability.skill.name : ""
       )
     ).toEqual(["Google Drive", "Generate Daily Report"]);
+  });
+
+  it("lists commands ahead of capabilities", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const skill = await SkillFactory.create(auth, {
+      name: "Aardvark Facts",
+      userFacingDescription: "",
+    });
+
+    const result = filterInputBarSlashSuggestions({
+      commands: INPUT_BAR_SLASH_COMMANDS,
+      query: "",
+      selectedMCPServerViewIds: new Set(),
+      serverViews: [],
+      skills: [skill.toJSON(auth)],
+    });
+
+    expect(result.map((capability) => capability.kind)).toEqual([
+      "command",
+      "skill",
+    ]);
+  });
+
+  it("filters commands by the query", async () => {
+    const result = filterInputBarSlashSuggestions({
+      commands: INPUT_BAR_SLASH_COMMANDS,
+      query: "comp",
+      selectedMCPServerViewIds: new Set(),
+      serverViews: [],
+      skills: [],
+    });
+
+    expect(
+      result.map((capability) =>
+        capability.kind === "command" ? capability.command.id : ""
+      )
+    ).toEqual(["compact"]);
+
+    expect(
+      filterInputBarSlashSuggestions({
+        commands: INPUT_BAR_SLASH_COMMANDS,
+        query: "zzz",
+        selectedMCPServerViewIds: new Set(),
+        serverViews: [],
+        skills: [],
+      })
+    ).toEqual([]);
   });
 });

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -27,6 +27,8 @@ import {
   useRef,
 } from "react";
 import {
+  INPUT_BAR_SLASH_COMMANDS,
+  type InputBarSlashCommand,
   type InputBarSlashSuggestionCapability,
   isInputBarSlashSuggestionCapability,
 } from "./InputBarSlashSuggestionTypes";
@@ -35,18 +37,40 @@ import {
 // exactly seven 3.25rem rows without showing a partial row or leaving extra bottom space.
 const LIST_MAX_HEIGHT_CLASS_NAME = "max-h-[22.75rem]";
 
+const COMMANDS_SECTION_LABEL = "Commands";
+const CAPABILITIES_SECTION_LABEL = "Capabilities";
+
 export function filterInputBarSlashSuggestions({
+  commands,
   query,
   selectedMCPServerViewIds,
   serverViews,
   skills,
 }: {
+  commands: InputBarSlashCommand[];
   query: string;
   selectedMCPServerViewIds: Set<string>;
   serverViews: MCPServerViewType[];
   skills: SkillWithoutInstructionsAndToolsType[];
 }): InputBarSlashSuggestionCapability[] {
   const normalizedQuery = query.trim().toLowerCase();
+
+  // Static commands form their own section ahead of capabilities; both are filtered by the query
+  // but sorted independently so command relevance is never weighed against capability names.
+  const commandMatches: (InputBarSlashSuggestionCapability & {
+    sortName: string;
+  })[] = commands
+    .filter((command) =>
+      matchesSlashCommandCapabilityQuery({
+        label: command.label,
+        query: normalizedQuery,
+      })
+    )
+    .map((command) => ({
+      kind: "command" as const,
+      command,
+      sortName: command.label.toLowerCase(),
+    }));
 
   const capabilities: (InputBarSlashSuggestionCapability & {
     sortName: string;
@@ -79,10 +103,16 @@ export function filterInputBarSlashSuggestions({
       })),
   ];
 
-  return sortSlashCommandCapabilityMatches({
-    items: capabilities,
-    normalizedQuery,
-  }).map(({ sortName: _sortName, ...capability }) => capability);
+  return [
+    ...sortSlashCommandCapabilityMatches({
+      items: commandMatches,
+      normalizedQuery,
+    }),
+    ...sortSlashCommandCapabilityMatches({
+      items: capabilities,
+      normalizedQuery,
+    }),
+  ].map(({ sortName: _sortName, ...capability }) => capability);
 }
 
 export const InputBarSlashSuggestionDropdown = forwardRef<
@@ -91,6 +121,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     SuggestionProps<InputBarSlashSuggestionCapability>,
     "clientRect" | "command" | "editor" | "query" | "range"
   > & {
+    conversationIdRef?: RefObject<string | null>;
     onClose: () => void;
     onDetailsRef?: RefObject<
       ((capability: InputBarSlashSuggestionCapability) => void) | undefined
@@ -103,6 +134,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     {
       clientRect,
       command,
+      conversationIdRef,
       editor,
       query,
       range,
@@ -129,16 +161,21 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     const { serverViews, isLoading: isServerViewsLoading } =
       useMCPServerViewsFromSpaces(owner, globalSpaces, { disabled: !isOpen });
 
+    // Static commands operate on the current conversation, so they are only offered once one
+    // exists.
+    const hasConversation = Boolean(conversationIdRef?.current);
+
     const filteredCapabilities = useMemo(
       () =>
         filterInputBarSlashSuggestions({
+          commands: hasConversation ? INPUT_BAR_SLASH_COMMANDS : [],
           query,
           selectedMCPServerViewIds:
             selectedMCPServerViewIdsRef.current ?? new Set<string>(),
           serverViews,
           skills,
         }),
-      [query, selectedMCPServerViewIdsRef, serverViews, skills]
+      [hasConversation, query, selectedMCPServerViewIdsRef, serverViews, skills]
     );
 
     // Items carry their capability in `data` so selection and details handlers can recover it
@@ -147,10 +184,24 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       () =>
         filteredCapabilities.flatMap((capability): SlashCommand[] => {
           switch (capability.kind) {
+            case "command":
+              return [
+                {
+                  action: "run-command",
+                  data: capability,
+                  description: capability.command.description,
+                  icon: capability.command.icon,
+                  id: `command-${capability.command.id}`,
+                  label: capability.command.label,
+                  sectionLabel: COMMANDS_SECTION_LABEL,
+                },
+              ];
             case "skill":
               return [
                 {
-                  ...getSkillSlashCommandItem(capability.skill),
+                  ...getSkillSlashCommandItem(capability.skill, {
+                    sectionLabel: CAPABILITIES_SECTION_LABEL,
+                  }),
                   data: capability,
                   id: `skill-${capability.skill.sId}`,
                 },
@@ -158,7 +209,9 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
             case "tool":
               return [
                 {
-                  ...getToolSlashCommandItem(capability.serverView),
+                  ...getToolSlashCommandItem(capability.serverView, {
+                    sectionLabel: CAPABILITIES_SECTION_LABEL,
+                  }),
                   data: capability,
                   id: `tool-${capability.serverView.sId}`,
                 },
@@ -178,9 +231,11 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       ref,
       () => ({
         onKeyDown: ({ event }) => {
+          // Static commands are shown while capabilities load, so selection is only blocked when
+          // the list has nothing to select.
           if (
             (event.key === "Enter" || event.key === "Tab") &&
-            (isCapabilitiesLoading || capabilityItems.length === 0)
+            capabilityItems.length === 0
           ) {
             event.preventDefault();
             return true;
@@ -189,7 +244,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
           return dropdownRef.current?.onKeyDown({ event }) ?? false;
         },
       }),
-      [capabilityItems.length, isCapabilitiesLoading]
+      [capabilityItems.length]
     );
 
     return (
@@ -208,11 +263,8 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
         }}
         clientRect={clientRect}
         emptyMessage={
-          isCapabilitiesLoading
-            ? "Loading capabilities…"
-            : "No capabilities found"
+          isCapabilitiesLoading ? "Loading capabilities…" : "No matches found"
         }
-        header="Capabilities"
         listMaxHeightClassName={LIST_MAX_HEIGHT_CLASS_NAME}
         onClose={onClose}
         onItemDetails={

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -10,6 +10,7 @@ import type {
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/skill_builder/SlashCommandDropdown";
+import { ResourceAvatar } from "@app/components/resources/resources_icons";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
@@ -190,7 +191,9 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
                   action: "run-command",
                   data: capability,
                   description: capability.command.description,
-                  icon: capability.command.icon,
+                  icon: () => (
+                    <ResourceAvatar icon={capability.command.icon} size="sm" />
+                  ),
                   id: `command-${capability.command.id}`,
                   label: capability.command.label,
                   sectionLabel: COMMANDS_SECTION_LABEL,

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -42,6 +42,7 @@ function isAllowedSlashQuery(state: EditorState, range: Range) {
 
 export interface InputBarSlashSuggestionExtensionOptions {
   owner?: WorkspaceType;
+  conversationIdRef?: RefObject<string | null>;
   enabledRef: RefObject<boolean>;
   onSelectRef: RefObject<
     ((capability: InputBarSlashSuggestionCapability) => void) | undefined
@@ -71,6 +72,7 @@ export const InputBarSlashSuggestionExtension =
     addOptions() {
       return {
         owner: undefined,
+        conversationIdRef: { current: null },
         enabledRef: { current: false },
         onSelectRef: { current: undefined },
         onDetailsRef: { current: undefined },
@@ -136,6 +138,7 @@ export const InputBarSlashSuggestionExtension =
                 component = new ReactRenderer(InputBarSlashSuggestionDropdown, {
                   props: {
                     ...props,
+                    conversationIdRef: extensionOptions.conversationIdRef,
                     onClose: closeSuggestionDropdown,
                     onDetailsRef: extensionOptions.onDetailsRef,
                     owner,
@@ -160,6 +163,7 @@ export const InputBarSlashSuggestionExtension =
                 activeTriggerStart = props.range.from;
                 component?.updateProps({
                   ...props,
+                  conversationIdRef: extensionOptions.conversationIdRef,
                   onClose: closeSuggestionDropdown,
                   onDetailsRef: extensionOptions.onDetailsRef,
                   owner,

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -1,7 +1,35 @@
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
+import { Minimize01 } from "@dust-tt/sparkle";
+import type React from "react";
+
+export type InputBarSlashCommandId = "compact";
+
+// Static command offered by the input bar `/` dropdown, as opposed to workspace capabilities
+// (skills and tools) which are fetched.
+export interface InputBarSlashCommand {
+  description: string;
+  icon: React.ComponentType;
+  id: InputBarSlashCommandId;
+  label: string;
+}
+
+// Static commands require an existing conversation to operate on; the dropdown only offers them
+// when one is present.
+export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
+  {
+    description: "Free up context by summarizing conversation",
+    icon: Minimize01,
+    id: "compact",
+    label: "compact",
+  },
+];
 
 export type InputBarSlashSuggestionCapability =
+  | {
+      kind: "command";
+      command: InputBarSlashCommand;
+    }
   | {
       kind: "skill";
       skill: SkillWithoutInstructionsAndToolsType;
@@ -20,6 +48,6 @@ export function isInputBarSlashSuggestionCapability(
     typeof data === "object" &&
     data !== null &&
     "kind" in data &&
-    (data.kind === "skill" || data.kind === "tool")
+    (data.kind === "command" || data.kind === "skill" || data.kind === "tool")
   );
 }

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -205,6 +205,8 @@ export interface CustomEditorProps {
     ((agentId: string) => void) | undefined
   >;
   slashSuggestion?: {
+    // The conversation may only exist after the editor is initialized, hence the ref.
+    conversationIdRef?: React.RefObject<string | null>;
     enabledRef: React.RefObject<boolean>;
     onSelectRef: React.RefObject<
       ((capability: InputBarSlashSuggestionCapability) => void) | undefined
@@ -356,6 +358,7 @@ export const buildEditorExtensions = ({
     extensions.push(
       InputBarSlashSuggestionExtension.configure({
         owner,
+        conversationIdRef: slashSuggestion.conversationIdRef,
         enabledRef: slashSuggestion.enabledRef,
         onSelectRef: slashSuggestion.onSelectRef,
         onDetailsRef: slashSuggestion.onDetailsRef,


### PR DESCRIPTION
## Description

Adds a static **Commands** section to the input bar `/` dropdown, ahead of the fetched **Capabilities** section, and ships the first command: `/compact`.

- Both sections are filtered by the typed query but sorted independently, so command relevance is never ranked against capability names. Commands are selectable immediately while capabilities are still loading.
- Commands are only offered when a conversation exists, threaded via a `conversationIdRef` since the TipTap extension captures its options at editor init while the conversation may be created later.
- `/compact` triggers conversation compaction through the existing `useCompactConversation` / `useConversationContextUsage` hooks. If the cached context usage has no model yet (endpoint reports it as pending), the handler revalidates on demand before surfacing an error.


Some improvements identified to the / system
- Position when just 1 item in a conversation going down is meh
- Scroll bar is meh
- highlight on hover is very surprising => kill
- steals the focus of the input bar even on hover

## Tests

Extended `filterInputBarSlashSuggestions` functional tests (commands rank ahead of capabilities, query filtering, gating when absent). Tested locally: section rendering, `/comp` + Enter triggering compaction, no Commands section on a fresh conversation.

## Risk

Low: input bar slash dropdown; commands are additive and gated behind an existing conversation. Can be reverted easily.

## Deploy Plan

- deploy `front`

cc @aubin-tchoi 