### PR TITLE
Fix: mcp server need to let the session id header pass.

### DIFF
--- a/front-api/middlewares/cors.ts
+++ b/front-api/middlewares/cors.ts
@@ -8,7 +8,8 @@ import { isDevelopment } from "@app/types/shared/env";
 import type { MiddlewareHandler } from "hono";
 
 const ALLOW_METHODS = "GET, POST, PUT, PATCH, DELETE, OPTIONS";
-const EXPOSE_HEADERS = "X-Reload-Required, WWW-Authenticate";
+const EXPOSE_HEADERS =
+  "X-Reload-Required, WWW-Authenticate, mcp-session-id, mcp-protocol-version";
 
 /**
  * Adds the cross-origin headers expected by browser clients to every

--- a/front-api/routes/mcp/index.ts
+++ b/front-api/routes/mcp/index.ts
@@ -81,8 +81,8 @@ mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
   setMcpTransportAuth(c, mcpAuthInfo);
   try {
     return await (parsedBody !== undefined
-      ? session!.transport.handleRequest(c, parsedBody)
-      : session!.transport.handleRequest(c));
+      ? session.transport.handleRequest(c, parsedBody)
+      : session.transport.handleRequest(c));
   } finally {
     clearMcpTransportAuth(c);
   }

--- a/front-api/routes/mcp/well-known.ts
+++ b/front-api/routes/mcp/well-known.ts
@@ -1,9 +1,15 @@
 import {
+  getMcpAuthorizationServers,
+  getMcpAuthorizationServerUrl,
   getMcpProtectedResourcePath,
   getMcpResourceServerUrl,
   getWorkOSAuthKitDomain,
+  getWorkOSAuthKitOAuthRegistrationUrl,
+  getWorkOSAuthKitOAuthTokenUrl,
+  shouldUseProxy,
 } from "@app/lib/api/mcp_server/urls";
 import { createHono } from "@front-api/lib/hono";
+import type { Context } from "hono";
 
 const WORKOS_AUTHKIT_DOMAIN = getWorkOSAuthKitDomain();
 const DUST_MCP_SERVER_URL = getMcpResourceServerUrl();
@@ -13,31 +19,90 @@ const authorizationServerMetadataUrl = new URL(
   WORKOS_AUTHKIT_DOMAIN
 );
 
-const protectedResourceMetadata = {
-  resource: DUST_MCP_SERVER_URL,
-  authorization_servers: [WORKOS_AUTHKIT_DOMAIN],
-  bearer_methods_supported: ["header"],
-} as const;
+function getProtectedResourceMetadata() {
+  return {
+    resource: DUST_MCP_SERVER_URL,
+    authorization_servers: getMcpAuthorizationServers(),
+    bearer_methods_supported: ["header"],
+  } as const;
+}
 
 export const mcpWellKnownApp = createHono();
 
 function serveProtectedResourceMetadata(c: {
   json: (body: unknown) => Response;
 }) {
-  return c.json(protectedResourceMetadata);
+  return c.json(getProtectedResourceMetadata());
+}
+
+type OAuthAuthorizationServerMetadata = {
+  token_endpoint?: string;
+  registration_endpoint?: string;
+  [key: string]: unknown;
+};
+
+function rewriteAuthorizationServerMetadataForBrowserClients(
+  metadata: OAuthAuthorizationServerMetadata
+): OAuthAuthorizationServerMetadata {
+  const mcpAuthorizationServerUrl = getMcpAuthorizationServerUrl();
+  return {
+    ...metadata,
+    token_endpoint: `${mcpAuthorizationServerUrl}/oauth2/token`,
+    ...(metadata.registration_endpoint
+      ? {
+          registration_endpoint: `${mcpAuthorizationServerUrl}/oauth2/register`,
+        }
+      : {}),
+  };
 }
 
 async function serveAuthorizationServerMetadata(c: {
   json: (body: unknown, status?: number) => Response;
 }) {
   const response = await fetch(authorizationServerMetadataUrl);
-  const metadata = await response.json();
+  const metadata = (await response.json()) as OAuthAuthorizationServerMetadata;
 
   if (!response.ok) {
     return c.json(metadata, response.status);
   }
 
-  return c.json(metadata);
+  if (!shouldUseProxy()) {
+    return c.json(metadata);
+  }
+
+  return c.json(rewriteAuthorizationServerMetadataForBrowserClients(metadata));
+}
+
+async function proxyOAuthPostRequest(
+  c: Context,
+  upstreamUrl: string
+): Promise<Response> {
+  const headers = new Headers();
+  const contentType = c.req.header("content-type");
+  if (contentType) {
+    headers.set("content-type", contentType);
+  }
+  const accept = c.req.header("accept");
+  if (accept) {
+    headers.set("accept", accept);
+  }
+
+  const response = await fetch(upstreamUrl, {
+    method: "POST",
+    headers,
+    body: await c.req.text(),
+  });
+
+  const responseHeaders = new Headers();
+  const responseContentType = response.headers.get("content-type");
+  if (responseContentType) {
+    responseHeaders.set("content-type", responseContentType);
+  }
+
+  return new Response(await response.text(), {
+    status: response.status,
+    headers: responseHeaders,
+  });
 }
 
 // Path-aware discovery for → /.well-known/oauth-protected-resource/mcp
@@ -55,3 +120,15 @@ mcpWellKnownApp.get(
   "/.well-known/oauth-authorization-server",
   serveAuthorizationServerMetadata
 );
+
+// Browser MCP clients in local dev exchange authorization codes via fetch;
+// proxy token/registration endpoints so CORS is handled by Dust instead of AuthKit.
+if (shouldUseProxy()) {
+  mcpWellKnownApp.post("/oauth2/token", async (c) =>
+    proxyOAuthPostRequest(c, getWorkOSAuthKitOAuthTokenUrl())
+  );
+
+  mcpWellKnownApp.post("/oauth2/register", async (c) =>
+    proxyOAuthPostRequest(c, getWorkOSAuthKitOAuthRegistrationUrl())
+  );
+}

--- a/front/lib/api/mcp_server/urls.ts
+++ b/front/lib/api/mcp_server/urls.ts
@@ -2,6 +2,18 @@ import config from "@app/lib/api/config";
 import { isDevelopment } from "@app/types/shared/env";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
+/** Flip to disable OAuth proxying in dev (e.g. native MCP clients → AuthKit direct). */
+const MCP_OAUTH_PROXY_ENABLED = true;
+
+/**
+ * Whether MCP OAuth metadata/token/registration should be proxied through the
+ * Dust MCP host. Enabled in development only; never active in production.
+ * Toggle via `MCP_OAUTH_PROXY_ENABLED` in this file.
+ */
+export function shouldUseProxy(): boolean {
+  return isDevelopment() && MCP_OAUTH_PROXY_ENABLED;
+}
+
 /**
  * AuthKit Connect domain for MCP OAuth (e.g. `your-env.authkit.app`).
  *
@@ -42,6 +54,25 @@ export function getMcpResourceServerUrl(): string {
 /** MCP server URL safe to display in client UI (uses public API base URL). */
 export function getMcpResourceServerUrlForClient(): string {
   return normalizeOAuthUrl(`${config.getApiBaseUrl().trim()}/mcp`);
+}
+
+/** MCP host origin for OAuth AS metadata discovery (proxied by front-api). */
+export function getMcpAuthorizationServerUrl(): string {
+  return normalizeOAuthUrl(new URL(getMcpResourceServerUrl()).origin);
+}
+
+export function getMcpAuthorizationServers(): string[] {
+  return shouldUseProxy()
+    ? [getMcpAuthorizationServerUrl()]
+    : [getWorkOSAuthKitDomain()];
+}
+
+export function getWorkOSAuthKitOAuthTokenUrl(): string {
+  return `${getWorkOSAuthKitDomain()}/oauth2/token`;
+}
+
+export function getWorkOSAuthKitOAuthRegistrationUrl(): string {
+  return `${getWorkOSAuthKitDomain()}/oauth2/register`;
 }
 
 export function getMcpResourceMetadataUrl(resourceServerUrl: string): URL {


### PR DESCRIPTION
## Description

Two fixes for MCP clients:

- Added `mcp-session-id` and `mcp-protocol-version` to `EXPOSE_HEADERS` in the CORS middleware so browser clients can read these response headers from the MCP server.
- Added a dev-only OAuth proxy (`shouldUseProxy()`) in `well-known.ts` that rewrites `authorization_servers` in the protected-resource metadata to point at the Dust host and proxies `/oauth2/token` and `/oauth2/register` POST requests to WorkOS AuthKit. This lets browser MCP clients complete the OAuth flow without hitting AuthKit directly (which doesn't set the required CORS headers). Controlled by `MCP_OAUTH_PROXY_ENABLED` in `urls.ts`; never active in production.
- Minor: removed non-null assertions on `session` in the MCP route handler (already guarded upstream).

## Tests

Tested with the MCP inspector and Claude.

## Risk

Low. The CORS header change is additive. The OAuth proxy is gated behind `shouldUseProxy()` which returns `false` in production (`isDevelopment() && MCP_OAUTH_PROXY_ENABLED`). No schema or DB changes.

## Deploy Plan

Deploy front-api.
