### PR TITLE
fix(credits): defer credit reconcile for payment-gated activation

### DIFF
--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -1,4 +1,5 @@
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
+import { reconcileCreditStateForNewContract } from "@app/lib/api/metronome/reconcile_credit_state";
 import {
   isMetronomeBillingEnabled,
   restoreWorkspaceAfterSubscription,
@@ -526,6 +527,12 @@ export async function handleSubscriptionActivationSuccess({
       );
     }
   }
+
+  await reconcileCreditStateForNewContract({
+    workspace,
+    metronomeCustomerId: workspace.metronomeCustomerId!,
+    metronomeContractId: contractId,
+  });
 
   // Restore workspace (unblock connectors, triggers, cancel scrub).
   await restoreWorkspaceAfterSubscription(auth);

--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -2,6 +2,7 @@ import {
   dispatchPaygCapReached,
   dispatchPerUserCapReached,
   dispatchPerUserCapResolved,
+  syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import * as defaultUserCapAlert from "@app/lib/metronome/alerts/spend_limits";
@@ -16,6 +17,8 @@ import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_POOL,
   getCreditTypeAwuId,
+  PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
+  PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
@@ -65,6 +68,7 @@ vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
     dispatchPerUserCapReached: vi.fn(),
     dispatchPerUserCapResolved: vi.fn(),
     dispatchPaygCapReached: vi.fn(),
+    syncPoolCreditStateFromBalance: vi.fn(),
   };
 });
 
@@ -195,6 +199,7 @@ beforeEach(() => {
     new Ok({} as never)
   );
   vi.mocked(restoreWorkspaceAfterSubscription).mockResolvedValue(undefined);
+  vi.mocked(syncPoolCreditStateFromBalance).mockResolvedValue(undefined);
   vi.mocked(dispatchPerUserCapReached).mockResolvedValue(new Ok(undefined));
   vi.mocked(dispatchPerUserCapResolved).mockResolvedValue(new Ok(undefined));
   vi.mocked(dispatchPaygCapReached).mockResolvedValue(undefined);
@@ -422,6 +427,62 @@ describe("processMetronomeWebhook — contract.start", () => {
     expect(oldSub!.status).toBe("ended");
 
     expect(restoreWorkspaceAfterSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles credit state for a non-payment-gated contract.start", async () => {
+    await PlanFactory.enterprise(ENT_PLAN_CODE);
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: { [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE },
+      } as never)
+    );
+
+    const result = await processMetronomeWebhook({
+      event: event as never,
+      workspace,
+    });
+    expect(result.isOk()).toBe(true);
+
+    expect(syncPoolCreditStateFromBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconcile credit state for a payment-gated activation contract", async () => {
+    await PlanFactory.enterprise(ENT_PLAN_CODE);
+    const workspace = await setupMetronomeWorkspace(OLD_CONTRACT_ID);
+    const event = contractEvent("contract.start", NEW_CONTRACT_ID);
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Ok({
+        id: NEW_CONTRACT_ID,
+        customer_id: METRONOME_CUSTOMER_ID,
+        starting_at: new Date().toISOString(),
+        custom_fields: {
+          [PLAN_CODE_CUSTOM_FIELD_KEY]: ENT_PLAN_CODE,
+          [PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY]:
+            PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
+        },
+      } as never)
+    );
+
+    const result = await processMetronomeWebhook({
+      event: event as never,
+      workspace,
+    });
+    expect(result.isOk()).toBe(true);
+
+    // Workspace stays on the old contract — the swap is deferred to
+    // payment_gate.payment_status — and credit state must not be reconciled
+    // onto the unpaid contract.
+    const refreshed = await WorkspaceResource.fetchById(workspace.sId);
+    const sub = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+      refreshed!.id
+    );
+    expect(sub!.metronomeContractId).toBe(OLD_CONTRACT_ID);
+    expect(syncPoolCreditStateFromBalance).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -23,7 +23,7 @@ import {
   dispatchSeatLowBalance,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
-import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
+import { reconcileCreditStateForNewContract } from "@app/lib/api/metronome/reconcile_credit_state";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
@@ -1417,38 +1417,6 @@ export async function processMetronomeWebhook({
     case "contract.start": {
       const { contract_id: contractId, customer_id: customerId } = event;
 
-      // Reconcile the workspace pool credit state against the new contract's
-      // live AWU balance. Replaces the in-process call we previously made
-      // from `provisionMetronomeContract` (removed to break a dependency
-      // cycle through auth → subscription_resource → contracts). Without
-      // this, a workspace whose previous contract ended `depleted` would
-      // stay stuck after the new contract spins up with a fresh commit.
-      await syncPoolCreditStateFromBalance({
-        workspace,
-        metronomeCustomerId: customerId,
-      });
-
-      // Reconcile per-user credit states against the new contract's live
-      // per-seat balances. Seats were synced to this contract at provision
-      // time (`syncContractQuantities` → `syncSeatCount`), but that path does
-      // not touch per-user credit states; now that the contract is active the
-      // balances are live, so this lands each user in the right seat↔pool
-      // state. Without it, a switch that changes seat allocations (e.g. moving
-      // onto a business plan) leaves users stuck in their previous state.
-      // Mirrors the pool reconcile above; pass the new contract id directly
-      // since the subscription swap below may not have happened yet.
-      await reconcileWorkspaceUserCreditStates({
-        workspace: renderLightWorkspaceType({ workspace }),
-        metronomeCustomerId: customerId,
-        metronomeContractId: contractId,
-      });
-
-      // Read the PLAN_CODE custom field to know which plan to swap the
-      // workspace subscription onto. The actual swap is gated below on
-      // `isMetronomeOnlyBilled` — other billing paths (shadow, pure
-      // Stripe) handle their own state transitions, and contracts whose
-      // start aligns with a synchronous DB flip get caught by the
-      // idempotency check.
       const contractResult = await getMetronomeContractById({
         metronomeCustomerId: customerId,
         metronomeContractId: contractId,
@@ -1471,6 +1439,21 @@ export async function processMetronomeWebhook({
         );
       }
 
+      const paymentGateType =
+        contractResult.value.custom_fields?.[
+          PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY
+        ];
+      const isPaymentGatedActivation =
+        paymentGateType === PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION;
+
+      if (!isPaymentGatedActivation) {
+        await reconcileCreditStateForNewContract({
+          workspace,
+          metronomeCustomerId: customerId,
+          metronomeContractId: contractId,
+        });
+      }
+
       const targetPlanCode =
         contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
       if (!targetPlanCode) {
@@ -1484,11 +1467,7 @@ export async function processMetronomeWebhook({
       // Payment-gated subscription activation: skip the automatic swap here.
       // The payment_gate.payment_status webhook handles the plan switch once
       // payment succeeds, ensuring the workspace stays on CP_FREE_PLAN until paid.
-      const paymentGateType =
-        contractResult.value.custom_fields?.[
-          PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY
-        ];
-      if (paymentGateType === PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION) {
+      if (isPaymentGatedActivation) {
         logger.info(
           { contractId, workspaceId: workspace.sId },
           "[Metronome Webhook] contract.start: payment-gated activation contract, skipping — payment_gate.payment_status will activate"

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -1,4 +1,7 @@
-import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
+import {
+  getWorkspacePoolAwuBalance,
+  syncPoolCreditStateFromBalance,
+} from "@app/lib/api/metronome/credit_state_dispatcher";
 import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
@@ -512,4 +515,25 @@ export async function reconcileWorkspaceUserCreditStates({
       );
     }
   }
+}
+
+export async function reconcileCreditStateForNewContract({
+  workspace,
+  metronomeCustomerId,
+  metronomeContractId,
+}: {
+  workspace: WorkspaceResource;
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+}): Promise<void> {
+  await syncPoolCreditStateFromBalance({
+    workspace,
+    metronomeCustomerId,
+  });
+
+  await reconcileWorkspaceUserCreditStates({
+    workspace: renderLightWorkspaceType({ workspace }),
+    metronomeCustomerId,
+    metronomeContractId,
+  });
 }


### PR DESCRIPTION
## Description

contract.start reconciled pool + per-user credit state before checking PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION, so an unpaid payment-gated contract moved the workspace onto the paid contract's credit state before payment succeeded.

Skip the reconcile in contract.start for payment-gated activation contracts and run it from handleSubscriptionActivationSuccess once the subscription actually flips. Extract reconcileCreditStateForNewContract as a shared helper so both paths call the same logic.

Added a test characterizing the bug (verified failing without the fix).
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
