### PR TITLE
[LLM] Add Anthropic output converter

### DIFF
--- a/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
@@ -1,8 +1,10 @@
 import type { Client } from "@app/lib/model_constructors/client";
 import {
+  accumulatedReasoningToReasoningEvent,
   accumulatedTextToTextEvent,
   messageStartToResponseIdEvent,
   type OutputEventConverters,
+  reasoningDeltaToReasoningDeltaEvent,
   textDeltaToTextDeltaEvent,
 } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
 
@@ -20,7 +22,9 @@ export function WithAnthropicOutputConverter<
   {
     messageStartToResponseIdEvent = messageStartToResponseIdEvent;
     textDeltaToTextDeltaEvent = textDeltaToTextDeltaEvent;
+    reasoningDeltaToReasoningDeltaEvent = reasoningDeltaToReasoningDeltaEvent;
     accumulatedTextToTextEvent = accumulatedTextToTextEvent;
+    accumulatedReasoningToReasoningEvent = accumulatedReasoningToReasoningEvent;
   }
 
   return WithAnthropicOutputConverter;

--- a/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
@@ -9,6 +9,7 @@ import {
   messageStartToResponseIdEvent,
   type OutputEventConverters,
   reasoningDeltaToReasoningDeltaEvent,
+  stopReasonToErrorEvent,
   textDeltaToTextDeltaEvent,
   toolUseBlockStartToToolCallStartedEvent,
 } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
@@ -36,6 +37,7 @@ export function WithAnthropicOutputConverter<
     accumulatedToolCallToToolCallEvent = accumulatedToolCallToToolCallEvent;
     invalidJsonToolCallToToolCallEvent = invalidJsonToolCallToToolCallEvent;
     messageDeltaUsageToTokenUsageEvent = messageDeltaUsageToTokenUsageEvent;
+    stopReasonToErrorEvent = stopReasonToErrorEvent;
   }
 
   return WithAnthropicOutputConverter;

--- a/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
@@ -5,6 +5,7 @@ import {
   accumulatedToolCallToToolCallEvent,
   inputJsonDeltaToToolCallDeltaEvent,
   invalidJsonToolCallToToolCallEvent,
+  messageDeltaUsageToTokenUsageEvent,
   messageStartToResponseIdEvent,
   type OutputEventConverters,
   reasoningDeltaToReasoningDeltaEvent,
@@ -34,6 +35,7 @@ export function WithAnthropicOutputConverter<
     inputJsonDeltaToToolCallDeltaEvent = inputJsonDeltaToToolCallDeltaEvent;
     accumulatedToolCallToToolCallEvent = accumulatedToolCallToToolCallEvent;
     invalidJsonToolCallToToolCallEvent = invalidJsonToolCallToToolCallEvent;
+    messageDeltaUsageToTokenUsageEvent = messageDeltaUsageToTokenUsageEvent;
   }
 
   return WithAnthropicOutputConverter;

--- a/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
@@ -10,6 +10,7 @@ import {
   type OutputEventConverters,
   reasoningDeltaToReasoningDeltaEvent,
   stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
   textDeltaToTextDeltaEvent,
   toolUseBlockStartToToolCallStartedEvent,
 } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
@@ -38,6 +39,7 @@ export function WithAnthropicOutputConverter<
     invalidJsonToolCallToToolCallEvent = invalidJsonToolCallToToolCallEvent;
     messageDeltaUsageToTokenUsageEvent = messageDeltaUsageToTokenUsageEvent;
     stopReasonToErrorEvent = stopReasonToErrorEvent;
+    streamErrorToErrorEvent = streamErrorToErrorEvent;
   }
 
   return WithAnthropicOutputConverter;

--- a/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
@@ -1,0 +1,27 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  accumulatedTextToTextEvent,
+  messageStartToResponseIdEvent,
+  type OutputEventConverters,
+  textDeltaToTextDeltaEvent,
+} from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Binds the Anthropic leaf output converters onto a client as class fields (an
+// endpoint can override a single leaf by re-declaring its field). The composite
+// is per-surface, so each supplies its own `rawOutputToEvents`.
+export function WithAnthropicOutputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithAnthropicOutputConverter
+    extends Base
+    implements OutputEventConverters
+  {
+    messageStartToResponseIdEvent = messageStartToResponseIdEvent;
+    textDeltaToTextDeltaEvent = textDeltaToTextDeltaEvent;
+    accumulatedTextToTextEvent = accumulatedTextToTextEvent;
+  }
+
+  return WithAnthropicOutputConverter;
+}

--- a/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/index.ts
@@ -2,10 +2,14 @@ import type { Client } from "@app/lib/model_constructors/client";
 import {
   accumulatedReasoningToReasoningEvent,
   accumulatedTextToTextEvent,
+  accumulatedToolCallToToolCallEvent,
+  inputJsonDeltaToToolCallDeltaEvent,
+  invalidJsonToolCallToToolCallEvent,
   messageStartToResponseIdEvent,
   type OutputEventConverters,
   reasoningDeltaToReasoningDeltaEvent,
   textDeltaToTextDeltaEvent,
+  toolUseBlockStartToToolCallStartedEvent,
 } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
 
 type AbstractConstructor<T> = abstract new (...args: any[]) => T;
@@ -25,6 +29,11 @@ export function WithAnthropicOutputConverter<
     reasoningDeltaToReasoningDeltaEvent = reasoningDeltaToReasoningDeltaEvent;
     accumulatedTextToTextEvent = accumulatedTextToTextEvent;
     accumulatedReasoningToReasoningEvent = accumulatedReasoningToReasoningEvent;
+    toolUseBlockStartToToolCallStartedEvent =
+      toolUseBlockStartToToolCallStartedEvent;
+    inputJsonDeltaToToolCallDeltaEvent = inputJsonDeltaToToolCallDeltaEvent;
+    accumulatedToolCallToToolCallEvent = accumulatedToolCallToToolCallEvent;
+    invalidJsonToolCallToToolCallEvent = invalidJsonToolCallToToolCallEvent;
   }
 
   return WithAnthropicOutputConverter;

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.test.ts
@@ -1,0 +1,1213 @@
+import {
+  AnthropicError,
+  APIConnectionError,
+  APIError,
+} from "@anthropic-ai/sdk";
+import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
+import type {
+  Message,
+  MessageDeltaUsage,
+  RawContentBlockDeltaEvent,
+  RawContentBlockStartEvent,
+  RawContentBlockStopEvent,
+  RawMessageDeltaEvent,
+  RawMessageStartEvent,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type { OutputEventConverters } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import {
+  accumulatedReasoningToReasoningEvent,
+  accumulatedTextToTextEvent,
+  accumulatedToolCallToToolCallEvent,
+  batchResultToEvents,
+  contentBlockDeltaToEvents,
+  contentBlockStartToEvents,
+  contentBlockStopToEvents,
+  getInvalidToolJsonMessage,
+  inputJsonDeltaToToolCallDeltaEvent,
+  invalidJsonToolCallToToolCallEvent,
+  messageDeltaToEvents,
+  messageDeltaUsageToTokenUsageEvent,
+  messageStartToResponseIdEvent,
+  messageToEvents,
+  rawOutputToEvents,
+  reasoningDeltaToReasoningDeltaEvent,
+  stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
+  textDeltaToTextDeltaEvent,
+  toolUseBlockStartToToolCallStartedEvent,
+} from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { describe, expect, it, vi } from "vitest";
+
+const metadata: EndpointMetadata = {
+  providerId: "anthropic",
+  api: "anthropic",
+  region: "us",
+  modelId: "claude-sonnet-4-6",
+};
+
+// The real leaf converters, bundled into the interface the composites consume.
+// Used wherever a test wants the genuine end-to-end conversion.
+const realConverters: OutputEventConverters = {
+  messageStartToResponseIdEvent,
+  textDeltaToTextDeltaEvent,
+  reasoningDeltaToReasoningDeltaEvent,
+  accumulatedTextToTextEvent,
+  accumulatedReasoningToReasoningEvent,
+  toolUseBlockStartToToolCallStartedEvent,
+  inputJsonDeltaToToolCallDeltaEvent,
+  accumulatedToolCallToToolCallEvent,
+  invalidJsonToolCallToToolCallEvent,
+  messageDeltaUsageToTokenUsageEvent,
+  stopReasonToErrorEvent,
+  streamErrorToErrorEvent,
+};
+
+// A fully stubbed converters object, so composites can be checked for pure
+// delegation independently of the leaf converters' real behavior.
+function makeStubConverters(): OutputEventConverters {
+  return {
+    messageStartToResponseIdEvent: vi.fn(() => ({
+      type: "response_id" as const,
+      content: { responseId: "stub-response-id" },
+      metadata,
+    })),
+    textDeltaToTextDeltaEvent: vi.fn(() => ({
+      type: "text_delta" as const,
+      content: { value: "stub-text-delta" },
+      metadata,
+    })),
+    reasoningDeltaToReasoningDeltaEvent: vi.fn(() => ({
+      type: "reasoning_delta" as const,
+      content: { value: "stub-reasoning-delta" },
+      metadata,
+    })),
+    accumulatedTextToTextEvent: vi.fn(() => ({
+      type: "text" as const,
+      content: { value: "stub-text" },
+      metadata,
+    })),
+    accumulatedReasoningToReasoningEvent: vi.fn(() => ({
+      type: "reasoning" as const,
+      content: { value: "stub-reasoning" },
+      metadata,
+    })),
+    toolUseBlockStartToToolCallStartedEvent: vi.fn(() => ({
+      type: "tool_call_started" as const,
+      content: { id: "stub-tool-id", index: 0, name: "stub-tool" },
+      metadata,
+    })),
+    inputJsonDeltaToToolCallDeltaEvent: vi.fn(() => ({
+      type: "tool_call_delta" as const,
+      metadata,
+    })),
+    accumulatedToolCallToToolCallEvent: vi.fn(() => ({
+      type: "tool_call" as const,
+      content: { id: "stub-tool-id", name: "stub-tool", arguments: {} },
+      metadata,
+    })),
+    invalidJsonToolCallToToolCallEvent: vi.fn(() => ({
+      type: "tool_call" as const,
+      content: {
+        id: "stub-tool-id",
+        name: "stub-tool",
+        arguments: { INVALID_JSON: "stub-invalid" },
+      },
+      metadata,
+    })),
+    messageDeltaUsageToTokenUsageEvent: vi.fn(() => ({
+      type: "token_usage" as const,
+      content: {
+        cacheCreated: 0,
+        cacheHit: 0,
+        standardInput: 0,
+        standardOutput: 0,
+        reasoning: 0,
+      },
+      metadata,
+    })),
+    stopReasonToErrorEvent: vi.fn(() => null),
+    streamErrorToErrorEvent: vi.fn(() => ({
+      type: "error" as const,
+      content: { type: "unknown_error" as const, message: "stub-error" },
+      metadata,
+    })),
+  };
+}
+
+// Yields the provided events as an async stream, optionally throwing at the end.
+async function* streamOf(
+  events: RawMessageStreamEvent[],
+  throwAtEnd?: unknown
+): AsyncGenerator<RawMessageStreamEvent> {
+  for (const event of events) {
+    yield event;
+  }
+  if (throwAtEnd !== undefined) {
+    throw throwAtEnd;
+  }
+}
+
+async function collect(
+  generator: AsyncGenerator<ModelResponseEvent>
+): Promise<ModelResponseEvent[]> {
+  const out: ModelResponseEvent[] = [];
+  for await (const event of generator) {
+    out.push(event);
+  }
+  return out;
+}
+
+const INVALID_TOOL_JSON_MESSAGE =
+  "Unable to parse tool parameter JSON: {bad json";
+
+function apiInvalidToolJsonError(): APIError {
+  return new APIError(
+    400,
+    {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: INVALID_TOOL_JSON_MESSAGE,
+      },
+    },
+    INVALID_TOOL_JSON_MESSAGE,
+    undefined,
+    "invalid_request_error"
+  );
+}
+
+describe("getInvalidToolJsonMessage", () => {
+  it("extracts the message from a matching APIError", () => {
+    expect(getInvalidToolJsonMessage(apiInvalidToolJsonError())).toBe(
+      INVALID_TOOL_JSON_MESSAGE
+    );
+  });
+
+  it("extracts the message from a matching AnthropicError", () => {
+    const err = new AnthropicError(INVALID_TOOL_JSON_MESSAGE);
+    expect(getInvalidToolJsonMessage(err)).toBe(INVALID_TOOL_JSON_MESSAGE);
+  });
+
+  it("returns null for an APIError that is neither structurally nor textually a tool-JSON error", () => {
+    const err = new APIError(
+      400,
+      {
+        type: "error",
+        error: { type: "api_error", message: "different problem" },
+      },
+      "different problem",
+      undefined,
+      "api_error"
+    );
+    expect(getInvalidToolJsonMessage(err)).toBeNull();
+  });
+
+  // The structured APIError guard requires type === "invalid_request_error", but
+  // APIError extends AnthropicError and its message embeds the serialized body.
+  // So a needle-bearing APIError still matches via the textual fallback even
+  // when its `type` is something else.
+  it("still matches a needle-bearing APIError via the AnthropicError fallback", () => {
+    const err = new APIError(
+      400,
+      {
+        type: "error",
+        error: { type: "api_error", message: INVALID_TOOL_JSON_MESSAGE },
+      },
+      INVALID_TOOL_JSON_MESSAGE,
+      undefined,
+      "api_error"
+    );
+    expect(getInvalidToolJsonMessage(err)).toContain(INVALID_TOOL_JSON_MESSAGE);
+  });
+
+  it("returns null for an APIError missing the needle", () => {
+    const err = new APIError(
+      400,
+      {
+        type: "error",
+        error: { type: "invalid_request_error", message: "Some other problem" },
+      },
+      "Some other problem",
+      undefined,
+      "invalid_request_error"
+    );
+    expect(getInvalidToolJsonMessage(err)).toBeNull();
+  });
+
+  it("returns null for an AnthropicError missing the needle", () => {
+    expect(
+      getInvalidToolJsonMessage(new AnthropicError("network blip"))
+    ).toBeNull();
+  });
+
+  it("returns null for an unrelated error", () => {
+    expect(getInvalidToolJsonMessage(new Error("boom"))).toBeNull();
+    expect(getInvalidToolJsonMessage("a string")).toBeNull();
+    expect(getInvalidToolJsonMessage(null)).toBeNull();
+  });
+});
+
+describe("messageStartToResponseIdEvent", () => {
+  it("maps the message id into a response_id event", () => {
+    const event = {
+      type: "message_start",
+      message: { id: "msg_123" },
+    } as RawMessageStartEvent;
+    expect(messageStartToResponseIdEvent(metadata, event)).toEqual({
+      type: "response_id",
+      content: { responseId: "msg_123" },
+      metadata,
+    });
+  });
+});
+
+describe("textDeltaToTextDeltaEvent", () => {
+  it("wraps the delta string in a text_delta event", () => {
+    expect(textDeltaToTextDeltaEvent(metadata, "chunk")).toEqual({
+      type: "text_delta",
+      content: { value: "chunk" },
+      metadata,
+    });
+  });
+});
+
+describe("reasoningDeltaToReasoningDeltaEvent", () => {
+  it("wraps the delta string in a reasoning_delta event", () => {
+    expect(reasoningDeltaToReasoningDeltaEvent(metadata, "thinking")).toEqual({
+      type: "reasoning_delta",
+      content: { value: "thinking" },
+      metadata,
+    });
+  });
+});
+
+describe("accumulatedTextToTextEvent", () => {
+  it("wraps the accumulated text in a text event", () => {
+    expect(accumulatedTextToTextEvent(metadata, "full text")).toEqual({
+      type: "text",
+      content: { value: "full text" },
+      metadata,
+    });
+  });
+});
+
+describe("accumulatedReasoningToReasoningEvent", () => {
+  it("emits a reasoning event without a signature when none is given", () => {
+    expect(accumulatedReasoningToReasoningEvent(metadata, "thoughts")).toEqual({
+      type: "reasoning",
+      content: { value: "thoughts" },
+      metadata,
+    });
+  });
+
+  it("threads the signature into metadata.content when present", () => {
+    expect(
+      accumulatedReasoningToReasoningEvent(metadata, "thoughts", "sig-1")
+    ).toEqual({
+      type: "reasoning",
+      content: { value: "thoughts" },
+      metadata: { ...metadata, content: { signature: "sig-1" } },
+    });
+  });
+});
+
+describe("toolUseBlockStartToToolCallStartedEvent", () => {
+  it("maps id, index and name into a tool_call_started event", () => {
+    expect(
+      toolUseBlockStartToToolCallStartedEvent(metadata, "id-1", 2, "search")
+    ).toEqual({
+      type: "tool_call_started",
+      content: { id: "id-1", index: 2, name: "search" },
+      metadata,
+    });
+  });
+});
+
+describe("inputJsonDeltaToToolCallDeltaEvent", () => {
+  it("emits a content-free tool_call_delta heartbeat", () => {
+    expect(inputJsonDeltaToToolCallDeltaEvent(metadata)).toEqual({
+      type: "tool_call_delta",
+      metadata,
+    });
+  });
+});
+
+describe("accumulatedToolCallToToolCallEvent", () => {
+  it("parses the arguments JSON into the tool_call event", () => {
+    expect(
+      accumulatedToolCallToToolCallEvent(
+        metadata,
+        "id-1",
+        "search",
+        '{"q":"cats"}'
+      )
+    ).toEqual({
+      type: "tool_call",
+      content: { id: "id-1", name: "search", arguments: { q: "cats" } },
+      metadata,
+    });
+  });
+
+  it("falls back to empty arguments for malformed JSON", () => {
+    expect(
+      accumulatedToolCallToToolCallEvent(metadata, "id-1", "search", "not json")
+        .content.arguments
+    ).toEqual({});
+  });
+});
+
+describe("invalidJsonToolCallToToolCallEvent", () => {
+  it("wraps the invalid JSON under an INVALID_JSON key", () => {
+    expect(
+      invalidJsonToolCallToToolCallEvent(metadata, "id-1", "search", "{bad")
+    ).toEqual({
+      type: "tool_call",
+      content: {
+        id: "id-1",
+        name: "search",
+        arguments: { INVALID_JSON: "{bad" },
+      },
+      metadata,
+    });
+  });
+});
+
+describe("messageDeltaUsageToTokenUsageEvent", () => {
+  it("splits reasoning out of output tokens when a breakdown is present", () => {
+    const usage: MessageDeltaUsage = {
+      cache_creation_input_tokens: 10,
+      cache_read_input_tokens: 20,
+      input_tokens: 100,
+      output_tokens: 50,
+      output_tokens_details: { thinking_tokens: 15 },
+      server_tool_use: null,
+    };
+    expect(messageDeltaUsageToTokenUsageEvent(metadata, usage)).toEqual({
+      type: "token_usage",
+      content: {
+        cacheCreated: 10,
+        cacheHit: 20,
+        standardInput: 100,
+        standardOutput: 35,
+        reasoning: 15,
+      },
+      metadata,
+    });
+  });
+
+  it("rolls reasoning into standardOutput when there is no breakdown", () => {
+    const usage: MessageDeltaUsage = {
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      input_tokens: null,
+      output_tokens: 40,
+      output_tokens_details: null,
+      server_tool_use: null,
+    };
+    expect(messageDeltaUsageToTokenUsageEvent(metadata, usage)).toEqual({
+      type: "token_usage",
+      content: {
+        cacheCreated: 0,
+        cacheHit: 0,
+        standardInput: 0,
+        standardOutput: 40,
+        reasoning: 0,
+      },
+      metadata,
+    });
+  });
+});
+
+describe("stopReasonToErrorEvent", () => {
+  it("maps max_tokens to a stop_error event", () => {
+    expect(stopReasonToErrorEvent(metadata, "max_tokens")).toMatchObject({
+      type: "error",
+      content: { type: "stop_error" },
+    });
+  });
+
+  it("maps refusal to a refusal_error event", () => {
+    expect(stopReasonToErrorEvent(metadata, "refusal")).toMatchObject({
+      type: "error",
+      content: { type: "refusal_error" },
+    });
+  });
+
+  it("returns null for end_turn and other stop reasons", () => {
+    expect(stopReasonToErrorEvent(metadata, "end_turn")).toBeNull();
+    expect(stopReasonToErrorEvent(metadata, "tool_use")).toBeNull();
+  });
+});
+
+describe("streamErrorToErrorEvent", () => {
+  it("maps invalid tool JSON to a retryable model_output_error", () => {
+    const result = streamErrorToErrorEvent(metadata, apiInvalidToolJsonError());
+    expect(result.content.type).toBe("model_output_error");
+  });
+
+  it("maps APIConnectionError to network_error", () => {
+    const err = new APIConnectionError({ message: "connection reset" });
+    const result = streamErrorToErrorEvent(metadata, err);
+    expect(result.content.type).toBe("network_error");
+    expect(result.content.originalError).toBe(err);
+  });
+
+  it.each([
+    [400, "invalid_request_error"],
+    [422, "invalid_request_error"],
+    [401, "authentication_error"],
+    [403, "permission_error"],
+    [404, "not_found_error"],
+    [429, "rate_limit_error"],
+    [503, "overloaded_error"],
+  ] as const)("maps HTTP %i to %s", (status, expectedType) => {
+    const err = new APIError(status, {}, "http failure", undefined, null);
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      expectedType
+    );
+  });
+
+  it("maps a generic 5xx status to server_error", () => {
+    const err = new APIError(500, {}, "kaboom", undefined, null);
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      "server_error"
+    );
+  });
+
+  it("maps an unrecognized status to unknown_error", () => {
+    const err = new APIError(418, {}, "teapot", undefined, null);
+    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
+      "unknown_error"
+    );
+  });
+
+  it("maps a non-SDK error to unknown_error", () => {
+    expect(streamErrorToErrorEvent(metadata, "boom").content.type).toBe(
+      "unknown_error"
+    );
+  });
+});
+
+describe("contentBlockStartToEvents", () => {
+  it("opens a text block with no events emitted", () => {
+    const event = {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "", citations: [] },
+    } as RawContentBlockStartEvent;
+    const [events, state] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(state).toEqual({ index: 0, accumulator: "", type: "text" });
+  });
+
+  it("opens a thinking block as a reasoning cursor", () => {
+    const event = {
+      type: "content_block_start",
+      index: 1,
+      content_block: { type: "thinking", thinking: "", signature: "" },
+    } as RawContentBlockStartEvent;
+    const [events, state] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(state).toEqual({ index: 1, accumulator: "", type: "reasoning" });
+  });
+
+  it("emits a tool_call_started event and a tool_use cursor", () => {
+    const stub = makeStubConverters();
+    const event = {
+      type: "content_block_start",
+      index: 3,
+      content_block: {
+        type: "tool_use",
+        id: "tu-1",
+        name: "lookup",
+        input: {},
+      },
+    } as RawContentBlockStartEvent;
+    const [events, state] = contentBlockStartToEvents(
+      event,
+      null,
+      metadata,
+      stub
+    );
+    expect(stub.toolUseBlockStartToToolCallStartedEvent).toHaveBeenCalledWith(
+      metadata,
+      "tu-1",
+      3,
+      "lookup"
+    );
+    expect(events).toHaveLength(1);
+    expect(state).toEqual({
+      index: 3,
+      accumulator: "",
+      type: "tool_use",
+      toolId: "tu-1",
+      toolName: "lookup",
+    });
+  });
+
+  it("passes through the existing state for ignored block types", () => {
+    const event = {
+      type: "content_block_start",
+      index: 4,
+      content_block: { type: "redacted_thinking", data: "xxx" },
+    } as RawContentBlockStartEvent;
+    const prior = { index: 0, accumulator: "abc", type: "text" as const };
+    const [events, state] = contentBlockStartToEvents(
+      event,
+      prior,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(state).toBe(prior);
+  });
+});
+
+describe("contentBlockDeltaToEvents", () => {
+  it("returns no events and null state when there is no open block", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "x" },
+    } as RawContentBlockDeltaEvent;
+    expect(
+      contentBlockDeltaToEvents(event, null, metadata, realConverters)
+    ).toEqual([[], null]);
+  });
+
+  it("emits a text_delta and accumulates onto the cursor", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "lo" },
+    } as RawContentBlockDeltaEvent;
+    const state = { index: 0, accumulator: "hel", type: "text" as const };
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      { type: "text_delta", content: { value: "lo" }, metadata },
+    ]);
+    expect(nextState).toEqual({ ...state, accumulator: "hello" });
+  });
+
+  it("emits a reasoning_delta and accumulates onto the cursor", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "more" },
+    } as RawContentBlockDeltaEvent;
+    const state = {
+      index: 0,
+      accumulator: "think ",
+      type: "reasoning" as const,
+    };
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      { type: "reasoning_delta", content: { value: "more" }, metadata },
+    ]);
+    expect(nextState).toEqual({ ...state, accumulator: "think more" });
+  });
+
+  it("emits a tool_call_delta heartbeat and accumulates the partial JSON", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: '{"a":' },
+    } as RawContentBlockDeltaEvent;
+    const state = {
+      index: 0,
+      accumulator: "",
+      type: "tool_use" as const,
+      toolId: "t",
+      toolName: "n",
+    };
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([{ type: "tool_call_delta", metadata }]);
+    expect(nextState).toEqual({ ...state, accumulator: '{"a":' });
+  });
+
+  it("accumulates a signature delta onto a reasoning cursor without emitting", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "signature_delta", signature: "abc" },
+    } as RawContentBlockDeltaEvent;
+    const state = {
+      index: 0,
+      accumulator: "",
+      type: "reasoning" as const,
+      signature: "sig-",
+    };
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(nextState).toEqual({ ...state, signature: "sig-abc" });
+  });
+
+  it("ignores a signature delta on a non-reasoning cursor", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "signature_delta", signature: "abc" },
+    } as RawContentBlockDeltaEvent;
+    const state = { index: 0, accumulator: "x", type: "text" as const };
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(nextState).toBe(state);
+  });
+
+  it("ignores a citations delta", () => {
+    const event = {
+      type: "content_block_delta",
+      index: 0,
+      delta: {
+        type: "citations_delta",
+        citation: {
+          type: "char_location",
+          cited_text: "x",
+          document_index: 0,
+          document_title: null,
+          start_char_index: 0,
+          end_char_index: 1,
+        },
+      },
+    } as RawContentBlockDeltaEvent;
+    const state = { index: 0, accumulator: "x", type: "text" as const };
+    const [events, nextState] = contentBlockDeltaToEvents(
+      event,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([]);
+    expect(nextState).toBe(state);
+  });
+});
+
+describe("contentBlockStopToEvents", () => {
+  const stopEvent = {
+    type: "content_block_stop",
+    index: 0,
+  } as RawContentBlockStopEvent;
+
+  it("returns no events when there is no open block", () => {
+    expect(
+      contentBlockStopToEvents(stopEvent, null, metadata, realConverters)
+    ).toEqual([[], null]);
+  });
+
+  it("flushes a text block into a text event and clears the cursor", () => {
+    const state = { index: 0, accumulator: "hello", type: "text" as const };
+    expect(
+      contentBlockStopToEvents(stopEvent, state, metadata, realConverters)
+    ).toEqual([
+      [{ type: "text", content: { value: "hello" }, metadata }],
+      null,
+    ]);
+  });
+
+  it("flushes a reasoning block, forwarding the accumulated signature", () => {
+    const state = {
+      index: 0,
+      accumulator: "deep",
+      type: "reasoning" as const,
+      signature: "sig-9",
+    };
+    const [events, nextState] = contentBlockStopToEvents(
+      stopEvent,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      {
+        type: "reasoning",
+        content: { value: "deep" },
+        metadata: { ...metadata, content: { signature: "sig-9" } },
+      },
+    ]);
+    expect(nextState).toBeNull();
+  });
+
+  it("flushes a tool_use block with valid JSON into a parsed tool_call", () => {
+    const state = {
+      index: 0,
+      accumulator: '{"q":"cats"}',
+      type: "tool_use" as const,
+      toolId: "tu-1",
+      toolName: "search",
+    };
+    const [events] = contentBlockStopToEvents(
+      stopEvent,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_call",
+        content: { id: "tu-1", name: "search", arguments: { q: "cats" } },
+        metadata,
+      },
+    ]);
+  });
+
+  it("wraps invalid tool_use JSON under INVALID_JSON", () => {
+    const state = {
+      index: 0,
+      accumulator: '{"q": ',
+      type: "tool_use" as const,
+      toolId: "tu-1",
+      toolName: "search",
+    };
+    const [events] = contentBlockStopToEvents(
+      stopEvent,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_call",
+        content: {
+          id: "tu-1",
+          name: "search",
+          arguments: { INVALID_JSON: '{"q": ' },
+        },
+        metadata,
+      },
+    ]);
+  });
+
+  it("treats an empty tool_use accumulator as a (valid) empty tool_call", () => {
+    const state = {
+      index: 0,
+      accumulator: "",
+      type: "tool_use" as const,
+      toolId: "tu-1",
+      toolName: "search",
+    };
+    const [events] = contentBlockStopToEvents(
+      stopEvent,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_call",
+        content: { id: "tu-1", name: "search", arguments: {} },
+        metadata,
+      },
+    ]);
+  });
+
+  it("skips eager validation for very large tool inputs", () => {
+    // Above MAX_EAGER_VALIDATION_INPUT_LENGTH (5000), invalid JSON is not
+    // wrapped — it flows through the regular tool_call converter (which parses
+    // and falls back to {}).
+    const accumulator = "x".repeat(5001);
+    const state = {
+      index: 0,
+      accumulator,
+      type: "tool_use" as const,
+      toolId: "tu-1",
+      toolName: "search",
+    };
+    const [events] = contentBlockStopToEvents(
+      stopEvent,
+      state,
+      metadata,
+      realConverters
+    );
+    expect(events).toEqual([
+      {
+        type: "tool_call",
+        content: { id: "tu-1", name: "search", arguments: {} },
+        metadata,
+      },
+    ]);
+  });
+});
+
+describe("messageDeltaToEvents", () => {
+  const usage: MessageDeltaUsage = {
+    cache_creation_input_tokens: null,
+    cache_read_input_tokens: null,
+    input_tokens: null,
+    output_tokens: 5,
+    output_tokens_details: null,
+    server_tool_use: null,
+  };
+
+  it("returns no events for a benign stop reason and forwards usage", () => {
+    const event = {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage,
+    } as RawMessageDeltaEvent;
+    expect(messageDeltaToEvents(event, metadata, realConverters)).toEqual([
+      [],
+      usage,
+    ]);
+  });
+
+  it("emits an error event for an erroring stop reason", () => {
+    const event = {
+      type: "message_delta",
+      delta: { stop_reason: "max_tokens", stop_sequence: null },
+      usage,
+    } as RawMessageDeltaEvent;
+    const [events, forwardedUsage] = messageDeltaToEvents(
+      event,
+      metadata,
+      realConverters
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ content: { type: "stop_error" } });
+    expect(forwardedUsage).toBe(usage);
+  });
+
+  it("returns no events when stop_reason is absent", () => {
+    const event = {
+      type: "message_delta",
+      delta: { stop_reason: null, stop_sequence: null },
+      usage,
+    } as RawMessageDeltaEvent;
+    expect(messageDeltaToEvents(event, metadata, realConverters)[0]).toEqual(
+      []
+    );
+  });
+});
+
+describe("rawOutputToEvents", () => {
+  const tokenUsage: MessageDeltaUsage = {
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    input_tokens: 3,
+    output_tokens: 2,
+    output_tokens_details: null,
+    server_tool_use: null,
+  };
+
+  it("drives a text stream into response_id, deltas, text, usage and success", async () => {
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf([
+          {
+            type: "message_start",
+            message: { id: "msg_1" },
+          } as RawMessageStartEvent,
+          {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "", citations: [] },
+          } as RawMessageStreamEvent,
+          {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Hi" },
+          } as RawMessageStreamEvent,
+          {
+            type: "content_block_stop",
+            index: 0,
+          } as RawMessageStreamEvent,
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn", stop_sequence: null },
+            usage: tokenUsage,
+          } as RawMessageStreamEvent,
+          { type: "message_stop" } as RawMessageStreamEvent,
+        ]),
+        metadata,
+        realConverters
+      )
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      "response_id",
+      "text_delta",
+      "text",
+      "token_usage",
+      "success",
+    ]);
+
+    const success = events.find((e) => e.type === "success");
+    expect(success).toMatchObject({
+      content: { aggregated: [{ type: "text", content: { value: "Hi" } }] },
+    });
+  });
+
+  it("maps a thrown SDK error to an error event and stops", async () => {
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf(
+          [
+            {
+              type: "message_start",
+              message: { id: "msg_1" },
+            } as RawMessageStartEvent,
+          ],
+          new APIError(429, {}, "slow down", undefined, null)
+        ),
+        metadata,
+        realConverters
+      )
+    );
+    expect(events.map((e) => e.type)).toEqual(["response_id", "error"]);
+    expect(events[1]).toMatchObject({ content: { type: "rate_limit_error" } });
+  });
+
+  it("recovers an in-progress tool call when invalid tool JSON aborts the stream", async () => {
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf(
+          [
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block: {
+                type: "tool_use",
+                id: "tu-1",
+                name: "search",
+                input: {},
+              },
+            } as RawMessageStreamEvent,
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "input_json_delta", partial_json: "{bad" },
+            } as RawMessageStreamEvent,
+          ],
+          new AnthropicError(INVALID_TOOL_JSON_MESSAGE)
+        ),
+        metadata,
+        realConverters
+      )
+    );
+
+    const toolCall = events.find((e) => e.type === "tool_call");
+    expect(toolCall).toMatchObject({
+      content: {
+        id: "tu-1",
+        name: "search",
+        arguments: { INVALID_JSON: "{bad json" },
+      },
+    });
+    // The recovered tool_call is aggregated into the trailing success event.
+    const success = events.find((e) => e.type === "success");
+    expect(success).toMatchObject({
+      content: { aggregated: [{ type: "tool_call" }] },
+    });
+  });
+
+  it("omits the token_usage event when no message_delta carried usage", async () => {
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf([{ type: "message_stop" } as RawMessageStreamEvent]),
+        metadata,
+        realConverters
+      )
+    );
+    expect(events.map((e) => e.type)).toEqual(["success"]);
+  });
+});
+
+describe("messageToEvents", () => {
+  function messageWith(overrides: Partial<Message>): Message {
+    return {
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-6",
+      content: [],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        input_tokens: 4,
+        output_tokens: 6,
+        output_tokens_details: null,
+        server_tool_use: null,
+      },
+      ...overrides,
+    } as Message;
+  }
+
+  it("converts text, thinking and tool_use blocks in order", () => {
+    const message = messageWith({
+      content: [
+        { type: "text", text: "hello", citations: [] },
+        { type: "thinking", thinking: "hmm", signature: "sig-1" },
+        { type: "tool_use", id: "tu-1", name: "search", input: { q: "cats" } },
+      ],
+    } as Partial<Message>);
+
+    const events = messageToEvents(message, metadata, realConverters);
+    expect(events.map((e) => e.type)).toEqual([
+      "response_id",
+      "text",
+      "reasoning",
+      "tool_call_started",
+      "tool_call",
+      "token_usage",
+      "success",
+    ]);
+
+    expect(events[4]).toMatchObject({
+      content: { id: "tu-1", name: "search", arguments: { q: "cats" } },
+    });
+  });
+
+  it("aggregates text, reasoning and tool_call into the success event", () => {
+    const message = messageWith({
+      content: [
+        { type: "text", text: "hi", citations: [] },
+        { type: "tool_use", id: "tu-1", name: "n", input: {} },
+      ],
+    } as Partial<Message>);
+    const events = messageToEvents(message, metadata, realConverters);
+    const success = events.find((e) => e.type === "success");
+    expect(success).toMatchObject({
+      content: {
+        aggregated: [{ type: "text" }, { type: "tool_call" }],
+      },
+    });
+  });
+
+  it("appends a stop error event before token usage when stop_reason errors", () => {
+    const message = messageWith({ stop_reason: "max_tokens" });
+    const events = messageToEvents(message, metadata, realConverters);
+    expect(events.map((e) => e.type)).toEqual([
+      "response_id",
+      "error",
+      "token_usage",
+      "success",
+    ]);
+  });
+
+  it("skips block types that are not surfaced", () => {
+    const message = messageWith({
+      content: [{ type: "redacted_thinking", data: "xxx" }],
+    } as Partial<Message>);
+    const events = messageToEvents(message, metadata, realConverters);
+    expect(events.map((e) => e.type)).toEqual([
+      "response_id",
+      "token_usage",
+      "success",
+    ]);
+  });
+});
+
+describe("batchResultToEvents", () => {
+  function succeededResult(): MessageBatchResult {
+    const message = {
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "claude-sonnet-4-6",
+      content: [{ type: "text", text: "ok", citations: [] }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      container: null,
+      stop_details: null,
+      usage: {
+        cache_creation: null,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        inference_geo: null,
+        input_tokens: 1,
+        output_tokens: 1,
+        output_tokens_details: null,
+        server_tool_use: null,
+        service_tier: null,
+      },
+    } as Message;
+    return { type: "succeeded", message };
+  }
+
+  it("converts a succeeded result via messageToEvents", () => {
+    const events = batchResultToEvents(
+      succeededResult(),
+      metadata,
+      realConverters
+    );
+    expect(events.map((e) => e.type)).toEqual([
+      "response_id",
+      "text",
+      "token_usage",
+      "success",
+    ]);
+  });
+
+  it("maps an errored result to a server_error event", () => {
+    const result = {
+      type: "errored",
+      error: {
+        type: "error",
+        error: { type: "api_error", message: "upstream blew up" },
+      },
+    } as MessageBatchResult;
+    const events = batchResultToEvents(result, metadata, realConverters);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      content: { type: "server_error", message: "upstream blew up" },
+    });
+  });
+
+  it("maps a canceled result to a stream_error event", () => {
+    const result = { type: "canceled" } as MessageBatchResult;
+    const events = batchResultToEvents(result, metadata, realConverters);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      content: { type: "stream_error" },
+    });
+  });
+
+  it("maps an expired result to a stream_error event", () => {
+    const result = { type: "expired" } as MessageBatchResult;
+    const events = batchResultToEvents(result, metadata, realConverters);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      content: { type: "stream_error" },
+    });
+  });
+});

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -3,6 +3,7 @@ import {
   APIConnectionError,
   APIError,
 } from "@anthropic-ai/sdk";
+import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
 import type {
   Message,
   MessageDeltaUsage,
@@ -851,4 +852,46 @@ export function messageToEvents(
   events.push({ type: "success", content: { aggregated }, metadata });
 
   return events;
+}
+
+// Converts a single Anthropic batch result into unified events.
+export function batchResultToEvents(
+  result: MessageBatchResult,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): NonDeltaResponseEvent[] {
+  switch (result.type) {
+    case "succeeded":
+      return messageToEvents(result.message, metadata, converters);
+    case "errored":
+      return [
+        buildErrorEvent({
+          metadata,
+          type: "server_error",
+          message: result.error.error.message,
+          originalError: result.error,
+        }),
+      ];
+    case "canceled":
+      return [
+        buildErrorEvent({
+          metadata,
+          type: "stream_error",
+          message: "Batch request was canceled.",
+        }),
+      ];
+    case "expired":
+      return [
+        buildErrorEvent({
+          metadata,
+          type: "stream_error",
+          message: "Batch request expired before processing completed.",
+        }),
+      ];
+    default:
+      // Anthropic may add new batch result types before we redeploy; ignore
+      // them rather than crashing.
+      assertNeverAndIgnore(result);
+      return [];
+  }
 }

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -1,0 +1,212 @@
+import type {
+  RawContentBlockDeltaEvent,
+  RawContentBlockStartEvent,
+  RawContentBlockStopEvent,
+  RawMessageStartEvent,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ModelResponseEvent,
+  ReasoningEvent,
+  ResponseIdEvent,
+  TextDeltaEvent,
+  TextEvent,
+  ToolCallEvent,
+} from "@app/lib/model_constructors/types/output/events";
+
+// Cursor for the content block being streamed; deltas accumulate here until
+// `content_block_stop` flushes it as an event.
+export type BlockState = {
+  index: number;
+  accumulator: string;
+  type: "text";
+};
+
+// The per-signal leaf converters. Composites below take an object satisfying
+// this interface (`this`), so overriding one leaf on an endpoint changes how
+// every composite uses it.
+export interface OutputEventConverters {
+  messageStartToResponseIdEvent(
+    metadata: EndpointMetadata,
+    event: RawMessageStartEvent
+  ): ResponseIdEvent;
+  textDeltaToTextDeltaEvent(
+    metadata: EndpointMetadata,
+    delta: string
+  ): TextDeltaEvent;
+  accumulatedTextToTextEvent(
+    metadata: EndpointMetadata,
+    text: string
+  ): TextEvent;
+}
+
+// -- Leaf converters: one unified event per Anthropic stream signal --
+
+export function messageStartToResponseIdEvent(
+  metadata: EndpointMetadata,
+  event: RawMessageStartEvent
+): ResponseIdEvent {
+  return {
+    type: "response_id",
+    content: { responseId: event.message.id },
+    metadata,
+  };
+}
+
+export function textDeltaToTextDeltaEvent(
+  metadata: EndpointMetadata,
+  delta: string
+): TextDeltaEvent {
+  return { type: "text_delta", content: { value: delta }, metadata };
+}
+
+export function accumulatedTextToTextEvent(
+  metadata: EndpointMetadata,
+  text: string
+): TextEvent {
+  return { type: "text", content: { value: text }, metadata };
+}
+
+// -- Composite state machine: depends on the leaf converters --
+
+export function contentBlockStartToEvents(
+  event: RawContentBlockStartEvent,
+  state: { current: BlockState | null },
+  _metadata: EndpointMetadata,
+  _converters: OutputEventConverters
+): ModelResponseEvent[] {
+  const block = event.content_block;
+  switch (block.type) {
+    case "text":
+      state.current = { index: event.index, accumulator: "", type: "text" };
+      return [];
+    default:
+      // Other block types are wired in in subsequent commits.
+      return [];
+  }
+}
+
+export function contentBlockDeltaToEvents(
+  event: RawContentBlockDeltaEvent,
+  state: { current: BlockState | null },
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): ModelResponseEvent[] {
+  if (state.current === null) {
+    return [];
+  }
+  const delta = event.delta;
+  switch (delta.type) {
+    case "text_delta":
+      state.current.accumulator += delta.text;
+      return [converters.textDeltaToTextDeltaEvent(metadata, delta.text)];
+    default:
+      // Other delta types are wired in in subsequent commits.
+      return [];
+  }
+}
+
+export function contentBlockStopToEvents(
+  _event: RawContentBlockStopEvent,
+  state: { current: BlockState | null },
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): ModelResponseEvent[] {
+  if (state.current === null) {
+    return [];
+  }
+  const block = state.current;
+  state.current = null;
+  switch (block.type) {
+    case "text":
+      return [
+        converters.accumulatedTextToTextEvent(metadata, block.accumulator),
+      ];
+    default:
+      // Other block types are wired in in subsequent commits.
+      return [];
+  }
+}
+
+// -- Entry point: drive the raw stream into unified events --
+
+export async function* rawOutputToEvents(
+  stream: AsyncGenerator<RawMessageStreamEvent>,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): AsyncGenerator<ModelResponseEvent> {
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const blockState: { current: BlockState | null } = { current: null };
+
+  while (true) {
+    let result: IteratorResult<RawMessageStreamEvent>;
+    try {
+      result = await stream.next();
+    } catch {
+      // Generic stream-error mapping is wired in in a subsequent commit.
+      return;
+    }
+    if (result.done) {
+      break;
+    }
+
+    const event = result.value;
+
+    let outputEvents: ModelResponseEvent[];
+    switch (event.type) {
+      case "message_start":
+        outputEvents = [
+          converters.messageStartToResponseIdEvent(metadata, event),
+        ];
+        break;
+      case "message_stop":
+        outputEvents = [];
+        break;
+      case "content_block_start":
+        outputEvents = contentBlockStartToEvents(
+          event,
+          blockState,
+          metadata,
+          converters
+        );
+        break;
+      case "content_block_delta":
+        outputEvents = contentBlockDeltaToEvents(
+          event,
+          blockState,
+          metadata,
+          converters
+        );
+        break;
+      case "content_block_stop":
+        outputEvents = contentBlockStopToEvents(
+          event,
+          blockState,
+          metadata,
+          converters
+        );
+        break;
+      default:
+        // Other stream event types are wired in in subsequent commits.
+        outputEvents = [];
+    }
+
+    for (const outputEvent of outputEvents) {
+      if (
+        outputEvent.type === "text" ||
+        outputEvent.type === "reasoning" ||
+        outputEvent.type === "tool_call"
+      ) {
+        aggregated.push(outputEvent);
+      }
+      yield outputEvent;
+    }
+  }
+
+  yield {
+    type: "success",
+    content: { aggregated },
+    metadata,
+  };
+}

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -455,39 +455,37 @@ export function streamErrorToErrorEvent(
 
 // -- Composite state machine: depends on the leaf converters --
 
+// Returns the events to emit alongside the next block state, so the caller owns
+// the cursor instead of us mutating it in place.
 export function contentBlockStartToEvents(
   event: RawContentBlockStartEvent,
-  state: { current: BlockState | null },
+  state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
-): ModelResponseEvent[] {
+): [ModelResponseEvent[], BlockState | null] {
   const block = event.content_block;
   switch (block.type) {
     case "text":
-      state.current = { index: event.index, accumulator: "", type: "text" };
-      return [];
+      return [[], { index: event.index, accumulator: "", type: "text" }];
     case "thinking":
-      state.current = {
-        index: event.index,
-        accumulator: "",
-        type: "reasoning",
-      };
-      return [];
+      return [[], { index: event.index, accumulator: "", type: "reasoning" }];
     case "tool_use":
-      state.current = {
-        index: event.index,
-        accumulator: "",
-        type: "tool_use",
-        toolId: block.id,
-        toolName: block.name,
-      };
       return [
-        converters.toolUseBlockStartToToolCallStartedEvent(
-          metadata,
-          block.id,
-          event.index,
-          block.name
-        ),
+        [
+          converters.toolUseBlockStartToToolCallStartedEvent(
+            metadata,
+            block.id,
+            event.index,
+            block.name
+          ),
+        ],
+        {
+          index: event.index,
+          accumulator: "",
+          type: "tool_use",
+          toolId: block.id,
+          toolName: block.name,
+        },
       ];
     // Block types we don't surface: redacted thinking, server tools, and their
     // result / container blocks. Listed explicitly so the default stays
@@ -501,80 +499,93 @@ export function contentBlockStartToEvents(
     case "text_editor_code_execution_tool_result":
     case "tool_search_tool_result":
     case "container_upload":
-      return [];
+      return [[], state];
     default:
       // Anthropic may add new block types before we redeploy; ignore them
       // rather than crashing the stream.
       assertNeverAndIgnore(block);
-      return [];
+      return [[], state];
   }
 }
 
 export function contentBlockDeltaToEvents(
   event: RawContentBlockDeltaEvent,
-  state: { current: BlockState | null },
+  state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
-): ModelResponseEvent[] {
-  if (state.current === null) {
-    return [];
+): [ModelResponseEvent[], BlockState | null] {
+  if (state === null) {
+    return [[], null];
   }
   const delta = event.delta;
   switch (delta.type) {
     case "text_delta":
-      state.current.accumulator += delta.text;
-      return [converters.textDeltaToTextDeltaEvent(metadata, delta.text)];
-    case "thinking_delta":
-      state.current.accumulator += delta.thinking;
       return [
-        converters.reasoningDeltaToReasoningDeltaEvent(
-          metadata,
-          delta.thinking
-        ),
+        [converters.textDeltaToTextDeltaEvent(metadata, delta.text)],
+        { ...state, accumulator: state.accumulator + delta.text },
+      ];
+    case "thinking_delta":
+      return [
+        [
+          converters.reasoningDeltaToReasoningDeltaEvent(
+            metadata,
+            delta.thinking
+          ),
+        ],
+        { ...state, accumulator: state.accumulator + delta.thinking },
       ];
     case "input_json_delta":
-      state.current.accumulator += delta.partial_json;
-      return [converters.inputJsonDeltaToToolCallDeltaEvent(metadata)];
+      return [
+        [converters.inputJsonDeltaToToolCallDeltaEvent(metadata)],
+        { ...state, accumulator: state.accumulator + delta.partial_json },
+      ];
     case "signature_delta":
-      if (state.current.type === "reasoning") {
+      if (state.type === "reasoning") {
         // Accumulate across deltas: Anthropic may chunk the signature.
-        state.current.signature =
-          (state.current.signature ?? "") + delta.signature;
+        return [
+          [],
+          { ...state, signature: (state.signature ?? "") + delta.signature },
+        ];
       }
-      return [];
+      return [[], state];
     case "citations_delta":
-      return [];
+      return [[], state];
     default:
       // Anthropic may add new delta types before we redeploy; ignore them
       // rather than crashing the stream.
       assertNeverAndIgnore(delta);
-      return [];
+      return [[], state];
   }
 }
 
+// Flushes the in-progress block as an event and clears the cursor (returns the
+// next state as `null`), so the caller resets its own variable.
 export function contentBlockStopToEvents(
   _event: RawContentBlockStopEvent,
-  state: { current: BlockState | null },
+  state: BlockState | null,
   metadata: EndpointMetadata,
   converters: OutputEventConverters
-): ModelResponseEvent[] {
-  if (state.current === null) {
-    return [];
+): [ModelResponseEvent[], BlockState | null] {
+  if (state === null) {
+    return [[], null];
   }
-  const block = state.current;
-  state.current = null;
+  const block = state;
   switch (block.type) {
     case "text":
       return [
-        converters.accumulatedTextToTextEvent(metadata, block.accumulator),
+        [converters.accumulatedTextToTextEvent(metadata, block.accumulator)],
+        null,
       ];
     case "reasoning":
       return [
-        converters.accumulatedReasoningToReasoningEvent(
-          metadata,
-          block.accumulator,
-          block.signature || undefined
-        ),
+        [
+          converters.accumulatedReasoningToReasoningEvent(
+            metadata,
+            block.accumulator,
+            block.signature || undefined
+          ),
+        ],
+        null,
       ];
     case "tool_use": {
       const input = block.accumulator;
@@ -588,22 +599,28 @@ export function contentBlockStopToEvents(
         const parsed = safeParseJSON(input);
         if (parsed.isErr()) {
           return [
-            converters.invalidJsonToolCallToToolCallEvent(
-              metadata,
-              block.toolId,
-              block.toolName,
-              input
-            ),
+            [
+              converters.invalidJsonToolCallToToolCallEvent(
+                metadata,
+                block.toolId,
+                block.toolName,
+                input
+              ),
+            ],
+            null,
           ];
         }
       }
       return [
-        converters.accumulatedToolCallToToolCallEvent(
-          metadata,
-          block.toolId,
-          block.toolName,
-          input
-        ),
+        [
+          converters.accumulatedToolCallToToolCallEvent(
+            metadata,
+            block.toolId,
+            block.toolName,
+            input
+          ),
+        ],
+        null,
       ];
     }
     default:
@@ -611,21 +628,21 @@ export function contentBlockStopToEvents(
   }
 }
 
+// Returns the events to emit alongside the latest usage snapshot, so the caller
+// tracks token usage in its own variable instead of us writing into a wrapper.
 export function messageDeltaToEvents(
   event: RawMessageDeltaEvent,
-  tokenUsage: { usage: MessageDeltaUsage | null },
   metadata: EndpointMetadata,
   converters: OutputEventConverters
-): ModelResponseEvent[] {
-  tokenUsage.usage = event.usage;
+): [ModelResponseEvent[], MessageDeltaUsage] {
   const stopReason = event.delta.stop_reason;
   if (stopReason) {
     const errorEvent = converters.stopReasonToErrorEvent(metadata, stopReason);
     if (errorEvent) {
-      return [errorEvent];
+      return [[errorEvent], event.usage];
     }
   }
-  return [];
+  return [[], event.usage];
 }
 
 // -- Entry point: drive the raw stream into unified events --
@@ -636,8 +653,8 @@ export async function* rawOutputToEvents(
   converters: OutputEventConverters
 ): AsyncGenerator<ModelResponseEvent> {
   const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
-  const blockState: { current: BlockState | null } = { current: null };
-  const tokenUsageState: { usage: MessageDeltaUsage | null } = { usage: null };
+  let blockState: BlockState | null = null;
+  let tokenUsage: MessageDeltaUsage | null = null;
 
   while (true) {
     let result: IteratorResult<RawMessageStreamEvent>;
@@ -650,8 +667,8 @@ export async function* rawOutputToEvents(
       const invalidJsonMessage = getInvalidToolJsonMessage(err);
       if (
         invalidJsonMessage !== null &&
-        blockState.current !== null &&
-        blockState.current.type === "tool_use"
+        blockState !== null &&
+        blockState.type === "tool_use"
       ) {
         const invalidJson = invalidJsonMessage.slice(
           invalidJsonMessage.lastIndexOf(INVALID_JSON_MARKER) +
@@ -659,13 +676,13 @@ export async function* rawOutputToEvents(
         );
         const ev = converters.invalidJsonToolCallToToolCallEvent(
           metadata,
-          blockState.current.toolId,
-          blockState.current.toolName,
+          blockState.toolId,
+          blockState.toolName,
           invalidJson
         );
         aggregated.push(ev);
         yield ev;
-        blockState.current = null;
+        blockState = null;
         break;
       }
       // Everything leaving the endpoint is an event: map any other SDK error to
@@ -689,38 +706,49 @@ export async function* rawOutputToEvents(
       case "message_stop":
         outputEvents = [];
         break;
-      case "content_block_start":
-        outputEvents = contentBlockStartToEvents(
+      case "content_block_start": {
+        const [events, nextState] = contentBlockStartToEvents(
           event,
           blockState,
           metadata,
           converters
         );
+        outputEvents = events;
+        blockState = nextState;
         break;
-      case "content_block_delta":
-        outputEvents = contentBlockDeltaToEvents(
+      }
+      case "content_block_delta": {
+        const [events, nextState] = contentBlockDeltaToEvents(
           event,
           blockState,
           metadata,
           converters
         );
+        outputEvents = events;
+        blockState = nextState;
         break;
-      case "content_block_stop":
-        outputEvents = contentBlockStopToEvents(
+      }
+      case "content_block_stop": {
+        const [events, nextState] = contentBlockStopToEvents(
           event,
           blockState,
           metadata,
           converters
         );
+        outputEvents = events;
+        blockState = nextState;
         break;
-      case "message_delta":
-        outputEvents = messageDeltaToEvents(
+      }
+      case "message_delta": {
+        const [events, usage] = messageDeltaToEvents(
           event,
-          tokenUsageState,
           metadata,
           converters
         );
+        outputEvents = events;
+        tokenUsage = usage;
         break;
+      }
       default:
         // Anthropic may add new stream event types before we redeploy; ignore
         // them rather than crashing the stream.
@@ -740,11 +768,8 @@ export async function* rawOutputToEvents(
     }
   }
 
-  if (tokenUsageState.usage !== null) {
-    yield converters.messageDeltaUsageToTokenUsageEvent(
-      metadata,
-      tokenUsageState.usage
-    );
+  if (tokenUsage !== null) {
+    yield converters.messageDeltaUsageToTokenUsageEvent(metadata, tokenUsage);
   }
 
   yield {

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -11,6 +11,7 @@ import type {
 import { parseToolArguments } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
+  ErrorEvent,
   ModelResponseEvent,
   ReasoningDeltaEvent,
   ReasoningEvent,
@@ -22,6 +23,7 @@ import type {
   ToolCallEvent,
   ToolCallStartedEvent,
 } from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
 import {
   assertNever,
   assertNeverAndIgnore,
@@ -151,6 +153,10 @@ export interface OutputEventConverters {
     metadata: EndpointMetadata,
     usage: MessageDeltaUsage
   ): TokenUsageEvent;
+  stopReasonToErrorEvent(
+    metadata: EndpointMetadata,
+    stopReason: string
+  ): ErrorEvent | null;
 }
 
 // -- Leaf converters: one unified event per Anthropic stream signal --
@@ -273,6 +279,29 @@ export function messageDeltaUsageToTokenUsageEvent(
     },
     metadata,
   };
+}
+
+export function stopReasonToErrorEvent(
+  metadata: EndpointMetadata,
+  stopReason: string
+): ErrorEvent | null {
+  switch (stopReason) {
+    case "max_tokens":
+      return buildErrorEvent({
+        metadata,
+        type: "stop_error",
+        message: "The maximum response length was reached.",
+      });
+    case "refusal":
+      return buildErrorEvent({
+        metadata,
+        type: "refusal_error",
+        message:
+          "Claude safety filters prevented this response. Try starting a new conversation or rephrasing your request.",
+      });
+    default:
+      return null;
+  }
 }
 
 // -- Composite state machine: depends on the leaf converters --
@@ -436,10 +465,17 @@ export function contentBlockStopToEvents(
 export function messageDeltaToEvents(
   event: RawMessageDeltaEvent,
   tokenUsage: { usage: MessageDeltaUsage | null },
-  _metadata: EndpointMetadata,
-  _converters: OutputEventConverters
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
 ): ModelResponseEvent[] {
   tokenUsage.usage = event.usage;
+  const stopReason = event.delta.stop_reason;
+  if (stopReason) {
+    const errorEvent = converters.stopReasonToErrorEvent(metadata, stopReason);
+    if (errorEvent) {
+      return [errorEvent];
+    }
+  }
   return [];
 }
 

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -4,6 +4,7 @@ import {
   APIError,
 } from "@anthropic-ai/sdk";
 import type {
+  Message,
   MessageDeltaUsage,
   RawContentBlockDeltaEvent,
   RawContentBlockStartEvent,
@@ -17,6 +18,7 @@ import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoin
 import type {
   ErrorEvent,
   ModelResponseEvent,
+  NonDeltaResponseEvent,
   ReasoningDeltaEvent,
   ReasoningEvent,
   ResponseIdEvent,
@@ -749,4 +751,104 @@ export async function* rawOutputToEvents(
     content: { aggregated },
     metadata,
   };
+}
+
+// -- Non-streaming entry point: complete message → events --
+
+// Turns a completed (non-streaming) Anthropic `Message` into the unified event
+// array, mirroring `rawOutputToEvents` minus the streaming-only delta heartbeats.
+export function messageToEvents(
+  message: Message,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): NonDeltaResponseEvent[] {
+  const events: NonDeltaResponseEvent[] = [];
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+
+  events.push({
+    type: "response_id",
+    content: { responseId: message.id },
+    metadata,
+  });
+
+  message.content.forEach((block, index) => {
+    switch (block.type) {
+      case "text": {
+        const event = converters.accumulatedTextToTextEvent(
+          metadata,
+          block.text
+        );
+        aggregated.push(event);
+        events.push(event);
+        break;
+      }
+      case "thinking": {
+        const event = converters.accumulatedReasoningToReasoningEvent(
+          metadata,
+          block.thinking,
+          block.signature || undefined
+        );
+        aggregated.push(event);
+        events.push(event);
+        break;
+      }
+      case "tool_use": {
+        events.push(
+          converters.toolUseBlockStartToToolCallStartedEvent(
+            metadata,
+            block.id,
+            index,
+            block.name
+          )
+        );
+        // Non-streaming responses carry the input as an already-parsed object;
+        // re-serialize so the shared converter (which parses) handles it.
+        const event = converters.accumulatedToolCallToToolCallEvent(
+          metadata,
+          block.id,
+          block.name,
+          JSON.stringify(block.input)
+        );
+        aggregated.push(event);
+        events.push(event);
+        break;
+      }
+      // Block types we don't surface: redacted thinking, server tools, and
+      // their result / container blocks. Listed explicitly so the default
+      // stays exhaustive.
+      case "redacted_thinking":
+      case "server_tool_use":
+      case "web_search_tool_result":
+      case "web_fetch_tool_result":
+      case "code_execution_tool_result":
+      case "bash_code_execution_tool_result":
+      case "text_editor_code_execution_tool_result":
+      case "tool_search_tool_result":
+      case "container_upload":
+        break;
+      default:
+        // Anthropic may add new block types before we redeploy; ignore them
+        // rather than crashing.
+        assertNeverAndIgnore(block);
+        break;
+    }
+  });
+
+  if (message.stop_reason) {
+    const errorEvent = converters.stopReasonToErrorEvent(
+      metadata,
+      message.stop_reason
+    );
+    if (errorEvent) {
+      events.push(errorEvent);
+    }
+  }
+
+  events.push(
+    converters.messageDeltaUsageToTokenUsageEvent(metadata, message.usage)
+  );
+
+  events.push({ type: "success", content: { aggregated }, metadata });
+
+  return events;
 }

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -1,3 +1,4 @@
+import { AnthropicError, APIError } from "@anthropic-ai/sdk";
 import type {
   RawContentBlockDeltaEvent,
   RawContentBlockStartEvent,
@@ -5,6 +6,7 @@ import type {
   RawMessageStartEvent,
   RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages";
+import { parseToolArguments } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   ModelResponseEvent,
@@ -13,17 +15,88 @@ import type {
   ResponseIdEvent,
   TextDeltaEvent,
   TextEvent,
+  ToolCallDeltaEvent,
   ToolCallEvent,
+  ToolCallStartedEvent,
 } from "@app/lib/model_constructors/types/output/events";
+import {
+  assertNever,
+  assertNeverAndIgnore,
+} from "@app/types/shared/utils/assert_never";
+import { isRecord } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+// Eager input streaming can produce invalid JSON. We validate inputs below this
+// size to avoid spending time parsing very large payloads.
+const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
+const INVALID_JSON_MARKER = "JSON: ";
+const INVALID_TOOL_JSON_NEEDLE = "Unable to parse tool parameter JSON";
+
+// Type guard: APIError carrying the server-side invalid-tool-JSON diagnostic.
+function isApiInvalidToolJsonError(
+  err: unknown
+): err is APIError & { error: { error: { message: string } } } {
+  if (!(err instanceof APIError) || err.type !== "invalid_request_error") {
+    return false;
+  }
+  const body = err.error;
+  if (typeof body !== "object" || body === null || !isRecord(body)) {
+    return false;
+  }
+  const innerError = body.error;
+  if (
+    typeof innerError !== "object" ||
+    innerError === null ||
+    !isRecord(innerError)
+  ) {
+    return false;
+  }
+  const { message } = innerError;
+  return (
+    typeof message === "string" &&
+    message.includes(INVALID_TOOL_JSON_NEEDLE) &&
+    message.includes(INVALID_JSON_MARKER)
+  );
+}
+
+// Type guard: AnthropicError thrown when the SDK fails to parse tool JSON client-side.
+function isAnthropicInvalidToolJsonError(err: unknown): err is AnthropicError {
+  return (
+    err instanceof AnthropicError &&
+    err.message.includes(INVALID_TOOL_JSON_NEEDLE) &&
+    err.message.includes(INVALID_JSON_MARKER)
+  );
+}
+
+// Extracts the "Unable to parse tool parameter JSON" message (ending in
+// `JSON: <raw>`) from either an APIError (server-side) or AnthropicError
+// (client-side), or null if unrelated.
+export function getInvalidToolJsonMessage(err: unknown): string | null {
+  if (isApiInvalidToolJsonError(err)) {
+    return err.error.error.message;
+  }
+  if (isAnthropicInvalidToolJsonError(err)) {
+    return err.message;
+  }
+  return null;
+}
 
 // Cursor for the content block being streamed; deltas accumulate here until
 // `content_block_stop` flushes it as an event.
-export type BlockState = {
-  index: number;
-  accumulator: string;
-  type: "text" | "reasoning";
-  signature?: string;
-};
+export type BlockState =
+  | {
+      index: number;
+      accumulator: string;
+      type: "text" | "reasoning";
+      signature?: string;
+    }
+  | {
+      index: number;
+      accumulator: string;
+      type: "tool_use";
+      toolId: string;
+      toolName: string;
+    };
 
 // The per-signal leaf converters. Composites below take an object satisfying
 // this interface (`this`), so overriding one leaf on an endpoint changes how
@@ -50,6 +123,27 @@ export interface OutputEventConverters {
     text: string,
     signature?: string
   ): ReasoningEvent;
+  toolUseBlockStartToToolCallStartedEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    index: number,
+    name: string
+  ): ToolCallStartedEvent;
+  inputJsonDeltaToToolCallDeltaEvent(
+    metadata: EndpointMetadata
+  ): ToolCallDeltaEvent;
+  accumulatedToolCallToToolCallEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    name: string,
+    argumentsJson: string
+  ): ToolCallEvent;
+  invalidJsonToolCallToToolCallEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    name: string,
+    invalidJson: string
+  ): ToolCallEvent;
 }
 
 // -- Leaf converters: one unified event per Anthropic stream signal --
@@ -101,13 +195,61 @@ export function accumulatedReasoningToReasoningEvent(
   };
 }
 
+export function toolUseBlockStartToToolCallStartedEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  index: number,
+  name: string
+): ToolCallStartedEvent {
+  return {
+    type: "tool_call_started",
+    content: { id, index, name },
+    metadata,
+  };
+}
+
+export function inputJsonDeltaToToolCallDeltaEvent(
+  metadata: EndpointMetadata
+): ToolCallDeltaEvent {
+  return { type: "tool_call_delta", metadata };
+}
+
+export function accumulatedToolCallToToolCallEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  name: string,
+  argumentsJson: string
+): ToolCallEvent {
+  return {
+    type: "tool_call",
+    content: { id, name, arguments: parseToolArguments(argumentsJson) },
+    metadata,
+  };
+}
+
+// Wraps invalid tool-call JSON in `{ INVALID_JSON: ... }` so the agent loop can
+// send it back and let the model self-correct.
+// https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses
+export function invalidJsonToolCallToToolCallEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  name: string,
+  invalidJson: string
+): ToolCallEvent {
+  return {
+    type: "tool_call",
+    content: { id, name, arguments: { INVALID_JSON: invalidJson } },
+    metadata,
+  };
+}
+
 // -- Composite state machine: depends on the leaf converters --
 
 export function contentBlockStartToEvents(
   event: RawContentBlockStartEvent,
   state: { current: BlockState | null },
-  _metadata: EndpointMetadata,
-  _converters: OutputEventConverters
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
 ): ModelResponseEvent[] {
   const block = event.content_block;
   switch (block.type) {
@@ -121,8 +263,39 @@ export function contentBlockStartToEvents(
         type: "reasoning",
       };
       return [];
+    case "tool_use":
+      state.current = {
+        index: event.index,
+        accumulator: "",
+        type: "tool_use",
+        toolId: block.id,
+        toolName: block.name,
+      };
+      return [
+        converters.toolUseBlockStartToToolCallStartedEvent(
+          metadata,
+          block.id,
+          event.index,
+          block.name
+        ),
+      ];
+    // Block types we don't surface: redacted thinking, server tools, and their
+    // result / container blocks. Listed explicitly so the default stays
+    // exhaustive.
+    case "redacted_thinking":
+    case "server_tool_use":
+    case "web_search_tool_result":
+    case "web_fetch_tool_result":
+    case "code_execution_tool_result":
+    case "bash_code_execution_tool_result":
+    case "text_editor_code_execution_tool_result":
+    case "tool_search_tool_result":
+    case "container_upload":
+      return [];
     default:
-      // Other block types are wired in in subsequent commits.
+      // Anthropic may add new block types before we redeploy; ignore them
+      // rather than crashing the stream.
+      assertNeverAndIgnore(block);
       return [];
   }
 }
@@ -149,6 +322,9 @@ export function contentBlockDeltaToEvents(
           delta.thinking
         ),
       ];
+    case "input_json_delta":
+      state.current.accumulator += delta.partial_json;
+      return [converters.inputJsonDeltaToToolCallDeltaEvent(metadata)];
     case "signature_delta":
       if (state.current.type === "reasoning") {
         // Accumulate across deltas: Anthropic may chunk the signature.
@@ -156,8 +332,12 @@ export function contentBlockDeltaToEvents(
           (state.current.signature ?? "") + delta.signature;
       }
       return [];
+    case "citations_delta":
+      return [];
     default:
-      // Other delta types are wired in in subsequent commits.
+      // Anthropic may add new delta types before we redeploy; ignore them
+      // rather than crashing the stream.
+      assertNeverAndIgnore(delta);
       return [];
   }
 }
@@ -186,9 +366,38 @@ export function contentBlockStopToEvents(
           block.signature || undefined
         ),
       ];
+    case "tool_use": {
+      const input = block.accumulator;
+      // With eager_input_streaming enabled, the model may produce invalid JSON.
+      // Validate inputs below a size limit; if invalid, wrap as INVALID_JSON so
+      // the agent loop can self-correct.
+      if (
+        input.length < MAX_EAGER_VALIDATION_INPUT_LENGTH &&
+        input.trim() !== ""
+      ) {
+        const parsed = safeParseJSON(input);
+        if (parsed.isErr()) {
+          return [
+            converters.invalidJsonToolCallToToolCallEvent(
+              metadata,
+              block.toolId,
+              block.toolName,
+              input
+            ),
+          ];
+        }
+      }
+      return [
+        converters.accumulatedToolCallToToolCallEvent(
+          metadata,
+          block.toolId,
+          block.toolName,
+          input
+        ),
+      ];
+    }
     default:
-      // Other block types are wired in in subsequent commits.
-      return [];
+      assertNever(block);
   }
 }
 
@@ -206,7 +415,31 @@ export async function* rawOutputToEvents(
     let result: IteratorResult<RawMessageStreamEvent>;
     try {
       result = await stream.next();
-    } catch {
+    } catch (err) {
+      // On invalid tool JSON aborting the stream, if a tool_use block is in
+      // progress, recover by emitting a tool_call wrapping the invalid JSON so
+      // the agent loop can send it back and let the model self-correct.
+      const invalidJsonMessage = getInvalidToolJsonMessage(err);
+      if (
+        invalidJsonMessage !== null &&
+        blockState.current !== null &&
+        blockState.current.type === "tool_use"
+      ) {
+        const invalidJson = invalidJsonMessage.slice(
+          invalidJsonMessage.lastIndexOf(INVALID_JSON_MARKER) +
+            INVALID_JSON_MARKER.length
+        );
+        const ev = converters.invalidJsonToolCallToToolCallEvent(
+          metadata,
+          blockState.current.toolId,
+          blockState.current.toolName,
+          invalidJson
+        );
+        aggregated.push(ev);
+        yield ev;
+        blockState.current = null;
+        break;
+      }
       // Generic stream-error mapping is wired in in a subsequent commit.
       return;
     }

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -1,8 +1,10 @@
 import { AnthropicError, APIError } from "@anthropic-ai/sdk";
 import type {
+  MessageDeltaUsage,
   RawContentBlockDeltaEvent,
   RawContentBlockStartEvent,
   RawContentBlockStopEvent,
+  RawMessageDeltaEvent,
   RawMessageStartEvent,
   RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages";
@@ -15,6 +17,7 @@ import type {
   ResponseIdEvent,
   TextDeltaEvent,
   TextEvent,
+  TokenUsageEvent,
   ToolCallDeltaEvent,
   ToolCallEvent,
   ToolCallStartedEvent,
@@ -144,6 +147,10 @@ export interface OutputEventConverters {
     name: string,
     invalidJson: string
   ): ToolCallEvent;
+  messageDeltaUsageToTokenUsageEvent(
+    metadata: EndpointMetadata,
+    usage: MessageDeltaUsage
+  ): TokenUsageEvent;
 }
 
 // -- Leaf converters: one unified event per Anthropic stream signal --
@@ -239,6 +246,31 @@ export function invalidJsonToolCallToToolCallEvent(
   return {
     type: "tool_call",
     content: { id, name, arguments: { INVALID_JSON: invalidJson } },
+    metadata,
+  };
+}
+
+export function messageDeltaUsageToTokenUsageEvent(
+  metadata: EndpointMetadata,
+  usage: MessageDeltaUsage
+): TokenUsageEvent {
+  const cacheCreated = usage.cache_creation_input_tokens ?? 0;
+  const cacheHit = usage.cache_read_input_tokens ?? 0;
+  const uncachedInput = usage.input_tokens ?? 0;
+  // thinking_tokens is the reasoning portion of output_tokens; subtracting
+  // yields non-reasoning generation. Null (no breakdown) rolls reasoning into
+  // standardOutput.
+  const thinkingTokens = usage.output_tokens_details?.thinking_tokens ?? 0;
+
+  return {
+    type: "token_usage",
+    content: {
+      cacheCreated,
+      cacheHit,
+      standardInput: uncachedInput,
+      standardOutput: usage.output_tokens - thinkingTokens,
+      reasoning: thinkingTokens,
+    },
     metadata,
   };
 }
@@ -401,6 +433,16 @@ export function contentBlockStopToEvents(
   }
 }
 
+export function messageDeltaToEvents(
+  event: RawMessageDeltaEvent,
+  tokenUsage: { usage: MessageDeltaUsage | null },
+  _metadata: EndpointMetadata,
+  _converters: OutputEventConverters
+): ModelResponseEvent[] {
+  tokenUsage.usage = event.usage;
+  return [];
+}
+
 // -- Entry point: drive the raw stream into unified events --
 
 export async function* rawOutputToEvents(
@@ -410,6 +452,7 @@ export async function* rawOutputToEvents(
 ): AsyncGenerator<ModelResponseEvent> {
   const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
   const blockState: { current: BlockState | null } = { current: null };
+  const tokenUsageState: { usage: MessageDeltaUsage | null } = { usage: null };
 
   while (true) {
     let result: IteratorResult<RawMessageStreamEvent>;
@@ -483,8 +526,18 @@ export async function* rawOutputToEvents(
           converters
         );
         break;
+      case "message_delta":
+        outputEvents = messageDeltaToEvents(
+          event,
+          tokenUsageState,
+          metadata,
+          converters
+        );
+        break;
       default:
-        // Other stream event types are wired in in subsequent commits.
+        // Anthropic may add new stream event types before we redeploy; ignore
+        // them rather than crashing the stream.
+        assertNeverAndIgnore(event);
         outputEvents = [];
     }
 
@@ -498,6 +551,13 @@ export async function* rawOutputToEvents(
       }
       yield outputEvent;
     }
+  }
+
+  if (tokenUsageState.usage !== null) {
+    yield converters.messageDeltaUsageToTokenUsageEvent(
+      metadata,
+      tokenUsageState.usage
+    );
   }
 
   yield {

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -1,4 +1,8 @@
-import { AnthropicError, APIError } from "@anthropic-ai/sdk";
+import {
+  AnthropicError,
+  APIConnectionError,
+  APIError,
+} from "@anthropic-ai/sdk";
 import type {
   MessageDeltaUsage,
   RawContentBlockDeltaEvent,
@@ -157,6 +161,10 @@ export interface OutputEventConverters {
     metadata: EndpointMetadata,
     stopReason: string
   ): ErrorEvent | null;
+  streamErrorToErrorEvent(
+    metadata: EndpointMetadata,
+    error: unknown
+  ): ErrorEvent;
 }
 
 // -- Leaf converters: one unified event per Anthropic stream signal --
@@ -301,6 +309,144 @@ export function stopReasonToErrorEvent(
       });
     default:
       return null;
+  }
+}
+
+function isApiConnectionError(err: unknown): err is APIConnectionError {
+  return err instanceof APIConnectionError;
+}
+
+function isApiError(err: unknown): err is APIError {
+  return err instanceof APIError;
+}
+
+// A stream error classified into the categories we surface. `APIConnectionError`
+// is checked before `APIError` since the former extends the latter.
+type ClassifiedStreamError =
+  | { kind: "invalid_tool_json" }
+  | { kind: "connection"; error: APIConnectionError }
+  | { kind: "api"; error: APIError }
+  | { kind: "unknown" };
+
+function classifyStreamError(error: unknown): ClassifiedStreamError {
+  if (getInvalidToolJsonMessage(error) !== null) {
+    return { kind: "invalid_tool_json" };
+  }
+  if (isApiConnectionError(error)) {
+    return { kind: "connection", error };
+  }
+  if (isApiError(error)) {
+    return { kind: "api", error };
+  }
+  return { kind: "unknown" };
+}
+
+// HTTP status is a number, not a union, so the 5xx range stays an `if` in the
+// default branch.
+function apiErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: APIError
+): ErrorEvent {
+  const status = error.status;
+  switch (status) {
+    case 400:
+    case 422:
+      return buildErrorEvent({
+        metadata,
+        type: "invalid_request_error",
+        message: `Invalid request to Anthropic: ${error.message}`,
+        originalError: error,
+      });
+    case 401:
+      return buildErrorEvent({
+        metadata,
+        type: "authentication_error",
+        message: `Authentication failed for Anthropic: ${error.message}`,
+        originalError: error,
+      });
+    case 403:
+      return buildErrorEvent({
+        metadata,
+        type: "permission_error",
+        message: `Permission denied for Anthropic: ${error.message}`,
+        originalError: error,
+      });
+    case 404:
+      return buildErrorEvent({
+        metadata,
+        type: "not_found_error",
+        message: `Resource not found for Anthropic: ${error.message}`,
+        originalError: error,
+      });
+    case 429:
+      return buildErrorEvent({
+        metadata,
+        type: "rate_limit_error",
+        message: `Rate limit exceeded for Anthropic/${metadata.modelId}: ${error.message}`,
+        originalError: error,
+      });
+    case 503:
+      return buildErrorEvent({
+        metadata,
+        type: "overloaded_error",
+        message: `Anthropic is overloaded: ${error.message}`,
+        originalError: error,
+      });
+    default:
+      if (status !== undefined && status >= 500 && status < 600) {
+        return buildErrorEvent({
+          metadata,
+          type: "server_error",
+          message: `Server error from Anthropic (${status}): ${error.message}`,
+          originalError: error,
+        });
+      }
+
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Error from Anthropic (${status}): ${error.message}`,
+        originalError: error,
+      });
+  }
+}
+
+// Maps any error thrown by the Anthropic SDK while streaming into a unified
+// `ErrorEvent`, so everything leaving the endpoint is an event, not an exception.
+export function streamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  const classified = classifyStreamError(error);
+  switch (classified.kind) {
+    // Invalid tool-call JSON aborted the stream with no tool_use block to
+    // recover from. Surface a distinct, retryable type so the agent loop
+    // re-samples instead of treating it as a terminal invalid_request_error.
+    case "invalid_tool_json":
+      return buildErrorEvent({
+        metadata,
+        type: "model_output_error",
+        message: `Model generated invalid tool call JSON for ${metadata.modelId}.`,
+        originalError: error,
+      });
+    case "connection":
+      return buildErrorEvent({
+        metadata,
+        type: "network_error",
+        message: `Network error connecting to Anthropic: ${classified.error.message}`,
+        originalError: error,
+      });
+    case "api":
+      return apiErrorToErrorEvent(metadata, classified.error);
+    case "unknown":
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Unknown error from Anthropic`,
+        originalError: error,
+      });
+    default:
+      assertNever(classified);
   }
 }
 
@@ -519,7 +665,9 @@ export async function* rawOutputToEvents(
         blockState.current = null;
         break;
       }
-      // Generic stream-error mapping is wired in in a subsequent commit.
+      // Everything leaving the endpoint is an event: map any other SDK error to
+      // a unified error event and terminate the stream rather than throwing.
+      yield converters.streamErrorToErrorEvent(metadata, err);
       return;
     }
     if (result.done) {

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -8,6 +8,7 @@ import type {
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type {
   ModelResponseEvent,
+  ReasoningDeltaEvent,
   ReasoningEvent,
   ResponseIdEvent,
   TextDeltaEvent,
@@ -20,7 +21,8 @@ import type {
 export type BlockState = {
   index: number;
   accumulator: string;
-  type: "text";
+  type: "text" | "reasoning";
+  signature?: string;
 };
 
 // The per-signal leaf converters. Composites below take an object satisfying
@@ -35,10 +37,19 @@ export interface OutputEventConverters {
     metadata: EndpointMetadata,
     delta: string
   ): TextDeltaEvent;
+  reasoningDeltaToReasoningDeltaEvent(
+    metadata: EndpointMetadata,
+    delta: string
+  ): ReasoningDeltaEvent;
   accumulatedTextToTextEvent(
     metadata: EndpointMetadata,
     text: string
   ): TextEvent;
+  accumulatedReasoningToReasoningEvent(
+    metadata: EndpointMetadata,
+    text: string,
+    signature?: string
+  ): ReasoningEvent;
 }
 
 // -- Leaf converters: one unified event per Anthropic stream signal --
@@ -61,11 +72,33 @@ export function textDeltaToTextDeltaEvent(
   return { type: "text_delta", content: { value: delta }, metadata };
 }
 
+export function reasoningDeltaToReasoningDeltaEvent(
+  metadata: EndpointMetadata,
+  delta: string
+): ReasoningDeltaEvent {
+  return { type: "reasoning_delta", content: { value: delta }, metadata };
+}
+
 export function accumulatedTextToTextEvent(
   metadata: EndpointMetadata,
   text: string
 ): TextEvent {
   return { type: "text", content: { value: text }, metadata };
+}
+
+export function accumulatedReasoningToReasoningEvent(
+  metadata: EndpointMetadata,
+  text: string,
+  signature?: string
+): ReasoningEvent {
+  return {
+    type: "reasoning",
+    content: { value: text },
+    metadata: {
+      ...metadata,
+      ...(signature ? { content: { signature } } : {}),
+    },
+  };
 }
 
 // -- Composite state machine: depends on the leaf converters --
@@ -80,6 +113,13 @@ export function contentBlockStartToEvents(
   switch (block.type) {
     case "text":
       state.current = { index: event.index, accumulator: "", type: "text" };
+      return [];
+    case "thinking":
+      state.current = {
+        index: event.index,
+        accumulator: "",
+        type: "reasoning",
+      };
       return [];
     default:
       // Other block types are wired in in subsequent commits.
@@ -101,6 +141,21 @@ export function contentBlockDeltaToEvents(
     case "text_delta":
       state.current.accumulator += delta.text;
       return [converters.textDeltaToTextDeltaEvent(metadata, delta.text)];
+    case "thinking_delta":
+      state.current.accumulator += delta.thinking;
+      return [
+        converters.reasoningDeltaToReasoningDeltaEvent(
+          metadata,
+          delta.thinking
+        ),
+      ];
+    case "signature_delta":
+      if (state.current.type === "reasoning") {
+        // Accumulate across deltas: Anthropic may chunk the signature.
+        state.current.signature =
+          (state.current.signature ?? "") + delta.signature;
+      }
+      return [];
     default:
       // Other delta types are wired in in subsequent commits.
       return [];
@@ -122,6 +177,14 @@ export function contentBlockStopToEvents(
     case "text":
       return [
         converters.accumulatedTextToTextEvent(metadata, block.accumulator),
+      ];
+    case "reasoning":
+      return [
+        converters.accumulatedReasoningToReasoningEvent(
+          metadata,
+          block.accumulator,
+          block.signature || undefined
+        ),
       ];
     default:
       // Other block types are wired in in subsequent commits.

--- a/front/lib/model_constructors/utils/build_error_event.ts
+++ b/front/lib/model_constructors/utils/build_error_event.ts
@@ -1,0 +1,23 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ErrorType,
+} from "@app/lib/model_constructors/types/output/events";
+
+export function buildErrorEvent({
+  metadata,
+  type,
+  message,
+  originalError,
+}: {
+  metadata: EndpointMetadata;
+  type: ErrorType;
+  message: string;
+  originalError?: unknown;
+}): ErrorEvent {
+  return {
+    type: "error",
+    content: { type, message, originalError },
+    metadata,
+  };
+}


### PR DESCRIPTION
## Description

Adds the Anthropic output converter for `model_constructors` — mapping streaming events, completed messages, and batch results into our unified `ModelResponseEvent` stream (stacked on the `anthropic-converters` PR).

## Tests

Not needed — pure conversion logic not yet wired into a live endpoint; type-checks (`tsgo`) and lints (`biome`) clean.

## Risk

None — not yet reachable at runtime.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`