### PR TITLE
Fix forked convos so they show the correct title

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -2565,6 +2565,71 @@ describe("listPrivateConversationsForUser", () => {
     expect(item?.nextWakeupAt).toBe(scheduledFireAt.getTime());
   });
 
+  it("derives the 'Branched from ...' title for forked conversations in the DB paginated list", async () => {
+    const parentConversationTitle = "Quarterly Review Data";
+    const parentConversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [new Date()],
+    });
+    await ConversationModel.update(
+      { title: parentConversationTitle },
+      { where: { id: parentConversation.id, workspaceId: workspace.id } }
+    );
+
+    // The forked child starts untitled; its display title must be derived from the fork data.
+    const childConversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [],
+    });
+    await ConversationModel.update(
+      { title: null },
+      { where: { id: childConversation.id, workspaceId: workspace.id } }
+    );
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: childConversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    const parentConversationResource = await ConversationResource.fetchById(
+      adminAuth,
+      parentConversation.sId
+    );
+    const childConversationResource = await ConversationResource.fetchById(
+      adminAuth,
+      childConversation.sId
+    );
+    assert(parentConversationResource, "Parent conversation not found");
+    assert(childConversationResource, "Child conversation not found");
+
+    const sourceMessage = await MessageModel.findOne({
+      where: {
+        conversationId: parentConversation.id,
+        workspaceId: workspace.id,
+        rank: 1,
+      },
+    });
+    assert(sourceMessage, "Source message not found");
+
+    await ConversationForkResource.makeNew(adminAuth, {
+      parentConversation: parentConversationResource,
+      childConversation: childConversationResource,
+      sourceMessageModelId: sourceMessage.id,
+      branchedAt: new Date(),
+    });
+
+    const result =
+      await ConversationResource.listPrivateConversationsForUserPaginatedFromDB(
+        userAuth,
+        { limit: 100 }
+      );
+    const item = result.conversations.find(
+      (c) => c.sId === childConversation.sId
+    );
+
+    expect(item?.title).toBe(`Branched from '${parentConversationTitle}'`);
+  });
+
   it("should return conversations with populated participation data", async () => {
     // First, get the raw participation data from the database to compare
     const { ConversationParticipantModel } = await import(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1693,7 +1693,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const conversations = await this.baseFetchWithAuthorization(
       auth,
-      {},
+      // Load forking data so `toListItem` can derive the "Branched from ..." title for untitled
+      // forked conversations (consistent with the ES-backed listing path).
+      { includeForkingData: true },
       {
         where: whereClause,
         order: [["updatedAt", orderDirection === "desc" ? "DESC" : "ASC"]],


### PR DESCRIPTION
 ## Description

  When branching a conversation, the sidebar optimistically shows a `Branched from '…'` title, but after a page refresh it reverted to **New Conversation**.

  ### Root cause

  A branched conversation is created with `title: null` — the `Branched from '…'` label is *derived*, not stored. `getConversationDisplayTitle()` derives it from the conversation's `forkingData`, and `toListItem()` relies on that.

  The Elasticsearch-backed listing path loads `forkingData`, but the **DB listing path** (`fetchPrivateConversationsPaginated`, the fallback used when the `conversation_search_read` flag is off — e.g. local/dev) fetched conversations *without* `includeForkingData`. So
  `forkingData` was `undefined`, and the title derivation fell through to the date-based "New Conversation" fallback.

  ### Fix

  Pass `{ includeForkingData: true }` to `baseFetchWithAuthorization` in `fetchPrivateConversationsPaginated`, so `toListItem()` can derive the branched title — consistent with the ES path and the per-conversation fetch path. This is a single `hasOne` join over the
  bounded page (not an N+1).

  ## Testing

  Added a regression test in `conversation_resource.test.ts` that forks an untitled child, lists via `listPrivateConversationsForUserPaginatedFromDB`, and asserts the item's title is `Branched from '<parent title>'`. Confirmed it **fails without the fix** and **passes with it**.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
