### PR TITLE
[LLM] Add Claude Sonnet 4.6 stream endpoints and model_constructors test harness

### DIFF
--- a/front/lib/model_constructors/client.ts
+++ b/front/lib/model_constructors/client.ts
@@ -1,4 +1,5 @@
 import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
@@ -8,6 +9,15 @@ export abstract class Client {
   // Re-type `this.constructor` (typed as `Function` by default) so the concrete
   // subclass's static config is visible at the type level.
   declare ["constructor"]: BaseModelConfiguration;
+
+  metadata(): EndpointMetadata {
+    return {
+      providerId: this.constructor.providerId,
+      api: this.constructor.api,
+      region: this.constructor.region,
+      modelId: this.constructor.modelId,
+    };
+  }
 
   // Generic `this` params P/A/R/M capture each concrete class's literal
   // identity fields, so the returned `id` is an exact literal (not the wide

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -8,7 +8,7 @@ import type { z } from "zod";
 
 export type BaseModelConfiguration = {
   // Identity
-  id: `${ProviderId}::${ProviderApi}::${Region}::${ModelId}`;
+  id: `${ProviderId}/${ProviderApi}/${Region}/${ModelId}`;
   providerId: ProviderId;
   api: ProviderApi;
   modelId: ModelId;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,0 +1,51 @@
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+const CONTEXT_SIZE = 400_000;
+const DEFAULT_REASONING_EFFORT = "high";
+const MAX_OUTPUT_TOKENS = 64_000;
+
+const baseConfig = inputConfigSchema.extend({
+  cacheKey: z.undefined(),
+});
+
+const configSchema = z.union([
+  baseConfig.extend({
+    reasoning: z
+      .object({
+        effort: z.enum(ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS),
+      })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    forceTool: z.undefined(),
+    // Reasoning requires temperature=1.
+    temperature: temperatureSchema.optional().transform(() => 1 as const),
+  }),
+  baseConfig.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+    temperature: temperatureSchema.optional().default(1),
+  }),
+]);
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithAnthropicClaudeSonnetFourDotSixConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class AnthropicClaudeSonnetFourDotSix extends Base {
+    static readonly modelId = CLAUDE_SONNET_4_6_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return AnthropicClaudeSonnetFourDotSix;
+}

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -50,11 +50,11 @@ export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
 
   private readonly client: AnthropicVertex;
 
-  constructor(credentials: Credentials) {
+  constructor({ AGENT_PLATFORM_PROJECT_ID }: Credentials) {
     super();
     this.client = new AnthropicVertex({
       region: this.constructor.regionalEndpoint,
-      projectId: credentials.AGENT_PLATFORM_PROJECT_ID,
+      projectId: AGENT_PLATFORM_PROJECT_ID,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -1,0 +1,81 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  MessageCreateParamsStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import AnthropicVertex from "@anthropic-ai/vertex-sdk";
+import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
+import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { AGENT_PLATFORM_API } from "@app/lib/model_constructors/types/provider_apis";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+
+import { z } from "zod";
+
+// Can be extended later (e.g. "us", "asia-east1"...)
+type AgentPlatformRegionalEndpoint = "global" | "europe-west1";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([
+        ...ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+        "none",
+      ]),
+    })
+    .optional(),
+});
+
+export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
+  WithAnthropicOutputConverter(
+    StreamEndpoint<MessageCreateParamsNonStreaming, RawMessageStreamEvent>
+  )
+) {
+  // Narrow `this.constructor` so the per-endpoint static below is visible.
+  declare ["constructor"]: BaseModelConfiguration & {
+    regionalEndpoint: AgentPlatformRegionalEndpoint;
+  };
+
+  static readonly providerId = ANTHROPIC_PROVIDER_ID;
+  static readonly api = AGENT_PLATFORM_API;
+
+  static readonly configSchema: z.ZodType<z.infer<typeof configSchema>> =
+    configSchema;
+
+  private readonly client: AnthropicVertex;
+
+  constructor(credentials: Credentials) {
+    super();
+    this.client = new AnthropicVertex({
+      region: this.constructor.regionalEndpoint,
+      projectId: credentials.AGENT_PLATFORM_PROJECT_ID,
+    });
+  }
+
+  async *streamRaw(
+    input: MessageCreateParamsNonStreaming
+  ): AsyncGenerator<RawMessageStreamEvent> {
+    const streamingInput: MessageCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = this.client.messages.stream(streamingInput);
+
+    // SDK mutates/reuses events; deep-copy.
+    for await (const event of stream) {
+      yield structuredClone(event);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<RawMessageStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -42,10 +42,10 @@ export abstract class AnthropicStream extends WithAnthropicInputConverter(
 
   private readonly client: AnthropicClient;
 
-  constructor(credentials: Credentials) {
+  constructor({ ANTHROPIC_API_KEY }: Credentials) {
     super();
     this.client = new AnthropicClient({
-      apiKey: credentials.ANTHROPIC_API_KEY,
+      apiKey: ANTHROPIC_API_KEY,
     });
   }
 

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -1,0 +1,73 @@
+import AnthropicClient from "@anthropic-ai/sdk";
+import type {
+  MessageCreateParamsNonStreaming,
+  MessageCreateParamsStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/messages/messages";
+import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
+import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { ANTHROPIC_API } from "@app/lib/model_constructors/types/provider_apis";
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+
+import { z } from "zod";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([
+        ...ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+        "none",
+      ]),
+    })
+    .optional(),
+});
+
+type AnthropicInputConfig = z.infer<typeof configSchema>;
+
+export abstract class AnthropicStream extends WithAnthropicInputConverter(
+  WithAnthropicOutputConverter(
+    StreamEndpoint<MessageCreateParamsNonStreaming, RawMessageStreamEvent>
+  )
+) {
+  static readonly providerId = ANTHROPIC_PROVIDER_ID;
+  static readonly api = ANTHROPIC_API;
+
+  static readonly configSchema: z.ZodType<AnthropicInputConfig> = configSchema;
+
+  private readonly client: AnthropicClient;
+
+  constructor(credentials: Credentials) {
+    super();
+    this.client = new AnthropicClient({
+      apiKey: credentials.ANTHROPIC_API_KEY,
+    });
+  }
+
+  async *streamRaw(
+    input: MessageCreateParamsNonStreaming
+  ): AsyncGenerator<RawMessageStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: MessageCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = this.client.messages.stream(streamingInput);
+
+    // The SDK reuses and mutates event objects, so deep-copy each one.
+    for await (const event of stream) {
+      yield structuredClone(event);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<RawMessageStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/configuration.ts
+++ b/front/lib/model_constructors/stream/configuration.ts
@@ -1,11 +1,8 @@
 import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
 import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
-import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
 
-export type StreamModelConfiguration = BaseModelConfiguration & {
-  supportedReasoningEfforts: ReasoningEffort[];
-};
+export type StreamModelConfiguration = BaseModelConfiguration;
 
 export type StreamEndpointConstructor = (new (
   credentials: Credentials

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -1,0 +1,21 @@
+import { WithAnthropicClaudeSonnetFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
+import { AgentPlatformStream } from "@app/lib/model_constructors/stream/clients/agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithAnthropicClaudeSonnetFourDotSixConfig(
+  AgentPlatformStream
+) {
+  // https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#europe-west1
+  static readonly tokenPricing = {
+    cacheCreated: 4.13,
+    cacheHit: 0.33,
+    standardInput: 3.3,
+    standardOutput: 16.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "europe-west1";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -1,0 +1,21 @@
+import { WithAnthropicClaudeSonnetFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
+import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AnthropicGlobalClaudeSonnetFourDotSixStream extends WithAnthropicClaudeSonnetFourDotSixConfig(
+  AnthropicStream
+) {
+  static readonly tokenPricing = {
+    cacheCreated: 3.75,
+    cacheHit: 0.3,
+    standardInput: 3.0,
+    standardOutput: 15.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicGlobalClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/test/cases.ts
+++ b/front/lib/model_constructors/test/cases.ts
@@ -1,0 +1,530 @@
+import type {
+  InputConfig,
+  OutputFormat,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type { BaseConversation } from "@app/lib/model_constructors/types/input/messages";
+import type { ErrorType } from "@app/lib/model_constructors/types/output/events";
+
+// Shared, endpoint-agnostic test definitions: conversations, tool specs, the
+// `TEST_CASES` matrix, and each case's default checkers. Per-endpoint files
+// (`test/endpoints/*`) narrow these and override expected outputs.
+
+const CALCULATOR_TOOL_SPEC: ToolSpecification = {
+  name: "calculator",
+  description: "Perform basic arithmetic calculations",
+  inputSchema: {
+    type: "object",
+    properties: {
+      operation: {
+        type: "string",
+        enum: ["add", "subtract", "multiply", "divide"],
+        description: "The operation to perform",
+      },
+      a: {
+        type: "number",
+        description: "First operand",
+      },
+      b: {
+        type: "number",
+        description: "Second operand",
+      },
+    },
+    required: ["operation", "a", "b"],
+    additionalProperties: false,
+  },
+};
+
+const UNRELIABLE_CALCULATOR_TOOL_NAME = "unreliable_calculator";
+const UNRELIABLE_CALCULATOR_TOOL_DESCRIPTION =
+  "Perform basic arithmetic calculations with randomness";
+
+const SIMPLE_CONVERSATION: BaseConversation = {
+  system: [],
+  messages: [
+    {
+      role: "user",
+      type: "text",
+      content: { value: 'Say "Hi"' },
+    },
+  ],
+};
+
+const SAME_ROLE_FOLLOWING_BLOCKS_CONVERSATION: BaseConversation = {
+  system: [],
+  messages: [
+    {
+      role: "user",
+      type: "text",
+      content: { value: 'Say "Hi"' },
+    },
+    {
+      role: "assistant",
+      type: "text",
+      content: { value: "Hi" },
+    },
+    {
+      role: "assistant",
+      type: "text",
+      content: { value: "How are you ?" },
+    },
+    {
+      role: "user",
+      type: "text",
+      content: { value: "Do only what I say" },
+    },
+    {
+      role: "user",
+      type: "text",
+      content: { value: "Now say hello." },
+    },
+  ],
+};
+
+const REASONING_CONVERSATION: BaseConversation = {
+  system: [
+    {
+      role: "system",
+      type: "text",
+      content: {
+        value: "You must reason as much as you can before answering logically.",
+      },
+    },
+  ],
+  messages: [
+    {
+      role: "user",
+      type: "text",
+      content: {
+        value:
+          "I am 4 times the age of my son. In 20 years, I will be twice his age. How old are we?",
+      },
+    },
+  ],
+};
+
+const CALCULATOR_CONVERSATION: BaseConversation = {
+  system: [
+    {
+      role: "system",
+      type: "text",
+      content: { value: "Use tools to answer." },
+    },
+  ],
+  messages: [
+    {
+      role: "user",
+      type: "text",
+      content: { value: "What is 2 + 3?" },
+    },
+  ],
+};
+
+const SIMPLE_OUTPUT_FORMAT: OutputFormat = {
+  type: "json_schema",
+  json_schema: {
+    name: "simple_response",
+    schema: {
+      type: "object",
+      properties: {
+        content: { type: "string" },
+        random: { type: "number" },
+      },
+      required: ["content", "random"],
+      additionalProperties: false,
+    },
+    strict: true,
+  },
+};
+
+const OUTPUT_FORMAT_CONVERSATION: BaseConversation = {
+  system: [
+    {
+      role: "system",
+      type: "text",
+      content: {
+        value:
+          "You are an assistant that answers with a simple laconic string response, one word if possible. Avoid json structures.",
+      },
+    },
+  ],
+  messages: [
+    {
+      role: "user",
+      type: "text",
+      content: { value: "What is the capital of France?" },
+    },
+  ],
+};
+
+export type ResponseChecker =
+  | { type: "error"; contentType: ErrorType }
+  | { type: "success" }
+  | {
+      type: "tool_call";
+      name: string;
+    }
+  | {
+      type: "text_contains";
+      value: string;
+    }
+  | {
+      type: "has_reasoning";
+    }
+  | {
+      type: "has_no_reasoning";
+    }
+  | {
+      type: "valid_output_format";
+      format: OutputFormat;
+    };
+
+export const INPUT_CONFIGURATION_ERROR: ResponseChecker = {
+  type: "error",
+  contentType: "input_configuration_error",
+};
+export const SUCCESS: ResponseChecker = { type: "success" };
+export const TOOL_CALL_CALCULATOR: ResponseChecker = {
+  type: "tool_call",
+  name: "calculator",
+};
+export const TEXT_CONTAINS_HI: ResponseChecker = {
+  type: "text_contains",
+  value: "hi",
+};
+export const HAS_REASONING: ResponseChecker = {
+  type: "has_reasoning",
+};
+export const HAS_NO_REASONING: ResponseChecker = {
+  type: "has_no_reasoning",
+};
+export const VALID_OUTPUT_FORMAT: ResponseChecker = {
+  type: "valid_output_format",
+  format: SIMPLE_OUTPUT_FORMAT,
+};
+
+export type TestCase = {
+  config: InputConfig;
+  conversation: BaseConversation;
+  defaultCheckers: readonly ResponseChecker[];
+};
+
+// Shorthand reasoning configs.
+const R_NONE = { effort: "none" } as const;
+const R_MINIMAL = { effort: "minimal" } as const;
+const R_LOW = { effort: "low" } as const;
+const R_MEDIUM = { effort: "medium" } as const;
+const R_HIGH = { effort: "high" } as const;
+const R_MAXIMAL = { effort: "maximal" } as const;
+
+export const TEST_KEYS = [
+  "simple/no-tools/t-default/r-default",
+  "simple/no-tools/t-default/r-none",
+  "simple/no-tools/t-default/r-minimal",
+  "simple/no-tools/t-default/r-low",
+  "simple/no-tools/t-default/r-medium",
+  "simple/no-tools/t-default/r-high",
+  "simple/no-tools/t-default/r-maximal",
+  "simple/no-tools/t-0/r-default",
+  "simple/no-tools/t-0/r-none",
+  "simple/no-tools/t-0/r-minimal",
+  "simple/no-tools/t-0/r-low",
+  "simple/no-tools/t-0/r-medium",
+  "simple/no-tools/t-0/r-high",
+  "simple/no-tools/t-0/r-maximal",
+  "simple/no-tools/t-0.1/r-default",
+  "simple/no-tools/t-0.1/r-none",
+  "simple/no-tools/t-0.1/r-minimal",
+  "simple/no-tools/t-0.1/r-low",
+  "simple/no-tools/t-0.1/r-medium",
+  "simple/no-tools/t-0.1/r-high",
+  "simple/no-tools/t-0.1/r-maximal",
+  "simple/no-tools/t-1/r-default",
+  "simple/no-tools/t-1/r-none",
+  "simple/no-tools/t-1/r-minimal",
+  "simple/no-tools/t-1/r-low",
+  "simple/no-tools/t-1/r-medium",
+  "simple/no-tools/t-1/r-high",
+  "simple/no-tools/t-1/r-maximal",
+
+  "calc/calc/t-default/r-medium",
+  "calc/calc/t-0.1/r-default",
+  "calc/calc/t-0.1/r-medium",
+
+  "calc/calc/t-default/r-default/force-tool-default",
+  "calc/calc/t-default/r-default/force-tool",
+  "calc/calc/t-default/r-none/force-tool",
+
+  "reasoning/no-tools/t-default/r-none",
+  "reasoning/no-tools/t-default/r-low",
+
+  "output-format/json-schema/t-default/r-none",
+  "output-format/json-schema/t-default/r-high",
+
+  "following/no-tools/t-default/r-default",
+] as const;
+
+export type TestKey = (typeof TEST_KEYS)[number];
+
+export const TEST_CASES: Record<TestKey, TestCase> = {
+  // SIMPLE conversation — checker: text_contains "hi"
+
+  // -- No tools --
+  "simple/no-tools/t-default/r-default": {
+    config: {},
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-default/r-none": {
+    config: { reasoning: R_NONE },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-default/r-minimal": {
+    config: { reasoning: R_MINIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-default/r-low": {
+    config: { reasoning: R_LOW },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-default/r-medium": {
+    config: { reasoning: R_MEDIUM },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-default/r-high": {
+    config: { reasoning: R_HIGH },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-default/r-maximal": {
+    config: { reasoning: R_MAXIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-default": {
+    config: { temperature: 0 },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-none": {
+    config: { temperature: 0, reasoning: R_NONE },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-minimal": {
+    config: { temperature: 0, reasoning: R_MINIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-low": {
+    config: { temperature: 0, reasoning: R_LOW },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-medium": {
+    config: { temperature: 0, reasoning: R_MEDIUM },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-high": {
+    config: { temperature: 0, reasoning: R_HIGH },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0/r-maximal": {
+    config: { temperature: 0, reasoning: R_MAXIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-default": {
+    config: { temperature: 0.1 },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-none": {
+    config: { temperature: 0.1, reasoning: R_NONE },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-minimal": {
+    config: { temperature: 0.1, reasoning: R_MINIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-low": {
+    config: { temperature: 0.1, reasoning: R_LOW },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-medium": {
+    config: { temperature: 0.1, reasoning: R_MEDIUM },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-high": {
+    config: { temperature: 0.1, reasoning: R_HIGH },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-0.1/r-maximal": {
+    config: { temperature: 0.1, reasoning: R_MAXIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-default": {
+    config: { temperature: 1 },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-none": {
+    config: { temperature: 1, reasoning: R_NONE },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-minimal": {
+    config: { temperature: 1, reasoning: R_MINIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-low": {
+    config: { temperature: 1, reasoning: R_LOW },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-medium": {
+    config: { temperature: 1, reasoning: R_MEDIUM },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-high": {
+    config: { temperature: 1, reasoning: R_HIGH },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+  "simple/no-tools/t-1/r-maximal": {
+    config: { temperature: 1, reasoning: R_MAXIMAL },
+    conversation: SIMPLE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
+  },
+
+  // -- Calculator tool → tool call --
+  "calc/calc/t-default/r-medium": {
+    config: { tools: [CALCULATOR_TOOL_SPEC], reasoning: R_MEDIUM },
+    conversation: CALCULATOR_CONVERSATION,
+    defaultCheckers: [TOOL_CALL_CALCULATOR],
+  },
+  "calc/calc/t-0.1/r-default": {
+    config: { temperature: 0.1, tools: [CALCULATOR_TOOL_SPEC] },
+    conversation: CALCULATOR_CONVERSATION,
+    defaultCheckers: [TOOL_CALL_CALCULATOR],
+  },
+  "calc/calc/t-0.1/r-medium": {
+    config: {
+      temperature: 0.1,
+      tools: [CALCULATOR_TOOL_SPEC],
+      reasoning: R_MEDIUM,
+    },
+    conversation: CALCULATOR_CONVERSATION,
+    defaultCheckers: [TOOL_CALL_CALCULATOR],
+  },
+  "calc/calc/t-default/r-default/force-tool-default": {
+    config: {
+      tools: [
+        CALCULATOR_TOOL_SPEC,
+        {
+          ...CALCULATOR_TOOL_SPEC,
+          name: UNRELIABLE_CALCULATOR_TOOL_NAME,
+          description: UNRELIABLE_CALCULATOR_TOOL_DESCRIPTION,
+        },
+      ],
+    },
+    conversation: CALCULATOR_CONVERSATION,
+    defaultCheckers: [TOOL_CALL_CALCULATOR],
+  },
+  "calc/calc/t-default/r-default/force-tool": {
+    config: {
+      tools: [
+        CALCULATOR_TOOL_SPEC,
+        {
+          ...CALCULATOR_TOOL_SPEC,
+          name: UNRELIABLE_CALCULATOR_TOOL_NAME,
+          description: UNRELIABLE_CALCULATOR_TOOL_DESCRIPTION,
+        },
+      ],
+      forceTool: UNRELIABLE_CALCULATOR_TOOL_NAME,
+    },
+    conversation: CALCULATOR_CONVERSATION,
+    defaultCheckers: [
+      {
+        type: "tool_call",
+        name: UNRELIABLE_CALCULATOR_TOOL_NAME,
+      },
+    ],
+  },
+  "calc/calc/t-default/r-none/force-tool": {
+    config: {
+      reasoning: R_NONE,
+      tools: [
+        CALCULATOR_TOOL_SPEC,
+        {
+          ...CALCULATOR_TOOL_SPEC,
+          name: UNRELIABLE_CALCULATOR_TOOL_NAME,
+          description: UNRELIABLE_CALCULATOR_TOOL_DESCRIPTION,
+        },
+      ],
+      forceTool: UNRELIABLE_CALCULATOR_TOOL_NAME,
+    },
+    conversation: CALCULATOR_CONVERSATION,
+    defaultCheckers: [
+      {
+        type: "tool_call",
+        name: UNRELIABLE_CALCULATOR_TOOL_NAME,
+      },
+    ],
+  },
+
+  // OUTPUT FORMAT — checker: valid JSON with { content: string }
+  "output-format/json-schema/t-default/r-none": {
+    config: {
+      reasoning: R_NONE,
+      outputFormat: SIMPLE_OUTPUT_FORMAT,
+    },
+    conversation: OUTPUT_FORMAT_CONVERSATION,
+    defaultCheckers: [VALID_OUTPUT_FORMAT],
+  },
+  "output-format/json-schema/t-default/r-high": {
+    config: {
+      reasoning: R_HIGH,
+      outputFormat: SIMPLE_OUTPUT_FORMAT,
+    },
+    conversation: OUTPUT_FORMAT_CONVERSATION,
+    defaultCheckers: [VALID_OUTPUT_FORMAT],
+  },
+
+  // -- Reasoning effort "none" or "low" --
+  "reasoning/no-tools/t-default/r-none": {
+    config: { reasoning: R_NONE },
+    conversation: REASONING_CONVERSATION,
+    defaultCheckers: [HAS_NO_REASONING],
+  },
+  "reasoning/no-tools/t-default/r-low": {
+    config: { reasoning: R_LOW },
+    conversation: REASONING_CONVERSATION,
+    defaultCheckers: [HAS_REASONING],
+  },
+
+  "following/no-tools/t-default/r-default": {
+    config: {},
+    conversation: SAME_ROLE_FOLLOWING_BLOCKS_CONVERSATION,
+    defaultCheckers: [
+      {
+        type: "text_contains",
+        value: "hello",
+      },
+    ],
+  },
+};

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeClaudeSonnetFourDotSixStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
+runStreamEndpointTests(AgentPlatformEuropeClaudeSonnetFourDotSixStream, setup);

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AnthropicGlobalClaudeSonnetFourDotSixStream({
+      ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
+runStreamEndpointTests(AnthropicGlobalClaudeSonnetFourDotSixStream, setup);

--- a/front/lib/model_constructors/test/runner.ts
+++ b/front/lib/model_constructors/test/runner.ts
@@ -1,0 +1,222 @@
+import type {
+  StreamEndpointConstructor,
+  StreamModelConfiguration,
+} from "@app/lib/model_constructors/stream/configuration";
+import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import {
+  type ResponseChecker,
+  TEST_CASES,
+  type TestCase,
+  type TestKey,
+} from "@app/lib/model_constructors/test/cases";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+import { runStream } from "@app/lib/model_constructors/test/stream";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import Ajv from "ajv";
+import { assert, describe, it } from "vitest";
+
+async function collectEvents(
+  instance: StreamEndpoint<any, any>,
+  configSchema: StreamModelConfiguration["configSchema"],
+  testCase: TestCase,
+  debug: boolean
+): Promise<ModelResponseEvent[]> {
+  const events: ModelResponseEvent[] = [];
+  for await (const event of runStream(
+    instance,
+    configSchema,
+    { conversation: testCase.conversation },
+    testCase.config,
+    { debug }
+  )) {
+    events.push(event);
+  }
+  return events;
+}
+
+function checkResponseChecker(
+  checker: ResponseChecker,
+  events: ModelResponseEvent[]
+): void {
+  const lastEvent = events[events.length - 1];
+  switch (checker.type) {
+    case "error":
+      assert(
+        lastEvent?.type === "error",
+        `Expected last event to be error, but got\n\n: ${JSON.stringify(lastEvent)}`
+      );
+      assert(
+        lastEvent.content.type === checker.contentType,
+        `Expected error content type to be "${checker.contentType}", but got: "${lastEvent.content.type}"`
+      );
+      break;
+    case "success":
+      assert(
+        lastEvent?.type === "success",
+        `Expected last event to be success, but got:\n\n ${JSON.stringify(lastEvent)}`
+      );
+      break;
+    case "tool_call": {
+      assert(
+        lastEvent?.type === "success",
+        `Expected last event to contain a tool call, but got:\n\n ${JSON.stringify(lastEvent)}`
+      );
+      assert(
+        lastEvent.content.aggregated.length > 0,
+        "Expected at least one aggregated event."
+      );
+      assert(
+        lastEvent.content.aggregated.find(
+          ({ type, content }) =>
+            type === "tool_call" && content.name === checker.name
+        ) !== undefined,
+        `Expected aggregated events to contain the ${checker.name} tool call.`
+      );
+      break;
+    }
+    case "text_contains": {
+      assert(
+        lastEvent?.type === "success",
+        `Expected last event to be success, but got:\n\n ${JSON.stringify(lastEvent)}`
+      );
+      const lastAgg =
+        lastEvent.content.aggregated[lastEvent.content.aggregated.length - 1];
+      assert(
+        lastAgg !== undefined,
+        "Expected at least one aggregated event, but got undefined"
+      );
+      assert(
+        lastAgg.type === "text",
+        `Expected last aggregated event to be text, but got type "${lastAgg.type}"`
+      );
+      assert(
+        lastAgg.content.value
+          .toLowerCase()
+          .includes(checker.value.toLowerCase()),
+        `Expected text to contain "${checker.value}", but got: "${lastAgg.content.value}"`
+      );
+      break;
+    }
+    case "has_reasoning": {
+      assert(
+        lastEvent?.type === "success",
+        `Expected last event to be success, but got:\n\n ${JSON.stringify(lastEvent)}`
+      );
+      assert(
+        lastEvent.content.aggregated.some((e) => e.type === "reasoning") ===
+          true,
+        "Expected at least one aggregated event with reasoning, but got undefined"
+      );
+      break;
+    }
+    case "has_no_reasoning": {
+      assert(
+        lastEvent?.type === "success",
+        `Expected last event to be success, but got:\n\n ${JSON.stringify(lastEvent)}`
+      );
+      assert(
+        lastEvent.content.aggregated.some((e) => e.type === "reasoning") ===
+          false,
+        "Expected no aggregated event with reasoning, but got at least one"
+      );
+      break;
+    }
+    case "valid_output_format": {
+      assert(
+        lastEvent?.type === "success",
+        `Expected last event to be success, but got:\n\n ${JSON.stringify(lastEvent)}`
+      );
+      const lastAgg =
+        lastEvent.content.aggregated[lastEvent.content.aggregated.length - 1];
+      assert(
+        lastAgg !== undefined,
+        "Expected at least one aggregated event, but got undefined"
+      );
+      assert(
+        lastAgg.type === "text",
+        `Expected last aggregated event to be text, but got type "${lastAgg.type}"`
+      );
+      const parsed = safeParseJSON(lastAgg.content.value);
+      if (!parsed.isOk()) {
+        assert.fail(
+          `Expected valid JSON, but got:\n\n${lastAgg.content.value}`
+        );
+      }
+
+      const ajv = new Ajv();
+      const validate = ajv.compile(checker.format.json_schema.schema);
+      const valid = validate(parsed.value);
+      assert(
+        valid,
+        `Expected payload to match JSON schema, but got errors:\n${JSON.stringify(validate.errors, null, 2)}\n\nPayload: ${JSON.stringify(parsed.value, null, 2)}`
+      );
+      break;
+    }
+    default:
+      assertNever(checker);
+  }
+}
+
+// Registers the shared `TEST_CASES` suite for a single stream endpoint. Gated on
+// NODE_ENV=test and RUN_LLM_TEST=true so CI never burns API tokens. Run with:
+// NODE_ENV=test RUN_LLM_TEST=true npm run test --config lib/model_constructors/test/vite.config.js lib/model_constructors/test/endpoints/<endpoint>.test.ts --run --bail 1
+export function runStreamEndpointTests(
+  ModelClass: StreamEndpointConstructor,
+  setup: StreamSetup
+): void {
+  const { id } = ModelClass;
+
+  if (process.env.NODE_ENV !== "test") {
+    console.warn(
+      `\n\x1b[33m${"=".repeat(60)}\n` +
+        `⏭️  Skipping LLM tests (NODE_ENV is not "test").\n` +
+        `\x1b[33m${"=".repeat(60)}\x1b[0m\n`
+    );
+    describe.skip(`${id} (NODE_ENV is not 'test')`, () => {
+      it.skip("skipped", () => undefined);
+    });
+    return;
+  }
+
+  if (process.env.RUN_LLM_TEST !== "true") {
+    console.warn(
+      `\n\x1b[33m${"=".repeat(60)}\n` +
+        `⏭️  Skipping LLM tests (RUN_LLM_TEST is not set).\n` +
+        `\x1b[33m${"=".repeat(60)}\x1b[0m\n`
+    );
+    describe.skip(`${id} (RUN_LLM_TEST is not set)`, () => {
+      it.skip("skipped", () => undefined);
+    });
+    return;
+  }
+
+  const { configSchema } = ModelClass;
+  const { createInstance, tests, debug = false } = setup;
+
+  const testIds = Object.keys(tests) as TestKey[];
+  const totalTestCases = Object.keys(TEST_CASES).length;
+
+  describe(id, () => {
+    const instance = createInstance();
+
+    console.warn(
+      `\n\x1b[33m${"=".repeat(60)}\n🧪 ${id}\n⚠️  Running ${testIds.length}/${totalTestCases} test case(s):\n${testIds.map((testId) => `   - ${testId}`).join("\n")}\n${"=".repeat(60)}\x1b[0m\n`
+    );
+
+    it.each(testIds)("[%s]", async (testId: TestKey) => {
+      const testCase = TEST_CASES[testId];
+      const events = await collectEvents(
+        instance,
+        configSchema,
+        testCase,
+        debug
+      );
+      // A `null` override falls back to the case's default checkers.
+      for (const checker of tests[testId] ?? testCase.defaultCheckers) {
+        checkResponseChecker(checker, events);
+      }
+    }, 20_000);
+  });
+}

--- a/front/lib/model_constructors/test/setup.ts
+++ b/front/lib/model_constructors/test/setup.ts
@@ -1,0 +1,12 @@
+import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type {
+  ResponseChecker,
+  TestKey,
+} from "@app/lib/model_constructors/test/cases";
+
+export type StreamSetup = {
+  // Deferred so a missing API key doesn't blow up when loaded without RUN_LLM_TEST.
+  createInstance: () => StreamEndpoint;
+  debug?: boolean; // Dump artifacts for all cases of the endpoint.
+  tests: Record<TestKey, ResponseChecker[] | null>;
+};

--- a/front/lib/model_constructors/test/stream.ts
+++ b/front/lib/model_constructors/test/stream.ts
@@ -1,0 +1,82 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { StreamModelConfiguration } from "@app/lib/model_constructors/stream/configuration";
+import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+
+export async function* runStream(
+  instance: StreamEndpoint<any, any>,
+  configSchema: StreamModelConfiguration["configSchema"],
+  payload: Payload,
+  config: InputConfig,
+  { debug = false }: { debug?: boolean } = {}
+): AsyncGenerator<ModelResponseEvent> {
+  const configValidationResult = configSchema.safeParse(config);
+  if (!configValidationResult.success) {
+    yield buildErrorEvent({
+      metadata: instance.metadata(),
+      type: "input_configuration_error",
+      message: "Configuration is invalid.",
+      originalError: configValidationResult.error.format(),
+    });
+    return;
+  }
+
+  const input = instance.buildRequestPayload(
+    payload,
+    configValidationResult.data
+  );
+
+  if (!debug) {
+    yield* instance.rawStreamOutputToEvents(instance.streamRaw(input));
+    return;
+  }
+
+  const dateString = new Date().toISOString();
+  await fs.promises.writeFile(
+    path.join(process.cwd(), `${dateString}_1_input.json`),
+    JSON.stringify({ payload, config }, null, 2),
+    "utf8"
+  );
+  await fs.promises.writeFile(
+    path.join(process.cwd(), `${dateString}_2_payload.json`),
+    JSON.stringify(input, null, 2),
+    "utf8"
+  );
+
+  const rawEvents: unknown[] = [];
+  const convertedEvents: ModelResponseEvent[] = [];
+
+  async function* tapRaw(
+    stream: AsyncGenerator<unknown>
+  ): AsyncGenerator<unknown> {
+    for await (const event of stream) {
+      rawEvents.push(event);
+      yield event;
+    }
+  }
+
+  try {
+    for await (const event of instance.rawStreamOutputToEvents(
+      tapRaw(instance.streamRaw(input))
+    )) {
+      convertedEvents.push(event);
+      yield event;
+    }
+  } finally {
+    await fs.promises.writeFile(
+      path.join(process.cwd(), `${dateString}_3_raw_output.json`),
+      JSON.stringify(rawEvents, null, 2),
+      "utf8"
+    );
+    await fs.promises.writeFile(
+      path.join(process.cwd(), `${dateString}_4_converted_output.json`),
+      JSON.stringify(convertedEvents, null, 2),
+      "utf8"
+    );
+  }
+}

--- a/front/lib/model_constructors/test/vite.config.js
+++ b/front/lib/model_constructors/test/vite.config.js
@@ -1,0 +1,15 @@
+import { mergeConfig } from "vite";
+
+import baseConfig from "../../../vite.config.mjs";
+
+const config = mergeConfig(baseConfig, {
+  test: {
+    globalSetup: [],
+    environment: "node",
+  },
+});
+
+// mergeConfig deep-merges arrays, so we must override after merging.
+config.test.globalSetup = [];
+
+export default config;


### PR DESCRIPTION
## Description

Adds the Anthropic and agent-platform stream clients, the global/EU Claude Sonnet 4.6 stream endpoints, and an integration test harness for stream endpoints.

## Tests

Added an integration test harness (`lib/model_constructors/test/`) gated on `NODE_ENV=test` + `RUN_LLM_TEST=true` so CI never burns API tokens; ran locally against the global Claude Sonnet 4.6 endpoint.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`