### PR TITLE
Add: workspace admin settings to control the MCP server.

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -4,6 +4,7 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { validateDustMcpServerAllowedRedirectUris } from "@app/lib/api/mcp_server/dust_mcp_server_settings";
 import type { GetWorkspaceResponseBody } from "@app/lib/api/workspace";
 import { renameWorkspace } from "@app/lib/api/workspace";
 import { hasFeatureFlag } from "@app/lib/auth";
@@ -151,6 +152,14 @@ const WorkspaceExtensionMcpToolsUpdateBodySchema = z.object({
   disableExtensionMcpTools: z.boolean(),
 });
 
+const WorkspaceDustMcpServerSettingsUpdateBodySchema = z.object({
+  dustMcpServerSettings: z.object({
+    disabled: z.boolean(),
+    acceptAllRedirectUris: z.boolean(),
+    allowedRedirectUris: z.array(z.string()),
+  }),
+});
+
 const WorkspaceOpenProjectsUpdateBodySchema = z.object({
   allowOpenProjects: z.boolean(),
 });
@@ -200,6 +209,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceAgentReinforcementUpdateBodySchema,
   WorkspaceReinforcementBatchModeUpdateBodySchema,
   WorkspaceExtensionMcpToolsUpdateBodySchema,
+  WorkspaceDustMcpServerSettingsUpdateBodySchema,
   WorkspaceOpenProjectsUpdateBodySchema,
   WorkspaceManualProjectKnowledgeManagementUpdateBodySchema,
   WorkspaceSandboxAgentEgressRequestsUpdateBodySchema,
@@ -476,6 +486,39 @@ app.post(
       const newMetadata = {
         ...previousMetadata,
         disableExtensionMcpTools: body.disableExtensionMcpTools,
+      };
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+    } else if ("dustMcpServerSettings" in body) {
+      const { dustMcpServerSettings } = body;
+
+      if (
+        !dustMcpServerSettings.disabled &&
+        !dustMcpServerSettings.acceptAllRedirectUris
+      ) {
+        const validation = validateDustMcpServerAllowedRedirectUris(
+          dustMcpServerSettings.allowedRedirectUris
+        );
+        if (validation.isErr()) {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: validation.error.message,
+            },
+          });
+        }
+        dustMcpServerSettings.allowedRedirectUris = validation.value;
+      }
+
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+        dustMcpServerDisabled: dustMcpServerSettings.disabled,
+        dustMcpServerAcceptAllRedirectUris:
+          dustMcpServerSettings.acceptAllRedirectUris,
+        dustMcpServerAllowedRedirectUris:
+          dustMcpServerSettings.allowedRedirectUris,
       };
       await workspace.updateWorkspaceSettings({ metadata: newMetadata });
       owner.metadata = newMetadata;

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -522,6 +522,21 @@ app.post(
       };
       await workspace.updateWorkspaceSettings({ metadata: newMetadata });
       owner.metadata = newMetadata;
+
+      void emitAuditLogEvent({
+        auth,
+        action: "dust_mcp_server.settings_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          disabled: String(dustMcpServerSettings.disabled),
+          accept_all_redirect_uris: String(
+            dustMcpServerSettings.acceptAllRedirectUris
+          ),
+          allowed_redirect_uris:
+            dustMcpServerSettings.allowedRedirectUris.join(","),
+        },
+      });
     } else if ("allowOpenProjects" in body) {
       const previousMetadata = owner.metadata ?? {};
       const newMetadata = {

--- a/front/admin/audit_log_schemas/dust_mcp_server.settings_updated.json
+++ b/front/admin/audit_log_schemas/dust_mcp_server.settings_updated.json
@@ -1,0 +1,13 @@
+{
+  "action": "dust_mcp_server.settings_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    }
+  ],
+  "metadata": {
+    "disabled": "string",
+    "accept_all_redirect_uris": "string",
+    "allowed_redirect_uris": "string"
+  }
+}

--- a/front/components/workspace/DustMcpServerSettingsSheet.tsx
+++ b/front/components/workspace/DustMcpServerSettingsSheet.tsx
@@ -1,0 +1,285 @@
+import type { DustMcpServerSettings } from "@app/lib/api/mcp_server/dust_mcp_server_settings";
+import {
+  normalizeDustMcpServerRedirectUri,
+  validateDustMcpServerRedirectUri,
+} from "@app/lib/api/mcp_server/dust_mcp_server_settings";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import {
+  Button,
+  ContentMessage,
+  Input,
+  Page,
+  Plus,
+  RadioGroup,
+  RadioGroupItem,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Trash01,
+} from "@dust-tt/sparkle";
+import { useEffect, useMemo, useState } from "react";
+
+interface DustMcpServerSettingsSheetProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  settings: DustMcpServerSettings;
+  isSaving: boolean;
+  onSave: (settings: DustMcpServerSettings) => Promise<boolean>;
+}
+
+export function DustMcpServerSettingsSheet({
+  isOpen,
+  onOpenChange,
+  settings,
+  isSaving,
+  onSave,
+}: DustMcpServerSettingsSheetProps) {
+  const { isAdmin } = useAuth();
+  const [draftSettings, setDraftSettings] = useState(settings);
+  const [redirectUriInput, setRedirectUriInput] = useState("");
+  const [wasOpen, setWasOpen] = useState(isOpen);
+
+  useEffect(() => {
+    if (isOpen && !wasOpen) {
+      setDraftSettings(settings);
+      setRedirectUriInput("");
+    }
+    setWasOpen(isOpen);
+  }, [isOpen, wasOpen, settings]);
+
+  const redirectUriValidation = useMemo(() => {
+    if (!redirectUriInput.trim()) {
+      return null;
+    }
+    return validateDustMcpServerRedirectUri(redirectUriInput);
+  }, [redirectUriInput]);
+
+  const normalizedRedirectUri =
+    redirectUriValidation?.isOk() === true ? redirectUriValidation.value : null;
+  const isDuplicateRedirectUri =
+    normalizedRedirectUri !== null &&
+    draftSettings.allowedRedirectUris.includes(normalizedRedirectUri);
+  const redirectUriInputMessage =
+    redirectUriValidation?.isErr() === true
+      ? redirectUriValidation.error.message
+      : isDuplicateRedirectUri
+        ? "This redirect URI is already in the list."
+        : normalizedRedirectUri
+          ? `Will be saved as ${normalizedRedirectUri}.`
+          : "Use a full redirect URI such as https://example.com/oauth/callback.";
+  const isRedirectUriInputInvalid =
+    redirectUriValidation?.isErr() === true || isDuplicateRedirectUri;
+  const canAddRedirectUri =
+    normalizedRedirectUri !== null &&
+    !isDuplicateRedirectUri &&
+    !isSaving &&
+    isAdmin;
+
+  const isDirty =
+    draftSettings.acceptAllRedirectUris !== settings.acceptAllRedirectUris ||
+    draftSettings.allowedRedirectUris.join("\n") !==
+      settings.allowedRedirectUris.join("\n");
+
+  const handleAddRedirectUri = () => {
+    if (!canAddRedirectUri || normalizedRedirectUri === null) {
+      return;
+    }
+
+    setDraftSettings((current) => ({
+      ...current,
+      allowedRedirectUris: [
+        ...current.allowedRedirectUris,
+        normalizedRedirectUri,
+      ],
+    }));
+    setRedirectUriInput("");
+  };
+
+  const handleRemoveRedirectUri = (uri: string) => {
+    setDraftSettings((current) => ({
+      ...current,
+      allowedRedirectUris: current.allowedRedirectUris.filter(
+        (existingUri) => existingUri !== uri
+      ),
+    }));
+  };
+
+  const handleSave = async () => {
+    if (!isAdmin) {
+      return;
+    }
+
+    if (
+      !draftSettings.acceptAllRedirectUris &&
+      draftSettings.allowedRedirectUris.length === 0
+    ) {
+      return;
+    }
+
+    const success = await onSave({
+      ...settings,
+      acceptAllRedirectUris: draftSettings.acceptAllRedirectUris,
+      allowedRedirectUris: draftSettings.allowedRedirectUris,
+    });
+    if (success) {
+      onOpenChange(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (isSaving) {
+      return;
+    }
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          handleClose();
+        }
+      }}
+    >
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>Redirect URIs</SheetTitle>
+        </SheetHeader>
+        <SheetContainer>
+          <Page.Vertical align="stretch" gap="lg">
+            {!isAdmin && (
+              <ContentMessage variant="info" size="lg">
+                Only workspace admins can manage MCP server settings.
+              </ContentMessage>
+            )}
+
+            <RadioGroup
+              value={draftSettings.acceptAllRedirectUris ? "all" : "allowlist"}
+              onValueChange={(value) => {
+                setDraftSettings((current) => ({
+                  ...current,
+                  acceptAllRedirectUris: value === "all",
+                }));
+              }}
+              className="flex flex-col gap-4"
+            >
+              <div className="flex flex-col gap-1">
+                <RadioGroupItem
+                  value="all"
+                  id="dust-mcp-redirect-uri-policy-all"
+                  label="Accept all redirect URIs"
+                  disabled={!isAdmin || isSaving}
+                />
+                <Page.P variant="secondary">
+                  Any redirect URI requested during OAuth will be allowed.
+                </Page.P>
+              </div>
+              <div className="flex flex-col gap-1">
+                <RadioGroupItem
+                  value="allowlist"
+                  id="dust-mcp-redirect-uri-policy-allowlist"
+                  label="Allowlisted redirect URIs only"
+                  disabled={!isAdmin || isSaving}
+                />
+                <Page.P variant="secondary">
+                  Only the redirect URIs listed below will be accepted.
+                </Page.P>
+              </div>
+            </RadioGroup>
+
+            {!draftSettings.acceptAllRedirectUris && (
+              <Page.Vertical align="stretch" gap="md">
+                <form
+                  className="flex flex-col gap-3 sm:flex-row sm:items-start"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    handleAddRedirectUri();
+                  }}
+                >
+                  <div className="grow">
+                    <Input
+                      label="Redirect URI"
+                      name="redirectUri"
+                      placeholder="https://example.com/oauth/callback"
+                      value={redirectUriInput}
+                      message={redirectUriInputMessage}
+                      messageStatus={
+                        isRedirectUriInputInvalid ? "error" : "info"
+                      }
+                      onChange={(event) =>
+                        setRedirectUriInput(
+                          normalizeDustMcpServerRedirectUri(event.target.value)
+                        )
+                      }
+                      disabled={!isAdmin || isSaving}
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    label="Add URI"
+                    icon={Plus}
+                    disabled={!canAddRedirectUri}
+                    isLoading={isSaving}
+                    className="mt-0 sm:mt-7"
+                  />
+                </form>
+
+                {draftSettings.allowedRedirectUris.length === 0 ? (
+                  <ContentMessage variant="outline" size="lg">
+                    Add at least one redirect URI before saving.
+                  </ContentMessage>
+                ) : (
+                  <div className="flex w-full flex-col divide-y divide-separator dark:divide-separator-night">
+                    {draftSettings.allowedRedirectUris.map((uri) => (
+                      <div key={uri} className="flex items-center gap-3 py-3">
+                        <pre
+                          title={uri}
+                          className="min-w-0 grow overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2 text-sm text-foreground dark:bg-muted-background-night dark:text-foreground-night"
+                        >
+                          {uri}
+                        </pre>
+                        <Button
+                          variant="warning"
+                          size="mini"
+                          icon={Trash01}
+                          tooltip={`Remove ${uri}`}
+                          disabled={!isAdmin || isSaving}
+                          onClick={() => handleRemoveRedirectUri(uri)}
+                          className="shrink-0"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Page.Vertical>
+            )}
+          </Page.Vertical>
+        </SheetContainer>
+        <SheetFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: handleClose,
+            disabled: isSaving,
+          }}
+          rightButtonProps={{
+            label: isSaving ? "Saving..." : "Save",
+            onClick: () => {
+              void handleSave();
+            },
+            disabled:
+              !isAdmin ||
+              isSaving ||
+              !isDirty ||
+              (!draftSettings.acceptAllRedirectUris &&
+                draftSettings.allowedRedirectUris.length === 0),
+          }}
+        />
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/workspace/settings/CapabilitiesSection.tsx
+++ b/front/components/workspace/settings/CapabilitiesSection.tsx
@@ -1,4 +1,5 @@
 import { AuditLogsToggle } from "@app/components/workspace/settings/AuditLogsToggle";
+import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/DustMcpServerSettingsItem";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharingToggle } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
 import { OpenProjectsPolicy } from "@app/components/workspace/settings/OpenProjectsPolicy";
@@ -37,6 +38,7 @@ export function CapabilitiesSection({
         <ProjectKnowledgePolicy owner={owner} />
         <EmailAgentsToggle owner={owner} />
         <PrivateConversationUrlsToggle owner={owner} />
+        <DustMcpServerSettingsItem owner={owner} />
         {hasAuditLogsAccess && <AuditLogsToggle owner={owner} />}
         {publishingRestrictionMessage && (
           <RestrictAgentsPublishingCapability

--- a/front/components/workspace/settings/DustMcpServerSettingsItem.tsx
+++ b/front/components/workspace/settings/DustMcpServerSettingsItem.tsx
@@ -1,0 +1,92 @@
+import { DustMcpServerSettingsSheet } from "@app/components/workspace/DustMcpServerSettingsSheet";
+import { useDustMcpServerSettings } from "@app/hooks/useDustMcpServerSettings";
+import { getMcpResourceServerUrlForClient } from "@app/lib/api/mcp_server/urls";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContextItem,
+  Server01,
+  Settings01,
+  SliderToggle,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+interface DustMcpServerSettingsItemProps {
+  owner: WorkspaceType;
+}
+
+export function DustMcpServerSettingsItem({
+  owner,
+}: DustMcpServerSettingsItemProps) {
+  const { isAdmin } = useAuth();
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const { settings, isSaving, saveSettings } = useDustMcpServerSettings({
+    owner,
+  });
+  const isEnabled = !settings.disabled;
+  const mcpServerUrl = getMcpResourceServerUrlForClient();
+
+  useEffect(() => {
+    if (settings.disabled) {
+      setIsSheetOpen(false);
+    }
+  }, [settings.disabled]);
+
+  const handleToggleEnabled = async () => {
+    await saveSettings({
+      ...settings,
+      disabled: isEnabled,
+    });
+  };
+
+  return (
+    <>
+      <ContextItem
+        title="MCP server"
+        subElement={
+          <>
+            Allow external MCP clients to connect to this workspace via{" "}
+            <b>{mcpServerUrl}</b>.
+          </>
+        }
+        visual={<Server01 className="h-6 w-6" />}
+        truncateSubElement={true}
+        hasSeparatorIfLast={true}
+        action={
+          <div className="flex shrink-0 items-center gap-2">
+            {isEnabled && (
+              <Button
+                label="Manage"
+                size="xs"
+                variant="outline"
+                icon={Settings01}
+                disabled={!isAdmin || isSaving}
+                tooltip={
+                  !isAdmin
+                    ? "Only workspace admins can manage MCP server settings."
+                    : undefined
+                }
+                onClick={() => setIsSheetOpen(true)}
+              />
+            )}
+            <SliderToggle
+              selected={isEnabled}
+              disabled={!isAdmin || isSaving}
+              onClick={() => {
+                void handleToggleEnabled();
+              }}
+            />
+          </div>
+        }
+      />
+      <DustMcpServerSettingsSheet
+        isOpen={isSheetOpen}
+        onOpenChange={setIsSheetOpen}
+        settings={settings}
+        isSaving={isSaving}
+        onSave={saveSettings}
+      />
+    </>
+  );
+}

--- a/front/hooks/useDustMcpServerSettings.ts
+++ b/front/hooks/useDustMcpServerSettings.ts
@@ -1,0 +1,70 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { DustMcpServerSettings } from "@app/lib/api/mcp_server/dust_mcp_server_settings";
+import { getDustMcpServerSettingsFromMetadata } from "@app/lib/api/mcp_server/dust_mcp_server_settings";
+import { clientFetch } from "@app/lib/egress/client";
+import { useAuthContext } from "@app/lib/swr/workspaces";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useEffect, useState } from "react";
+
+interface UseDustMcpServerSettingsProps {
+  owner: LightWorkspaceType;
+}
+
+export function useDustMcpServerSettings({
+  owner,
+}: UseDustMcpServerSettingsProps) {
+  const sendNotification = useSendNotification();
+  const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
+  const [settings, setSettings] = useState<DustMcpServerSettings>(() =>
+    getDustMcpServerSettingsFromMetadata(owner.metadata)
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setSettings(getDustMcpServerSettingsFromMetadata(owner.metadata));
+  }, [owner.metadata]);
+
+  const saveSettings = async (
+    nextSettings: DustMcpServerSettings
+  ): Promise<boolean> => {
+    setIsSaving(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          dustMcpServerSettings: nextSettings,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to update Dust MCP server settings");
+      }
+
+      setSettings(nextSettings);
+      // Revalidation is best-effort; failure does not mean the save failed.
+      await mutateAuthContext().catch(() => {
+        // Non-critical — settings will sync on next navigation.
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update Dust MCP server settings",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    settings,
+    isSaving,
+    saveSettings,
+  };
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -26,6 +26,7 @@
   "domain.verification_failed": 2,
   "domain.verified": 2,
   "dsync.connection_deleted": 3,
+  "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
   "invitation.revoked": 3,
   "invitation.role_updated": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -61,6 +61,7 @@ export const AUDIT_ACTIONS = [
   "credentials.revoked",
   "credentials.invalidated",
   // MCP Connections.
+  "dust_mcp_server.settings_updated",
   "mcp_connection.created",
   "mcp_connection.deleted",
   // Projects.

--- a/front/lib/api/mcp_server/dust_mcp_server_settings.test.ts
+++ b/front/lib/api/mcp_server/dust_mcp_server_settings.test.ts
@@ -1,0 +1,40 @@
+import {
+  DEFAULT_DUST_MCP_SERVER_ALLOWED_REDIRECT_URIS,
+  getDustMcpServerSettingsFromMetadata,
+  validateDustMcpServerAllowedRedirectUris,
+  validateDustMcpServerRedirectUri,
+} from "@app/lib/api/mcp_server/dust_mcp_server_settings";
+import { describe, expect, it } from "vitest";
+
+describe("dust_mcp_server_settings", () => {
+  it("returns defaults when metadata is unset", () => {
+    expect(getDustMcpServerSettingsFromMetadata(undefined)).toEqual({
+      disabled: false,
+      acceptAllRedirectUris: true,
+      allowedRedirectUris: [...DEFAULT_DUST_MCP_SERVER_ALLOWED_REDIRECT_URIS],
+    });
+  });
+
+  it("validates redirect URIs", () => {
+    expect(
+      validateDustMcpServerRedirectUri(
+        "https://www.cursor.com/agents/mcp/oauth/callback"
+      ).isOk()
+    ).toBe(true);
+    expect(
+      validateDustMcpServerRedirectUri(
+        "cursor://anysphere.cursor-mcp/oauth/callback"
+      ).isOk()
+    ).toBe(true);
+    expect(validateDustMcpServerRedirectUri("not-a-uri").isErr()).toBe(true);
+  });
+
+  it("rejects duplicate redirect URIs", () => {
+    const result = validateDustMcpServerAllowedRedirectUris([
+      "http://localhost:*",
+      "http://localhost:*",
+    ]);
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/mcp_server/dust_mcp_server_settings.ts
+++ b/front/lib/api/mcp_server/dust_mcp_server_settings.ts
@@ -80,6 +80,7 @@ export function validateDustMcpServerAllowedRedirectUris(
   allowedRedirectUris: string[]
 ): Result<string[], Error> {
   const normalizedUris: string[] = [];
+  const seenUris = new Set<string>();
 
   for (const uri of allowedRedirectUris) {
     const validation = validateDustMcpServerRedirectUri(uri);
@@ -87,10 +88,11 @@ export function validateDustMcpServerAllowedRedirectUris(
       return validation;
     }
 
-    if (normalizedUris.includes(validation.value)) {
+    if (seenUris.has(validation.value)) {
       return new Err(new Error(`Duplicate redirect URI: ${validation.value}`));
     }
 
+    seenUris.add(validation.value);
     normalizedUris.push(validation.value);
   }
 

--- a/front/lib/api/mcp_server/dust_mcp_server_settings.ts
+++ b/front/lib/api/mcp_server/dust_mcp_server_settings.ts
@@ -1,0 +1,98 @@
+import type { WorkspaceMetadata } from "@app/lib/api/workspace";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const DEFAULT_DUST_MCP_SERVER_ALLOWED_REDIRECT_URIS = [
+  "http://localhost:*",
+  "http://127.0.0.1:*",
+  // "cursor://anysphere.cursor-mcp/oauth/callback",
+  // "https://www.cursor.com/agents/mcp/oauth/callback",
+] as const;
+
+export type DustMcpServerRedirectUriPolicy = "all" | "allowlist";
+
+export interface DustMcpServerSettings {
+  disabled: boolean;
+  acceptAllRedirectUris: boolean;
+  allowedRedirectUris: string[];
+}
+
+export function isDustMcpServerEnabled(
+  metadata?: WorkspaceMetadata | null
+): boolean {
+  return metadata?.dustMcpServerDisabled !== true;
+}
+
+export function getDustMcpServerRedirectUriPolicy(
+  metadata?: WorkspaceMetadata | null
+): DustMcpServerRedirectUriPolicy {
+  if (metadata?.dustMcpServerAcceptAllRedirectUris === false) {
+    return "allowlist";
+  }
+  return "all";
+}
+
+export function getDustMcpServerAllowedRedirectUris(
+  metadata?: WorkspaceMetadata | null
+): string[] {
+  return (
+    metadata?.dustMcpServerAllowedRedirectUris ?? [
+      ...DEFAULT_DUST_MCP_SERVER_ALLOWED_REDIRECT_URIS,
+    ]
+  );
+}
+
+export function getDustMcpServerSettingsFromMetadata(
+  metadata?: WorkspaceMetadata | null
+): DustMcpServerSettings {
+  return {
+    disabled: !isDustMcpServerEnabled(metadata),
+    acceptAllRedirectUris:
+      getDustMcpServerRedirectUriPolicy(metadata) === "all",
+    allowedRedirectUris: getDustMcpServerAllowedRedirectUris(metadata),
+  };
+}
+
+export function normalizeDustMcpServerRedirectUri(uri: string): string {
+  return uri.trim();
+}
+
+export function validateDustMcpServerRedirectUri(
+  uri: string
+): Result<string, Error> {
+  const normalized = normalizeDustMcpServerRedirectUri(uri);
+  if (!normalized) {
+    return new Err(new Error("Redirect URI cannot be empty."));
+  }
+
+  if (!/^[a-z][a-z0-9+.-]*:\/\/.+/i.test(normalized)) {
+    return new Err(
+      new Error(
+        "Redirect URI must include a scheme (for example http://, https://, or cursor://)."
+      )
+    );
+  }
+
+  return new Ok(normalized);
+}
+
+export function validateDustMcpServerAllowedRedirectUris(
+  allowedRedirectUris: string[]
+): Result<string[], Error> {
+  const normalizedUris: string[] = [];
+
+  for (const uri of allowedRedirectUris) {
+    const validation = validateDustMcpServerRedirectUri(uri);
+    if (validation.isErr()) {
+      return validation;
+    }
+
+    if (normalizedUris.includes(validation.value)) {
+      return new Err(new Error(`Duplicate redirect URI: ${validation.value}`));
+    }
+
+    normalizedUris.push(validation.value);
+  }
+
+  return new Ok(normalizedUris);
+}

--- a/front/lib/api/mcp_server/urls.ts
+++ b/front/lib/api/mcp_server/urls.ts
@@ -39,6 +39,11 @@ export function getMcpResourceServerUrl(): string {
   );
 }
 
+/** MCP server URL safe to display in client UI (uses public API base URL). */
+export function getMcpResourceServerUrlForClient(): string {
+  return normalizeOAuthUrl(`${config.getApiBaseUrl().trim()}/mcp`);
+}
+
 export function getMcpResourceMetadataUrl(resourceServerUrl: string): URL {
   const url = new URL(resourceServerUrl);
   return new URL(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -551,6 +551,9 @@ export interface WorkspaceMetadata {
   autoCreateSpaceForProvisionedGroups?: boolean;
   disableManualInvitations?: boolean;
   disableExtensionMcpTools?: boolean;
+  dustMcpServerDisabled?: boolean;
+  dustMcpServerAcceptAllRedirectUris?: boolean;
+  dustMcpServerAllowedRedirectUris?: string[];
   disableAuditLogs?: boolean;
   isBusiness?: boolean;
   phoneCountry?: string;

--- a/sparkle/src/components/RadioGroup.tsx
+++ b/sparkle/src/components/RadioGroup.tsx
@@ -113,7 +113,15 @@ const RadioGroupItem = React.forwardRef<
           item
         )}
         {icon && renderIcon(icon)}
-        <Label htmlFor={id} {...labelProps}>
+        <Label
+          htmlFor={id}
+          {...labelProps}
+          className={cn(
+            "s-cursor-pointer",
+            props.disabled && "s-cursor-not-allowed s-opacity-70",
+            labelProps?.className
+          )}
+        >
           {label}
         </Label>
       </div>


### PR DESCRIPTION
## Description

Adds a new **MCP server** section to the workspace admin settings (Capabilities tab) that lets admins enable/disable the Dust MCP server and configure its OAuth redirect URI policy.

- `DustMcpServerSettings` (`disabled`, `acceptAllRedirectUris`, `allowedRedirectUris`) stored in `WorkspaceMetadata` as `dustMcpServerDisabled`, `dustMcpServerAcceptAllRedirectUris`, `dustMcpServerAllowedRedirectUris`.
- `DustMcpServerSettingsItem` renders a toggle in the Capabilities section; a "Manage" button opens `DustMcpServerSettingsSheet` to configure redirect URI policy (accept all vs. allowlist with add/remove).
- `useDustMcpServerSettings` hook handles optimistic state and saves via `POST /api/w/:wId` with the new `dustMcpServerSettings` body branch; server-side validates and normalizes the URI list via `validateDustMcpServerAllowedRedirectUris`.
- Default allowed URIs: `http://localhost:*` and `http://127.0.0.1:*`.
- `getMcpResourceServerUrlForClient()` exposes the public MCP URL for display.
- Minor sparkle fix: `RadioGroupItem` label now applies `cursor-pointer` / `cursor-not-allowed` based on `disabled` state.

<img width="1135" height="472" alt="image" src="https://github.com/user-attachments/assets/22c0a442-456b-4206-8b8c-9cfe28a2a37f" />
<img width="589" height="661" alt="image" src="https://github.com/user-attachments/assets/e7dd9890-b8df-4e0b-bb7c-e31ed957f38d" />


## Tests

- Added unit tests in `dust_mcp_server_settings.test.ts` covering default metadata parsing, individual URI validation, and duplicate URI rejection.
- Tested locally: toggle enable/disable, add/remove URIs, save with validation errors.

## Risk

Low. Front-only changes; settings are stored in existing `WorkspaceMetadata` (no schema migration). New fields are optional and default to safe values (MCP enabled, accept-all redirect URIs). Rollback is safe — missing metadata fields fall back to defaults.

## Deploy Plan

Deploy front.
