### PR TITLE
Migrate project files listing to DustFileSystem

### DIFF
--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
@@ -12,10 +12,10 @@ import { describe, expect, it } from "vitest";
 const PROJECT_ID = "spc_test123";
 
 describe("parseProjectScopedPath", () => {
-  it("strips the pod scope prefix", () => {
-    expect(parseProjectScopedPath("pod/reports/q1/summary.pdf")).toBe(
-      "reports/q1/summary.pdf"
-    );
+  it("strips the pod-{podId} scope prefix", () => {
+    expect(
+      parseProjectScopedPath("pod-spc_abc123/reports/q1/summary.pdf")
+    ).toBe("reports/q1/summary.pdf");
   });
 
   it("returns null for non-pod paths", () => {

--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.test.ts
@@ -14,7 +14,7 @@ const PROJECT_ID = "spc_test123";
 describe("parseProjectScopedPath", () => {
   it("strips the pod-{podId} scope prefix", () => {
     expect(
-      parseProjectScopedPath("pod-spc_abc123/reports/q1/summary.pdf")
+      parseProjectScopedPath(`pod-${PROJECT_ID}/reports/q1/summary.pdf`)
     ).toBe("reports/q1/summary.pdf");
   });
 

--- a/connectors/src/connectors/dust_project/lib/mount_path_utils.ts
+++ b/connectors/src/connectors/dust_project/lib/mount_path_utils.ts
@@ -1,19 +1,21 @@
 import { PROJECT_CONTEXT_FOLDER_ID } from "@connectors/connectors/dust_project/lib/constants";
 import { createHash } from "crypto";
 
-const POD_SCOPE_PREFIX = "pod/";
+// Matches pod-scoped paths from DustFileSystem: pod-{podId}/...
+const POD_SCOPE_RE = /^pod-[^/]+\//;
 
 /**
- * Strip the `pod/` scope prefix from a scoped mount path.
- * Returns null when the path is not a pod-scoped mount path.
+ * Strip the pod scope prefix from a scoped mount path.
+ * Returns null when the path is not pod-scoped.
  */
 export function parseProjectScopedPath(scopedPath: string): string | null {
-  if (!scopedPath.startsWith(POD_SCOPE_PREFIX)) {
-    return null;
+  const podMatch = scopedPath.match(POD_SCOPE_RE);
+  if (podMatch) {
+    const relativePath = scopedPath.slice(podMatch[0].length);
+    return relativePath.length > 0 ? relativePath : null;
   }
 
-  const relativePath = scopedPath.slice(POD_SCOPE_PREFIX.length);
-  return relativePath.length > 0 ? relativePath : null;
+  return null;
 }
 
 export function getMountDirInternalId(

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,21 +1,31 @@
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const listGCSMountFilesMock = vi.hoisted(() => vi.fn());
-const getConversationFileMountSignedUrlMock = vi.hoisted(() => vi.fn());
+const getAllFilesByPrefixMock = vi.hoisted(() => vi.fn());
+const getSignedUrlMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@app/lib/api/files/gcs_mount/files", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@app/lib/api/files/gcs_mount/files")>();
+vi.mock("@app/lib/file_storage/config", () => ({
+  default: { getGcsPrivateUploadsBucket: vi.fn(() => "test-bucket") },
+}));
+
+function makeGCSFile(
+  name: string,
+  contentType = "text/plain",
+  size = 1024,
+  updatedMs = 2000
+) {
   return {
-    ...actual,
-    listGCSMountFiles: listGCSMountFilesMock,
-    getConversationFileMountSignedUrl: getConversationFileMountSignedUrlMock,
+    name,
+    metadata: {
+      contentType,
+      size: String(size),
+      updated: new Date(updatedMs).toISOString(),
+    },
   };
-});
+}
 
 function getProjectFiles(
   workspace: { sId: string },
@@ -33,11 +43,14 @@ function getProjectFiles(
 
 describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
   beforeEach(() => {
-    listGCSMountFilesMock.mockReset();
-    getConversationFileMountSignedUrlMock.mockReset();
-    getConversationFileMountSignedUrlMock.mockResolvedValue(
-      new Ok("https://signed.example/read")
-    );
+    getAllFilesByPrefixMock.mockReset();
+    getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
+    getSignedUrlMock.mockReset();
+    getSignedUrlMock.mockResolvedValue("https://signed.example/read");
+    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+      getAllFilesByPrefix: getAllFilesByPrefixMock,
+      getSignedUrl: getSignedUrlMock,
+    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
   });
 
   it("returns 403 if not system key", async () => {
@@ -97,66 +110,46 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     });
   });
 
-  it("returns 500 when GCS listing fails", async () => {
+  it("returns files for a project space with canonical scoped paths", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,
     });
 
     const space = await SpaceFactory.project(workspace);
+    const prefix = `w/${workspace.sId}/pods/${space.sId}/files/`;
 
-    listGCSMountFilesMock.mockResolvedValue(
-      new Err(new Error("socket hang up"))
-    );
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [makeGCSFile(`${prefix}a.txt`, "text/plain", 3, 2000)],
+      pageFetchCount: 1,
+    });
 
     const response = await getProjectFiles(workspace, key, space.sId);
 
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({
-      error: {
-        type: "internal_server_error",
-        message: "Failed to list project files.",
-      },
-    });
+    expect(response.status).toBe(200);
+    expect(getAllFilesByPrefixMock).toHaveBeenCalledWith(
+      expect.objectContaining({ prefix })
+    );
+    const body = await response.json();
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].path).toBe(`pod-${space.sId}/a.txt`);
+    expect(body.files[0].signedDownloadUrl).toBe("https://signed.example/read");
   });
 
-  it("returns files for a project space and filters by updatedSince", async () => {
+  it("filters by updatedSince", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,
     });
 
     const space = await SpaceFactory.project(workspace);
+    const prefix = `w/${workspace.sId}/pods/${space.sId}/files/`;
 
-    const mockFile = {
-      isDirectory: false as const,
-      fileName: "a.txt",
-      path: "pod/a.txt",
-      sizeBytes: 3,
-      lastModifiedMs: 2000,
-      contentType: "text/plain",
-      fileId: null,
-      thumbnailUrl: null,
-    };
-
-    const mockFileWithUrl = {
-      ...mockFile,
-      signedDownloadUrl: "https://signed.example/read",
-    };
-
-    listGCSMountFilesMock.mockResolvedValue(
-      new Ok([
-        mockFile,
-        {
-          isDirectory: false as const,
-          fileName: "old.txt",
-          path: "pod/old.txt",
-          sizeBytes: 1,
-          lastModifiedMs: 500,
-          contentType: "text/plain",
-          fileId: null,
-          thumbnailUrl: null,
-        },
-      ])
-    );
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [
+        makeGCSFile(`${prefix}a.txt`, "text/plain", 3, 2000),
+        makeGCSFile(`${prefix}old.txt`, "text/plain", 1, 500),
+      ],
+      pageFetchCount: 1,
+    });
 
     const response = await getProjectFiles(
       workspace,
@@ -166,12 +159,8 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(listGCSMountFilesMock).toHaveBeenCalledWith(expect.anything(), {
-      useCase: "pod",
-      podId: space.sId,
-    });
-    expect(await response.json()).toEqual({
-      files: [mockFileWithUrl],
-    });
+    const body = await response.json();
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0].path).toBe(`pod-${space.sId}/a.txt`);
   });
 });

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,10 +1,7 @@
-import {
-  type GCSMountEntry,
-  getConversationFileMountSignedUrl,
-  getGCSPathFromScopedPath,
-  listGCSMountFiles,
-} from "@app/lib/api/files/gcs_mount/files";
-import { getPodFilesBasePath } from "@app/lib/api/files/mount_path";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -15,7 +12,7 @@ import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
 export type GetSpaceGCSMountFilesResponseType = {
-  files: GCSMountEntry[];
+  files: FileSystemEntry[];
 };
 
 const ParamsSchema = z.object({
@@ -73,12 +70,8 @@ app.get(
         ? updatedSinceMs
         : null;
 
-    const filesResult = await listGCSMountFiles(auth, {
-      useCase: "pod",
-      podId: space.sId,
-    });
-
-    if (filesResult.isErr()) {
+    const fsResult = await DustFileSystem.forPod(auth, space);
+    if (fsResult.isErr()) {
       return apiError(ctx, {
         status_code: 500,
         api_error: {
@@ -87,41 +80,28 @@ app.get(
         },
       });
     }
+    const dustFs = fsResult.value;
 
-    let files = filesResult.value;
+    let entries = await enrichListWithFileResourceIds(
+      auth,
+      dustFs,
+      await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`)
+    );
 
     if (updatedSinceFilter !== null) {
-      files = files.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
+      entries = entries.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
     }
 
-    const owner = auth.getNonNullableWorkspace();
-    const gcsPrefix = getPodFilesBasePath({
-      workspaceId: owner.sId,
-      podId: space.sId,
-    });
-
     const filesWithSignedUrls = await concurrentExecutor(
-      files,
+      entries,
       async (entry) => {
         if (entry.isDirectory) {
           return entry;
         }
-        const gcsPath = getGCSPathFromScopedPath({
-          prefix: gcsPrefix,
-          scopedPath: entry.path,
-          useCase: "pod",
-        });
-        if (!gcsPath) {
-          return { ...entry, signedDownloadUrl: null };
-        }
-        const signed = await getConversationFileMountSignedUrl(
-          auth,
-          { useCase: "pod", podId: space.sId },
-          gcsPath
-        );
+        const urlResult = await dustFs.getDownloadUrl(entry.path);
         return {
           ...entry,
-          signedDownloadUrl: signed.isOk() ? signed.value : null,
+          signedDownloadUrl: urlResult.isOk() ? urlResult.value : null,
         };
       },
       { concurrency: 8 }

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -9,14 +9,12 @@ import {
   getConversationFileMountSignedUrl,
   getGCSPathFromScopedPath,
   getScopedPathFromGCSPath,
-  listGCSMountFiles,
   renameGCSMountDirectory,
   renameGCSMountFile,
 } from "@app/lib/api/files/gcs_mount/files";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -275,147 +273,6 @@ describe("createGCSMountDirectory", () => {
 
     assert(entryRes.isOk());
     expect(saveMock).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("listGCSMountFiles", () => {
-  let auth: Authenticator;
-  let conversationId: string;
-  let workspaceId: string;
-  let getAllFilesByPrefixMock: ReturnType<typeof vi.fn>;
-
-  beforeEach(async () => {
-    getAllFilesByPrefixMock = vi.fn();
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      getAllFilesByPrefix: getAllFilesByPrefixMock,
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
-
-    const { authenticator, conversationsSpace } = await createResourceTest({});
-    auth = authenticator;
-    workspaceId = auth.getNonNullableWorkspace().sId;
-
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
-      name: "Test Agent",
-      description: "Test Agent",
-    });
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agentConfig.sId,
-      messagesCreatedAt: [],
-      spaceId: conversationsSpace.id,
-    });
-    conversationId = conversation.sId;
-  });
-
-  function gcsFile({
-    name,
-    contentType = "text/plain",
-    size = 100,
-  }: {
-    name: string;
-    contentType?: string;
-    size?: number;
-  }) {
-    return {
-      name,
-      metadata: {
-        contentType,
-        size: String(size),
-        updated: new Date().toISOString(),
-      },
-    };
-  }
-
-  it("excludes *.processed.<ext> siblings by default", async () => {
-    const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
-    getAllFilesByPrefixMock.mockResolvedValue({
-      files: [
-        gcsFile({
-          name: `${prefix}report.pdf`,
-          contentType: "application/pdf",
-        }),
-        gcsFile({ name: `${prefix}report.processed.txt` }),
-        gcsFile({ name: `${prefix}photo.jpg`, contentType: "image/jpeg" }),
-        gcsFile({
-          name: `${prefix}photo.processed.jpg`,
-          contentType: "image/jpeg",
-        }),
-      ],
-      pageFetchCount: 1,
-    });
-
-    const result = await listGCSMountFiles(auth, {
-      useCase: "conversation",
-      conversationId,
-    });
-
-    assert(result.isOk());
-    const paths = result.value.filter((e) => !e.isDirectory).map((e) => e.path);
-    expect(paths).toEqual(
-      expect.arrayContaining([
-        "conversation/report.pdf",
-        "conversation/photo.jpg",
-      ])
-    );
-    expect(paths).not.toEqual(
-      expect.arrayContaining([
-        "conversation/report.processed.txt",
-        "conversation/photo.processed.jpg",
-      ])
-    );
-  });
-
-  it("includes *.processed.<ext> siblings when includeProcessed is true", async () => {
-    const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
-    getAllFilesByPrefixMock.mockResolvedValue({
-      files: [
-        gcsFile({
-          name: `${prefix}report.pdf`,
-          contentType: "application/pdf",
-        }),
-        gcsFile({ name: `${prefix}report.processed.txt` }),
-      ],
-      pageFetchCount: 1,
-    });
-
-    const result = await listGCSMountFiles(
-      auth,
-      { useCase: "conversation", conversationId },
-      { includeProcessed: true }
-    );
-
-    assert(result.isOk());
-    const paths = result.value.filter((e) => !e.isDirectory).map((e) => e.path);
-    expect(paths).toEqual(
-      expect.arrayContaining([
-        "conversation/report.pdf",
-        "conversation/report.processed.txt",
-      ])
-    );
-  });
-
-  it("logs a warning when GCS listing used more than one page", async () => {
-    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
-    const prefix = `w/${workspaceId}/conversations/${conversationId}/files/`;
-    getAllFilesByPrefixMock.mockResolvedValue({
-      files: [gcsFile({ name: `${prefix}report.pdf` })],
-      pageFetchCount: 2,
-    });
-
-    await listGCSMountFiles(auth, {
-      useCase: "conversation",
-      conversationId,
-    });
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspaceId,
-        prefix,
-        pageFetchCount: 2,
-        objectCount: 1,
-      }),
-      "GCS mount file listing required multiple list requests; prefix has many objects."
-    );
-    warnSpy.mockRestore();
   });
 });
 

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -9,13 +9,12 @@ import {
   getConversationFilesBasePath,
   getPodFilesBasePath,
   getProjectFilesBasePath,
-  TOOL_OUTPUTS_FOLDER_NAME,
   toProjectMountFilePath,
 } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -211,136 +210,6 @@ function makeThumbnailUrl({
 
     default:
       assertNever(scope);
-  }
-}
-
-/**
- * List files from a GCS mount point (mounted bucket as source of truth).
- *
- * `.processed.<ext>` siblings are filtered out by default — they are
- * auto-generated artifacts (resized images, transcripts, extracted text) and
- * the UI file panel should not surface them. The MCP `files__list` tool opts
- * in via `includeProcessed: true` so the agent can read them directly.
- */
-export async function listGCSMountFiles(
-  auth: Authenticator,
-  scope: GCSMountPoint,
-  { includeProcessed = false }: { includeProcessed?: boolean } = {}
-): Promise<Result<GCSMountEntry[], Error>> {
-  const owner = auth.getNonNullableWorkspace();
-  const prefix = resolvePrefix(owner, scope);
-
-  try {
-    const bucket = getPrivateUploadBucket();
-    const { files: gcsFiles, pageFetchCount } =
-      await bucket.getAllFilesByPrefix({
-        prefix,
-        pageSize: 200,
-      });
-
-    if (pageFetchCount > 1) {
-      logger.warn(
-        {
-          workspaceId: owner.sId,
-          prefix,
-          scope,
-          pageFetchCount,
-          objectCount: gcsFiles.length,
-        },
-        "GCS mount file listing required multiple list requests; prefix has many objects."
-      );
-    }
-
-    // GCS folder placeholders are zero-byte objects whose path ends with "/".
-    const folderPlaceholders = gcsFiles.filter((f) => f.name.endsWith("/"));
-    const regularFiles = gcsFiles.filter((f) => {
-      if (f.name.endsWith("/")) {
-        return false;
-      }
-
-      if (includeProcessed) {
-        return true;
-      }
-
-      const name = f.name.split("/").pop() ?? "";
-      return !name.includes(".processed.");
-    });
-
-    // GCS files are listed under `pods/` but some FileResource rows still store the
-    // `projects/` form. Query both shapes so old rows still resolve.
-    const mountPaths = regularFiles.map((f) => f.name);
-    const legacyMountPaths = mountPaths.map((p) =>
-      p.replace("/pods/", "/projects/")
-    );
-    const fileResources = await FileResource.fetchByMountFilePaths(auth, [
-      ...mountPaths,
-      ...legacyMountPaths,
-    ]);
-    const fileResourceByMountPath = new Map<string, FileResource>();
-    for (const r of fileResources) {
-      if (r.mountFilePath) {
-        fileResourceByMountPath.set(
-          r.mountFilePath.replace("/projects/", "/pods/"),
-          r
-        );
-      }
-    }
-
-    const folderEntries: GCSMountDirectoryEntry[] = folderPlaceholders.flatMap(
-      (f) => {
-        const trimmed = f.name.replace(/\/$/, "");
-        const name = trimmed.split("/").pop() ?? "";
-        // Skip hidden folders (name starting with "."), except the tool outputs folder which is
-        // surfaced to users despite its dot prefix.
-        if (
-          !name ||
-          (name.startsWith(".") && name !== TOOL_OUTPUTS_FOLDER_NAME)
-        ) {
-          return [];
-        }
-
-        return [
-          makeDirectoryEntry(
-            {
-              fileName: name,
-              relativeFilePath: trimmed.slice(prefix.length),
-              sizeBytes: 0,
-              lastModifiedMs: isString(f.metadata.updated)
-                ? new Date(f.metadata.updated).getTime()
-                : 0,
-            },
-            scope
-          ),
-        ];
-      }
-    );
-
-    const fileEntries: GCSMountFileEntry[] = regularFiles.map((gcsFile) => {
-      const metadata = gcsFile.metadata;
-      const contentType = isString(metadata.contentType)
-        ? metadata.contentType
-        : "application/octet-stream";
-      const fileResource = fileResourceByMountPath.get(gcsFile.name) ?? null;
-
-      return makeFileEntry(
-        {
-          fileName: gcsFile.name.split("/").pop() ?? gcsFile.name,
-          relativeFilePath: gcsFile.name.slice(prefix.length),
-          sizeBytes: Number(metadata.size ?? 0),
-          contentType,
-          lastModifiedMs: isString(metadata.updated)
-            ? new Date(metadata.updated).getTime()
-            : 0,
-          fileId: fileResource?.sId ?? null,
-        },
-        scope,
-        owner.sId
-      );
-    });
-
-    return new Ok([...folderEntries, ...fileEntries]);
-  } catch (err) {
-    return new Err(normalizeError(err));
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The project files endpoint was calling into GCS directly, bypassing the `DustFileSystem` abstraction used everywhere else for pod storage. This PR migrates it to go through `DustFileSystem`, which also lets us generate download URLs through the same path as the rest of the file system rather than a one-off helper.

The scoped path format returned by the endpoint changes from `pod/<file>` to `pod-<spaceId>/<file>` to match what `DustFileSystem` produces. This has a one-time side effect on connectors the next time a full sync runs. Two scenarios:
- For files that have an associated file record, only the connector tracking row is recreated, the document ID in the search index is derived from the file record ID and stays stable, so no content is re-indexed.
- For files written directly by agents without a file record, the document ID is derived from the path, so it changes: the old search index entry is deleted and a new one is created from scratch.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Deploy connectors
- [ ] Deploy front
