### PR TITLE
[LLM] Add Anthropic stream client and Claude Sonnet 4.6 endpoints

### DIFF
--- a/front/lib/model_constructors/client.ts
+++ b/front/lib/model_constructors/client.ts
@@ -1,4 +1,5 @@
 import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
@@ -8,6 +9,15 @@ export abstract class Client {
   // Re-type `this.constructor` (typed as `Function` by default) so the concrete
   // subclass's static config is visible at the type level.
   declare ["constructor"]: BaseModelConfiguration;
+
+  metadata(): EndpointMetadata {
+    return {
+      providerId: this.constructor.providerId,
+      api: this.constructor.api,
+      region: this.constructor.region,
+      modelId: this.constructor.modelId,
+    };
+  }
 
   // Generic `this` params P/A/R/M capture each concrete class's literal
   // identity fields, so the returned `id` is an exact literal (not the wide

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -8,7 +8,7 @@ import type { z } from "zod";
 
 export type BaseModelConfiguration = {
   // Identity
-  id: `${ProviderId}::${ProviderApi}::${Region}::${ModelId}`;
+  id: `${ProviderId}/${ProviderApi}/${Region}/${ModelId}`;
   providerId: ProviderId;
   api: ProviderApi;
   modelId: ModelId;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,0 +1,51 @@
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+const CONTEXT_SIZE = 400_000;
+const DEFAULT_REASONING_EFFORT = "high";
+const MAX_OUTPUT_TOKENS = 64_000;
+
+const baseConfig = inputConfigSchema.extend({
+  cacheKey: z.undefined(),
+});
+
+const configSchema = z.union([
+  baseConfig.extend({
+    reasoning: z
+      .object({
+        effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
+      })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    forceTool: z.undefined(),
+    // Reasoning requires temperature=1.
+    temperature: temperatureSchema.optional().transform(() => 1 as const),
+  }),
+  baseConfig.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+    temperature: temperatureSchema.optional().default(1),
+  }),
+]);
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithAnthropicClaudeSonnetFourDotSixConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class AnthropicClaudeSonnetFourDotSix extends Base {
+    static readonly modelId = CLAUDE_SONNET_4_6_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return AnthropicClaudeSonnetFourDotSix;
+}

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -50,11 +50,11 @@ export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
 
   private readonly client: AnthropicVertex;
 
-  constructor(credentials: Credentials) {
+  constructor({ AGENT_PLATFORM_PROJECT_ID }: Credentials) {
     super();
     this.client = new AnthropicVertex({
       region: this.constructor.regionalEndpoint,
-      projectId: credentials.AGENT_PLATFORM_PROJECT_ID,
+      projectId: AGENT_PLATFORM_PROJECT_ID,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -1,0 +1,81 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  MessageCreateParamsStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import AnthropicVertex from "@anthropic-ai/vertex-sdk";
+import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
+import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { AGENT_PLATFORM_API } from "@app/lib/model_constructors/types/provider_apis";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+
+import { z } from "zod";
+
+// Can be extended later (e.g. "us", "asia-east1"...)
+type AgentPlatformRegionalEndpoint = "global" | "europe-west1";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([
+        ...ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+        "none",
+      ]),
+    })
+    .optional(),
+});
+
+export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
+  WithAnthropicOutputConverter(
+    StreamEndpoint<MessageCreateParamsNonStreaming, RawMessageStreamEvent>
+  )
+) {
+  // Narrow `this.constructor` so the per-endpoint static below is visible.
+  declare ["constructor"]: BaseModelConfiguration & {
+    regionalEndpoint: AgentPlatformRegionalEndpoint;
+  };
+
+  static readonly providerId = ANTHROPIC_PROVIDER_ID;
+  static readonly api = AGENT_PLATFORM_API;
+
+  static readonly configSchema: z.ZodType<z.infer<typeof configSchema>> =
+    configSchema;
+
+  private readonly client: AnthropicVertex;
+
+  constructor(credentials: Credentials) {
+    super();
+    this.client = new AnthropicVertex({
+      region: this.constructor.regionalEndpoint,
+      projectId: credentials.AGENT_PLATFORM_PROJECT_ID,
+    });
+  }
+
+  async *streamRaw(
+    input: MessageCreateParamsNonStreaming
+  ): AsyncGenerator<RawMessageStreamEvent> {
+    const streamingInput: MessageCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = this.client.messages.stream(streamingInput);
+
+    // SDK mutates/reuses events; deep-copy.
+    for await (const event of stream) {
+      yield structuredClone(event);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<RawMessageStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -42,10 +42,10 @@ export abstract class AnthropicStream extends WithAnthropicInputConverter(
 
   private readonly client: AnthropicClient;
 
-  constructor(credentials: Credentials) {
+  constructor({ ANTHROPIC_API_KEY }: Credentials) {
     super();
     this.client = new AnthropicClient({
-      apiKey: credentials.ANTHROPIC_API_KEY,
+      apiKey: ANTHROPIC_API_KEY,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -1,0 +1,73 @@
+import AnthropicClient from "@anthropic-ai/sdk";
+import type {
+  MessageCreateParamsNonStreaming,
+  MessageCreateParamsStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
+import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { ANTHROPIC_API } from "@app/lib/model_constructors/types/provider_apis";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+
+import { z } from "zod";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([
+        ...ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+        "none",
+      ]),
+    })
+    .optional(),
+});
+
+type AnthropicInputConfig = z.infer<typeof configSchema>;
+
+export abstract class AnthropicStream extends WithAnthropicInputConverter(
+  WithAnthropicOutputConverter(
+    StreamEndpoint<MessageCreateParamsNonStreaming, RawMessageStreamEvent>
+  )
+) {
+  static readonly providerId = ANTHROPIC_PROVIDER_ID;
+  static readonly api = ANTHROPIC_API;
+
+  static readonly configSchema: z.ZodType<AnthropicInputConfig> = configSchema;
+
+  private readonly client: AnthropicClient;
+
+  constructor(credentials: Credentials) {
+    super();
+    this.client = new AnthropicClient({
+      apiKey: credentials.ANTHROPIC_API_KEY,
+    });
+  }
+
+  async *streamRaw(
+    input: MessageCreateParamsNonStreaming
+  ): AsyncGenerator<RawMessageStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: MessageCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = this.client.messages.stream(streamingInput);
+
+    // The SDK reuses and mutates event objects, so deep-copy each one.
+    for await (const event of stream) {
+      yield structuredClone(event);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<RawMessageStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/configuration.ts
+++ b/front/lib/model_constructors/stream/configuration.ts
@@ -1,11 +1,8 @@
 import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
 import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
-import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
 
-export type StreamModelConfiguration = BaseModelConfiguration & {
-  supportedReasoningEfforts: ReasoningEffort[];
-};
+export type StreamModelConfiguration = BaseModelConfiguration;
 
 export type StreamEndpointConstructor = (new (
   credentials: Credentials

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -1,0 +1,21 @@
+import { WithAnthropicClaudeSonnetFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
+import { AgentPlatformStream } from "@app/lib/model_constructors/stream/clients/agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithAnthropicClaudeSonnetFourDotSixConfig(
+  AgentPlatformStream
+) {
+  // https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#europe-west1
+  static readonly tokenPricing = {
+    cacheCreated: 4.13,
+    cacheHit: 0.33,
+    standardInput: 3.3,
+    standardOutput: 16.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "europe-west1";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -1,0 +1,21 @@
+import { WithAnthropicClaudeSonnetFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
+import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AnthropicGlobalClaudeSonnetFourDotSixStream extends WithAnthropicClaudeSonnetFourDotSixConfig(
+  AnthropicStream
+) {
+  static readonly tokenPricing = {
+    cacheCreated: 3.75,
+    cacheHit: 0.3,
+    standardInput: 3.0,
+    standardOutput: 15.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicGlobalClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor;


### PR DESCRIPTION
## Description

Adds the Anthropic provider to the new `model_constructors` framework — input/output converters, a stream client, the agent-platform stream client, and Claude Sonnet 4.6 configuration with global and EU agent-platform stream endpoints.

## Tests

Not yet tested — will be validated against a test suite in a follow-up PR before branching to prod.

## Risk

Low. New, self-contained code paths under `model_constructors`; nothing existing is rewired.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`