### PR TITLE
Fix 400 => 404 when missing session, log failures

### DIFF
--- a/front-api/routes/mcp/index.ts
+++ b/front-api/routes/mcp/index.ts
@@ -1,5 +1,6 @@
 import { mcpServerAuthMiddleware } from "@app/lib/api/mcp_server/auth";
 import { buildMcpAuthInfo } from "@app/lib/api/mcp_server/context";
+import type { WorkOSWorkspaceAuthenticator } from "@app/lib/api/workos_authenticator";
 import logger from "@app/logger/logger";
 import { createHono } from "@front-api/lib/hono";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
@@ -9,6 +10,35 @@ import type { Context } from "hono";
 import { createMcpSession, getMcpSession } from "./sessions";
 
 export const mcpApp = createHono();
+
+type McpSessionFailureReason =
+  | "unknown_session"
+  | "no_session"
+  | "missing_session_id_after_init";
+
+function logMcpSessionFailure(
+  auth: WorkOSWorkspaceAuthenticator,
+  {
+    method,
+    mcpSessionId,
+    reason,
+  }: {
+    method: string;
+    mcpSessionId: string | undefined;
+    reason: McpSessionFailureReason;
+  }
+) {
+  logger.warn(
+    {
+      userId: auth.user().sId,
+      workspaceId: auth.workspace().sId,
+      method,
+      mcpSessionId: mcpSessionId ?? null,
+      reason,
+    },
+    "[dust-mcp-server] MCP session resolution failed"
+  );
+}
 
 function extractBearerToken(authHeader: string | undefined): string | null {
   const match = authHeader?.match(/^Bearer\s+(.+)$/i);
@@ -40,7 +70,27 @@ mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
   let session = sessionIdHeader ? getMcpSession(sessionIdHeader) : undefined;
 
   if (!session) {
+    if (sessionIdHeader) {
+      logMcpSessionFailure(auth, {
+        method: c.req.method,
+        mcpSessionId: sessionIdHeader,
+        reason: "unknown_session",
+      });
+      return c.json(
+        {
+          error: "not_found",
+          error_description: "MCP session not found",
+        },
+        404
+      );
+    }
+
     if (c.req.method !== "POST") {
+      logMcpSessionFailure(auth, {
+        method: c.req.method,
+        mcpSessionId: sessionIdHeader,
+        reason: "no_session",
+      });
       return c.json(
         {
           error: "invalid_request",
@@ -53,6 +103,11 @@ mcpApp.all("/", mcpServerAuthMiddleware, async (c) => {
     parsedBody = await c.req.json();
     const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
     if (!messages.some(isInitializeRequest)) {
+      logMcpSessionFailure(auth, {
+        method: c.req.method,
+        mcpSessionId: sessionIdHeader,
+        reason: "missing_session_id_after_init",
+      });
       return c.json(
         {
           error: "invalid_request",


### PR DESCRIPTION
## Description

Requests to the MCP server that include an `mcp-session-id` header for a session that no longer exists were returning 400 instead of 404. The fix adds an explicit early check: if `sessionIdHeader` is present but `getMcpSession` returns nothing, respond with `404 not_found` immediately.

Also adds `logMcpSessionFailure` — a structured `logger.warn` with `userId`, `workspaceId`, `method`, `mcpSessionId`, and a typed `reason` (`unknown_session`, `no_session`, `missing_session_id_after_init`) — across all three session-resolution failure paths in the MCP request handler.

## Tests

Tested manually by sending requests with a missing/expired `mcp-session-id` and verifying the 404 response. No automated tests added (error path in HTTP middleware).

## Risk

Low. The change only affects the error response code for an already-failing path (400→404) and adds logging. No logic changes for successful session resolution.

## Deploy Plan

Deploy `front-api`.
