### PR TITLE
[front] BillingPage: dedicated layout for free plan workspaces

### DIFF
--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -2,11 +2,13 @@ import { BillingInformation } from "@app/components/workspace/billing/BillingInf
 import { BillingOverview } from "@app/components/workspace/billing/BillingOverview";
 import { BillingSeatsOverview } from "@app/components/workspace/billing/BillingSeatsOverview";
 import { BillingUpgrade } from "@app/components/workspace/billing/BillingUpgrade";
+import { FreePlanBilling } from "@app/components/workspace/billing/FreePlanBilling";
 import { NextInvoiceOverview } from "@app/components/workspace/billing/NextInvoiceOverview";
 import { NextInvoicePreview } from "@app/components/workspace/billing/NextInvoicePreview";
 import { RecentInvoices } from "@app/components/workspace/billing/RecentInvoices";
 import { SubscriptionProvider } from "@app/components/workspace/billing/SubscriptionContext";
 import { useAuth } from "@app/lib/auth/AuthContext";
+import { isCreditPricedFreePlan } from "@app/lib/plans/plan_codes";
 import {
   CreditCard01,
   Page,
@@ -18,6 +20,7 @@ import {
 
 export function BillingPage() {
   const { workspace: owner, subscription } = useAuth();
+  const freePlan = isCreditPricedFreePlan(subscription.plan.code);
 
   return (
     <Page.Vertical gap="xl" align="stretch">
@@ -27,32 +30,36 @@ export function BillingPage() {
         description="Change your subscription and edit your billing information."
       />
       <SubscriptionProvider owner={owner} subscription={subscription}>
-        <Tabs defaultValue="billing-information">
-          <TabsList>
-            <TabsTrigger
-              value="billing-information"
-              label="Billing information"
-            />
-            <TabsTrigger value="invoices" label="Invoices" />
-          </TabsList>
-          <TabsContent value="billing-information">
-            <div className="flex flex-col mt-8 gap-8">
-              <div className="flex flex-col gap-4">
-                <BillingOverview />
-                <BillingSeatsOverview owner={owner} />
+        {freePlan ? (
+          <FreePlanBilling owner={owner} subscription={subscription} />
+        ) : (
+          <Tabs defaultValue="billing-information">
+            <TabsList>
+              <TabsTrigger
+                value="billing-information"
+                label="Billing information"
+              />
+              <TabsTrigger value="invoices" label="Invoices" />
+            </TabsList>
+            <TabsContent value="billing-information">
+              <div className="flex flex-col mt-8 gap-8">
+                <div className="flex flex-col gap-4">
+                  <BillingOverview />
+                  <BillingSeatsOverview owner={owner} />
+                </div>
+                <BillingUpgrade />
+                <BillingInformation />
               </div>
-              <BillingUpgrade />
-              <BillingInformation />
-            </div>
-          </TabsContent>
-          <TabsContent value="invoices">
-            <div className="flex flex-col mt-8 gap-8">
-              <NextInvoiceOverview />
-              <NextInvoicePreview />
-              <RecentInvoices />
-            </div>
-          </TabsContent>
-        </Tabs>
+            </TabsContent>
+            <TabsContent value="invoices">
+              <div className="flex flex-col mt-8 gap-8">
+                <NextInvoiceOverview />
+                <NextInvoicePreview />
+                <RecentInvoices />
+              </div>
+            </TabsContent>
+          </Tabs>
+        )}
       </SubscriptionProvider>
     </Page.Vertical>
   );

--- a/front/components/workspace/billing/BillingSeatsOverview.tsx
+++ b/front/components/workspace/billing/BillingSeatsOverview.tsx
@@ -89,6 +89,9 @@ export function BillingSeatsOverview({ owner }: BillingSeatsOverviewProps) {
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
       {orderedPlansWithMembers.map(
         ({ seatType, plan, membersCount, unassignedCount }) => {
+          if (membersCount === 0 && !unassignedCount) {
+            return null;
+          }
           const avatarColors = seatTypeAvatarColors(seatType);
 
           return (

--- a/front/components/workspace/billing/FreePlanBilling.tsx
+++ b/front/components/workspace/billing/FreePlanBilling.tsx
@@ -1,0 +1,25 @@
+import { FreePlanSeatsSection } from "@app/components/workspace/billing/FreePlanSeatsSection";
+import { FreePlanUpgradeSection } from "@app/components/workspace/billing/FreePlanUpgradeSection";
+import { SubscriptionStatusChip } from "@app/components/workspace/billing/SubscriptionStatusChip";
+import type { SubscriptionType } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
+
+interface FreePlanBillingProps {
+  owner: LightWorkspaceType;
+  subscription: SubscriptionType;
+}
+
+export function FreePlanBilling({ owner, subscription }: FreePlanBillingProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <span className="text-base font-semibold text-foreground dark:text-foreground-night">
+          Business
+        </span>
+        <SubscriptionStatusChip />
+      </div>
+      <FreePlanSeatsSection owner={owner} subscription={subscription} />
+      <FreePlanUpgradeSection owner={owner} />
+    </div>
+  );
+}

--- a/front/components/workspace/billing/FreePlanSeatsSection.tsx
+++ b/front/components/workspace/billing/FreePlanSeatsSection.tsx
@@ -1,0 +1,69 @@
+import { useMembers } from "@app/lib/swr/memberships";
+import type { SubscriptionType } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Icon, InfoSquare, Spinner } from "@dust-tt/sparkle";
+
+interface FreePlanSeatsSectionProps {
+  owner: LightWorkspaceType;
+  subscription: SubscriptionType;
+}
+
+export function FreePlanSeatsSection({
+  owner,
+  subscription,
+}: FreePlanSeatsSectionProps) {
+  const { total, isMembersLoading } = useMembers({ workspaceId: owner.sId });
+  const maxSeats = subscription.plan.limits.users.maxUsers;
+
+  if (maxSeats <= 0) {
+    return null;
+  }
+
+  if (isMembersLoading) {
+    return (
+      <div className="flex items-center justify-center rounded-2xl bg-muted-background p-4 dark:bg-muted-background-night">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const isAtCapacity = total >= maxSeats;
+  const fillPercent =
+    maxSeats > 0 ? Math.min((total / maxSeats) * 100, 100) : 0;
+
+  const heading = isAtCapacity
+    ? `You've used all ${maxSeats} free seats`
+    : `${total} of ${maxSeats} free seats used`;
+
+  const description = isAtCapacity
+    ? "You can't invite anyone else on the free plan. Upgrade a member to a Pro or Max seat on the Members page to add more, the cap lifts instantly."
+    : `Free workspaces include ${maxSeats} members. Upgrade a member to a Pro or Max seat anytime to go beyond the cap and unlock paid models.`;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-muted-background p-4 dark:bg-muted-background-night">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-1.5">
+          <Icon visual={InfoSquare} size="sm" />
+          <span className="text-base font-semibold text-foreground dark:text-foreground-night">
+            {heading}
+          </span>
+        </div>
+        <p className="text-sm text-foreground dark:text-foreground-night">
+          {description}
+        </p>
+      </div>
+
+      <div className="flex h-1 w-full gap-0.5">
+        {fillPercent > 0 && (
+          <div
+            className="h-full shrink-0 rounded-lg bg-foreground dark:bg-foreground-night"
+            style={{ width: `${fillPercent}%` }}
+          />
+        )}
+        {!isAtCapacity && (
+          <div className="h-full min-w-0 flex-1 rounded-lg bg-black/[0.08] dark:bg-white/[0.08]" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/billing/FreePlanUpgradeSection.tsx
+++ b/front/components/workspace/billing/FreePlanUpgradeSection.tsx
@@ -1,0 +1,46 @@
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, Check, Icon } from "@dust-tt/sparkle";
+
+const UPGRADE_FEATURES = [
+  "Invite members beyond the 5-seat cap",
+  "Unlock Pro & Max seats",
+  "Manage billing and roles in one place",
+] as const;
+
+interface FreePlanUpgradeSectionProps {
+  owner: LightWorkspaceType;
+}
+
+export function FreePlanUpgradeSection({ owner }: FreePlanUpgradeSectionProps) {
+  return (
+    <div className="flex flex-col gap-4 rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-highlight">
+            Unlock the full workspace
+          </span>
+          <span className="text-base font-semibold text-foreground dark:text-foreground-night">
+            One paid seat opens up the whole workspace
+          </span>
+        </div>
+        <Button
+          label="Upgrade a member"
+          size="sm"
+          variant="highlight"
+          href={`/w/${owner.sId}/usage`}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {UPGRADE_FEATURES.map((feature) => (
+          <div key={feature} className="flex items-center gap-2">
+            <Icon visual={Check} size="xs" className="text-highlight" />
+            <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {feature}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/billing/NextInvoiceOverview.tsx
+++ b/front/components/workspace/billing/NextInvoiceOverview.tsx
@@ -19,6 +19,7 @@ export function NextInvoiceOverview() {
   } = useSubscriptionContext();
 
   const periodLabel: Record<SubscriptionStatus, string | null> = {
+    free: null,
     active: invoice
       ? `${formatBillingPeriod(invoice.billingPeriod)} - Next billing date: ${periodEndLabel}`
       : null,

--- a/front/components/workspace/billing/SubscriptionStatusChip.tsx
+++ b/front/components/workspace/billing/SubscriptionStatusChip.tsx
@@ -1,24 +1,29 @@
+import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { Chip } from "@dust-tt/sparkle";
 import { useSubscriptionContext } from "./SubscriptionContext";
 
-export type SubscriptionStatus = "active" | "cancelled" | "ended";
+export type SubscriptionStatus = "free" | "active" | "cancelled" | "ended";
 
 const STATUS_CHIP: Record<
   SubscriptionStatus,
-  { label: string; color: "blue" | "golden" | "rose" }
+  { label: string; color: "green" | "blue" | "golden" | "rose" }
 > = {
+  free: { label: "Free", color: "green" },
   active: { label: "Active", color: "blue" },
   cancelled: { label: "Cancelled", color: "golden" },
   ended: { label: "Ended", color: "rose" },
 };
 
 export function SubscriptionStatusChip() {
-  const { subscriptionStatus } = useSubscriptionContext();
+  const { subscriptionStatus, subscription } = useSubscriptionContext();
+  const status = isFreePlan(subscription.plan.code)
+    ? "free"
+    : subscriptionStatus;
   return (
     <Chip
       size="mini"
-      color={STATUS_CHIP[subscriptionStatus].color}
-      label={STATUS_CHIP[subscriptionStatus].label}
+      color={STATUS_CHIP[status].color}
+      label={STATUS_CHIP[status].label}
     />
   );
 }

--- a/front/lib/plans/credit_priced_plans.ts
+++ b/front/lib/plans/credit_priced_plans.ts
@@ -60,7 +60,7 @@ if (isDevelopment() || isTest()) {
   });
   CREDIT_PRICED_PLANS_DATA.push({
     code: CREDIT_PRICED_FREE_PLAN_CODE,
-    name: "Free Trial",
+    name: "Free",
     maxMessages: 100,
     maxMessagesTimeframe: "lifetime",
     maxAwuCredits: -1,

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -58,6 +58,9 @@ export const isFriendsAndFamilyPlan = (planCode: string) =>
 export const isCreditPricedBusinessPlan = (planCode: string) =>
   planCode === CREDIT_PRICED_BUSINESS_PLAN_CODE;
 
+export const isCreditPricedFreePlan = (planCode: string) =>
+  planCode === CREDIT_PRICED_FREE_PLAN_CODE;
+
 export const isBusinessPlanPrefix = (planCode: string) =>
   planCode.startsWith("CP_BUSINESS_");
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8853

Free plan workspaces now get a tab-less billing page instead of the standard tabbed layout (Billing information / Invoices), from figma desing
<img width="1154" height="560" alt="image" src="https://github.com/user-attachments/assets/b05f6e85-e93b-4525-a828-cf353ab96add" />

Details:
* FreePlanSeatsSection — displays seat usage (X of N free seats used) with a 4px progress bar; switches to a "capacity full" state when total >= maxUsers; returns null when the plan has no seat cap (maxUsers <= 0)
* FreePlanUpgradeSection — upgrade card with blue "Unlock the full workspace" label, "One paid seat opens up the whole workspace" heading, and an "Upgrade a member" button linking to the usage page
* FreePlanBilling — composes the two sections with the plan header
* BillingPage — gates on isCreditPricedFreePlan and renders FreePlanBilling or the existing tabbed layout within the shared SubscriptionProvider

## Tests

Tested locally

## Risk

Low, only UI, for credit priced free plan

## Deploy Plan

Deploy front