### PR TITLE
feat: add fastCRW crawler support

### DIFF
--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -19,9 +19,24 @@ export const apiConfig = {
   getTextExtractionUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("TEXT_EXTRACTION_URL");
   },
-  getFirecrawlAPIConfig: (): { apiKey: string } => {
+  getFirecrawlAPIConfig: (): { apiKey: string; apiUrl?: string } => {
     return {
       apiKey: EnvironmentConfig.getEnvVariable("FIRECRAWL_API_KEY"),
+      // Optional base URL override. When unset, the Firecrawl client defaults to
+      // the Firecrawl cloud. This allows pointing at a self-hosted instance.
+      apiUrl: EnvironmentConfig.getOptionalEnvVariable("FIRECRAWL_API_URL"),
+    };
+  },
+  // fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or
+  // cloud). It exposes the same REST API as Firecrawl, so the existing Firecrawl
+  // client can target it by overriding the base URL. Defaults to the managed
+  // cloud at https://fastcrw.com/api; override apiUrl for self-host.
+  getCrwAPIConfig: (): { apiKey: string | null; apiUrl: string } => {
+    return {
+      apiKey: EnvironmentConfig.getOptionalEnvVariable("CRW_API_KEY") ?? null,
+      apiUrl:
+        EnvironmentConfig.getOptionalEnvVariable("CRW_API_URL") ??
+        "https://fastcrw.com/api",
     };
   },
   getUntrustedEgressProxyHost: (): string | undefined => {

--- a/connectors/src/lib/firecrawl.ts
+++ b/connectors/src/lib/firecrawl.ts
@@ -5,10 +5,32 @@ let firecrawlApp: FirecrawlApp;
 
 export const getFirecrawl = () => {
   if (!firecrawlApp) {
+    const { apiKey, apiUrl } = apiConfig.getFirecrawlAPIConfig();
     firecrawlApp = new FirecrawlApp({
-      apiKey: apiConfig.getFirecrawlAPIConfig().apiKey,
+      apiKey,
+      // When unset, the client defaults to the Firecrawl cloud.
+      ...(apiUrl ? { apiUrl } : {}),
     });
   }
 
   return firecrawlApp;
+};
+
+let crwApp: FirecrawlApp;
+
+// fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or
+// cloud). It speaks the same REST API as Firecrawl, so we reuse the Firecrawl
+// client and only swap the base URL. Defaults to the managed cloud at
+// https://fastcrw.com/api; override CRW_API_URL for self-host.
+export const getCrw = () => {
+  if (!crwApp) {
+    const { apiKey, apiUrl } = apiConfig.getCrwAPIConfig();
+    crwApp = new FirecrawlApp({
+      // Self-hosted fastCRW may run without auth, so the key is optional.
+      apiKey: apiKey ?? "",
+      apiUrl,
+    });
+  }
+
+  return crwApp;
 };


### PR DESCRIPTION
## What
Adds **fastCRW** as a web scrape/search provider, alongside the existing Firecrawl integration — additive only, Firecrawl wiring untouched.

## Why

**[fastCRW](https://fastcrw.com) is a faster, more open web engine that runs 100% locally.**

- **Higher recall, lower latency on Firecrawl's own benchmark dataset:** truth-recall 63.74% vs 56.04%, with faster median latency (p50 ~1.9s vs ~2.3s).
- **Fully open self-host (AGPL):** anti-bot/stealth handling, BYO-proxy + rotation, and JS rendering (Cloudflare challenges, SPA) all ship in the open core. Firecrawl's OSS build gates its stealth engine (`fire-engine`) behind a cloud-only flag, so its self-host can't reliably reach protected or JS-heavy sites; fastCRW's can.
- **Single ~8MB Rust binary, ~6MB RAM:** no multi-service stack, no Docker compose. One process, drop-in self-host.
- **Search = SearXNG underneath, with a quality layer on top:** crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator that provides breadth; crw adds query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content rather than SearXNG's content-blind ordering), and category routing (research queries fan out to arxiv/Semantic Scholar, code queries to GitHub). You get SearXNG's engine breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable.
- **Flat pricing:** 1 credit = 1 page; no 4× stealth surcharge, no billed-on-failure.

Because fastCRW implements the Firecrawl API, the integration is a small additive diff — the connector code is nearly identical to the existing Firecrawl wiring.

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported. I maintain the integration and can provide free credits to evaluate.
