### PR TITLE
Support scope file system paths as template sources

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -65,8 +65,10 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
         .string()
         .max(MAX_FILE_SIZE_BYTES)
         .describe(
-          "When mode='template': the ID of an existing content node to use as a template " +
-            "(e.g., 'template_node_id'). The node's content will be fetched server-side without consuming tokens. " +
+          "When mode='template': a reference to an existing document to use as a template. " +
+            "Accepts either a knowledge base node ID or a scoped file system path " +
+            "(e.g. `pod-<id>/templates/my_template.tsx` or `conversation-<id>/my_template.tsx`). " +
+            "Content is fetched server-side without consuming tokens. " +
             "When mode='inline': the actual content for the Interactive Content file. " +
             "Should be complete and ready for execution or interaction."
         ),

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -8,10 +8,7 @@ import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guard
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { getSkillDataSourceConfigurations } from "@app/lib/api/assistant/skill_actions";
 import config from "@app/lib/api/config";
-import {
-  DustFileSystem,
-  parseScopedPrefix,
-} from "@app/lib/api/file_system";
+import { DustFileSystem, parseScopedPrefix } from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -8,6 +8,10 @@ import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guard
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { getSkillDataSourceConfigurations } from "@app/lib/api/assistant/skill_actions";
 import config from "@app/lib/api/config";
+import {
+  DustFileSystem,
+  parseScopedPrefix,
+} from "@app/lib/api/file_system";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -19,28 +23,104 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const MAX_TEMPLATE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
 
+async function fetchTemplateFromCanonicalPath(
+  auth: Authenticator,
+  runContext: AgentLoopRunContextType,
+  canonicalPath: string
+): Promise<Result<string, MCPError>> {
+  const { conversation } = runContext;
+
+  const fsResult = await DustFileSystem.forAgentLoop(auth, {
+    conversation,
+    scopedPaths: [canonicalPath],
+  });
+  if (fsResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Could not access file system for template path: ${canonicalPath}. Error: ${fsResult.error.message}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const dustFs = fsResult.value;
+
+  const statResult = await dustFs.stat(canonicalPath);
+  if (statResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Could not stat template file: ${canonicalPath}. Error: ${statResult.error.message}`,
+        { tracked: false }
+      )
+    );
+  }
+  if (!statResult.value) {
+    return new Err(
+      new MCPError(
+        `Template file not found: ${canonicalPath}. The file may not exist or may not be accessible.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  if (statResult.value.sizeBytes > MAX_TEMPLATE_SIZE_BYTES) {
+    return new Err(
+      new MCPError(
+        `Template content is too large (${statResult.value.sizeBytes} bytes). Maximum size is ${MAX_TEMPLATE_SIZE_BYTES} bytes.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const readResult = await dustFs.readBuffer(canonicalPath);
+  if (readResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Could not read template file: ${canonicalPath}. Error: ${readResult.error.message}`,
+        { tracked: readResult.error.code === "internal" }
+      )
+    );
+  }
+  if (readResult.value === null) {
+    return new Err(
+      new MCPError(`Template file not found: ${canonicalPath}.`, {
+        tracked: false,
+      })
+    );
+  }
+
+  return new Ok(readResult.value.toString("utf-8"));
+}
+
 /**
- * Fetches template content from a knowledge node using the agent's skills and action data sources.
+ * Fetches template content from a knowledge node (by node ID) or a canonical file system path.
+ *
+ * - Node ID: looks up the document via the Core API across the agent's data sources.
+ * - Canonical path (e.g. `pod-{spaceId}/...` or `conversation-{cId}/...`): reads directly from the DustFileSystem.
  */
 export async function fetchTemplateContent(
   auth: Authenticator,
   runContext: AgentLoopRunContextType,
   {
-    templateNodeId,
+    templateRef,
   }: {
-    templateNodeId: string;
+    templateRef: string;
   }
 ): Promise<Result<string, MCPError>> {
-  // Reject file IDs, we have seen cases where the model confuses file IDs with template node IDs.
-  if (isResourceSId("file", templateNodeId)) {
+  // Reject file IDs, we have seen cases where the model confuses file IDs with template refs.
+  if (isResourceSId("file", templateRef)) {
     return new Err(
       new MCPError(
-        `Invalid template ID: "${templateNodeId}" is a file ID, not a template node ID. ` +
+        `Invalid template reference: "${templateRef}" is a file ID, not a template node ID or canonical path. ` +
           "If the file comes from the conversation, please read it and pass as the `source` " +
           "parameter in `inline` mode.",
         { tracked: false }
       )
     );
+  }
+
+  if (parseScopedPrefix(templateRef)) {
+    return fetchTemplateFromCanonicalPath(auth, runContext, templateRef);
   }
 
   const { agentConfiguration, conversation } = runContext;
@@ -121,7 +201,7 @@ export async function fetchTemplateContent(
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const searchResult = await coreAPI.searchNodes({
     filter: {
-      node_ids: [templateNodeId],
+      node_ids: [templateRef],
       data_source_views: makeCoreSearchNodesFilters({
         agentDataSourceConfigurations,
       }),
@@ -131,7 +211,7 @@ export async function fetchTemplateContent(
   if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
     return new Err(
       new MCPError(
-        `Could not find template node: ${templateNodeId}. ${
+        `Could not find template node: ${templateRef}. ${
           searchResult.isErr()
             ? `Error: ${searchResult.error.message}`
             : "The node may not exist or may not be accessible through the agent's configuration."
@@ -159,7 +239,7 @@ export async function fetchTemplateContent(
   if (!dataSource) {
     return new Err(
       new MCPError(
-        `Could not find data source for template node: ${templateNodeId}`,
+        `Could not find data source for template node: ${templateRef}`,
         { tracked: false }
       )
     );
@@ -174,7 +254,7 @@ export async function fetchTemplateContent(
   if (readResult.isErr()) {
     return new Err(
       new MCPError(
-        `Could not read template node: ${templateNodeId}. Error: ${readResult.error.message}`,
+        `Could not read template node: ${templateRef}. Error: ${readResult.error.message}`,
         { tracked: false }
       )
     );
@@ -184,7 +264,7 @@ export async function fetchTemplateContent(
   if (templateContent.length > MAX_TEMPLATE_SIZE_BYTES) {
     return new Err(
       new MCPError(
-        `Template content is too large (${templateContent.length} bytes). Maximum size is ${MAX_TEMPLATE_SIZE_BYTES} bytes (1MB).`,
+        `Template content is too large (${templateContent.length} bytes). Maximum size is ${MAX_TEMPLATE_SIZE_BYTES} bytes.`,
         { tracked: false }
       )
     );

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -51,7 +51,7 @@ export function createInteractiveContentTools(
 
       if (mode === "template") {
         const templateResult = await fetchTemplateContent(auth, runContext, {
-          templateNodeId: source,
+          templateRef: source,
         });
 
         if (templateResult.isErr()) {

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -63,7 +63,9 @@ type ParsedScopedPrefix =
   | { kind: "conversation"; id: string }
   | { kind: "pod"; id: string };
 
-export function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
+export function parseScopedPrefix(
+  scopedPath: string
+): ParsedScopedPrefix | null {
   const prefix = scopedPath.includes("/")
     ? scopedPath.slice(0, scopedPath.indexOf("/"))
     : scopedPath;

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -63,7 +63,7 @@ type ParsedScopedPrefix =
   | { kind: "conversation"; id: string }
   | { kind: "pod"; id: string };
 
-function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
+export function parseScopedPrefix(scopedPath: string): ParsedScopedPrefix | null {
   const prefix = scopedPath.includes("/")
     ? scopedPath.slice(0, scopedPath.indexOf("/"))
     : scopedPath;
@@ -656,6 +656,38 @@ export class DustFileSystem {
       return resolved;
     }
     return this.backend.read(resolved.value.path);
+  }
+
+  /**
+   * Returns `Ok(null)` when the file does not exist, `Ok(Buffer)` with the full file contents on success.
+   * Returns `Err` for path/permission errors (including `legacy_path`) or stream read errors.
+   */
+  async readBuffer(
+    scopedPath: string
+  ): Promise<Result<Buffer | null, DustFileSystemError>> {
+    const streamResult = await this.read(scopedPath);
+    if (streamResult.isErr()) {
+      return streamResult;
+    }
+    if (streamResult.value === null) {
+      return new Ok(null);
+    }
+
+    const chunks: Buffer[] = [];
+    try {
+      for await (const chunk of streamResult.value) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError(
+          "internal",
+          `Failed to read file content: ${err instanceof Error ? err.message : String(err)}`
+        )
+      );
+    }
+
+    return new Ok(Buffer.concat(chunks));
   }
 
   /**

--- a/front/lib/api/file_system/index.ts
+++ b/front/lib/api/file_system/index.ts
@@ -1,6 +1,7 @@
 export {
   DustFileSystem,
   DustFileSystemError,
+  parseScopedPrefix,
   sanitizeFileSystemName,
 } from "@app/lib/api/file_system/dust_file_system";
 export type {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Templates for interactive content files could previously only reference knowledge base nodes by their node ID. This change also accepts scoped file system paths (`pod-{spaceId}/...` and `conversation-{cId}/...`), allowing templates to live in the file system rather than only in connected data sources. The file is stat-checked for size before reading to avoid unnecessary downloads, and the stream collection logic was moved into the file system layer as a reusable method rather than left as boilerplate at the call site.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
