### PR TITLE
fix(triggers): log when a scheduled run completes without a conversation

### DIFF
--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -303,6 +303,16 @@ export async function runTriggeredAgentsActivity({
       errorType === "webhook_storage_error";
 
     if (isNonRetryable) {
+      logger.info(
+        {
+          triggerId: trigger.sId,
+          agentConfigurationId: trigger.agentConfigurationId,
+          workspaceId: auth.workspace()?.sId,
+          errorType,
+        },
+        "Trigger run completed without creating a conversation."
+      );
+
       // If the agent is inaccessible, disable the trigger.
       if (errorType === "agent_inaccessible") {
         logger.info(


### PR DESCRIPTION
## Description

Scheduled triggers run `runTriggeredAgentsActivity`, which creates a conversation then posts the message that invokes the agent. When `postUserMessage` fails with a non-retryable error (`plan_message_limit_exceeded`, `credits_exhausted`, `user_cap_reached`, `model_disabled`, `invalid_request_error`, `agent_inaccessible`, `webhook_storage_error`) we return without throwing on purpose, so Temporal marks the workflow completed even though no usable conversation came out of it.

Only `agent_inaccessible` logged anything on that branch. The other cases returned silently, so a completed workflow with no conversation left nothing to grep for in Datadog.

Adds one log line on that branch with `triggerId`, `agentConfigurationId`, `workspaceId` and `errorType`. Came out of digging into `agent-schedule-0V2bUPDUd0-trg_Td1RntTGQBIp`, where the cause turned out to be `plan_message_limit_exceeded` but was only visible through the generic message-send error.

## Tests

None. One log line, no behavior change.

Query after deploy:
`service:front-worker "Trigger run completed without creating a conversation."`

## Risk

None.

## Deploy Plan

Normal front-worker deploy.