### PR TITLE
Fix: too much recursive calls when rendering intercom conversation to markdown

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -21,6 +21,7 @@ import {
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
 import { DataSourceQuotaExceededError } from "@connectors/lib/error";
+import { htmlToMarkdown } from "@connectors/lib/html_to_markdown";
 import {
   IntercomConversationModel,
   IntercomTeamModel,
@@ -29,10 +30,6 @@ import {
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import TurndownService from "turndown";
-
-const turndownService = new TurndownService();
-
 export async function deleteTeamAndConversations({
   connectorId,
   dataSourceConfig,
@@ -237,7 +234,7 @@ export async function syncConversation({
   const source = conversation.source?.type ?? null;
   const firstMessageAuthor = conversation.source?.author ?? null;
   const firstMessageContent = conversation.source?.body
-    ? turndownService.turndown(conversation.source.body)
+    ? htmlToMarkdown(conversation.source.body)
     : null;
 
   markdown += `# ${convoTitle}\n\n`;
@@ -253,9 +250,7 @@ export async function syncConversation({
   conversation.conversation_parts.conversation_parts.forEach(
     (part: ConversationPartType) => {
       const messageAuthor = part.author;
-      const messageContent = part.body
-        ? turndownService.turndown(part.body)
-        : null;
+      const messageContent = part.body ? htmlToMarkdown(part.body) : null;
       const type = part.part_type === "note" ? "Internal note" : "Message";
 
       const shouldSync =

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -23,6 +23,7 @@ import {
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
+import { htmlToMarkdown } from "@connectors/lib/html_to_markdown";
 import type { IntercomHelpCenterModel } from "@connectors/lib/models/intercom";
 import {
   IntercomArticleModel,
@@ -36,9 +37,6 @@ import {
   INTERNAL_MIME_TYPES,
   safeSubstring,
 } from "@connectors/types";
-import TurndownService from "turndown";
-
-const turndownService = new TurndownService();
 
 /**
  * If our rights were revoked or the help center is not on intercom anymore we delete it
@@ -369,9 +367,7 @@ export async function upsertArticle({
       : "";
 
   let articleContentInMarkdown =
-    typeof article.body === "string"
-      ? turndownService.turndown(article.body)
-      : "";
+    typeof article.body === "string" ? htmlToMarkdown(article.body) : "";
 
   if (!articleContentInMarkdown) {
     logger.warn(

--- a/connectors/src/lib/html_to_markdown.test.ts
+++ b/connectors/src/lib/html_to_markdown.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { htmlToMarkdown } from "./html_to_markdown";
+
+describe("htmlToMarkdown", () => {
+  it("converts simple HTML to markdown", () => {
+    expect(htmlToMarkdown("<p>Hello <strong>world</strong></p>")).toContain(
+      "Hello"
+    );
+    expect(htmlToMarkdown("<p>Hello <strong>world</strong></p>")).toContain(
+      "world"
+    );
+  });
+
+  it("falls back to plain text for deeply nested markup", () => {
+    let html = "deeply nested content";
+    for (let i = 0; i < 3000; i++) {
+      html = `<blockquote>${html}</blockquote>`;
+    }
+
+    expect(() => htmlToMarkdown(html)).not.toThrow();
+    expect(htmlToMarkdown(html)).toContain("deeply nested content");
+  });
+});

--- a/connectors/src/lib/html_to_markdown.ts
+++ b/connectors/src/lib/html_to_markdown.ts
@@ -1,0 +1,93 @@
+import logger from "@connectors/logger/logger";
+import { Parser } from "htmlparser2";
+import TurndownService from "turndown";
+
+const turndownService = new TurndownService();
+
+const BLOCK_TAGS = new Set([
+  "address",
+  "article",
+  "aside",
+  "blockquote",
+  "br",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hr",
+  "li",
+  "main",
+  "nav",
+  "ol",
+  "p",
+  "pre",
+  "section",
+  "table",
+  "tr",
+  "ul",
+]);
+
+function htmlToPlainText(html: string): string {
+  const chunks: string[] = [];
+
+  const parser = new Parser(
+    {
+      onopentag(name) {
+        if (BLOCK_TAGS.has(name)) {
+          chunks.push("\n");
+        }
+      },
+      ontext(text) {
+        chunks.push(text);
+      },
+      onclosetag(name) {
+        if (BLOCK_TAGS.has(name)) {
+          chunks.push("\n");
+        }
+      },
+    },
+    { decodeEntities: true }
+  );
+
+  parser.write(html);
+  parser.end();
+
+  return chunks
+    .join("")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Converts HTML to markdown. Falls back to plain-text extraction when Turndown's
+ * domino parser overflows the stack on deeply nested markup (e.g. long email reply chains).
+ */
+export function htmlToMarkdown(html: string): string {
+  try {
+    return turndownService.turndown(html);
+  } catch (error) {
+    if (!(error instanceof RangeError)) {
+      throw error;
+    }
+
+    logger.warn(
+      { htmlLength: html.length },
+      "HTML to markdown conversion failed due to excessive nesting, falling back to plain text extraction."
+    );
+
+    return htmlToPlainText(html);
+  }
+}


### PR DESCRIPTION
## Description

Intercom email conversations can contain deeply nested HTML (e.g., long reply chains with hundreds of stacked `<blockquote>` tags), causing `TurndownService.turndown()` to crash with a `RangeError` (stack overflow) via domino's recursive DOM parser. This broke syncing for affected conversations entirely.

Extracted HTML→markdown conversion into a shared `htmlToMarkdown` helper (`connectors/src/lib/html_to_markdown.ts`) that catches `RangeError` and falls back to a SAX-based plain-text extractor using `htmlparser2`. Both `sync_conversation.ts` and `sync_help_center.ts` now use this helper in place of their module-level `TurndownService` instances.

## Tests

Added unit tests in `html_to_markdown.test.ts`, including a regression case with 3000 nested `<blockquote>` tags confirming the fallback doesn't throw and still returns the inner text content. Tested locally against an Intercom connector sync.

## Risk

Low. The `RangeError` fallback is strictly additive — all well-formed HTML takes the same Turndown path as before. Pathological inputs that previously caused a crash now yield plain text instead of markdown, which is a safe degradation.

## Deploy Plan

Deploy connectors.
