### PR TITLE
fix:  handle GCS network errors in file listing

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -82,10 +82,21 @@ app.get(
     }
     const dustFs = fsResult.value;
 
+    const listResult = await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`);
+    if (listResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to list project files.",
+        },
+      });
+    }
+
     let entries = await enrichListWithFileResourceIds(
       auth,
       dustFs,
-      await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`)
+      listResult.value
     );
 
     if (updatedSinceFilter !== null) {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/files/index.ts
@@ -55,10 +55,21 @@ app.get(
     // Scope the listing to the conversation mount only. For pod conversations the
     // DustFileSystem also has a pod mount and we do not want to expose pod files here.
     const dustFs = fsResult.value;
+    const listResult = await dustFs.list(`${SCOPED_PREFIX_CONVERSATION}${cId}`);
+    if (listResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to list conversation files.",
+        },
+      });
+    }
+
     const files = await enrichListWithFileResourceIds(
       auth,
       dustFs,
-      await dustFs.list(`${SCOPED_PREFIX_CONVERSATION}${cId}`)
+      listResult.value
     );
 
     return ctx.json({ files });

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -54,10 +54,21 @@ app.get(
     }
 
     const dustFs = fsResult.value;
+    const listResult = await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`);
+    if (listResult.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to list space files.",
+        },
+      });
+    }
+
     const files = await enrichListWithFileResourceIds(
       auth,
       dustFs,
-      await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`)
+      listResult.value
     );
 
     return ctx.json({ files });

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -154,9 +154,7 @@ export async function listHandler(
 
   const listRes = await dustFs.list(scopedPrefix, { includeProcessed: true });
   if (listRes.isErr()) {
-    return new Err(
-      new MCPError("Failed to list files.", { tracked: true })
-    );
+    return new Err(new MCPError("Failed to list files.", { tracked: true }));
   }
 
   // Enrich, so we can expose ids for interactive content files.

--- a/front/lib/api/actions/servers/files/tools/list.ts
+++ b/front/lib/api/actions/servers/files/tools/list.ts
@@ -152,11 +152,18 @@ export async function listHandler(
       assertNever(listScope);
   }
 
+  const listRes = await dustFs.list(scopedPrefix, { includeProcessed: true });
+  if (listRes.isErr()) {
+    return new Err(
+      new MCPError("Failed to list files.", { tracked: true })
+    );
+  }
+
   // Enrich, so we can expose ids for interactive content files.
   const entries = await enrichListWithFileResourceIds(
     extra.auth,
     dustFs,
-    await dustFs.list(scopedPrefix, { includeProcessed: true })
+    listRes.value
   );
 
   const [dirs, files] = partition(entries, (e) => e.isDirectory);

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -434,10 +434,17 @@ export function createProjectManagerTools(
             })
           );
         }
-        const podFiles = await fsResult.value.list(
+        const podFilesResult = await fsResult.value.list(
           `${SCOPED_PREFIX_POD}${pod.sId}`
         );
-        const projectFileCount = podFiles.filter((e) => !e.isDirectory).length;
+        if (podFilesResult.isErr()) {
+          return new Err(
+            new MCPError("Failed to list Pod files.", { tracked: true })
+          );
+        }
+        const projectFileCount = podFilesResult.value.filter(
+          (e) => !e.isDirectory
+        ).length;
 
         // Construct project URL
         const projectPath = getPodRoute(owner.sId, pod.sId);

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -25,11 +25,12 @@ export interface FileSystemBackend {
    * List entries under `scopedPath` (should end with `/` to list a prefix).
    * Returns an empty array when nothing exists under that path.
    * `.processed.*` siblings are filtered out unless `includeProcessed` is true.
+   * Returns `Err` on storage errors (e.g. network failure).
    */
   list(
     scopedPath: string,
     opts?: { maxFiles?: number; includeProcessed?: boolean }
-  ): Promise<FileSystemEntry[]>;
+  ): Promise<Result<FileSystemEntry[], DustFileSystemError>>;
 
   /**
    * Returns `Ok(null)` when the file does not exist, `Ok(Readable)` on success.

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -1,6 +1,7 @@
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
+import assert from "assert";
 import { Readable } from "stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -101,7 +102,9 @@ describe("GCSFileSystemBackend.list", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`);
+    assert(result.isOk());
+    const entries = result.value;
 
     const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
     expect(paths).toContain(`conversation-${CONV_ID}/report.pdf`);
@@ -123,9 +126,11 @@ describe("GCSFileSystemBackend.list", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`, {
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`, {
       includeProcessed: true,
     });
+    assert(result.isOk());
+    const entries = result.value;
 
     const paths = entries.filter((e) => !e.isDirectory).map((e) => e.path);
     expect(paths).toContain(`conversation-${CONV_ID}/report.pdf`);
@@ -139,7 +144,9 @@ describe("GCSFileSystemBackend.list", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`);
+    assert(result.isOk());
+    const entries = result.value;
 
     expect(entries[0].path).toBe(`conversation-${CONV_ID}/subdir/data.csv`);
     expect(entries[0].fileName).toBe("data.csv");
@@ -155,9 +162,10 @@ describe("GCSFileSystemBackend.list", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`);
+    assert(result.isOk());
 
-    for (const entry of entries) {
+    for (const entry of result.value) {
       expect(entry.isDirectory).toBe(false);
       if (!entry.isDirectory) {
         expect(entry.thumbnailUrl).toBeNull();
@@ -175,7 +183,9 @@ describe("GCSFileSystemBackend.list", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`);
+    assert(result.isOk());
+    const entries = result.value;
 
     const dirs = entries.filter((e) => e.isDirectory);
     const files = entries.filter((e) => !e.isDirectory);
@@ -197,8 +207,9 @@ describe("GCSFileSystemBackend.list", () => {
       pageFetchCount: 1,
     });
 
-    const entries = await makeBackend().list(`conversation-${CONV_ID}/`);
-    const entry = entries[0];
+    const result = await makeBackend().list(`conversation-${CONV_ID}/`);
+    assert(result.isOk());
+    const entry = result.value[0];
 
     expect(entry.isDirectory).toBe(false);
     if (!entry.isDirectory) {

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -235,8 +235,9 @@ describe("GCSFileSystemBackend.list", () => {
   });
 
   it("returns empty array for unrecognised scoped path prefix", async () => {
-    const entries = await makeBackend().list("unknown-prefix/foo");
-    expect(entries).toEqual([]);
+    const result = await makeBackend().list("unknown-prefix/foo");
+    assert(result.isOk());
+    expect(result.value).toEqual([]);
   });
 });
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -140,7 +140,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       maxFiles,
       includeProcessed = false,
     }: { maxFiles?: number; includeProcessed?: boolean } = {}
-  ): Promise<FileSystemEntry[]> {
+  ): Promise<Result<FileSystemEntry[], DustFileSystemError>> {
     const normalised = scopedPath.endsWith("/") ? scopedPath : `${scopedPath}/`;
     const gcsPrefix = this.toGCSPath(normalised);
 
@@ -150,36 +150,42 @@ export class GCSFileSystemBackend implements FileSystemBackend {
         "GCSFileSystemBackend.list: unrecognised scoped path"
       );
 
-      return [];
+      return new Ok([]);
     }
 
     const bucket = getPrivateUploadBucket();
     let rawFiles: { name: string; metadata: Record<string, unknown> }[];
 
-    if (maxFiles !== undefined) {
-      rawFiles = await bucket.getFiles({
-        prefix: gcsPrefix,
-        maxResults: maxFiles,
-      });
-    } else {
-      const result = await bucket.getAllFilesByPrefix({
-        prefix: gcsPrefix,
-        pageSize: GCS_LIST_PAGE_SIZE,
-      });
+    try {
+      if (maxFiles !== undefined) {
+        rawFiles = await bucket.getFiles({
+          prefix: gcsPrefix,
+          maxResults: maxFiles,
+        });
+      } else {
+        const result = await bucket.getAllFilesByPrefix({
+          prefix: gcsPrefix,
+          pageSize: GCS_LIST_PAGE_SIZE,
+        });
 
-      if (result.pageFetchCount > 1) {
-        logger.warn(
-          {
-            workspaceId: this.workspaceId,
-            prefix: gcsPrefix,
-            pageFetchCount: result.pageFetchCount,
-            objectCount: result.files.length,
-          },
-          "GCSFileSystemBackend.list: multiple GCS list requests, prefix has many objects"
-        );
+        if (result.pageFetchCount > 1) {
+          logger.warn(
+            {
+              workspaceId: this.workspaceId,
+              prefix: gcsPrefix,
+              pageFetchCount: result.pageFetchCount,
+              objectCount: result.files.length,
+            },
+            "GCSFileSystemBackend.list: multiple GCS list requests, prefix has many objects"
+          );
+        }
+
+        rawFiles = result.files;
       }
-
-      rawFiles = result.files;
+    } catch (err) {
+      return new Err(
+        new DustFileSystemError("internal", normalizeError(err).message)
+      );
     }
 
     const folderPlaceholders = rawFiles.filter((f) => f.name.endsWith("/"));
@@ -248,7 +254,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
       };
     });
 
-    return [...folderEntries, ...fileEntries];
+    return new Ok([...folderEntries, ...fileEntries]);
   }
 
   async read(

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -878,9 +878,10 @@ describe("DustFileSystem.list thumbnail URLs", () => {
 
     const fsResult = await DustFileSystem.forConversation(auth, conversation);
     assert(fsResult.isOk());
-    const entries = await fsResult.value.list();
+    const listResult = await fsResult.value.list();
+    assert(listResult.isOk());
 
-    const file = entries.find((e) => !e.isDirectory);
+    const file = listResult.value.find((e) => !e.isDirectory);
     assert(file !== undefined && !file.isDirectory);
     expect(file.thumbnailUrl).toBe(
       `https://dust.tt/api/w/${workspaceId}` +
@@ -919,9 +920,10 @@ describe("DustFileSystem.list thumbnail URLs", () => {
 
     const fsResult = await DustFileSystem.forConversation(auth, conversation);
     assert(fsResult.isOk());
-    const entries = await fsResult.value.list();
+    const listResult = await fsResult.value.list();
+    assert(listResult.isOk());
 
-    const file = entries.find((e) => !e.isDirectory);
+    const file = listResult.value.find((e) => !e.isDirectory);
     assert(file !== undefined && !file.isDirectory);
     expect(file.thumbnailUrl).toBeNull();
   });

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -611,8 +611,9 @@ export class DustFileSystem {
   async list(
     scopedPath?: string,
     opts?: { maxFiles?: number; includeProcessed?: boolean }
-  ): Promise<FileSystemEntry[]> {
+  ): Promise<Result<FileSystemEntry[], DustFileSystemError>> {
     const workspaceId = this.auth.getNonNullableWorkspace().sId;
+
     const withThumbnails = (entries: FileSystemEntry[]): FileSystemEntry[] =>
       entries.map((entry) =>
         entry.isDirectory
@@ -630,9 +631,15 @@ export class DustFileSystem {
           { err: resolved.error, scopedPath },
           "DustFileSystem.list: access check failed"
         );
-        return [];
+        return new Ok([]);
       }
-      return withThumbnails(await this.backend.list(resolved.value.path, opts));
+
+      const listResult = await this.backend.list(resolved.value.path, opts);
+      if (listResult.isErr()) {
+        return listResult;
+      }
+
+      return new Ok(withThumbnails(listResult.value));
     }
 
     const results: FileSystemEntry[] = [];
@@ -640,10 +647,18 @@ export class DustFileSystem {
       if (!mount.permissions.canRead) {
         continue;
       }
-      const entries = await this.backend.list(`${mount.scopedPrefix}/`, opts);
-      results.push(...withThumbnails(entries));
+
+      const listResult = await this.backend.list(
+        `${mount.scopedPrefix}/`,
+        opts
+      );
+      if (listResult.isErr()) {
+        return listResult;
+      }
+
+      results.push(...withThumbnails(listResult.value));
     }
-    return results;
+    return new Ok(results);
   }
 
   /**

--- a/front/lib/api/mcp_server/tools/files/list.ts
+++ b/front/lib/api/mcp_server/tools/files/list.ts
@@ -28,13 +28,16 @@ export function registerFilesListTool(server: McpServer) {
         return mcpError(fsResult.error);
       }
 
-      const text = await formatFileListOutput(
+      const textResult = await formatFileListOutput(
         auth,
         fsResult.value,
         scopedPrefixForScope(scope)
       );
+      if (textResult.isErr()) {
+        return mcpError("Failed to list files.");
+      }
 
-      return mcpJsonResponse({ text });
+      return mcpJsonResponse({ text: textResult.value });
     }
   );
 }

--- a/front/lib/api/mcp_server/tools/files/list_output.ts
+++ b/front/lib/api/mcp_server/tools/files/list_output.ts
@@ -11,7 +11,7 @@ import {
   stripMimeParameters,
 } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import partition from "lodash/partition";
 
 function getDirAndFileName(path: string): { dir: string; fileName: string } {

--- a/front/lib/api/mcp_server/tools/files/list_output.ts
+++ b/front/lib/api/mcp_server/tools/files/list_output.ts
@@ -10,6 +10,8 @@ import {
   isInteractiveContentType,
   stripMimeParameters,
 } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import partition from "lodash/partition";
 
 function getDirAndFileName(path: string): { dir: string; fileName: string } {
@@ -28,11 +30,18 @@ export async function formatFileListOutput(
   auth: Authenticator,
   dustFs: DustFileSystem,
   scopedPrefix: string
-): Promise<string> {
+): Promise<Result<string, Error>> {
+  const listResult = await dustFs.list(scopedPrefix, {
+    includeProcessed: true,
+  });
+  if (listResult.isErr()) {
+    return listResult;
+  }
+
   const entries = await enrichListWithFileResourceIds(
     auth,
     dustFs,
-    await dustFs.list(scopedPrefix, { includeProcessed: true })
+    listResult.value
   );
 
   const [dirs, rawFiles] = partition(entries, (e) => e.isDirectory);
@@ -41,10 +50,10 @@ export async function formatFileListOutput(
   );
 
   if (dirs.length === 0 && files.length === 0) {
-    return "No files available.";
+    return new Ok("No files available.");
   }
 
-  return formatFileEntries(dirs, files);
+  return new Ok(formatFileEntries(dirs, files));
 }
 
 function formatFileEntries(

--- a/front/lib/api/mcp_server/tools/pods/get.ts
+++ b/front/lib/api/mcp_server/tools/pods/get.ts
@@ -49,10 +49,15 @@ export function registerPodsGetTool(server: McpServer) {
       if (fsResult.isErr()) {
         return mcpError("Failed to initialise file system for this Pod.");
       }
-      const podFiles = await fsResult.value.list(
+      const podFilesResult = await fsResult.value.list(
         `${SCOPED_PREFIX_POD}${pod.sId}`
       );
-      const fileCount = podFiles.filter((entry) => !entry.isDirectory).length;
+      if (podFilesResult.isErr()) {
+        return mcpError("Failed to list Pod files.");
+      }
+      const fileCount = podFilesResult.value.filter(
+        (entry) => !entry.isDirectory
+      ).length;
 
       return mcpJsonResponse({
         pod: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Transient GCS network failures during file listing (such as socket hang ups) were propagating as unhandled exceptions and crashing the request rather than being returned as a structured error. This was causing noisy 500s in production with no graceful degradation.

The listing operation now follows the same contract as every other operation in the backend: it catches storage-layer errors and surfaces them as a typed domain error, which routes map to a proper 500 response. The GCS SDK already retries these failures internally. This change handles the case where all retries are exhausted.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
