### PR TITLE
feat(billing): reset seats when resetting plan to FREE_NO_PLAN

### DIFF
--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -744,4 +744,84 @@ describe("MembershipResource", () => {
       expect(future[0].creditState).toBe("on_pool");
     });
   });
+
+  describe("resetAllSeatsToNoneForWorkspace", () => {
+    let workspace: WorkspaceType;
+    let lightWorkspace: LightWorkspaceType;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      lightWorkspace = renderLightWorkspaceType({ workspace });
+    });
+
+    it("resets every active membership to the none seat type", async () => {
+      const userA = await UserFactory.basic();
+      const userB = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, userA, {
+        role: "admin",
+        seatType: "workspace",
+      });
+      await MembershipFactory.associate(workspace, userB, {
+        role: "user",
+        seatType: "max",
+      });
+
+      await MembershipResource.resetAllSeatsToNoneForWorkspace({
+        workspace: lightWorkspace,
+      });
+
+      const counts =
+        await MembershipResource.getActiveSeatTypeCountsForWorkspace({
+          workspace: lightWorkspace,
+        });
+      expect(counts).toEqual({ none: 2 });
+
+      const membershipA =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: userA,
+          workspace: lightWorkspace,
+        });
+      expect(membershipA?.seatType).toBe("none");
+      expect(membershipA?.creditState).toBe("on_pool");
+    });
+
+    it("leaves already-ended memberships untouched", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, {
+        role: "user",
+        seatType: "max",
+      });
+      await MembershipResource.revokeMembership({
+        user,
+        workspace: lightWorkspace,
+      });
+
+      await MembershipResource.resetAllSeatsToNoneForWorkspace({
+        workspace: lightWorkspace,
+      });
+
+      const ended =
+        await MembershipResource.getLatestMembershipOfUserInWorkspace({
+          user,
+          workspace: lightWorkspace,
+        });
+      expect(ended?.seatType).toBe("max");
+    });
+
+    it("invalidates the active seats cache", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, {
+        role: "user",
+        seatType: "workspace",
+      });
+
+      deletedKeys.length = 0;
+      await MembershipResource.resetAllSeatsToNoneForWorkspace({
+        workspace: lightWorkspace,
+      });
+
+      const seatsCacheKey = `cacheWithRedis-_countActiveSeatsInWorkspaceUncached-count-active-seats-in-workspace:${workspace.sId}`;
+      expect(deletedKeys).toContain(seatsCacheKey);
+    });
+  });
 });

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -818,6 +818,34 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return counts;
   }
 
+  static async resetAllSeatsToNoneForWorkspace({
+    workspace,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<void> {
+    const now = new Date();
+    await MembershipModel.update(
+      {
+        seatType: "none",
+        creditState: initialCreditStateForSeatType("none"),
+      },
+      {
+        where: {
+          workspaceId: workspace.id,
+          endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gt]: now }] },
+        },
+        transaction,
+      }
+    );
+
+    const workspaceId = workspace.sId;
+    invalidateCacheAfterCommit(transaction, () =>
+      MembershipResource.invalidateActiveSeatsCache(workspaceId)
+    );
+  }
+
   /**
    * Counts used to enforce the plan-level `free`-seat caps
    * (`plan.limits.users.maxFreeUsers` / `maxLifetimeFreeUsers`).

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -47,6 +47,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
   cacheWithRedis,
@@ -756,6 +757,18 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     const workspace = await this.findWorkspaceOrThrow(workspaceId);
 
     await this.endActiveSubscription(workspace);
+
+    // No plan anymore: clear billed seat assignments and plan-level seat caps.
+    await withTransaction(async (t) => {
+      await MembershipResource.resetAllSeatsToNoneForWorkspace({
+        workspace,
+        transaction: t,
+      });
+      await WorkspaceSeatLimitResource.deleteAllForWorkspace({
+        workspace,
+        transaction: t,
+      });
+    });
 
     await SubscriptionResource.invalidateSubscriptionCache(workspace.id);
 

--- a/front/lib/resources/workspace_seat_limit_resource.test.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.test.ts
@@ -1,4 +1,3 @@
-import { Authenticator } from "@app/lib/auth";
 import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -155,8 +154,7 @@ describe("WorkspaceSeatLimitResource", () => {
       minSeats: 1,
     });
 
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    await WorkspaceSeatLimitResource.deleteAllForWorkspace(auth);
+    await WorkspaceSeatLimitResource.deleteAllForWorkspace({ workspace });
 
     const limits = await WorkspaceSeatLimitResource.fetchByWorkspace({
       workspace,

--- a/front/lib/resources/workspace_seat_limit_resource.ts
+++ b/front/lib/resources/workspace_seat_limit_resource.ts
@@ -111,14 +111,18 @@ export class WorkspaceSeatLimitResource extends BaseResource<WorkspaceSeatLimitM
   /**
    * Delete all seat-limit rows for a workspace. Called during workspace
    * deletion/scrubbing to satisfy the `ON DELETE RESTRICT` FK before the
-   * workspace row itself is removed.
+   * workspace row itself is removed, and when a workspace loses its plan
+   * (reset to FREE_NO_PLAN), where plan-level seat caps no longer apply.
    */
-  static async deleteAllForWorkspace(
-    auth: Authenticator,
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<void> {
+  static async deleteAllForWorkspace({
+    workspace,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    transaction?: Transaction;
+  }): Promise<void> {
     await this.model.destroy({
-      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      where: { workspaceId: workspace.id },
       transaction,
     });
   }

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -778,7 +778,7 @@ export async function deleteWorkspaceActivity({
   await ProgrammaticUsageConfigurationResource.deleteAllForWorkspace(auth);
   await SelfImprovingSkillsUsageResource.deleteAllForWorkspace(auth);
   await WorkspaceVerificationAttemptResource.deleteAllForWorkspace(auth);
-  await WorkspaceSeatLimitResource.deleteAllForWorkspace(auth);
+  await WorkspaceSeatLimitResource.deleteAllForWorkspace({ workspace });
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 


### PR DESCRIPTION
## Description

- Add MembershipResource.resetAllSeatsToNoneForWorkspace to clear billed seat assignments (and align credit state) on all still-open memberships
- Add WorkspaceSeatLimitResource.removeAllForWorkspace to drop plan-level seat caps without an Authenticator
- Wire both resets into SubscriptionResource.internalSubscribeWorkspaceToFreeNoPlan
- Cover the new behavior with resource tests

Ticket: https://github.com/dust-tt/tasks/issues/8833

## Tests

Unit

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front