### PR TITLE
Replace directory creation with a proper DustFileSystem.mkdir method

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
@@ -43,7 +43,7 @@ describe("GET /api/w/:wId/spaces/:spaceId/files", () => {
   it("returns 200 with an empty list when no files exist", async () => {
     const { workspace, project } = await setupProject();
 
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       getAllFilesByPrefix: vi
         .fn()
         .mockResolvedValue({ files: [], pageFetchCount: 1 }),
@@ -61,7 +61,7 @@ describe("GET /api/w/:wId/spaces/:spaceId/files", () => {
   it("returns 200 and lists files with canonical scoped paths", async () => {
     const { workspace, project } = await setupProject();
 
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       getAllFilesByPrefix: vi.fn().mockResolvedValue({
         files: [
           makeGCSFile(workspace.sId, project.sId, "report.pdf", {
@@ -98,7 +98,7 @@ describe("GET /api/w/:wId/spaces/:spaceId/files", () => {
   it("returns 200 and includes directory entries from GCS folder placeholders", async () => {
     const { workspace, project } = await setupProject();
 
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
+    vi.mocked(getPrivateUploadBucket).mockReturnValueOnce({
       getAllFilesByPrefix: vi.fn().mockResolvedValue({
         files: [
           // GCS folder placeholder (trailing slash)

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.test.ts
@@ -1,5 +1,6 @@
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -127,18 +128,11 @@ describe("GET /api/w/:wId/spaces/:spaceId/files", () => {
 describe("POST /api/w/:wId/spaces/:spaceId/files (create folder)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fileStorageMock.setFileExists(() => false);
   });
 
   it("returns 201 after creating a folder", async () => {
     const { workspace, project } = await setupProject();
-
-    // Mock the GCS save call used by createGCSMountDirectory.
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn().mockReturnValue({
-        save: vi.fn().mockResolvedValue(undefined),
-        exists: vi.fn().mockResolvedValue([false]),
-      }),
-    } as any);
 
     const res = await honoApp.request(
       `/api/w/${workspace.sId}/spaces/${project.sId}/files`,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -4,10 +4,11 @@ import type {
   GetSpaceFilesResponseBody,
   PostSpaceFolderResponseBody,
 } from "@app/lib/api/file_system/types";
-import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import {
+  isDustFileSystemError,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system/types";
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
-import { isGCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
-import type { GCSMountDirectoryEntry } from "@app/lib/api/files/gcs_mount/files";
 import { createProjectFolder } from "@app/lib/api/projects/context";
 import { PostPodFolderRequestBodySchema } from "@app/lib/api/projects/pod_mount_schemas";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -18,7 +19,7 @@ import { withSpace } from "@front-api/middlewares/with_space";
 
 import rel from "./[...rel]";
 
-export type { FileSystemEntry, GCSMountDirectoryEntry };
+export type { FileSystemEntry };
 
 // Mounted under /api/w/:wId/spaces/:spaceId/files.
 const app = workspaceApp();
@@ -100,7 +101,7 @@ app.post(
     });
     if (createResult.isErr()) {
       return apiError(c, {
-        status_code: isGCSMountDirectoryAlreadyExistsError(createResult.error)
+        status_code: isDustFileSystemError(createResult.error, "already_exists")
           ? 409
           : 400,
         api_error: {

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -1,6 +1,7 @@
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
 import type {
   DustFileSystemError,
+  FileSystemDirectoryEntry,
   FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
@@ -68,6 +69,14 @@ export interface FileSystemBackend {
     content: Buffer | string | Readable,
     contentType: string
   ): Promise<Result<void, DustFileSystemError>>;
+
+  /**
+   * Create a directory placeholder at `scopedPath`.
+   * Returns `Err("already_exists")` when a directory already exists there.
+   */
+  mkdir(
+    scopedPath: string
+  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>>;
 
   /**
    * Returns `Err("not_found")` when the path does not exist and `ignoreNotFound` is false.

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -2,6 +2,7 @@ import type { GCSMountTarget } from "@app/lib/api/file_system/sandbox/gcs_sandbo
 import { GCSSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
 import type {
+  FileSystemDirectoryEntry,
   FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
@@ -371,6 +372,51 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       }
 
       return new Ok(undefined);
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
+    }
+  }
+
+  async mkdir(
+    scopedPath: string
+  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
+    const gcsPath = this.toGCSPath(scopedPath);
+    if (!gcsPath) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          `GCSFileSystemBackend.mkdir: unrecognised scoped path: ${scopedPath}`
+        )
+      );
+    }
+
+    const dirGcsPath = `${gcsPath}/`;
+    try {
+      const bucket = getPrivateUploadBucket();
+      const [exists] = await bucket.file(dirGcsPath).exists();
+      if (exists) {
+        return new Err(
+          new DustFileSystemError(
+            "already_exists",
+            "A directory already exists at this path."
+          )
+        );
+      }
+
+      await bucket.file(dirGcsPath).save(Buffer.alloc(0), {
+        contentType: "application/x-directory",
+      });
+
+      const fileName = gcsPath.split("/").pop() ?? "";
+      return new Ok({
+        isDirectory: true as const,
+        fileName,
+        path: scopedPath,
+        sizeBytes: 0,
+        lastModifiedMs: Date.now(),
+      });
     } catch (err) {
       return new Err(
         new DustFileSystemError("internal", normalizeError(err).message)

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -18,6 +18,7 @@ import config from "@app/lib/api/config";
 import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import type {
+  FileSystemDirectoryEntry,
   FileSystemEntry,
   FileSystemFileEntry,
   FileSystemMount,
@@ -749,6 +750,17 @@ export class DustFileSystem {
       return resolved;
     }
     return this.backend.delete(resolved.value.path, opts);
+  }
+
+  async mkdir(
+    scopedPath: string
+  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
+    const resolved = this.requireWriteMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+
+    return this.backend.mkdir(resolved.value.path);
   }
 
   /** `src` requires read access, `dest` requires write access. */

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -8,8 +8,6 @@
  * sandbox mount point, backward-compat aliases, and per-mount permissions.
  */
 
-import type { GCSMountDirectoryEntry } from "@app/lib/api/files/gcs_mount/files";
-
 export type FileSystemMountKind = "conversation" | "pod";
 
 /** Canonical scoped-path prefixes (include the trailing dash). */
@@ -95,10 +93,20 @@ export class DustFileSystemError extends Error {
   }
 }
 
+export function isDustFileSystemError(
+  err: unknown,
+  code?: DustFileSystemErrorCode
+): err is DustFileSystemError {
+  return (
+    err instanceof DustFileSystemError &&
+    (code === undefined || err.code === code)
+  );
+}
+
 export type GetSpaceFilesResponseBody = {
   files: FileSystemEntry[];
 };
 
 export type PostSpaceFolderResponseBody = {
-  folder: GCSMountDirectoryEntry;
+  folder: FileSystemDirectoryEntry;
 };

--- a/front/lib/api/files/gcs_mount/files.test.ts
+++ b/front/lib/api/files/gcs_mount/files.test.ts
@@ -1,8 +1,6 @@
-import { GCSMountDirectoryAlreadyExistsError } from "@app/lib/api/files/gcs_mount/errors";
 import {
   copyConversationGCSMount,
   copyMountFile,
-  createGCSMountDirectory,
   createGCSMountFile,
   deleteGCSMountFile,
   type GCSMountFileEntry,
@@ -165,113 +163,6 @@ describe("createGCSMountFile", () => {
 
     const bucket = vi.mocked(getPrivateUploadBucket)();
     expect(bucket.file).toHaveBeenCalledTimes(1);
-    expect(saveMock).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("createGCSMountDirectory", () => {
-  let auth: Authenticator;
-  let conversationId: string;
-  let workspaceId: string;
-  let saveMock: ReturnType<typeof vi.fn>;
-  let existsMock: ReturnType<typeof vi.fn>;
-
-  beforeEach(async () => {
-    existsMock = vi.fn().mockResolvedValue([false]);
-    saveMock = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(getPrivateUploadBucket).mockReturnValue({
-      file: vi.fn(() => ({ save: saveMock, exists: existsMock })),
-    } as unknown as ReturnType<typeof getPrivateUploadBucket>);
-
-    const { authenticator, conversationsSpace } = await createResourceTest({});
-    auth = authenticator;
-    workspaceId = auth.getNonNullableWorkspace().sId;
-
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
-      name: "Test Agent",
-      description: "Test Agent",
-    });
-    const conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agentConfig.sId,
-      messagesCreatedAt: [],
-      spaceId: conversationsSpace.id,
-    });
-    conversationId = conversation.sId;
-  });
-
-  it("writes a trailing-slash placeholder to the correct GCS path", async () => {
-    const entryRes = await createGCSMountDirectory(
-      auth,
-      { useCase: "conversation", conversationId },
-      { relativeDirPath: "reports/q1" }
-    );
-
-    assert(entryRes.isOk());
-    expect(entryRes.value).toMatchObject({
-      isDirectory: true,
-      fileName: "q1",
-      path: "conversation/reports/q1",
-      sizeBytes: 0,
-    });
-    const bucket = vi.mocked(getPrivateUploadBucket)();
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/conversations/${conversationId}/files/reports/q1/`
-    );
-    expect(saveMock).toHaveBeenCalledWith(Buffer.alloc(0), {
-      contentType: "application/x-directory",
-    });
-  });
-
-  it("returns Err when the folder already exists", async () => {
-    existsMock.mockResolvedValue([true]);
-
-    const entryRes = await createGCSMountDirectory(
-      auth,
-      { useCase: "conversation", conversationId },
-      { relativeDirPath: "reports" }
-    );
-
-    expect(entryRes.isErr()).toBe(true);
-    if (entryRes.isErr()) {
-      expect(entryRes.error).toBeInstanceOf(
-        GCSMountDirectoryAlreadyExistsError
-      );
-    }
-    expect(saveMock).not.toHaveBeenCalled();
-  });
-
-  it("dual-writes the placeholder on the projects/ mirror for pod use-case", async () => {
-    const entryRes = await createGCSMountDirectory(
-      auth,
-      { useCase: "pod", podId: "proj123" },
-      { relativeDirPath: "reports/q1" }
-    );
-
-    assert(entryRes.isOk());
-    const bucket = vi.mocked(getPrivateUploadBucket)();
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/pods/proj123/files/reports/q1/`
-    );
-    expect(bucket.file).toHaveBeenCalledWith(
-      `w/${workspaceId}/projects/proj123/files/reports/q1/`
-    );
-    expect(saveMock).toHaveBeenCalledTimes(2);
-    expect(saveMock).toHaveBeenNthCalledWith(1, Buffer.alloc(0), {
-      contentType: "application/x-directory",
-    });
-    expect(saveMock).toHaveBeenNthCalledWith(2, Buffer.alloc(0), {
-      contentType: "application/x-directory",
-    });
-  });
-
-  it("does not write to projects/ for conversation use-case", async () => {
-    const entryRes = await createGCSMountDirectory(
-      auth,
-      { useCase: "conversation", conversationId },
-      { relativeDirPath: "reports/q1" }
-    );
-
-    assert(entryRes.isOk());
     expect(saveMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/front/lib/api/files/gcs_mount/files.ts
+++ b/front/lib/api/files/gcs_mount/files.ts
@@ -122,29 +122,6 @@ export function getScopedPathFromGCSPath({
   return `${useCase}/${gcsPath.slice(prefix.length)}`;
 }
 
-function makeDirectoryEntry(
-  {
-    fileName,
-    relativeFilePath,
-    sizeBytes,
-    lastModifiedMs,
-  }: {
-    fileName: string;
-    relativeFilePath: string;
-    sizeBytes: number;
-    lastModifiedMs: number;
-  },
-  scope: GCSMountPoint
-): GCSMountDirectoryEntry {
-  return {
-    isDirectory: true,
-    fileName,
-    path: `${scope.useCase}/${relativeFilePath}`,
-    sizeBytes,
-    lastModifiedMs,
-  };
-}
-
 function makeFileEntry(
   {
     fileName,
@@ -404,64 +381,6 @@ export async function createGCSMountFile(
       },
       scope,
       owner.sId
-    )
-  );
-}
-
-/**
- * Create an empty folder in a GCS mount point via a zero-byte object whose name ends with "/".
- * Returns the entry as it would appear in listGCSMountFiles.
- */
-export async function createGCSMountDirectory(
-  auth: Authenticator,
-  scope: GCSMountPoint,
-  { relativeDirPath }: { relativeDirPath: string }
-): Promise<Result<GCSMountDirectoryEntry, Error>> {
-  const owner = auth.getNonNullableWorkspace();
-  const prefix = resolvePrefix(owner, scope);
-
-  const normalized = relativeDirPath.replace(/^\/+|\/+$/g, "");
-  if (!normalized) {
-    return new Err(new Error("relativeDirPath is required."));
-  }
-
-  const gcsPath = `${prefix}${normalized}/`;
-  const bucket = getPrivateUploadBucket();
-  try {
-    const [exists] = await bucket.file(gcsPath).exists();
-    if (exists) {
-      return new Err(new GCSMountDirectoryAlreadyExistsError());
-    }
-
-    await bucket.file(gcsPath).save(Buffer.alloc(0), {
-      contentType: "application/x-directory",
-    });
-
-    // Mirror the directory placeholder on the projects/ side for pod files.
-    if (scope.useCase === "pod") {
-      const projectsPrefix = getProjectFilesBasePath({
-        workspaceId: owner.sId,
-        projectId: scope.podId,
-      });
-      const projectsGcsPath = `${projectsPrefix}${normalized}/`;
-      await bucket.file(projectsGcsPath).save(Buffer.alloc(0), {
-        contentType: "application/x-directory",
-      });
-    }
-  } catch (error) {
-    return new Err(normalizeError(error));
-  }
-
-  const fileName = normalized.split("/").pop() ?? normalized;
-  return new Ok(
-    makeDirectoryEntry(
-      {
-        fileName,
-        relativeFilePath: normalized,
-        sizeBytes: 0,
-        lastModifiedMs: Date.now(),
-      },
-      scope
     )
   );
 }

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -6,11 +6,13 @@ import {
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import type { FileSystemDirectoryEntry } from "@app/lib/api/file_system/types";
 import {
-  createGCSMountDirectory,
+  DustFileSystemError,
+  SCOPED_PREFIX_POD,
+} from "@app/lib/api/file_system/types";
+import {
   deleteGCSMountFile,
-  type GCSMountDirectoryEntry,
   moveFile,
   renameGCSMountDirectory,
   renameGCSMountFile,
@@ -637,19 +639,25 @@ export async function createProjectFolder(
     folderName: string;
     parentRelativePath?: string;
   }
-): Promise<Result<GCSMountDirectoryEntry, Error>> {
+): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
   if (!space.isProject()) {
-    return new Err(new Error("Space is not a project."));
+    return new Err(
+      new DustFileSystemError("invalid_path", "Space is not a project.")
+    );
   }
 
   const folderNameRes = validateMountFolderName(folderName);
   if (folderNameRes.isErr()) {
-    return folderNameRes;
+    return new Err(
+      new DustFileSystemError("invalid_path", folderNameRes.error.message)
+    );
   }
 
   const parentRes = normalizeMountParentRelativePath(parentRelativePath);
   if (parentRes.isErr()) {
-    return parentRes;
+    return new Err(
+      new DustFileSystemError("invalid_path", parentRes.error.message)
+    );
   }
 
   const relativeDirPath = joinMountRelativePath(
@@ -657,10 +665,13 @@ export async function createProjectFolder(
     folderNameRes.value
   );
 
-  return createGCSMountDirectory(
-    auth,
-    { useCase: "pod", podId: space.sId },
-    { relativeDirPath }
+  const fsResult = await DustFileSystem.forPod(auth, space);
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  return fsResult.value.mkdir(
+    `${SCOPED_PREFIX_POD}${space.sId}/${relativeDirPath}`
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Directory creation in project spaces previously bypassed the `DustFileSystem` abstraction entirely, calling directly into the GCS layer with its own path resolution logic. This made it the only write operation on the pod file system that did not flow through the unified backend, and it carried legacy `projects/` double-write mirroring that is no longer needed now.

This change adds a `mkdir` method to the backend interface and implements it in `GCSFileSystemBackend`, following the same scoped-path discipline as every other write operation. `DustFileSystem` exposes it as a first-class method with the usual permission check. The folder creation handler now uses this path, returning a `FileSystemDirectoryEntry` instead of the old GCS-specific type.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
