### PR TITLE
Show spaces used by agents in poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -8,6 +8,7 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import uniq from "lodash/uniq";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -43,10 +44,10 @@ app.get(
     const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
     const [latestAgentConfiguration] = agentConfigurations;
 
-    const spaces = await SpaceResource.fetchByIds(
-      auth,
-      latestAgentConfiguration.requestedSpaceIds
+    const allRequestedSpaceIds = uniq(
+      agentConfigurations.flatMap((config) => config.requestedSpaceIds)
     );
+    const spaces = await SpaceResource.fetchByIds(auth, allRequestedSpaceIds);
     const authors = await getAuthors(agentConfigurations);
 
     // `SkillResource.listByAgentConfigurations` only works for custom agents, as global agents are not versioned.

--- a/front/components/poke/assistants/AgentOverviewTable.tsx
+++ b/front/components/poke/assistants/AgentOverviewTable.tsx
@@ -1,3 +1,4 @@
+import { RequestedSpacesList } from "@app/components/poke/assistants/RequestedSpacesList";
 import {
   PokeTable,
   PokeTableBody,
@@ -6,36 +7,64 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { SpaceType } from "@app/types/space";
-import type { UserType } from "@app/types/user";
-import { Chip } from "@dust-tt/sparkle";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { ContentMessage, InfoCircle } from "@dust-tt/sparkle";
 
 interface AgentOverviewTableProps {
   agentConfiguration: AgentConfigurationType;
   authors: UserType[];
-  spaces: SpaceType[];
+  owner: LightWorkspaceType;
+  spacesById: Map<string, SpaceType>;
 }
 
 export function AgentOverviewTable({
   agentConfiguration,
   authors,
-  spaces,
+  owner,
+  spacesById,
 }: AgentOverviewTableProps) {
   const author = authors.find(
     (user) => user.id === agentConfiguration.versionAuthorId
   );
 
+  const restrictedSpaces = agentConfiguration.requestedSpaceIds
+    .map((spaceId) => spacesById.get(spaceId))
+    .filter(
+      (space): space is SpaceType => space !== undefined && space.isRestricted
+    );
+
   return (
     <>
       <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
+          <h2 className="text-md flex-grow pb-4 font-bold">
+            @{agentConfiguration.name}
+          </h2>
         </div>
+        {restrictedSpaces.length > 0 && (
+          <ContentMessage
+            title="Restricted space access"
+            variant="warning"
+            icon={InfoCircle}
+            size="lg"
+            className="mb-4 w-full"
+          >
+            <div className="flex flex-col gap-2">
+              <div>
+                Only users who are members of all restricted spaces can access
+                this agent. API keys must also be scoped to include all of these
+                spaces.
+              </div>
+              <RequestedSpacesList
+                owner={owner}
+                requestedSpaceIds={restrictedSpaces.map((space) => space.sId)}
+                spacesById={spacesById}
+              />
+            </div>
+          </ContentMessage>
+        )}
         <PokeTable>
           <PokeTableBody>
-            <PokeTableRow>
-              <PokeTableCell>Name</PokeTableCell>
-              <PokeTableCell>@{agentConfiguration.name}</PokeTableCell>
-            </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>Description</PokeTableCell>
               <PokeTableCell>{agentConfiguration.description}</PokeTableCell>
@@ -48,29 +77,21 @@ export function AgentOverviewTable({
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>Spaces</PokeTableCell>
-              <PokeTableCell className="flex flex-row space-x-2">
-                {spaces.map((s) => {
-                  return (
-                    <Chip
-                      key={s.sId}
-                      size="sm"
-                      color={s.isRestricted ? "warning" : "blue"}
-                    >
-                      {s.name}
-                    </Chip>
-                  );
-                })}
+              <PokeTableCell>
+                <RequestedSpacesList
+                  owner={owner}
+                  requestedSpaceIds={agentConfiguration.requestedSpaceIds}
+                  spacesById={spacesById}
+                />
               </PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>Status</PokeTableCell>
               <PokeTableCell>
-                <span className="capitalize">{agentConfiguration.status}</span>
+                <span className="capitalize">
+                  {agentConfiguration.status} (v{agentConfiguration.version})
+                </span>
               </PokeTableCell>
-            </PokeTableRow>
-            <PokeTableRow>
-              <PokeTableCell>Version</PokeTableCell>
-              <PokeTableCell>v{agentConfiguration.version}</PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>Created at</PokeTableCell>

--- a/front/components/poke/assistants/RequestedSpacesList.tsx
+++ b/front/components/poke/assistants/RequestedSpacesList.tsx
@@ -1,0 +1,56 @@
+import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
+import type { SpaceType } from "@app/types/space";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Icon, LinkWrapper } from "@dust-tt/sparkle";
+
+interface RequestedSpacesListProps {
+  owner?: LightWorkspaceType;
+  requestedSpaceIds: string[];
+  spacesById: Map<string, SpaceType>;
+}
+
+export function RequestedSpacesList({
+  owner,
+  requestedSpaceIds,
+  spacesById,
+}: RequestedSpacesListProps) {
+  if (requestedSpaceIds.length === 0) {
+    return <div>None</div>;
+  }
+
+  return (
+    <div className="flex flex-row flex-wrap gap-x-4 gap-y-2">
+      {requestedSpaceIds.map((spaceId) => {
+        const space = spacesById.get(spaceId);
+        if (!space) {
+          return (
+            <span
+              key={spaceId}
+              className="text-sm text-muted-foreground dark:text-muted-foreground-night"
+            >
+              {spaceId} (unknown)
+            </span>
+          );
+        }
+
+        const spaceLabel = (
+          <div key={spaceId} className="flex items-center gap-1.5">
+            <Icon visual={getSpaceIcon(space)} size="xs" className="shrink-0" />
+            {owner ? (
+              <LinkWrapper
+                href={`/poke/${owner.sId}/spaces/${space.sId}`}
+                className="text-highlight-500"
+              >
+                {getSpaceName(space)}
+              </LinkWrapper>
+            ) : (
+              <span>{getSpaceName(space)}</span>
+            )}
+          </div>
+        );
+
+        return spaceLabel;
+      })}
+    </div>
+  );
+}

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -1,4 +1,5 @@
 import { AgentOverviewTable } from "@app/components/poke/assistants/AgentOverviewTable";
+import { RequestedSpacesList } from "@app/components/poke/assistants/RequestedSpacesList";
 import { ConversationAgentDataTable } from "@app/components/poke/conversation/agent_table";
 import { DatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
@@ -77,6 +78,7 @@ export function AssistantDetailsPage() {
     spaces,
     skillsByVersion,
   } = agentDetails;
+  const spacesById = new Map(spaces.map((space) => [space.sId, space]));
 
   return (
     <div>
@@ -129,7 +131,8 @@ export function AssistantDetailsPage() {
             <AgentOverviewTable
               agentConfiguration={agentConfigurations[0]}
               authors={authors}
-              spaces={spaces}
+              owner={owner}
+              spacesById={spacesById}
             />
             <div className="flex flex-grow flex-col">
               <PluginList
@@ -228,6 +231,14 @@ export function AssistantDetailsPage() {
                               />
                             </div>
                           ))}
+                        </div>
+                        <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                          <div className="font-bold">Requested spaces:</div>
+                          <RequestedSpacesList
+                            owner={owner}
+                            requestedSpaceIds={a.requestedSpaceIds}
+                            spacesById={spacesById}
+                          />
                         </div>
                         <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
                           <div className="font-bold">Skills:</div>


### PR DESCRIPTION
## Description

(spent too long to figure out that an agent wasn't working in an api call because it was using restricted spaces)

Improves the agent details page in Poke to surface the spaces used by each version of an agent.

- New `RequestedSpacesList` component renders spaces with icons and deep links to their Poke page; falls back to displaying the raw sId for unknown spaces.
- `AgentOverviewTable` now accepts `spacesById: Map<string, SpaceType>` + `owner` (replacing the flat `spaces` array), uses `RequestedSpacesList` for the Spaces row, inlines the agent name as the card heading, and merges version into the status row.
- A `ContentMessage` warning banner appears when any requested space is restricted, listing the relevant spaces and noting that API keys must be scoped accordingly.
- The version history section in `AssistantDetailsPage` now shows "Requested spaces" per version entry using the same component.
- Fixed: the Poke details API was fetching spaces only from the latest version's `requestedSpaceIds`; now unions all IDs across every version via `uniq(agentConfigurations.flatMap(...))`.

<img width="1117" height="503" alt="image" src="https://github.com/user-attachments/assets/8d0eff5c-8605-4dbe-92b7-b996ce7da42e" />


## Tests

Tested manually in Poke.

## Risk

Low — Poke-only UI changes with no data model modifications. The API fix is additive (broader set of space IDs fetched, no behavior change for the common case where all versions share the same spaces).

## Deploy Plan

Deploy `front`.
