### PR TITLE
Apply workspace Dust MCP settings in MCP server and fix sticky auth.

### DIFF
--- a/front-api/middlewares/request_logger.ts
+++ b/front-api/middlewares/request_logger.ts
@@ -99,7 +99,8 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
     const auth = c.get("auth");
     const session = c.get("session");
     const streaming = c.get("streaming") ?? false;
-    const user = auth?.user();
+    const user =
+      auth && typeof auth.user === "function" ? auth.user() : undefined;
 
     const tags = [
       `method:${c.req.method}`,
@@ -125,7 +126,10 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
         streaming,
         url: c.req.path,
         ...(user ? { user: { sId: user.sId } } : {}),
-        workspaceId: auth?.workspace()?.sId,
+        workspaceId:
+          auth && typeof auth.workspace === "function"
+            ? auth.workspace()?.sId
+            : undefined,
       },
       "Processed request"
     );

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -82,8 +82,6 @@ export function apiError(
  * throughput / latency metrics.
  */
 export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
-  // console log the stack trace
-  console.log(err.stack);
   // Hono throws `HTTPException` for client-facing errors raised inside the app
   // before our handlers run — most notably the JSON body parse failure in
   // `@hono/zod-validator` ("Malformed JSON in request body"). These are client

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -82,6 +82,8 @@ export function apiError(
  * throughput / latency metrics.
  */
 export const unhandledErrorHandler: ErrorHandler = (err, ctx) => {
+  // console log the stack trace
+  console.log(err.stack);
   // Hono throws `HTTPException` for client-facing errors raised inside the app
   // before our handlers run — most notably the JSON body parse failure in
   // `@hono/zod-validator` ("Malformed JSON in request body"). These are client

--- a/front-api/routes/mcp/index.ts
+++ b/front-api/routes/mcp/index.ts
@@ -1,26 +1,89 @@
 import { mcpServerAuthMiddleware } from "@app/lib/api/mcp_server/auth";
-import { runWithMcpContext } from "@app/lib/api/mcp_server/context";
-import { createDustMcpServer } from "@app/lib/api/mcp_server/server";
+import { buildMcpAuthInfo } from "@app/lib/api/mcp_server/context";
 import logger from "@app/logger/logger";
 import { createHono } from "@front-api/lib/hono";
-import { StreamableHTTPTransport } from "@hono/mcp";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { Context } from "hono";
 
-const dustMcpServer = createDustMcpServer();
-const transport = new StreamableHTTPTransport();
+import { createMcpSession, getMcpSession } from "./sessions";
 
 export const mcpApp = createHono();
 
+function extractBearerToken(authHeader: string | undefined): string | null {
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+  return token ? token : null;
+}
+
+// @hono/mcp reads ctx.get("auth") as MCP AuthInfo. Use a dedicated setter so we
+// do not clobber the Dust Authenticator that request_logger expects on "auth".
+function setMcpTransportAuth(c: Context, authInfo: AuthInfo): void {
+  c.set("auth", authInfo as never);
+}
+
+function clearMcpTransportAuth(c: Context): void {
+  c.set("auth", undefined as never);
+}
+
 // POST, GET, DELETE /mcp — all MCP protocol traffic from remote clients.
 mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
-  if (!dustMcpServer.isConnected()) {
-    await dustMcpServer.connect(transport);
+  const auth = c.get("mcpAuth");
+  const token = extractBearerToken(c.req.header("Authorization"));
+  if (!token) {
+    return c.json({ error: "unauthorized" }, 401);
   }
 
-  const auth = c.get("mcpAuth");
+  const sessionIdHeader = c.req.header("mcp-session-id");
+  let parsedBody: unknown | undefined;
+
+  let session = sessionIdHeader ? getMcpSession(sessionIdHeader) : undefined;
+
+  if (!session) {
+    if (c.req.method !== "POST") {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "Bad Request: No valid MCP session",
+        },
+        400
+      );
+    }
+
+    parsedBody = await c.req.json();
+    const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+    if (!messages.some(isInitializeRequest)) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description:
+            "Bad Request: Mcp-Session-Id header is required after initialization",
+        },
+        400
+      );
+    }
+
+    session = await createMcpSession();
+  }
+
   logger.info(
-    { userId: auth.user().sId, workspaceId: auth.workspace().sId },
+    {
+      userId: auth.user().sId,
+      workspaceId: auth.workspace().sId,
+      sessionId: sessionIdHeader ?? session.sessionId,
+      method: c.req.method,
+    },
     "[dust-mcp-server] Inbound request"
   );
 
-  return runWithMcpContext({ auth }, () => transport.handleRequest(c));
+  const mcpAuthInfo = buildMcpAuthInfo(auth, token);
+
+  setMcpTransportAuth(c, mcpAuthInfo);
+  try {
+    return await (parsedBody !== undefined
+      ? session!.transport.handleRequest(c, parsedBody)
+      : session!.transport.handleRequest(c));
+  } finally {
+    clearMcpTransportAuth(c);
+  }
 });

--- a/front-api/routes/mcp/sessions.ts
+++ b/front-api/routes/mcp/sessions.ts
@@ -1,0 +1,64 @@
+import { randomUUID } from "node:crypto";
+
+import { createDustMcpServer } from "@app/lib/api/mcp_server/server";
+import { StreamableHTTPTransport } from "@hono/mcp";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export type McpSession = {
+  sessionId: string | null;
+  transport: StreamableHTTPTransport;
+  server: McpServer;
+};
+
+const sessions = new Map<string, McpSession>();
+
+export function getMcpSession(sessionId: string): McpSession | undefined {
+  return sessions.get(sessionId);
+}
+
+export async function deleteMcpSession(sessionId: string): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+
+  sessions.delete(sessionId);
+  try {
+    await session.server.close();
+  } catch {
+    // Ignore double-close races when transport hooks fire more than once.
+  }
+}
+
+export async function createMcpSession(): Promise<McpSession> {
+  const server = createDustMcpServer();
+  let session: McpSession | null = null;
+
+  const transport = new StreamableHTTPTransport({
+    sessionIdGenerator: () => randomUUID(),
+    onsessioninitialized: (sessionId: string) => {
+      if (!session) {
+        return;
+      }
+      session.sessionId = sessionId;
+      sessions.set(sessionId, session);
+    },
+  });
+
+  session = {
+    sessionId: null,
+    transport,
+    server,
+  };
+
+  transport.onclose = () => {
+    const sessionId = transport.sessionId;
+    if (sessionId) {
+      void deleteMcpSession(sessionId);
+    }
+  };
+
+  await server.connect(transport);
+
+  return session;
+}

--- a/front/lib/api/mcp_server/README.md
+++ b/front/lib/api/mcp_server/README.md
@@ -19,7 +19,7 @@ HTTP entrypoints live in `front-api/routes/mcp/`. This folder holds the auth and
 | Tool definitions | `tools/` (registered from `server.ts`; grouped under `tools/agents/`, `tools/conversations/`, `tools/pods/`, `tools/search/`, `tools/files/`) |
 | Token verification | `auth.ts` |
 | User + workspace resolution from the token | `authenticator.ts` |
-| How tools access per-request auth | `context.ts` |
+| How tools access per-request auth | `context.ts`, `tools/register.ts` |
 | URLs, env vars, AuthKit domain | `urls.ts` |
 
 ## Key concepts (stable)
@@ -28,11 +28,13 @@ HTTP entrypoints live in `front-api/routes/mcp/`. This folder holds the auth and
 
 **Tools use a standard `Authenticator`.** Once auth is resolved, tool code should look like any other Dust backend code that receives an `Authenticator` — same permissions, same APIs.
 
-**The MCP server is a singleton.** Per-request state (the `Authenticator`) is threaded separately from tool registration. See `context.ts` and the route handler in `front-api/routes/mcp/index.ts`.
+**Each MCP client session gets its own transport.** On each HTTP request, auth middleware builds a fresh `authInfo` (with the Dust `Authenticator` in `extra`) that `@hono/mcp` passes to tool handlers.
+
+**Tools use `registerDustMcpTool`.** Handlers receive `(auth, args)`; the wrapper reads auth from `extra.authInfo`.
 
 ## Adding a tool
 
-Add a file under `tools/` and register it in `tools/index.ts`. Use `getAuthenticatorFromMcpContext()` to access the scoped auth inside handlers. MCP clients cache tool lists — reconnect after adding or renaming tools.
+Add a file under `tools/` and register it with `registerDustMcpTool` in `tools/index.ts`. Handlers receive `(auth, args)`. MCP clients cache tool lists — reconnect after adding or renaming tools.
 
 ## Local dev & config
 

--- a/front/lib/api/mcp_server/auth.ts
+++ b/front/lib/api/mcp_server/auth.ts
@@ -1,16 +1,21 @@
 import {
+  areRedirectUrisAllowed,
+  getDustMcpServerAllowedRedirectUris,
+  getDustMcpServerRedirectUriPolicy,
+  isDustMcpServerEnabled,
+} from "@app/lib/api/mcp_server/dust_mcp_server_settings";
+import {
   getMcpResourceMetadataUrl,
   getMcpResourceServerUrl,
   getWorkOSAuthKitDomain,
   normalizeOAuthUrl,
 } from "@app/lib/api/mcp_server/urls";
-import type { WorkOSJwtPayload } from "@app/lib/api/workos";
+import { getWorkOSConnectApplication } from "@app/lib/api/workos";
 import {
   getAuthenticatorFromWorkOSClaims,
   type WorkOSWorkspaceAuthenticator,
 } from "@app/lib/api/workos_authenticator";
 import logger from "@app/logger/logger";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import {
@@ -21,8 +26,6 @@ import {
 } from "jose";
 
 export type McpServerAuthVariables = {
-  mcpUser: WorkOSJwtPayload;
-  mcpAuthInfo: AuthInfo;
   mcpAuth: WorkOSWorkspaceAuthenticator;
 };
 
@@ -54,6 +57,16 @@ function tokenAudienceMatchesResource(
   return audiences.some(
     (value) => normalizeOAuthUrl(String(value)) === expectedResource
   );
+}
+
+function forbiddenResponse(
+  c: Context,
+  {
+    error = "forbidden",
+    description = "Access denied",
+  }: { error?: string; description?: string } = {}
+) {
+  return c.json({ error, error_description: description }, 403);
 }
 
 /** RFC 9728 challenge — must be present on every 401 so MCP clients start OAuth. */
@@ -142,7 +155,76 @@ export const mcpServerAuthMiddleware = createMiddleware<{
       });
     }
 
-    c.set("mcpAuth", authResult.value.authenticator);
+    const authenticator = authResult.value.authenticator;
+    const workspace = authenticator.workspace();
+    const workspaceMetadata = workspace.metadata;
+
+    if (!isDustMcpServerEnabled(workspaceMetadata)) {
+      logger.warn(
+        { workspaceId: workspace.sId },
+        "[dust-mcp-server] MCP server is disabled for workspace"
+      );
+      return forbiddenResponse(c, {
+        description: "MCP server is disabled for this workspace",
+      });
+    }
+
+    if (getDustMcpServerRedirectUriPolicy(workspaceMetadata) === "allowlist") {
+      const clientId = payload["application:client_id"];
+      if (typeof clientId !== "string" || !clientId.trim()) {
+        logger.warn(
+          { workspaceId: workspace.sId },
+          "[dust-mcp-server] Access token missing application:client_id claim"
+        );
+        return forbiddenResponse(c, {
+          description:
+            "Access token is missing Connect application information",
+        });
+      }
+
+      const applicationResult = await getWorkOSConnectApplication(
+        clientId.trim()
+      );
+      if (applicationResult.isErr()) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            clientId: clientId.trim(),
+            err: applicationResult.error,
+          },
+          "[dust-mcp-server] Failed to fetch WorkOS Connect application"
+        );
+        return forbiddenResponse(c, {
+          description: "Failed to validate Connect application redirect URIs",
+        });
+      }
+
+      const application = applicationResult.value;
+      const redirectUris =
+        application.application_type === "oauth"
+          ? application.redirect_uris.map(({ uri }) => uri)
+          : [];
+
+      const allowedPatterns =
+        getDustMcpServerAllowedRedirectUris(workspaceMetadata);
+      if (!areRedirectUrisAllowed(redirectUris, allowedPatterns)) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            clientId: clientId.trim(),
+            redirectUris,
+            allowedPatterns,
+          },
+          "[dust-mcp-server] Connect application redirect URIs are not allowed"
+        );
+        return forbiddenResponse(c, {
+          description:
+            "Connect application redirect URIs are not allowed for this workspace",
+        });
+      }
+    }
+
+    c.set("mcpAuth", authenticator);
     await next();
   } catch (err) {
     let decoded: JWTPayload | undefined;

--- a/front/lib/api/mcp_server/context.test.ts
+++ b/front/lib/api/mcp_server/context.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 function makeAuthenticator(userId: string): WorkOSWorkspaceAuthenticator {
   return {
+    authMethod: () => "oauth",
     user: () =>
       ({ sId: userId }) as ReturnType<WorkOSWorkspaceAuthenticator["user"]>,
     workspace: () =>
@@ -30,5 +31,11 @@ describe("mcp_server context", () => {
     const authInfo = buildMcpAuthInfo(auth, "token");
 
     expect(authInfo.extra?.[MCP_AUTHENTICATOR_AUTH_EXTRA_KEY]).toBe(auth);
+  });
+
+  it("throws when authInfo extra does not contain an authenticator", () => {
+    expect(() => getAuthenticatorFromMcpContext({})).toThrow(
+      "MCP tool called without authenticated request context."
+    );
   });
 });

--- a/front/lib/api/mcp_server/context.test.ts
+++ b/front/lib/api/mcp_server/context.test.ts
@@ -1,0 +1,34 @@
+import {
+  buildMcpAuthInfo,
+  getAuthenticatorFromMcpContext,
+  MCP_AUTHENTICATOR_AUTH_EXTRA_KEY,
+} from "@app/lib/api/mcp_server/context";
+import type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
+import { describe, expect, it } from "vitest";
+
+function makeAuthenticator(userId: string): WorkOSWorkspaceAuthenticator {
+  return {
+    user: () =>
+      ({ sId: userId }) as ReturnType<WorkOSWorkspaceAuthenticator["user"]>,
+    workspace: () =>
+      ({ sId: "w1" }) as ReturnType<WorkOSWorkspaceAuthenticator["workspace"]>,
+  } as WorkOSWorkspaceAuthenticator;
+}
+
+describe("mcp_server context", () => {
+  it("resolves auth from authInfo.extra", () => {
+    const auth = makeAuthenticator("user-from-extra");
+    const authInfo = buildMcpAuthInfo(auth, "token");
+
+    expect(getAuthenticatorFromMcpContext({ authInfo }).user().sId).toBe(
+      "user-from-extra"
+    );
+  });
+
+  it("stores the authenticator under a stable authInfo extra key", () => {
+    const auth = makeAuthenticator("user-1");
+    const authInfo = buildMcpAuthInfo(auth, "token");
+
+    expect(authInfo.extra?.[MCP_AUTHENTICATOR_AUTH_EXTRA_KEY]).toBe(auth);
+  });
+});

--- a/front/lib/api/mcp_server/context.ts
+++ b/front/lib/api/mcp_server/context.ts
@@ -1,32 +1,34 @@
-import { AsyncLocalStorage } from "node:async_hooks";
-
 import type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
 export type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
 
-type McpContext = {
-  auth: WorkOSWorkspaceAuthenticator;
+export const MCP_AUTHENTICATOR_AUTH_EXTRA_KEY = "dustAuthenticator";
+
+export type McpRequestExtra = {
+  authInfo?: AuthInfo;
 };
 
-const mcpContext = new AsyncLocalStorage<McpContext>();
-
-export function runWithMcpContext<T>(
-  context: { auth: WorkOSWorkspaceAuthenticator },
-  fn: () => T
-): T {
-  return mcpContext.run(context, fn);
+export function buildMcpAuthInfo(
+  auth: WorkOSWorkspaceAuthenticator,
+  token: string
+): AuthInfo {
+  return {
+    token,
+    clientId: "",
+    scopes: [],
+    extra: {
+      [MCP_AUTHENTICATOR_AUTH_EXTRA_KEY]: auth,
+    },
+  };
 }
 
-export function getMcpContext(): McpContext | undefined {
-  return mcpContext.getStore();
-}
-
-export function getAuthenticatorFromMcpContext(): WorkOSWorkspaceAuthenticator {
-  const auth = getMcpContext()?.auth;
+export function getAuthenticatorFromMcpContext(
+  extra: McpRequestExtra
+): WorkOSWorkspaceAuthenticator {
+  const auth = extra.authInfo?.extra?.[MCP_AUTHENTICATOR_AUTH_EXTRA_KEY];
   if (!auth) {
-    throw new Error(
-      "getAuthenticatorFromMcpContext called outside MCP context."
-    );
+    throw new Error("MCP tool called without authenticated request context.");
   }
-  return auth;
+  return auth as WorkOSWorkspaceAuthenticator;
 }

--- a/front/lib/api/mcp_server/context.ts
+++ b/front/lib/api/mcp_server/context.ts
@@ -1,4 +1,7 @@
-import type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
+import {
+  isWorkOSWorkspaceAuthenticator,
+  type WorkOSWorkspaceAuthenticator,
+} from "@app/lib/api/workos_authenticator";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
 export type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
@@ -27,8 +30,8 @@ export function getAuthenticatorFromMcpContext(
   extra: McpRequestExtra
 ): WorkOSWorkspaceAuthenticator {
   const auth = extra.authInfo?.extra?.[MCP_AUTHENTICATOR_AUTH_EXTRA_KEY];
-  if (!auth) {
+  if (!isWorkOSWorkspaceAuthenticator(auth)) {
     throw new Error("MCP tool called without authenticated request context.");
   }
-  return auth as WorkOSWorkspaceAuthenticator;
+  return auth;
 }

--- a/front/lib/api/mcp_server/dust_mcp_server_settings.test.ts
+++ b/front/lib/api/mcp_server/dust_mcp_server_settings.test.ts
@@ -1,6 +1,9 @@
 import {
+  areRedirectUrisAllowed,
   DEFAULT_DUST_MCP_SERVER_ALLOWED_REDIRECT_URIS,
   getDustMcpServerSettingsFromMetadata,
+  isRedirectUriAllowed,
+  redirectUriMatchesAllowedPattern,
   validateDustMcpServerAllowedRedirectUris,
   validateDustMcpServerRedirectUri,
 } from "@app/lib/api/mcp_server/dust_mcp_server_settings";
@@ -36,5 +39,86 @@ describe("dust_mcp_server_settings", () => {
     ]);
 
     expect(result.isErr()).toBe(true);
+  });
+
+  describe("redirectUriMatchesAllowedPattern", () => {
+    it("matches the global wildcard", () => {
+      expect(
+        redirectUriMatchesAllowedPattern("https://example.com/callback", "*")
+      ).toBe(true);
+    });
+
+    it("matches port wildcards with or without an explicit port", () => {
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "http://localhost:8080/oauth/callback",
+          "http://localhost:*"
+        )
+      ).toBe(true);
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "http://localhost/oauth/callback",
+          "http://localhost:*"
+        )
+      ).toBe(true);
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "http://127.0.0.1:3000/",
+          "http://127.0.0.1:*"
+        )
+      ).toBe(true);
+    });
+
+    it("matches exact redirect URIs", () => {
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "cursor://anysphere.cursor-mcp/oauth/callback",
+          "cursor://anysphere.cursor-mcp/oauth/callback"
+        )
+      ).toBe(true);
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "https://www.cursor.com/agents/mcp/oauth/callback",
+          "https://www.cursor.com/agents/mcp/oauth/callback"
+        )
+      ).toBe(true);
+    });
+
+    it("rejects non-matching redirect URIs", () => {
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "http://evil.example.com/callback",
+          "http://localhost:*"
+        )
+      ).toBe(false);
+      expect(
+        redirectUriMatchesAllowedPattern(
+          "https://example.com/callback",
+          "http://localhost:*"
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("areRedirectUrisAllowed", () => {
+    it("requires every redirect URI to match at least one pattern", () => {
+      const allowedPatterns = ["http://localhost:*", "*"];
+
+      expect(
+        areRedirectUrisAllowed(
+          ["http://localhost:8080/callback", "https://example.com/callback"],
+          allowedPatterns
+        )
+      ).toBe(true);
+      expect(
+        isRedirectUriAllowed("http://localhost/callback", allowedPatterns)
+      ).toBe(true);
+      expect(
+        areRedirectUrisAllowed(
+          ["http://localhost/callback", "http://evil.example.com/callback"],
+          ["http://localhost:*"]
+        )
+      ).toBe(false);
+    });
   });
 });

--- a/front/lib/api/mcp_server/dust_mcp_server_settings.ts
+++ b/front/lib/api/mcp_server/dust_mcp_server_settings.ts
@@ -98,3 +98,106 @@ export function validateDustMcpServerAllowedRedirectUris(
 
   return new Ok(normalizedUris);
 }
+
+type ParsedRedirectUri = {
+  scheme: string;
+  host: string;
+  port: number | null;
+  path: string;
+};
+
+function parseRedirectUri(uri: string): ParsedRedirectUri {
+  const parsed = new URL(uri);
+  return {
+    scheme: parsed.protocol.replace(/:$/, "").toLowerCase(),
+    host: parsed.hostname.toLowerCase(),
+    port: parsed.port === "" ? null : Number(parsed.port),
+    path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+  };
+}
+
+const PORT_WILDCARD_PATTERN =
+  /^([a-z][a-z0-9+.-]*):\/\/([^:/]+):\*(?:\/(.*))?$/i;
+
+function redirectUrisMatchExactly(uri: string, pattern: string): boolean {
+  if (uri === pattern) {
+    return true;
+  }
+
+  try {
+    const parsedUri = parseRedirectUri(uri);
+    const parsedPattern = parseRedirectUri(pattern);
+    return (
+      parsedUri.scheme === parsedPattern.scheme &&
+      parsedUri.host === parsedPattern.host &&
+      parsedUri.port === parsedPattern.port &&
+      parsedUri.path === parsedPattern.path
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns whether a redirect URI matches an allowed pattern.
+ * Supports the `*` wildcard, exact patterns, and port wildcards such as
+ * `http://localhost:*`. URIs without an explicit port match port-wildcard
+ * patterns for the same host.
+ */
+export function redirectUriMatchesAllowedPattern(
+  redirectUri: string,
+  allowedPattern: string
+): boolean {
+  const normalizedUri = normalizeDustMcpServerRedirectUri(redirectUri);
+  const normalizedPattern = normalizeDustMcpServerRedirectUri(allowedPattern);
+
+  if (normalizedPattern === "*") {
+    return true;
+  }
+
+  const portWildcardMatch = normalizedPattern.match(PORT_WILDCARD_PATTERN);
+  if (portWildcardMatch) {
+    const [, scheme, host, pathSuffix] = portWildcardMatch;
+
+    try {
+      const parsed = parseRedirectUri(normalizedUri);
+
+      if (parsed.scheme !== scheme.toLowerCase()) {
+        return false;
+      }
+      if (parsed.host !== host.toLowerCase()) {
+        return false;
+      }
+      if (pathSuffix !== undefined && pathSuffix !== "") {
+        const expectedPath = `/${pathSuffix}`;
+        if (parsed.path !== expectedPath) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return redirectUrisMatchExactly(normalizedUri, normalizedPattern);
+}
+
+export function isRedirectUriAllowed(
+  redirectUri: string,
+  allowedPatterns: string[]
+): boolean {
+  return allowedPatterns.some((pattern) =>
+    redirectUriMatchesAllowedPattern(redirectUri, pattern)
+  );
+}
+
+export function areRedirectUrisAllowed(
+  redirectUris: string[],
+  allowedPatterns: string[]
+): boolean {
+  return redirectUris.every((redirectUri) =>
+    isRedirectUriAllowed(redirectUri, allowedPatterns)
+  );
+}

--- a/front/lib/api/mcp_server/tools/agents/list.ts
+++ b/front/lib/api/mcp_server/tools/agents/list.ts
@@ -1,5 +1,5 @@
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { filterAndSortAgents } from "@app/lib/utils";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -22,16 +22,15 @@ const inputSchema = {
 };
 
 export function registerAgentsListTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "list_agents",
     {
       description:
         "List agents accessible to the authenticated user in the current workspace (25 per page). Supports cursor pagination via lastValue. Optionally filter by agent name.",
       inputSchema,
     },
-    async ({ name, lastValue }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { name, lastValue }) => {
       const agents = await getAgentConfigurationsForView({
         auth,
         agentsGetView: "list",

--- a/front/lib/api/mcp_server/tools/conversations/create.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create.ts
@@ -4,7 +4,7 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import config from "@app/lib/api/config";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -38,15 +38,14 @@ const inputSchema = {
 };
 
 export function registerConversationsCreateTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "create_conversation",
     {
       description: `Create a new conversation in the current workspace. Optionally pass podId to create it in a Pod, and message to post the first user message in the same call (triggers the "${DEFAULT_AGENT_NAME}" agent by default; pass agentName: null to post without triggering any agent).`,
       inputSchema,
     },
-    async ({ title, podId, message, agentName }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { title, podId, message, agentName }) => {
       let resolvedSpaceModelId: number | null = null;
       let podName: string | null = null;
 

--- a/front/lib/api/mcp_server/tools/conversations/create_message.ts
+++ b/front/lib/api/mcp_server/tools/conversations/create_message.ts
@@ -3,7 +3,7 @@ import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
 import config from "@app/lib/api/config";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -26,14 +26,14 @@ const inputSchema = {
 };
 
 export function registerConversationsCreateMessageTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "create_conversation_message",
     {
       description: `Post a user message to an existing conversation. By default triggers the "${DEFAULT_AGENT_NAME}" agent. Pass agentName: null to post without triggering any agent.`,
       inputSchema,
     },
-    async ({ conversationId, message, agentName }) => {
-      const auth = getAuthenticatorFromMcpContext();
+    async (auth, { conversationId, message, agentName }) => {
       const user = auth.user();
 
       const conversationRes = await getConversation(auth, conversationId);

--- a/front/lib/api/mcp_server/tools/conversations/get_messages.ts
+++ b/front/lib/api/mcp_server/tools/conversations/get_messages.ts
@@ -1,7 +1,7 @@
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { getConversationApiError } from "@app/lib/api/assistant/conversation/helper";
 import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { mcpJsonResponse } from "../response";
@@ -22,16 +22,15 @@ const inputSchema = {
 };
 
 export function registerConversationsGetMessagesTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "get_conversation_messages",
     {
       description:
         "Fetch a paginated page of messages from a conversation (25 per page, most recent first). Returns human-readable message text. Use lastValue to load older messages.",
       inputSchema,
     },
-    async ({ conversationId, lastValue }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { conversationId, lastValue }) => {
       const conversationRes = await getLightConversation(
         auth,
         conversationId,

--- a/front/lib/api/mcp_server/tools/conversations/list.ts
+++ b/front/lib/api/mcp_server/tools/conversations/list.ts
@@ -1,4 +1,4 @@
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -30,16 +30,15 @@ const inputSchema = {
 };
 
 export function registerConversationsListTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "list_conversations",
     {
       description:
         "List conversations for the authenticated user in the current workspace (25 per page), sorted by most recently updated. Supports cursor pagination via lastValue. When podId is provided, lists conversations in that Pod instead.",
       inputSchema,
     },
-    async ({ podId, lastValue, orderDirection }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { podId, lastValue, orderDirection }) => {
       const resolvedOrderDirection =
         orderDirection ?? LIST_CONVERSATIONS_ORDER_DIRECTION;
 

--- a/front/lib/api/mcp_server/tools/files/cat.ts
+++ b/front/lib/api/mcp_server/tools/files/cat.ts
@@ -4,7 +4,7 @@ import {
   CAT_LINES_MAX,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { isLLMVisionSupportedImageContentType } from "@app/types/files";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -119,7 +119,8 @@ async function readTextFilePage(
 }
 
 export function registerFilesCatTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "files_cat",
     {
       description:
@@ -128,9 +129,7 @@ export function registerFilesCatTool(server: McpServer) {
         "Requires an explicit scope with conversation_id or pod_id.",
       inputSchema,
     },
-    async ({ scope, path, offset, limit }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { scope, path, offset, limit }) => {
       const pathError = validatePathMatchesScope(path, scope);
       if (pathError) {
         return mcpError(pathError);

--- a/front/lib/api/mcp_server/tools/files/create.ts
+++ b/front/lib/api/mcp_server/tools/files/create.ts
@@ -3,7 +3,7 @@ import {
   frameFileCreateRejectedError,
   frameFileEditRejectedError,
 } from "@app/lib/api/actions/servers/files/tools/utils";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import {
   isInteractiveContentType,
   stripMimeParameters,
@@ -32,7 +32,8 @@ const inputSchema = {
 };
 
 export function registerFilesCreateTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "files_create",
     {
       description:
@@ -41,9 +42,7 @@ export function registerFilesCreateTool(server: McpServer) {
         "Requires an explicit scope with conversation_id or pod_id.",
       inputSchema,
     },
-    async ({ scope, path, content, content_type }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { scope, path, content, content_type }) => {
       const pathError = validatePathMatchesScope(path, scope);
       if (pathError) {
         return mcpError(pathError);

--- a/front/lib/api/mcp_server/tools/files/grep.ts
+++ b/front/lib/api/mcp_server/tools/files/grep.ts
@@ -1,6 +1,6 @@
 import { GREP_MATCHES_MAX } from "@app/lib/api/actions/servers/files/metadata";
 import { isReadableAsText } from "@app/lib/api/actions/servers/files/tools/utils";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as readline from "readline";
@@ -26,7 +26,8 @@ const inputSchema = {
 };
 
 export function registerFilesGrepTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "files_grep",
     {
       description:
@@ -35,9 +36,7 @@ export function registerFilesGrepTool(server: McpServer) {
         "Requires an explicit scope with conversation_id or pod_id.",
       inputSchema,
     },
-    async ({ scope, path, pattern }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { scope, path, pattern }) => {
       const pathError = validatePathMatchesScope(path, scope);
       if (pathError) {
         return mcpError(pathError);

--- a/front/lib/api/mcp_server/tools/files/list.ts
+++ b/front/lib/api/mcp_server/tools/files/list.ts
@@ -1,4 +1,4 @@
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { mcpError, mcpJsonResponse } from "../response";
 import { getDustFileSystemForScope, scopedPrefixForScope } from "./context";
@@ -12,7 +12,8 @@ const inputSchema = {
 };
 
 export function registerFilesListTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "files_list",
     {
       description:
@@ -21,9 +22,7 @@ export function registerFilesListTool(server: McpServer) {
         "Requires an explicit conversation_id or pod_id.",
       inputSchema,
     },
-    async ({ scope }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { scope }) => {
       const fsResult = await getDustFileSystemForScope(auth, scope);
       if (fsResult.isErr()) {
         return mcpError(fsResult.error);

--- a/front/lib/api/mcp_server/tools/files/resolve.ts
+++ b/front/lib/api/mcp_server/tools/files/resolve.ts
@@ -2,7 +2,7 @@ import {
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -62,7 +62,8 @@ const inputSchema = {
 };
 
 export function registerFilesResolveTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "files_resolve",
     {
       description:
@@ -71,9 +72,7 @@ export function registerFilesResolveTool(server: McpServer) {
         "Requires an explicit scope with conversation_id or pod_id.",
       inputSchema,
     },
-    async ({ scope, file_id }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (auth, { scope, file_id }) => {
       const file = await FileResource.fetchById(auth, file_id);
       if (!file) {
         return mcpError(`File not found: \`${file_id}\`.`);

--- a/front/lib/api/mcp_server/tools/identity.ts
+++ b/front/lib/api/mcp_server/tools/identity.ts
@@ -1,16 +1,16 @@
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { mcpJsonResponse } from "./response";
 
 export function registerIdentityTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "identity",
     {
       description:
         "Returns information about the authenticated user and workspace.",
     },
-    async () => {
-      const auth = getAuthenticatorFromMcpContext();
+    async (auth) => {
       const user = auth.user();
       const workspace = auth.workspace();
 

--- a/front/lib/api/mcp_server/tools/pods/get.ts
+++ b/front/lib/api/mcp_server/tools/pods/get.ts
@@ -1,7 +1,7 @@
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import config from "@app/lib/api/config";
 import { DustFileSystem, SCOPED_PREFIX_POD } from "@app/lib/api/file_system";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { listProjectContextAttachments } from "@app/lib/api/projects/context";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -15,15 +15,15 @@ const inputSchema = {
 };
 
 export function registerPodsGetTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "get_pod",
     {
       description:
         "Get information about a Pod: title, description, URL, pinned frame, linked content nodes, and file count.",
       inputSchema,
     },
-    async ({ podId }) => {
-      const auth = getAuthenticatorFromMcpContext();
+    async (auth, { podId }) => {
       const owner = auth.workspace();
       const { nonArchivedSpaces } =
         await listNonArchivedMemberSpacesWithMetadata(auth);

--- a/front/lib/api/mcp_server/tools/pods/get_tasks.ts
+++ b/front/lib/api/mcp_server/tools/pods/get_tasks.ts
@@ -1,4 +1,4 @@
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -32,21 +32,18 @@ const inputSchema = {
 };
 
 export function registerPodsGetTasksTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "get_pod_tasks",
     {
       description:
         "List tasks in a Pod. Defaults to all assignees and open tasks. Use statusFilter='done' or 'all' with daysAgo to include recently completed tasks.",
       inputSchema,
     },
-    async ({
-      podId,
-      assigneeFilter = "all",
-      statusFilter = "open",
-      daysAgo = 7,
-    }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (
+      auth,
+      { podId, assigneeFilter = "all", statusFilter = "open", daysAgo = 7 }
+    ) => {
       const { nonArchivedSpaces } =
         await listNonArchivedMemberSpacesWithMetadata(auth);
       const pod = nonArchivedSpaces.find(

--- a/front/lib/api/mcp_server/tools/pods/list.ts
+++ b/front/lib/api/mcp_server/tools/pods/list.ts
@@ -1,19 +1,19 @@
 import config from "@app/lib/api/config";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
 import { getPodRoute } from "@app/lib/utils/router";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { mcpJsonResponse } from "../response";
 
 export function registerPodsListTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "list_pods",
     {
       description:
         "List non-archived Pods that you are a member of in the current workspace.",
     },
-    async () => {
-      const auth = getAuthenticatorFromMcpContext();
+    async (auth) => {
       const owner = auth.workspace();
       const { nonArchivedSpaces } =
         await listNonArchivedMemberSpacesWithMetadata(auth);

--- a/front/lib/api/mcp_server/tools/register.ts
+++ b/front/lib/api/mcp_server/tools/register.ts
@@ -1,0 +1,61 @@
+import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
+import type {
+  McpServer,
+  ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { z } from "zod";
+
+type DustMcpInputSchema = Record<string, z.ZodTypeAny>;
+
+type InferMcpToolArgs<T extends DustMcpInputSchema> = {
+  [K in keyof T]: z.infer<T[K]>;
+};
+
+type DustMcpToolConfig<T extends DustMcpInputSchema | undefined = undefined> = {
+  title?: string;
+  description?: string;
+  inputSchema?: T;
+  _meta?: Record<string, unknown>;
+};
+
+type DustMcpToolHandlerResult = CallToolResult | Promise<CallToolResult>;
+
+type DustMcpToolHandler<T extends DustMcpInputSchema | undefined> =
+  T extends DustMcpInputSchema
+    ? (
+        auth: WorkOSWorkspaceAuthenticator,
+        args: InferMcpToolArgs<T>
+      ) => DustMcpToolHandlerResult
+    : (auth: WorkOSWorkspaceAuthenticator) => DustMcpToolHandlerResult;
+
+export function registerDustMcpTool<
+  T extends DustMcpInputSchema | undefined = undefined,
+>(
+  server: McpServer,
+  name: string,
+  config: DustMcpToolConfig<T>,
+  handler: DustMcpToolHandler<T>
+): void {
+  if (config.inputSchema === undefined) {
+    server.registerTool(
+      name,
+      {
+        title: config.title,
+        description: config.description,
+        _meta: config._meta,
+      },
+      ((extra) => {
+        const auth = getAuthenticatorFromMcpContext(extra);
+        return (handler as DustMcpToolHandler<undefined>)(auth);
+      }) as ToolCallback<undefined>
+    );
+    return;
+  }
+
+  server.registerTool(name, config, ((args, extra) => {
+    const auth = getAuthenticatorFromMcpContext(extra);
+    return (handler as DustMcpToolHandler<DustMcpInputSchema>)(auth, args);
+  }) as ToolCallback<DustMcpInputSchema>);
+}

--- a/front/lib/api/mcp_server/tools/search/search.ts
+++ b/front/lib/api/mcp_server/tools/search/search.ts
@@ -2,7 +2,7 @@ import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_co
 import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
 import { getDataSourcesAndWorkspaceIdForGlobalAgents } from "@app/lib/api/assistant/global_agents/tools";
-import { getAuthenticatorFromMcpContext } from "@app/lib/api/mcp_server/context";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
 import { isIncludedInDefaultCompanyData } from "@app/lib/data_sources";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -49,16 +49,18 @@ const inputSchema = {
 };
 
 export function registerSearchTool(server: McpServer) {
-  server.registerTool(
+  registerDustMcpTool(
+    server,
     "search",
     {
       description:
         "Semantic search across all globally accessible spaces in Dust. Returns matching document chunks ranked by relevance.",
       inputSchema,
     },
-    async ({ query, relativeTimeFrame, tagsIn, tagsNot, nodeIds, topK }) => {
-      const auth = getAuthenticatorFromMcpContext();
-
+    async (
+      auth,
+      { query, relativeTimeFrame, tagsIn, tagsNot, nodeIds, topK }
+    ) => {
       const { dataSourceViews, workspaceId } =
         await getDataSourcesAndWorkspaceIdForGlobalAgents(auth);
 

--- a/front/lib/api/workos_authenticator.ts
+++ b/front/lib/api/workos_authenticator.ts
@@ -14,6 +14,23 @@ export interface WorkOSWorkspaceAuthenticator extends Authenticator {
   user(): UserResource;
 }
 
+export function isWorkOSWorkspaceAuthenticator(
+  value: unknown
+): value is WorkOSWorkspaceAuthenticator {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  return (
+    "user" in value &&
+    typeof value.user === "function" &&
+    "workspace" in value &&
+    typeof value.workspace === "function" &&
+    "authMethod" in value &&
+    typeof value.authMethod === "function"
+  );
+}
+
 export type WorkOSWorkspaceAuthenticatorError =
   | "organization_missing"
   | "workspace_not_found"


### PR DESCRIPTION
## Description

Two related fixes to the Dust MCP server:

- **Workspace settings enforcement in `mcpServerAuthMiddleware`**: reads workspace metadata to gate access — returns 403 when `isDustMcpServerEnabled` is false, and when the policy is `allowlist`, fetches the WorkOS Connect application via `getWorkOSConnectApplication` and validates its `redirect_uris` against the workspace-configured patterns using the new `areRedirectUrisAllowed` helpers (supports `*`, exact matches, port wildcards like `http://localhost:*`).
- **Fix sticky auth**: the old singleton `dustMcpServer` + `StreamableHTTPTransport` with `AsyncLocalStorage` caused auth to leak across requests. Replaced with per-session `McpSession` objects (UUID-keyed `Map` in `sessions.ts`). Auth is threaded through `authInfo.extra[MCP_AUTHENTICATOR_AUTH_EXTRA_KEY]` via `buildMcpAuthInfo`; `setMcpTransportAuth`/`clearMcpTransportAuth` temporarily swap `ctx.get("auth")` for the duration of `handleRequest`. All tool handlers migrated to `registerDustMcpTool(server, name, config, (auth, args) => ...)`.

PR targets `sflory/add-workspace-admin-settings-to` (workspace settings admin UI).

## Tests

- Added `context.test.ts` covering `buildMcpAuthInfo` / `getAuthenticatorFromMcpContext` round-trip.
- Added redirect URI pattern matching tests in `dust_mcp_server_settings.test.ts` (wildcard, port wildcard, exact, rejection cases).
- Tested locally with a real MCP client across multiple sessions to confirm auth isolation.

## Risk

Medium. The transport layer is fully rewritten — per-session `McpSession` instances replace the singleton. Session cleanup relies on the `transport.onclose` hook; a missed close won't crash but could accumulate entries in the `sessions` Map. The 403 gates are additive and only affect workspaces with the MCP server configured as disabled or with a redirect URI policy. `request_logger.ts` now guards `auth.user()` / `auth.workspace()` with `typeof === "function"` checks since the context variable transiently holds an `AuthInfo` object during `handleRequest`. Rollback: revert front, no data migrations.

## Deploy Plan

Deploy front when `sflory/add-workspace-admin-settings-to` base branch is ready to merge.
