### PR TITLE
Default seat assignation

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -57,8 +57,7 @@ import type { Transaction } from "sequelize";
  *     (`workspace_seat_limits.minSeats`) still has unassigned slots is picked.
  *  2. **Free seat** — if no committed slot is available and `free` is on the
  *     contract, it is assigned unless any of the following are true:
- *       - `isReturningMember` (one-shot: `free` cannot be re-granted).
- *       - `useFreeSeat` is false (caller opted out).
+ *       - `isReturningMember` is true (one-shot: returning members cannot get `free`).
  *       - `plan.limits.users.maxFreeUsers` reached.
  *       - `plan.limits.users.maxLifetimeFreeUsers` reached.
  *  3. **None** — if both phases are exhausted the member is assigned `"none"`
@@ -75,8 +74,7 @@ import type { Transaction } from "sequelize";
  */
 async function resolveSeatTypeForNewMembership(
   user: UserResource,
-  workspace: LightWorkspaceType,
-  { useFreeSeat = true }: { useFreeSeat?: boolean } = {}
+  workspace: LightWorkspaceType
 ): Promise<MembershipSeatType | undefined> {
   if (!workspace.metronomeCustomerId) {
     return undefined;
@@ -92,11 +90,10 @@ async function resolveSeatTypeForNewMembership(
     return undefined;
   }
   const planLimits = subscription.toJSON().plan.limits.users;
-  // `isReturningMember` is always queried — the one-shot rule (`free`
-  // cannot be re-granted to a user who already had a membership) holds
-  // independently of any configured cap. `freeSeatCounts` is only needed
-  // when at least one of the two caps is set; skip the count queries
-  // otherwise.
+  // `isReturningMember` is always queried — `free` is a one-shot starter tier
+  // that cannot be assigned to any user who previously held any membership in
+  // this workspace (regardless of seat type). `freeSeatCounts` is only needed
+  // when at least one of the two caps is set; skip the count queries otherwise.
   const limitsActive =
     planLimits.maxFreeUsers !== -1 || planLimits.maxLifetimeFreeUsers !== -1;
   const [productSeatTypes, isReturningMember, freeSeatCounts, seatLimits] =
@@ -122,7 +119,6 @@ async function resolveSeatTypeForNewMembership(
 
   return getDefaultSeatTypeForContract(contract, productSeatTypes, {
     isReturningMember,
-    useFreeSeat,
     freeSeatCounts,
     freeSeatLimits: {
       maxActiveFreeUsers: planLimits.maxFreeUsers,
@@ -136,29 +132,21 @@ async function resolveSeatTypeForNewMembership(
 /**
  * Create a membership with tracking, audit logging, and Metronome seat provisioning.
  *
- * For Metronome-billed workspaces with a seat-billed contract, the seat
- * type assigned to the new membership is the lowest-allowance tier billed
- * on the contract (with `free` skipped for returning members, when
- * `useFreeSeat` is false, or when the plan's free-seat caps are hit).
- * Refuses to create the row when no tier is assignable.
- *
- * `useFreeSeat` (default `true`) lets the caller opt the new member out
- * of `free` even when it would otherwise be available — e.g. an admin
- * provisioning a new member directly onto a paid tier.
+ * For Metronome-billed workspaces with a seat-billed contract, the seat type
+ * assigned follows the committed-seat → free → none priority order defined by
+ * `resolveSeatTypeForNewMembership`.
  */
 export async function createAndTrackMembership({
   user,
   workspace,
   role,
   origin,
-  useFreeSeat = true,
   auditActor,
 }: {
   user: UserResource;
   workspace: WorkspaceResource | WorkspaceModel | LightWorkspaceType;
   role: ActiveRoleType;
   origin: MembershipOriginType;
-  useFreeSeat?: boolean;
   // Override for the audit-log actor. Defaults to the user themselves, which
   // is correct for self-signup. SCIM/system-driven provisioning should pass
   // `{ type: "system", id: directoryId, name: "Directory Sync" }` so the
@@ -171,9 +159,7 @@ export async function createAndTrackMembership({
       ? renderLightWorkspaceType({ workspace })
       : workspace;
 
-  const seatType = await resolveSeatTypeForNewMembership(user, w, {
-    useFreeSeat,
-  });
+  const seatType = await resolveSeatTypeForNewMembership(user, w);
 
   const m = await MembershipResource.createMembership({
     role,

--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -10,52 +10,47 @@ import { describe, expect, it } from "vitest";
 // Drives new-member seat assignment (`resolveSeatTypeForNewMembership`).
 describe("getDefaultSeatTypeForContract — entitlement", () => {
   const productSeatTypes = new Map<string, MembershipSeatType>([
-    ["workspace-product", "workspace"],
-    ["workspace-yearly-product", "workspace_yearly"],
+    ["pro-product", "pro"],
+    ["pro-yearly-product", "pro_yearly"],
   ]);
 
-  // Contract carries both the monthly and yearly workspace seat subscriptions,
-  // but only `workspace_yearly` is entitled (the monthly one is dormant).
+  // Contract carries both the monthly and yearly pro seat subscriptions,
+  // but only `pro_yearly` is entitled (the monthly one is dormant).
   const contract = {
     subscriptions: [
       {
-        id: "sub_ws",
+        id: "sub_pro",
         subscription_rate: {
-          product: { id: "workspace-product", name: "workspace" },
+          product: { id: "pro-product", name: "Pro" },
         },
       },
       {
-        id: "sub_ws_yearly",
+        id: "sub_pro_yearly",
         subscription_rate: {
-          product: {
-            id: "workspace-yearly-product",
-            name: "Workspace Seat (Yearly)",
-          },
+          product: { id: "pro-yearly-product", name: "Pro (Yearly)" },
         },
       },
     ],
     recurring_credits: [],
-    overrides: [
-      { entitled: true, product: { id: "workspace-yearly-product" } },
-    ],
+    overrides: [{ entitled: true, product: { id: "pro-yearly-product" } }],
   } as unknown as CachedContract;
 
   it("assigns the entitled committed seat, not a dormant lower-name subscription", () => {
     // Both seats are 0 AWU; without entitlement filtering the tie-break would
-    // pick "workspace" (< "workspace_yearly"). Entitlement must win: only
-    // workspace_yearly is in onContract, so its committed slot is assigned.
+    // pick "pro" (< "pro_yearly"). Entitlement must win: only pro_yearly is in
+    // onContract, so its committed slot is assigned.
     const seatLimits = new Map<MembershipSeatType, SeatLimit>([
-      ["workspace_yearly", { minSeats: 10, maxSeats: null }],
+      ["pro_yearly", { minSeats: 10, maxSeats: null }],
     ]);
     const seatCounts: Partial<Record<MembershipSeatType, number>> = {
-      workspace_yearly: 0,
+      pro_yearly: 0,
     };
     expect(
       getDefaultSeatTypeForContract(contract, productSeatTypes, {
         seatLimits,
         seatCounts,
       })
-    ).toBe("workspace_yearly");
+    ).toBe("pro_yearly");
   });
 });
 
@@ -126,20 +121,6 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     ).toBe("none");
   });
 
-  it("returns none when committed exhausted and free blocked (useFreeSeat=false)", () => {
-    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
-      ["pro", { minSeats: 5, maxSeats: null }],
-    ]);
-    const seatCounts: Partial<Record<MembershipSeatType, number>> = { pro: 5 };
-    expect(
-      getDefaultSeatTypeForContract(contract, productSeatTypes, {
-        useFreeSeat: false,
-        seatLimits,
-        seatCounts,
-      })
-    ).toBe("none");
-  });
-
   it("returns none when no committed seats configured and free not available", () => {
     // No seatLimits — committed phase skipped entirely → free → none (returning)
     expect(
@@ -154,6 +135,41 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     expect(getDefaultSeatTypeForContract(contract, productSeatTypes)).toBe(
       "free"
     );
+  });
+
+  it("skips max even when it has committed slots, falls through to free", () => {
+    // max is not auto-assignable regardless of committed configuration.
+    const maxProductSeatTypes = new Map<string, MembershipSeatType>([
+      ["max-product", "max"],
+      ["free-product", "free"],
+    ]);
+    const maxContract = {
+      subscriptions: [
+        {
+          id: "sub_max",
+          subscription_rate: { product: { id: "max-product", name: "Max" } },
+        },
+        {
+          id: "sub_free",
+          subscription_rate: { product: { id: "free-product", name: "Free" } },
+        },
+      ],
+      recurring_credits: [],
+      overrides: [
+        { entitled: true, product: { id: "max-product" } },
+        { entitled: true, product: { id: "free-product" } },
+      ],
+    } as unknown as CachedContract;
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["max", { minSeats: 5, maxSeats: null }],
+    ]);
+    const seatCounts: Partial<Record<MembershipSeatType, number>> = { max: 0 };
+    expect(
+      getDefaultSeatTypeForContract(maxContract, maxProductSeatTypes, {
+        seatLimits,
+        seatCounts,
+      })
+    ).toBe("free");
   });
 
   it("legacy: no-seat-subscription contract returns workspace regardless", () => {

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -133,15 +133,15 @@ export type FreeSeatCounts = {
  *
  * The seat is chosen in three phases:
  *
- *  1. **Committed seats** — iterate the contract's non-`free` seat types
- *     ordered by AWU allowance ascending (cheapest first). For each type that
- *     has a committed allocation (`seatLimits.minSeats > 0`) with remaining
- *     slots (`assignedCount < minSeats`), assign it.
+ *  1. **Committed seats** — iterate `pro` and `pro_yearly` seat types ordered
+ *     by AWU allowance ascending. For each type that has a committed allocation
+ *     (`seatLimits.minSeats > 0`) with remaining slots (`assignedCount <
+ *     minSeats`), assign it. Higher tiers (`max`, `workspace`, …) are never
+ *     auto-assigned; they must be set manually.
  *
  *  2. **Free seat** — if `free` is on the contract and all of the following
  *     hold, assign `free`:
  *       - `isReturningMember` is false (`free` is a one-shot starter tier).
- *       - `useFreeSeat` is true (caller has not opted out).
  *       - Active free-seat cap not exceeded.
  *       - Lifetime free-seat cap not exceeded.
  *
@@ -161,14 +161,12 @@ export function getDefaultSeatTypeForContract(
   productSeatTypes: Map<string, MembershipSeatType>,
   {
     isReturningMember = false,
-    useFreeSeat = true,
     freeSeatCounts,
     freeSeatLimits,
     seatLimits,
     seatCounts,
   }: {
     isReturningMember?: boolean;
-    useFreeSeat?: boolean;
     freeSeatCounts?: FreeSeatCounts;
     freeSeatLimits?: FreeSeatLimits;
     seatLimits?: Map<MembershipSeatType, SeatLimit>;
@@ -191,11 +189,19 @@ export function getDefaultSeatTypeForContract(
     // and free = 0 on a hybrid contract).
     .sort((a, b) => a.awu - b.awu || a.seatType.localeCompare(b.seatType));
 
+  // Only `pro` and `pro_yearly` are eligible for auto-assignment. Higher tiers
+  // (`max`, `max_yearly`, `workspace`, `workspace_yearly`) must be assigned
+  // manually; they are never handed out automatically to new joiners.
+  const AUTO_ASSIGNABLE: ReadonlySet<MembershipSeatType> = new Set([
+    "pro",
+    "pro_yearly",
+  ]);
+
   // Phase 1: assign to the cheapest committed seat type with remaining slots.
   // A seat type is committed if seatLimits.minSeats > 0. The commitment is
   // exhausted once assignedCount >= minSeats.
   for (const { seatType } of ordered) {
-    if (seatType === "free") {
+    if (!AUTO_ASSIGNABLE.has(seatType)) {
       continue;
     }
     const limit = seatLimits?.get(seatType);
@@ -211,7 +217,7 @@ export function getDefaultSeatTypeForContract(
   // Phase 2: committed seats exhausted — try "free" if on the contract and
   // the caller/workspace conditions allow it.
   if (seatTypesOnContract.includes("free")) {
-    if (!isReturningMember && useFreeSeat) {
+    if (!isReturningMember) {
       const activeCapHit =
         freeSeatLimits !== undefined &&
         freeSeatCounts !== undefined &&

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -166,49 +166,44 @@ describe("resolveRemappedSeatType", () => {
   });
 
   it("keeps a seat type the contract still bills", () => {
+    expect(resolveRemappedSeatType("max", contract, productSeatTypes)).toBe(
+      "max"
+    );
     expect(
-      resolveRemappedSeatType("max", contract, productSeatTypes, false)
-    ).toBe("max");
-    expect(
-      resolveRemappedSeatType("pro_yearly", contract, productSeatTypes, false)
+      resolveRemappedSeatType("pro_yearly", contract, productSeatTypes)
     ).toBe("pro_yearly");
   });
 
   it("converts a monthly seat to its yearly equivalent when present", () => {
-    expect(
-      resolveRemappedSeatType("pro", contract, productSeatTypes, false)
-    ).toBe("pro_yearly");
+    expect(resolveRemappedSeatType("pro", contract, productSeatTypes)).toBe(
+      "pro_yearly"
+    );
   });
 
   it("falls back to the default tier (no free) otherwise", () => {
     // `free` has no yearly equivalent on the contract → default lowest tier.
-    expect(
-      resolveRemappedSeatType("free", contract, productSeatTypes, false)
-    ).toBe("pro_yearly");
+    expect(resolveRemappedSeatType("free", contract, productSeatTypes)).toBe(
+      "pro_yearly"
+    );
     // `max_yearly` (already yearly) isn't billed → default tier.
     expect(
-      resolveRemappedSeatType("max_yearly", contract, productSeatTypes, false)
+      resolveRemappedSeatType("max_yearly", contract, productSeatTypes)
     ).toBe("pro_yearly");
   });
 });
 
-describe("resolveRemappedSeatType (useFreeSeat)", () => {
+describe("resolveRemappedSeatType (free always skipped in fallback)", () => {
   // Contract bills `free` (0 AWU) and `pro` (8000 AWU).
   const { contract, productSeatTypes } = makeContract({
     seats: [{ seatType: "free" }, { seatType: "pro", awu: 8000 }],
   });
 
-  it("falls back to free when useFreeSeat is true", () => {
-    // `workspace` is not on the contract → falls back to the default tier.
-    // With useFreeSeat=true the lowest tier (`free`) is eligible.
+  it("skips free in the fallback and assigns the cheapest non-free tier", () => {
+    // `workspace` is not on the contract → falls back; `free` is always skipped
+    // since the remap only operates on existing members who can never receive
+    // the one-shot `free` starter tier.
     expect(
-      resolveRemappedSeatType("workspace", contract, productSeatTypes, true)
-    ).toBe("free");
-  });
-
-  it("skips free and falls back to the next tier when useFreeSeat is false", () => {
-    expect(
-      resolveRemappedSeatType("workspace", contract, productSeatTypes, false)
+      resolveRemappedSeatType("workspace", contract, productSeatTypes)
     ).toBe("pro");
   });
 });
@@ -228,27 +223,22 @@ describe("resolveRemappedSeatType (entitlement-aware)", () => {
     // `workspace` has a (dormant) subscription but isn't entitled → convert to
     // its entitled yearly equivalent.
     expect(
-      resolveRemappedSeatType("workspace", contract, productSeatTypes, false)
+      resolveRemappedSeatType("workspace", contract, productSeatTypes)
     ).toBe("workspace_yearly");
   });
 
   it("keeps an entitled seat type", () => {
     expect(
-      resolveRemappedSeatType(
-        "workspace_yearly",
-        contract,
-        productSeatTypes,
-        false
-      )
+      resolveRemappedSeatType("workspace_yearly", contract, productSeatTypes)
     ).toBe("workspace_yearly");
   });
 
   it("falls back to the only entitled tier for unrelated seats", () => {
     // `pro` is on the contract but not entitled, no `pro_yearly` entitled →
     // default tier among entitled seats = `workspace_yearly`.
-    expect(
-      resolveRemappedSeatType("pro", contract, productSeatTypes, false)
-    ).toBe("workspace_yearly");
+    expect(resolveRemappedSeatType("pro", contract, productSeatTypes)).toBe(
+      "workspace_yearly"
+    );
   });
 });
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -23,7 +23,6 @@ import {
   FREE_SEAT_LIFETIME_AWU_CREDITS,
   getCreditTypeAwuId,
   getProductSeatSubscriptionCreditsId,
-  PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
@@ -41,7 +40,7 @@ import {
   USAGE_TAG,
 } from "@app/lib/metronome/setup_common";
 import type { BillingFrequency } from "@app/lib/metronome/types";
-import { isFreePlan } from "@app/lib/plans/plan_codes";
+
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
@@ -249,8 +248,11 @@ export function classifySeatChange({
  *  - keep the current type if the contract still bills it;
  *  - if the current type is monthly and the contract bills its yearly
  *    equivalent (`<type>_yearly`), convert to yearly;
- *  - otherwise fall back to the cheapest seat type on the contract, skipping
- *    `free` when `useFreeSeat` is false.
+ *  - otherwise fall back to the cheapest non-`free` seat type on the contract.
+ *    `free` is always skipped: it is a one-shot starter tier, the resource-level
+ *    updateMembershipSeat has no one-shot guard, and the remap bypasses
+ *    grantFreeSeatCredits — so assigning `free` here would set the seat type
+ *    without issuing the AWU credit.
  *
  * Returns `undefined` when no target is resolvable (caller leaves the
  * membership untouched).
@@ -258,8 +260,7 @@ export function classifySeatChange({
 export function resolveRemappedSeatType(
   currentSeatType: MembershipSeatType,
   contract: CachedContract,
-  productSeatTypes: Map<string, MembershipSeatType>,
-  useFreeSeat: boolean
+  productSeatTypes: Map<string, MembershipSeatType>
 ): MembershipSeatType | undefined {
   const onContract = new Set(
     getSeatSubscriptionsFromContract(contract, productSeatTypes).keys()
@@ -273,8 +274,11 @@ export function resolveRemappedSeatType(
       return yearly;
     }
   }
-  // Fallback: assign the cheapest seat type billed on the contract (by AWU
-  // allowance), skipping "free" when the caller opted out.
+  // Fallback: cheapest non-free seat type on the contract. `free` is always
+  // skipped here — it is a one-shot starter tier and the resource-level
+  // updateMembershipSeat has no one-shot guard. Re-assigning it through the
+  // remap path would also bypass grantFreeSeatCredits, leaving the member with
+  // a `free` seat type but no AWU credit.
   const ordered = [...onContract]
     .map((seatType) => ({
       seatType,
@@ -282,7 +286,7 @@ export function resolveRemappedSeatType(
     }))
     .sort((a, b) => a.awu - b.awu || a.seatType.localeCompare(b.seatType));
   for (const { seatType } of ordered) {
-    if (seatType === "free" && !useFreeSeat) {
+    if (seatType === "free") {
       continue;
     }
     return seatType;
@@ -338,11 +342,6 @@ export async function remapMembershipSeatTypesForContract({
     }
     resolvedContract = fetched.value;
   }
-
-  const targetPlanCode =
-    resolvedContract.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
-  const isFreePlanContract =
-    targetPlanCode !== undefined ? isFreePlan(targetPlanCode) : false;
 
   const productSeatTypes = await getProductSeatTypes();
   const onContract = getSeatSubscriptionsFromContract(
@@ -417,13 +416,16 @@ export async function remapMembershipSeatTypesForContract({
       );
       continue;
     }
-    const target = resolveRemappedSeatType(
-      membership.seatType,
-      resolvedContract,
-      productSeatTypes,
-      isFreePlanContract
-    );
-    if (!target || target === membership.seatType) {
+    // When no non-free seat type exists on the contract, fall back to "none"
+    // so the member is explicitly unprovisioned rather than silently left on
+    // their old (now-unbilled) seat type.
+    const target =
+      resolveRemappedSeatType(
+        membership.seatType,
+        resolvedContract,
+        productSeatTypes
+      ) ?? "none";
+    if (target === membership.seatType) {
       logger.info(
         {
           workspaceId: workspace.sId,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -413,11 +413,11 @@ export class MembershipResource extends BaseResource<MembershipModel> {
   }
 
   /**
-   * Returns true when the user has *any* prior membership row in the
-   * workspace — current, future-scheduled, or revoked. Used to enforce
-   * that `"free"` is a one-shot starter tier: it can only be assigned at
-   * the very first membership creation; any subsequent change refuses
-   * `"free"` (including re-joining after revoke).
+   * Returns true when the user has any prior membership row in the workspace
+   * (current, future-scheduled, or revoked). Used to enforce the one-shot rule:
+   * `free` is a starter tier that can only be assigned on a user's very first
+   * membership creation — any prior membership, regardless of seat type,
+   * disqualifies them from receiving `free` again.
    */
   static async hasAnyMembershipOfUserInWorkspace({
     user,


### PR DESCRIPTION
## Description

Overhauls the seat assignment logic for new workspace members and contract remapping. Key changes across `getDefaultSeatTypeForContract`, `resolveSeatTypeForNewMembership`, `resolveRemappedSeatType`, and `remapMembershipSeatTypesForContract`.

### New member seat assignment (`getDefaultSeatTypeForContract`)

Replaces the old "pick cheapest tier" logic with an explicit three-phase algorithm:

1. **Committed seats** — assign the cheapest `pro` or `pro_yearly` seat type whose committed allocation (`workspace_seat_limits.minSeats`) still has unassigned slots. Higher tiers (`max`, `max_yearly`, `workspace`, …) are never auto-assigned.
2. **Free seat** — if no committed slot is available, assign `free` unless the member is a returning user (one-shot rule: any prior membership disqualifies them) or workspace caps are hit.
3. **None** — assign `"none"` when both phases are exhausted.

Return type narrowed from `MembershipSeatType | undefined` to `MembershipSeatType` (phase 3 always returns `"none"` instead of throwing).

### `resolveSeatTypeForNewMembership`

- Seat counts are now fetched only when committed seats are configured (`minSeats > 0`), replacing the old `hasAnyCap` (`maxSeats`) condition.
- Removed the now-dead `!defaultSeatType` error throw.
- Removed the `useFreeSeat` parameter (no caller ever passed `false`).

### `createAndTrackMembership`

- Removed the `useFreeSeat` parameter (propagated from above).

### `resolveRemappedSeatType` (contract remap on switch)

- Removed the `useFreeSeat` parameter: `free` is now **always** skipped in the fallback. The remap only runs on existing members who are ineligible for the one-shot `free` starter tier, and the resource-level `updateMembershipSeat` has no one-shot guard — so letting the fallback return `free` would silently write it without going through `grantFreeSeatCredits`.
- Removed the `isFreePlanContract` / `PLAN_CODE_CUSTOM_FIELD_KEY` logic that was the only source of `useFreeSeat = true`.

### `remapMembershipSeatTypesForContract`

- When `resolveRemappedSeatType` returns `undefined` (no non-free seat on the new contract), now falls back to `"none"` instead of silently skipping the member — making the unprovision explicit.

### `hasAnyMembershipOfUserInWorkspace`

- Doc clarified: this is the one-shot `free` guard — any prior membership (not just a prior `free` seat) disqualifies a returning user from the free starter tier.

## Tests

- `seat_types.test.ts`: rewritten to cover the new three-phase algorithm (committed slot available → assign; exhausted → free; free blocked by returning member or caps → none; `max` skipped even with committed slots; legacy contract → workspace; entitlement filtering still respected).
- `seats.test.ts`: `resolveRemappedSeatType` tests updated to drop the `useFreeSeat` argument; added a test confirming `free` is always skipped in the remap fallback.

## Risk

Low. Changes affect:
- New member creation on Metronome-billed workspaces (committed-seat priority replaces cheapest-tier).
- Contract remapping (`free` removed from fallback, `undefined` → `"none"` for empty contracts).

Workspaces without `workspace_seat_limits.minSeats` configured will assign `free` (new members) or `none` (no free on contract) — matching the intended product behaviour.

## Deploy Plan

No migration needed. Takes effect immediately on deploy.