### PR TITLE
Enforce member limits, count pending invitations

### DIFF
--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -106,13 +106,17 @@ vi.mock("@app/lib/resources/workspace_sandbox_env_var_resource", () => ({
   },
 }));
 
-vi.mock("@app/logger/logger", () => ({
-  default: {
+vi.mock("@app/logger/logger", () => {
+  const child = vi.fn();
+  const mock = {
     error: mockLoggerError,
     info: mockLoggerInfo,
     warn: mockLoggerWarn,
-  },
-}));
+    child,
+  };
+  child.mockReturnValue(mock);
+  return { default: mock };
+});
 
 import {
   addEgressDomainTool,

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -235,14 +235,22 @@ export async function handleMembershipInvitations(
       await getWorkspaceAdministrationVersionLock(owner, t);
 
       if (maxUsers !== -1) {
-        const membersCount =
-          await MembershipResource.getMembersCountForWorkspace({
+        const [membersCount, pendingInvitationsCount] = await Promise.all([
+          MembershipResource.getMembersCountForWorkspace({
             workspace: owner,
             activeOnly: true,
             transaction: t,
-          });
+          }),
+          MembershipInvitationResource.getPendingInvitationsCountForWorkspace({
+            workspace: owner,
+            transaction: t,
+          }),
+        ]);
 
-        const availableSeats = Math.max(maxUsers - membersCount, 0);
+        const availableSeats = Math.max(
+          maxUsers - membersCount - pendingInvitationsCount,
+          0
+        );
 
         if (availableSeats < invitationRequests.length) {
           const message =

--- a/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_coupon.test.ts
@@ -68,9 +68,12 @@ vi.mock("@app/lib/metronome/constants", async () => {
   };
 });
 
-vi.mock("@app/logger/logger", () => ({
-  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
-}));
+vi.mock("@app/logger/logger", () => {
+  const child = vi.fn();
+  const mock = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), child };
+  child.mockReturnValue(mock);
+  return { default: mock };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -7,6 +7,7 @@ import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { getUsageToReportForSubscriptionItem } from "@app/lib/plans/usage";
 import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import type { MembershipsPaginationParams } from "@app/lib/resources/membership_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -429,13 +430,18 @@ export async function evaluateWorkspaceSeatAvailability(
     return true;
   }
 
-  const activeMembersCount =
-    await MembershipResource.getMembersCountForWorkspace({
-      workspace: renderLightWorkspaceType({ workspace }),
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const [activeMembersCount, pendingInvitationsCount] = await Promise.all([
+    MembershipResource.getMembersCountForWorkspace({
+      workspace: lightWorkspace,
       activeOnly: true,
-    });
+    }),
+    MembershipInvitationResource.getPendingInvitationsCountForWorkspace({
+      workspace: lightWorkspace,
+    }),
+  ]);
 
-  return activeMembersCount < maxUsers;
+  return activeMembersCount + pendingInvitationsCount < maxUsers;
 }
 
 export async function unsafeGetWorkspacesByModelId(

--- a/front/lib/metronome/coupons.test.ts
+++ b/front/lib/metronome/coupons.test.ts
@@ -96,9 +96,12 @@ vi.mock("@app/lib/metronome/constants", async () => {
   };
 });
 
-vi.mock("@app/logger/logger", () => ({
-  default: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
-}));
+vi.mock("@app/logger/logger", () => {
+  const child = vi.fn();
+  const mock = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), child };
+  child.mockReturnValue(mock);
+  return { default: mock };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -298,6 +298,22 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     });
   }
 
+  static async getPendingInvitationsCountForWorkspace({
+    workspace,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<number> {
+    return this.model.count({
+      where: {
+        workspaceId: workspace.id,
+        status: "pending",
+      },
+      transaction,
+    });
+  }
+
   static async getPendingInvitations(
     auth: Authenticator,
     { includeExpired = false }: { includeExpired?: boolean } = {}


### PR DESCRIPTION
## Problem

The workspace member limit was not fully enforced when sending invitations or during domain-based auto-join.

With `n-1` active members against a plan limit of `n`, an admin could send multiple invitations in parallel — each request would see 1 available seat and succeed. Similarly, auto-join could race with pending invitations and push the workspace over its limit.

## Fix

Pending invitations now count against available seats in both enforcement points:

- **Invitations** (`lib/api/invitation.ts`): the seat check inside the workspace admin lock now subtracts both active members and pending (non-consumed, non-revoked) invitations from `maxUsers`.
- **Auto-join** (`lib/api/workspace.ts` — `evaluateWorkspaceSeatAvailability`): same fix; also widened the function signature to accept `LightWorkspaceType` directly.
- **New helper** (`lib/resources/membership_invitation_resource.ts`): `getPendingInvitationsCountForWorkspace` — a simple `COUNT` query on `status = 'pending'` scoped to the workspace, reused by both callers.