### PR TITLE
Disable unusable settings, labels

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -2,12 +2,12 @@ import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
 import { ConfirmContext } from "@app/components/Confirm";
 import { InviteEmailButtonWithModal } from "@app/components/members/InviteEmailButtonWithModal";
-import { AwuUsageChart } from "@app/components/workspace/AwuUsageChart";
 import { BuyAwuCreditsDialog } from "@app/components/workspace/BuyAwuCreditsDialog";
 import { ChangeSeatModal } from "@app/components/workspace/ChangeSeatModal";
 import { EditSpendLimitModal } from "@app/components/workspace/EditSpendLimitModal";
 import { MembersUsageTable } from "@app/components/workspace/MembersUsageTable";
 import { UpgradeRequestsTable } from "@app/components/workspace/UpgradeRequestsTable";
+import { LockedSection } from "@app/components/workspace/usage/LockedSection";
 import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNotificationsCard";
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
@@ -58,20 +58,17 @@ import {
   AlertCircle,
   ArrowUp,
   Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Icon,
   Page,
   PieChart01,
   SearchInput,
   Spinner,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { PaginationState, SortingState } from "@tanstack/react-table";
 import capitalize from "lodash/capitalize";
@@ -360,10 +357,9 @@ export function UsagePage() {
       disabled: !showBuyCreditDialog,
     });
 
-  const { billingCycleStartDay, isCreditPurchaseInfoLoading } =
-    useCreditPurchaseInfo({
-      workspaceId: owner.sId,
-    });
+  const { billingCycleStartDay } = useCreditPurchaseInfo({
+    workspaceId: owner.sId,
+  });
 
   // Legacy contracts have no pool credits or commits, so the pool summary's
   // overage figure is meaningless. In read-only mode we instead show the
@@ -454,10 +450,15 @@ export function UsagePage() {
     totalActiveCredits - totalRemainingCredits
   );
   const initialTotalCredits = totalActiveCredits;
+  const hasPool = totalActiveCredits > 0;
 
   if (!canViewUsage) {
     return null;
   }
+
+  const showPoolSection =
+    !isAwuPoolSummaryLoading &&
+    (!!isAwuPoolSummaryError || hasPool || isReadOnly);
 
   const searchAndInviteRow = (
     <div className="flex flex-row gap-2">
@@ -549,20 +550,23 @@ export function UsagePage() {
       />
 
       <div className="flex flex-col items-stretch gap-10 pb-20">
-        <Page.Vertical gap="xs">
-          <Icon
-            visual={PieChart01}
-            className="text-muted-foreground dark:text-muted-foreground-night"
-            size="lg"
-          />
-          <Page.H variant="h3">Usage</Page.H>
-          <Page.P variant="secondary">
-            Manage the usage of your Dust workspace
-          </Page.P>
-        </Page.Vertical>
+        <div className="flex items-center justify-between">
+          <Page.Header title="Usage" icon={PieChart01} />
+          {!isReadOnly && !isEnterprise && (
+            <Button
+              label="Top up"
+              icon={ArrowUp}
+              size="sm"
+              variant="outline"
+              onClick={() => setShowBuyCreditDialog(true)}
+            />
+          )}
+        </div>
 
-        {!isFreePlanWorkspace && (
+        {showPoolSection && (
           <Page.Vertical gap="xs" align="stretch">
+            <Page.H variant="h4">Workspace Credit Pool</Page.H>
+
             {isAwuPoolSummaryError && (
               <ContentMessage
                 title="Failed to load Workspace Credits Pool"
@@ -591,6 +595,16 @@ export function UsagePage() {
                     /{formatCredits(initialTotalCredits)}
                   </span>
                 </div>
+                {hasPool && (
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted-foreground/20">
+                    <div
+                      className="h-full rounded-full bg-foreground/80 transition-all"
+                      style={{
+                        width: `${Math.min(100, initialTotalCredits > 0 ? (totalConsumedCredits / initialTotalCredits) * 100 : 0)}%`,
+                      }}
+                    />
+                  </div>
+                )}
                 <div className="flex items-center gap-2">
                   {isReadOnly ? (
                     <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
@@ -604,18 +618,10 @@ export function UsagePage() {
                           {formatCredits(overageCredits)} overage credits
                         </span>
                       )}
-                      {isEnterprise ? (
+                      {isEnterprise && (
                         <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
                           Contact your Dust sales representative to buy credits
                         </span>
-                      ) : (
-                        <Button
-                          label="Top up"
-                          icon={ArrowUp}
-                          size="xs"
-                          variant="outline"
-                          onClick={() => setShowBuyCreditDialog(true)}
-                        />
                       )}
                     </>
                   )}
@@ -625,47 +631,45 @@ export function UsagePage() {
           </Page.Vertical>
         )}
 
-        {isCreditPurchaseInfoLoading ? (
-          <div className="h-64 animate-pulse rounded bg-muted-foreground/20" />
-        ) : (
-          <AwuUsageChart
-            workspaceId={owner.sId}
-            billingCycleStartDay={billingCycleStartDay ?? 1}
-          />
-        )}
-
-        {!isFreePlanWorkspace && (
-          <>
-            <UsageSettingsCard workspaceId={owner.sId} readOnly={isReadOnly} />
-
-            <UsageProgrammaticLimitCard
+        <Page.Vertical gap="md" align="stretch">
+          <Page.H variant="h4">Settings</Page.H>
+          <div className="flex flex-col gap-10">
+            <UsageSettingsCard
               workspaceId={owner.sId}
               readOnly={isReadOnly}
+              hasPool={hasPool}
             />
-
-            <UsageNotificationsCard
-              workspaceId={owner.sId}
-              readOnly={isReadOnly}
-            />
-          </>
-        )}
+            <LockedSection
+              locked={!isAwuPoolSummaryLoading && !hasPool}
+              className="flex flex-col gap-10"
+            >
+              <UsageProgrammaticLimitCard
+                workspaceId={owner.sId}
+                readOnly={isReadOnly}
+              />
+              <UsageNotificationsCard
+                workspaceId={owner.sId}
+                readOnly={isReadOnly}
+              />
+            </LockedSection>
+          </div>
+        </Page.Vertical>
 
         <Page.Vertical gap="sm" align="stretch">
-          <span className="heading-2xl text-foreground dark:text-foreground-night">
-            Members
-          </span>
+          <Page.H variant="h4">Members</Page.H>
           {searchAndInviteRow}
           {isWorkspaceAdmin ? (
-            <Tabs
-              value={membersTab}
-              onValueChange={(value) =>
-                setMembersTab(value === "requests" ? "requests" : "members")
-              }
-            >
+            <div className="flex flex-col gap-2">
               <div className="flex flex-row items-center justify-between gap-2">
-                <TabsList border={false} className="w-auto">
-                  <TabsTrigger value="members" label="Members" />
-                  <TabsTrigger
+                <ButtonsSwitchList
+                  size="xs"
+                  defaultValue="members"
+                  onValueChange={(v) =>
+                    setMembersTab(v === "requests" ? "requests" : "members")
+                  }
+                >
+                  <ButtonsSwitch value="members" label="Members" />
+                  <ButtonsSwitch
                     value="requests"
                     label="Requests"
                     isCounter
@@ -675,14 +679,13 @@ export function UsagePage() {
                         : undefined
                     }
                   />
-                </TabsList>
+                </ButtonsSwitchList>
                 {membersTab === "members" && seatFilterDropdown}
               </div>
-              <TabsContent value="members">
-                <div className="pt-2">{membersTable}</div>
-              </TabsContent>
-              <TabsContent value="requests">
-                <div className="pt-2">
+              <div className="pt-2">
+                {membersTab === "members" ? (
+                  membersTable
+                ) : (
                   <UpgradeRequestsTable
                     requests={filteredUpgradeRequests}
                     isLoading={isUpgradeRequestsLoading}
@@ -692,9 +695,9 @@ export function UsagePage() {
                     onEditLimit={handleEditLimitRequest}
                     onDeny={handleDenyRequest}
                   />
-                </div>
-              </TabsContent>
-            </Tabs>
+                )}
+              </div>
+            </div>
           ) : (
             <>
               {seatFilterDropdown && (
@@ -706,43 +709,43 @@ export function UsagePage() {
             </>
           )}
         </Page.Vertical>
-
-        {inviteBlockedPopupReason && (
-          <ReachedLimitPopup
-            isAdmin={isAdmin(owner)}
-            isOpened={!!inviteBlockedPopupReason}
-            onClose={() => setInviteBlockedPopupReason(null)}
-            subscription={subscription}
-            owner={owner}
-            code={inviteBlockedPopupReason}
-          />
-        )}
-
-        <ChangeSeatModal
-          isOpen={changeSeatMember !== null}
-          onClose={() => {
-            setChangeSeatMember(null);
-            setPendingApproveRequestId(null);
-          }}
-          member={changeSeatMember}
-          owner={owner}
-          seatPlans={seatPlans}
-          onSavingChange={handleSeatChangePendingChange}
-          onSaved={handleApproveOnModalSaved}
-        />
-
-        <EditSpendLimitModal
-          isOpen={editSpendLimitMember !== null}
-          onClose={() => {
-            setEditSpendLimitMember(null);
-            setPendingApproveRequestId(null);
-          }}
-          member={editSpendLimitMember}
-          owner={owner}
-          onSavingChange={handleUsagePendingChange}
-          onSaved={handleApproveOnModalSaved}
-        />
       </div>
+
+      {inviteBlockedPopupReason && (
+        <ReachedLimitPopup
+          isAdmin={isAdmin(owner)}
+          isOpened={!!inviteBlockedPopupReason}
+          onClose={() => setInviteBlockedPopupReason(null)}
+          subscription={subscription}
+          owner={owner}
+          code={inviteBlockedPopupReason}
+        />
+      )}
+
+      <ChangeSeatModal
+        isOpen={changeSeatMember !== null}
+        onClose={() => {
+          setChangeSeatMember(null);
+          setPendingApproveRequestId(null);
+        }}
+        member={changeSeatMember}
+        owner={owner}
+        seatPlans={seatPlans}
+        onSavingChange={handleSeatChangePendingChange}
+        onSaved={handleApproveOnModalSaved}
+      />
+
+      <EditSpendLimitModal
+        isOpen={editSpendLimitMember !== null}
+        onClose={() => {
+          setEditSpendLimitMember(null);
+          setPendingApproveRequestId(null);
+        }}
+        member={editSpendLimitMember}
+        owner={owner}
+        onSavingChange={handleUsagePendingChange}
+        onSaved={handleApproveOnModalSaved}
+      />
     </>
   );
 }

--- a/front/components/workspace/usage/LockedSection.tsx
+++ b/front/components/workspace/usage/LockedSection.tsx
@@ -1,0 +1,45 @@
+import {
+  cn,
+  TooltipContent,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from "@dust-tt/sparkle";
+
+interface LockedSectionProps {
+  locked: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function LockedSection({
+  locked,
+  children,
+  className,
+}: LockedSectionProps) {
+  if (!locked) {
+    return <>{children}</>;
+  }
+  return (
+    <TooltipProvider delayDuration={300}>
+      <TooltipRoot>
+        <div className="relative">
+          <div
+            className={cn(
+              "pointer-events-none select-none opacity-40",
+              className
+            )}
+          >
+            {children}
+          </div>
+          <TooltipTrigger asChild>
+            <div className="absolute inset-0 cursor-not-allowed" />
+          </TooltipTrigger>
+        </div>
+        <TooltipContent>
+          Top up your credit pool to enable these settings
+        </TooltipContent>
+      </TooltipRoot>
+    </TooltipProvider>
+  );
+}

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -71,8 +71,8 @@ export function UsageNotificationsCard({
       </div>
       <SettingsList>
         <SettingsList.Row
-          title="Credit balance threshold"
-          description="Email all workspace admins when your remaining credit balance drops below this amount (in credits). Set to 0 to disable."
+          title="Workspace credit pool threshold"
+          description="Email all workspace admins when your remaining workspace credit pool balance drops below this amount (in credits). Set to 0 to disable."
           action={
             <div className="w-52">
               <InputWithSave
@@ -88,7 +88,7 @@ export function UsageNotificationsCard({
           }
         />
         <SettingsList.Row
-          title="Upgrade request"
+          title="Upgrade request emails"
           description="Email all workspace admins when a member requests a spend-limit upgrade."
           action={
             <SliderToggle

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -51,7 +51,7 @@ export function UsageProgrammaticLimitCard({
       <SettingsList>
         <SettingsList.Row
           title="Programmatic monthly limit"
-          description="Maximum credits allowed for programmatic usage per month"
+          description="Maximum credits allowed for programmatic usage per month."
           action={
             <div className="w-52">
               <InputWithSave

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -1,3 +1,4 @@
+import { LockedSection } from "@app/components/workspace/usage/LockedSection";
 import {
   useDefaultUserSpendLimit,
   useUpdateDefaultUserSpendLimit,
@@ -19,11 +20,13 @@ import { useState } from "react";
 interface UsageSettingsCardProps {
   workspaceId: string;
   readOnly: boolean;
+  hasPool: boolean;
 }
 
 export function UsageSettingsCard({
   workspaceId,
   readOnly,
+  hasPool,
 }: UsageSettingsCardProps) {
   const { defaultUserSpendLimit, isDefaultUserSpendLimitLoading } =
     useDefaultUserSpendLimit({ workspaceId });
@@ -67,34 +70,36 @@ export function UsageSettingsCard({
 
   return (
     <Page.Vertical gap="sm" align="stretch">
-      <span className="heading-2xl text-foreground dark:text-foreground-night">
-        Settings
+      <span className="heading-base text-foreground dark:text-foreground-night">
+        Spending policies
       </span>
       <SettingsList>
-        <SettingsList.Row
-          title="Default pool credit limit"
-          description="Define the pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance."
-          action={
-            <div className="w-52">
-              <InputWithSave
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={
-                  currentDefaultLimit !== null
-                    ? String(currentDefaultLimit)
-                    : ""
-                }
-                unit="credits"
-                normalizeValue={(value) => value.replace(/[^\d]/g, "")}
-                onSave={handleSaveDefaultLimit}
-                disabled={readOnly || isDefaultUserSpendLimitLoading}
-              />
-            </div>
-          }
-        />
+        <LockedSection locked={!hasPool}>
+          <SettingsList.Row
+            title="Default Workspace Credit Pool limit"
+            description="Define the Workspace Credit Pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance. Can be overridden per user in the members table."
+            action={
+              <div className="w-52">
+                <InputWithSave
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={
+                    currentDefaultLimit !== null
+                      ? String(currentDefaultLimit)
+                      : ""
+                  }
+                  unit="credits"
+                  normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                  onSave={handleSaveDefaultLimit}
+                  disabled={readOnly || isDefaultUserSpendLimitLoading}
+                />
+              </div>
+            }
+          />
+        </LockedSection>
         <SettingsList.Row
           title="Upgrade request"
-          description="Allow members who reach their pool credit limit to request an upgrade. Workspace admins review requests on the Usage page."
+          description="Allow members who reach their limit to request an upgrade. Workspace admins review requests on the this page."
           action={
             <SliderToggle
               selected={usageSettings.allowUpgradeRequest}


### PR DESCRIPTION
## Description

Billing usage page cleanup ([#8898](https://github.com/dust-tt/tasks/issues/8898), [#8858](https://github.com/dust-tt/tasks/issues/8858)):

- **Rename** page header from "Usage" to "Workspace Credit Pool"
- **Remove** the usage chart (moving to Analytics)
- **Add** a simple progress bar for pool consumption
- **Hide** pool balance when no credits exist; show a Top-up button (or enterprise contact text) instead
- **Settings** locked with a disabled overlay + tooltip when no pool exists, rather than hidden — except the "Upgrade request" toggle which stays always accessible
- **Rename** "Upgrade request" notification row to "Upgrade request emails" to distinguish it from the allow-requests toggle
- **Replace** the Members/Requests Tabs component with a custom segmented control matching the Figma design (gray pill, white active tab, blue badge)

## Tests

Tested manually on a workspace with and without a credit pool.

## Risk

Low — UI-only changes, no backend or data model modifications.

## Deploy Plan

Standard frontend deploy, no migration needed.