### PR TITLE
Add: deeplink with conversation auto-draft.

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8147,6 +8147,58 @@
         }
       }
     },
+    "/api/w/{wId}/assistant/go-template": {
+      "get": {
+        "summary": "Resolve a conversation go template draft",
+        "description": "Fetches a Contentful conversation go template by slug and returns a composer-ready draft with optional pre-uploaded attachments.",
+        "tags": [
+          "Private Assistant"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "slug",
+            "required": true,
+            "description": "Contentful template slug",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Composer draft resolved from the template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetGoTemplateDraftResponseBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template not found or disabled"
+          },
+          "422": {
+            "description": "Missing slug query parameter"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/assistant/mentions/suggestions": {
       "get": {
         "summary": "Get mention suggestions",
@@ -11011,6 +11063,72 @@
               },
               "down": {
                 "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "GetGoTemplateDraftResponseBody": {
+        "type": "object",
+        "description": "Composer draft resolved from a Contentful conversation go template.",
+        "required": [
+          "title",
+          "prompt",
+          "attachments",
+          "attachmentErrors"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "fileId",
+                "name",
+                "contentType",
+                "size",
+                "url"
+              ],
+              "properties": {
+                "fileId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "contentType": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "attachmentErrors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "url",
+                "message"
+              ],
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -802,6 +802,52 @@
  *               type: integer
  *             down:
  *               type: integer
+ *     GetGoTemplateDraftResponseBody:
+ *       type: object
+ *       description: Composer draft resolved from a Contentful conversation go template.
+ *       required:
+ *         - title
+ *         - prompt
+ *         - attachments
+ *         - attachmentErrors
+ *       properties:
+ *         title:
+ *           type: string
+ *         prompt:
+ *           type: string
+ *         attachments:
+ *           type: array
+ *           items:
+ *             type: object
+ *             required:
+ *               - fileId
+ *               - name
+ *               - contentType
+ *               - size
+ *               - url
+ *             properties:
+ *               fileId:
+ *                 type: string
+ *               name:
+ *                 type: string
+ *               contentType:
+ *                 type: string
+ *               size:
+ *                 type: integer
+ *               url:
+ *                 type: string
+ *         attachmentErrors:
+ *           type: array
+ *           items:
+ *             type: object
+ *             required:
+ *               - url
+ *               - message
+ *             properties:
+ *               url:
+ *                 type: string
+ *               message:
+ *                 type: string
  *     PrivateFileWithUploadUrl:
  *       type: object
  *       description: File record with a pre-signed upload URL.

--- a/front-api/routes/w/[wId]/assistant/go-template.ts
+++ b/front-api/routes/w/[wId]/assistant/go-template.ts
@@ -1,0 +1,70 @@
+import {
+  type GetGoTemplateDraftResponseBody,
+  resolveGoTemplateDraft,
+} from "@app/lib/api/assistant/go_template";
+import { isString } from "@app/types/shared/utils/general";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/assistant/go-template.
+const app = workspaceApp();
+
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/go-template:
+ *   get:
+ *     summary: Resolve a conversation go template draft
+ *     description: Fetches a Contentful conversation go template by slug and returns a composer-ready draft with optional pre-uploaded attachments.
+ *     tags:
+ *       - Private Assistant
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: slug
+ *         required: true
+ *         description: Contentful template slug
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Composer draft resolved from the template
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetGoTemplateDraftResponseBody'
+ *       404:
+ *         description: Template not found or disabled
+ *       422:
+ *         description: Missing slug query parameter
+ */
+app.get("/", async (ctx): HandlerResult<GetGoTemplateDraftResponseBody> => {
+  const auth = ctx.get("auth");
+  const slug = ctx.req.query("slug");
+
+  if (!isString(slug) || slug.trim() === "") {
+    return apiError(ctx, {
+      status_code: 422,
+      api_error: {
+        type: "unprocessable_entity",
+        message: "The slug query parameter is invalid or missing.",
+      },
+    });
+  }
+
+  const result = await resolveGoTemplateDraft(auth, slug);
+  if (result.isErr()) {
+    return apiError(ctx, result.error);
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/index.ts
+++ b/front-api/routes/w/[wId]/assistant/index.ts
@@ -4,6 +4,7 @@ import agentConfigurations from "./agent_configurations";
 import builder from "./builder";
 import conversations from "./conversations";
 import globalAgents from "./global_agents";
+import goTemplate from "./go-template";
 import mentions from "./mentions";
 import skills from "./skills";
 
@@ -14,6 +15,7 @@ app.route("/agent_configurations", agentConfigurations);
 app.route("/builder", builder);
 app.route("/conversations", conversations);
 app.route("/global_agents", globalAgents);
+app.route("/go-template", goTemplate);
 app.route("/mentions", mentions);
 app.route("/skills", skills);
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -113,6 +113,7 @@ export const InputBar = React.memo(function InputBar({
     selectedSingleAgent,
     getAndClearPendingInputText,
     fileUploaderService,
+    isLoadingGoTemplate,
   } = useContext(InputBarContext);
 
   // We use this specific hook because this component is involved in the new conversation page.
@@ -128,6 +129,12 @@ export const InputBar = React.memo(function InputBar({
     draftKey,
     shouldUseDraft: !isAgentBuilder,
   });
+
+  useEffect(() => {
+    if (isLoadingGoTemplate) {
+      clearDraft();
+    }
+  }, [isLoadingGoTemplate, clearDraft]);
 
   useEffect(() => {
     if (droppedFiles.length > 0) {
@@ -488,7 +495,9 @@ export const InputBar = React.memo(function InputBar({
             stickyMentions={stickyMentions}
             fileUploaderService={fileUploaderService}
             isSubmitting={
-              isLocalSubmitting || fileUploaderService.isProcessingFiles
+              isLocalSubmitting ||
+              fileUploaderService.isProcessingFiles ||
+              isLoadingGoTemplate
             }
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,6 +1,7 @@
 import { ContextUsageIndicator } from "@app/components/assistant/conversation/input_bar/ContextUsageIndicator";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
+import type { PendingInputText } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
   INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
   INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
@@ -139,7 +140,7 @@ export interface InputBarContainerProps {
   onResetMCPServerViews: () => void;
   owner: WorkspaceType;
   saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
-  pendingInputText: string | null;
+  pendingInputText: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
   stickyMentions?: RichMention[];
@@ -197,7 +198,7 @@ const InputBarContainer = ({
   );
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
-  const { selectedSingleAgent, setSelectedSingleAgent } =
+  const { selectedSingleAgent, setSelectedSingleAgent, isLoadingGoTemplate } =
     useContext(InputBarContext);
 
   const [startsWithUserMention, setStartsWithUserMention] = useState(false);
@@ -994,6 +995,47 @@ const InputBarContainer = ({
     };
   }, [clientType, editorService]);
 
+  useEffect(() => {
+    editorService.setLoading(isLoadingGoTemplate);
+  }, [editorService, isLoadingGoTemplate]);
+
+  const pendingReplaceInputRef = useRef<PendingInputText | null>(null);
+
+  // Apply replace-mode pending text once the editor is ready. The async /go
+  // template fetch often completes before TipTap initializes; applying earlier
+  // would no-op and the pending payload is already consumed by InputBar.
+  useEffect(() => {
+    if (pendingInputText?.replace) {
+      pendingReplaceInputRef.current = pendingInputText;
+    }
+
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      !editor.isEditable ||
+      !editor.isInitialized
+    ) {
+      return;
+    }
+
+    const pending = pendingReplaceInputRef.current;
+    if (!pending?.replace) {
+      return;
+    }
+
+    pendingReplaceInputRef.current = null;
+    queueMicrotask(() =>
+      editorService.setContent(pending.text, { focus: !disableAutoFocus })
+    );
+  }, [
+    pendingInputText,
+    editor,
+    editor?.isInitialized,
+    editor?.isEditable,
+    editorService,
+    disableAutoFocus,
+  ]);
+
   // Restore draft text when switching conversations (including new conversations).
   // Agent selection is handled by useHandleMention.
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -1004,6 +1046,10 @@ const InputBarContainer = ({
       !editor.isEditable ||
       !editor.isInitialized
     ) {
+      return;
+    }
+
+    if (pendingReplaceInputRef.current?.replace) {
       return;
     }
 

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -24,6 +24,11 @@ export type PendingConversationMessage = {
   contentFragments: ContentFragmentsType;
 };
 
+export type PendingInputText = {
+  text: string;
+  replace: boolean;
+};
+
 type CaptureActions = {
   onCapture: (type: "text" | "screenshot") => void;
   isCapturing: boolean;
@@ -38,8 +43,11 @@ export const InputBarContext = createContext<{
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
   setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
-  getAndClearPendingInputText: () => string | null;
-  setPendingInputText: (text: string | null) => void;
+  getAndClearPendingInputText: () => PendingInputText | null;
+  setPendingInputText: (
+    text: string | null,
+    options?: { replace?: boolean }
+  ) => void;
   peekPendingFirstMessage: (
     conversationId: string
   ) => PendingConversationMessage | null;
@@ -48,6 +56,8 @@ export const InputBarContext = createContext<{
     message: PendingConversationMessage
   ) => void;
   clearPendingFirstMessage: (conversationId: string) => void;
+  isLoadingGoTemplate: boolean;
+  setIsLoadingGoTemplate: (loading: boolean) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
 }>({
@@ -62,6 +72,8 @@ export const InputBarContext = createContext<{
   peekPendingFirstMessage: () => null,
   setPendingFirstMessage: () => {},
   clearPendingFirstMessage: () => {},
+  isLoadingGoTemplate: false,
+  setIsLoadingGoTemplate: () => {},
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -97,10 +109,10 @@ export function InputBarContextProvider({
   const [selectedSingleAgent, setSelectedSingleAgent] =
     useState<RichAgentMention | null>(null);
 
-  // Useful when a component needs to pre-fill the input bar with text (e.g. butler suggestions).
-  const [pendingInputText, setPendingInputTextState] = useState<string | null>(
-    null
-  );
+  // Useful when a component needs to pre-fill the input bar with text.
+  const [pendingInputText, setPendingInputTextState] =
+    useState<PendingInputText | null>(null);
+  const [isLoadingGoTemplate, setIsLoadingGoTemplate] = useState(false);
 
   // First message stashed while navigating to a newly-created conversation (deferred-send flow).
   const [
@@ -153,14 +165,24 @@ export function InputBarContextProvider({
   }, [selectedAgent, setSelectedAgent]);
 
   const getAndClearPendingInputText = useCallback(() => {
-    const text = pendingInputText;
+    const pending = pendingInputText;
     setPendingInputTextState(null);
-    return text;
+    return pending;
   }, [pendingInputText]);
 
-  const setPendingInputText = useCallback((text: string | null) => {
-    setPendingInputTextState(text);
-  }, []);
+  const setPendingInputText = useCallback(
+    (text: string | null, options?: { replace?: boolean }) => {
+      if (text === null) {
+        setPendingInputTextState(null);
+        return;
+      }
+      setPendingInputTextState({
+        text,
+        replace: options?.replace ?? false,
+      });
+    },
+    []
+  );
 
   const value = useMemo(
     () => ({
@@ -175,6 +197,8 @@ export function InputBarContextProvider({
       peekPendingFirstMessage,
       setPendingFirstMessage,
       clearPendingFirstMessage,
+      isLoadingGoTemplate,
+      setIsLoadingGoTemplate,
       captureActions,
       fileUploaderService,
     }),
@@ -188,6 +212,7 @@ export function InputBarContextProvider({
       peekPendingFirstMessage,
       setPendingFirstMessage,
       clearPendingFirstMessage,
+      isLoadingGoTemplate,
       captureActions,
       fileUploaderService,
     ]

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,4 +1,7 @@
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import {
+  InputBarContext,
+  type PendingInputText,
+} from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -23,7 +26,7 @@ interface UseHandleMentionsOptions {
     agentMention?: RichAgentMention | null;
   } | null;
   isAgentBuilder: boolean;
-  pendingInputText?: string | null;
+  pendingInputText?: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
   stickyMentions?: RichMention[];
 }
@@ -110,8 +113,8 @@ const useHandleMentions = ({
       // @TODO we should handle this in each event handler and not inside the useEffect
       setSelectedSingleAgent(selectedAgent);
       externalAgentSetRef.current = true;
-    } else if (pendingInputText) {
-      queueMicrotask(() => editorService.insertText(pendingInputText));
+    } else if (pendingInputText && !pendingInputText.replace) {
+      queueMicrotask(() => editorService.insertText(pendingInputText.text));
     }
   }, [selectedAgent, pendingInputText, editorService, setSelectedSingleAgent]);
 

--- a/front/components/pages/conversation/ConversationPage.tsx
+++ b/front/components/pages/conversation/ConversationPage.tsx
@@ -1,6 +1,7 @@
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAgentFromSearchParam } from "@app/hooks/useAgentFromSearchParam";
+import { useGoTemplateFromSearchParam } from "@app/hooks/useGoTemplateFromSearchParam";
 import { useOnboardingConversation } from "@app/hooks/useOnboardingConversation";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
@@ -37,6 +38,9 @@ export function ConversationPage() {
 
   // Consume ?agent= param: fetch agent, set it in input bar, clean up URL.
   useAgentFromSearchParam(owner.sId);
+
+  // Consume ?go= param: fetch Contentful template, prefill composer, clean up URL.
+  useGoTemplateFromSearchParam(owner.sId);
 
   return (
     <ConversationContainerVirtuoso

--- a/front/hooks/useGoTemplateFromSearchParam.ts
+++ b/front/hooks/useGoTemplateFromSearchParam.ts
@@ -1,0 +1,138 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  GetGoTemplateDraftResponseBodySchema,
+  GoTemplateApiErrorBodySchema,
+} from "@app/lib/api/assistant/go_template";
+import { clientFetch } from "@app/lib/egress/client";
+import { useSearchParam } from "@app/lib/platform";
+import { isSupportedFileContentType } from "@app/types/files";
+import { useContext, useEffect, useRef } from "react";
+
+/**
+ * Reads the ?go= search param, fetches the corresponding Contentful template
+ * draft, pre-fills the composer, attaches any template files, and cleans up
+ * the param from the URL.
+ */
+export function useGoTemplateFromSearchParam(workspaceId: string) {
+  const goSlug = useSearchParam("go");
+  const { setPendingInputText, fileUploaderService, setIsLoadingGoTemplate } =
+    useContext(InputBarContext);
+  const sendNotification = useSendNotification();
+  const loadedSlugRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!goSlug) {
+      setIsLoadingGoTemplate(false);
+      return;
+    }
+
+    if (loadedSlugRef.current === goSlug) {
+      setIsLoadingGoTemplate(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingGoTemplate(true);
+
+    const loadTemplate = async () => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/assistant/go-template?slug=${encodeURIComponent(goSlug)}`
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        if (!response.ok) {
+          let message = "This link template could not be loaded.";
+          try {
+            const body = GoTemplateApiErrorBodySchema.safeParse(
+              await response.json()
+            );
+            if (body.success && body.data.error?.message) {
+              message = body.data.error.message;
+            }
+          } catch {
+            // Keep default message.
+          }
+          sendNotification({
+            type: "error",
+            title: "Template unavailable",
+            description: message,
+          });
+          return;
+        }
+
+        const parsed = GetGoTemplateDraftResponseBodySchema.safeParse(
+          await response.json()
+        );
+        if (!parsed.success) {
+          sendNotification({
+            type: "error",
+            title: "Template unavailable",
+            description: "This link template could not be loaded.",
+          });
+          return;
+        }
+
+        const draft = parsed.data;
+        loadedSlugRef.current = goSlug;
+
+        fileUploaderService.resetUpload();
+        setPendingInputText(draft.prompt, { replace: true });
+
+        for (const attachment of draft.attachments) {
+          if (!isSupportedFileContentType(attachment.contentType)) {
+            continue;
+          }
+          fileUploaderService.addUploadedFile({
+            fileId: attachment.fileId,
+            filename: attachment.name,
+            contentType: attachment.contentType,
+            size: attachment.size,
+            sourceUrl: attachment.url,
+          });
+        }
+
+        if (draft.attachmentErrors.length > 0) {
+          sendNotification({
+            type: "info",
+            title: "Some attachments could not be loaded",
+            description: `${draft.attachmentErrors.length} attachment(s) were skipped.`,
+          });
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        if (params.has("go")) {
+          params.delete("go");
+          const qs = params.toString();
+          window.history.replaceState(
+            null,
+            "",
+            `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingGoTemplate(false);
+        }
+      }
+    };
+
+    void loadTemplate();
+
+    return () => {
+      cancelled = true;
+      setIsLoadingGoTemplate(false);
+    };
+  }, [
+    goSlug,
+    workspaceId,
+    setPendingInputText,
+    setIsLoadingGoTemplate,
+    fileUploaderService,
+    sendNotification,
+  ]);
+}

--- a/front/lib/api/assistant/go_template.test.ts
+++ b/front/lib/api/assistant/go_template.test.ts
@@ -1,0 +1,78 @@
+import { resolveGoTemplateDraft } from "@app/lib/api/assistant/go_template";
+import { getConversationDraftBySlug } from "@app/lib/contentful/client";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/contentful/client", () => ({
+  getConversationDraftBySlug: vi.fn(),
+  isHttpsUrl: (url: string) => url.startsWith("https://"),
+}));
+
+vi.mock("@app/lib/api/files/upload", () => ({
+  processAndStoreFromUrl: vi.fn(),
+}));
+
+import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
+
+describe("resolveGoTemplateDraft", () => {
+  it("returns 404 when template is missing", async () => {
+    vi.mocked(getConversationDraftBySlug).mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: null,
+    } as never);
+
+    const result = await resolveGoTemplateDraft({} as never, "abcd");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(404);
+    }
+  });
+
+  it("returns prompt and skips invalid attachment URLs", async () => {
+    vi.mocked(getConversationDraftBySlug).mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        slug: "abcd",
+        title: "RFP Review",
+        prompt: "Review this RFP",
+        attachments: [
+          {
+            url: "http://insecure.example/file.pdf",
+            fileName: "insecure.pdf",
+            contentType: "application/pdf",
+          },
+          {
+            url: "https://example.com/file.pdf",
+            fileName: "file.pdf",
+            contentType: "application/pdf",
+          },
+        ],
+      },
+    } as never);
+
+    vi.mocked(processAndStoreFromUrl).mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        sId: "file123",
+        fileName: "file.pdf",
+        contentType: "application/pdf",
+        fileSize: 1234,
+      },
+    } as never);
+
+    const result = await resolveGoTemplateDraft({} as never, "abcd");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.prompt).toBe("Review this RFP");
+      expect(result.value.attachments).toHaveLength(1);
+      expect(result.value.attachmentErrors).toHaveLength(1);
+      expect(result.value.attachmentErrors[0]?.url).toBe(
+        "http://insecure.example/file.pdf"
+      );
+    }
+  });
+});

--- a/front/lib/api/assistant/go_template.ts
+++ b/front/lib/api/assistant/go_template.ts
@@ -1,0 +1,143 @@
+import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getConversationDraftBySlug,
+  isHttpsUrl,
+} from "@app/lib/contentful/client";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { SupportedFileContentType } from "@app/types/files";
+import { isSupportedFileContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+export type GoTemplateAttachment = {
+  fileId: string;
+  name: string;
+  contentType: SupportedFileContentType;
+  size: number;
+  url: string;
+};
+
+export type GoTemplateAttachmentError = {
+  url: string;
+  message: string;
+};
+
+const GoTemplateAttachmentSchema = z.object({
+  fileId: z.string(),
+  name: z.string(),
+  contentType: z.string(),
+  size: z.number(),
+  url: z.string(),
+});
+
+const GoTemplateAttachmentErrorSchema = z.object({
+  url: z.string(),
+  message: z.string(),
+});
+
+export const GetGoTemplateDraftResponseBodySchema = z.object({
+  title: z.string(),
+  prompt: z.string(),
+  attachments: z.array(GoTemplateAttachmentSchema),
+  attachmentErrors: z.array(GoTemplateAttachmentErrorSchema),
+});
+
+export const GoTemplateApiErrorBodySchema = z.object({
+  error: z
+    .object({
+      message: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * @swaggerschema GetGoTemplateDraftResponseBody (swagger_private_schemas.ts)
+ */
+export type GetGoTemplateDraftResponseBody = z.infer<
+  typeof GetGoTemplateDraftResponseBodySchema
+>;
+
+export async function resolveGoTemplateDraft(
+  auth: Authenticator,
+  slug: string
+): Promise<
+  Result<GetGoTemplateDraftResponseBody, APIErrorWithContentfulStatusCode>
+> {
+  const templateResult = await getConversationDraftBySlug(slug);
+  if (templateResult.isErr()) {
+    return new Err({
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to load template.",
+      },
+    });
+  }
+
+  const template = templateResult.value;
+  if (!template) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "template_not_found",
+        message: `Template "${slug}" was not found.`,
+      },
+    });
+  }
+
+  const attachments: GoTemplateAttachment[] = [];
+  const attachmentErrors: GoTemplateAttachmentError[] = [];
+
+  for (const attachment of template.attachments) {
+    const { url } = attachment;
+    if (!isHttpsUrl(url)) {
+      attachmentErrors.push({
+        url,
+        message: "Only public HTTPS URLs are supported.",
+      });
+      continue;
+    }
+
+    const uploadResult = await processAndStoreFromUrl(auth, {
+      url,
+      useCase: "conversation",
+      fileName: attachment.fileName,
+      contentType: attachment.contentType ?? undefined,
+    });
+
+    if (uploadResult.isErr()) {
+      attachmentErrors.push({
+        url,
+        message: uploadResult.error.message,
+      });
+      continue;
+    }
+
+    const file = uploadResult.value;
+    const contentType = file.contentType;
+    if (!isSupportedFileContentType(contentType)) {
+      attachmentErrors.push({
+        url,
+        message: `Unsupported content type: ${contentType}`,
+      });
+      continue;
+    }
+
+    attachments.push({
+      fileId: file.sId,
+      name: file.fileName,
+      contentType,
+      size: file.fileSize,
+      url,
+    });
+  }
+
+  return new Ok({
+    title: template.title,
+    prompt: template.prompt,
+    attachments,
+    attachmentErrors,
+  });
+}

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -1,0 +1,146 @@
+import config from "@app/lib/api/config";
+import type {
+  ConversationDraft,
+  ConversationDraftAttachment,
+  ConversationDraftSkeleton,
+} from "@app/lib/contentful/types";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import type { Asset, ContentfulClientApi, Entry } from "contentful";
+import { createClient } from "contentful";
+import { z } from "zod";
+
+let client: ContentfulClientApi<undefined> | null = null;
+
+function getClient() {
+  if (!client) {
+    const spaceId = config.getContentfulSpaceId();
+    const accessToken = config.getContentfulAccessToken();
+
+    if (!spaceId || !accessToken) {
+      throw new Error(
+        "Contentful credentials not configured. " +
+          "Set CONTENTFUL_SPACE_ID and CONTENTFUL_ACCESS_TOKEN environment variables."
+      );
+    }
+
+    client = createClient({
+      space: spaceId,
+      accessToken,
+      environment: process.env.CONTENTFUL_ENVIRONMENT ?? "master",
+    });
+  }
+  return client.withoutUnresolvableLinks;
+}
+
+function isContentfulAsset(value: unknown): value is Asset {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "sys" in value &&
+    "fields" in value &&
+    value.fields !== undefined
+  );
+}
+
+const ConversationDraftFieldsSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  prompt: z.string().min(1),
+  attachments: z
+    .array(z.custom<Asset>((value): value is Asset => isContentfulAsset(value)))
+    .optional(),
+});
+
+function contentfulAssetToAttachment(
+  asset: Asset
+): ConversationDraftAttachment | null {
+  const file = asset.fields?.file;
+  if (!file || !isString(file.url)) {
+    return null;
+  }
+
+  const url = file.url.startsWith("//")
+    ? `https:${file.url}`
+    : file.url.startsWith("http")
+      ? file.url
+      : `https:${file.url}`;
+
+  const fileName =
+    (isString(asset.fields.title) ? asset.fields.title : null) ||
+    (isString(file.fileName) ? file.fileName : null) ||
+    new URL(url).pathname.split("/").pop() ||
+    "attachment";
+
+  const contentType = isString(file.contentType) ? file.contentType : null;
+
+  return { url, fileName, contentType };
+}
+
+function contentfulEntryToConversationDraft(
+  entry: Entry<ConversationDraftSkeleton>
+): ConversationDraft | null {
+  const result = ConversationDraftFieldsSchema.safeParse(entry.fields);
+  if (!result.success) {
+    return null;
+  }
+
+  const parsed = result.data;
+
+  const attachments = (parsed.attachments ?? [])
+    .map(contentfulAssetToAttachment)
+    .filter(
+      (attachment): attachment is ConversationDraftAttachment =>
+        attachment !== null
+    );
+
+  return {
+    slug: parsed.slug,
+    title: parsed.title,
+    prompt: parsed.prompt.trim(),
+    attachments,
+  };
+}
+
+export async function getConversationDraftBySlug(
+  slug: string
+): Promise<Result<ConversationDraft | null, Error>> {
+  try {
+    const contentfulClient = getClient();
+    const queryParams: Record<string, string | number> = {
+      content_type: "conversationDraft",
+      "fields.slug": slug,
+      limit: 1,
+      include: 1,
+    };
+    const response =
+      await contentfulClient.getEntries<ConversationDraftSkeleton>(queryParams);
+
+    if (response.items.length === 0) {
+      return new Ok(null);
+    }
+
+    return new Ok(contentfulEntryToConversationDraft(response.items[0]));
+  } catch (error) {
+    logger.error(
+      { error, slug },
+      "[Contentful] Failed to get conversation draft by slug"
+    );
+    return new Err(normalizeError(error));
+  }
+}
+
+export function isHttpsUrl(url: string): boolean {
+  if (!isString(url)) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -1,0 +1,35 @@
+import type { Asset, EntrySkeletonType } from "contentful";
+
+/**
+ * Contentful content type: `conversationDraft`
+ *
+ * Fields:
+ * - slug (Symbol, required, unique, exactly 4 chars)
+ * - title (Symbol, required, unique)
+ * - prompt (Long text, required)
+ * - attachments (Array of Asset links, optional, max 8)
+ */
+export interface ConversationDraftFields {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments?: Asset[];
+}
+
+export type ConversationDraftSkeleton = EntrySkeletonType<
+  ConversationDraftFields,
+  "conversationDraft"
+>;
+
+export interface ConversationDraftAttachment {
+  url: string;
+  fileName: string;
+  contentType: string | null;
+}
+
+export interface ConversationDraft {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments: ConversationDraftAttachment[];
+}

--- a/marketing/lib/api/authContext.ts
+++ b/marketing/lib/api/authContext.ts
@@ -1,0 +1,75 @@
+import config from "@marketing/lib/api/config";
+import logger from "@marketing/logger/logger";
+import { normalizeError } from "@marketing/types/shared/utils/error_utils";
+import type { UserType } from "@marketing/types/user";
+import { z } from "zod";
+
+export const AUTH_CONTEXT_URL = `${config.getApiBaseUrl()}/api/auth-context`;
+
+// Cap SSR auth-context lookups so a slow/unavailable front API never hangs pages.
+export const AUTH_CONTEXT_TIMEOUT_MS = 1500;
+
+export type MarketingAuthContext = {
+  user: UserType;
+  defaultWorkspaceId: string | null;
+};
+
+const AuthContextUserSchema = z.object({
+  sId: z.string(),
+  id: z.number(),
+  createdAt: z.number(),
+  provider: z
+    .enum(["auth0", "github", "google", "okta", "samlp", "waad"])
+    .nullable(),
+  username: z.string(),
+  email: z.string(),
+  firstName: z.string(),
+  lastName: z.string().nullable(),
+  fullName: z.string(),
+  image: z.string().nullable(),
+  lastLoginAt: z.number().nullable(),
+});
+
+const AuthContextResponseSchema = z.object({
+  user: AuthContextUserSchema,
+  defaultWorkspaceId: z.string().nullable().optional(),
+});
+
+export function hasWorkosSessionCookie(cookieHeader: string): boolean {
+  return cookieHeader.includes("workos_session=");
+}
+
+/**
+ * Server-side auth-context lookup for marketing pages.
+ *
+ * Marketing has no WorkOS code of its own, so it asks `front` via
+ * `/api/auth-context`, forwarding the incoming cookies — the
+ * `workos_session` cookie is scoped to the shared `*.dust.tt` domain.
+ */
+export async function fetchAuthContext(
+  cookieHeader: string,
+  {
+    failureLogMessage = "auth-context lookup failed",
+  }: { failureLogMessage?: string } = {}
+): Promise<MarketingAuthContext | null> {
+  try {
+    const res = await fetch(AUTH_CONTEXT_URL, {
+      headers: { cookie: cookieHeader },
+      signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const parsed = AuthContextResponseSchema.safeParse(await res.json());
+    if (!parsed.success) {
+      return null;
+    }
+    return {
+      user: parsed.data.user,
+      defaultWorkspaceId: parsed.data.defaultWorkspaceId ?? null,
+    };
+  } catch (err) {
+    logger.warn({ err: normalizeError(err) }, failureLogMessage);
+    return null;
+  }
+}

--- a/marketing/lib/contentful/client.ts
+++ b/marketing/lib/contentful/client.ts
@@ -30,6 +30,9 @@ import type {
   QuizSettings,
   QuizSettingsSkeleton,
   SearchableItem,
+  ConversationDraft,
+  ConversationDraftAttachment,
+  ConversationDraftSkeleton,
 } from "@marketing/lib/contentful/types";
 import {
   ACADEMY_LOCALE_COOKIE,
@@ -1877,6 +1880,94 @@ export async function getAllHomepageNews(
     return new Ok(items);
   } catch (error) {
     logger.error({ error }, "[Contentful] Failed to fetch homepage news");
+    return new Err(normalizeError(error));
+  }
+}
+
+const ConversationDraftFieldsSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  prompt: z.string().min(1),
+  attachments: z
+    .array(z.custom<Asset>((value): value is Asset => isContentfulAsset(value)))
+    .optional(),
+});
+
+function contentfulAssetToAttachment(
+  asset: Asset
+): ConversationDraftAttachment | null {
+  const file = asset.fields?.file;
+  if (!file || !isString(file.url)) {
+    return null;
+  }
+
+  const url = file.url.startsWith("//")
+    ? `https:${file.url}`
+    : file.url.startsWith("http")
+      ? file.url
+      : `https:${file.url}`;
+
+  const fileName =
+    (isString(asset.fields.title) ? asset.fields.title : null) ||
+    (isString(file.fileName) ? file.fileName : null) ||
+    new URL(url).pathname.split("/").pop() ||
+    "attachment";
+
+  const contentType = isString(file.contentType) ? file.contentType : null;
+
+  return { url, fileName, contentType };
+}
+
+function contentfulEntryToConversationDraft(
+  entry: Entry<ConversationDraftSkeleton>
+): ConversationDraft | null {
+  const result = ConversationDraftFieldsSchema.safeParse(entry.fields);
+  if (!result.success) {
+    return null;
+  }
+
+  const parsed = result.data;
+
+  const attachments = (parsed.attachments ?? [])
+    .map(contentfulAssetToAttachment)
+    .filter(
+      (attachment): attachment is ConversationDraftAttachment =>
+        attachment !== null
+    );
+
+  return {
+    slug: parsed.slug,
+    title: parsed.title,
+    prompt: parsed.prompt.trim(),
+    attachments,
+  };
+}
+
+export async function getConversationDraftBySlug(
+  slug: string,
+  resolvedUrl: string = ""
+): Promise<Result<ConversationDraft | null, Error>> {
+  try {
+    const contentfulClient = getContentfulClient(resolvedUrl);
+    const queryParams: Record<string, string | number> = {
+      content_type: "conversationDraft",
+      "fields.slug": slug,
+      limit: 1,
+      include: 1,
+    };
+    const response =
+      await contentfulClient.getEntries<ConversationDraftSkeleton>(queryParams);
+
+    if (response.items.length === 0) {
+      return new Ok(null);
+    }
+
+    return new Ok(contentfulEntryToConversationDraft(response.items[0]));
+  } catch (error) {
+    logger.error(
+      { error, slug },
+      "[Contentful] Failed to get conversation draft by slug"
+    );
     return new Err(normalizeError(error));
   }
 }

--- a/marketing/lib/contentful/types.ts
+++ b/marketing/lib/contentful/types.ts
@@ -603,3 +603,31 @@ export interface LessonPageProps {
   academySettings: AcademySettings;
   quizSettings: QuizSettings;
 }
+
+// Conversation draft (deeplink) types
+//
+// Contentful content type id: `conversationDraft`
+export interface ConversationDraftFields {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments?: Asset[];
+}
+
+export type ConversationDraftSkeleton = EntrySkeletonType<
+  ConversationDraftFields,
+  "conversationDraft"
+>;
+
+export interface ConversationDraftAttachment {
+  url: string;
+  fileName: string;
+  contentType: string | null;
+}
+
+export interface ConversationDraft {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments: ConversationDraftAttachment[];
+}

--- a/marketing/lib/go/resolveDestination.ts
+++ b/marketing/lib/go/resolveDestination.ts
@@ -1,0 +1,54 @@
+import config from "@marketing/lib/api/config";
+import {
+  fetchAuthContext,
+  hasWorkosSessionCookie,
+} from "@marketing/lib/api/authContext";
+import { getConversationDraftBySlug } from "@marketing/lib/contentful/client";
+import logger from "@marketing/logger/logger";
+
+export type GoDestinationResult =
+  | { kind: "redirect"; destination: string }
+  | { kind: "not_found" }
+  | { kind: "error" };
+
+function buildLoginRedirect(slug: string): string {
+  const returnTo = encodeURIComponent(`/go/${slug}`);
+  return `${config.getApiBaseUrl()}/api/workos/login?returnTo=${returnTo}`;
+}
+
+export async function resolveGoDestination(
+  slug: string,
+  cookieHeader: string
+): Promise<GoDestinationResult> {
+  const templateResult = await getConversationDraftBySlug(slug);
+  if (templateResult.isErr()) {
+    logger.error(
+      { slug, error: templateResult.error },
+      "Failed to fetch conversation draft"
+    );
+    return { kind: "error" };
+  }
+
+  const template = templateResult.value;
+  if (!template) {
+    return { kind: "not_found" };
+  }
+
+  const authContext = hasWorkosSessionCookie(cookieHeader)
+    ? await fetchAuthContext(cookieHeader, {
+        failureLogMessage: "auth-context lookup failed during /go resolve",
+      })
+    : null;
+
+  if (authContext?.defaultWorkspaceId) {
+    return {
+      kind: "redirect",
+      destination: `${config.getAppUrl()}/w/${authContext.defaultWorkspaceId}/conversation/new?go=${encodeURIComponent(slug)}`,
+    };
+  }
+
+  return {
+    kind: "redirect",
+    destination: buildLoginRedirect(slug),
+  };
+}

--- a/marketing/lib/go/schemas.ts
+++ b/marketing/lib/go/schemas.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const GoResolveSuccessSchema = z.object({
+  destination: z.string(),
+});

--- a/marketing/lib/swr/website.ts
+++ b/marketing/lib/swr/website.ts
@@ -1,15 +1,10 @@
-import config from "@marketing/lib/api/config";
+import {
+  AUTH_CONTEXT_URL,
+  type MarketingAuthContext,
+} from "@marketing/lib/api/authContext";
 import { useSWRWithDefaults } from "@marketing/lib/swr/swr";
-import type { UserType } from "@marketing/types/user";
 
-type GetNoWorkspaceAuthContextResponseType = {
-  user: UserType;
-  defaultWorkspaceId: string | null;
-};
-
-// /api/auth-context lives on front. Marketing reads it cross-origin with
-// credentials so the session cookie still travels.
-const AUTH_CONTEXT_URL = `${config.getApiBaseUrl()}/api/auth-context`;
+type GetNoWorkspaceAuthContextResponseType = MarketingAuthContext;
 
 // A fetcher that does NOT redirect to login on auth errors.
 // The global fetcher in fetcher.ts redirects to /api/workos/login on

--- a/marketing/pages/api/go/[slug].ts
+++ b/marketing/pages/api/go/[slug].ts
@@ -1,0 +1,35 @@
+/** @ignoreswagger */
+import { resolveGoDestination } from "@marketing/lib/go/resolveDestination";
+import { isString } from "@marketing/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type GoResolveResponse =
+  | { destination: string }
+  | { error: "template_not_found" | "invalid_slug" | "internal_server_error" };
+
+// biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GoResolveResponse>
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "internal_server_error" });
+  }
+
+  const slug = req.query.slug;
+  if (!isString(slug) || slug.trim() === "") {
+    return res.status(400).json({ error: "invalid_slug" });
+  }
+
+  const cookieHeader = req.headers.cookie ?? "";
+  const result = await resolveGoDestination(slug, cookieHeader);
+
+  switch (result.kind) {
+    case "redirect":
+      return res.status(200).json({ destination: result.destination });
+    case "not_found":
+      return res.status(404).json({ error: "template_not_found" });
+    case "error":
+      return res.status(500).json({ error: "internal_server_error" });
+  }
+}

--- a/marketing/pages/go/[slug].tsx
+++ b/marketing/pages/go/[slug].tsx
@@ -1,0 +1,97 @@
+import CustomErrorPage from "@marketing/components/pages/CustomErrorPage";
+import { GoResolveSuccessSchema } from "@marketing/lib/go/schemas";
+import { clientFetch } from "@marketing/lib/egress/client";
+import { isString } from "@marketing/types/shared/utils/general";
+import { LogIn01, SpinnerBrand } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+type GoPageState = "loading" | "not_found" | "error";
+
+export default function GoPageNextJS() {
+  const router = useRouter();
+  const [pageState, setPageState] = useState<GoPageState>("loading");
+  const slug = router.query.slug;
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    if (!isString(slug) || slug.trim() === "") {
+      setPageState("not_found");
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const response = await clientFetch(
+          `/m/api/go/${encodeURIComponent(slug)}`,
+          { credentials: "include" }
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.status === 404) {
+          setPageState("not_found");
+          return;
+        }
+
+        if (!response.ok) {
+          setPageState("error");
+          return;
+        }
+
+        const parsed = GoResolveSuccessSchema.safeParse(await response.json());
+        if (!parsed.success) {
+          setPageState("error");
+          return;
+        }
+
+        window.location.replace(parsed.data.destination);
+      } catch {
+        if (!cancelled) {
+          setPageState("error");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router.isReady, slug]);
+
+  if (pageState === "not_found") {
+    return (
+      <CustomErrorPage
+        title="404: Template not found"
+        description="This conversation template doesn't exist or is no longer available."
+        href="/"
+        label="Back to homepage"
+        icon={LogIn01}
+      />
+    );
+  }
+
+  if (pageState === "error") {
+    return (
+      <CustomErrorPage
+        title="Something went wrong"
+        description="We couldn't load this conversation template. Please try again later."
+        href="/"
+        label="Back to homepage"
+        icon={LogIn01}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <SpinnerBrand size="lg" />
+    </div>
+  );
+}

--- a/marketing/pages/index.tsx
+++ b/marketing/pages/index.tsx
@@ -1,11 +1,14 @@
 import type { LandingLayoutProps } from "@marketing/components/home/LandingLayout";
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import config from "@marketing/lib/api/config";
+import {
+  fetchAuthContext,
+  hasWorkosSessionCookie,
+} from "@marketing/lib/api/authContext";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
 import { extractUTMParams } from "@marketing/lib/utils/utm";
 import { Landing } from "@marketing/pages/home";
-import { normalizeError } from "@marketing/types/shared/utils/error_utils";
 import logger from "@marketing/logger/logger";
 import type { GetServerSideProps } from "next";
 import type { ParsedUrlQuery } from "querystring";
@@ -18,18 +21,11 @@ interface HomeProps {
   gtmTrackingId: string | null;
 }
 
-// Cap the SSR auth-context lookup so a slow/unavailable front API never hangs
-// the marketing homepage — we render the landing instead.
-const AUTH_CONTEXT_TIMEOUT_MS = 1500;
-
 /**
  * Resolve where an already-authenticated visitor should be sent, server-side.
  *
  * Mirrors the old `front` behaviour (`front/pages/index.tsx` `getServerSideProps`,
- * which called `getSession` and redirected before rendering). Marketing has no
- * WorkOS code of its own, so it asks `front` via `/api/auth-context`, forwarding
- * the incoming cookies — the `workos_session` cookie is scoped to the shared
- * `*.dust.tt` domain (`WORKOS_SESSION_COOKIE_DOMAIN`), so it reaches us here.
+ * which called `getSession` and redirected before rendering).
  *
  * `/api/auth-context` already returns the default workspace, so we redirect
  * straight to the app (`/w/<id>`) rather than bouncing through `/api/login`,
@@ -45,44 +41,29 @@ async function resolveAuthedRedirectDestination(
   cookieHeader: string,
   query: ParsedUrlQuery
 ): Promise<string | null> {
-  try {
-    const res = await fetch(`${config.getApiBaseUrl()}/api/auth-context`, {
-      headers: { cookie: cookieHeader },
-      signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      return null;
-    }
-    const data = (await res.json()) as {
-      user?: { sId?: string };
-      defaultWorkspaceId?: string | null;
-    };
-    if (!data.user) {
-      return null;
-    }
-
-    // Forward only marketing/attribution params (UTM + click IDs) so the
-    // destination keeps signup attribution.
-    const utmSearchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(extractUTMParams(query))) {
-      if (value) {
-        utmSearchParams.set(key, value);
-      }
-    }
-    const utmQueryString = utmSearchParams.toString();
-    const destinationUrl = data.defaultWorkspaceId
-      ? `${config.getAppUrl()}/w/${data.defaultWorkspaceId}`
-      : `${config.getApiBaseUrl()}/api/login`;
-    return utmQueryString
-      ? `${destinationUrl}?${utmQueryString}`
-      : destinationUrl;
-  } catch (err) {
-    logger.warn(
-      { err: normalizeError(err) },
-      "auth-context lookup failed during marketing root SSR; rendering landing"
-    );
+  const authContext = await fetchAuthContext(cookieHeader, {
+    failureLogMessage:
+      "auth-context lookup failed during marketing root SSR; rendering landing",
+  });
+  if (!authContext) {
     return null;
   }
+
+  // Forward only marketing/attribution params (UTM + click IDs) so the
+  // destination keeps signup attribution.
+  const utmSearchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(extractUTMParams(query))) {
+    if (value) {
+      utmSearchParams.set(key, value);
+    }
+  }
+  const utmQueryString = utmSearchParams.toString();
+  const destinationUrl = authContext.defaultWorkspaceId
+    ? `${config.getAppUrl()}/w/${authContext.defaultWorkspaceId}`
+    : `${config.getApiBaseUrl()}/api/login`;
+  return utmQueryString
+    ? `${destinationUrl}?${utmQueryString}`
+    : destinationUrl;
 }
 
 export const getServerSideProps: GetServerSideProps<HomeProps> = async (
@@ -97,7 +78,7 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
   // inviteToken: an expired/invalid one makes /api/login 400, and the redirect
   // intent doesn't depend on it.
   const cookieHeader = context.req.headers.cookie ?? "";
-  if (cookieHeader.includes("workos_session=")) {
+  if (hasWorkosSessionCookie(cookieHeader)) {
     const destination = await resolveAuthedRedirectDestination(
       cookieHeader,
       context.query


### PR DESCRIPTION
## Description

Adds a `dust.tt/go/<slug>` deeplink system that pre-fills the conversation composer from a Contentful `conversationDraft` entry (slug, prompt, attachments).

- **Marketing `/go/[slug]`**: client-side page calls `/m/api/go/<slug>`, which resolves the Contentful template via `getConversationDraftBySlug` and checks for an active WorkOS session. Authenticated users are redirected to `/w/<workspaceId>/conversation/new?go=<slug>`; unauthenticated users hit the login flow with a `returnTo`.
- **`front` API `GET /api/w/:wId/assistant/go-template?slug=`**: `resolveGoTemplateDraft` fetches the template from Contentful, uploads attachments server-side via `processAndStoreFromUrl` (HTTPS-only, skipping invalid URLs gracefully), and returns `{ title, prompt, attachments, attachmentErrors }`.
- **`useGoTemplateFromSearchParam`**: on the conversation page, reads `?go=`, calls the API, sets `isLoadingGoTemplate` (blocks submit, clears existing draft), injects the prompt with `replace: true` into `InputBarContainer`, attaches pre-uploaded files, then removes `?go=` from the URL.
- Refactors `marketing/lib/api/authContext.ts` (`fetchAuthContext`, `hasWorkosSessionCookie`) extracted from `pages/index.tsx` and reused in the `/go` resolver.

<img width="1276" height="1323" alt="image" src="https://github.com/user-attachments/assets/8b463a51-89c7-4446-8695-99026e25ddb5" />

https://github.com/user-attachments/assets/f8c0ba56-fa50-4135-8f0e-73c0714b9865


## Tests

- Added unit tests in `go_template.test.ts` covering: missing template (404), HTTPS-only attachment filtering, and `processAndStoreFromUrl` error handling.
- Tested the full deeplink flow manually end-to-end: unauthenticated redirect → login → returnTo → `/go/<slug>` → conversation page prefill.

## Risk

Low. The deeplink is entirely additive — existing composer flows are unaffected. `isLoadingGoTemplate` guard prevents double-submit. Template fetch errors surface as toast notifications rather than hard failures. Contentful outage degrades gracefully (error notification, composer stays usable). `processAndStoreFromUrl` for attachments is sequential and could be slow for many/large files, but this runs per-request on template load, not in the hot path.

## Deploy Plan

1. Add `CONTENTFUL_SPACE_ID`, `CONTENTFUL_ACCESS_TOKEN` (and optionally `CONTENTFUL_ENVIRONMENT`) to the `front` service environment.
2. Create the `conversationDraft` content type in Contentful (fields: `slug`, `title`, `prompt`, `attachments`).
3. Deploy marketing.
4. Deploy front.
