### PR TITLE
Remove all mentions to beta testing for  self-improving skills

### DIFF
--- a/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
@@ -1,11 +1,7 @@
 import { SelfImprovingSkillsConsumptionSection } from "@app/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection";
 import { SelfImprovingSkillsListSection } from "@app/components/workspace/settings/SelfImprovingSkillsListSection";
 import { SelfImprovingSkillsSettingsSection } from "@app/components/workspace/settings/SelfImprovingSkillsSettingsSection";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import {
   getReinforcementMonthlyCapAwuCredits,
@@ -14,21 +10,13 @@ import {
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { useReinforcementBillingUnit } from "@app/lib/swr/useSelfImprovingSkillsSettings";
-import {
-  ContentMessage,
-  InfoCircle,
-  LinkWrapper,
-  Page,
-  Stars02,
-} from "@dust-tt/sparkle";
+import { ContentMessage, InfoCircle, Page, Stars02 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 export function SelfImprovingSkillsPage() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const { hasFeature } = useFeatureFlags();
   const hasSelfImprovement = useIsSelfImprovementAvailable();
-  const isBetaTester = hasFeature("self_improvement_beta_tester");
 
   const unit = useReinforcementBillingUnit({ owner });
 
@@ -63,24 +51,6 @@ export function SelfImprovingSkillsPage() {
     }
     return (
       <>
-        {isBetaTester && (
-          <ContentMessage variant="info" size="lg">
-            This feature is currently in <strong>beta</strong>, and only
-            available to a select group of customers.
-            <br />
-            Note that the feature is currently free during beta testing but will
-            generate additional costs upon release.
-            <br />
-            Contact{" "}
-            <LinkWrapper
-              href="mailto:self-improving-skills@dust.tt"
-              className="underline"
-            >
-              self-improving-skills@dust.tt
-            </LinkWrapper>{" "}
-            to share some feedback about this feature.
-          </ContentMessage>
-        )}
         <SelfImprovingSkillsSettingsSection
           owner={owner}
           onCapSaved={setCap}

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -4,10 +4,8 @@ import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/Skil
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
-  Chip,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -23,9 +21,6 @@ export function SkillBuilderSettingsSection({
   skill,
   hasSelfImprovingSkills,
 }: SkillBuilderSettingsSectionProps) {
-  const { hasFeature } = useFeatureFlags();
-  const isBetaTester = hasFeature("self_improvement_beta_tester");
-
   return (
     <div className="space-y-5">
       <h2 className="heading-lg text-foreground dark:text-foreground-night">
@@ -48,12 +43,9 @@ export function SkillBuilderSettingsSection({
       </div>
       {hasSelfImprovingSkills && (
         <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <Label className="text-base font-semibold text-foreground dark:text-foreground-night">
-              Self Improvement
-            </Label>
-            {isBetaTester && <Chip size="xs" color="golden" label="Beta" />}
-          </div>
+          <Label className="text-base font-semibold text-foreground dark:text-foreground-night">
+            Self Improvement
+          </Label>
           <SkillBuilderEnableSuggestionsSection
             selfImprovementLock={skill?.selfImprovementLock ?? false}
           />

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -7,15 +7,8 @@ import {
   usePatchSkillSuggestions,
   useSkillSuggestions,
 } from "@app/hooks/useSkillSuggestions";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
-import {
-  Chip,
-  ContentMessage,
-  Lightbulb04,
-  ScrollArea,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { Lightbulb04, ScrollArea, Spinner } from "@dust-tt/sparkle";
 import { useCallback } from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -33,8 +26,6 @@ export function SkillBuilderSuggestionsPanel({
     setSelectedSuggestionId,
     acceptInstructionEdits,
   } = useSkillBuilderContext();
-  const { hasFeature } = useFeatureFlags();
-  const isBetaTester = hasFeature("self_improvement_beta_tester");
   const { getValues, setValue } = useFormContext<SkillBuilderFormData>();
 
   const getSkillInstructionsHtml = useCallback(
@@ -159,18 +150,9 @@ export function SkillBuilderSuggestionsPanel({
   return (
     <div className="flex h-full flex-col">
       <div className="flex flex-col gap-1 px-4 pb-3 pt-4">
-        <div className="flex items-center gap-2">
-          <h2 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-            Suggestions
-          </h2>
-          {isBetaTester && <Chip size="xs" color="golden" label="Beta" />}
-        </div>
-        {isBetaTester && (
-          <ContentMessage variant="info" size="lg">
-            Skill suggestions are currently in beta testing. We are very
-            interested in your feedback to improve the feature.
-          </ContentMessage>
-        )}
+        <h2 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+          Suggestions
+        </h2>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           Dust continuously analyses conversations using this skill to suggest
           improvements.

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -16,7 +16,7 @@ import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
-import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { intelligenceAwuFromRunUsages } from "@app/lib/metronome/events";
 import { getRemainingProgrammaticUsageFromMetronome } from "@app/lib/metronome/programmatic_awu_usage";
 import {
@@ -102,10 +102,8 @@ export { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 /**
  * Report usage for a single self-improvement LLM step to billing and ES
  * analytics: as Metronome usage events for workspaces billed by Metronome on
- * a credit-priced plan, as programmatic usage otherwise. Workspaces with the
- * `self_improvement_beta_tester` feature flag report nothing and run for
- * free. Fire-and-forget: failures are logged but do not break the
- * reinforcement workflow.
+ * a credit-priced plan, as programmatic usage otherwise. Fire-and-forget:
+ * failures are logged but do not break the reinforcement workflow.
  */
 async function reportSelfImprovingSkillsStepUsage({
   auth,
@@ -122,10 +120,6 @@ async function reportSelfImprovingSkillsStepUsage({
   userMessageId: string;
   dustRunIds?: string[];
 }): Promise<void> {
-  if (await hasFeatureFlag(auth, "self_improvement_beta_tester")) {
-    return;
-  }
-
   // Reinforcement messages are created with default version 0 and are never
   // retried at a higher version (Temporal retries create new message sIds).
   const agentLoopArgs: AgentLoopArgs = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -248,11 +248,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable self-improvement (background analysis of conversations to suggest improvements to skills).",
     stage: "dust_only",
   },
-  self_improvement_beta_tester: {
-    description:
-      "Self-improvement runs for free: consumption is not reported to billing (Metronome or programmatic usage).",
-    stage: "dust_only",
-  },
   collapsible_messages: {
     description: "Enable collapsible messages in conversations",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -743,7 +743,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "power_bi_mcp"
   | "reinforced_agents"
   | "self_improvement_beta_tester"
-  | "legacy_billing"
+  | "metronome_billing"
   | "plan_mode"
   | "pod_default_agent"
   | "poke_mcp"


### PR DESCRIPTION
## Description

 - remove the beta testing flag so all beta testers start to pay
 - They won't loose access to the feature if they have the reinforced_agent flag still present. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
