### PR TITLE
fix: duplicate messages in pod branches

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -561,7 +561,13 @@ export const ConversationViewer = ({
     const branchMessages = convertLightMessageTypeToVirtuosoMessages(
       openBranch.messages
     );
+    const existingMessageIds = new Set(
+      virtuosoMessageListRef.current.data.get().map((message) => message.sId)
+    );
     for (const msg of branchMessages) {
+      if (existingMessageIds.has(msg.sId)) {
+        continue;
+      }
       const insertIdx = getBranchedInsertIndex(
         virtuosoMessageListRef.current.data.get(),
         msg


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8861

This PR fixes duplicate messages appearing when restoring a pod branch in `ConversationViewer`.

- When restoring a branch, messages can arrive via the conversation SSE stream before the branch restoration effect runs; inserting them again would create duplicate rows.
- Before each insertion, the fix now checks whether a message with the same id already exists in the Virtuoso list and skips it if so.

## Tests

Manually.

## Risks

## Deploy Plan
