### PR TITLE
Enforce maximum size for POST /mcp/results

### DIFF
--- a/front-api/middlewares/body_limit.ts
+++ b/front-api/middlewares/body_limit.ts
@@ -1,0 +1,22 @@
+import { apiError } from "@front-api/middlewares/utils";
+import { bodyLimit as honoBodyLimit } from "hono/body-limit";
+
+/**
+ * Wraps Hono's `bodyLimit` so an over-limit request returns our standard
+ * `{ error: { type, message } }` envelope with a 413 status instead of the
+ * default plain-text "Payload Too Large" body. Mirrors the declarative
+ * `bodyParser.sizeLimit` config that the Next.js handlers used.
+ */
+export function bodyLimit(maxSizeBytes: number) {
+  return honoBodyLimit({
+    maxSize: maxSizeBytes,
+    onError: (ctx) =>
+      apiError(ctx, {
+        status_code: 413,
+        api_error: {
+          type: "content_too_large",
+          message: "Request body too large.",
+        },
+      }),
+  });
+}

--- a/front-api/routes/sse/v1/w/[wId]/mcp/requests.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/mcp/requests.test.ts
@@ -10,9 +10,13 @@ vi.mock("@app/lib/api/actions/mcp/client_side_registry", () => ({
   validateMCPServerAccess: vi.fn(),
 }));
 
-vi.mock("@app/lib/api/assistant/mcp_events", () => ({
-  getMCPEventsForServer: vi.fn(),
-}));
+vi.mock(
+  import("@app/lib/api/assistant/mcp_events"),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    getMCPEventsForServer: vi.fn(),
+  })
+);
 
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { getMCPEventsForServer } from "@app/lib/api/assistant/mcp_events";

--- a/front-api/routes/sse/w/[wId]/mcp/requests.test.ts
+++ b/front-api/routes/sse/w/[wId]/mcp/requests.test.ts
@@ -10,9 +10,13 @@ vi.mock("@app/lib/api/actions/mcp/client_side_registry", () => ({
   validateMCPServerAccess: vi.fn(),
 }));
 
-vi.mock("@app/lib/api/assistant/mcp_events", () => ({
-  getMCPEventsForServer: vi.fn(),
-}));
+vi.mock(
+  import("@app/lib/api/assistant/mcp_events"),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    getMCPEventsForServer: vi.fn(),
+  })
+);
 
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { getMCPEventsForServer } from "@app/lib/api/assistant/mcp_events";

--- a/front-api/routes/v1/w/[wId]/mcp/results.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/results.ts
@@ -2,10 +2,14 @@ import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_re
 import { publishMCPResults } from "@app/lib/api/assistant/mcp_events";
 import type { PostMCPResultsResponseType } from "@dust-tt/client";
 import { PublicPostMCPResultsRequestBodySchema } from "@dust-tt/client";
+import { bodyLimit } from "@front-api/middlewares/body_limit";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+
+// MCP tool results can be large (e.g. file contents): allow up to 16MB.
+const MCP_RESULTS_MAX_SIZE_BYTES = 16 * 1024 * 1024;
 
 // Mounted at /api/v1/w/:wId/mcp/results.
 const app = publicApiApp();
@@ -62,6 +66,7 @@ const app = publicApiApp();
  */
 app.post(
   "/",
+  bodyLimit(MCP_RESULTS_MAX_SIZE_BYTES),
   validate("json", PublicPostMCPResultsRequestBodySchema),
   async (ctx): HandlerResult<PostMCPResultsResponseType> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/v1/w/[wId]/mcp/results.ts
+++ b/front-api/routes/v1/w/[wId]/mcp/results.ts
@@ -1,5 +1,8 @@
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
-import { publishMCPResults } from "@app/lib/api/assistant/mcp_events";
+import {
+  MCP_RESULTS_MAX_SIZE_BYTES,
+  publishMCPResults,
+} from "@app/lib/api/assistant/mcp_events";
 import type { PostMCPResultsResponseType } from "@dust-tt/client";
 import { PublicPostMCPResultsRequestBodySchema } from "@dust-tt/client";
 import { bodyLimit } from "@front-api/middlewares/body_limit";
@@ -7,9 +10,6 @@ import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-
-// MCP tool results can be large (e.g. file contents): allow up to 16MB.
-const MCP_RESULTS_MAX_SIZE_BYTES = 16 * 1024 * 1024;
 
 // Mounted at /api/v1/w/:wId/mcp/results.
 const app = publicApiApp();

--- a/front-api/routes/w/[wId]/mcp/results.ts
+++ b/front-api/routes/w/[wId]/mcp/results.ts
@@ -1,13 +1,13 @@
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
-import { publishMCPResults } from "@app/lib/api/assistant/mcp_events";
+import {
+  MCP_RESULTS_MAX_SIZE_BYTES,
+  publishMCPResults,
+} from "@app/lib/api/assistant/mcp_events";
 import { bodyLimit } from "@front-api/middlewares/body_limit";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
-
-// MCP tool results can be large (e.g. file contents): allow up to 16MB.
-const MCP_RESULTS_MAX_SIZE_BYTES = 16 * 1024 * 1024;
 
 const PostMCPResultsBodySchema = z.object({
   result: z.unknown(),

--- a/front-api/routes/w/[wId]/mcp/results.ts
+++ b/front-api/routes/w/[wId]/mcp/results.ts
@@ -1,9 +1,13 @@
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import { publishMCPResults } from "@app/lib/api/assistant/mcp_events";
+import { bodyLimit } from "@front-api/middlewares/body_limit";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
+
+// MCP tool results can be large (e.g. file contents): allow up to 16MB.
+const MCP_RESULTS_MAX_SIZE_BYTES = 16 * 1024 * 1024;
 
 const PostMCPResultsBodySchema = z.object({
   result: z.unknown(),
@@ -14,27 +18,33 @@ const PostMCPResultsBodySchema = z.object({
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.post("/", validate("json", PostMCPResultsBodySchema), async (ctx) => {
-  const auth = ctx.get("auth");
-  const { serverId, result } = ctx.req.valid("json");
+app.post(
+  "/",
+  bodyLimit(MCP_RESULTS_MAX_SIZE_BYTES),
+  validate("json", PostMCPResultsBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { serverId, result } = ctx.req.valid("json");
 
-  const isValidAccess = await validateMCPServerAccess(auth, { serverId });
-  if (!isValidAccess) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "mcp_auth_error",
-        message: "You don't have access to this MCP server or it has expired.",
-      },
+    const isValidAccess = await validateMCPServerAccess(auth, { serverId });
+    if (!isValidAccess) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "mcp_auth_error",
+          message:
+            "You don't have access to this MCP server or it has expired.",
+        },
+      });
+    }
+
+    await publishMCPResults(auth, {
+      mcpServerId: serverId,
+      result,
     });
+
+    return ctx.json({ success: true });
   }
-
-  await publishMCPResults(auth, {
-    mcpServerId: serverId,
-    result,
-  });
-
-  return ctx.json({ success: true });
-});
+);
 
 export default app;

--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -17,6 +17,9 @@ interface GetMCPEventsForServerOptions {
 
 const MCP_EVENTS_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes.
 
+// MCP tool results can be large (e.g. file contents): allow up to 16MB.
+export const MCP_RESULTS_MAX_SIZE_BYTES = 16 * 1024 * 1024;
+
 export async function* getMCPEventsForServer(
   auth: Authenticator,
   { mcpServerId, lastEventId }: GetMCPEventsForServerOptions,


### PR DESCRIPTION
 ## Description

  The Hono migration of `POST /mcp/results` dropped the 16MB request body limit that the
  Next.js handler enforced declaratively via `bodyParser.sizeLimit: "16mb"`. As a result, both
  the private and public MCP results endpoints had **no body size enforcement** — no per-route
  check, no global `bodyLimit` middleware, and `@hono/node-server` imposes no default cap.

  This restores the limit on both endpoints.

  ## Changes

  - **New shared middleware** `front-api/middlewares/body_limit.ts`: thin wrapper around Hono's
    built-in `bodyLimit` that returns our standard `apiError` envelope
    (`type: "content_too_large"`, status **413**) instead of the default plain-text
    "Payload Too Large" body. 413 is the status the client (`BrowserMCPTransport.ts`) already
    handles.
  - **`front-api/routes/w/[wId]/mcp/results.ts`** (private): added
    `bodyLimit(MCP_RESULTS_MAX_SIZE_BYTES)` (16MB) before the `validate` middleware.
  - **`front-api/routes/v1/w/[wId]/mcp/results.ts`** (public v1): same addition — this endpoint
    had the gap too.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
