### PR TITLE
Avoid double user sync

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -3,7 +3,9 @@ import { listMetronomePackages } from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
+  syncContractQuantities,
 } from "@app/lib/metronome/contracts";
+import { remapMembershipSeatTypesForContract } from "@app/lib/metronome/seats";
 import { PlanModel } from "@app/lib/models/plan";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
@@ -42,6 +44,17 @@ vi.mock("@app/lib/metronome/contracts", async () => {
     ...actual,
     ensureMetronomeCustomerForWorkspace: vi.fn(),
     provisionMetronomeContract: vi.fn(),
+    syncContractQuantities: vi.fn(),
+  };
+});
+
+vi.mock("@app/lib/metronome/seats", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seats")
+  >("@app/lib/metronome/seats");
+  return {
+    ...actual,
+    remapMembershipSeatTypesForContract: vi.fn(),
   };
 });
 
@@ -224,6 +237,10 @@ beforeEach(() => {
   vi.mocked(provisionMetronomeContract).mockResolvedValue(
     new Ok({ metronomeContractId: NEW_CONTRACT_ID })
   );
+  vi.mocked(remapMembershipSeatTypesForContract).mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.mocked(syncContractQuantities).mockResolvedValue(new Ok(undefined));
 });
 
 describe("POST /api/poke/workspaces/[wId]/switch_contract — Enterprise", () => {

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -468,6 +468,11 @@ export async function switchContract({
     }
   }
 
+  // Disable the internal seat sync — switchContract always runs its own
+  // remap + sync at the end (after seat-rate overrides), so the contract sees
+  // the final effective entitlements. Running the sync here first (on package
+  // defaults) then again after overrides would produce an incorrect intermediate
+  // remap that could briefly assign the wrong seat type to members.
   const provisionResult = await provisionMetronomeContract({
     metronomeCustomerId,
     workspace: renderLightWorkspaceType({ workspace: owner }),
@@ -477,6 +482,7 @@ export async function switchContract({
     enableStripeBilling: body.stripeCustomerId !== undefined,
     planCode: body.planCode,
     fromContractId: currentSubscription?.metronomeContractId ?? undefined,
+    enableSeatSync: false,
   });
   if (provisionResult.isErr()) {
     return new Err(
@@ -775,59 +781,47 @@ export async function switchContract({
         )
       );
     }
+  }
 
-    // Re-remap memberships and re-sync seat quantities now that entitlements
-    // have changed. Both ran inside `provisionMetronomeContract` BEFORE these
-    // overrides were applied, so they only saw the package's default-entitled
-    // seats. Without re-running:
-    //  - a membership on a seat the operator just DISABLED (e.g. pro_yearly,
-    //    swapped for pro) would stay on that now-unbilled seat type, and
-    //  - a seat the operator just ENTITLED would stay at quantity 0 (unbilled).
-    // The remap moves members off disabled seats onto an entitled one; the sync
-    // then reconciles quantities. Both re-fetch the contract fresh (no cache),
-    // so the new effective entitlements are visible. Skipped when no override
-    // changed entitlement.
-    if (seatRateOverrides.length > 0) {
-      const ownerLight = renderLightWorkspaceType({ workspace: owner });
-      const remapResult = await remapMembershipSeatTypesForContract({
-        metronomeCustomerId,
-        contractId: metronomeContractId,
-        workspace: ownerLight,
-        swapAt,
-        startingAt: alignedStart,
-      });
-      if (remapResult.isErr()) {
-        return new Err(
-          new SwitchContractError(
-            "provision_inconsistent",
-            `Provisioned Metronome contract ${metronomeContractId} and applied ` +
-              `seat entitlement overrides, but failed to re-map membership seat ` +
-              `types: ${remapResult.error.message}. Members may remain on a seat ` +
-              "type the new contract no longer bills. Manual reconciliation may " +
-              "be required."
-          )
-        );
-      }
-
-      const resyncResult = await syncContractQuantities(
-        metronomeCustomerId,
-        metronomeContractId,
-        ownerLight,
-        alignedStart.toISOString()
-      );
-      if (resyncResult.isErr()) {
-        return new Err(
-          new SwitchContractError(
-            "provision_inconsistent",
-            `Provisioned Metronome contract ${metronomeContractId} and applied ` +
-              `seat entitlement overrides, but failed to re-sync seat ` +
-              `quantities: ${resyncResult.error.message}. The newly entitled ` +
-              "seats may bill at quantity 0 until the next sync. Manual " +
-              "reconciliation may be required."
-          )
-        );
-      }
-    }
+  // Remap memberships and sync seat quantities against the final contract state
+  // (all overrides already applied). This is the single authoritative seat sync
+  // for switchContract — provisionMetronomeContract runs with enableSeatSync:false
+  // to avoid an incorrect intermediate remap on package-default entitlements.
+  const ownerLight = renderLightWorkspaceType({ workspace: owner });
+  const remapResult = await remapMembershipSeatTypesForContract({
+    metronomeCustomerId,
+    contractId: metronomeContractId,
+    workspace: ownerLight,
+    swapAt,
+    startingAt: alignedStart,
+  });
+  if (remapResult.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "provision_inconsistent",
+        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
+          `map membership seat types: ${remapResult.error.message}. Members may ` +
+          "remain on a seat type the new contract no longer bills. Manual " +
+          "reconciliation may be required."
+      )
+    );
+  }
+  const resyncResult = await syncContractQuantities(
+    metronomeCustomerId,
+    metronomeContractId,
+    ownerLight,
+    alignedStart.toISOString()
+  );
+  if (resyncResult.isErr()) {
+    return new Err(
+      new SwitchContractError(
+        "provision_inconsistent",
+        `Provisioned Metronome contract ${metronomeContractId} but failed to ` +
+          `sync seat quantities: ${resyncResult.error.message}. Seats may bill ` +
+          "at incorrect quantities until the next sync. Manual reconciliation " +
+          "may be required."
+      )
+    );
   }
 
   // The operator supplies the AWU usage cap in credits directly — no fiat


### PR DESCRIPTION
## Description

In `switchContract`, `provisionMetronomeContract` was called with the default `enableSeatSync: true`, which runs `remapMembershipSeatTypesForContract` + `syncContractQuantities` internally on the package's **default** entitlements. Then, if seat-rate overrides were applied (disabling/enabling seats), a second remap + sync ran to correct what the first one got wrong.

This was both redundant and incorrect: the first remap could move members to a seat the operator was about to disable (e.g. `pro_yearly` → `pro`), producing a brief wrong intermediate state.

**Fix:**
- Pass `enableSeatSync: false` to `provisionMetronomeContract` in `switchContract`.
- Remove the conditional `if (seatRateOverrides.length > 0)` remap + sync block.
- Run a single unconditional remap + sync after all overrides are applied, so it always sees the final effective entitlements.

## Tests

Existing seats.test.ts passes. Manually verified via poke switchContract.

## Risk

Low. The remap + sync still always runs — it just runs once, at the right time, on the correct entitlements.

## Deploy Plan

No migration needed. Takes effect immediately on deploy.