### PR TITLE
Assign free seat when enabling free plan

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -11,8 +11,10 @@ import { BUSINESS_USD_PACKAGE_ALIAS } from "@app/lib/metronome/types";
 import { PlanModel } from "@app/lib/models/plan";
 import { CREDIT_PRICED_FREE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
@@ -82,6 +84,34 @@ export async function activateCreditPricedFreePlan(
     );
   }
   const { metronomeCustomerId } = customerResult.value;
+
+  // Assign "free" to all members who still hold the pre-contract DB default
+  // ("workspace") before provisioning. The seat sync inside
+  // provisionMetronomeContract reads DB seat state to issue AWU credits, so the
+  // seat must already be correct in DB when that sync runs.
+  // For CP_FREE_PLAN the initial seat is always "free".
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: lightWorkspace,
+  });
+  const users = await UserResource.fetchByModelIds(
+    memberships.map((m) => m.userId)
+  );
+  const userByModelId = new Map(users.map((u) => [u.id, u]));
+  for (const membership of memberships) {
+    if (membership.seatType !== "workspace") {
+      continue;
+    }
+    const user = userByModelId.get(membership.userId);
+    if (!user) {
+      continue;
+    }
+    await membership.updateMembershipSeat({
+      user,
+      workspace: lightWorkspace,
+      newSeatType: "free",
+      author: "no-author",
+    });
+  }
 
   const contractResult = await provisionMetronomeContract({
     metronomeCustomerId,


### PR DESCRIPTION
## Description

In `activateCreditPricedFreePlan`, before provisioning the Metronome contract, update any active member still on the DB-default `"workspace"` seat to `"free"`.

**Why:** the workspace creator joins before the contract exists (no Metronome customer yet), so `resolveSeatTypeForNewMembership` returns `undefined` and the DB default `"workspace"` is applied. When the contract is later provisioned, `remapMembershipSeatTypesForContract` sees `"workspace"` (not on the business package), falls through to the cheapest non-`free` seat, and sets the creator to `"pro"`.

**Fix:** set the seat to `"free"` in DB *before* `provisionMetronomeContract` runs. The seat sync inside provisioning reads DB state to issue AWU credits, so the seat must already be correct when that sync runs. With the seat already `"free"`, the remap's step-1 (`onContract.has("free")`) keeps it unchanged and the sync grants the AWU lifetime credit.

## Tests

Manual — creating a new workspace with CP_FREE_PLAN now correctly assigns the creator a `"free"` seat.

## Risk

Low. The update only touches members whose seat is the DB default `"workspace"` (i.e. created before any contract existed). All other seat types are left untouched.

## Deploy Plan

No migration needed. Takes effect immediately on deploy.