### PR TITLE
[LLM] Add Dust config layer for Claude Sonnet 4.6 stream endpoints

### DIFF
--- a/front/lib/llms/configuration.ts
+++ b/front/lib/llms/configuration.ts
@@ -1,0 +1,21 @@
+import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+type ReasoningEffortOf<C extends InputConfig> = NonNullable<
+  C["reasoning"]
+>["effort"];
+
+export type DustModelConfiguration<C extends InputConfig> =
+  BaseModelConfiguration<C> & {
+    // Description
+    displayName: string;
+    description: string;
+
+    // Behavior
+    defaultReasoningEffort: ReasoningEffortOf<C>;
+
+    // Filters
+    byok: boolean;
+    featureFlags: WhitelistableFeature[];
+  };

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,0 +1,18 @@
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export function WithDustClaudeSonnetFourDotSixConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustClaudeSonnetFourDotSix extends Base {
+    static readonly displayName = "Claude Sonnet 4.6";
+    static readonly description =
+      "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (200k context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+    static readonly featureFlags: WhitelistableFeature[] = [];
+  }
+
+  return DustClaudeSonnetFourDotSix;
+}

--- a/front/lib/llms/stream/dust_stream_endpoint.ts
+++ b/front/lib/llms/stream/dust_stream_endpoint.ts
@@ -1,0 +1,31 @@
+import type { DustModelConfiguration } from "@app/lib/llms/configuration";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+
+// Generic over raw payload `I`, raw stream event `O`, input config `C`.
+export abstract class DustStreamEndpoint<
+  I = unknown,
+  O = unknown,
+  C extends InputConfig = InputConfig,
+> extends StreamEndpoint<I, O> {
+  declare ["constructor"]: DustModelConfiguration<C>;
+}
+
+// Like `StreamEndpointConstructor`, but with `DustModelConfiguration`.
+export type DustStreamEndpointConstructor<
+  I = unknown,
+  O = unknown,
+  C extends InputConfig = InputConfig,
+> = (new (
+  credentials: Credentials
+) => StreamEndpoint<I, O>) &
+  DustModelConfiguration<C>;
+
+// Infers `C` from the class's `configSchema` so `defaultReasoningEffort` is
+// checked against the endpoint's supported efforts. Returns the class unchanged.
+export function defineDustStreamEndpoint<I, O, C extends InputConfig>(
+  endpoint: DustStreamEndpointConstructor<I, O, C>
+): DustStreamEndpointConstructor<I, O, C> {
+  return endpoint;
+}

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -1,0 +1,9 @@
+import { WithDustClaudeSonnetFourDotSixConfig } from "@app/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+
+export class DustAgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithDustClaudeSonnetFourDotSixConfig(
+  AgentPlatformEuropeClaudeSonnetFourDotSixStream
+) {}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeSonnetFourDotSixStream);

--- a/front/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -1,0 +1,9 @@
+import { WithDustClaudeSonnetFourDotSixConfig } from "@app/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+
+export class DustAnthropicGlobalClaudeSonnetFourDotSixStream extends WithDustClaudeSonnetFourDotSixConfig(
+  AnthropicGlobalClaudeSonnetFourDotSixStream
+) {}
+
+defineDustStreamEndpoint(DustAnthropicGlobalClaudeSonnetFourDotSixStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,0 +1,11 @@
+import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
+
+export const DUST_STREAM_ENDPOINTS = {
+  [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
+    DustAnthropicGlobalClaudeSonnetFourDotSixStream,
+  [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
+    DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
+} as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -6,7 +6,7 @@ import type { Region } from "@app/lib/model_constructors/types/regions";
 import type { TokenPricing } from "@app/lib/model_constructors/types/token_pricing";
 import type { z } from "zod";
 
-export type BaseModelConfiguration = {
+export type BaseModelConfiguration<C extends InputConfig = InputConfig> = {
   // Identity
   id: `${ProviderId}/${ProviderApi}/${Region}/${ModelId}`;
   providerId: ProviderId;
@@ -17,7 +17,7 @@ export type BaseModelConfiguration = {
   // Capabilities
   contextSize: number;
   maxOutputTokens: number;
-  configSchema: z.ZodType<InputConfig>;
+  configSchema: z.ZodType<C>;
 
   // Pricing
   tokenPricing: TokenPricing;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,0 +1,12 @@
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+
+export const STREAM_ENDPOINTS = {
+  [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
+    AnthropicGlobalClaudeSonnetFourDotSixStream,
+  [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
+    AgentPlatformEuropeClaudeSonnetFourDotSixStream,
+} as const satisfies Record<string, StreamEndpointConstructor>;
+
+export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;


### PR DESCRIPTION
## Description

Adds the `llms` Dust config layer on top of `model_constructors`: a `DustModelConfiguration` type, a `DustStreamEndpoint` base, a Claude Sonnet 4.6 config mixin (display metadata, reasoning effort, feature flags) and the Dust stream endpoints registry; also makes `BaseModelConfiguration` generic over its input config and adds the underlying stream endpoints registry.

## Tests

Not needed — type-level scaffolding and config wiring with no callers yet.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`