### PR TITLE
Add Contentful conversationDraft types and marketing auth context helper.

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -462,6 +462,12 @@ const config = {
   getContentfulAccessToken: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("CONTENTFUL_ACCESS_TOKEN");
   },
+  getContentfulEnvironment: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("CONTENTFUL_ENVIRONMENT") ??
+      "master"
+    );
+  },
   getContentfulPreviewSecret: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(
       "CONTENTFUL_PREVIEW_SECRET"

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -1,0 +1,146 @@
+import config from "@app/lib/api/config";
+import type {
+  ConversationDraft,
+  ConversationDraftAttachment,
+  ConversationDraftSkeleton,
+} from "@app/lib/contentful/types";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
+import type { Asset, ContentfulClientApi, Entry } from "contentful";
+import { createClient } from "contentful";
+import { z } from "zod";
+
+let client: ContentfulClientApi<undefined> | null = null;
+
+function getClient() {
+  if (!client) {
+    const spaceId = config.getContentfulSpaceId();
+    const accessToken = config.getContentfulAccessToken();
+
+    if (!spaceId || !accessToken) {
+      throw new Error(
+        "Contentful credentials not configured. " +
+          "Set CONTENTFUL_SPACE_ID and CONTENTFUL_ACCESS_TOKEN environment variables."
+      );
+    }
+
+    client = createClient({
+      space: spaceId,
+      accessToken,
+      environment: process.env.CONTENTFUL_ENVIRONMENT ?? "master",
+    });
+  }
+  return client.withoutUnresolvableLinks;
+}
+
+function isContentfulAsset(value: unknown): value is Asset {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "sys" in value &&
+    "fields" in value &&
+    value.fields !== undefined
+  );
+}
+
+const ConversationDraftFieldsSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  prompt: z.string().min(1),
+  attachments: z
+    .array(z.custom<Asset>((value): value is Asset => isContentfulAsset(value)))
+    .optional(),
+});
+
+function contentfulAssetToAttachment(
+  asset: Asset
+): ConversationDraftAttachment | null {
+  const file = asset.fields?.file;
+  if (!file || !isString(file.url)) {
+    return null;
+  }
+
+  const url = file.url.startsWith("//")
+    ? `https:${file.url}`
+    : file.url.startsWith("http")
+      ? file.url
+      : `https:${file.url}`;
+
+  const fileName =
+    (isString(asset.fields.title) ? asset.fields.title : null) ||
+    (isString(file.fileName) ? file.fileName : null) ||
+    new URL(url).pathname.split("/").pop() ||
+    "attachment";
+
+  const contentType = isString(file.contentType) ? file.contentType : null;
+
+  return { url, fileName, contentType };
+}
+
+function contentfulEntryToConversationDraft(
+  entry: Entry<ConversationDraftSkeleton>
+): ConversationDraft | null {
+  const result = ConversationDraftFieldsSchema.safeParse(entry.fields);
+  if (!result.success) {
+    return null;
+  }
+
+  const parsed = result.data;
+
+  const attachments = (parsed.attachments ?? [])
+    .map(contentfulAssetToAttachment)
+    .filter(
+      (attachment): attachment is ConversationDraftAttachment =>
+        attachment !== null
+    );
+
+  return {
+    slug: parsed.slug,
+    title: parsed.title,
+    prompt: parsed.prompt.trim(),
+    attachments,
+  };
+}
+
+export async function getConversationDraftBySlug(
+  slug: string
+): Promise<Result<ConversationDraft | null, Error>> {
+  try {
+    const contentfulClient = getClient();
+    const queryParams: Record<string, string | number> = {
+      content_type: "conversationDraft",
+      "fields.slug": slug,
+      limit: 1,
+      include: 1,
+    };
+    const response =
+      await contentfulClient.getEntries<ConversationDraftSkeleton>(queryParams);
+
+    if (response.items.length === 0) {
+      return new Ok(null);
+    }
+
+    return new Ok(contentfulEntryToConversationDraft(response.items[0]));
+  } catch (error) {
+    logger.error(
+      { error, slug },
+      "[Contentful] Failed to get conversation draft by slug"
+    );
+    return new Err(normalizeError(error));
+  }
+}
+
+export function isHttpsUrl(url: string): boolean {
+  if (!isString(url)) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -30,7 +30,7 @@ function getClient() {
     client = createClient({
       space: spaceId,
       accessToken,
-      environment: process.env.CONTENTFUL_ENVIRONMENT ?? "master",
+      environment: config.getContentfulEnvironment(),
     });
   }
   return client.withoutUnresolvableLinks;

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -1,0 +1,35 @@
+import type { Asset, EntrySkeletonType } from "contentful";
+
+/**
+ * Contentful content type: `conversationDraft`
+ *
+ * Fields:
+ * - slug (Symbol, required, unique, exactly 4 chars)
+ * - title (Symbol, required, unique)
+ * - prompt (Long text, required)
+ * - attachments (Array of Asset links, optional, max 8)
+ */
+export interface ConversationDraftFields {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments?: Asset[];
+}
+
+export type ConversationDraftSkeleton = EntrySkeletonType<
+  ConversationDraftFields,
+  "conversationDraft"
+>;
+
+export interface ConversationDraftAttachment {
+  url: string;
+  fileName: string;
+  contentType: string | null;
+}
+
+export interface ConversationDraft {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments: ConversationDraftAttachment[];
+}

--- a/marketing/lib/api/authContext.ts
+++ b/marketing/lib/api/authContext.ts
@@ -1,0 +1,75 @@
+import config from "@marketing/lib/api/config";
+import logger from "@marketing/logger/logger";
+import { normalizeError } from "@marketing/types/shared/utils/error_utils";
+import type { UserType } from "@marketing/types/user";
+import { z } from "zod";
+
+export const AUTH_CONTEXT_URL = `${config.getApiBaseUrl()}/api/auth-context`;
+
+// Cap SSR auth-context lookups so a slow/unavailable front API never hangs pages.
+export const AUTH_CONTEXT_TIMEOUT_MS = 1500;
+
+export type MarketingAuthContext = {
+  user: UserType;
+  defaultWorkspaceId: string | null;
+};
+
+const AuthContextUserSchema = z.object({
+  sId: z.string(),
+  id: z.number(),
+  createdAt: z.number(),
+  provider: z
+    .enum(["auth0", "github", "google", "okta", "samlp", "waad"])
+    .nullable(),
+  username: z.string(),
+  email: z.string(),
+  firstName: z.string(),
+  lastName: z.string().nullable(),
+  fullName: z.string(),
+  image: z.string().nullable(),
+  lastLoginAt: z.number().nullable(),
+});
+
+const AuthContextResponseSchema = z.object({
+  user: AuthContextUserSchema,
+  defaultWorkspaceId: z.string().nullable().optional(),
+});
+
+export function hasWorkosSessionCookie(cookieHeader: string): boolean {
+  return cookieHeader.includes("workos_session=");
+}
+
+/**
+ * Server-side auth-context lookup for marketing pages.
+ *
+ * Marketing has no WorkOS code of its own, so it asks `front` via
+ * `/api/auth-context`, forwarding the incoming cookies — the
+ * `workos_session` cookie is scoped to the shared `*.dust.tt` domain.
+ */
+export async function fetchAuthContext(
+  cookieHeader: string,
+  {
+    failureLogMessage = "auth-context lookup failed",
+  }: { failureLogMessage?: string } = {}
+): Promise<MarketingAuthContext | null> {
+  try {
+    const res = await fetch(AUTH_CONTEXT_URL, {
+      headers: { cookie: cookieHeader },
+      signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const parsed = AuthContextResponseSchema.safeParse(await res.json());
+    if (!parsed.success) {
+      return null;
+    }
+    return {
+      user: parsed.data.user,
+      defaultWorkspaceId: parsed.data.defaultWorkspaceId ?? null,
+    };
+  } catch (err) {
+    logger.warn({ err: normalizeError(err) }, failureLogMessage);
+    return null;
+  }
+}

--- a/marketing/lib/contentful/client.ts
+++ b/marketing/lib/contentful/client.ts
@@ -30,6 +30,9 @@ import type {
   QuizSettings,
   QuizSettingsSkeleton,
   SearchableItem,
+  ConversationDraft,
+  ConversationDraftAttachment,
+  ConversationDraftSkeleton,
 } from "@marketing/lib/contentful/types";
 import {
   ACADEMY_LOCALE_COOKIE,
@@ -1877,6 +1880,94 @@ export async function getAllHomepageNews(
     return new Ok(items);
   } catch (error) {
     logger.error({ error }, "[Contentful] Failed to fetch homepage news");
+    return new Err(normalizeError(error));
+  }
+}
+
+const ConversationDraftFieldsSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  prompt: z.string().min(1),
+  attachments: z
+    .array(z.custom<Asset>((value): value is Asset => isContentfulAsset(value)))
+    .optional(),
+});
+
+function contentfulAssetToAttachment(
+  asset: Asset
+): ConversationDraftAttachment | null {
+  const file = asset.fields?.file;
+  if (!file || !isString(file.url)) {
+    return null;
+  }
+
+  const url = file.url.startsWith("//")
+    ? `https:${file.url}`
+    : file.url.startsWith("http")
+      ? file.url
+      : `https:${file.url}`;
+
+  const fileName =
+    (isString(asset.fields.title) ? asset.fields.title : null) ||
+    (isString(file.fileName) ? file.fileName : null) ||
+    new URL(url).pathname.split("/").pop() ||
+    "attachment";
+
+  const contentType = isString(file.contentType) ? file.contentType : null;
+
+  return { url, fileName, contentType };
+}
+
+function contentfulEntryToConversationDraft(
+  entry: Entry<ConversationDraftSkeleton>
+): ConversationDraft | null {
+  const result = ConversationDraftFieldsSchema.safeParse(entry.fields);
+  if (!result.success) {
+    return null;
+  }
+
+  const parsed = result.data;
+
+  const attachments = (parsed.attachments ?? [])
+    .map(contentfulAssetToAttachment)
+    .filter(
+      (attachment): attachment is ConversationDraftAttachment =>
+        attachment !== null
+    );
+
+  return {
+    slug: parsed.slug,
+    title: parsed.title,
+    prompt: parsed.prompt.trim(),
+    attachments,
+  };
+}
+
+export async function getConversationDraftBySlug(
+  slug: string,
+  resolvedUrl: string = ""
+): Promise<Result<ConversationDraft | null, Error>> {
+  try {
+    const contentfulClient = getContentfulClient(resolvedUrl);
+    const queryParams: Record<string, string | number> = {
+      content_type: "conversationDraft",
+      "fields.slug": slug,
+      limit: 1,
+      include: 1,
+    };
+    const response =
+      await contentfulClient.getEntries<ConversationDraftSkeleton>(queryParams);
+
+    if (response.items.length === 0) {
+      return new Ok(null);
+    }
+
+    return new Ok(contentfulEntryToConversationDraft(response.items[0]));
+  } catch (error) {
+    logger.error(
+      { error, slug },
+      "[Contentful] Failed to get conversation draft by slug"
+    );
     return new Err(normalizeError(error));
   }
 }

--- a/marketing/lib/contentful/types.ts
+++ b/marketing/lib/contentful/types.ts
@@ -603,3 +603,31 @@ export interface LessonPageProps {
   academySettings: AcademySettings;
   quizSettings: QuizSettings;
 }
+
+// Conversation draft (deeplink) types
+//
+// Contentful content type id: `conversationDraft`
+export interface ConversationDraftFields {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments?: Asset[];
+}
+
+export type ConversationDraftSkeleton = EntrySkeletonType<
+  ConversationDraftFields,
+  "conversationDraft"
+>;
+
+export interface ConversationDraftAttachment {
+  url: string;
+  fileName: string;
+  contentType: string | null;
+}
+
+export interface ConversationDraft {
+  slug: string;
+  title: string;
+  prompt: string;
+  attachments: ConversationDraftAttachment[];
+}

--- a/marketing/lib/swr/website.ts
+++ b/marketing/lib/swr/website.ts
@@ -1,15 +1,10 @@
-import config from "@marketing/lib/api/config";
+import {
+  AUTH_CONTEXT_URL,
+  type MarketingAuthContext,
+} from "@marketing/lib/api/authContext";
 import { useSWRWithDefaults } from "@marketing/lib/swr/swr";
-import type { UserType } from "@marketing/types/user";
 
-type GetNoWorkspaceAuthContextResponseType = {
-  user: UserType;
-  defaultWorkspaceId: string | null;
-};
-
-// /api/auth-context lives on front. Marketing reads it cross-origin with
-// credentials so the session cookie still travels.
-const AUTH_CONTEXT_URL = `${config.getApiBaseUrl()}/api/auth-context`;
+type GetNoWorkspaceAuthContextResponseType = MarketingAuthContext;
 
 // A fetcher that does NOT redirect to login on auth errors.
 // The global fetcher in fetcher.ts redirects to /api/workos/login on

--- a/marketing/pages/index.tsx
+++ b/marketing/pages/index.tsx
@@ -1,11 +1,14 @@
 import type { LandingLayoutProps } from "@marketing/components/home/LandingLayout";
 import LandingLayout from "@marketing/components/home/LandingLayout";
 import config from "@marketing/lib/api/config";
+import {
+  fetchAuthContext,
+  hasWorkosSessionCookie,
+} from "@marketing/lib/api/authContext";
 import type { NewsItem } from "@marketing/lib/homepage_news";
 import { fetchHomepageNews } from "@marketing/lib/homepage_news";
 import { extractUTMParams } from "@marketing/lib/utils/utm";
 import { Landing } from "@marketing/pages/home";
-import { normalizeError } from "@marketing/types/shared/utils/error_utils";
 import logger from "@marketing/logger/logger";
 import type { GetServerSideProps } from "next";
 import type { ParsedUrlQuery } from "querystring";
@@ -18,18 +21,11 @@ interface HomeProps {
   gtmTrackingId: string | null;
 }
 
-// Cap the SSR auth-context lookup so a slow/unavailable front API never hangs
-// the marketing homepage — we render the landing instead.
-const AUTH_CONTEXT_TIMEOUT_MS = 1500;
-
 /**
  * Resolve where an already-authenticated visitor should be sent, server-side.
  *
  * Mirrors the old `front` behaviour (`front/pages/index.tsx` `getServerSideProps`,
- * which called `getSession` and redirected before rendering). Marketing has no
- * WorkOS code of its own, so it asks `front` via `/api/auth-context`, forwarding
- * the incoming cookies — the `workos_session` cookie is scoped to the shared
- * `*.dust.tt` domain (`WORKOS_SESSION_COOKIE_DOMAIN`), so it reaches us here.
+ * which called `getSession` and redirected before rendering).
  *
  * `/api/auth-context` already returns the default workspace, so we redirect
  * straight to the app (`/w/<id>`) rather than bouncing through `/api/login`,
@@ -45,44 +41,29 @@ async function resolveAuthedRedirectDestination(
   cookieHeader: string,
   query: ParsedUrlQuery
 ): Promise<string | null> {
-  try {
-    const res = await fetch(`${config.getApiBaseUrl()}/api/auth-context`, {
-      headers: { cookie: cookieHeader },
-      signal: AbortSignal.timeout(AUTH_CONTEXT_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      return null;
-    }
-    const data = (await res.json()) as {
-      user?: { sId?: string };
-      defaultWorkspaceId?: string | null;
-    };
-    if (!data.user) {
-      return null;
-    }
-
-    // Forward only marketing/attribution params (UTM + click IDs) so the
-    // destination keeps signup attribution.
-    const utmSearchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(extractUTMParams(query))) {
-      if (value) {
-        utmSearchParams.set(key, value);
-      }
-    }
-    const utmQueryString = utmSearchParams.toString();
-    const destinationUrl = data.defaultWorkspaceId
-      ? `${config.getAppUrl()}/w/${data.defaultWorkspaceId}`
-      : `${config.getApiBaseUrl()}/api/login`;
-    return utmQueryString
-      ? `${destinationUrl}?${utmQueryString}`
-      : destinationUrl;
-  } catch (err) {
-    logger.warn(
-      { err: normalizeError(err) },
-      "auth-context lookup failed during marketing root SSR; rendering landing"
-    );
+  const authContext = await fetchAuthContext(cookieHeader, {
+    failureLogMessage:
+      "auth-context lookup failed during marketing root SSR; rendering landing",
+  });
+  if (!authContext) {
     return null;
   }
+
+  // Forward only marketing/attribution params (UTM + click IDs) so the
+  // destination keeps signup attribution.
+  const utmSearchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(extractUTMParams(query))) {
+    if (value) {
+      utmSearchParams.set(key, value);
+    }
+  }
+  const utmQueryString = utmSearchParams.toString();
+  const destinationUrl = authContext.defaultWorkspaceId
+    ? `${config.getAppUrl()}/w/${authContext.defaultWorkspaceId}`
+    : `${config.getApiBaseUrl()}/api/login`;
+  return utmQueryString
+    ? `${destinationUrl}?${utmQueryString}`
+    : destinationUrl;
 }
 
 export const getServerSideProps: GetServerSideProps<HomeProps> = async (
@@ -97,7 +78,7 @@ export const getServerSideProps: GetServerSideProps<HomeProps> = async (
   // inviteToken: an expired/invalid one makes /api/login 400, and the redirect
   // intent doesn't depend on it.
   const cookieHeader = context.req.headers.cookie ?? "";
-  if (cookieHeader.includes("workos_session=")) {
+  if (hasWorkosSessionCookie(cookieHeader)) {
     const destination = await resolveAuthedRedirectDestination(
       cookieHeader,
       context.query


### PR DESCRIPTION
## Description

Two independent additions to support Contentful-driven conversation deeplinks:

- **`conversationDraft` Contentful types + client** — adds `ConversationDraft`, `ConversationDraftSkeleton`, and `ConversationDraftAttachment` to both `front/lib/contentful/` (new singleton client with `getConversationDraftBySlug`) and `marketing/lib/contentful/` (extends existing `getContentfulClient`). Asset fields are normalized to HTTPS URLs with a `contentfulAssetToAttachment` helper; Zod validates slugs/prompts before mapping.
- **`marketing/lib/api/authContext.ts`** — extracts `fetchAuthContext()`, `hasWorkosSessionCookie()`, `AUTH_CONTEXT_URL`, and `AUTH_CONTEXT_TIMEOUT_MS` from the inlined logic in `marketing/pages/index.tsx` into a shared helper, so upcoming marketing SSR pages (e.g. the `/go/[slug]` deeplink handler) can reuse it without duplicating the fetch + Zod parse + timeout pattern.

No behavioral changes to existing marketing homepage flow.

## Tests

Tested locally. These are additive infrastructure changes — new types and client functions not yet wired into any page. No existing test surface changed.

## Risk

Low. Purely additive: new files, new exported functions, and a no-op refactor of `index.tsx` that replaces inlined fetch logic with the extracted helper. Rollback safe — nothing calls the new Contentful functions yet.

## Deploy Plan

Deploy marketing, then front.
