### PR TITLE
[front] CP_FREE_PLAN, update maxUsersInWorkspace to 5

### DIFF
--- a/front/lib/plans/credit_priced_plans.ts
+++ b/front/lib/plans/credit_priced_plans.ts
@@ -66,7 +66,7 @@ if (isDevelopment() || isTest()) {
     maxAwuCredits: -1,
     maxAwuCreditsTimeframe: "lifetime",
     isDeepDiveAllowed: false,
-    maxUsersInWorkspace: 3,
+    maxUsersInWorkspace: 5,
     maxFreeUsersInWorkspace: 5,
     maxLifetimeFreeUsersInWorkspace: 5,
     maxVaultsInWorkspace: 5,


### PR DESCRIPTION
## Description

Currently maxUsersInWorkspace is set to 3 for plan CP_FREE_PLAN
=> update it to 5 

## Tests

Tested locally

## Risk

Low, the change here only has impact on DB initialization

## Deploy Plan

Update maxUsersInWorkspace for plan CP_FREE_PLAN manually in poke
