### PR TITLE
Fix client-side MCP server registration leak exhausting the per-user instance limit

### DIFF
--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -84,6 +84,18 @@ export class BrowserMCPTransport implements Transport {
    */
   private async registerServer(): Promise<boolean> {
     try {
+      // If we already hold a registration (e.g. re-registering after a failed
+      // heartbeat), release it first so the server reuses the same slot instead
+      // of allocating a new serverId suffix that would linger until its TTL
+      // expires. Without this, repeated re-registrations leak slots and
+      // eventually exhaust the per-user limit ("Maximum number of servers
+      // reached").
+      if (this.serverId) {
+        const previousServerId = this.serverId;
+        this.serverId = null;
+        await this.deregisterServer(previousServerId);
+      }
+
       const response = await clientFetch(
         `/api/w/${this.workspaceId}/mcp/register`,
         {


### PR DESCRIPTION
  ## Problem

  We were seeing high rates of `400` errors (e.g. 150 in 5 seconds for the same
  workspace) on `POST /api/w/[wId]/mcp/register`:

  > Maximum number of servers (256) with name "dust-chrome-extension" reached

  The registration limit is per `(workspace, user, serverName)`. Each registration
  is a Redis key with a 10-minute TTL, kept alive by a 5-minute client heartbeat and
  released on `deregister`.

  The root cause is in `BrowserMCPTransport.registerServer()`: it **always** allocated
  a fresh `serverId` suffix (`.1`, `.2`, …) via `SET NX` and never released the slot it
  already held. The heartbeat-failure path (`setupHeartbeat` re-calls `registerServer()`
  on any non-OK / thrown / `success: false` response) therefore leaked a slot on every
  retry, and those orphaned keys linger for the full 10-minute TTL.

  Once 256 live keys accumulate for a single user, every subsequent `register` returns
  the 400. And because hitting the cap leaves `transport` unset, the client keeps
  retrying — turning a slow leak into the observed error bursts (each failed call also
  doing up to 256 sequential Redis `SET NX` round-trips).

  ## Fix

  `registerServer()` now deregisters the registration it currently holds before
  registering again, so the server reuses the same slot instead of leaking a new
  suffix. This bounds each transport to a single live registration and makes the
  re-register path self-healing.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
