### PR TITLE
Fix MCP connect race spawning orphaned transports

### DIFF
--- a/extension/platforms/chrome/services/mcp.ts
+++ b/extension/platforms/chrome/services/mcp.ts
@@ -60,25 +60,35 @@ export class ChromeMcpService extends McpService {
       throw new Error("Cannot connect null server");
     }
 
-    try {
-      if (this.transport) {
-        return;
+    if (this.transport) {
+      return;
+    }
+
+    const transport = new BrowserMCPTransport(
+      owner.sId,
+      "dust-chrome-extension",
+      (serverId) => {
+        this.serverId = serverId;
+        onServerIdReceived(serverId);
       }
+    );
 
-      const transport = new BrowserMCPTransport(
-        owner.sId,
-        "dust-chrome-extension",
-        (serverId) => {
-          this.serverId = serverId;
-          onServerIdReceived(serverId);
-        }
-      );
+    // Claim the slot synchronously, before the async `server.connect` round-trip,
+    // so a concurrent getOrCreateServer/connectServer call short-circuits on the
+    // guard above instead of creating a second transport. A leaked transport keeps
+    // a heartbeat timer alive forever; many such timers firing on the same tick
+    // produce bursts of register/heartbeat calls.
+    this.server = server;
+    this.transport = transport;
 
+    try {
       await server.connect(transport);
-
-      this.server = server;
-      this.transport = transport;
     } catch (error) {
+      // Roll back the claim and tear down the half-open transport so a later
+      // attempt can retry cleanly.
+      this.server = null;
+      this.transport = null;
+      await transport.close();
       logger.error({ err: error }, "Failed to connect MCP server.");
       throw error;
     }

--- a/extension/platforms/firefox/services/mcp.ts
+++ b/extension/platforms/firefox/services/mcp.ts
@@ -55,25 +55,35 @@ export class FirefoxMcpService extends McpService {
       throw new Error("Cannot connect null server");
     }
 
-    try {
-      if (this.transport) {
-        return;
+    if (this.transport) {
+      return;
+    }
+
+    const transport = new BrowserMCPTransport(
+      owner.sId,
+      "dust-firefox-extension",
+      (serverId) => {
+        this.serverId = serverId;
+        onServerIdReceived(serverId);
       }
+    );
 
-      const transport = new BrowserMCPTransport(
-        owner.sId,
-        "dust-firefox-extension",
-        (serverId) => {
-          this.serverId = serverId;
-          onServerIdReceived(serverId);
-        }
-      );
+    // Claim the slot synchronously, before the async `server.connect` round-trip,
+    // so a concurrent getOrCreateServer/connectServer call short-circuits on the
+    // guard above instead of creating a second transport. A leaked transport keeps
+    // a heartbeat timer alive forever; many such timers firing on the same tick
+    // produce bursts of register/heartbeat calls.
+    this.server = server;
+    this.transport = transport;
 
+    try {
       await server.connect(transport);
-
-      this.server = server;
-      this.transport = transport;
     } catch (error) {
+      // Roll back the claim and tear down the half-open transport so a later
+      // attempt can retry cleanly.
+      this.server = null;
+      this.transport = null;
+      await transport.close();
       console.error("Failed to connect MCP server:", error);
       throw error;
     }

--- a/extension/platforms/front/services/mcp.ts
+++ b/extension/platforms/front/services/mcp.ts
@@ -73,29 +73,38 @@ export class FrontMcpService extends McpService {
       throw new Error("Cannot connect null server");
     }
 
-    try {
-      // If we already have a transport for this workspace, reuse it.
-      if (this.transport) {
-        return;
+    // If we already have a transport for this workspace, reuse it.
+    if (this.transport) {
+      return;
+    }
+
+    // Create our custom transport with workspace-scoped registration.
+    const transport = new BrowserMCPTransport(
+      owner.sId,
+      "front-extension-client",
+      (serverId) => {
+        this.serverId = serverId;
+        onServerIdReceived(serverId);
       }
+    );
 
-      // Create our custom transport with workspace-scoped registration.
-      const transport = new BrowserMCPTransport(
-        owner.sId,
-        "front-extension-client",
-        (serverId) => {
-          this.serverId = serverId;
-          onServerIdReceived(serverId);
-        }
-      );
+    // Claim the slot synchronously, before the async `server.connect` round-trip,
+    // so a concurrent getOrCreateServer/connectServer call short-circuits on the
+    // guard above instead of creating a second transport. A leaked transport keeps
+    // a heartbeat timer alive forever; many such timers firing on the same tick
+    // produce bursts of register/heartbeat calls.
+    this.server = server;
+    this.transport = transport;
 
+    try {
       // Connect the server to the transport.
       await server.connect(transport);
-
-      // Store the server and transport for future reuse.
-      this.server = server;
-      this.transport = transport;
     } catch (error) {
+      // Roll back the claim and tear down the half-open transport so a later
+      // attempt can retry cleanly.
+      this.server = null;
+      this.transport = null;
+      await transport.close();
       logger.error({ err: error }, "Failed to connect MCP server.");
       throw error;
     }


### PR DESCRIPTION
  ## Problem

  In production we saw a single client fire ~93 `mcp/heartbeat` / `mcp/register` calls within ~0.1s, then go silent — a burst far too tight to come from one transport's 5-minute heartbeat `setInterval`.

  Root cause is a race in the MCP service layer. `connectServer` guards on `this.transport`, but that field is only assigned **after** the async `server.connect()` round-trip (which itself performs the register HTTP call):

  ```ts
  if (this.transport) { return; }                 // guard
  const transport = new BrowserMCPTransport(...);
  await server.connect(transport);                 // full register round-trip
  this.transport = transport;                      // guard only effective HERE
```

  Any concurrent getOrCreateServer/connectServer call that lands inside that
  window passes the guard and constructs another BrowserMCPTransport, each
  starting its own heartbeat setInterval. The service's disconnect() only
  closes the last-assigned this.transport, so every other transport is orphaned
  with a heartbeat timer that is never cleared.

  Because the orphans are all created in the same brief churn episode (e.g. auth
  flapping / rapid effect re-runs toggling workspaceId), their timers are
  phase-aligned and all fire on the same ~5-minute tick — producing the observed
  burst of heartbeat calls (each failed heartbeat also triggers a re-register,
  hence the heartbeat+register mix).

  Fix

  Claim this.server / this.transport synchronously, before awaiting
  server.connect(), so the existing guard short-circuits concurrent calls and a
  second transport can never be created. On connect failure, roll both fields back
  to null and call transport.close() (which clears the heartbeat timer) so a
  later attempt can retry cleanly.

  Applied identically to all three MCP service implementations:

  - extension/platforms/chrome/services/mcp.ts
  - extension/platforms/firefox/services/mcp.ts
  - extension/platforms/front/services/mcp.ts

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
