### PR TITLE
Fix: refresh authenticator during agent loop

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -6,8 +6,7 @@ import {
   getWhitelistedProviders,
 } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
-import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
@@ -80,9 +79,7 @@ export async function ensureConversationTitleFromAgentLoop(
     throw runAgentDataRes.error;
   }
 
-  const { conversation, userMessage } = runAgentDataRes.value;
-
-  const auth = await Authenticator.fromJSON(authType);
+  const { conversation, userMessage, auth } = runAgentDataRes.value;
 
   return ensureConversationTitle(auth, { conversation, userMessage });
 }

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -152,7 +152,8 @@ describe("Authenticator.fromJSON", () => {
     const staleAuth = await Authenticator.fromJSON(staleAuthJson);
     expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(false);
 
-    const freshAuth = await Authenticator.fromJSONForAgentLoop(staleAuthJson);
+    const freshAuth =
+      await Authenticator.fromJsonWithRefrehedGroups(staleAuthJson);
     expect(freshAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
   });
 });

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -83,7 +83,9 @@ import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { PlanFactory } from "@app/tests/utils/PlanFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 
 async function swapSubscription(workspaceId: string): Promise<string> {
@@ -128,5 +130,29 @@ describe("Authenticator.fromJSON", () => {
     const fresh = await Authenticator.fromJSON(authJson);
     expect(fresh.plan()).not.toBeNull();
     expect(fresh.subscription()?.sId).toBe(newSubId);
+  });
+
+  it("refreshes group memberships so pod admin access granted mid-run is visible after serialization", async () => {
+    const {
+      workspace,
+      user,
+      authenticator: auth,
+    } = await createResourceTest({
+      role: "user",
+    });
+
+    const staleAuthJson = auth.toJSON();
+
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const editorGroup = pod.groups.find(
+      (group) => group.kind === "space_editors"
+    );
+    expect(editorGroup).toBeDefined();
+
+    const staleAuth = await Authenticator.fromJSON(staleAuthJson);
+    expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(false);
+
+    const freshAuth = await Authenticator.fromJSONForAgentLoop(staleAuthJson);
+    expect(freshAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
   });
 });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1313,7 +1313,7 @@ export class Authenticator {
    * workflow start: tools that grant new group access (e.g. create_pod) must see
    * up-to-date memberships on subsequent steps.
    */
-  static async fromJSONForAgentLoop(
+  static async fromJsonWithRefrehedGroups(
     authType: AuthenticatorType
   ): Promise<Authenticator> {
     const auth = await Authenticator.fromJSON(authType);

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1306,6 +1306,20 @@ export class Authenticator {
       clientIp: authType.clientIp,
     });
   }
+
+  /**
+   * Rebuilds an Authenticator from a serialized snapshot and refreshes group
+   * memberships from the database. Used by the agent loop, which freezes auth at
+   * workflow start: tools that grant new group access (e.g. create_pod) must see
+   * up-to-date memberships on subsequent steps.
+   */
+  static async fromJSONForAgentLoop(
+    authType: AuthenticatorType
+  ): Promise<Authenticator> {
+    const auth = await Authenticator.fromJSON(authType);
+    await auth.refresh();
+    return auth;
+  }
 }
 
 /**

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -502,7 +502,7 @@ export async function notifyWorkflowError(
   { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
   error: { message: string; name: string }
 ): Promise<void> {
-  const auth = await AuthenticatorClass.fromJSONForAgentLoop(authType);
+  const auth = await AuthenticatorClass.fromJsonWithRefrehedGroups(authType);
 
   // Use lighter fetchConversationWithoutContent
   const conversation = await ConversationResource.fetchById(

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -502,7 +502,7 @@ export async function notifyWorkflowError(
   { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
   error: { message: string; name: string }
 ): Promise<void> {
-  const auth = await AuthenticatorClass.fromJSON(authType);
+  const auth = await AuthenticatorClass.fromJSONForAgentLoop(authType);
 
   // Use lighter fetchConversationWithoutContent
   const conversation = await ConversationResource.fetchById(

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -22,7 +22,7 @@ export async function compactionActivity(
     sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
   const compactionRes = await runCompaction(auth, {
     conversationId,
     compactionMessageId,
@@ -48,7 +48,7 @@ export async function compactionCleanupActivity(
     compactionMessageVersion: number;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
   await failCompactionMessage(auth, {
     conversationId,
     compactionMessageId,

--- a/front/temporal/agent_loop/activities/compaction.ts
+++ b/front/temporal/agent_loop/activities/compaction.ts
@@ -22,7 +22,7 @@ export async function compactionActivity(
     sourceConversation?: CompactionSourceConversation;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
   const compactionRes = await runCompaction(auth, {
     conversationId,
     compactionMessageId,
@@ -48,7 +48,7 @@ export async function compactionCleanupActivity(
     compactionMessageVersion: number;
   }
 ): Promise<void> {
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
   await failCompactionMessage(auth, {
     conversationId,
     compactionMessageId,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -24,7 +24,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -52,7 +52,7 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
 ): Promise<void> {
   await finalizeGracefulStop(authType, agentLoopArgs);
 
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -81,7 +81,7 @@ export async function finalizeInterruptedAgentLoopActivity(
 ): Promise<void> {
   await finalizeInterruption(authType, agentLoopArgs);
 
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -102,7 +102,7 @@ export async function finalizeCancelledAgentLoopActivity(
 ): Promise<void> {
   await finalizeCancellation(authType, agentLoopArgs);
 
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -127,7 +127,7 @@ export async function finalizeErroredAgentLoopActivity(
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -24,7 +24,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -52,7 +52,7 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
 ): Promise<void> {
   await finalizeGracefulStop(authType, agentLoopArgs);
 
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -81,7 +81,7 @@ export async function finalizeInterruptedAgentLoopActivity(
 ): Promise<void> {
   await finalizeInterruption(authType, agentLoopArgs);
 
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -102,7 +102,7 @@ export async function finalizeCancelledAgentLoopActivity(
 ): Promise<void> {
   await finalizeCancellation(authType, agentLoopArgs);
 
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),
@@ -127,7 +127,7 @@ export async function finalizeErroredAgentLoopActivity(
 ): Promise<void> {
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   await Promise.all([
     snapshotAgentMessageSkills(auth, agentLoopArgs),

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -98,7 +98,7 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
   const [runAgentDataRes, action] = await startActiveObservation(

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -98,7 +98,7 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
   const [runAgentDataRes, action] = await startActiveObservation(

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -149,7 +149,7 @@ export async function getAgentLoopData(
     AgentLoopDataError | Error
   >
 > {
-  const auth = await Authenticator.fromJSONForAgentLoop(authType);
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   return getAgentLoopDataWithAuth(auth, agentLoopArgs);
 }

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -149,7 +149,7 @@ export async function getAgentLoopData(
     AgentLoopDataError | Error
   >
 > {
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromJSONForAgentLoop(authType);
 
   return getAgentLoopDataWithAuth(auth, agentLoopArgs);
 }


### PR DESCRIPTION
## Description

The Temporal agent loop serializes `Authenticator` at workflow start. When a tool (e.g. `create_pod`) grants new group memberships mid-run, subsequent activities deserialize a stale snapshot via `Authenticator.fromJSON()` and miss the new access.

Introduces `Authenticator.fromJSONForAgentLoop()` — a thin wrapper that calls `fromJSON()` then `auth.refresh()` to reload group memberships from the DB. All Temporal agent loop activities (`run_tool`, `finalize`, `compaction`, `common`) now use this method. Also removes a redundant `fromJSON` call in `title.ts` where `auth` is already available from `getAgentLoopData`.

## Tests

Added a unit test in `auth.fromjson.test.ts` covering the exact scenario: a pod is created after serialization, `fromJSON` misses the new editor group membership, `fromJSONForAgentLoop` sees it correctly. Tested locally.

## Risk

Low. `auth.refresh()` is an additive DB read; existing callers that didn't need fresh groups are unaffected. The only behavioral change is that activities now see up-to-date group memberships, which is the intended fix.

## Deploy Plan

Deploy `front`.
