### PR TITLE
Change logged url field to be just the path, matching old Next logic

### DIFF
--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -45,7 +45,7 @@ export function apiError(
   logger.error(
     {
       method: ctx.req.method,
-      url: ctx.req.url,
+      url: ctx.req.path,
       statusCode: err.status_code,
       apiError: { ...err, callstack },
       error: errorAttrs,


### PR DESCRIPTION
## Description

Even though it's called `url`, we only want to log the path, as we did in the old code.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
