### PR TITLE
[front] Remove description tooltips from capabilities lists

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -9,11 +9,7 @@ import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal
 import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
-import {
-  DUST_PROVIDED_SKILL_LABEL,
-  getSkillAvatarIcon,
-  isDustProvidedSkill,
-} from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   useAvailableMCPServers,
   useMCPServerViewsFromSpaces,
@@ -42,7 +38,6 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  DropdownTooltipTrigger,
   LoadingBlock,
   ScrollArea,
   ShapesPlus,
@@ -59,7 +54,6 @@ interface CapabilityPickerItemBase {
   id: string;
   label: string;
   sortName: string;
-  tooltip?: string;
 }
 
 type CapabilityPickerItem = CapabilityPickerItemBase &
@@ -237,28 +231,6 @@ function CapabilitiesPickerItemsList({
                   }}
                 />
               );
-
-            if (item.kind !== "uninstalled_tool" && item.tooltip) {
-              return (
-                <DropdownTooltipTrigger
-                  key={item.id}
-                  description={item.tooltip}
-                  side="right"
-                  sideOffset={8}
-                >
-                  <DropdownMenuItem
-                    icon={item.icon}
-                    itemId={item.id}
-                    label={item.label}
-                    description={item.description}
-                    truncateText
-                    endComponent={endComponent}
-                    className="group"
-                    onClick={() => onItemSelect(item)}
-                  />
-                </DropdownTooltipTrigger>
-              );
-            }
 
             return (
               <DropdownMenuItem
@@ -482,12 +454,6 @@ export function CapabilitiesPicker({
     if (isSkillsDataReady && isToolsDataReady) {
       for (const skill of skills) {
         const description = skill.userFacingDescription;
-        const isDustProvided = isDustProvidedSkill(skill);
-        const tooltip = isDustProvided
-          ? description
-            ? `${description}\n\n${DUST_PROVIDED_SKILL_LABEL}`
-            : DUST_PROVIDED_SKILL_LABEL
-          : description || undefined;
 
         if (
           !matchesCapabilityPickerSearchQuery({
@@ -507,7 +473,6 @@ export function CapabilitiesPicker({
           label: skill.name,
           sortName: skill.name.toLowerCase(),
           description,
-          tooltip,
         });
       }
 
@@ -535,7 +500,6 @@ export function CapabilitiesPicker({
           label,
           sortName: label.toLowerCase(),
           description,
-          tooltip: description || undefined,
         });
       }
     }

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -172,9 +172,6 @@ describe("getToolSlashCommandItem", () => {
       id: "mcp_server_view_linear",
       label: "Create ticket (Product)",
       sectionLabel: "Capabilities",
-      tooltip: {
-        description: "Draft a ticket.",
-      },
     });
   });
 });

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -5,11 +5,7 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import {
-  DUST_PROVIDED_SKILL_LABEL,
-  getSkillAvatarIcon,
-  isDustProvidedSkill,
-} from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 
@@ -100,13 +96,6 @@ export function getSkillSlashCommandItem(
   skill: SlashCommandSkillSuggestion,
   { sectionLabel }: { sectionLabel?: string } = {}
 ): SkillSlashCommand {
-  const isDustProvided = isDustProvidedSkill(skill);
-  const tooltipDescription = isDustProvided
-    ? skill.userFacingDescription
-      ? `${skill.userFacingDescription}\n\n${DUST_PROVIDED_SKILL_LABEL}`
-      : DUST_PROVIDED_SKILL_LABEL
-    : skill.userFacingDescription;
-
   return {
     action: SELECT_SKILL_SLASH_COMMAND_ACTION,
     data: {
@@ -118,9 +107,6 @@ export function getSkillSlashCommandItem(
     id: skill.sId,
     label: skill.name,
     sectionLabel,
-    tooltip: tooltipDescription
-      ? { description: tooltipDescription }
-      : undefined,
   };
 }
 
@@ -147,10 +133,5 @@ export function getToolSlashCommandItem(
     id: tool.sId,
     label: name,
     sectionLabel,
-    tooltip: description
-      ? {
-          description,
-        }
-      : undefined,
   };
 }


### PR DESCRIPTION
## Description

Removes the hover tooltips that repeat the item description in the capabilities lists (input bar `/` dropdown, skill builder capability suggestions, capabilities picker):

- They survive list reflows anchored to stale rows — no pointer events fire when rows move under a stationary cursor while typing/backspacing, so the tooltip stays open on the wrong row.
- They duplicate the description already shown (truncated) on the row; the full description remains available from the details ("…") sheet.

The skill builder's static "Attach knowledge" media tooltip is untouched.

## Tests

Updated the item builder tests. Tested locally: no tooltip beside rows, no stale tooltip after typing/backspacing.

## Risk

Low: visual-only removal scoped to the capabilities lists.

## Deploy Plan

- deploy `front`

🤖 Generated with [Claude Code](https://claude.com/claude-code)