### PR TITLE
[Skills] Fix format-check on main: remove unused hasFeature in SkillBuilder

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -25,7 +25,6 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillIcon } from "@app/lib/skill";
@@ -62,7 +61,6 @@ export default function SkillBuilder({
   onSaved,
 }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
-  const { hasFeature } = useFeatureFlags();
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);


### PR DESCRIPTION
## Description

Fixes `format-check` (biome `noUnusedVariables`) on main: #27315 replaced the `hasFeature(...)` usages in `SkillBuilder.tsx` with `useIsSelfImprovementAvailable()` but left the destructure and the now-unused `useFeatureFlags` import.

## Risks

Blast radius: none (dead code removal)
Risk: none

## Deploy Plan
- pmrr
- none