### PR TITLE
[InputBar] Give slash command items a distinct action so shared guards stay sound

### DIFF
--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -27,6 +27,7 @@ import {
   useRef,
 } from "react";
 import {
+  INPUT_BAR_SLASH_COMMAND_ACTION,
   type InputBarSlashSuggestionCapability,
   isInputBarSlashSuggestionCapability,
 } from "./InputBarSlashSuggestionTypes";
@@ -151,6 +152,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
               return [
                 {
                   ...getSkillSlashCommandItem(capability.skill),
+                  action: INPUT_BAR_SLASH_COMMAND_ACTION,
                   data: capability,
                   id: `skill-${capability.skill.sId}`,
                 },
@@ -159,6 +161,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
               return [
                 {
                   ...getToolSlashCommandItem(capability.serverView),
+                  action: INPUT_BAR_SLASH_COMMAND_ACTION,
                   data: capability,
                   id: `tool-${capability.serverView.sId}`,
                 },

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -1,6 +1,11 @@
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 
+// Distinct from the skill/tool builder actions: input bar items carry their payload in `data` and
+// are narrowed via `isInputBarSlashSuggestionCapability`, so they must not match the shared
+// action-based guards (isSkillSlashCommand / isToolSlashCommand).
+export const INPUT_BAR_SLASH_COMMAND_ACTION = "input-bar-capability";
+
 export type InputBarSlashSuggestionCapability =
   | {
       kind: "skill";


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/27313.

In #27313, the input bar builds its slash command items by spreading the shared
`getSkillSlashCommandItem` / `getToolSlashCommandItem` builders and then overriding `data` with the
input-bar capability shape (`{ kind, skill | serverView }`). The spread keeps the builders'
`action` (`select-skill` / `select-tool`), but the payload under `data` is no longer the shape those
actions imply.

The shared guards `isSkillSlashCommand` / `isToolSlashCommand` narrow purely on `action` and promise
the builder's `data` shape (`{ skill }` / `{ tool: { view, ... } }`). So applying them to an input
bar item type-checks but is unsound: e.g. `isToolSlashCommand(inputBarItem)` returns `true` while
`item.data.tool` is `undefined`, which would crash on access.

There's no live bug today (the input bar uses its own `isInputBarSlashSuggestionCapability` guard
and never the shared ones), but it's a trap for the planned non-capability slash commands (`/compact`)
that #27313 is groundwork for. This gives input bar items a distinct `INPUT_BAR_SLASH_COMMAND_ACTION`
so the shared action-based guards can never match them. The input bar disambiguates via `data.kind`,
so it never relied on the shared `action` semantics.

## Risks

Blast radius: input bar slash command items (skills/tools dropdown)
Risk: none — items already carry their own `data` discriminant and are narrowed via
`isInputBarSlashSuggestionCapability`; only the unused `action` value changes.

## Deploy Plan
- deploy `front`