### PR TITLE
Add front go-template API and composer prefilling.

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8147,6 +8147,58 @@
         }
       }
     },
+    "/api/w/{wId}/assistant/go-template": {
+      "get": {
+        "summary": "Resolve a conversation go template draft",
+        "description": "Fetches a Contentful conversation go template by slug and returns a composer-ready draft with optional pre-uploaded attachments.",
+        "tags": [
+          "Private Assistant"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "slug",
+            "required": true,
+            "description": "Contentful template slug",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Composer draft resolved from the template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetGoTemplateDraftResponseBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template not found or disabled"
+          },
+          "422": {
+            "description": "Missing slug query parameter"
+          }
+        }
+      }
+    },
     "/api/w/{wId}/assistant/mentions/suggestions": {
       "get": {
         "summary": "Get mention suggestions",
@@ -11011,6 +11063,72 @@
               },
               "down": {
                 "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "GetGoTemplateDraftResponseBody": {
+        "type": "object",
+        "description": "Composer draft resolved from a Contentful conversation go template.",
+        "required": [
+          "title",
+          "prompt",
+          "attachments",
+          "attachmentErrors"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "fileId",
+                "name",
+                "contentType",
+                "size",
+                "url"
+              ],
+              "properties": {
+                "fileId": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "contentType": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "attachmentErrors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "url",
+                "message"
+              ],
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -802,6 +802,52 @@
  *               type: integer
  *             down:
  *               type: integer
+ *     GetGoTemplateDraftResponseBody:
+ *       type: object
+ *       description: Composer draft resolved from a Contentful conversation go template.
+ *       required:
+ *         - title
+ *         - prompt
+ *         - attachments
+ *         - attachmentErrors
+ *       properties:
+ *         title:
+ *           type: string
+ *         prompt:
+ *           type: string
+ *         attachments:
+ *           type: array
+ *           items:
+ *             type: object
+ *             required:
+ *               - fileId
+ *               - name
+ *               - contentType
+ *               - size
+ *               - url
+ *             properties:
+ *               fileId:
+ *                 type: string
+ *               name:
+ *                 type: string
+ *               contentType:
+ *                 type: string
+ *               size:
+ *                 type: integer
+ *               url:
+ *                 type: string
+ *         attachmentErrors:
+ *           type: array
+ *           items:
+ *             type: object
+ *             required:
+ *               - url
+ *               - message
+ *             properties:
+ *               url:
+ *                 type: string
+ *               message:
+ *                 type: string
  *     PrivateFileWithUploadUrl:
  *       type: object
  *       description: File record with a pre-signed upload URL.

--- a/front-api/routes/w/[wId]/assistant/go-template.ts
+++ b/front-api/routes/w/[wId]/assistant/go-template.ts
@@ -1,11 +1,39 @@
 import {
   type GetGoTemplateDraftResponseBody,
+  type GoTemplateError,
   resolveGoTemplateDraft,
 } from "@app/lib/api/assistant/go_template";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isString } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
+
+function getGoTemplateApiError(
+  error: GoTemplateError
+): APIErrorWithContentfulStatusCode {
+  switch (error.type) {
+    case "template_not_found":
+      return {
+        status_code: 404,
+        api_error: {
+          type: "template_not_found",
+          message: `Template "${error.slug}" was not found.`,
+        },
+      };
+    case "contentful_fetch_failed":
+      return {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to load template.",
+        },
+      };
+    default:
+      assertNever(error);
+  }
+}
 
 // Mounted at /api/w/:wId/assistant/go-template.
 const app = workspaceApp();
@@ -61,7 +89,7 @@ app.get("/", async (ctx): HandlerResult<GetGoTemplateDraftResponseBody> => {
 
   const result = await resolveGoTemplateDraft(auth, slug);
   if (result.isErr()) {
-    return apiError(ctx, result.error);
+    return apiError(ctx, getGoTemplateApiError(result.error));
   }
 
   return ctx.json(result.value);

--- a/front-api/routes/w/[wId]/assistant/go-template.ts
+++ b/front-api/routes/w/[wId]/assistant/go-template.ts
@@ -1,0 +1,70 @@
+import {
+  type GetGoTemplateDraftResponseBody,
+  resolveGoTemplateDraft,
+} from "@app/lib/api/assistant/go_template";
+import { isString } from "@app/types/shared/utils/general";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/assistant/go-template.
+const app = workspaceApp();
+
+/**
+ * @swagger
+ * /api/w/{wId}/assistant/go-template:
+ *   get:
+ *     summary: Resolve a conversation go template draft
+ *     description: Fetches a Contentful conversation go template by slug and returns a composer-ready draft with optional pre-uploaded attachments.
+ *     tags:
+ *       - Private Assistant
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: slug
+ *         required: true
+ *         description: Contentful template slug
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Composer draft resolved from the template
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/GetGoTemplateDraftResponseBody'
+ *       404:
+ *         description: Template not found or disabled
+ *       422:
+ *         description: Missing slug query parameter
+ */
+app.get("/", async (ctx): HandlerResult<GetGoTemplateDraftResponseBody> => {
+  const auth = ctx.get("auth");
+  const slug = ctx.req.query("slug");
+
+  if (!isString(slug) || slug.trim() === "") {
+    return apiError(ctx, {
+      status_code: 422,
+      api_error: {
+        type: "unprocessable_entity",
+        message: "The slug query parameter is invalid or missing.",
+      },
+    });
+  }
+
+  const result = await resolveGoTemplateDraft(auth, slug);
+  if (result.isErr()) {
+    return apiError(ctx, result.error);
+  }
+
+  return ctx.json(result.value);
+});
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/index.ts
+++ b/front-api/routes/w/[wId]/assistant/index.ts
@@ -4,6 +4,7 @@ import agentConfigurations from "./agent_configurations";
 import builder from "./builder";
 import conversations from "./conversations";
 import globalAgents from "./global_agents";
+import goTemplate from "./go-template";
 import mentions from "./mentions";
 import skills from "./skills";
 
@@ -14,6 +15,7 @@ app.route("/agent_configurations", agentConfigurations);
 app.route("/builder", builder);
 app.route("/conversations", conversations);
 app.route("/global_agents", globalAgents);
+app.route("/go-template", goTemplate);
 app.route("/mentions", mentions);
 app.route("/skills", skills);
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -113,6 +113,7 @@ export const InputBar = React.memo(function InputBar({
     selectedSingleAgent,
     getAndClearPendingInputText,
     fileUploaderService,
+    isLoadingGoTemplate,
   } = useContext(InputBarContext);
 
   // We use this specific hook because this component is involved in the new conversation page.
@@ -128,6 +129,12 @@ export const InputBar = React.memo(function InputBar({
     draftKey,
     shouldUseDraft: !isAgentBuilder,
   });
+
+  useEffect(() => {
+    if (isLoadingGoTemplate) {
+      clearDraft();
+    }
+  }, [isLoadingGoTemplate, clearDraft]);
 
   useEffect(() => {
     if (droppedFiles.length > 0) {
@@ -488,7 +495,9 @@ export const InputBar = React.memo(function InputBar({
             stickyMentions={stickyMentions}
             fileUploaderService={fileUploaderService}
             isSubmitting={
-              isLocalSubmitting || fileUploaderService.isProcessingFiles
+              isLocalSubmitting ||
+              fileUploaderService.isProcessingFiles ||
+              isLoadingGoTemplate
             }
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,6 +1,7 @@
 import { ContextUsageIndicator } from "@app/components/assistant/conversation/input_bar/ContextUsageIndicator";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
+import type { PendingInputText } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
   INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
   INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
@@ -139,7 +140,7 @@ export interface InputBarContainerProps {
   onResetMCPServerViews: () => void;
   owner: WorkspaceType;
   saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
-  pendingInputText: string | null;
+  pendingInputText: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
   stickyMentions?: RichMention[];
@@ -197,7 +198,7 @@ const InputBarContainer = ({
   );
   const { subscription } = useAuth();
   const isMobile = useIsMobile();
-  const { selectedSingleAgent, setSelectedSingleAgent } =
+  const { selectedSingleAgent, setSelectedSingleAgent, isLoadingGoTemplate } =
     useContext(InputBarContext);
 
   const [startsWithUserMention, setStartsWithUserMention] = useState(false);
@@ -994,6 +995,47 @@ const InputBarContainer = ({
     };
   }, [clientType, editorService]);
 
+  useEffect(() => {
+    editorService.setLoading(isLoadingGoTemplate);
+  }, [editorService, isLoadingGoTemplate]);
+
+  const pendingReplaceInputRef = useRef<PendingInputText | null>(null);
+
+  // Apply replace-mode pending text once the editor is ready. The async /go
+  // template fetch often completes before TipTap initializes; applying earlier
+  // would no-op and the pending payload is already consumed by InputBar.
+  useEffect(() => {
+    if (pendingInputText?.replace) {
+      pendingReplaceInputRef.current = pendingInputText;
+    }
+
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      !editor.isEditable ||
+      !editor.isInitialized
+    ) {
+      return;
+    }
+
+    const pending = pendingReplaceInputRef.current;
+    if (!pending?.replace) {
+      return;
+    }
+
+    pendingReplaceInputRef.current = null;
+    queueMicrotask(() =>
+      editorService.setContent(pending.text, { focus: !disableAutoFocus })
+    );
+  }, [
+    pendingInputText,
+    editor,
+    editor?.isInitialized,
+    editor?.isEditable,
+    editorService,
+    disableAutoFocus,
+  ]);
+
   // Restore draft text when switching conversations (including new conversations).
   // Agent selection is handled by useHandleMention.
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -1004,6 +1046,10 @@ const InputBarContainer = ({
       !editor.isEditable ||
       !editor.isInitialized
     ) {
+      return;
+    }
+
+    if (pendingReplaceInputRef.current?.replace) {
       return;
     }
 

--- a/front/components/assistant/conversation/input_bar/InputBarContext.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContext.tsx
@@ -24,6 +24,11 @@ export type PendingConversationMessage = {
   contentFragments: ContentFragmentsType;
 };
 
+export type PendingInputText = {
+  text: string;
+  replace: boolean;
+};
+
 type CaptureActions = {
   onCapture: (type: "text" | "screenshot") => void;
   isCapturing: boolean;
@@ -38,8 +43,11 @@ export const InputBarContext = createContext<{
   setSelectedAgent: (agentMention: RichAgentMention | null) => void;
   selectedSingleAgent: RichAgentMention | null;
   setSelectedSingleAgent: (agentMention: RichAgentMention | null) => void;
-  getAndClearPendingInputText: () => string | null;
-  setPendingInputText: (text: string | null) => void;
+  getAndClearPendingInputText: () => PendingInputText | null;
+  setPendingInputText: (
+    text: string | null,
+    options?: { replace?: boolean }
+  ) => void;
   peekPendingFirstMessage: (
     conversationId: string
   ) => PendingConversationMessage | null;
@@ -48,6 +56,8 @@ export const InputBarContext = createContext<{
     message: PendingConversationMessage
   ) => void;
   clearPendingFirstMessage: (conversationId: string) => void;
+  isLoadingGoTemplate: boolean;
+  setIsLoadingGoTemplate: (loading: boolean) => void;
   fileUploaderService: FileUploaderService;
   captureActions?: CaptureActions;
 }>({
@@ -62,6 +72,8 @@ export const InputBarContext = createContext<{
   peekPendingFirstMessage: () => null,
   setPendingFirstMessage: () => {},
   clearPendingFirstMessage: () => {},
+  isLoadingGoTemplate: false,
+  setIsLoadingGoTemplate: () => {},
   fileUploaderService: {
     fileBlobs: [],
     handleFileChange: async () => undefined,
@@ -97,10 +109,10 @@ export function InputBarContextProvider({
   const [selectedSingleAgent, setSelectedSingleAgent] =
     useState<RichAgentMention | null>(null);
 
-  // Useful when a component needs to pre-fill the input bar with text (e.g. butler suggestions).
-  const [pendingInputText, setPendingInputTextState] = useState<string | null>(
-    null
-  );
+  // Useful when a component needs to pre-fill the input bar with text.
+  const [pendingInputText, setPendingInputTextState] =
+    useState<PendingInputText | null>(null);
+  const [isLoadingGoTemplate, setIsLoadingGoTemplate] = useState(false);
 
   // First message stashed while navigating to a newly-created conversation (deferred-send flow).
   const [
@@ -153,14 +165,24 @@ export function InputBarContextProvider({
   }, [selectedAgent, setSelectedAgent]);
 
   const getAndClearPendingInputText = useCallback(() => {
-    const text = pendingInputText;
+    const pending = pendingInputText;
     setPendingInputTextState(null);
-    return text;
+    return pending;
   }, [pendingInputText]);
 
-  const setPendingInputText = useCallback((text: string | null) => {
-    setPendingInputTextState(text);
-  }, []);
+  const setPendingInputText = useCallback(
+    (text: string | null, options?: { replace?: boolean }) => {
+      if (text === null) {
+        setPendingInputTextState(null);
+        return;
+      }
+      setPendingInputTextState({
+        text,
+        replace: options?.replace ?? false,
+      });
+    },
+    []
+  );
 
   const value = useMemo(
     () => ({
@@ -175,6 +197,8 @@ export function InputBarContextProvider({
       peekPendingFirstMessage,
       setPendingFirstMessage,
       clearPendingFirstMessage,
+      isLoadingGoTemplate,
+      setIsLoadingGoTemplate,
       captureActions,
       fileUploaderService,
     }),
@@ -188,6 +212,7 @@ export function InputBarContextProvider({
       peekPendingFirstMessage,
       setPendingFirstMessage,
       clearPendingFirstMessage,
+      isLoadingGoTemplate,
       captureActions,
       fileUploaderService,
     ]

--- a/front/components/editor/input_bar/useHandleMentions.tsx
+++ b/front/components/editor/input_bar/useHandleMentions.tsx
@@ -1,4 +1,7 @@
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import {
+  InputBarContext,
+  type PendingInputText,
+} from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import type { EditorService } from "@app/components/editor/input_bar/useCustomEditor";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
@@ -23,7 +26,7 @@ interface UseHandleMentionsOptions {
     agentMention?: RichAgentMention | null;
   } | null;
   isAgentBuilder: boolean;
-  pendingInputText?: string | null;
+  pendingInputText?: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
   stickyMentions?: RichMention[];
 }
@@ -110,8 +113,8 @@ const useHandleMentions = ({
       // @TODO we should handle this in each event handler and not inside the useEffect
       setSelectedSingleAgent(selectedAgent);
       externalAgentSetRef.current = true;
-    } else if (pendingInputText) {
-      queueMicrotask(() => editorService.insertText(pendingInputText));
+    } else if (pendingInputText && !pendingInputText.replace) {
+      queueMicrotask(() => editorService.insertText(pendingInputText.text));
     }
   }, [selectedAgent, pendingInputText, editorService, setSelectedSingleAgent]);
 

--- a/front/components/pages/conversation/ConversationPage.tsx
+++ b/front/components/pages/conversation/ConversationPage.tsx
@@ -1,6 +1,7 @@
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useAgentFromSearchParam } from "@app/hooks/useAgentFromSearchParam";
+import { useGoTemplateFromSearchParam } from "@app/hooks/useGoTemplateFromSearchParam";
 import { useOnboardingConversation } from "@app/hooks/useOnboardingConversation";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
@@ -37,6 +38,9 @@ export function ConversationPage() {
 
   // Consume ?agent= param: fetch agent, set it in input bar, clean up URL.
   useAgentFromSearchParam(owner.sId);
+
+  // Consume ?go= param: fetch Contentful template, prefill composer, clean up URL.
+  useGoTemplateFromSearchParam(owner.sId);
 
   return (
     <ConversationContainerVirtuoso

--- a/front/hooks/useGoTemplateFromSearchParam.ts
+++ b/front/hooks/useGoTemplateFromSearchParam.ts
@@ -1,0 +1,138 @@
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  GetGoTemplateDraftResponseBodySchema,
+  GoTemplateApiErrorBodySchema,
+} from "@app/lib/api/assistant/go_template";
+import { clientFetch } from "@app/lib/egress/client";
+import { useSearchParam } from "@app/lib/platform";
+import { isSupportedFileContentType } from "@app/types/files";
+import { useContext, useEffect, useRef } from "react";
+
+/**
+ * Reads the ?go= search param, fetches the corresponding Contentful template
+ * draft, pre-fills the composer, attaches any template files, and cleans up
+ * the param from the URL.
+ */
+export function useGoTemplateFromSearchParam(workspaceId: string) {
+  const goSlug = useSearchParam("go");
+  const { setPendingInputText, fileUploaderService, setIsLoadingGoTemplate } =
+    useContext(InputBarContext);
+  const sendNotification = useSendNotification();
+  const loadedSlugRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!goSlug) {
+      setIsLoadingGoTemplate(false);
+      return;
+    }
+
+    if (loadedSlugRef.current === goSlug) {
+      setIsLoadingGoTemplate(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingGoTemplate(true);
+
+    const loadTemplate = async () => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/assistant/go-template?slug=${encodeURIComponent(goSlug)}`
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        if (!response.ok) {
+          let message = "This link template could not be loaded.";
+          try {
+            const body = GoTemplateApiErrorBodySchema.safeParse(
+              await response.json()
+            );
+            if (body.success && body.data.error?.message) {
+              message = body.data.error.message;
+            }
+          } catch {
+            // Keep default message.
+          }
+          sendNotification({
+            type: "error",
+            title: "Template unavailable",
+            description: message,
+          });
+          return;
+        }
+
+        const parsed = GetGoTemplateDraftResponseBodySchema.safeParse(
+          await response.json()
+        );
+        if (!parsed.success) {
+          sendNotification({
+            type: "error",
+            title: "Template unavailable",
+            description: "This link template could not be loaded.",
+          });
+          return;
+        }
+
+        const draft = parsed.data;
+        loadedSlugRef.current = goSlug;
+
+        fileUploaderService.resetUpload();
+        setPendingInputText(draft.prompt, { replace: true });
+
+        for (const attachment of draft.attachments) {
+          if (!isSupportedFileContentType(attachment.contentType)) {
+            continue;
+          }
+          fileUploaderService.addUploadedFile({
+            fileId: attachment.fileId,
+            filename: attachment.name,
+            contentType: attachment.contentType,
+            size: attachment.size,
+            sourceUrl: attachment.url,
+          });
+        }
+
+        if (draft.attachmentErrors.length > 0) {
+          sendNotification({
+            type: "info",
+            title: "Some attachments could not be loaded",
+            description: `${draft.attachmentErrors.length} attachment(s) were skipped.`,
+          });
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        if (params.has("go")) {
+          params.delete("go");
+          const qs = params.toString();
+          window.history.replaceState(
+            null,
+            "",
+            `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingGoTemplate(false);
+        }
+      }
+    };
+
+    void loadTemplate();
+
+    return () => {
+      cancelled = true;
+      setIsLoadingGoTemplate(false);
+    };
+  }, [
+    goSlug,
+    workspaceId,
+    setPendingInputText,
+    setIsLoadingGoTemplate,
+    fileUploaderService,
+    sendNotification,
+  ]);
+}

--- a/front/hooks/useGoTemplateFromSearchParam.ts
+++ b/front/hooks/useGoTemplateFromSearchParam.ts
@@ -3,7 +3,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import {
   GetGoTemplateDraftResponseBodySchema,
   GoTemplateApiErrorBodySchema,
-} from "@app/lib/api/assistant/go_template";
+} from "@app/lib/api/assistant/go_template_types";
 import { clientFetch } from "@app/lib/egress/client";
 import { useSearchParam } from "@app/lib/platform";
 import { isSupportedFileContentType } from "@app/types/files";

--- a/front/lib/api/assistant/go_template.test.ts
+++ b/front/lib/api/assistant/go_template.test.ts
@@ -1,5 +1,7 @@
 import { resolveGoTemplateDraft } from "@app/lib/api/assistant/go_template";
+import type { Authenticator } from "@app/lib/auth";
 import { getConversationDraftBySlug } from "@app/lib/contentful/client";
+import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/contentful/client", () => ({
@@ -13,27 +15,26 @@ vi.mock("@app/lib/api/files/upload", () => ({
 
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 
-describe("resolveGoTemplateDraft", () => {
-  it("returns 404 when template is missing", async () => {
-    vi.mocked(getConversationDraftBySlug).mockResolvedValue({
-      isOk: () => true,
-      isErr: () => false,
-      value: null,
-    } as never);
+const auth = {} as Authenticator;
 
-    const result = await resolveGoTemplateDraft({} as never, "abcd");
+describe("resolveGoTemplateDraft", () => {
+  it("returns template_not_found when template is missing", async () => {
+    vi.mocked(getConversationDraftBySlug).mockResolvedValue(new Ok(null));
+
+    const result = await resolveGoTemplateDraft(auth, "abcd");
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.status_code).toBe(404);
+      expect(result.error).toEqual({
+        type: "template_not_found",
+        slug: "abcd",
+      });
     }
   });
 
   it("returns prompt and skips invalid attachment URLs", async () => {
-    vi.mocked(getConversationDraftBySlug).mockResolvedValue({
-      isOk: () => true,
-      isErr: () => false,
-      value: {
+    vi.mocked(getConversationDraftBySlug).mockResolvedValue(
+      new Ok({
         slug: "abcd",
         title: "RFP Review",
         prompt: "Review this RFP",
@@ -49,21 +50,19 @@ describe("resolveGoTemplateDraft", () => {
             contentType: "application/pdf",
           },
         ],
-      },
-    } as never);
+      })
+    );
 
-    vi.mocked(processAndStoreFromUrl).mockResolvedValue({
-      isOk: () => true,
-      isErr: () => false,
-      value: {
+    vi.mocked(processAndStoreFromUrl).mockResolvedValue(
+      new Ok({
         sId: "file123",
         fileName: "file.pdf",
         contentType: "application/pdf",
         fileSize: 1234,
-      },
-    } as never);
+      })
+    );
 
-    const result = await resolveGoTemplateDraft({} as never, "abcd");
+    const result = await resolveGoTemplateDraft(auth, "abcd");
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {

--- a/front/lib/api/assistant/go_template.test.ts
+++ b/front/lib/api/assistant/go_template.test.ts
@@ -1,0 +1,78 @@
+import { resolveGoTemplateDraft } from "@app/lib/api/assistant/go_template";
+import { getConversationDraftBySlug } from "@app/lib/contentful/client";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/contentful/client", () => ({
+  getConversationDraftBySlug: vi.fn(),
+  isHttpsUrl: (url: string) => url.startsWith("https://"),
+}));
+
+vi.mock("@app/lib/api/files/upload", () => ({
+  processAndStoreFromUrl: vi.fn(),
+}));
+
+import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
+
+describe("resolveGoTemplateDraft", () => {
+  it("returns 404 when template is missing", async () => {
+    vi.mocked(getConversationDraftBySlug).mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: null,
+    } as never);
+
+    const result = await resolveGoTemplateDraft({} as never, "abcd");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(404);
+    }
+  });
+
+  it("returns prompt and skips invalid attachment URLs", async () => {
+    vi.mocked(getConversationDraftBySlug).mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        slug: "abcd",
+        title: "RFP Review",
+        prompt: "Review this RFP",
+        attachments: [
+          {
+            url: "http://insecure.example/file.pdf",
+            fileName: "insecure.pdf",
+            contentType: "application/pdf",
+          },
+          {
+            url: "https://example.com/file.pdf",
+            fileName: "file.pdf",
+            contentType: "application/pdf",
+          },
+        ],
+      },
+    } as never);
+
+    vi.mocked(processAndStoreFromUrl).mockResolvedValue({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        sId: "file123",
+        fileName: "file.pdf",
+        contentType: "application/pdf",
+        fileSize: 1234,
+      },
+    } as never);
+
+    const result = await resolveGoTemplateDraft({} as never, "abcd");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.prompt).toBe("Review this RFP");
+      expect(result.value.attachments).toHaveLength(1);
+      expect(result.value.attachmentErrors).toHaveLength(1);
+      expect(result.value.attachmentErrors[0]?.url).toBe(
+        "http://insecure.example/file.pdf"
+      );
+    }
+  });
+});

--- a/front/lib/api/assistant/go_template.test.ts
+++ b/front/lib/api/assistant/go_template.test.ts
@@ -1,6 +1,7 @@
 import { resolveGoTemplateDraft } from "@app/lib/api/assistant/go_template";
 import type { Authenticator } from "@app/lib/auth";
 import { getConversationDraftBySlug } from "@app/lib/contentful/client";
+import type { FileResource } from "@app/lib/resources/file_resource";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -59,7 +60,7 @@ describe("resolveGoTemplateDraft", () => {
         fileName: "file.pdf",
         contentType: "application/pdf",
         fileSize: 1234,
-      })
+      } as unknown as FileResource)
     );
 
     const result = await resolveGoTemplateDraft(auth, "abcd");

--- a/front/lib/api/assistant/go_template.ts
+++ b/front/lib/api/assistant/go_template.ts
@@ -1,66 +1,27 @@
+import type {
+  GetGoTemplateDraftResponseBody,
+  GoTemplateAttachment,
+  GoTemplateAttachmentError,
+} from "@app/lib/api/assistant/go_template_types";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import {
   getConversationDraftBySlug,
   isHttpsUrl,
 } from "@app/lib/contentful/client";
-import type { SupportedFileContentType } from "@app/types/files";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { z } from "zod";
 
-export type GoTemplateAttachment = {
-  fileId: string;
-  name: string;
-  contentType: SupportedFileContentType;
-  size: number;
-  url: string;
-};
-
-export type GoTemplateAttachmentError = {
-  url: string;
-  message: string;
-};
+export type { GetGoTemplateDraftResponseBody } from "@app/lib/api/assistant/go_template_types";
+export {
+  GetGoTemplateDraftResponseBodySchema,
+  GoTemplateApiErrorBodySchema,
+} from "@app/lib/api/assistant/go_template_types";
 
 export type GoTemplateError =
   | { type: "template_not_found"; slug: string }
   | { type: "contentful_fetch_failed" };
-
-const GoTemplateAttachmentSchema = z.object({
-  fileId: z.string(),
-  name: z.string(),
-  contentType: z.string(),
-  size: z.number(),
-  url: z.string(),
-});
-
-const GoTemplateAttachmentErrorSchema = z.object({
-  url: z.string(),
-  message: z.string(),
-});
-
-export const GetGoTemplateDraftResponseBodySchema = z.object({
-  title: z.string(),
-  prompt: z.string(),
-  attachments: z.array(GoTemplateAttachmentSchema),
-  attachmentErrors: z.array(GoTemplateAttachmentErrorSchema),
-});
-
-export const GoTemplateApiErrorBodySchema = z.object({
-  error: z
-    .object({
-      message: z.string().optional(),
-    })
-    .optional(),
-});
-
-/**
- * @swaggerschema GetGoTemplateDraftResponseBody (swagger_private_schemas.ts)
- */
-export type GetGoTemplateDraftResponseBody = z.infer<
-  typeof GetGoTemplateDraftResponseBodySchema
->;
 
 export async function resolveGoTemplateDraft(
   auth: Authenticator,

--- a/front/lib/api/assistant/go_template.ts
+++ b/front/lib/api/assistant/go_template.ts
@@ -4,7 +4,6 @@ import {
   getConversationDraftBySlug,
   isHttpsUrl,
 } from "@app/lib/contentful/client";
-import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { SupportedFileContentType } from "@app/types/files";
 import { isSupportedFileContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
@@ -23,6 +22,10 @@ export type GoTemplateAttachmentError = {
   url: string;
   message: string;
 };
+
+export type GoTemplateError =
+  | { type: "template_not_found"; slug: string }
+  | { type: "contentful_fetch_failed" };
 
 const GoTemplateAttachmentSchema = z.object({
   fileId: z.string(),
@@ -62,29 +65,15 @@ export type GetGoTemplateDraftResponseBody = z.infer<
 export async function resolveGoTemplateDraft(
   auth: Authenticator,
   slug: string
-): Promise<
-  Result<GetGoTemplateDraftResponseBody, APIErrorWithContentfulStatusCode>
-> {
+): Promise<Result<GetGoTemplateDraftResponseBody, GoTemplateError>> {
   const templateResult = await getConversationDraftBySlug(slug);
   if (templateResult.isErr()) {
-    return new Err({
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: "Failed to load template.",
-      },
-    });
+    return new Err({ type: "contentful_fetch_failed" });
   }
 
   const template = templateResult.value;
   if (!template) {
-    return new Err({
-      status_code: 404,
-      api_error: {
-        type: "template_not_found",
-        message: `Template "${slug}" was not found.`,
-      },
-    });
+    return new Err({ type: "template_not_found", slug });
   }
 
   const attachments: GoTemplateAttachment[] = [];

--- a/front/lib/api/assistant/go_template.ts
+++ b/front/lib/api/assistant/go_template.ts
@@ -1,0 +1,143 @@
+import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getConversationDraftBySlug,
+  isHttpsUrl,
+} from "@app/lib/contentful/client";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import type { SupportedFileContentType } from "@app/types/files";
+import { isSupportedFileContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+
+export type GoTemplateAttachment = {
+  fileId: string;
+  name: string;
+  contentType: SupportedFileContentType;
+  size: number;
+  url: string;
+};
+
+export type GoTemplateAttachmentError = {
+  url: string;
+  message: string;
+};
+
+const GoTemplateAttachmentSchema = z.object({
+  fileId: z.string(),
+  name: z.string(),
+  contentType: z.string(),
+  size: z.number(),
+  url: z.string(),
+});
+
+const GoTemplateAttachmentErrorSchema = z.object({
+  url: z.string(),
+  message: z.string(),
+});
+
+export const GetGoTemplateDraftResponseBodySchema = z.object({
+  title: z.string(),
+  prompt: z.string(),
+  attachments: z.array(GoTemplateAttachmentSchema),
+  attachmentErrors: z.array(GoTemplateAttachmentErrorSchema),
+});
+
+export const GoTemplateApiErrorBodySchema = z.object({
+  error: z
+    .object({
+      message: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * @swaggerschema GetGoTemplateDraftResponseBody (swagger_private_schemas.ts)
+ */
+export type GetGoTemplateDraftResponseBody = z.infer<
+  typeof GetGoTemplateDraftResponseBodySchema
+>;
+
+export async function resolveGoTemplateDraft(
+  auth: Authenticator,
+  slug: string
+): Promise<
+  Result<GetGoTemplateDraftResponseBody, APIErrorWithContentfulStatusCode>
+> {
+  const templateResult = await getConversationDraftBySlug(slug);
+  if (templateResult.isErr()) {
+    return new Err({
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to load template.",
+      },
+    });
+  }
+
+  const template = templateResult.value;
+  if (!template) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "template_not_found",
+        message: `Template "${slug}" was not found.`,
+      },
+    });
+  }
+
+  const attachments: GoTemplateAttachment[] = [];
+  const attachmentErrors: GoTemplateAttachmentError[] = [];
+
+  for (const attachment of template.attachments) {
+    const { url } = attachment;
+    if (!isHttpsUrl(url)) {
+      attachmentErrors.push({
+        url,
+        message: "Only public HTTPS URLs are supported.",
+      });
+      continue;
+    }
+
+    const uploadResult = await processAndStoreFromUrl(auth, {
+      url,
+      useCase: "conversation",
+      fileName: attachment.fileName,
+      contentType: attachment.contentType ?? undefined,
+    });
+
+    if (uploadResult.isErr()) {
+      attachmentErrors.push({
+        url,
+        message: uploadResult.error.message,
+      });
+      continue;
+    }
+
+    const file = uploadResult.value;
+    const contentType = file.contentType;
+    if (!isSupportedFileContentType(contentType)) {
+      attachmentErrors.push({
+        url,
+        message: `Unsupported content type: ${contentType}`,
+      });
+      continue;
+    }
+
+    attachments.push({
+      fileId: file.sId,
+      name: file.fileName,
+      contentType,
+      size: file.fileSize,
+      url,
+    });
+  }
+
+  return new Ok({
+    title: template.title,
+    prompt: template.prompt,
+    attachments,
+    attachmentErrors,
+  });
+}

--- a/front/lib/api/assistant/go_template_types.ts
+++ b/front/lib/api/assistant/go_template_types.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+const GoTemplateAttachmentSchema = z.object({
+  fileId: z.string(),
+  name: z.string(),
+  contentType: z.string(),
+  size: z.number(),
+  url: z.string(),
+});
+
+const GoTemplateAttachmentErrorSchema = z.object({
+  url: z.string(),
+  message: z.string(),
+});
+
+export type GoTemplateAttachment = z.infer<typeof GoTemplateAttachmentSchema>;
+export type GoTemplateAttachmentError = z.infer<
+  typeof GoTemplateAttachmentErrorSchema
+>;
+
+export const GetGoTemplateDraftResponseBodySchema = z.object({
+  title: z.string(),
+  prompt: z.string(),
+  attachments: z.array(GoTemplateAttachmentSchema),
+  attachmentErrors: z.array(GoTemplateAttachmentErrorSchema),
+});
+
+export const GoTemplateApiErrorBodySchema = z.object({
+  error: z
+    .object({
+      message: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * @swaggerschema GetGoTemplateDraftResponseBody (swagger_private_schemas.ts)
+ */
+export type GetGoTemplateDraftResponseBody = z.infer<
+  typeof GetGoTemplateDraftResponseBodySchema
+>;


### PR DESCRIPTION
## Description

Adds the front-side resolution of Contentful `conversationDraft` templates and wires them into the conversation composer via the `?go=<slug>` URL param.

- `GET /api/w/:wId/assistant/go-template?slug=` — calls `resolveGoTemplateDraft`, which fetches the Contentful draft by slug, uploads each attachment via `processAndStoreFromUrl` (HTTPS-only guard), and returns `{title, prompt, attachments[], attachmentErrors[]}` as `GetGoTemplateDraftResponseBody`.
- `useGoTemplateFromSearchParam` — reads `?go=`, sets `isLoadingGoTemplate` (blocks submit, clears draft), calls `setPendingInputText(prompt, {replace:true})`, injects pre-uploaded files into `fileUploaderService`, then removes the param from the URL.
- `PendingInputText` gains a `replace` flag; `InputBarContainer` defers `replace`-mode text via `pendingReplaceInputRef` to wait for TipTap initialization before calling `editorService.setContent`.


<img width="1276" height="1323" alt="image" src="https://github.com/user-attachments/assets/8b463a51-89c7-4446-8695-99026e25ddb5" />

https://github.com/user-attachments/assets/f8c0ba56-fa50-4135-8f0e-73c0714b9865

## Tests

- Added `go_template.test.ts` covering 404 (missing template) and HTTPS URL guard (insecure attachment skipped → `attachmentErrors`).
- Tested locally: `?go=<slug>` on a new conversation page prefills composer prompt and attaches files; `isLoadingGoTemplate` correctly blocks submit during fetch.

## Risk

Low. Additive endpoint and hook with no SQL migrations. `isLoadingGoTemplate` is scoped to the new conversation page. The `replace:true` deferred-text path is gated behind ref checks that prevent overwriting existing editor content. Rollback: remove the `useGoTemplateFromSearchParam` call in `ConversationPage`.

## Deploy Plan

Deploy front.