### PR TITLE
Add marketing /go deeplink redirect flow.

### DIFF
--- a/marketing/lib/go/resolveDestination.ts
+++ b/marketing/lib/go/resolveDestination.ts
@@ -1,0 +1,54 @@
+import config from "@marketing/lib/api/config";
+import {
+  fetchAuthContext,
+  hasWorkosSessionCookie,
+} from "@marketing/lib/api/authContext";
+import { getConversationDraftBySlug } from "@marketing/lib/contentful/client";
+import logger from "@marketing/logger/logger";
+
+export type GoDestinationResult =
+  | { kind: "redirect"; destination: string }
+  | { kind: "not_found" }
+  | { kind: "error" };
+
+function buildLoginRedirect(slug: string): string {
+  const returnTo = encodeURIComponent(`/go/${slug}`);
+  return `${config.getApiBaseUrl()}/api/workos/login?returnTo=${returnTo}`;
+}
+
+export async function resolveGoDestination(
+  slug: string,
+  cookieHeader: string
+): Promise<GoDestinationResult> {
+  const templateResult = await getConversationDraftBySlug(slug);
+  if (templateResult.isErr()) {
+    logger.error(
+      { slug, error: templateResult.error },
+      "Failed to fetch conversation draft"
+    );
+    return { kind: "error" };
+  }
+
+  const template = templateResult.value;
+  if (!template) {
+    return { kind: "not_found" };
+  }
+
+  const authContext = hasWorkosSessionCookie(cookieHeader)
+    ? await fetchAuthContext(cookieHeader, {
+        failureLogMessage: "auth-context lookup failed during /go resolve",
+      })
+    : null;
+
+  if (authContext?.defaultWorkspaceId) {
+    return {
+      kind: "redirect",
+      destination: `${config.getAppUrl()}/w/${authContext.defaultWorkspaceId}/conversation/new?go=${encodeURIComponent(slug)}`,
+    };
+  }
+
+  return {
+    kind: "redirect",
+    destination: buildLoginRedirect(slug),
+  };
+}

--- a/marketing/lib/go/schemas.ts
+++ b/marketing/lib/go/schemas.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const GoResolveSuccessSchema = z.object({
+  destination: z.string(),
+});

--- a/marketing/pages/api/go/[slug].ts
+++ b/marketing/pages/api/go/[slug].ts
@@ -1,0 +1,35 @@
+/** @ignoreswagger */
+import { resolveGoDestination } from "@marketing/lib/go/resolveDestination";
+import { isString } from "@marketing/types/shared/utils/general";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type GoResolveResponse =
+  | { destination: string }
+  | { error: "template_not_found" | "invalid_slug" | "internal_server_error" };
+
+// biome-ignore lint/plugin/nextjsPageComponentNaming: pre-existing
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GoResolveResponse>
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "internal_server_error" });
+  }
+
+  const slug = req.query.slug;
+  if (!isString(slug) || slug.trim() === "") {
+    return res.status(400).json({ error: "invalid_slug" });
+  }
+
+  const cookieHeader = req.headers.cookie ?? "";
+  const result = await resolveGoDestination(slug, cookieHeader);
+
+  switch (result.kind) {
+    case "redirect":
+      return res.status(200).json({ destination: result.destination });
+    case "not_found":
+      return res.status(404).json({ error: "template_not_found" });
+    case "error":
+      return res.status(500).json({ error: "internal_server_error" });
+  }
+}

--- a/marketing/pages/api/go/[slug].ts
+++ b/marketing/pages/api/go/[slug].ts
@@ -1,5 +1,6 @@
 /** @ignoreswagger */
 import { resolveGoDestination } from "@marketing/lib/go/resolveDestination";
+import { assertNever } from "@marketing/types/shared/utils/assert_never";
 import { isString } from "@marketing/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";
 
@@ -31,5 +32,7 @@ export default async function handler(
       return res.status(404).json({ error: "template_not_found" });
     case "error":
       return res.status(500).json({ error: "internal_server_error" });
+    default:
+      assertNever(result);
   }
 }

--- a/marketing/pages/go/[slug].tsx
+++ b/marketing/pages/go/[slug].tsx
@@ -1,0 +1,97 @@
+import CustomErrorPage from "@marketing/components/pages/CustomErrorPage";
+import { GoResolveSuccessSchema } from "@marketing/lib/go/schemas";
+import { clientFetch } from "@marketing/lib/egress/client";
+import { isString } from "@marketing/types/shared/utils/general";
+import { LogIn01, SpinnerBrand } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+type GoPageState = "loading" | "not_found" | "error";
+
+export default function GoPageNextJS() {
+  const router = useRouter();
+  const [pageState, setPageState] = useState<GoPageState>("loading");
+  const slug = router.query.slug;
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    if (!isString(slug) || slug.trim() === "") {
+      setPageState("not_found");
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const response = await clientFetch(
+          `/m/api/go/${encodeURIComponent(slug)}`,
+          { credentials: "include" }
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        if (response.status === 404) {
+          setPageState("not_found");
+          return;
+        }
+
+        if (!response.ok) {
+          setPageState("error");
+          return;
+        }
+
+        const parsed = GoResolveSuccessSchema.safeParse(await response.json());
+        if (!parsed.success) {
+          setPageState("error");
+          return;
+        }
+
+        window.location.replace(parsed.data.destination);
+      } catch {
+        if (!cancelled) {
+          setPageState("error");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router.isReady, slug]);
+
+  if (pageState === "not_found") {
+    return (
+      <CustomErrorPage
+        title="404: Template not found"
+        description="This conversation template doesn't exist or is no longer available."
+        href="/"
+        label="Back to homepage"
+        icon={LogIn01}
+      />
+    );
+  }
+
+  if (pageState === "error") {
+    return (
+      <CustomErrorPage
+        title="Something went wrong"
+        description="We couldn't load this conversation template. Please try again later."
+        href="/"
+        label="Back to homepage"
+        icon={LogIn01}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <SpinnerBrand size="lg" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds the `dust.tt/go/:slug` deeplink flow on the marketing site. `GoPageNextJS` renders a spinner and calls `/m/api/go/:slug` (credentials included) to resolve the destination server-side. `resolveGoDestination` looks up a Contentful conversation draft by slug, then checks the WorkOS session cookie via `hasWorkosSessionCookie`+`fetchAuthContext`: authenticated users are redirected to `/w/:defaultWorkspaceId/conversation/new?go=:slug`; unauthenticated users hit WorkOS login with `returnTo=/go/:slug`. Client validates the JSON response via `GoResolveSuccessSchema` before calling `window.location.replace`.

This PR builds on `sflory/go-contentful-and-auth` which provides `getConversationDraftBySlug` and `fetchAuthContext`.

## Tests

Tested manually: valid slug with active session redirects to the app; valid slug without session redirects to WorkOS login; unknown slug returns 404 error page.

## Risk

Low. New routes only — no changes to existing pages or auth flows. Worst case a bad slug shows the error page. Rollback is safe (delete the new files).

## Deploy Plan

Deploy marketing