### PR TITLE
[Skills] Fix stale skill chips in instructions summary on version restore

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -305,10 +305,11 @@ export function SkillBuilderInstructionsEditor({
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
   const hasInstructionReferenceSummary =
     (attachedKnowledgeField.value?.length ?? 0) > 0 ||
-    referencedSkills.length > 0 ||
     tools.length > 0 ||
     (instructionsField.value?.includes("<knowledge ") ?? false) ||
-    (instructionsField.value?.includes("<tool ") ?? false);
+    (instructionsField.value?.includes("<tool ") ?? false) ||
+    (instructionsField.value?.includes("<skill ") ?? false) ||
+    (instructionsField.value?.includes("<unavailable_skill ") ?? false);
 
   const syncAttachedKnowledgeFromEditor = useCallback(
     (editor: Editor) => {
@@ -838,7 +839,6 @@ export function SkillBuilderInstructionsEditor({
             hasError={displayError}
             instructions={instructionsField.value ?? ""}
             onReferenceClick={handleReferenceClick}
-            referencedSkills={referencedSkills}
             tools={tools}
           />
         </div>

--- a/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsReferenceSummary.tsx
@@ -1,12 +1,10 @@
 import { ToolChip } from "@app/components/editor/extensions/skill_builder/ToolChip";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
-import type {
-  AttachedKnowledgeFormData,
-  ReferencedSkillFormData,
-} from "@app/components/skill_builder/SkillBuilderFormContext";
+import type { AttachedKnowledgeFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillIcon } from "@app/lib/skill";
+import { extractSkillReferenceTags } from "@app/lib/skills/format";
 import { extractToolTags } from "@app/lib/tools/format";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { AttachmentChip, Chip, cn, File02 } from "@dust-tt/sparkle";
@@ -19,7 +17,6 @@ interface SkillBuilderInstructionsReferenceSummaryProps {
   hasError: boolean;
   instructions: string;
   onReferenceClick: (target: ReferenceSummaryItem) => void;
-  referencedSkills: ReferencedSkillFormData[];
   tools: BuilderAction[];
 }
 
@@ -118,7 +115,6 @@ export function SkillBuilderInstructionsReferenceSummary({
   hasError,
   instructions,
   onReferenceClick,
-  referencedSkills,
   tools,
 }: SkillBuilderInstructionsReferenceSummaryProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
@@ -135,16 +131,19 @@ export function SkillBuilderInstructionsReferenceSummary({
     [attachedKnowledge]
   );
 
+  // Derived from the instructions (like inline tool references below) so the
+  // chips stay in sync when the content is replaced without editor updates,
+  // e.g. when restoring a previous version.
   const skillReferences = useMemo(
     () =>
       dedupeById(
-        referencedSkills.map((skill) => ({
+        extractSkillReferenceTags(instructions).map((skill) => ({
           icon: skill.icon,
           id: skill.id,
           title: skill.name,
         }))
       ),
-    [referencedSkills]
+    [instructions]
   );
 
   const inlineToolReferences = useMemo(


### PR DESCRIPTION
## Description

The capabilities-and-knowledge panel under the instructions sourced its skill chips from the `referencedSkills` form field, which is only maintained by editor sync callbacks. Restoring a previous version replaces the editor content with `emitUpdate: false`, so the chips showed the pre-restore skill references.

Skill chips are now derived from the skill tags in the `instructions` form value — the same pattern inline tool chips already use — so they follow any restored content. Side effect: `<unavailable_skill>` tags now show as an "Unavailable skill" chip in the summary, consistent with the inline editor chips.

`referencedSkills` itself stays: the requested-spaces section consumes its `requestedSpaceIds` metadata, which instruction tags do not carry. Knowledge chips are intentionally out of scope (they come from the `attachedKnowledge` field and have the same staleness on restore; can be a follow-up).

## Risks

Blast radius: skill chips in the Skill Builder instructions summary panel
Risk: low

## Deploy Plan
- pmrr
- deploy front