### PR TITLE
Add workspace-branded OG image generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,18 @@ services:
       timeout: 10s
       retries: 20
 
+  gotenberg:
+    image: gotenberg/gotenberg:8
+    profiles:
+      - gotenberg
+    ports:
+      - "3100:3000"
+    command:
+      - gotenberg
+      - --chromium-disable-javascript=false
+      - --chromium-allow-list=.*
+      - --chromium-deny-list=
+
 volumes:
   pgsql:
   qdrant_primary:

--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -113,12 +113,13 @@ app.get(
       : false;
     const requiresEmailVerification = isEmailScope && hasActiveGrants;
 
-    const { faviconUrl, logoUrl } =
+    const { faviconUrl, logoUrl, ogImageUrl } =
       await getWorkspaceBrandingPublicUrls(workspace);
 
     return ctx.json({
       faviconUrl,
       logoUrl,
+      ogImageUrl,
       requiresEmailVerification,
       shareUrl,
       title: file.fileName,

--- a/front-api/routes/v1/public/branding/index.ts
+++ b/front-api/routes/v1/public/branding/index.ts
@@ -43,13 +43,13 @@ function redirectToDefaultAsset(ctx: Context, asset: BrandingAssetName) {
  * when the workspace is entitled and has one uploaded, Dust default asset otherwise.
  *
  * Caching model: Cache-Control: public, max-age=86400, immutable. Safe because ?v= is
- * a content-addressed cache-buster — the same URL always returns the same bytes.
+ * a content-addressed cache-buster. The same URL always returns the same bytes.
  *
  * History note (do not reintroduce signed URL redirects): the previous design returned a
  * 302 to a short-lived signed URL, with Cache-Control on the redirect itself. Once the
  * browser cached the 302, it would serve the cached redirect after the signed URL had
  * expired (5 min), producing 403s from the storage backend. The ?v= immutability and
- * the signed URL expiry were solving the same problem twice; signed URLs added latency
+ * the signed URL expiry were solving the same problem twice. Signed URLs added latency
  * and a failure mode with no benefit.
  */
 app.get("/:wId/:asset", validate("param", ParamsSchema), async (ctx) => {

--- a/front-api/routes/v1/public/branding/index.ts
+++ b/front-api/routes/v1/public/branding/index.ts
@@ -89,7 +89,7 @@ app.get("/:wId/:asset", validate("param", ParamsSchema), async (ctx) => {
   }
 
   const bucket = getPrivateUploadBucket();
-  const storagePath = buildBrandingAssetStoragePath(wId, asset);
+  const storagePath = buildBrandingAssetStoragePath({ wId, asset });
   const contentTypeResult = await bucket.getFileContentType(storagePath);
   if (contentTypeResult.isErr()) {
     return redirectToDefaultAsset(ctx, asset);

--- a/front-api/routes/w/[wId]/branding/index.ts
+++ b/front-api/routes/w/[wId]/branding/index.ts
@@ -6,6 +6,7 @@ import {
 import type { BrandingAssetState } from "@app/lib/api/workspace_branding";
 import {
   deleteBrandingAsset,
+  generateAndStoreOgImage,
   getBrandingAssetState,
   promoteBrandingAsset,
   USER_UPLOADABLE_BRANDING_ASSET_NAMES,
@@ -102,6 +103,11 @@ app.patch(
         });
       }
 
+      // When the logo is removed, the OG card is no longer relevant.
+      if (asset === "logo") {
+        await deleteBrandingAsset(auth, "og");
+      }
+
       void emitAuditLogEvent({
         auth,
         action: "workspace_branding.asset_deleted",
@@ -145,6 +151,11 @@ app.patch(
           message: "Failed to promote branding asset.",
         },
       });
+    }
+
+    // Regenerate the OG card whenever the logo is updated.
+    if (asset === "logo") {
+      await generateAndStoreOgImage(auth);
     }
 
     void emitAuditLogEvent({

--- a/front-spa/src/share/ShareApp.tsx
+++ b/front-spa/src/share/ShareApp.tsx
@@ -2,6 +2,7 @@ import { PostHogTracker } from "@dust-tt/front/components/app/PostHogTracker";
 import { ErrorBoundary } from "@dust-tt/front/components/error_boundary/ErrorBoundary";
 import { SharedFilePage } from "@dust-tt/front/components/pages/share/SharedFilePage";
 import { SharedFramePage } from "@dust-tt/front/components/pages/share/SharedFramePage";
+import { ShareOgPage } from "@dust-tt/front/components/pages/share/ShareOgPage";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
 import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
@@ -24,6 +25,11 @@ const router = createBrowserRouter(
         {
           path: "/share/file/:token",
           element: <SharedFilePage />,
+        },
+        // OG card: /share/og/:wId, rendered by Gotenberg for og:image generation
+        {
+          path: "/share/og/:wId",
+          element: <ShareOgPage />,
         },
       ],
     },

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -305,6 +305,8 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       port: appDefinition.port,
+      host: true,
+      allowedHosts: ["host.docker.internal"],
       // No proxy - client calls API directly using VITE_DUST_API_URL.
       fs: {
         // Allow serving files from the front directory (for shared code)

--- a/front/components/pages/share/ShareOgPage.tsx
+++ b/front/components/pages/share/ShareOgPage.tsx
@@ -1,0 +1,37 @@
+import { useSearchParam } from "@app/lib/platform";
+import { useEffect } from "react";
+
+const setOgReady = () => document.body.setAttribute("data-og-ready", "true");
+
+export function ShareOgPage() {
+  const name = useSearchParam("name") ?? "";
+  const logoUrl = useSearchParam("logoUrl") ?? "";
+
+  // When there is no logo, signal ready immediately after mount.
+  useEffect(() => {
+    if (!logoUrl) {
+      setOgReady();
+    }
+  }, [logoUrl]);
+
+  return (
+    <div className="relative flex h-[630px] w-[1200px] items-center overflow-hidden bg-gray-50 pl-16">
+      <div className="absolute right-[-343px] top-[479px] size-40 origin-top-left rotate-[33.49deg] rounded-tl-full rounded-tr-full bg-brand-sky-blue" />
+      <div className="absolute right-[-257px] top-[302px] h-32 w-44 origin-top-left -rotate-45 bg-lime-200" />
+      <div className="absolute right-[-160px] top-14 h-[523px] w-[893px] overflow-hidden rounded-2xl bg-white outline outline-[6px] outline-neutral-50 shadow-[0px_0px_0px_2px_rgba(207,207,207,0.25),0px_-1px_14px_3px_rgba(0,0,0,0.05)]" />
+      <div className="relative z-10 flex w-80 flex-col items-start gap-6">
+        {logoUrl && (
+          <img
+            src={logoUrl}
+            className="h-12 w-52 object-contain"
+            onLoad={setOgReady}
+            onError={setOgReady}
+          />
+        )}
+        <h1 className="break-words font-['Geist'] text-[60px] font-normal leading-[64px] text-black">
+          {name}
+        </h1>
+      </div>
+    </div>
+  );
+}

--- a/front/components/pages/share/ShareOgPage.tsx
+++ b/front/components/pages/share/ShareOgPage.tsx
@@ -1,24 +1,26 @@
 import { useSearchParam } from "@app/lib/platform";
-import { useEffect } from "react";
-
-const setOgReady = () => document.body.setAttribute("data-og-ready", "true");
+import { useCallback, useEffect } from "react";
 
 export function ShareOgPage() {
   const name = useSearchParam("name") ?? "";
   const logoUrl = useSearchParam("logoUrl") ?? "";
+
+  const setOgReady = useCallback(() => {
+    document.body.setAttribute("data-og-ready", "true");
+  }, []);
 
   // When there is no logo, signal ready immediately after mount.
   useEffect(() => {
     if (!logoUrl) {
       setOgReady();
     }
-  }, [logoUrl]);
+  }, [logoUrl, setOgReady]);
 
   return (
-    <div className="relative flex h-[630px] w-[1200px] items-center overflow-hidden bg-gray-50 pl-16">
+    <div className="relative flex h-screen w-screen items-center overflow-hidden bg-gray-50 pl-16">
       <div className="absolute right-[-343px] top-[479px] size-40 origin-top-left rotate-[33.49deg] rounded-tl-full rounded-tr-full bg-brand-sky-blue" />
       <div className="absolute right-[-257px] top-[302px] h-32 w-44 origin-top-left -rotate-45 bg-lime-200" />
-      <div className="absolute right-[-160px] top-14 h-[523px] w-[893px] overflow-hidden rounded-2xl bg-white outline outline-[6px] outline-neutral-50 shadow-[0px_0px_0px_2px_rgba(207,207,207,0.25),0px_-1px_14px_3px_rgba(0,0,0,0.05)]" />
+      <div className="absolute inset-y-14 -right-40 left-1/3 overflow-hidden rounded-2xl bg-white shadow-md ring-1 ring-neutral-100" />
       <div className="relative z-10 flex w-80 flex-col items-start gap-6">
         {logoUrl && (
           <img
@@ -28,7 +30,7 @@ export function ShareOgPage() {
             onError={setOgReady}
           />
         )}
-        <h1 className="break-words font-['Geist'] text-[60px] font-normal leading-[64px] text-black">
+        <h1 className="break-words font-sans text-6xl font-normal text-black">
           {name}
         </h1>
       </div>

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -119,7 +119,7 @@ export function SharedFramePage() {
     addMeta({ property: "og:image:width", content: "1200" });
     addMeta({
       property: "og:image",
-      content: "https://dust.tt/static/og/ic.png",
+      content: shareMetadata.ogImageUrl ?? "https://dust.tt/static/og/ic.png",
     });
     addMeta({ property: "og:site_name", content: "Dust" });
     addMeta({ property: "og:url", content: shareMetadata.shareUrl });

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -387,6 +387,22 @@ const config = {
   getDocumentRendererUrl: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DOCUMENT_RENDERER_URL");
   },
+  // In local dev Gotenberg runs in Docker and cannot reach localhost.
+  // Set DOCUMENT_RENDERER_APP_URL=http://host.docker.internal:3011 in .env.local.
+  getDocumentRendererAppUrl: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("DOCUMENT_RENDERER_APP_URL") ??
+      config.getAppUrl()
+    );
+  },
+  // API URL reachable from Gotenberg's Chromium (inside Docker).
+  // Set DOCUMENT_RENDERER_API_URL=http://host.docker.internal:3000 in .env.local.
+  getDocumentRendererApiUrl: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("DOCUMENT_RENDERER_API_URL") ??
+      config.getApiBaseUrl()
+    );
+  },
   // Public viz URL (used by Gotenberg which routes through egress proxy).
   getVizPublicUrl: (): string => {
     return EnvironmentConfig.getEnvVariable("VIZ_PUBLIC_URL");

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -138,9 +138,11 @@ function collectScopedPrefixesFromPaths(scopedPaths: string[]): {
       case "conversation":
         conversationIds.add(parsed.id);
         break;
+
       case "pod":
         podIds.add(parsed.id);
         break;
+
       default:
         assertNever(parsed);
     }

--- a/front/lib/api/files/share.ts
+++ b/front/lib/api/files/share.ts
@@ -1,6 +1,7 @@
 export interface GetShareFrameMetadataResponseBody {
   faviconUrl: string | null;
   logoUrl: string | null;
+  ogImageUrl: string | null;
   requiresEmailVerification: boolean;
   shareUrl: string;
   title: string;

--- a/front/lib/api/workspace_branding/index.ts
+++ b/front/lib/api/workspace_branding/index.ts
@@ -1,12 +1,12 @@
 /**
- * Workspace branding assets — GCS path helpers and asset allowlist.
+ * Workspace branding assets, GCS path helpers and asset allowlist.
  *
  * GCS layout (private bucket):
- *   w/{wId}/branding/logo     — primary logo (light backgrounds)
- *   w/{wId}/branding/favicon  — square mark (256×256)
- *   w/{wId}/branding/og       — 1200×630 OG card (PNG, auto-generated)
+ *   w/{wId}/branding/logo     primary logo (light backgrounds)
+ *   w/{wId}/branding/favicon  square mark (256x256)
+ *   w/{wId}/branding/og       1200x630 OG card (PNG, auto-generated)
  *
- * Keys are extensionless; content type lives in GCS object metadata.
+ * Keys are extensionless, content type lives in GCS object metadata.
  */
 
 import config from "@app/lib/api/config";
@@ -21,39 +21,26 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-export const BRANDING_ASSET_NAMES = ["logo", "favicon", "og"] as const;
-export type BrandingAssetName = (typeof BRANDING_ASSET_NAMES)[number];
+export type {
+  BrandingAssetName,
+  BrandingAssetState,
+  UserUploadableBrandingAssetName,
+} from "./paths";
+export {
+  BRANDING_ASSET_NAMES,
+  BRANDING_DEFAULT_ASSET_PATHS,
+  USER_UPLOADABLE_BRANDING_ASSET_NAMES,
+  buildBrandingAssetPublicUrl,
+  buildBrandingAssetStoragePath,
+  isBrandingAssetName,
+} from "./paths";
+export { generateAndStoreOgImage } from "./og";
 
-export const USER_UPLOADABLE_BRANDING_ASSET_NAMES = [
-  "logo",
-  "favicon",
-] as const;
-export type UserUploadableBrandingAssetName =
-  (typeof USER_UPLOADABLE_BRANDING_ASSET_NAMES)[number];
-
-export type BrandingAssetState = { version: string } | null;
-
-export function isBrandingAssetName(value: string): value is BrandingAssetName {
-  return (BRANDING_ASSET_NAMES as readonly string[]).includes(value);
-}
-
-export function buildBrandingAssetStoragePath(
-  wId: string,
-  asset: BrandingAssetName
-): string {
-  return `w/${wId}/branding/${asset}`;
-}
-
-/**
- * Default public-asset paths (served from /public/static/branding/).
- * These are the Dust defaults returned when a workspace has no custom branding, is not entitled,
- * or has not uploaded a specific asset yet.
- */
-export const BRANDING_DEFAULT_ASSET_PATHS: Record<BrandingAssetName, string> = {
-  logo: "/static/DustHorizontalIcon.png",
-  favicon: "/static/favicon.png",
-  og: "/static/og/ic.png",
-};
+import type { BrandingAssetName, BrandingAssetState } from "./paths";
+import {
+  buildBrandingAssetPublicUrl,
+  buildBrandingAssetStoragePath,
+} from "./paths";
 
 // Takes `wId` directly rather than `Authenticator` because the public branding endpoint
 // serves unauthenticated requests. No auth context is available at that call site.
@@ -82,43 +69,47 @@ export async function getBrandingAssetState(
   }
 }
 
-function buildBrandingAssetPublicUrl(
-  workspace: WorkspaceResource,
-  asset: UserUploadableBrandingAssetName,
-  { version }: { version: string }
-): string {
-  return `${config.getApiBaseUrl()}/api/v1/public/branding/${workspace.sId}/${asset}?v=${version}`;
-}
-
 export async function getWorkspaceBrandingPublicUrls(
   workspace: WorkspaceResource
-): Promise<{ faviconUrl: string | null; logoUrl: string | null }> {
+): Promise<{
+  faviconUrl: string | null;
+  logoUrl: string | null;
+  ogImageUrl: string | null;
+}> {
   const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
     workspace.id
   );
   if (!subscription?.getPlan().isBrandedFramesAllowed) {
-    return { faviconUrl: null, logoUrl: null };
+    return { faviconUrl: null, logoUrl: null, ogImageUrl: null };
   }
 
-  const [logoState, faviconState] = await Promise.all([
+  const [logoState, faviconState, ogState] = await Promise.all([
     getBrandingAssetState({ wId: workspace.sId }, "logo"),
     getBrandingAssetState({ wId: workspace.sId }, "favicon"),
+    getBrandingAssetState({ wId: workspace.sId }, "og"),
   ]);
 
   return {
     faviconUrl:
       faviconState.isOk() && faviconState.value
-        ? buildBrandingAssetPublicUrl(workspace, "favicon", {
+        ? buildBrandingAssetPublicUrl(workspace.sId, "favicon", {
             version: faviconState.value.version,
           })
         : null,
     logoUrl:
       logoState.isOk() && logoState.value
-        ? buildBrandingAssetPublicUrl(workspace, "logo", {
+        ? buildBrandingAssetPublicUrl(workspace.sId, "logo", {
             version: logoState.value.version,
           })
         : null,
+    ogImageUrl:
+      ogState.isOk() && ogState.value
+        ? buildBrandingAssetPublicUrl(workspace.sId, "og", {
+            version: ogState.value.version,
+          })
+        : null,
   };
+
 }
 
 export async function promoteBrandingAsset(

--- a/front/lib/api/workspace_branding/index.ts
+++ b/front/lib/api/workspace_branding/index.ts
@@ -9,7 +9,6 @@
  * Keys are extensionless, content type lives in GCS object metadata.
  */
 
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
@@ -21,6 +20,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
+export { generateAndStoreOgImage } from "./og";
 export type {
   BrandingAssetName,
   BrandingAssetState,
@@ -29,12 +29,11 @@ export type {
 export {
   BRANDING_ASSET_NAMES,
   BRANDING_DEFAULT_ASSET_PATHS,
-  USER_UPLOADABLE_BRANDING_ASSET_NAMES,
   buildBrandingAssetPublicUrl,
   buildBrandingAssetStoragePath,
   isBrandingAssetName,
+  USER_UPLOADABLE_BRANDING_ASSET_NAMES,
 } from "./paths";
-export { generateAndStoreOgImage } from "./og";
 
 import type { BrandingAssetName, BrandingAssetState } from "./paths";
 import {
@@ -109,7 +108,6 @@ export async function getWorkspaceBrandingPublicUrls(
           })
         : null,
   };
-
 }
 
 export async function promoteBrandingAsset(

--- a/front/lib/api/workspace_branding/index.ts
+++ b/front/lib/api/workspace_branding/index.ts
@@ -49,7 +49,7 @@ export async function getBrandingAssetState(
 ): Promise<Result<BrandingAssetState, Error>> {
   try {
     const [metadata] = await getPrivateUploadBucket()
-      .file(buildBrandingAssetStoragePath(wId, asset))
+      .file(buildBrandingAssetStoragePath({ asset, wId }))
       .getMetadata();
 
     return new Ok({ version: String(metadata.generation ?? "") });
@@ -91,21 +91,30 @@ export async function getWorkspaceBrandingPublicUrls(
   return {
     faviconUrl:
       faviconState.isOk() && faviconState.value
-        ? buildBrandingAssetPublicUrl(workspace.sId, "favicon", {
-            version: faviconState.value.version,
-          })
+        ? buildBrandingAssetPublicUrl(
+            { asset: "favicon", wId: workspace.sId },
+            {
+              version: faviconState.value.version,
+            }
+          )
         : null,
     logoUrl:
       logoState.isOk() && logoState.value
-        ? buildBrandingAssetPublicUrl(workspace.sId, "logo", {
-            version: logoState.value.version,
-          })
+        ? buildBrandingAssetPublicUrl(
+            { asset: "logo", wId: workspace.sId },
+            {
+              version: logoState.value.version,
+            }
+          )
         : null,
     ogImageUrl:
       ogState.isOk() && ogState.value
-        ? buildBrandingAssetPublicUrl(workspace.sId, "og", {
-            version: ogState.value.version,
-          })
+        ? buildBrandingAssetPublicUrl(
+            { asset: "og", wId: workspace.sId },
+            {
+              version: ogState.value.version,
+            }
+          )
         : null,
   };
 }
@@ -120,7 +129,7 @@ export async function promoteBrandingAsset(
   try {
     await getPrivateUploadBucket().copyFile(
       srcPath,
-      buildBrandingAssetStoragePath(wId, asset)
+      buildBrandingAssetStoragePath({ asset, wId })
     );
 
     return new Ok(undefined);
@@ -143,7 +152,7 @@ export async function deleteBrandingAsset(
 
   try {
     await getPrivateUploadBucket().delete(
-      buildBrandingAssetStoragePath(wId, asset),
+      buildBrandingAssetStoragePath({ asset, wId }),
       {
         ignoreNotFound: true,
       }

--- a/front/lib/api/workspace_branding/og.ts
+++ b/front/lib/api/workspace_branding/og.ts
@@ -1,0 +1,54 @@
+import config from "@app/lib/api/config";
+import {
+  buildBrandingAssetPublicUrl,
+  buildBrandingAssetStoragePath,
+} from "@app/lib/api/workspace_branding/paths";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import logger from "@app/logger/logger";
+import { DocumentRenderer } from "@app/types/shared/document_renderer";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export async function generateAndStoreOgImage(
+  auth: Authenticator
+): Promise<Result<void, Error>> {
+  const documentRendererUrl = config.getDocumentRendererUrl();
+  if (!documentRendererUrl) {
+    return new Err(new Error("Document renderer not configured."));
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const logoUrl = buildBrandingAssetPublicUrl(workspace.sId, "logo", {
+    baseUrl: config.getDocumentRendererApiUrl(),
+  });
+  const pageUrl =
+    `${config.getDocumentRendererAppUrl()}/share/og/${workspace.sId}` +
+    `?name=${encodeURIComponent(workspace.name)}` +
+    `&logoUrl=${encodeURIComponent(logoUrl)}`;
+
+  const renderer = new DocumentRenderer(documentRendererUrl, logger);
+  const result = await renderer.captureScreenshot({
+    url: pageUrl,
+    waitForExpression:
+      "document.body.getAttribute('data-og-ready') === 'true'",
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+
+  const ogPath = buildBrandingAssetStoragePath(workspace.sId, "og");
+  try {
+    await getPrivateUploadBucket()
+      .file(ogPath)
+      .save(result.value, { contentType: "image/png", resumable: false });
+    return new Ok(undefined);
+  } catch (err) {
+    logger.error(
+      { wId: workspace.sId, error: normalizeError(err) },
+      "Error saving OG image"
+    );
+    return new Err(normalizeError(err));
+  }
+}

--- a/front/lib/api/workspace_branding/og.ts
+++ b/front/lib/api/workspace_branding/og.ts
@@ -20,9 +20,12 @@ export async function generateAndStoreOgImage(
   }
 
   const workspace = auth.getNonNullableWorkspace();
-  const logoUrl = buildBrandingAssetPublicUrl(workspace.sId, "logo", {
-    baseUrl: config.getDocumentRendererApiUrl(),
-  });
+  const logoUrl = buildBrandingAssetPublicUrl(
+    { asset: "logo", wId: workspace.sId },
+    {
+      baseUrl: config.getDocumentRendererApiUrl(),
+    }
+  );
   const pageUrl =
     `${config.getDocumentRendererAppUrl()}/share/og/${workspace.sId}` +
     `?name=${encodeURIComponent(workspace.name)}` +
@@ -37,17 +40,22 @@ export async function generateAndStoreOgImage(
     return new Err(result.error);
   }
 
-  const ogPath = buildBrandingAssetStoragePath(workspace.sId, "og");
+  const ogPath = buildBrandingAssetStoragePath({
+    asset: "og",
+    wId: workspace.sId,
+  });
   try {
     await getPrivateUploadBucket()
       .file(ogPath)
       .save(result.value, { contentType: "image/png", resumable: false });
+
     return new Ok(undefined);
   } catch (err) {
     logger.error(
       { wId: workspace.sId, error: normalizeError(err) },
       "Error saving OG image"
     );
+
     return new Err(normalizeError(err));
   }
 }

--- a/front/lib/api/workspace_branding/og.ts
+++ b/front/lib/api/workspace_branding/og.ts
@@ -31,8 +31,7 @@ export async function generateAndStoreOgImage(
   const renderer = new DocumentRenderer(documentRendererUrl, logger);
   const result = await renderer.captureScreenshot({
     url: pageUrl,
-    waitForExpression:
-      "document.body.getAttribute('data-og-ready') === 'true'",
+    waitForExpression: "document.body.getAttribute('data-og-ready') === 'true'",
   });
   if (result.isErr()) {
     return new Err(result.error);

--- a/front/lib/api/workspace_branding/paths.ts
+++ b/front/lib/api/workspace_branding/paths.ts
@@ -1,0 +1,46 @@
+import config from "@app/lib/api/config";
+
+export const BRANDING_ASSET_NAMES = ["logo", "favicon", "og"] as const;
+export type BrandingAssetName = (typeof BRANDING_ASSET_NAMES)[number];
+
+export const USER_UPLOADABLE_BRANDING_ASSET_NAMES = [
+  "logo",
+  "favicon",
+] as const;
+export type UserUploadableBrandingAssetName =
+  (typeof USER_UPLOADABLE_BRANDING_ASSET_NAMES)[number];
+
+export type BrandingAssetState = { version: string } | null;
+
+export function isBrandingAssetName(value: string): value is BrandingAssetName {
+  return (BRANDING_ASSET_NAMES as readonly string[]).includes(value);
+}
+
+export function buildBrandingAssetStoragePath(
+  wId: string,
+  asset: BrandingAssetName
+): string {
+  return `w/${wId}/branding/${asset}`;
+}
+
+/**
+ * Default public-asset paths (served from /public/static/branding/).
+ * These are the Dust defaults returned when a workspace has no custom branding, is not entitled,
+ * or has not uploaded a specific asset yet.
+ */
+export const BRANDING_DEFAULT_ASSET_PATHS: Record<BrandingAssetName, string> = {
+  logo: "/static/DustHorizontalIcon.png",
+  favicon: "/static/favicon.png",
+  og: "/static/og/ic.png",
+};
+
+export function buildBrandingAssetPublicUrl(
+  wId: string,
+  asset: BrandingAssetName,
+  { version, baseUrl }: { version?: string; baseUrl?: string } = {}
+): string {
+  const base = baseUrl ?? config.getApiBaseUrl();
+  const url = `${base}/api/v1/public/branding/${wId}/${asset}`;
+
+  return version ? `${url}?v=${version}` : url;
+}

--- a/front/lib/api/workspace_branding/paths.ts
+++ b/front/lib/api/workspace_branding/paths.ts
@@ -16,10 +16,13 @@ export function isBrandingAssetName(value: string): value is BrandingAssetName {
   return (BRANDING_ASSET_NAMES as readonly string[]).includes(value);
 }
 
-export function buildBrandingAssetStoragePath(
-  wId: string,
-  asset: BrandingAssetName
-): string {
+export function buildBrandingAssetStoragePath({
+  asset,
+  wId,
+}: {
+  asset: BrandingAssetName;
+  wId: string;
+}): string {
   return `w/${wId}/branding/${asset}`;
 }
 
@@ -35,8 +38,7 @@ export const BRANDING_DEFAULT_ASSET_PATHS: Record<BrandingAssetName, string> = {
 };
 
 export function buildBrandingAssetPublicUrl(
-  wId: string,
-  asset: BrandingAssetName,
+  { asset, wId }: { asset: BrandingAssetName; wId: string },
   { version, baseUrl }: { version?: string; baseUrl?: string } = {}
 ): string {
   const base = baseUrl ?? config.getApiBaseUrl();

--- a/front/types/shared/document_renderer/index.ts
+++ b/front/types/shared/document_renderer/index.ts
@@ -23,6 +23,7 @@ export interface PdfOptions {
 export interface ScreenshotOptions {
   clip?: boolean;
   height?: number;
+  waitForExpression?: string;
   width?: number;
 }
 
@@ -147,6 +148,78 @@ export class DocumentRenderer {
       return new Ok(result);
     } catch (error) {
       this.logger.error({ error }, "PDF export network error");
+      return new Err(
+        new DocumentRendererError(
+          "network_error",
+          normalizeError(error).message
+        )
+      );
+    }
+  }
+
+  /**
+   * Capture a screenshot of a self-contained HTML string.
+   * The HTML is uploaded directly to Gotenberg so no public URL is required.
+   */
+  async captureScreenshotFromHtml(
+    {html, options = {}}: { html: string, options?: ScreenshotOptions },
+  ): Promise<Result<Buffer, DocumentRendererError>> {
+    const { clip, height, waitForExpression, width } = {
+      ...DEFAULT_SCREENSHOT_OPTIONS,
+      ...options,
+    };
+
+    const formData = new FormData();
+    formData.append(
+      "files",
+      new Blob([html], { type: "text/html" }),
+      "index.html"
+    );
+    formData.append("width", width.toString());
+    formData.append("height", height.toString());
+    formData.append("format", "png");
+
+    if (clip) {
+      formData.append("clip", "true");
+    }
+
+    if (waitForExpression) {
+      formData.append("waitForExpression", waitForExpression);
+    }
+
+    try {
+      // eslint-disable-next-line no-restricted-globals
+      const response = await fetch(
+        `${this.serviceUrl}/forms/chromium/screenshot/html`,
+        {
+          method: "POST",
+          body: formData,
+          signal: AbortSignal.timeout(this.timeoutMs),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+
+        this.logger.error(
+          { status: response.status, error: errorText },
+          "HTML screenshot capture failed"
+        );
+
+        return new Err(
+          new DocumentRendererError(
+            "render_failed",
+            `HTML screenshot capture failed: ${errorText}`,
+            response.status
+          )
+        );
+
+      }
+
+      return new Ok(Buffer.from(await response.arrayBuffer()));
+    } catch (error) {
+      this.logger.error({ error }, "HTML screenshot capture network error");
+
       return new Err(
         new DocumentRendererError(
           "network_error",

--- a/front/types/shared/document_renderer/index.ts
+++ b/front/types/shared/document_renderer/index.ts
@@ -57,7 +57,9 @@ const DEFAULT_PDF_OPTIONS: Omit<Required<PdfOptions>, "footerHtml"> = {
 };
 
 // This matches Open Graph image dimensions for link previews.
-const DEFAULT_SCREENSHOT_OPTIONS: Required<ScreenshotOptions> = {
+const DEFAULT_SCREENSHOT_OPTIONS: Required<
+  Omit<ScreenshotOptions, "waitForExpression">
+> = {
   clip: true,
   height: 630,
   width: 1200,

--- a/front/types/shared/document_renderer/index.ts
+++ b/front/types/shared/document_renderer/index.ts
@@ -161,9 +161,13 @@ export class DocumentRenderer {
    * Capture a screenshot of a self-contained HTML string.
    * The HTML is uploaded directly to Gotenberg so no public URL is required.
    */
-  async captureScreenshotFromHtml(
-    {html, options = {}}: { html: string, options?: ScreenshotOptions },
-  ): Promise<Result<Buffer, DocumentRendererError>> {
+  async captureScreenshotFromHtml({
+    html,
+    options = {},
+  }: {
+    html: string;
+    options?: ScreenshotOptions;
+  }): Promise<Result<Buffer, DocumentRendererError>> {
     const { clip, height, waitForExpression, width } = {
       ...DEFAULT_SCREENSHOT_OPTIONS,
       ...options,
@@ -213,7 +217,6 @@ export class DocumentRenderer {
             response.status
           )
         );
-
       }
 
       return new Ok(Buffer.from(await response.arrayBuffer()));


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Workspaces with the branded frames entitlement can now generate a custom Open Graph image that's used as the `og:image` for their shared frames.

When a logo is promoted via the branding settings, the backend captures a screenshot of a React page served from front-spa at `/share/og/:wId` using Gotenberg. The page receives the workspace name and logo URL as query parameters so no API calls are needed from the renderer, which avoids Docker networking issues. The resulting PNG is stored in the private GCS bucket alongside the other branding assets and served through the existing public branding endpoint.

Two new config vars (`DOCUMENT_RENDERER_APP_URL`, `DOCUMENT_RENDERER_API_URL`) let the renderer reach the SPA and API separately, which is necessary when Gotenberg runs inside Docker and must use `host.docker.internal` rather than localhost.

> [!NOTE]
> This will be moved to a dedicated worker very soon since we want to do it per frame.

**Example** (log broken on purpose)
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/cd26713c-7e5c-4023-80fe-7dbf5a3a2926" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
