### PR TITLE
[front] Align capabilities scrollbars with the agents picker

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -40,9 +40,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSearchbar,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
   LoadingBlock,
+  ScrollArea,
   ShapesPlus,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -198,12 +200,9 @@ function CapabilitiesPickerItemsList({
 
   return (
     <div className="relative">
-      <div
-        ref={listRef}
-        className={cn(
-          "overflow-y-auto",
-          CAPABILITIES_PICKER_LIST_MAX_HEIGHT_CLASS_NAME
-        )}
+      <ScrollArea
+        viewportRef={listRef}
+        viewportClassName={CAPABILITIES_PICKER_LIST_MAX_HEIGHT_CLASS_NAME}
       >
         <div className="relative">
           <div
@@ -276,7 +275,7 @@ function CapabilitiesPickerItemsList({
             );
           })}
         </div>
-      </div>
+      </ScrollArea>
       <div
         className={cn(
           "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",
@@ -638,6 +637,7 @@ export function CapabilitiesPicker({
             value={searchText}
             onChange={setSearchText}
           />
+          <DropdownMenuSeparator />
           {(!isSkillsDataReady || !isToolsDataReady) && (
             <CapabilitiesPickerLoading />
           )}

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
+  ScrollArea,
 } from "@dust-tt/sparkle";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import type React from "react";
@@ -264,9 +265,9 @@ export const SlashCommandDropdown = forwardRef<
             </div>
           ) : (
             <div className="relative">
-              <div
-                ref={listRef}
-                className={cn("overflow-y-auto", listMaxHeightClassName)}
+              <ScrollArea
+                viewportRef={listRef}
+                viewportClassName={listMaxHeightClassName}
               >
                 <div className="relative">
                   <div
@@ -344,7 +345,7 @@ export const SlashCommandDropdown = forwardRef<
                     );
                   })}
                 </div>
-              </div>
+              </ScrollArea>
               <div
                 className={cn(
                   "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -25,7 +25,6 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSkillSuggestions } from "@app/hooks/useSkillSuggestions";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillIcon } from "@app/lib/skill";
@@ -62,7 +61,6 @@ export default function SkillBuilder({
   onSaved,
 }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
-  const { hasFeature } = useFeatureFlags();
   const router = useAppRouter();
   const sendNotification = useSendNotification();
   const [isSaving, setIsSaving] = useState(false);


### PR DESCRIPTION
## Description

The slash command dropdown and the capabilities picker rendered their own native `overflow-y-auto` list inside `DropdownMenuContent`, showing the thick browser scrollbar instead of the thin `ScrollArea` thumb the agents picker gets from the dropdown's built-in viewport.

- Both now use the sparkle `ScrollArea` directly, with the existing seven-row max-height moved to the viewport and the scroll-fade `IntersectionObserver` wired to the viewport element — scroll fades, keyboard scroll-into-view, and list sizing are unchanged.
- Also adds the same searchbar divider the agents picker has to the capabilities picker.

## Tests

N/A, tested locally (agents picker as reference, capabilities picker, `/` dropdown; scroll fades still trigger on overflow).

## Risk

Low: visual-only change to two dropdown scroll containers.

## Deploy Plan

- deploy `front`

🤖 Generated with [Claude Code](https://claude.com/claude-code)