### PR TITLE
Add mechanism to skip logging for certain paths

### DIFF
--- a/front-api/middlewares/request_logger.ts
+++ b/front-api/middlewares/request_logger.ts
@@ -14,8 +14,25 @@ type RequestLoggerEnv = {
     auth?: Authenticator;
     session?: SessionWithUser;
     streaming?: boolean;
+    skipRequestLog?: boolean;
   };
 };
+
+export type SkipRequestLogEnv = {
+  Variables: {
+    skipRequestLog?: boolean;
+  };
+};
+
+// Mark a route subtree as too noisy to log. Mount it (`app.use("*",
+// skipRequestLog)`) inside the route module that should opt out; requestLogger
+// reads the flag after the handler runs and drops the log line.
+export const skipRequestLog = createMiddleware<SkipRequestLogEnv>(
+  async (c, next) => {
+    c.set("skipRequestLog", true);
+    return next();
+  }
+);
 
 // We skip k8s probes path to avoid noisy logs and skewed distribution
 const SKIP_LOGGER_PATHS = new Set([
@@ -114,24 +131,29 @@ export const requestLogger = createMiddleware<RequestLoggerEnv>(
       tags
     );
 
-    logger.info(
-      {
-        clientIp,
-        durationMs,
-        method: c.req.method,
-        peakConcurrency: peakRef.peak,
-        route,
-        sessionId: session?.sessionId ?? "unknown",
-        statusCode,
-        streaming,
-        url: c.req.path,
-        ...(user ? { user: { sId: user.sId } } : {}),
-        workspaceId:
-          auth && typeof auth.workspace === "function"
-            ? auth.workspace()?.sId
-            : undefined,
-      },
-      "Processed request"
-    );
+    // Routes that opted out via `skipRequestLog` are too noisy to log. The flag
+    // is set by a downstream route middleware, so it is only readable here,
+    // after `next()` has run the handler.
+    if (!c.get("skipRequestLog")) {
+      logger.info(
+        {
+          clientIp,
+          durationMs,
+          method: c.req.method,
+          peakConcurrency: peakRef.peak,
+          route,
+          sessionId: session?.sessionId ?? "unknown",
+          statusCode,
+          streaming,
+          url: c.req.path,
+          ...(user ? { user: { sId: user.sId } } : {}),
+          workspaceId:
+            auth && typeof auth.workspace === "function"
+              ? auth.workspace()?.sId
+              : undefined,
+        },
+        "Processed request"
+      );
+    }
   }
 );

--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -9,6 +9,7 @@ import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/
 import { upgradeRequestCreatedWorkflow } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { createHono } from "@front-api/lib/hono";
+import { skipRequestLog } from "@front-api/middlewares/request_logger";
 import type { ServeHandlerOptions } from "@novu/framework";
 import { NovuRequestHandler } from "@novu/framework";
 
@@ -56,6 +57,9 @@ const handler = new NovuRequestHandler<[Request], Response>({
 }).createHandler();
 
 const app = createHono();
+
+// Novu polls this endpoint frequently; too noisy to log every request.
+app.use("*", skipRequestLog);
 
 /** @ignoreswagger */
 app.get("/", (ctx) => handler(ctx.req.raw));

--- a/front-api/routes/subtle1.ts
+++ b/front-api/routes/subtle1.ts
@@ -1,6 +1,7 @@
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
+import { skipRequestLog } from "@front-api/middlewares/request_logger";
 import type { Context } from "hono";
 import { proxy } from "hono/proxy";
 
@@ -13,6 +14,9 @@ const POSTHOG_ASSETS_URL = "https://eu-assets.i.posthog.com";
 
 // Mounted at /subtle1 (root level, not under /api).
 const app = createHono();
+
+// High-volume PostHog analytics proxy; too noisy to log every request.
+app.use("*", skipRequestLog);
 
 const proxyToPostHog = (upstreamBaseUrl: string) => async (c: Context) => {
   const url = new URL(c.req.url);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8441

  Right now `front-api` logs every request via the `requestLogger` middleware, with the only opt-out being a hardcoded `SKIP_LOGGER_PATHS` set for k8s probes. Some routes used to not be logged when we used Next (e.g. the PostHog analytics proxy at `/subtle1/*` and the Novu polling endpoint at `/api/novu`), and a central exact-match list doesn't handle subtrees and tends to drift from the routes themselves.

  This change lets a route opt out of request logging by mounting a single middleware at its own registration — co-located with the route, no central list to maintain, and prefix matching falls out for free.

  ## Changes

  - **`front-api/middlewares/request_logger.ts`**
    - Added a `skipRequestLog` middleware (and `SkipRequestLogEnv` type) that sets a `skipRequestLog` context flag.
    - Added `skipRequestLog?: boolean` to `RequestLoggerEnv`.
    - Guarded the final `logger.info(...)` with `if (!c.get("skipRequestLog"))`. This works because `requestLogger` logs *after* `await next()`, so a flag set by a downstream route middleware is readable at log time (Hono shares one `c` across the parent and mounted
  sub-apps).
  - **`front-api/routes/novu/index.ts`** and **`front-api/routes/subtle1.ts`**
    - Each mounts `app.use("*", skipRequestLog)` with a short comment explaining why it's noisy.

  ## Notes

  - This drops **only the log line**. StatsD metrics, the APM trace, and concurrency tracking still run for these routes.
  - The hardcoded early-return for k8s probes (`SKIP_LOGGER_PATHS`) is unchanged — that decision happens before routing and also drops the APM trace, which is a different concern.
  - Adding another noisy route is now a one-liner in that route's module.

## Tests

Manual

## Risk

Low

## Deploy Plan

Front