### PR TITLE
tim-outlook

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -459,7 +459,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "outlook": {
     "create_contact": "high",
     "create_draft": "medium",
-    "create_reply_draft": "medium",
     "delete_draft": "low",
     "get_attachments": "never_ask",
     "get_contacts": "never_ask",

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -135,32 +135,69 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_draft: {
-    description: `Create a new email draft in Outlook.
+    description: `Create a new email draft in Outlook, or a reply draft to an existing message.
 - The draft will be saved in the user's Outlook account and can be reviewed and sent later.
-- The draft will include proper email headers and formatting`,
+- The draft will include proper email headers and formatting.`,
     schema: {
-      to: z.array(z.string()).describe("The email addresses of the recipients"),
-      cc: z.array(z.string()).optional().describe("The email addresses to CC"),
+      to: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The email addresses of the recipients (required if replyToMessageId is not set, acts as override if replyToMessageId is set)."
+        ),
+      cc: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The CC email addresses (optional, acts as override if replyToMessageId is set)."
+        ),
       bcc: z
         .array(z.string())
         .optional()
-        .describe("The email addresses to BCC"),
+        .describe(
+          "The BCC email addresses (optional, acts as override if replyToMessageId is set)."
+        ),
       replyTo: z
         .array(z.string())
         .optional()
         .describe(
           "Reply-to email addresses. Replies will go to these addresses instead of the sender."
         ),
-      subject: z.string().describe("The subject line of the email"),
-      contentType: z
+      subject: z
         .string()
-        .default("text")
-        .describe("The content type of the email (text or html)."),
+        .optional()
+        .describe(
+          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
+        ),
+      contentType: z
+        .enum(["text", "html"])
+        .optional()
+        .describe(
+          "The content type of the email body (required if replyToMessageId is not set, must be omitted if replyToMessageId is set — forced to html for replies)."
+        ),
       body: z.string().describe("The body of the email"),
       importance: z
         .string()
         .optional()
         .describe("The importance level of the email"),
+      replyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with the original message quoted."
+        ),
+      replyAll: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to reply to all recipients. Only used when replyToMessageId is set. Defaults to false."
+        ),
+      attachmentFilePath: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -179,43 +216,6 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Deleting draft",
       done: "Delete draft",
-    },
-  },
-  create_reply_draft: {
-    description: `Create a reply draft to an existing email in Outlook.
-- The draft will be saved in the user's Outlook account and can be reviewed and sent later.
-- The reply will be properly formatted with the original message quoted.
-- The draft will include proper email headers and threading information.`,
-    schema: {
-      messageId: z.string().describe("The ID of the message to reply to"),
-      body: z.string().describe("The body of the reply email"),
-      contentType: z
-        .string()
-        .optional()
-        .describe(
-          "The content type of the email (text or html). Defaults to html."
-        ),
-      replyAll: z
-        .boolean()
-        .optional()
-        .describe("Whether to reply to all recipients. Defaults to false."),
-      to: z
-        .array(z.string())
-        .optional()
-        .describe("Override the To recipients for the reply."),
-      cc: z
-        .array(z.string())
-        .optional()
-        .describe("Override the CC recipients for the reply."),
-      bcc: z
-        .array(z.string())
-        .optional()
-        .describe("Override the BCC recipients for the reply."),
-    },
-    stake: "medium",
-    displayLabels: {
-      running: "Creating reply draft",
-      done: "Create reply draft",
     },
   },
   send_mail: {
@@ -257,6 +257,12 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
           "The email address of the shared mailbox to send from (e.g. 'support@company.com'). " +
             "Leave empty to send from your own mailbox. " +
             "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
+      attachmentFilePath: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -143,7 +143,7 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .optional()
         .describe(
-          "The email addresses of the recipients (required if replyToMessageId is not set, acts as override if replyToMessageId is set)."
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
         ),
       cc: z
         .array(z.string())
@@ -173,18 +173,18 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .enum(["text", "html"])
         .optional()
         .describe(
-          "The content type of the email body (required if replyToMessageId is not set, must be omitted if replyToMessageId is set — forced to html for replies)."
+          "The content type of the email body (required if replyToMessageId is not set, must be omitted if replyToMessageId is set (forced to html for replies))."
         ),
       body: z.string().describe("The body of the email"),
       importance: z
-        .string()
+        .enum(["low", "normal", "high"])
         .optional()
-        .describe("The importance level of the email"),
+        .describe("The importance level of the email."),
       replyToMessageId: z
         .string()
         .optional()
         .describe(
-          "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with the original message quoted."
+          "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with proper threading headers and the original message quoted."
         ),
       replyAll: z
         .boolean()
@@ -197,6 +197,14 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe(
           "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+        ),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to create the draft in (e.g. 'support@company.com'). " +
+            "Leave empty to create the draft in your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
         ),
     },
     stake: "medium",
@@ -211,6 +219,12 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       messageId: z.string().describe("The ID of the draft to delete"),
       subject: z.string().describe("The subject of the draft to delete"),
       to: z.array(z.string()).describe("The email addresses of the recipients"),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox containing the draft. Omit to use the authenticated user's mailbox."
+        ),
     },
     stake: "low",
     displayLabels: {
@@ -225,8 +239,10 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     schema: {
       to: z
         .array(z.string())
-        .min(1)
-        .describe("The email addresses of the recipients"),
+        .optional()
+        .describe(
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
+        ),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
       bcc: z
         .array(z.string())
@@ -238,17 +254,29 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Reply-to email addresses. Replies will go to these addresses instead of the sender."
         ),
-      subject: z.string().describe("The subject line of the email"),
+      subject: z
+        .string()
+        .optional()
+        .describe(
+          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
+        ),
       contentType: z
         .enum(["text", "html"])
-        .default("text")
-        .describe("The content type of the email body (text or html)."),
+        .optional()
+        .describe(
+          "The content type of the email body (text or html). Required when replyToMessageId is not set. Must be omitted when replyToMessageId is set."
+        ),
       body: z.string().describe("The body of the email"),
+      importance: z
+        .enum(["low", "normal", "high"])
+        .optional()
+        .describe("The importance level of the email."),
       saveToSentItems: z
         .boolean()
         .optional()
         .describe(
-          "Whether to save the sent email to the Sent Items folder. Defaults to true."
+          "Whether to save the sent email to the Sent Items folder. Defaults to true. " +
+            "Note: this option is ignored when replyToMessageId is set or when an attachment is provided — the email will always be saved to Sent Items in those cases."
         ),
       sharedMailboxAddress: z
         .string()
@@ -263,6 +291,18 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe(
           "Optional. Scoped path of the file to attach to the email (e.g. `conversation-<id>/report.pdf` or `pod-<id>/data.csv`)."
+        ),
+      replyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
+        ),
+      replyAll: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to reply to all recipients. Only used when replyToMessageId is set. Defaults to false."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -1,12 +1,18 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { OUTLOOK_MAIL_FOLDER_LIST_MIME_TYPE } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type {
+  ToolHandlerExtra,
+  ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   extractTextFromBuffer,
   processAttachment,
 } from "@app/lib/actions/mcp_internal_actions/utils/attachment_processing";
-import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import {
+  getFileFromConversationAttachment,
+  sanitizeFilename,
+} from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import { getAllowedLabelsForMCPServer } from "@app/lib/api/actions/servers/microsoft/utils";
 import { OUTLOOK_TOOLS_METADATA } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -14,6 +20,49 @@ import { Err, Ok } from "@app/types/shared/result";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import sanitizeHtml from "sanitize-html";
 import { z } from "zod";
+
+const MAX_ATTACHMENT_SIZE_BYTES = 3 * 1024 * 1024; // 3MB — Graph API inline attachment limit
+
+async function fetchAttachment(
+  auth: ToolHandlerExtra["auth"],
+  attachmentFilePath: string | undefined,
+  agentLoopContext: ToolHandlerExtra["agentLoopContext"]
+): Promise<
+  | Ok<{ buffer: Buffer; filename: string; contentType: string } | null>
+  | Err<MCPError>
+> {
+  if (!attachmentFilePath) {
+    return new Ok(null);
+  }
+
+  if (!agentLoopContext) {
+    return new Err(new MCPError("No agent context available"));
+  }
+
+  const fileResult = await getFileFromConversationAttachment(
+    auth,
+    attachmentFilePath,
+    agentLoopContext
+  );
+
+  if (fileResult.isErr()) {
+    return new Err(
+      new MCPError(`File not found: ${attachmentFilePath}`, { tracked: false })
+    );
+  }
+
+  const { buffer, filename, contentType } = fileResult.value;
+
+  if (buffer.length > MAX_ATTACHMENT_SIZE_BYTES) {
+    return new Err(
+      new MCPError(
+        `Attachment file size exceeds the ${MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)}MB limit.`
+      )
+    );
+  }
+
+  return new Ok({ buffer, filename, contentType });
+}
 
 const DEFAULT_MESSAGE_FIELDS = [
   "id",
@@ -827,74 +876,218 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, replyTo, subject, contentType, body, importance = "normal" },
-    { authInfo }
+    {
+      to,
+      cc,
+      bcc,
+      replyTo,
+      subject,
+      contentType,
+      body,
+      importance = "normal",
+      replyToMessageId,
+      replyAll = false,
+      attachmentFilePath,
+    },
+    { authInfo, auth, agentLoopContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
 
-    // Create the email message object for Microsoft Graph API
-    const message: Record<string, unknown> = {
-      subject,
-      importance,
-      body: {
-        contentType,
-        content: body,
-      },
-      toRecipients: to.map((email) => ({
-        emailAddress: { address: email },
-      })),
-      isDraft: true,
-    };
+    const attachmentResult = await fetchAttachment(
+      auth,
+      attachmentFilePath,
+      agentLoopContext
+    );
+    if (attachmentResult.isErr()) {
+      return attachmentResult;
+    }
+    const attachment = attachmentResult.value;
 
-    if (cc && cc.length > 0) {
-      message.ccRecipients = cc.map((email) => ({
-        emailAddress: { address: email },
-      }));
+    let draftId: string;
+    let conversationId: string | undefined;
+
+    if (replyToMessageId) {
+      if (subject) {
+        return new Err(
+          new MCPError("subject must be omitted when replyToMessageId is set.")
+        );
+      }
+      if (contentType) {
+        return new Err(
+          new MCPError(
+            "contentType must be omitted when replyToMessageId is set."
+          )
+        );
+      }
+
+      const endpoint = replyAll
+        ? `/me/messages/${replyToMessageId}/createReplyAll`
+        : `/me/messages/${replyToMessageId}/createReply`;
+
+      const createDraftResponse = await fetchFromOutlook(
+        endpoint,
+        accessToken,
+        { method: "POST" }
+      );
+
+      if (!createDraftResponse.ok) {
+        const errorText = await getErrorText(createDraftResponse);
+        if (createDraftResponse.status === 404) {
+          return new Err(
+            new MCPError(`Message not found: ${replyToMessageId}`, {
+              tracked: false,
+            })
+          );
+        }
+        return new Err(
+          new MCPError(
+            `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
+          )
+        );
+      }
+
+      const createDraftResult = await createDraftResponse.json();
+      draftId = createDraftResult.id;
+      conversationId = createDraftResult.conversationId;
+
+      const existingBody = createDraftResult.body?.content ?? "";
+      const sanitizedBody = sanitizeHtml(body);
+      const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
+
+      const updatePayload: Record<string, unknown> = {
+        body: { contentType: "html", content: combinedBody },
+      };
+      if (to && to.length > 0) {
+        updatePayload.toRecipients = to.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+      if (cc && cc.length > 0) {
+        updatePayload.ccRecipients = cc.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+      if (bcc && bcc.length > 0) {
+        updatePayload.bccRecipients = bcc.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+
+      const updateDraftResponse = await fetchFromOutlook(
+        `/me/messages/${draftId}`,
+        accessToken,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updatePayload),
+        }
+      );
+
+      if (!updateDraftResponse.ok) {
+        const errorText = await getErrorText(updateDraftResponse);
+        return new Err(
+          new MCPError(`Failed to update reply draft: ${errorText}`)
+        );
+      }
+    } else {
+      if (!to || to.length === 0) {
+        return new Err(
+          new MCPError(
+            "At least one recipient is required when replyToMessageId is not set."
+          )
+        );
+      }
+      if (!subject?.trim()) {
+        return new Err(
+          new MCPError("subject is required when replyToMessageId is not set.")
+        );
+      }
+      if (!contentType) {
+        return new Err(
+          new MCPError(
+            "contentType is required when replyToMessageId is not set."
+          )
+        );
+      }
+
+      const message: Record<string, unknown> = {
+        subject,
+        importance,
+        body: { contentType, content: body },
+        toRecipients: to.map((email) => ({
+          emailAddress: { address: email },
+        })),
+        isDraft: true,
+      };
+
+      if (cc && cc.length > 0) {
+        message.ccRecipients = cc.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+      if (bcc && bcc.length > 0) {
+        message.bccRecipients = bcc.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+      if (replyTo && replyTo.length > 0) {
+        message.replyTo = replyTo.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+
+      const response = await fetchFromOutlook("/me/messages", accessToken, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(message),
+      });
+
+      if (!response.ok) {
+        const errorText = await getErrorText(response);
+        return new Err(new MCPError(`Failed to create draft: ${errorText}`));
+      }
+
+      const result = await response.json();
+      draftId = result.id;
+      conversationId = result.conversationId;
     }
 
-    if (bcc && bcc.length > 0) {
-      message.bccRecipients = bcc.map((email) => ({
-        emailAddress: { address: email },
-      }));
+    if (attachment) {
+      const attachmentResponse = await fetchFromOutlook(
+        `/me/messages/${draftId}/attachments`,
+        accessToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            name: sanitizeFilename(attachment.filename),
+            contentType: attachment.contentType,
+            contentBytes: attachment.buffer.toString("base64"),
+          }),
+        }
+      );
+
+      if (!attachmentResponse.ok) {
+        // Clean up the orphan draft — fire-and-forget, non-fatal
+        void fetchFromOutlook(`/me/messages/${draftId}`, accessToken, {
+          method: "DELETE",
+        });
+        const errorText = await getErrorText(attachmentResponse);
+        return new Err(
+          new MCPError(`Failed to add attachment to draft: ${errorText}`)
+        );
+      }
     }
-
-    if (replyTo && replyTo.length > 0) {
-      message.replyTo = replyTo.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    // Make the API call to create the draft in Outlook
-    const response = await fetchFromOutlook("/me/messages", accessToken, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(message),
-    });
-
-    if (!response.ok) {
-      const errorText = await getErrorText(response);
-      return new Err(new MCPError(`Failed to create draft: ${errorText}`));
-    }
-
-    const result = await response.json();
 
     return new Ok([
       { type: "text" as const, text: "Draft created successfully" },
       {
         type: "text" as const,
-        text: JSON.stringify(
-          {
-            messageId: result.id,
-            conversationId: result.conversationId,
-          },
-          null,
-          2
-        ),
+        text: JSON.stringify({ messageId: draftId, conversationId }, null, 2),
       },
     ]);
   },
@@ -927,125 +1120,6 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     ]);
   },
 
-  create_reply_draft: async (
-    { messageId, body, contentType = "html", replyAll = false, to, cc, bcc },
-    { authInfo }
-  ) => {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    // Create the reply draft
-    const endpoint = replyAll
-      ? `/me/messages/${messageId}/createReplyAll`
-      : `/me/messages/${messageId}/createReply`;
-
-    const replyMessage: Record<string, unknown> = {
-      message: {
-        body: {
-          contentType,
-          content: body,
-        },
-      },
-    };
-
-    // Add recipients if overriding
-    if (to && to.length > 0) {
-      (replyMessage.message as Record<string, unknown>).toRecipients = to.map(
-        (email) => ({
-          emailAddress: { address: email },
-        })
-      );
-    }
-
-    if (cc && cc.length > 0) {
-      (replyMessage.message as Record<string, unknown>).ccRecipients = cc.map(
-        (email) => ({
-          emailAddress: { address: email },
-        })
-      );
-    }
-
-    if (bcc && bcc.length > 0) {
-      (replyMessage.message as Record<string, unknown>).bccRecipients = bcc.map(
-        (email) => ({
-          emailAddress: { address: email },
-        })
-      );
-    }
-
-    // Create the empty draft
-    const createDraftResponse = await fetchFromOutlook(endpoint, accessToken, {
-      method: "POST",
-    });
-
-    if (!createDraftResponse.ok) {
-      const errorText = await getErrorText(createDraftResponse);
-      if (createDraftResponse.status === 404) {
-        return new Err(
-          new MCPError(`Message not found: ${messageId}`, {
-            tracked: false,
-          })
-        );
-      }
-      return new Err(
-        new MCPError(
-          `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
-        )
-      );
-    }
-
-    const createDraftResult = await createDraftResponse.json();
-
-    // Get the existing body content from the created draft (includes quoted original message)
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const existingBody = createDraftResult.body?.content || "";
-
-    // Prepend the new body to the existing HTML content
-    const sanitizedBody = sanitizeHtml(body);
-    const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
-
-    const updateDraftResponse = await fetchFromOutlook(
-      `/me/messages/${createDraftResult.id}`,
-      accessToken,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          body: {
-            contentType: "html",
-            content: combinedBody,
-          },
-        }),
-      }
-    );
-
-    if (!updateDraftResponse.ok) {
-      const errorText = await getErrorText(updateDraftResponse);
-      return new Err(new MCPError(`Failed to update the draft: ${errorText}`));
-    }
-
-    return new Ok([
-      { type: "text" as const, text: "Reply draft created successfully" },
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            messageId: createDraftResult.id,
-            conversationId: createDraftResult.conversationId,
-            originalMessageId: messageId,
-            subject: createDraftResult.subject,
-          },
-          null,
-          2
-        ),
-      },
-    ]);
-  },
-
   send_mail: async (
     {
       to,
@@ -1057,71 +1131,164 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       body,
       saveToSentItems = true,
       sharedMailboxAddress,
+      attachmentFilePath,
     },
-    { authInfo }
+    { authInfo, auth, agentLoopContext }
   ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
 
+    const attachmentResult = await fetchAttachment(
+      auth,
+      attachmentFilePath,
+      agentLoopContext
+    );
+    if (attachmentResult.isErr()) {
+      return attachmentResult;
+    }
+    const attachment = attachmentResult.value;
+
     const basePath = getMailboxBasePath(sharedMailboxAddress);
 
+    if (!attachment) {
+      // No attachment — send directly in one shot
+      const message: Record<string, unknown> = {
+        subject,
+        body: { contentType, content: body },
+        toRecipients: to.map((email) => ({ emailAddress: { address: email } })),
+      };
+
+      if (sharedMailboxAddress) {
+        message.from = { emailAddress: { address: sharedMailboxAddress } };
+      }
+      if (cc && cc.length > 0) {
+        message.ccRecipients = cc.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+      if (bcc && bcc.length > 0) {
+        message.bccRecipients = bcc.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+      if (replyTo && replyTo.length > 0) {
+        message.replyTo = replyTo.map((email) => ({
+          emailAddress: { address: email },
+        }));
+      }
+
+      const response = await fetchFromOutlook(
+        `${basePath}/sendMail`,
+        accessToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message, saveToSentItems }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await getErrorText(response);
+        return new Err(
+          new MCPError(
+            `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
+          )
+        );
+      }
+
+      return new Ok([
+        { type: "text" as const, text: "Email sent successfully" },
+      ]);
+    }
+
+    // With attachment — three steps: create draft, add attachment, send
     const message: Record<string, unknown> = {
       subject,
-      body: {
-        contentType,
-        content: body,
-      },
-      toRecipients: to.map((email) => ({
-        emailAddress: { address: email },
-      })),
+      body: { contentType, content: body },
+      toRecipients: to.map((email) => ({ emailAddress: { address: email } })),
+      isDraft: true,
     };
 
     if (sharedMailboxAddress) {
-      message.from = {
-        emailAddress: { address: sharedMailboxAddress },
-      };
+      message.from = { emailAddress: { address: sharedMailboxAddress } };
     }
-
     if (cc && cc.length > 0) {
       message.ccRecipients = cc.map((email) => ({
         emailAddress: { address: email },
       }));
     }
-
     if (bcc && bcc.length > 0) {
       message.bccRecipients = bcc.map((email) => ({
         emailAddress: { address: email },
       }));
     }
-
     if (replyTo && replyTo.length > 0) {
       message.replyTo = replyTo.map((email) => ({
         emailAddress: { address: email },
       }));
     }
 
-    const response = await fetchFromOutlook(
-      `${basePath}/sendMail`,
+    const createResponse = await fetchFromOutlook(
+      `${basePath}/messages`,
       accessToken,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(message),
+      }
+    );
+
+    if (!createResponse.ok) {
+      const errorText = await getErrorText(createResponse);
+      return new Err(
+        new MCPError(`Failed to create draft for sending: ${errorText}`)
+      );
+    }
+
+    const draft = await createResponse.json();
+    const draftId: string = draft.id;
+
+    const attachmentResponse = await fetchFromOutlook(
+      `${basePath}/messages/${draftId}/attachments`,
+      accessToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          message,
-          saveToSentItems,
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          name: sanitizeFilename(attachment.filename),
+          contentType: attachment.contentType,
+          contentBytes: attachment.buffer.toString("base64"),
         }),
       }
     );
 
-    if (!response.ok) {
-      const errorText = await getErrorText(response);
+    if (!attachmentResponse.ok) {
+      // Clean up orphan draft — fire-and-forget, non-fatal
+      void fetchFromOutlook(`${basePath}/messages/${draftId}`, accessToken, {
+        method: "DELETE",
+      });
+      const errorText = await getErrorText(attachmentResponse);
+      return new Err(new MCPError(`Failed to add attachment: ${errorText}`));
+    }
+
+    const sendResponse = await fetchFromOutlook(
+      `${basePath}/messages/${draftId}/send`,
+      accessToken,
+      { method: "POST" }
+    );
+
+    if (!sendResponse.ok) {
+      // Clean up orphan draft — fire-and-forget, non-fatal
+      void fetchFromOutlook(`${basePath}/messages/${draftId}`, accessToken, {
+        method: "DELETE",
+      });
+      const errorText = await getErrorText(sendResponse);
       return new Err(
         new MCPError(
-          `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
+          `Failed to send email: ${sendResponse.status} ${sendResponse.statusText} - ${errorText}`
         )
       );
     }

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -401,6 +401,323 @@ const findFolderByPath = async (
   return { folderId: parentFolderId };
 };
 
+async function createOutlookDraft({
+  basePath,
+  accessToken,
+  replyToMessageId,
+  replyAll,
+  subject,
+  contentType,
+  body,
+  importance,
+  to,
+  cc,
+  bcc,
+  replyTo,
+  sharedMailboxAddress,
+  attachment,
+}: {
+  basePath: string;
+  accessToken: string;
+  replyToMessageId?: string;
+  replyAll?: boolean;
+  subject?: string;
+  contentType?: string;
+  body: string;
+  importance?: string;
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  sharedMailboxAddress?: string;
+  attachment: { buffer: Buffer; filename: string; contentType: string } | null;
+}): Promise<Ok<{ draftId: string; conversationId?: string }> | Err<MCPError>> {
+  let draftId: string;
+  let conversationId: string | undefined;
+
+  if (replyToMessageId) {
+    const endpoint =
+      (replyAll ?? false)
+        ? `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/createReplyAll`
+        : `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/createReply`;
+
+    const createDraftResponse = await fetchFromOutlook(endpoint, accessToken, {
+      method: "POST",
+    });
+
+    if (!createDraftResponse.ok) {
+      const errorText = await getErrorText(createDraftResponse);
+      if (createDraftResponse.status === 404) {
+        return new Err(
+          new MCPError(`Message not found: ${replyToMessageId}`, {
+            tracked: false,
+          })
+        );
+      }
+      return new Err(
+        new MCPError(
+          `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
+        )
+      );
+    }
+
+    const createDraftResult = await createDraftResponse.json();
+    draftId = createDraftResult.id;
+    conversationId = createDraftResult.conversationId;
+
+    const existingBody = createDraftResult.body?.content ?? "";
+    const sanitizedBody = sanitizeHtml(body);
+    const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
+
+    const updatePayload: Record<string, unknown> = {
+      body: { contentType: "html", content: combinedBody },
+      importance,
+    };
+    if (to && to.length > 0) {
+      updatePayload.toRecipients = to.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (cc && cc.length > 0) {
+      updatePayload.ccRecipients = cc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (bcc && bcc.length > 0) {
+      updatePayload.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (replyTo && replyTo.length > 0) {
+      updatePayload.replyTo = replyTo.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    const encodedDraftId = encodeURIComponent(draftId);
+
+    const updateDraftResponse = await fetchFromOutlook(
+      `${basePath}/messages/${encodedDraftId}`,
+      accessToken,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updatePayload),
+      }
+    );
+
+    if (!updateDraftResponse.ok) {
+      void fetchFromOutlook(
+        `${basePath}/messages/${encodedDraftId}`,
+        accessToken,
+        { method: "DELETE" }
+      );
+      const errorText = await getErrorText(updateDraftResponse);
+      return new Err(
+        new MCPError(`Failed to update reply draft: ${errorText}`)
+      );
+    }
+  } else {
+    const message: Record<string, unknown> = {
+      subject,
+      importance,
+      body: { contentType, content: body },
+      toRecipients: (to ?? []).map((email) => ({
+        emailAddress: { address: email },
+      })),
+      isDraft: true,
+    };
+
+    if (sharedMailboxAddress) {
+      message.from = { emailAddress: { address: sharedMailboxAddress } };
+    }
+    if (cc && cc.length > 0) {
+      message.ccRecipients = cc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (bcc && bcc.length > 0) {
+      message.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (replyTo && replyTo.length > 0) {
+      message.replyTo = replyTo.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    const response = await fetchFromOutlook(
+      `${basePath}/messages`,
+      accessToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(message),
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(new MCPError(`Failed to create draft: ${errorText}`));
+    }
+
+    const result = await response.json();
+    draftId = result.id;
+    conversationId = result.conversationId;
+  }
+
+  if (attachment) {
+    const encodedDraftId = encodeURIComponent(draftId);
+    const attachmentResponse = await fetchFromOutlook(
+      `${basePath}/messages/${encodedDraftId}/attachments`,
+      accessToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          "@odata.type": "#microsoft.graph.fileAttachment",
+          name: sanitizeFilename(attachment.filename),
+          contentType: attachment.contentType,
+          contentBytes: attachment.buffer.toString("base64"),
+        }),
+      }
+    );
+
+    if (!attachmentResponse.ok) {
+      void fetchFromOutlook(
+        `${basePath}/messages/${encodedDraftId}`,
+        accessToken,
+        { method: "DELETE" }
+      );
+      const errorText = await getErrorText(attachmentResponse);
+      return new Err(new MCPError(`Failed to add attachment: ${errorText}`));
+    }
+  }
+
+  return new Ok({ draftId, conversationId });
+}
+
+async function sendDirectMail({
+  basePath,
+  accessToken,
+  to,
+  cc,
+  bcc,
+  replyTo,
+  subject,
+  contentType,
+  body,
+  importance,
+  saveToSentItems,
+  sharedMailboxAddress,
+}: {
+  basePath: string;
+  accessToken: string;
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  subject?: string;
+  contentType?: string;
+  body: string;
+  importance?: string;
+  saveToSentItems: boolean;
+  sharedMailboxAddress?: string;
+}): Promise<Ok<null> | Err<MCPError>> {
+  const message: Record<string, unknown> = {
+    subject,
+    importance,
+    body: { contentType: contentType ?? "text", content: body },
+    toRecipients: (to ?? []).map((email) => ({
+      emailAddress: { address: email },
+    })),
+  };
+  if (sharedMailboxAddress) {
+    message.from = { emailAddress: { address: sharedMailboxAddress } };
+  }
+  if (cc && cc.length > 0) {
+    message.ccRecipients = cc.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (bcc && bcc.length > 0) {
+    message.bccRecipients = bcc.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (replyTo && replyTo.length > 0) {
+    message.replyTo = replyTo.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+
+  const response = await fetchFromOutlook(`${basePath}/sendMail`, accessToken, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message, saveToSentItems }),
+  });
+
+  if (!response.ok) {
+    const errorText = await getErrorText(response);
+    return new Err(
+      new MCPError(
+        `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
+      )
+    );
+  }
+
+  return new Ok(null);
+}
+
+function validateMailParams({
+  replyToMessageId,
+  subject,
+  contentType,
+  to,
+}: {
+  replyToMessageId?: string;
+  subject?: string;
+  contentType?: string;
+  to?: string[];
+}): Err<MCPError> | null {
+  if (replyToMessageId) {
+    if (subject) {
+      return new Err(
+        new MCPError("subject must be omitted when replyToMessageId is set.")
+      );
+    }
+    if (contentType) {
+      return new Err(
+        new MCPError(
+          "contentType must be omitted when replyToMessageId is set."
+        )
+      );
+    }
+  } else {
+    if (!to || to.length === 0) {
+      return new Err(
+        new MCPError(
+          "At least one recipient is required when replyToMessageId is not set."
+        )
+      );
+    }
+    if (!subject?.trim()) {
+      return new Err(
+        new MCPError("subject is required when replyToMessageId is not set.")
+      );
+    }
+    if (!contentType) {
+      return new Err(
+        new MCPError(
+          "contentType is required when replyToMessageId is not set."
+        )
+      );
+    }
+  }
+  return null;
+}
+
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
     { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
@@ -888,6 +1205,7 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       replyToMessageId,
       replyAll = false,
       attachmentFilePath,
+      sharedMailboxAddress,
     },
     { authInfo, auth, agentLoopContext }
   ) => {
@@ -895,6 +1213,18 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
+
+    const validationError = validateMailParams({
+      replyToMessageId,
+      subject,
+      contentType,
+      to,
+    });
+    if (validationError) {
+      return validationError;
+    }
+
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
 
     const attachmentResult = await fetchAttachment(
       auth,
@@ -904,195 +1234,47 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     if (attachmentResult.isErr()) {
       return attachmentResult;
     }
-    const attachment = attachmentResult.value;
 
-    let draftId: string;
-    let conversationId: string | undefined;
-
-    if (replyToMessageId) {
-      if (subject) {
-        return new Err(
-          new MCPError("subject must be omitted when replyToMessageId is set.")
-        );
-      }
-      if (contentType) {
-        return new Err(
-          new MCPError(
-            "contentType must be omitted when replyToMessageId is set."
-          )
-        );
-      }
-
-      const endpoint = replyAll
-        ? `/me/messages/${replyToMessageId}/createReplyAll`
-        : `/me/messages/${replyToMessageId}/createReply`;
-
-      const createDraftResponse = await fetchFromOutlook(
-        endpoint,
-        accessToken,
-        { method: "POST" }
-      );
-
-      if (!createDraftResponse.ok) {
-        const errorText = await getErrorText(createDraftResponse);
-        if (createDraftResponse.status === 404) {
-          return new Err(
-            new MCPError(`Message not found: ${replyToMessageId}`, {
-              tracked: false,
-            })
-          );
-        }
-        return new Err(
-          new MCPError(
-            `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
-          )
-        );
-      }
-
-      const createDraftResult = await createDraftResponse.json();
-      draftId = createDraftResult.id;
-      conversationId = createDraftResult.conversationId;
-
-      const existingBody = createDraftResult.body?.content ?? "";
-      const sanitizedBody = sanitizeHtml(body);
-      const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
-
-      const updatePayload: Record<string, unknown> = {
-        body: { contentType: "html", content: combinedBody },
-      };
-      if (to && to.length > 0) {
-        updatePayload.toRecipients = to.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-      if (cc && cc.length > 0) {
-        updatePayload.ccRecipients = cc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-      if (bcc && bcc.length > 0) {
-        updatePayload.bccRecipients = bcc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      const updateDraftResponse = await fetchFromOutlook(
-        `/me/messages/${draftId}`,
-        accessToken,
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(updatePayload),
-        }
-      );
-
-      if (!updateDraftResponse.ok) {
-        const errorText = await getErrorText(updateDraftResponse);
-        return new Err(
-          new MCPError(`Failed to update reply draft: ${errorText}`)
-        );
-      }
-    } else {
-      if (!to || to.length === 0) {
-        return new Err(
-          new MCPError(
-            "At least one recipient is required when replyToMessageId is not set."
-          )
-        );
-      }
-      if (!subject?.trim()) {
-        return new Err(
-          new MCPError("subject is required when replyToMessageId is not set.")
-        );
-      }
-      if (!contentType) {
-        return new Err(
-          new MCPError(
-            "contentType is required when replyToMessageId is not set."
-          )
-        );
-      }
-
-      const message: Record<string, unknown> = {
-        subject,
-        importance,
-        body: { contentType, content: body },
-        toRecipients: to.map((email) => ({
-          emailAddress: { address: email },
-        })),
-        isDraft: true,
-      };
-
-      if (cc && cc.length > 0) {
-        message.ccRecipients = cc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-      if (bcc && bcc.length > 0) {
-        message.bccRecipients = bcc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-      if (replyTo && replyTo.length > 0) {
-        message.replyTo = replyTo.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      const response = await fetchFromOutlook("/me/messages", accessToken, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(message),
-      });
-
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        return new Err(new MCPError(`Failed to create draft: ${errorText}`));
-      }
-
-      const result = await response.json();
-      draftId = result.id;
-      conversationId = result.conversationId;
-    }
-
-    if (attachment) {
-      const attachmentResponse = await fetchFromOutlook(
-        `/me/messages/${draftId}/attachments`,
-        accessToken,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            "@odata.type": "#microsoft.graph.fileAttachment",
-            name: sanitizeFilename(attachment.filename),
-            contentType: attachment.contentType,
-            contentBytes: attachment.buffer.toString("base64"),
-          }),
-        }
-      );
-
-      if (!attachmentResponse.ok) {
-        // Clean up the orphan draft — fire-and-forget, non-fatal
-        void fetchFromOutlook(`/me/messages/${draftId}`, accessToken, {
-          method: "DELETE",
-        });
-        const errorText = await getErrorText(attachmentResponse);
-        return new Err(
-          new MCPError(`Failed to add attachment to draft: ${errorText}`)
-        );
-      }
+    const result = await createOutlookDraft({
+      basePath,
+      accessToken,
+      replyToMessageId,
+      replyAll,
+      subject,
+      contentType,
+      body,
+      importance,
+      to,
+      cc,
+      bcc,
+      replyTo,
+      sharedMailboxAddress,
+      attachment: attachmentResult.value,
+    });
+    if (result.isErr()) {
+      return result;
     }
 
     return new Ok([
       { type: "text" as const, text: "Draft created successfully" },
       {
         type: "text" as const,
-        text: JSON.stringify({ messageId: draftId, conversationId }, null, 2),
+        text: JSON.stringify(
+          {
+            messageId: result.value.draftId,
+            conversationId: result.value.conversationId,
+          },
+          null,
+          2
+        ),
       },
     ]);
   },
 
-  delete_draft: async ({ messageId, subject, to }, { authInfo }) => {
+  delete_draft: async (
+    { messageId, subject, to, sharedMailboxAddress },
+    { authInfo }
+  ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -1105,8 +1287,10 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       );
     }
 
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
+
     const response = await fetchFromOutlook(
-      `/me/messages/${messageId}`,
+      `${basePath}/messages/${messageId}`,
       accessToken,
       { method: "DELETE" }
     );
@@ -1127,11 +1311,14 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       bcc,
       replyTo,
       subject,
-      contentType = "text",
+      contentType,
       body,
+      importance,
       saveToSentItems = true,
       sharedMailboxAddress,
       attachmentFilePath,
+      replyToMessageId,
+      replyAll = false,
     },
     { authInfo, auth, agentLoopContext }
   ) => {
@@ -1139,6 +1326,18 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
     }
+
+    const validationError = validateMailParams({
+      replyToMessageId,
+      subject,
+      contentType,
+      to,
+    });
+    if (validationError) {
+      return validationError;
+    }
+
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
 
     const attachmentResult = await fetchAttachment(
       auth,
@@ -1150,141 +1349,64 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     }
     const attachment = attachmentResult.value;
 
-    const basePath = getMailboxBasePath(sharedMailboxAddress);
-
-    if (!attachment) {
-      // No attachment — send directly in one shot
-      const message: Record<string, unknown> = {
-        subject,
-        body: { contentType, content: body },
-        toRecipients: to.map((email) => ({ emailAddress: { address: email } })),
-      };
-
-      if (sharedMailboxAddress) {
-        message.from = { emailAddress: { address: sharedMailboxAddress } };
-      }
-      if (cc && cc.length > 0) {
-        message.ccRecipients = cc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-      if (bcc && bcc.length > 0) {
-        message.bccRecipients = bcc.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-      if (replyTo && replyTo.length > 0) {
-        message.replyTo = replyTo.map((email) => ({
-          emailAddress: { address: email },
-        }));
-      }
-
-      const response = await fetchFromOutlook(
-        `${basePath}/sendMail`,
+    if (!replyToMessageId && !attachment) {
+      const result = await sendDirectMail({
+        basePath,
         accessToken,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ message, saveToSentItems }),
-        }
-      );
-
-      if (!response.ok) {
-        const errorText = await getErrorText(response);
-        return new Err(
-          new MCPError(
-            `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
-          )
-        );
+        to,
+        cc,
+        bcc,
+        replyTo,
+        subject,
+        contentType,
+        body,
+        importance,
+        saveToSentItems,
+        sharedMailboxAddress,
+      });
+      if (result.isErr()) {
+        return result;
       }
-
       return new Ok([
         { type: "text" as const, text: "Email sent successfully" },
       ]);
     }
 
-    // With attachment — three steps: create draft, add attachment, send
-    const message: Record<string, unknown> = {
+    // Reply or attachment path — create draft, then send
+    const draftResult = await createOutlookDraft({
+      basePath,
+      accessToken,
+      replyToMessageId,
+      replyAll,
       subject,
-      body: { contentType, content: body },
-      toRecipients: to.map((email) => ({ emailAddress: { address: email } })),
-      isDraft: true,
-    };
-
-    if (sharedMailboxAddress) {
-      message.from = { emailAddress: { address: sharedMailboxAddress } };
+      contentType,
+      body,
+      importance,
+      to,
+      cc,
+      bcc,
+      replyTo,
+      sharedMailboxAddress,
+      attachment,
+    });
+    if (draftResult.isErr()) {
+      return draftResult;
     }
-    if (cc && cc.length > 0) {
-      message.ccRecipients = cc.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-    if (bcc && bcc.length > 0) {
-      message.bccRecipients = bcc.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-    if (replyTo && replyTo.length > 0) {
-      message.replyTo = replyTo.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    const createResponse = await fetchFromOutlook(
-      `${basePath}/messages`,
-      accessToken,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(message),
-      }
-    );
-
-    if (!createResponse.ok) {
-      const errorText = await getErrorText(createResponse);
-      return new Err(
-        new MCPError(`Failed to create draft for sending: ${errorText}`)
-      );
-    }
-
-    const draft = await createResponse.json();
-    const draftId: string = draft.id;
-
-    const attachmentResponse = await fetchFromOutlook(
-      `${basePath}/messages/${draftId}/attachments`,
-      accessToken,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          "@odata.type": "#microsoft.graph.fileAttachment",
-          name: sanitizeFilename(attachment.filename),
-          contentType: attachment.contentType,
-          contentBytes: attachment.buffer.toString("base64"),
-        }),
-      }
-    );
-
-    if (!attachmentResponse.ok) {
-      // Clean up orphan draft — fire-and-forget, non-fatal
-      void fetchFromOutlook(`${basePath}/messages/${draftId}`, accessToken, {
-        method: "DELETE",
-      });
-      const errorText = await getErrorText(attachmentResponse);
-      return new Err(new MCPError(`Failed to add attachment: ${errorText}`));
-    }
+    const { draftId } = draftResult.value;
+    const encodedDraftId = encodeURIComponent(draftId);
 
     const sendResponse = await fetchFromOutlook(
-      `${basePath}/messages/${draftId}/send`,
+      `${basePath}/messages/${encodedDraftId}/send`,
       accessToken,
       { method: "POST" }
     );
 
     if (!sendResponse.ok) {
-      // Clean up orphan draft — fire-and-forget, non-fatal
-      void fetchFromOutlook(`${basePath}/messages/${draftId}`, accessToken, {
-        method: "DELETE",
-      });
+      void fetchFromOutlook(
+        `${basePath}/messages/${encodedDraftId}`,
+        accessToken,
+        { method: "DELETE" }
+      );
       const errorText = await getErrorText(sendResponse);
       return new Err(
         new MCPError(

--- a/x/henry/dust-hive/src/proxy-daemon.ts
+++ b/x/henry/dust-hive/src/proxy-daemon.ts
@@ -30,6 +30,7 @@ type Target = "front-api" | "marketing";
 const ROUTES: ReadonlyArray<{ pattern: RegExp; target: Target }> = [
   { pattern: /^\/m\/api(\/.*)?$/, target: "marketing" }, // /m/api/*
   { pattern: /^\/api(\/.*)?$/, target: "front-api" }, //   /api/*
+  { pattern: /^\/oauth(\/.*)?$/, target: "front-api" }, // /oauth/*
 ];
 
 const DEFAULT_TARGET: Target = "marketing";


### PR DESCRIPTION
## Description

Refactor of the Outlook MCP mail tools to align with the Gmail MCP implementation and extend functionality.
- Merged create_draft_reply into create_draft.
- Added reply support to send_mail.
- added attachment file support to send_maill & create_draft.

## Tests

Tested manually.

## Risk

Low, no shared infrastructure touched.

## Deploy Plan
