### PR TITLE
[front] Add defaultAgentSId to project_metadata

### DIFF
--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -22,7 +22,7 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   /** Scoped path to a project frame file, e.g. `project/banner.html`. */
   declare pinnedFramePath: CreationOptional<string | null>;
   /** sId of the agent pre-selected for new conversations in this pod. Null = @dust. */
-  declare defaultAgentSId: CreationOptional<string | null>;
+  declare defaultAgentId: CreationOptional<string | null>;
 }
 
 ProjectMetadataModel.init(
@@ -62,11 +62,11 @@ ProjectMetadataModel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
-    defaultAgentSId: {
+    defaultAgentId: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,
-      field: "defaultAgentId",
+      field: "defaultAgentSId",
     },
   },
   {

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -21,6 +21,8 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare description: string | null;
   /** Scoped path to a project frame file, e.g. `project/banner.html`. */
   declare pinnedFramePath: CreationOptional<string | null>;
+  /** sId of the agent pre-selected for new conversations in this pod. Null = @dust. */
+  declare defaultAgentSId: CreationOptional<string | null>;
 }
 
 ProjectMetadataModel.init(
@@ -59,6 +61,12 @@ ProjectMetadataModel.init(
     pinnedFramePath: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    defaultAgentSId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+      field: "defaultAgentId",
     },
   },
   {

--- a/front/migrations/db/migration_679.sql
+++ b/front/migrations/db/migration_679.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jun 12, 2026
+ALTER TABLE "public"."project_metadata" ADD COLUMN "defaultAgentId" VARCHAR(255) DEFAULT NULL;

--- a/front/migrations/db/migration_679.sql
+++ b/front/migrations/db/migration_679.sql
@@ -1,2 +1,2 @@
 -- Migration created on Jun 12, 2026
-ALTER TABLE "public"."project_metadata" ADD COLUMN "defaultAgentId" VARCHAR(255) DEFAULT NULL;
+ALTER TABLE "public"."project_metadata" ADD COLUMN "defaultAgentSId" VARCHAR(255) DEFAULT NULL;


### PR DESCRIPTION
## Description
For the default agent feature in pods.

Added a new column to the "project_metadata" table called "defaultAgentSId" to track the default agent that a user has selected in a pod. Published agents will be saved in the table and can be used by all members of the pod

## Tests
Manually tested

## Risk
Currently a string in a column, may run into issues if the string doesn't exist. Added a check to ensure this doesn't happen

## Deploy Plan
- Migration needed before deploying the code
