### PR TITLE
Assign free seat when enabling free plan

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -75,19 +75,19 @@ import type { Transaction } from "sequelize";
 async function resolveSeatTypeForNewMembership(
   user: UserResource,
   workspace: LightWorkspaceType
-): Promise<MembershipSeatType | undefined> {
+): Promise<MembershipSeatType> {
   if (!workspace.metronomeCustomerId) {
-    return undefined;
+    return "none";
   }
   const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
     workspace.id
   );
   if (!subscription?.metronomeContractId) {
-    return undefined;
+    return "none";
   }
   const contract = await getActiveContract(workspace.sId);
   if (!contract) {
-    return undefined;
+    return "none";
   }
   const planLimits = subscription.toJSON().plan.limits.users;
   // `isReturningMember` is always queried — `free` is a one-shot starter tier

--- a/front/lib/metronome/seat_types.test.ts
+++ b/front/lib/metronome/seat_types.test.ts
@@ -172,7 +172,7 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     ).toBe("free");
   });
 
-  it("legacy: no-seat-subscription contract returns workspace regardless", () => {
+  it("legacy: no-seat-subscription contract returns none", () => {
     const legacyContract = {
       subscriptions: [],
       recurring_credits: [],
@@ -180,7 +180,7 @@ describe("getDefaultSeatTypeForContract — committed seats", () => {
     } as unknown as CachedContract;
     expect(
       getDefaultSeatTypeForContract(legacyContract, productSeatTypes)
-    ).toBe("workspace");
+    ).toBe("none");
   });
 });
 

--- a/front/lib/metronome/seat_types.ts
+++ b/front/lib/metronome/seat_types.ts
@@ -177,7 +177,7 @@ export function getDefaultSeatTypeForContract(
     ...getSeatSubscriptionsFromContract(contract, productSeatTypes).keys(),
   ];
   if (seatTypesOnContract.length === 0) {
-    return "workspace";
+    return "none";
   }
   const ordered = seatTypesOnContract
     .map((seatType) => ({

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_SEAT_CREDIT_NAME,
   PRO_SEAT_CREDIT_NAME,
 } from "@app/lib/metronome/setup_common";
+import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -155,9 +156,8 @@ describe("hasContractSeatSubscription", () => {
   });
 });
 
-describe("resolveRemappedSeatType", () => {
-  // Contract bills `pro_yearly` (8000 AWU) and `max` (40000 AWU) — no monthly
-  // `pro`. Lowest non-free tier → `pro_yearly`.
+describe("resolveRemappedSeatType — keep / yearly-convert", () => {
+  // Contract bills `pro_yearly` (8000 AWU) and `max` (40000 AWU).
   const { contract, productSeatTypes } = makeContract({
     seats: [
       { seatType: "pro_yearly", awu: 8000, frequency: "ANNUAL" },
@@ -180,64 +180,88 @@ describe("resolveRemappedSeatType", () => {
     );
   });
 
-  it("falls back to the default tier (no free) otherwise", () => {
-    // `free` has no yearly equivalent on the contract → default lowest tier.
-    expect(resolveRemappedSeatType("free", contract, productSeatTypes)).toBe(
-      "pro_yearly"
-    );
-    // `max_yearly` (already yearly) isn't billed → default tier.
+  it("converts a yearly seat to its monthly equivalent when only monthly is billed", () => {
+    // Contract bills `pro_yearly` and `max` — no `max_yearly`. A member on
+    // `max_yearly` (not on contract) should fall back to `max` (monthly).
     expect(
       resolveRemappedSeatType("max_yearly", contract, productSeatTypes)
-    ).toBe("pro_yearly");
+    ).toBe("max");
+  });
+
+  it("returns none for returning members when no seat matches", () => {
+    // `free` not on contract, no yearly equivalent, no committed seatLimits → none.
+    expect(resolveRemappedSeatType("free", contract, productSeatTypes)).toBe(
+      "none"
+    );
   });
 });
 
-describe("resolveRemappedSeatType (free always skipped in fallback)", () => {
+describe("resolveRemappedSeatType — fallback via getDefaultSeatTypeForContract", () => {
   // Contract bills `free` (0 AWU) and `pro` (8000 AWU).
   const { contract, productSeatTypes } = makeContract({
     seats: [{ seatType: "free" }, { seatType: "pro", awu: 8000 }],
   });
 
-  it("skips free in the fallback and assigns the cheapest non-free tier", () => {
-    // `workspace` is not on the contract → falls back; `free` is always skipped
-    // since the remap only operates on existing members who can never receive
-    // the one-shot `free` starter tier.
+  it("returns none for returning members (free blocked by one-shot rule)", () => {
+    // Default isReturningMember=true → free blocked → none.
+    expect(resolveRemappedSeatType("none", contract, productSeatTypes)).toBe(
+      "none"
+    );
+  });
+
+  it("assigns free for members who only ever had none seats", () => {
+    // isReturningMember=false → free on contract → free.
     expect(
-      resolveRemappedSeatType("workspace", contract, productSeatTypes)
+      resolveRemappedSeatType("none", contract, productSeatTypes, {
+        isReturningMember: false,
+      })
+    ).toBe("free");
+  });
+
+  it("assigns committed seat in fallback when slots available", () => {
+    const seatLimits = new Map<MembershipSeatType, SeatLimit>([
+      ["pro", { minSeats: 5, maxSeats: null }],
+    ]);
+    const seatCounts = { pro: 2 };
+    expect(
+      resolveRemappedSeatType("none", contract, productSeatTypes, {
+        isReturningMember: false,
+        seatLimits,
+        seatCounts,
+      })
     ).toBe("pro");
   });
 });
 
-describe("resolveRemappedSeatType (entitlement-aware)", () => {
-  // Contract carries every seat subscription, but only `workspace_yearly` is
+describe("resolveRemappedSeatType — entitlement-aware", () => {
+  // Contract carries every seat subscription, but only `pro_yearly` is
   // entitled (the others are dormant `entitled:false` baseline).
   const { contract, productSeatTypes } = makeContract({
     seats: [
-      { seatType: "workspace" },
-      { seatType: "workspace_yearly", entitled: true },
       { seatType: "pro" },
+      { seatType: "pro_yearly", entitled: true },
+      { seatType: "max" },
     ],
   });
 
   it("does not keep a seat whose subscription exists but is not entitled", () => {
-    // `workspace` has a (dormant) subscription but isn't entitled → convert to
-    // its entitled yearly equivalent.
-    expect(
-      resolveRemappedSeatType("workspace", contract, productSeatTypes)
-    ).toBe("workspace_yearly");
+    // `pro` has a (dormant) subscription but isn't entitled → convert to yearly.
+    expect(resolveRemappedSeatType("pro", contract, productSeatTypes)).toBe(
+      "pro_yearly"
+    );
   });
 
   it("keeps an entitled seat type", () => {
     expect(
-      resolveRemappedSeatType("workspace_yearly", contract, productSeatTypes)
-    ).toBe("workspace_yearly");
+      resolveRemappedSeatType("pro_yearly", contract, productSeatTypes)
+    ).toBe("pro_yearly");
   });
 
-  it("falls back to the only entitled tier for unrelated seats", () => {
-    // `pro` is on the contract but not entitled, no `pro_yearly` entitled →
-    // default tier among entitled seats = `workspace_yearly`.
-    expect(resolveRemappedSeatType("pro", contract, productSeatTypes)).toBe(
-      "workspace_yearly"
+  it("returns none for unrelated seats with no committed config", () => {
+    // `max` not entitled on the new contract, no `max_yearly`, no committed
+    // seatLimits → none.
+    expect(resolveRemappedSeatType("max", contract, productSeatTypes)).toBe(
+      "none"
     );
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -27,6 +27,7 @@ import {
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   getAwuAllocationForSeatType,
+  getDefaultSeatTypeForContract,
   getNextSeatCreditRenewalDate,
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
@@ -247,21 +248,34 @@ export function classifySeatChange({
  * remap policy when switching contracts:
  *  - keep the current type if the contract still bills it;
  *  - if the current type is monthly and the contract bills its yearly
- *    equivalent (`<type>_yearly`), convert to yearly;
- *  - otherwise fall back to the cheapest non-`free` seat type on the contract.
- *    `free` is always skipped: it is a one-shot starter tier, the resource-level
- *    updateMembershipSeat has no one-shot guard, and the remap bypasses
- *    grantFreeSeatCredits — so assigning `free` here would set the seat type
- *    without issuing the AWU credit.
+ *    equivalent (`<type>_yearly`), convert to yearly; conversely, if the
+ *    current type is yearly and the contract bills only the monthly equivalent,
+ *    convert to monthly;
+ *  - otherwise delegate to `getDefaultSeatTypeForContract` (committed seat →
+ *    free → none), using the caller-supplied `isReturningMember`,
+ *    `seatLimits`, and `seatCounts`.
  *
- * Returns `undefined` when no target is resolvable (caller leaves the
- * membership untouched).
+ * `isReturningMember` defaults to `true` (conservative). Pass `false` only
+ * when the user never held a real seat in this workspace (all prior rows had
+ * `seatType = "none"`), allowing the fallback to assign `free`.
+ *
+ * Free-seat workspace caps (`freeSeatCounts` / `freeSeatLimits`) are not
+ * checked here — those caps gate new-member creation, not contract remaps.
  */
 export function resolveRemappedSeatType(
   currentSeatType: MembershipSeatType,
   contract: CachedContract,
-  productSeatTypes: Map<string, MembershipSeatType>
-): MembershipSeatType | undefined {
+  productSeatTypes: Map<string, MembershipSeatType>,
+  {
+    isReturningMember = true,
+    seatLimits,
+    seatCounts,
+  }: {
+    isReturningMember?: boolean;
+    seatLimits?: Map<MembershipSeatType, SeatLimit>;
+    seatCounts?: Partial<Record<MembershipSeatType, number>>;
+  } = {}
+): MembershipSeatType {
   const onContract = new Set(
     getSeatSubscriptionsFromContract(contract, productSeatTypes).keys()
   );
@@ -273,25 +287,17 @@ export function resolveRemappedSeatType(
     if (isMembershipSeatType(yearly) && onContract.has(yearly)) {
       return yearly;
     }
-  }
-  // Fallback: cheapest non-free seat type on the contract. `free` is always
-  // skipped here — it is a one-shot starter tier and the resource-level
-  // updateMembershipSeat has no one-shot guard. Re-assigning it through the
-  // remap path would also bypass grantFreeSeatCredits, leaving the member with
-  // a `free` seat type but no AWU credit.
-  const ordered = [...onContract]
-    .map((seatType) => ({
-      seatType,
-      awu: getAwuAllocationForSeatType(contract, seatType, productSeatTypes),
-    }))
-    .sort((a, b) => a.awu - b.awu || a.seatType.localeCompare(b.seatType));
-  for (const { seatType } of ordered) {
-    if (seatType === "free") {
-      continue;
+  } else {
+    const monthly = currentSeatType.slice(0, -"_yearly".length);
+    if (isMembershipSeatType(monthly) && onContract.has(monthly)) {
+      return monthly;
     }
-    return seatType;
   }
-  return undefined;
+  return getDefaultSeatTypeForContract(contract, productSeatTypes, {
+    isReturningMember,
+    seatLimits,
+    seatCounts,
+  });
 }
 
 /**
@@ -387,12 +393,24 @@ export async function remapMembershipSeatTypesForContract({
     return new Ok(undefined);
   }
 
-  // `updateMembershipSeat` / `scheduleSeatChange` need a `UserResource`; the
-  // membership only carries the user attributes. Batch-fetch them.
-  const users = await UserResource.fetchByModelIds(
-    memberships.map((m) => m.userId)
-  );
+  // Pre-fetch everything resolveRemappedSeatType needs so the per-member loop
+  // makes no extra DB calls.
+  const [users, seatLimits, seatCounts] = await Promise.all([
+    UserResource.fetchByModelIds(memberships.map((m) => m.userId)),
+    WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
+    MembershipResource.getActiveSeatTypeCountsForWorkspace({ workspace }),
+  ]);
   const userByModelId = new Map(users.map((u) => [u.id, u]));
+
+  // Determine which members had a real (non-"none") seat at any point. Members
+  // whose entire history is "none" are treated as new members and are eligible
+  // for the "free" starter tier in the fallback.
+  const noneMembers = memberships.filter((m) => m.seatType === "none");
+  const returningMemberIds =
+    await MembershipResource.getUserIdsWithRealSeatHistory({
+      workspace,
+      userIds: noneMembers.map((m) => m.userId),
+    });
 
   // Apply immediately when the contract already started — either the operator
   // swapped at the current hour, or backdated the start to the past. Scheduling
@@ -416,15 +434,18 @@ export async function remapMembershipSeatTypesForContract({
       );
       continue;
     }
-    // When no non-free seat type exists on the contract, fall back to "none"
-    // so the member is explicitly unprovisioned rather than silently left on
-    // their old (now-unbilled) seat type.
-    const target =
-      resolveRemappedSeatType(
-        membership.seatType,
-        resolvedContract,
-        productSeatTypes
-      ) ?? "none";
+    // A member is "returning" (ineligible for the one-shot free tier) if they
+    // currently hold a real seat OR ever held one in the past.
+    const isReturningMember =
+      membership.seatType !== "none" ||
+      returningMemberIds.has(membership.userId);
+
+    const target = resolveRemappedSeatType(
+      membership.seatType,
+      resolvedContract,
+      productSeatTypes,
+      { isReturningMember, seatLimits, seatCounts }
+    );
     if (target === membership.seatType) {
       logger.info(
         {
@@ -454,6 +475,20 @@ export async function remapMembershipSeatTypesForContract({
     // methods, so we don't catch our own errors (a DB failure throws → 500,
     // surfacing that the remap didn't fully apply rather than silently leaving
     // a member on an unbilled seat).
+    // Keep the in-memory seatCounts snapshot in sync so that later members in
+    // this loop see accurate counts when resolveRemappedSeatType checks
+    // committed-slot availability (minSeats). Without this, every member would
+    // see the pre-loop count and all could be assigned the same committed slot.
+    if (target !== membership.seatType) {
+      seatCounts[target] = (seatCounts[target] ?? 0) + 1;
+      const prevSeatType: MembershipSeatType = membership.seatType;
+      if (prevSeatType !== "none") {
+        seatCounts[prevSeatType] = Math.max(
+          0,
+          (seatCounts[prevSeatType] ?? 1) - 1
+        );
+      }
+    }
     if (applyImmediately) {
       await membership.updateMembershipSeat({
         user,

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -421,10 +421,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
 
   /**
    * Returns true when the user has any prior membership row in the workspace
-   * (current, future-scheduled, or revoked). Used to enforce the one-shot rule:
-   * `free` is a starter tier that can only be assigned on a user's very first
-   * membership creation — any prior membership, regardless of seat type,
-   * disqualifies them from receiving `free` again.
+   * with a real seat (i.e. `seatType != "none"`). `"none"` is the initial
+   * placeholder assigned before a Metronome contract exists and is not counted
+   * as a "real" membership for the one-shot `free` rule. A user who only ever
+   * held `"none"` seats is treated as a new member and is eligible for `free`.
    */
   static async hasAnyMembershipOfUserInWorkspace({
     user,
@@ -439,10 +439,41 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       where: {
         userId: user.id,
         workspaceId: workspace.id,
+        seatType: { [Op.ne]: "none" },
       },
       transaction,
     });
     return count > 0;
+  }
+
+  /**
+   * Batch version of `hasAnyMembershipOfUserInWorkspace` for use in the
+   * contract remap loop. Returns the subset of `userIds` (numeric model IDs)
+   * that have at least one membership row with `seatType != "none"` in the
+   * workspace.
+   */
+  static async getUserIdsWithRealSeatHistory({
+    workspace,
+    userIds,
+  }: {
+    workspace: LightWorkspaceType;
+    userIds: number[];
+  }): Promise<Set<number>> {
+    if (userIds.length === 0) {
+      return new Set();
+    }
+    const rows = await this.model.findAll({
+      attributes: ["userId"],
+      where: {
+        workspaceId: workspace.id,
+        userId: { [Op.in]: userIds },
+        seatType: { [Op.ne]: "none" },
+        // Exclude future-scheduled rows: a pending upgrade should not count as
+        // prior real-seat history when deciding free-tier eligibility.
+        startAt: { [Op.lte]: new Date() },
+      },
+    });
+    return new Set(rows.map((r) => r.userId));
   }
 
   /**
@@ -1468,7 +1499,16 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       return { previousSeatType, newSeatType };
     }
 
-    await this.update({ seatType: newSeatType }, transaction);
+    await this.update(
+      {
+        seatType: newSeatType,
+        // Reset credit state to the optimistic initial state for the new seat
+        // type (same logic as createMembership) so the member isn't stuck in
+        // the wrong state during the seat sync's debounce window.
+        creditState: initialCreditStateForSeatType(newSeatType),
+      },
+      transaction
+    );
 
     auditLog(
       {


### PR DESCRIPTION
## Description

Consolidates and corrects seat assignment logic for both new-member creation and contract remapping.

### New-member creation (`resolveSeatTypeForNewMembership` / `createAndTrackMembership`)

- `resolveSeatTypeForNewMembership` now returns `"none"` instead of `undefined` when there is no Metronome customer, no contract ID, or no active contract. Return type narrowed to `Promise<MembershipSeatType>`.
- `createAndTrackMembership` passes `seatType` directly (no `?? "none"` fallback needed).

### `getDefaultSeatTypeForContract`

- Legacy contracts with no seat subscriptions now return `"none"` instead of `"workspace"`.

### `hasAnyMembershipOfUserInWorkspace` (one-shot `free` rule)

- Now excludes `seatType = "none"` rows. A user who only ever held `"none"` seats is treated as a new member and remains eligible for the `free` starter tier.
- Added `getUserIdsWithRealSeatHistory` — batch version for the remap loop to avoid N+1 queries.

### `resolveRemappedSeatType` — rewritten

- Keeps the "current type already on contract" and "monthly ↔ yearly conversion" steps:
  - monthly → yearly: if `<type>_yearly` is on the new contract, convert to it.
  - yearly → monthly: if the base `<type>` is on the new contract (and no yearly), convert to monthly.
- **Fallback now delegates to `getDefaultSeatTypeForContract`** (committed seat → free → none) instead of the old "cheapest non-free tier" heuristic.
- Accepts `{ isReturningMember, seatLimits, seatCounts }` — same parameters as `getDefaultSeatTypeForContract`.
- Return type is now `MembershipSeatType` (never `undefined`).

### `remapMembershipSeatTypesForContract`

- Pre-fetches `seatLimits`, `seatCounts`, and batches `getUserIdsWithRealSeatHistory` before the member loop — no per-member DB queries.
- Computes `isReturningMember` per member: `true` if they currently have a real seat OR ever had one; `false` if all prior rows were `"none"` (allows them to receive `free` on the new contract).

## Tests

Updated `seats.test.ts` and `seat_types.test.ts` to cover:
- Monthly ↔ yearly conversion in both directions.
- Fallback via `getDefaultSeatTypeForContract`: returning members get `"none"`, non-returning members get `"free"` or a committed seat.
- Legacy no-seat contract → `"none"`.

## Risk

Low. The remap and new-member paths now share the same seat-assignment logic (`getDefaultSeatTypeForContract`), eliminating the divergence that caused workspace creators to be incorrectly assigned `"pro"` instead of `"free"`.

## Deploy Plan

No migration needed. Takes effect immediately on deploy.