### PR TITLE
Add: tool to upload files from url.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -123,6 +123,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list": "never_ask",
     "move": "never_ask",
     "resolve": "never_ask",
+    "upload_from_url": "never_ask",
   },
   "freshservice": {
     "add_ticket_note": "low",

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -6,6 +6,7 @@ import {
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_SERVER_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -15,6 +16,7 @@ export const FILES_LIST_ACTION_NAME = "list" as const;
 export const FILES_CAT_ACTION_NAME = "cat" as const;
 export const FILES_GREP_ACTION_NAME = "grep" as const;
 export const FILES_CREATE_ACTION_NAME = "create" as const;
+export const FILES_UPLOAD_FROM_URL_ACTION_NAME = "upload_from_url" as const;
 export const FILES_DELETE_ACTION_NAME = "delete" as const;
 export const FILES_COPY_ACTION_NAME = "copy" as const;
 export const FILES_MOVE_ACTION_NAME = "move" as const;
@@ -25,6 +27,8 @@ export const CAT_LINES_DEFAULT = 200;
 export const CAT_LINES_MAX = 500;
 export const GREP_MATCHES_MAX = 50;
 export const CREATE_CONTENT_MAX_BYTES = 50 * 1024; // 50 KB (~12K tokens).
+
+const FRAME_FILES_UNSUPPORTED = `Does not support Frame files (\`${frameContentType}\`, \`${frameSlideshowContentType}\`)`;
 
 // Shared `list` description that opens with the generic file-system listing capability and is
 // followed by a context-specific suffix injected by the conversation-only or pod-aware
@@ -233,8 +237,7 @@ const FILES_TOOLS_COMMON_METADATA = {
       "Accepts UTF-8 text content only. Binary files cannot be created via this tool. " +
       `Content is capped at ${CREATE_CONTENT_MAX_BYTES / 1024} KB. ` +
       "If the file already exists it is silently overwritten (shell \`>\` semantics). " +
-      "Does not support Frame files (`application/vnd.dust.frame`, " +
-      "`application/vnd.dust.frame.slideshow`); use " +
+      `${FRAME_FILES_UNSUPPORTED}; use ` +
       `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to create or ` +
       `\`${getPrefixedToolName(INTERACTIVE_CONTENT_SERVER_NAME, EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME)}\` to edit them. ` +
       "Returns whether the file was created or updated, along with its path and size.",
@@ -255,6 +258,37 @@ const FILES_TOOLS_COMMON_METADATA = {
     displayLabels: {
       running: "Writing file",
       done: "Write file",
+    },
+  },
+  [FILES_UPLOAD_FROM_URL_ACTION_NAME]: {
+    description:
+      "Download a file from a public HTTP(S) URL and store it in a conversation or Pod file system. " +
+      "Use this for binary files (PDF, images, spreadsheets, etc.) that cannot be created with " +
+      `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CREATE_ACTION_NAME)}\`. ` +
+      "If the file already exists it is silently overwritten. " +
+      `${FRAME_FILES_UNSUPPORTED}. ` +
+      "Returns whether the file was created or updated, along with its path and size.",
+    schema: {
+      path: z
+        .string()
+        .describe(
+          "Scoped destination path (e.g. `conversation-<id>/report.pdf`, `pod-<id>/assets/logo.png`)"
+        ),
+      url: z
+        .string()
+        .url()
+        .describe("Public HTTP(S) URL of the file to download and store"),
+      content_type: z
+        .string()
+        .optional()
+        .describe(
+          "Optional MIME content type override when the remote server does not send a reliable Content-Type header"
+        ),
+    },
+    stake: "never_ask" as const,
+    displayLabels: {
+      running: "Uploading file from URL",
+      done: "Uploaded file from URL",
     },
   },
   [FILES_DELETE_ACTION_NAME]: {

--- a/front/lib/api/actions/servers/files/tools/index.ts
+++ b/front/lib/api/actions/servers/files/tools/index.ts
@@ -10,6 +10,7 @@ import {
   FILES_MOVE_ACTION_NAME,
   FILES_RESOLVE_ACTION_NAME,
   FILES_TOOLS_METADATA,
+  FILES_UPLOAD_FROM_URL_ACTION_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import { catHandler } from "@app/lib/api/actions/servers/files/tools/cat";
 import { copyHandler } from "@app/lib/api/actions/servers/files/tools/copy";
@@ -20,11 +21,13 @@ import { grepHandler } from "@app/lib/api/actions/servers/files/tools/grep";
 import { listHandler } from "@app/lib/api/actions/servers/files/tools/list";
 import { moveHandler } from "@app/lib/api/actions/servers/files/tools/move";
 import { resolveHandler } from "@app/lib/api/actions/servers/files/tools/resolve";
+import { uploadFromUrlHandler } from "@app/lib/api/actions/servers/files/tools/upload_from_url";
 
 const HANDLERS = {
   [FILES_CAT_ACTION_NAME]: catHandler,
   [FILES_COPY_ACTION_NAME]: copyHandler,
   [FILES_CREATE_ACTION_NAME]: createHandler,
+  [FILES_UPLOAD_FROM_URL_ACTION_NAME]: uploadFromUrlHandler,
   [FILES_DELETE_ACTION_NAME]: deleteHandler,
   [FILES_EXTRACT_TEXT_ACTION_NAME]: extractTextHandler,
   [FILES_GREP_ACTION_NAME]: grepHandler,

--- a/front/lib/api/actions/servers/files/tools/upload_from_url.ts
+++ b/front/lib/api/actions/servers/files/tools/upload_from_url.ts
@@ -1,0 +1,81 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  getDustFileSystemForAgentLoop,
+  requireAgentLoopConversation,
+  scopedPathsFromArgs,
+} from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import { uploadFileFromUrlToFileSystem } from "@app/lib/api/file_system/upload_from_url";
+import { isAllSupportedFileContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+export async function uploadFromUrlHandler(
+  {
+    path,
+    url,
+    content_type,
+  }: { path: string; url: string; content_type?: string },
+  { auth, agentLoopContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const conversationRes = requireAgentLoopConversation({ agentLoopContext });
+  if (conversationRes.isErr()) {
+    return conversationRes;
+  }
+
+  const fsResult = await getDustFileSystemForAgentLoop(
+    auth,
+    conversationRes.value,
+    scopedPathsFromArgs(path)
+  );
+  if (fsResult.isErr()) {
+    return fsResult;
+  }
+
+  const uploadResult = await uploadFileFromUrlToFileSystem(fsResult.value, {
+    path,
+    url,
+    contentType: content_type,
+  });
+
+  if (uploadResult.isErr()) {
+    return new Err(
+      new MCPError(uploadResult.error.message, { tracked: false })
+    );
+  }
+
+  const { contentType, sizeBytes, existed } = uploadResult.value;
+  const fileName = path.split("/").pop() ?? path;
+  const sizeKb = Math.ceil(sizeBytes / 1024);
+  const verb = existed ? "Updated" : "Created";
+
+  const items: Array<
+    | { type: "text"; text: string }
+    | { type: "resource"; resource: ToolGeneratedFilePathType }
+  > = [
+    {
+      type: "text",
+      text: `${verb} \`${path}\` from URL (${contentType}, ${sizeKb} KB). The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+    },
+  ];
+
+  if (isAllSupportedFileContentType(contentType)) {
+    items.push({
+      type: "resource",
+      resource: {
+        text: `${verb} \`${path}\` from URL`,
+        uri: path,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+        path,
+        title: fileName,
+        contentType,
+      },
+    });
+  }
+
+  return new Ok(items);
+}

--- a/front/lib/api/file_system/upload_from_url.test.ts
+++ b/front/lib/api/file_system/upload_from_url.test.ts
@@ -1,0 +1,213 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { uploadFileFromUrlToFileSystem } from "@app/lib/api/file_system/upload_from_url";
+import { untrustedFetch } from "@app/lib/egress/server";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Readable } from "stream";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/egress/server", () => ({
+  untrustedFetch: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/url_safety", () => ({
+  validateExternalUrl: vi.fn().mockResolvedValue(null),
+}));
+
+function asUntrustedFetchResponse(
+  response: Pick<
+    Awaited<ReturnType<typeof untrustedFetch>>,
+    "ok" | "status" | "statusText" | "headers" | "body"
+  >
+): Awaited<ReturnType<typeof untrustedFetch>> {
+  return response as unknown as Awaited<ReturnType<typeof untrustedFetch>>;
+}
+
+function mockFetchResponse({
+  ok = true,
+  status = 200,
+  statusText = "OK",
+  contentType = "text/plain",
+  contentLength,
+  body,
+}: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  contentType?: string;
+  contentLength?: string;
+  body?: string;
+}) {
+  const headers = new Headers({ "content-type": contentType });
+  if (contentLength !== undefined) {
+    headers.set("content-length", contentLength);
+  }
+
+  vi.mocked(untrustedFetch).mockResolvedValue(
+    asUntrustedFetchResponse({
+      ok,
+      status,
+      statusText,
+      headers,
+      body: body === undefined ? null : Readable.toWeb(Readable.from([body])),
+    })
+  );
+}
+
+describe("uploadFileFromUrlToFileSystem", () => {
+  it("rejects invalid URLs", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    expect(fsResult.isOk()).toBe(true);
+    if (!fsResult.isOk()) {
+      return;
+    }
+
+    const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
+      path: `conversation-${conversation.sId}/notes.txt`,
+      url: "not-a-url",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Invalid URL");
+    }
+  });
+
+  it("uploads a file from a public HTTP URL", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    mockFetchResponse({
+      body: "hello from url",
+      contentType: "text/plain",
+      contentLength: "15",
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    expect(fsResult.isOk()).toBe(true);
+    if (!fsResult.isOk()) {
+      return;
+    }
+
+    const path = `conversation-${conversation.sId}/imported-${Date.now()}.txt`;
+    const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
+      path,
+      url: "http://example.com/imported.txt",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+
+    expect(result.value.contentType).toBe("text/plain");
+    expect(result.value.sizeBytes).toBe(15);
+  });
+
+  it("uploads a file from a public HTTPS URL", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    mockFetchResponse({
+      body: "hello from url",
+      contentType: "text/plain",
+      contentLength: "15",
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    expect(fsResult.isOk()).toBe(true);
+    if (!fsResult.isOk()) {
+      return;
+    }
+
+    const path = `conversation-${conversation.sId}/imported-${Date.now()}.txt`;
+    const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
+      path,
+      url: "https://example.com/imported.txt",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+
+    expect(result.value.contentType).toBe("text/plain");
+    expect(result.value.sizeBytes).toBe(15);
+  });
+
+  it("returns an error when the remote file exceeds the size limit", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    mockFetchResponse({
+      contentType: "application/pdf",
+      contentLength: String(60 * 1024 * 1024),
+      body: "ignored",
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    expect(fsResult.isOk()).toBe(true);
+    if (!fsResult.isOk()) {
+      return;
+    }
+
+    const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
+      path: `conversation-${conversation.sId}/large.pdf`,
+      url: "https://example.com/large.pdf",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("maximum supported size");
+    }
+  });
+
+  it("rejects frame content types", async () => {
+    const { authenticator: auth } = await createResourceTest({ role: "admin" });
+    const conversation = await createConversation(auth, {
+      title: "Test",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    mockFetchResponse({
+      contentType: "application/vnd.dust.frame",
+      body: "<html></html>",
+    });
+
+    const fsResult = await DustFileSystem.forConversation(auth, conversation);
+    expect(fsResult.isOk()).toBe(true);
+    if (!fsResult.isOk()) {
+      return;
+    }
+
+    const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
+      path: `conversation-${conversation.sId}/frame.html`,
+      url: "https://example.com/frame.html",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("interactive_content");
+    }
+  });
+});

--- a/front/lib/api/file_system/upload_from_url.ts
+++ b/front/lib/api/file_system/upload_from_url.ts
@@ -1,0 +1,206 @@
+import {
+  frameFileCreateRejectedError,
+  frameFileEditRejectedError,
+} from "@app/lib/api/actions/servers/files/tools/utils";
+import type { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { validateExternalUrl } from "@app/lib/api/url_safety";
+import { untrustedFetch } from "@app/lib/egress/server";
+import {
+  getFileFormatCategory,
+  isInteractiveContentType,
+  isSupportedFileContentType,
+  MAX_FILE_SIZES,
+  stripMimeParameters,
+} from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import {
+  sanitizeUrlForDisplay,
+  validateUrl,
+} from "@app/types/shared/utils/url_utils";
+import { Readable, Transform } from "stream";
+
+const UPLOAD_FROM_URL_TIMEOUT_MS = 60_000;
+
+export type UploadFromUrlError = {
+  message: string;
+};
+
+export type UploadFromUrlResult = {
+  contentType: string;
+  sizeBytes: number;
+  existed: boolean;
+};
+
+function getMaxUploadBytes(contentType: string): number {
+  const category = getFileFormatCategory(contentType);
+  if (category) {
+    return MAX_FILE_SIZES[category];
+  }
+  return MAX_FILE_SIZES.data;
+}
+
+function limitReadableStream(
+  stream: Readable,
+  maxBytes: number
+): { stream: Readable; getBytesRead: () => number } {
+  let bytesRead = 0;
+
+  const limited = new Transform({
+    transform(chunk, _encoding, callback) {
+      bytesRead += chunk.length;
+      if (bytesRead > maxBytes) {
+        callback(
+          new Error(
+            `File exceeds the maximum supported size of ${Math.ceil(maxBytes / (1024 * 1024))} MB.`
+          )
+        );
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+
+  limited.on("error", () => stream.destroy());
+
+  return {
+    stream: stream.pipe(limited),
+    getBytesRead: () => bytesRead,
+  };
+}
+
+export async function uploadFileFromUrlToFileSystem(
+  dustFs: DustFileSystem,
+  {
+    path,
+    url,
+    contentType: contentTypeOverride,
+  }: {
+    path: string;
+    url: string;
+    contentType?: string;
+  }
+): Promise<Result<UploadFromUrlResult, UploadFromUrlError>> {
+  const validUrl = validateUrl(url);
+  if (!validUrl.valid) {
+    return new Err({ message: "Invalid URL." });
+  }
+
+  const sanitizedUrl = sanitizeUrlForDisplay(validUrl.standardized);
+
+  const urlSafetyError = await validateExternalUrl(validUrl.standardized);
+  if (urlSafetyError) {
+    return new Err({ message: urlSafetyError });
+  }
+
+  let response: Awaited<ReturnType<typeof untrustedFetch>>;
+  try {
+    response = await untrustedFetch(validUrl.standardized, {
+      signal: AbortSignal.timeout(UPLOAD_FROM_URL_TIMEOUT_MS),
+    });
+  } catch {
+    return new Err({ message: `Failed to fetch URL: ${sanitizedUrl}` });
+  }
+
+  if (!response.ok) {
+    return new Err({
+      message: `Failed to fetch URL: HTTP ${response.status} ${response.statusText}`,
+    });
+  }
+
+  if (!response.body) {
+    return new Err({ message: "Response body is empty." });
+  }
+
+  const finalContentType = stripMimeParameters(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    contentTypeOverride ||
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      response.headers.get("content-type") ||
+      "application/octet-stream"
+  );
+
+  if (isInteractiveContentType(finalContentType)) {
+    return new Err({ message: frameFileCreateRejectedError().message });
+  }
+
+  if (!isSupportedFileContentType(finalContentType)) {
+    return new Err({
+      message: `Unsupported content type: ${finalContentType}`,
+    });
+  }
+
+  const maxBytes = getMaxUploadBytes(finalContentType);
+  const contentLengthHeader = response.headers.get("content-length");
+  const contentLength =
+    contentLengthHeader !== null
+      ? parseInt(contentLengthHeader, 10)
+      : undefined;
+  if (
+    contentLength !== undefined &&
+    Number.isFinite(contentLength) &&
+    contentLength > maxBytes
+  ) {
+    return new Err({
+      message: `File exceeds the maximum supported size of ${Math.ceil(maxBytes / (1024 * 1024))} MB.`,
+    });
+  }
+
+  const statResult = await dustFs.stat(path);
+  if (statResult.isErr()) {
+    const err = statResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err({ message: err.message });
+      case "invalid_path":
+        return new Err({ message: `Invalid path: \`${path}\`.` });
+      default:
+        return new Err({
+          message: `Failed to read \`${path}\`: ${err.message}`,
+        });
+    }
+  }
+
+  const existed = statResult.value !== null;
+
+  if (statResult.value !== null) {
+    const existingMimeType = stripMimeParameters(statResult.value.contentType);
+    if (isInteractiveContentType(existingMimeType)) {
+      return new Err({ message: frameFileEditRejectedError().message });
+    }
+  }
+
+  const sourceStream = Readable.fromWeb(response.body);
+  const { stream: limitedStream, getBytesRead } = limitReadableStream(
+    sourceStream,
+    maxBytes
+  );
+
+  const writeResult = await dustFs.write(path, limitedStream, finalContentType);
+  if (writeResult.isErr()) {
+    const err = writeResult.error;
+    switch (err.code) {
+      case "legacy_path":
+      case "unauthorized":
+        return new Err({ message: err.message });
+      case "invalid_path":
+        return new Err({ message: `Invalid path: \`${path}\`.` });
+      default:
+        return new Err({
+          message: `Failed to write file \`${path}\`: ${err.message}`,
+        });
+    }
+  }
+
+  const sizeBytes =
+    contentLength !== undefined && Number.isFinite(contentLength)
+      ? contentLength
+      : getBytesRead();
+
+  return new Ok({
+    contentType: finalContentType,
+    sizeBytes,
+    existed,
+  });
+}

--- a/front/lib/api/mcp_server/tools/files/index.ts
+++ b/front/lib/api/mcp_server/tools/files/index.ts
@@ -4,6 +4,7 @@ import { registerFilesCreateTool } from "./create";
 import { registerFilesGrepTool } from "./grep";
 import { registerFilesListTool } from "./list";
 import { registerFilesResolveTool } from "./resolve";
+import { registerFilesUploadFromUrlTool } from "./upload_from_url";
 
 export function registerFilesTools(server: McpServer) {
   registerFilesListTool(server);
@@ -11,4 +12,5 @@ export function registerFilesTools(server: McpServer) {
   registerFilesCreateTool(server);
   registerFilesGrepTool(server);
   registerFilesResolveTool(server);
+  registerFilesUploadFromUrlTool(server);
 }

--- a/front/lib/api/mcp_server/tools/files/upload_from_url.ts
+++ b/front/lib/api/mcp_server/tools/files/upload_from_url.ts
@@ -1,0 +1,77 @@
+import { uploadFileFromUrlToFileSystem } from "@app/lib/api/file_system/upload_from_url";
+import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
+import { sanitizeUrlForDisplay } from "@app/types/shared/utils/url_utils";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+import { getDustFileSystemForScope, validatePathMatchesScope } from "./context";
+import { FILES_SCOPE_SCHEMA } from "./schemas";
+
+const inputSchema = {
+  scope: FILES_SCOPE_SCHEMA.describe(
+    "File system scope matching the path's conversation or Pod."
+  ),
+  path: z
+    .string()
+    .describe(
+      "Scoped destination path (e.g. `conversation-<id>/report.pdf` or `pod-<id>/assets/logo.png`). Overwrites if the file already exists."
+    ),
+  url: z
+    .string()
+    .url()
+    .describe("Public HTTP(S) URL of the file to download and store."),
+  content_type: z
+    .string()
+    .optional()
+    .describe(
+      "Optional MIME content type override when the remote server does not send a reliable Content-Type header."
+    ),
+};
+
+export function registerFilesUploadFromUrlTool(server: McpServer) {
+  registerDustMcpTool(
+    server,
+    "files_upload_from_url",
+    {
+      description:
+        "Download a file from a public HTTP(S) URL and store it in a conversation or Pod file system. " +
+        "Supports binary files (PDF, images, spreadsheets, etc.) that cannot be created with `files_create`. " +
+        "Overwrites existing files at the destination path. " +
+        "Requires an explicit scope with conversation_id or pod_id.",
+      inputSchema,
+    },
+    async (auth, { scope, path, url, content_type }) => {
+      const pathError = validatePathMatchesScope(path, scope);
+      if (pathError) {
+        return mcpError(pathError);
+      }
+
+      const fsResult = await getDustFileSystemForScope(auth, scope);
+      if (fsResult.isErr()) {
+        return mcpError(fsResult.error);
+      }
+
+      const uploadResult = await uploadFileFromUrlToFileSystem(fsResult.value, {
+        path,
+        url,
+        contentType: content_type,
+      });
+
+      if (uploadResult.isErr()) {
+        return mcpError(uploadResult.error.message);
+      }
+
+      const { contentType, sizeBytes, existed } = uploadResult.value;
+      const sizeKb = Math.ceil(sizeBytes / 1024);
+      const verb = existed ? "Updated" : "Created";
+
+      return mcpJsonResponse({
+        message: `${verb} \`${path}\` from URL (${contentType}, ${sizeKb} KB)`,
+        path,
+        contentType,
+        sizeBytes,
+        sourceUrl: sanitizeUrlForDisplay(url),
+      });
+    }
+  );
+}

--- a/front/lib/api/url_safety.ts
+++ b/front/lib/api/url_safety.ts
@@ -34,7 +34,7 @@ function isPrivateIp(address: string, family: 4 | 6): boolean {
 }
 
 /**
- * Validates that a URL is safe to fetch server-side: must use HTTPS and must
+ * Validates that a URL is safe to fetch server-side: must use HTTP(S) and must
  * not resolve to a private/reserved IP. Returns an error message string on
  * failure, or null on success.
  *
@@ -50,8 +50,8 @@ export async function validateExternalUrl(url: string): Promise<string | null> {
     return "Invalid URL format.";
   }
 
-  if (parsed.protocol !== "https:") {
-    return "Only HTTPS URLs are allowed.";
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return "Only HTTP(S) URLs are allowed.";
   }
 
   const hostname = parsed.hostname;

--- a/front/types/shared/utils/url_utils.ts
+++ b/front/types/shared/utils/url_utils.ts
@@ -29,6 +29,16 @@ export const validateUrl = (
   return { valid: true, standardized: url.href };
 };
 
+/** Strips credentials, query params, and fragments for safe display in errors. */
+export function sanitizeUrlForDisplay(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return "[invalid URL]";
+  }
+}
+
 /**
  * Validates and sanitizes a path to ensure it's a relative path.
  * This prevents open redirect vulnerabilities by rejecting absolute URLs.


### PR DESCRIPTION
## Description

Adds `upload_from_url` to the files MCP server, letting agents download binary files from a public HTTPS URL and write them directly into a conversation or Pod file system. The `files__create` tool only accepts text content, so PDFs, images, spreadsheets, and other binary assets previously had no agent-accessible upload path.

Core logic lives in `uploadFileFromUrlToFileSystem` (`front/lib/api/file_system/upload_from_url.ts`): enforces HTTPS-only URLs, validates content type (blocks Frame MIME types, rejects unsupported types), enforces per-format max size limits with a streaming `Transform` guard, and uses `untrustedFetch` with a 60 s `AbortSignal` timeout. The tool is registered with `stake: "never_ask"` (no user approval required). Both the agent-loop internal MCP handler (`uploadFromUrlHandler`) and the external-facing `files_upload_from_url` MCP server tool share the same core function.

## Tests

Added vitest unit tests in `upload_from_url.test.ts` covering:
- HTTPS enforcement (rejects `http://` URLs)
- Happy-path upload with mocked `untrustedFetch`
- Size limit rejection via `content-length` header
- Frame content type rejection

## Risk

Low. Purely additive — new tool, no changes to existing handlers. `untrustedFetch` already handles egress sandboxing. Size and content-type guards mirror what `files__create` enforces.

## Deploy Plan

Deploy front when base branch (`sflory/go-front-composer`) is ready. No migrations, no infra changes.
