### PR TITLE
Remove Next from the Hono image

### DIFF
--- a/.github/workflows/build-and-test-front-api.yml
+++ b/.github/workflows/build-and-test-front-api.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Check swagger.json is up to date
         working-directory: front-api
         run: |
-          npx next-swagger-doc-cli swagger.json
+          npx tsx scripts/generate-swagger.ts
           if ! git diff --exit-code public/swagger.json; then
             echo "Error: public/swagger.json is out of date. Run 'npm run docs' in front-api/ and commit the result."
             exit 1

--- a/front-api/lib/swagger.ts
+++ b/front-api/lib/swagger.ts
@@ -1,0 +1,37 @@
+import { join } from "node:path";
+
+import type { Options as SwaggerJsdocOptions } from "swagger-jsdoc";
+import swaggerJsdoc from "swagger-jsdoc";
+
+interface BuildSwaggerSpecOptions {
+  apiFolder: string;
+  schemaFolders?: string[];
+  definition: SwaggerJsdocOptions["definition"];
+}
+
+// Build an OpenAPI spec by scanning route files for `@swagger` JSDoc annotations.
+// Replaces `next-swagger-doc`'s `createSwaggerSpec`: same glob-building behavior,
+// minus its Next.js-only bits (`.next/server` build-dir scanning and the
+// `__NEXT_ROUTER_BASEPATH` server injection), neither of which applies to our
+// Hono server.
+export function buildSwaggerSpec({
+  apiFolder,
+  schemaFolders = [],
+  definition,
+}: BuildSwaggerSpecOptions): object {
+  const scanFolders = [apiFolder, ...schemaFolders];
+  const apis = scanFolders.flatMap((folder) => {
+    const apiDirectory = join(process.cwd(), folder);
+    const publicDirectory = join(process.cwd(), "public");
+    const fileTypes = ["ts", "tsx", "jsx", "js", "json", "swagger.yaml"];
+    return [
+      ...fileTypes.map((fileType) => `${apiDirectory}/**/*.${fileType}`),
+      // Support loading static specs from the public directory.
+      ...["swagger.yaml", "json"].map(
+        (fileType) => `${publicDirectory}/**/*.${fileType}`
+      ),
+    ];
+  });
+
+  return swaggerJsdoc({ apis, definition });
+}

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -18,9 +18,7 @@
     "@hono/node-server": "^1.19.10",
     "@hono/zod-validator": "^0.7.6",
     "hono": "^4.12.15",
-    "jose": "^6.2.3",
     "jsonwebtoken": "^9.0.0",
-    "openai": "^6.33.0",
     "swagger-jsdoc": "^6.2.8",
     "zod": "^3.25.76",
     "zod-validation-error": "^3.4.0"

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -8,7 +8,7 @@
     "test": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI vitest --run",
     "test:ci": "vitest --reporter=junit --watch=false --test-timeout=30000",
     "lint:swagger-annotations": "BAD_FILES=$(grep -rlE 'app\\.(get|post|patch|put|delete)\\(' routes --include='*.ts' | grep -v '\\.test\\.ts$' | xargs grep -rL '@swagger\\|@ignoreswagger'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: The following API route files register a handler but are missing the @swagger or @ignoreswagger annotation:\"; echo \"$BAD_FILES\"; exit 1; else echo \"Swagger annotation check: OK.\"; exit 0; fi",
-    "docs": "npx next-swagger-doc-cli swagger.json 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
+    "docs": "tsx scripts/generate-swagger.ts 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "tsgo": "tsgo"
   },
@@ -20,14 +20,14 @@
     "hono": "^4.12.15",
     "jose": "^6.2.3",
     "jsonwebtoken": "^9.0.0",
-    "next": "^14.2.35",
-    "next-swagger-doc": "^0.4.0",
     "openai": "^6.33.0",
+    "swagger-jsdoc": "^6.2.8",
     "zod": "^3.25.76",
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.2",
+    "@types/swagger-jsdoc": "^6.0.4",
     "esbuild": "^0.27.3",
     "tsx": "^4.21.0"
   }

--- a/front-api/routes/doc.ts
+++ b/front-api/routes/doc.ts
@@ -1,10 +1,10 @@
 import logger from "@app/logger/logger";
 import { createHono } from "@front-api/lib/hono";
-import { createSwaggerSpec } from "next-swagger-doc";
+import { buildSwaggerSpec } from "@front-api/lib/swagger";
 
 const app = createHono();
 
-// `next-swagger-doc` resolves `apiFolder` against `process.cwd()`. The Hono
+// `buildSwaggerSpec` resolves `apiFolder` against `process.cwd()`. The Hono
 // server runs from `front-api/`, so we scan our own public API routes for the
 // `@swagger` JSDoc annotations (and the shared component schemas defined in
 // `routes/v1/w/[wId]/swagger_schemas.ts`).
@@ -12,11 +12,11 @@ const API_FOLDER = "./routes/v1";
 
 app.get("/", (ctx) => {
   try {
-    const spec = createSwaggerSpec({
+    const spec = buildSwaggerSpec({
       definition: {
         openapi: "3.0.0",
         info: {
-          title: "NextJS Swagger",
+          title: "Dust Swagger",
           version: "0.1.0",
         },
       },

--- a/front-api/scripts/generate-swagger.ts
+++ b/front-api/scripts/generate-swagger.ts
@@ -1,0 +1,15 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+import { buildSwaggerSpec } from "@front-api/lib/swagger";
+
+// Generates the static OpenAPI spec from `swagger.json` (which holds the API
+// folder to scan and the base OpenAPI definition) into `public/swagger.json`.
+// Replaces the former `next-swagger-doc-cli` invocation. Any YAML parse errors
+// in `@swagger` annotations are reported to stderr by `swagger-jsdoc`, which the
+// `docs` npm script greps for to fail the build.
+const CONFIG_PATH = "swagger.json";
+const OUTPUT_PATH = "public/swagger.json";
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+const spec = buildSwaggerSpec(config);
+writeFileSync(OUTPUT_PATH, JSON.stringify(spec, null, 2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -746,14 +746,14 @@
         "hono": "^4.12.15",
         "jose": "^6.2.3",
         "jsonwebtoken": "^9.0.0",
-        "next": "^14.2.35",
-        "next-swagger-doc": "^0.4.0",
         "openai": "^6.33.0",
+        "swagger-jsdoc": "^6.2.8",
         "zod": "^3.25.76",
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.2",
+        "@types/swagger-jsdoc": "^6.0.4",
         "esbuild": "^0.27.3",
         "tsx": "^4.21.0"
       }
@@ -20212,6 +20212,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
       "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tapable": {
@@ -23446,19 +23447,6 @@
       },
       "peerDependencies": {
         "webpack": ">=4.0.0 <6.0.0"
-      }
-    },
-    "node_modules/cleye": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/cleye/-/cleye-1.3.2.tgz",
-      "integrity": "sha512-MngIC2izcCz07iRKr3Pe8Z6ZBv4zbKFl/YnQEN/aMHis6PpH+MxI2e6n0bMUAmSVlMoAyQkdBCSTbfDmtcSovQ==",
-      "license": "MIT",
-      "dependencies": {
-        "terminal-columns": "^1.4.1",
-        "type-flag": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/cleye?sponsor=1"
       }
     },
     "node_modules/cli-boxes": {
@@ -32219,12 +32207,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
-    },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -37720,27 +37702,6 @@
       "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-swagger-doc": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/next-swagger-doc/-/next-swagger-doc-0.4.1.tgz",
-      "integrity": "sha512-pFmFUOwNlJh7mr9P6b2obAHa9JAwgPK3oNTIzE9g/Gs+h2OG1T3C5SanzrqGA3dDncagyf/DbO5U+ZzNxKadWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/swagger-jsdoc": "6.0.4",
-        "cleye": "1.3.2",
-        "isarray": "2.0.5",
-        "swagger-jsdoc": "6.2.8"
-      },
-      "bin": {
-        "next-swagger-doc-cli": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "next": ">=9"
-      }
     },
     "node_modules/next-themes": {
       "version": "0.4.6",
@@ -50286,15 +50247,6 @@
         "streamx": "^2.12.5"
       }
     },
-    "node_modules/terminal-columns": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terminal-columns/-/terminal-columns-1.4.1.tgz",
-      "integrity": "sha512-IKVL/itiMy947XWVv4IHV7a0KQXvKjj4ptbi7Ew9MPMcOLzkiQeyx3Gyvh62hKrfJ0RZc4M1nbhzjNM39Kyujw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/terminal-columns?sponsor=1"
-      }
-    },
     "node_modules/terser": {
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
@@ -51367,15 +51319,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/type-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
-      "integrity": "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/type-flag?sponsor=1"
       }
     },
     "node_modules/type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -744,9 +744,7 @@
         "@hono/node-server": "^1.19.10",
         "@hono/zod-validator": "^0.7.6",
         "hono": "^4.12.15",
-        "jose": "^6.2.3",
         "jsonwebtoken": "^9.0.0",
-        "openai": "^6.33.0",
         "swagger-jsdoc": "^6.2.8",
         "zod": "^3.25.76",
         "zod-validation-error": "^3.4.0"
@@ -785,27 +783,6 @@
       },
       "peerDependenciesMeta": {
         "unstorage": {
-          "optional": true
-        }
-      }
-    },
-    "front-api/node_modules/openai": {
-      "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
-      "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
           "optional": true
         }
       }


### PR DESCRIPTION
 ## What

Fixes https://github.com/dust-tt/tasks/issues/8288

  `front` no longer uses Next.js, but `next` (103M) plus its `@next` swc native
  binaries (110M) — **~213MB** — were still being installed into the front Docker
  image. This PR removes them.

Also removed unused jose and openai dependencies, though they still end up getting pulled indirectly (but still good hygiene).

  ## Why it was still there

  The image build runs `npm ci -w sdks/js -w sparkle -w front -w front-spa -w front-api`.
  `next` was pulled in purely through `front-api`:

  - `front-api/package.json` declared `next` as a direct dependency.
  - It used `next-swagger-doc`, whose only link to `next` is a **peer dependency**
    that its runtime code never loads — `createSwaggerSpec` just wraps `swagger-jsdoc`.

  Because npm 7+ auto-installs non-optional peer deps, deleting the `next` line alone
  wouldn't have worked — `next-swagger-doc` had to go too. (`viz`/`marketing` also use
  `next`, but neither is part of the front image build, so they're unaffected.)

  ## Changes

  - **`front-api/lib/swagger.ts`** (new) — `buildSwaggerSpec()`, a direct `swagger-jsdoc`
    wrapper replicating `createSwaggerSpec`'s glob logic, minus its two Next.js-only
    behaviors (`.next/server` scanning and `__NEXT_ROUTER_BASEPATH`) that never applied here.
  - **`front-api/scripts/generate-swagger.ts`** (new) — replaces the `next-swagger-doc-cli`
    build step; reads `swagger.json`, writes `public/swagger.json`.
  - **`front-api/routes/doc.ts`** — uses `buildSwaggerSpec` (also fixed the stray
    `"NextJS Swagger"` title → `"Dust Swagger"`).
  - **`front-api/package.json`** — removed `next` + `next-swagger-doc`, added
    `swagger-jsdoc` + `@types/swagger-jsdoc`. The `docs` script keeps the same shell
    pipeline, so `YAML.*Error` detection still works (`swagger-jsdoc` reports those
    via `console.error`).
  - **`.github/workflows/build-and-test-front-api.yml`** — the "swagger up to date"
    check now runs the new generator.
  - **`package-lock.json`** — regenerated.

  ## Verification

  - Faithfully simulated the Dockerfile's exact `npm ci -w ...` scope in a temp dir →
    **`next` and `@next` are no longer installed**; `swagger-jsdoc` is present.
  - Generator output is **byte-identical** to the committed `public/swagger.json` (no diff).
  - `tsgo --noEmit` passes, the esbuild server bundle builds, biome is clean.

## Risk

Need to make sure there is no unexpected dependency on it.

## Deploy Plan

Front