### PR TITLE
[front & sparkle] improve capabilities scrolling and highlight style

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -39,7 +39,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   LoadingBlock,
-  ScrollArea,
   ShapesPlus,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -190,55 +189,55 @@ function CapabilitiesPickerItemsList({
 
   return (
     <div className="relative" ref={listRef}>
-        <div className="relative">
-          <div
-            ref={topScrollSentinelRef}
-            className="pointer-events-none absolute left-0 top-0 h-px w-px"
-            aria-hidden
-          />
-          <div
-            ref={bottomScrollSentinelRef}
-            className="pointer-events-none absolute bottom-0 left-0 h-px w-px"
-            aria-hidden
-          />
-          {items.map((item) => {
-            const endComponent =
-              item.kind === "uninstalled_tool" ? (
-                <Chip size="xs" color="golden" label="Configure" />
-              ) : (
-                <Button
-                  icon={DotsHorizontal}
-                  variant="outline"
-                  size="mini"
-                  className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
+      <div className="relative">
+        <div
+          ref={topScrollSentinelRef}
+          className="pointer-events-none absolute left-0 top-0 h-px w-px"
+          aria-hidden
+        />
+        <div
+          ref={bottomScrollSentinelRef}
+          className="pointer-events-none absolute bottom-0 left-0 h-px w-px"
+          aria-hidden
+        />
+        {items.map((item) => {
+          const endComponent =
+            item.kind === "uninstalled_tool" ? (
+              <Chip size="xs" color="golden" label="Configure" />
+            ) : (
+              <Button
+                icon={DotsHorizontal}
+                variant="outline"
+                size="mini"
+                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
 
-                    if (item.kind === "skill") {
-                      onSkillDetails(item.skill.sId);
-                    } else {
-                      onToolDetails(item.serverView);
-                    }
-                  }}
-                />
-              );
-
-            return (
-              <DropdownMenuItem
-                key={item.id}
-                icon={item.icon}
-                itemId={item.id}
-                label={item.label}
-                description={item.description}
-                truncateText
-                endComponent={endComponent}
-                className="group"
-                onClick={() => onItemSelect(item)}
+                  if (item.kind === "skill") {
+                    onSkillDetails(item.skill.sId);
+                  } else {
+                    onToolDetails(item.serverView);
+                  }
+                }}
               />
             );
-          })}
-        </div>
+
+          return (
+            <DropdownMenuItem
+              key={item.id}
+              icon={item.icon}
+              itemId={item.id}
+              label={item.label}
+              description={item.description}
+              truncateText
+              endComponent={endComponent}
+              className="group"
+              onClick={() => onItemSelect(item)}
+            />
+          );
+        })}
+      </div>
       <div
         className={cn(
           "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -130,43 +130,43 @@ function CapabilitiesPickerItemsList({
 
   return (
     <div className="relative" ref={listRef}>
-        {items.map((item) => {
-          const endComponent =
-            item.kind === "uninstalled_tool" ? (
-              <Chip size="xs" color="golden" label="Configure" />
-            ) : (
-              <Button
-                icon={DotsHorizontal}
-                variant="outline"
-                size="mini"
-                className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
+      {items.map((item) => {
+        const endComponent =
+          item.kind === "uninstalled_tool" ? (
+            <Chip size="xs" color="golden" label="Configure" />
+          ) : (
+            <Button
+              icon={DotsHorizontal}
+              variant="outline"
+              size="mini"
+              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
 
-                  if (item.kind === "skill") {
-                    onSkillDetails(item.skill.sId);
-                  } else {
-                    onToolDetails(item.serverView);
-                  }
-                }}
-              />
-            );
-
-          return (
-            <DropdownMenuItem
-              key={item.id}
-              icon={item.icon}
-              itemId={item.id}
-              label={item.label}
-              description={item.description}
-              truncateText
-              endComponent={endComponent}
-              className="group"
-              onClick={() => onItemSelect(item)}
+                if (item.kind === "skill") {
+                  onSkillDetails(item.skill.sId);
+                } else {
+                  onToolDetails(item.serverView);
+                }
+              }}
             />
           );
-        })}
+
+        return (
+          <DropdownMenuItem
+            key={item.id}
+            icon={item.icon}
+            itemId={item.id}
+            label={item.label}
+            description={item.description}
+            truncateText
+            endComponent={endComponent}
+            className="group"
+            onClick={() => onItemSelect(item)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -44,10 +44,6 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-// Rare case where we need a Tailwind arbitrary value: after the fixed search bar, the scrollable list should fit
-// exactly seven 3.25rem rows without showing a partial row or leaving extra bottom space.
-const CAPABILITIES_PICKER_LIST_MAX_HEIGHT_CLASS_NAME = "max-h-[22.75rem]";
-
 interface CapabilityPickerItemBase {
   description?: string;
   icon: DropdownMenuItemProps["icon"];
@@ -193,11 +189,7 @@ function CapabilitiesPickerItemsList({
   }
 
   return (
-    <div className="relative">
-      <ScrollArea
-        viewportRef={listRef}
-        viewportClassName={CAPABILITIES_PICKER_LIST_MAX_HEIGHT_CLASS_NAME}
-      >
+    <div className="relative" ref={listRef}>
         <div className="relative">
           <div
             ref={topScrollSentinelRef}
@@ -247,7 +239,6 @@ function CapabilitiesPickerItemsList({
             );
           })}
         </div>
-      </ScrollArea>
       <div
         className={cn(
           "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",
@@ -593,15 +584,19 @@ export function CapabilitiesPicker({
               setIsClosing(false);
             }
           }}
+          dropdownHeaders={
+            <>
+              <DropdownMenuSearchbar
+                autoFocus={!isMobile}
+                name="search-capabilities"
+                placeholder="Search capabilities"
+                value={searchText}
+                onChange={setSearchText}
+              />
+              <DropdownMenuSeparator />
+            </>
+          }
         >
-          <DropdownMenuSearchbar
-            autoFocus={!isMobile}
-            name="search-capabilities"
-            placeholder="Search capabilities"
-            value={searchText}
-            onChange={setSearchText}
-          />
-          <DropdownMenuSeparator />
           {(!isSkillsDataReady || !isToolsDataReady) && (
             <CapabilitiesPickerLoading />
           )}

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -139,7 +139,7 @@ function CapabilitiesPickerItemsList({
               icon={DotsHorizontal}
               variant="outline"
               size="mini"
-              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+              className="opacity-0 group-data-[highlighted]:opacity-100 group-focus-within:opacity-100"
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -30,7 +30,6 @@ import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
 import {
   Button,
   Chip,
-  cn,
   DotsHorizontal,
   DropdownMenu,
   DropdownMenuContent,
@@ -119,65 +118,7 @@ function CapabilitiesPickerItemsList({
   onSkillDetails,
   onToolDetails,
 }: CapabilitiesPickerItemsListProps) {
-  const [scrollFadeState, setScrollFadeState] = useState({
-    hasContentAbove: false,
-    hasContentBelow: false,
-  });
   const listRef = useRef<HTMLDivElement>(null);
-  const topScrollSentinelRef = useRef<HTMLDivElement>(null);
-  const bottomScrollSentinelRef = useRef<HTMLDivElement>(null);
-  const itemCount = items.length;
-
-  useEffect(() => {
-    const list = listRef.current;
-    const topScrollSentinel = topScrollSentinelRef.current;
-    const bottomScrollSentinel = bottomScrollSentinelRef.current;
-
-    if (
-      itemCount === 0 ||
-      !list ||
-      !topScrollSentinel ||
-      !bottomScrollSentinel ||
-      typeof IntersectionObserver === "undefined"
-    ) {
-      setScrollFadeState((previousState) =>
-        previousState.hasContentAbove || previousState.hasContentBelow
-          ? {
-              hasContentAbove: false,
-              hasContentBelow: false,
-            }
-          : previousState
-      );
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        setScrollFadeState((previousState) => {
-          const nextState = { ...previousState };
-
-          for (const entry of entries) {
-            if (entry.target === topScrollSentinel) {
-              nextState.hasContentAbove = !entry.isIntersecting;
-            } else if (entry.target === bottomScrollSentinel) {
-              nextState.hasContentBelow = !entry.isIntersecting;
-            }
-          }
-
-          return previousState.hasContentAbove === nextState.hasContentAbove &&
-            previousState.hasContentBelow === nextState.hasContentBelow
-            ? previousState
-            : nextState;
-        });
-      },
-      { root: list }
-    );
-
-    observer.observe(topScrollSentinel);
-    observer.observe(bottomScrollSentinel);
-
-    return () => observer.disconnect();
-  }, [itemCount]);
 
   if (items.length === 0) {
     return (
@@ -189,17 +130,6 @@ function CapabilitiesPickerItemsList({
 
   return (
     <div className="relative" ref={listRef}>
-      <div className="relative">
-        <div
-          ref={topScrollSentinelRef}
-          className="pointer-events-none absolute left-0 top-0 h-px w-px"
-          aria-hidden
-        />
-        <div
-          ref={bottomScrollSentinelRef}
-          className="pointer-events-none absolute bottom-0 left-0 h-px w-px"
-          aria-hidden
-        />
         {items.map((item) => {
           const endComponent =
             item.kind === "uninstalled_tool" ? (
@@ -237,25 +167,6 @@ function CapabilitiesPickerItemsList({
             />
           );
         })}
-      </div>
-      <div
-        className={cn(
-          "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",
-          "from-transparent via-background/65 to-background opacity-0 transition-opacity duration-200",
-          "dark:via-muted-background-night/65 dark:to-muted-background-night",
-          scrollFadeState.hasContentAbove && "opacity-100"
-        )}
-        aria-hidden
-      />
-      <div
-        className={cn(
-          "pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b",
-          "from-transparent via-background/65 to-background opacity-0 transition-opacity duration-200",
-          "dark:via-muted-background-night/65 dark:to-muted-background-night",
-          scrollFadeState.hasContentBelow && "opacity-100"
-        )}
-        aria-hidden
-      />
     </div>
   );
 }

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -129,7 +129,7 @@ function CapabilitiesPickerItemsList({
   }
 
   return (
-    <div className="relative" ref={listRef}>
+    <div ref={listRef}>
       {items.map((item) => {
         const endComponent =
           item.kind === "uninstalled_tool" ? (

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -228,7 +228,6 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
               }
             : undefined
         }
-        showScrollFade
         size="wide"
       />
     );

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -290,7 +290,10 @@ export const SlashCommandDropdown = forwardRef<
                           icon={DotsHorizontal}
                           variant="outline"
                           size="mini"
-                          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                          className={cn(
+                            "opacity-0 group-focus-within:opacity-100",
+                            index === selectedIndex && "opacity-100"
+                          )}
                           onClick={(e) => {
                             e.stopPropagation();
                             e.preventDefault();

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -268,7 +268,7 @@ export const SlashCommandDropdown = forwardRef<
           ) : (
             <div
               ref={listRef}
-              className={cn("relative", listMaxHeightClassName)}
+              className={listMaxHeightClassName}
             >
               {items.map((item, index) => {
                 const sectionLabel =
@@ -345,28 +345,6 @@ export const SlashCommandDropdown = forwardRef<
                   </Fragment>
                 );
               })}
-              <div
-                className={cn(
-                  "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",
-                  "from-transparent via-background/65 to-background opacity-0 transition-opacity duration-200",
-                  "dark:via-muted-background-night/65 dark:to-muted-background-night",
-                  showScrollFade &&
-                    scrollFadeState.hasContentAbove &&
-                    "opacity-100"
-                )}
-                aria-hidden
-              />
-              <div
-                className={cn(
-                  "pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b",
-                  "from-transparent via-background/65 to-background opacity-0 transition-opacity duration-200",
-                  "dark:via-muted-background-night/65 dark:to-muted-background-night",
-                  showScrollFade &&
-                    scrollFadeState.hasContentBelow &&
-                    "opacity-100"
-                )}
-                aria-hidden
-              />
             </div>
           )}
         </DropdownMenuContent>

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -29,16 +29,6 @@ const DEFAULT_EMPTY_MESSAGE = "No commands found";
 
 const DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME = "max-h-96";
 
-interface ScrollFadeState {
-  hasContentAbove: boolean;
-  hasContentBelow: boolean;
-}
-
-const EMPTY_SCROLL_FADE_STATE: ScrollFadeState = {
-  hasContentAbove: false,
-  hasContentBelow: false,
-};
-
 export interface SlashCommand {
   action: string;
   // Command-specific payload, opaque to the dropdown. Consumers narrow it back with type guards
@@ -92,13 +82,7 @@ export const SlashCommandDropdown = forwardRef<
     ref
   ) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
-    const [scrollFadeState, setScrollFadeState] = useState<ScrollFadeState>(
-      EMPTY_SCROLL_FADE_STATE
-    );
-    const itemCount = items.length;
     const listRef = useRef<HTMLDivElement>(null);
-    const topScrollSentinelRef = useRef<HTMLDivElement>(null);
-    const bottomScrollSentinelRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
       useState<React.CSSProperties>({});
 
@@ -148,56 +132,6 @@ export const SlashCommandDropdown = forwardRef<
       }),
       [selectItem, selectedIndex, items.length]
     );
-
-    useEffect(() => {
-      const list = listRef.current;
-      const topScrollSentinel = topScrollSentinelRef.current;
-      const bottomScrollSentinel = bottomScrollSentinelRef.current;
-
-      if (
-        !showScrollFade ||
-        itemCount === 0 ||
-        !list ||
-        !topScrollSentinel ||
-        !bottomScrollSentinel ||
-        typeof IntersectionObserver === "undefined"
-      ) {
-        setScrollFadeState((previousState) =>
-          previousState.hasContentAbove || previousState.hasContentBelow
-            ? EMPTY_SCROLL_FADE_STATE
-            : previousState
-        );
-        return;
-      }
-
-      const observer = new IntersectionObserver(
-        (entries) => {
-          setScrollFadeState((previousState) => {
-            const nextState = { ...previousState };
-
-            for (const entry of entries) {
-              if (entry.target === topScrollSentinel) {
-                nextState.hasContentAbove = !entry.isIntersecting;
-              } else if (entry.target === bottomScrollSentinel) {
-                nextState.hasContentBelow = !entry.isIntersecting;
-              }
-            }
-
-            return previousState.hasContentAbove ===
-              nextState.hasContentAbove &&
-              previousState.hasContentBelow === nextState.hasContentBelow
-              ? previousState
-              : nextState;
-          });
-        },
-        { root: list }
-      );
-
-      observer.observe(topScrollSentinel);
-      observer.observe(bottomScrollSentinel);
-
-      return () => observer.disconnect();
-    }, [itemCount, showScrollFade]);
 
     // Reset selected index when items change.
     // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -266,10 +200,7 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div
-              ref={listRef}
-              className={listMaxHeightClassName}
-            >
+            <div ref={listRef} className={listMaxHeightClassName}>
               {items.map((item, index) => {
                 const sectionLabel =
                   item.sectionLabel &&

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -54,7 +54,6 @@ export interface SlashCommandDropdownProps
   listMaxHeightClassName?: `max-h-${string}`;
   onClose?: () => void;
   onItemDetails?: (item: SlashCommand) => void;
-  showScrollFade?: boolean;
   size?: "default" | "wide";
 }
 
@@ -76,7 +75,6 @@ export const SlashCommandDropdown = forwardRef<
       listMaxHeightClassName = DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME,
       onClose,
       onItemDetails,
-      showScrollFade = false,
       size = "default",
     },
     ref

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -266,79 +266,82 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div ref={listRef} className={cn("relative", listMaxHeightClassName)}>
-                  {items.map((item, index) => {
-                    const sectionLabel =
-                      item.sectionLabel &&
-                      items[index - 1]?.sectionLabel !== item.sectionLabel
-                        ? item.sectionLabel
-                        : undefined;
-                    const canShowDetails = !!onItemDetails && !!item.hasDetails;
-                    const menuItem = (
-                      <DropdownMenuItem
-                        icon={item.icon}
-                        itemId={item.id}
-                        label={item.label}
-                        description={item.description}
-                        truncateText
-                        endComponent={
-                          canShowDetails ? (
-                            <Button
-                              icon={DotsHorizontal}
-                              variant="outline"
-                              size="mini"
-                              className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                e.preventDefault();
-                                onItemDetails?.(item);
-                              }}
-                            />
-                          ) : undefined
-                        }
-                        onClick={() => selectItem(index)}
-                        // onPointerMove only fires on actual pointer movement
-                        // (not when items scroll under a stationary cursor).
-                        // preventDefault stops Radix from setting
-                        // data-highlighted, avoiding a double highlight.
-                        onPointerMove={(e) => {
-                          e.preventDefault();
-                          setSelectedIndex(index);
-                        }}
-                        onPointerLeave={(e) => e.preventDefault()}
-                        className={cn(
-                          "group",
-                          index === selectedIndex &&
-                            "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                        )}
-                      />
-                    );
+            <div
+              ref={listRef}
+              className={cn("relative", listMaxHeightClassName)}
+            >
+              {items.map((item, index) => {
+                const sectionLabel =
+                  item.sectionLabel &&
+                  items[index - 1]?.sectionLabel !== item.sectionLabel
+                    ? item.sectionLabel
+                    : undefined;
+                const canShowDetails = !!onItemDetails && !!item.hasDetails;
+                const menuItem = (
+                  <DropdownMenuItem
+                    icon={item.icon}
+                    itemId={item.id}
+                    label={item.label}
+                    description={item.description}
+                    truncateText
+                    endComponent={
+                      canShowDetails ? (
+                        <Button
+                          icon={DotsHorizontal}
+                          variant="outline"
+                          size="mini"
+                          className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            onItemDetails?.(item);
+                          }}
+                        />
+                      ) : undefined
+                    }
+                    onClick={() => selectItem(index)}
+                    // onPointerMove only fires on actual pointer movement
+                    // (not when items scroll under a stationary cursor).
+                    // preventDefault stops Radix from setting
+                    // data-highlighted, avoiding a double highlight.
+                    onPointerMove={(e) => {
+                      e.preventDefault();
+                      setSelectedIndex(index);
+                    }}
+                    onPointerLeave={(e) => e.preventDefault()}
+                    className={cn(
+                      "group",
+                      index === selectedIndex &&
+                        "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                    )}
+                  />
+                );
 
-                    // Wrap with DropdownTooltipTrigger if command has tooltip property.
-                    const itemContent = item.tooltip ? (
-                      <DropdownTooltipTrigger
-                        description={item.tooltip.description}
-                        media={item.tooltip.media}
-                        side="right"
-                        sideOffset={8}
-                      >
-                        {menuItem}
-                      </DropdownTooltipTrigger>
-                    ) : (
-                      menuItem
-                    );
+                // Wrap with DropdownTooltipTrigger if command has tooltip property.
+                const itemContent = item.tooltip ? (
+                  <DropdownTooltipTrigger
+                    description={item.tooltip.description}
+                    media={item.tooltip.media}
+                    side="right"
+                    sideOffset={8}
+                  >
+                    {menuItem}
+                  </DropdownTooltipTrigger>
+                ) : (
+                  menuItem
+                );
 
-                    return (
-                      <Fragment key={item.id}>
-                        {sectionLabel ? (
-                          <div className="px-3 py-2 text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
-                            {sectionLabel}
-                          </div>
-                        ) : null}
-                        {itemContent}
-                      </Fragment>
-                    );
-                  })}
+                return (
+                  <Fragment key={item.id}>
+                    {sectionLabel ? (
+                      <div className="px-3 py-2 text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
+                        {sectionLabel}
+                      </div>
+                    ) : null}
+                    {itemContent}
+                  </Fragment>
+                );
+              })}
               <div
                 className={cn(
                   "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -266,18 +266,7 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div className={cn("relative", listMaxHeightClassName)}  ref={listRef}>
-                <div className="relative">
-                  <div
-                    ref={topScrollSentinelRef}
-                    className="pointer-events-none absolute left-0 top-0 h-px w-px"
-                    aria-hidden
-                  />
-                  <div
-                    ref={bottomScrollSentinelRef}
-                    className="pointer-events-none absolute bottom-0 left-0 h-px w-px"
-                    aria-hidden
-                  />
+            <div ref={listRef} className={cn("relative", listMaxHeightClassName)}>
                   {items.map((item, index) => {
                     const sectionLabel =
                       item.sectionLabel &&
@@ -308,9 +297,15 @@ export const SlashCommandDropdown = forwardRef<
                           ) : undefined
                         }
                         onClick={() => selectItem(index)}
-                        onPointerMove={(e) => e.preventDefault()}
+                        // onPointerMove only fires on actual pointer movement
+                        // (not when items scroll under a stationary cursor).
+                        // preventDefault stops Radix from setting
+                        // data-highlighted, avoiding a double highlight.
+                        onPointerMove={(e) => {
+                          e.preventDefault();
+                          setSelectedIndex(index);
+                        }}
                         onPointerLeave={(e) => e.preventDefault()}
-                        onMouseEnter={() => setSelectedIndex(index)}
                         className={cn(
                           "group",
                           index === selectedIndex &&
@@ -344,7 +339,6 @@ export const SlashCommandDropdown = forwardRef<
                       </Fragment>
                     );
                   })}
-              </div>
               <div
                 className={cn(
                   "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -174,9 +174,7 @@ export const SlashCommandDropdown = forwardRef<
           <div style={virtualTriggerStyle} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          className={cn(
-            size === "wide" ? "w-80" : "w-64"
-          )}
+          className={size === "wide" ? "w-80" : "w-64"}
           align="start"
           avoidCollisions
           collisionPadding={12}

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -175,7 +175,6 @@ export const SlashCommandDropdown = forwardRef<
         </DropdownMenuTrigger>
         <DropdownMenuContent
           className={cn(
-            listMaxHeightClassName,
             size === "wide" ? "w-80" : "w-64"
           )}
           align="start"

--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -7,7 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
-  ScrollArea,
 } from "@dust-tt/sparkle";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import type React from "react";
@@ -241,7 +240,10 @@ export const SlashCommandDropdown = forwardRef<
           <div style={virtualTriggerStyle} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          className={size === "wide" ? "w-80" : "w-64"}
+          className={cn(
+            listMaxHeightClassName,
+            size === "wide" ? "w-80" : "w-64"
+          )}
           align="start"
           avoidCollisions
           collisionPadding={12}
@@ -264,11 +266,7 @@ export const SlashCommandDropdown = forwardRef<
               {emptyMessage}
             </div>
           ) : (
-            <div className="relative">
-              <ScrollArea
-                viewportRef={listRef}
-                viewportClassName={listMaxHeightClassName}
-              >
+            <div className={cn("relative", listMaxHeightClassName)}  ref={listRef}>
                 <div className="relative">
                   <div
                     ref={topScrollSentinelRef}
@@ -310,6 +308,8 @@ export const SlashCommandDropdown = forwardRef<
                           ) : undefined
                         }
                         onClick={() => selectItem(index)}
+                        onPointerMove={(e) => e.preventDefault()}
+                        onPointerLeave={(e) => e.preventDefault()}
                         onMouseEnter={() => setSelectedIndex(index)}
                         className={cn(
                           "group",
@@ -344,8 +344,7 @@ export const SlashCommandDropdown = forwardRef<
                       </Fragment>
                     );
                   })}
-                </div>
-              </ScrollArea>
+              </div>
               <div
                 className={cn(
                   "pointer-events-none absolute inset-x-0 top-0 h-10 bg-gradient-to-t",

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -52,21 +52,18 @@ export const menuStyleClasses = {
         variant: {
           default: cn(
             "s-p-2",
-            "hover:s-bg-muted-background dark:hover:s-bg-muted-night",
-            "focus:s-text-foreground dark:focus:s-text-foreground-night",
-            "focus:s-bg-muted-background dark:focus:s-bg-muted-night"
+            "data-[highlighted]:s-text-foreground dark:data-[highlighted]:s-text-foreground-night",
+            "data-[highlighted]:s-bg-muted-background dark:data-[highlighted]:s-bg-muted-night"
           ),
           tags: cn(
             "s-p-0.5",
-            "hover:s-bg-muted-background dark:hover:s-bg-muted-night",
-            "focus:s-text-foreground dark:focus:s-text-foreground-night",
-            "focus:s-bg-muted-background dark:focus:s-bg-muted-night"
+            "data-[highlighted]:s-text-foreground dark:data-[highlighted]:s-text-foreground-night",
+            "data-[highlighted]:s-bg-muted-background dark:data-[highlighted]:s-bg-muted-night"
           ),
           warning: cn(
             "s-p-2",
             "s-text-warning-500 dark:s-text-warning-500-night",
-            "hover:s-bg-warning-50 dark:hover:s-bg-warning-50-night",
-            "focus:s-bg-warning-50 dark:focus:s-bg-warning-50-night",
+            "data-[highlighted]:s-bg-warning-50 dark:data-[highlighted]:s-bg-warning-50-night",
             "active:s-bg-warning-100 dark:active:s-bg-warning-100-night"
           ),
         },


### PR DESCRIPTION
## Description
This PR is aim to

- fix double highlight issue in capability dropdown when you navigate via keyboard but your cursor is somewhere inside the dropdown content
- remove the fade effects (was not working in the capabilities picker)
- revert and fix scrollbar issues from [this PR](https://github.com/dust-tt/dust/pull/27330)

Also if your cursor is somewhere in the list when you navigate via keyboard, once you reach to the end of currently shown item it goes back to the hover place and then start navigating, instead of directly going to the next item. This is fixed in / command but not dropdown yet.
 
https://github.com/user-attachments/assets/5630da21-1d8d-4f08-b85c-aa6a38368016



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
