### PR TITLE
feat(model_constructors): OpenAI Responses provider and GPT-5.5 stream endpoint

### DIFF
--- a/front/lib/model_constructors/providers/openai/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/openai/converters/input/index.ts
@@ -1,0 +1,101 @@
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseInputItem,
+} from "openai/resources/responses/responses";
+
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  assistantReasoningMessageToInputItems,
+  assistantTextMessageToInputItem,
+  assistantToolCallRequestToInputItem,
+  conversationToInput,
+  forceToolToToolChoice,
+  type MessageItemConverters,
+  outputFormatToResponseFormat,
+  reasoningToOpenAIReasoning,
+  systemMessagesToInputItems,
+  systemMessageToInputItem,
+  toFunctionTool,
+  toolCallResultMessageToInputItem,
+  userImageMessageToInputItem,
+  userTextMessageToInputItem,
+} from "@app/lib/model_constructors/providers/openai/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  Payload,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the OpenAI Responses API
+// request shape. Leaf converters are bound as class fields and composites route
+// through `this`, so an endpoint can override a single leaf.
+export function WithOpenAIResponsesInputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithOpenAIResponsesInputConverter
+    extends Base
+    implements MessageItemConverters
+  {
+    systemMessageToInputItem = systemMessageToInputItem;
+    userTextMessageToInputItem = userTextMessageToInputItem;
+    userImageMessageToInputItem = userImageMessageToInputItem;
+    toolCallResultMessageToInputItem = toolCallResultMessageToInputItem;
+    assistantTextMessageToInputItem = assistantTextMessageToInputItem;
+    assistantReasoningMessageToInputItems =
+      assistantReasoningMessageToInputItems;
+    assistantToolCallRequestToInputItem = assistantToolCallRequestToInputItem;
+
+    conversationToInput(
+      conversation: Payload["conversation"]
+    ): ResponseInputItem[] {
+      return conversationToInput(conversation, this);
+    }
+
+    systemMessagesToInputItems(
+      system: SystemTextMessage[]
+    ): ResponseInputItem[] {
+      return systemMessagesToInputItems(system, this);
+    }
+
+    buildRequestPayload(
+      payload: Payload,
+      config: InputConfig
+    ): ResponseCreateParamsNonStreaming {
+      const { conversation } = payload;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        forceTool,
+        outputFormat,
+      } = config;
+
+      const reasoningConfig = reasoningToOpenAIReasoning(reasoning);
+
+      return {
+        model: this.constructor.modelId,
+        max_output_tokens: this.constructor.maxOutputTokens,
+        input: [
+          ...this.systemMessagesToInputItems(conversation.system),
+          ...this.conversationToInput(conversation),
+        ],
+        ...(reasoningConfig
+          ? {
+              reasoning: reasoningConfig,
+              include: ["reasoning.encrypted_content"],
+            }
+          : {}),
+        tools: tools.map((tool) => toFunctionTool(tool)),
+        tool_choice: forceToolToToolChoice(tools, forceTool),
+        ...(outputFormat
+          ? { text: { format: outputFormatToResponseFormat(outputFormat) } }
+          : {}),
+        temperature,
+      };
+    }
+  }
+
+  return WithOpenAIResponsesInputConverter;
+}

--- a/front/lib/model_constructors/providers/openai/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/openai/converters/input/utils.ts
@@ -1,0 +1,233 @@
+import type {
+  FunctionTool,
+  ResponseFormatTextJSONSchemaConfig,
+  ResponseInputItem,
+  ToolChoiceFunction,
+} from "openai/resources/responses/responses";
+import type { Reasoning as OpenAIReasoning } from "openai/resources/shared";
+
+import { isOpenAISupportedReasoningEffort } from "@app/lib/model_constructors/providers/openai/reasoning_efforts";
+import type {
+  OutputFormat,
+  Reasoning,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+// The per-message leaf converters. Composites below take an object satisfying
+// this interface (`this`), so overriding one leaf on an endpoint changes how
+// every composite uses it.
+export interface MessageItemConverters {
+  systemMessageToInputItem(message: SystemTextMessage): ResponseInputItem;
+  userTextMessageToInputItem(message: BaseUserTextMessage): ResponseInputItem;
+  userImageMessageToInputItem(message: BaseUserImageMessage): ResponseInputItem;
+  toolCallResultMessageToInputItem(
+    message: BaseToolCallResultMessage
+  ): ResponseInputItem;
+  assistantTextMessageToInputItem(
+    message: BaseAssistantTextMessage
+  ): ResponseInputItem;
+  assistantReasoningMessageToInputItems(
+    message: BaseAssistantReasoningMessage
+  ): ResponseInputItem[];
+  assistantToolCallRequestToInputItem(
+    message: BaseAssistantToolCallRequestMessage
+  ): ResponseInputItem;
+}
+
+// -- Leaf converters: one Responses input item per message --
+
+// OpenAI uses the "developer" role for the system prompt on reasoning models.
+export function systemMessageToInputItem(
+  message: SystemTextMessage
+): ResponseInputItem {
+  return {
+    role: "developer",
+    content: [{ type: "input_text", text: message.content.value }],
+  };
+}
+
+export function userTextMessageToInputItem(
+  message: BaseUserTextMessage
+): ResponseInputItem {
+  return {
+    role: "user",
+    content: [{ type: "input_text", text: message.content.value }],
+  };
+}
+
+export function userImageMessageToInputItem(
+  message: BaseUserImageMessage
+): ResponseInputItem {
+  return {
+    role: "user",
+    content: [
+      { type: "input_image", image_url: message.content.url, detail: "auto" },
+    ],
+  };
+}
+
+export function toolCallResultMessageToInputItem(
+  message: BaseToolCallResultMessage
+): ResponseInputItem {
+  // The Responses function_call_output takes a single string; flatten parts.
+  const output = message.content.parts
+    .map((part) => {
+      switch (part.type) {
+        case "text":
+          return part.text;
+        case "image_url":
+          return `[image: ${part.url}]`;
+        default:
+          return assertNever(part);
+      }
+    })
+    .join("\n");
+  return {
+    type: "function_call_output",
+    call_id: message.content.callId,
+    output,
+  };
+}
+
+export function assistantTextMessageToInputItem(
+  message: BaseAssistantTextMessage
+): ResponseInputItem {
+  return { role: "assistant", content: message.content.value };
+}
+
+export function assistantReasoningMessageToInputItems(
+  _message: BaseAssistantReasoningMessage
+): ResponseInputItem[] {
+  // Replaying a reasoning item requires the original item id + encrypted
+  // content, which our message type doesn't carry, so drop it (mirrors
+  // dropping unsigned Anthropic thinking blocks).
+  return [];
+}
+
+export function assistantToolCallRequestToInputItem(
+  message: BaseAssistantToolCallRequestMessage
+): ResponseInputItem {
+  return {
+    type: "function_call",
+    call_id: message.content.callId,
+    name: message.content.toolName,
+    arguments: message.content.arguments,
+  };
+}
+
+// -- Composite message converters (depend on the leaf converters) --
+
+export function userMessageToInputItems(
+  message: BaseUserMessage,
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  switch (message.type) {
+    case "text":
+      return [converters.userTextMessageToInputItem(message)];
+    case "image_url":
+      return [converters.userImageMessageToInputItem(message)];
+    case "tool_call_result":
+      return [converters.toolCallResultMessageToInputItem(message)];
+    default:
+      assertNever(message);
+  }
+}
+
+export function assistantMessageToInputItems(
+  message: BaseAssistantMessage,
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  switch (message.type) {
+    case "text":
+      return [converters.assistantTextMessageToInputItem(message)];
+    case "reasoning":
+      return converters.assistantReasoningMessageToInputItems(message);
+    case "tool_call_request":
+      return [converters.assistantToolCallRequestToInputItem(message)];
+    default:
+      assertNever(message);
+  }
+}
+
+export function conversationToInput(
+  conversation: BaseConversation,
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  return conversation.messages.flatMap((message) => {
+    switch (message.role) {
+      case "user":
+        return userMessageToInputItems(message, converters);
+      case "assistant":
+        return assistantMessageToInputItems(message, converters);
+      default:
+        assertNever(message);
+    }
+  });
+}
+
+export function systemMessagesToInputItems(
+  system: SystemTextMessage[],
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  return system.map((message) => converters.systemMessageToInputItem(message));
+}
+
+// -- Config converters (pure) --
+
+export function toFunctionTool(tool: ToolSpecification): FunctionTool {
+  return {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    // Permissive schemas: skip OpenAI's strict all-required/no-additional rule.
+    strict: false,
+    parameters: { type: "object", ...tool.inputSchema },
+  };
+}
+
+export function forceToolToToolChoice(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ToolChoiceFunction | "auto" {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? { type: "function", name: forceTool }
+    : "auto";
+}
+
+export function outputFormatToResponseFormat(
+  outputFormat: OutputFormat
+): ResponseFormatTextJSONSchemaConfig {
+  return {
+    type: "json_schema",
+    name: outputFormat.json_schema.name,
+    schema: outputFormat.json_schema.schema,
+    description: outputFormat.json_schema.description,
+    strict: outputFormat.json_schema.strict ?? undefined,
+  };
+}
+
+export function reasoningToOpenAIReasoning(
+  reasoning: Reasoning | undefined
+): OpenAIReasoning | undefined {
+  if (!reasoning) {
+    return undefined;
+  }
+  if (!isOpenAISupportedReasoningEffort(reasoning.effort)) {
+    // "maximal" has no OpenAI equivalent; fall back to the strongest supported.
+    return { effort: "xhigh", summary: "auto" };
+  }
+  return { effort: reasoning.effort, summary: "auto" };
+}

--- a/front/lib/model_constructors/providers/openai/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/openai/converters/output/index.ts
@@ -1,0 +1,42 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  accumulatedReasoningToReasoningEvent,
+  accumulatedTextToTextEvent,
+  argumentsDeltaToToolCallDeltaEvent,
+  functionCallToToolCallEvent,
+  functionCallToToolCallStartedEvent,
+  type OutputEventConverters,
+  reasoningSummaryDeltaToReasoningDeltaEvent,
+  responseCreatedToResponseIdEvent,
+  streamErrorToErrorEvent,
+  textDeltaToTextDeltaEvent,
+  usageToTokenUsageEvent,
+} from "@app/lib/model_constructors/providers/openai/converters/output/utils";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Binds the OpenAI leaf output converters onto a client as class fields (an
+// endpoint can override a single leaf by re-declaring its field). The composite
+// is per-surface, so each supplies its own `rawOutputToEvents`.
+export function WithOpenAIResponsesOutputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithOpenAIResponsesOutputConverter
+    extends Base
+    implements OutputEventConverters
+  {
+    responseCreatedToResponseIdEvent = responseCreatedToResponseIdEvent;
+    textDeltaToTextDeltaEvent = textDeltaToTextDeltaEvent;
+    reasoningSummaryDeltaToReasoningDeltaEvent =
+      reasoningSummaryDeltaToReasoningDeltaEvent;
+    functionCallToToolCallStartedEvent = functionCallToToolCallStartedEvent;
+    argumentsDeltaToToolCallDeltaEvent = argumentsDeltaToToolCallDeltaEvent;
+    accumulatedTextToTextEvent = accumulatedTextToTextEvent;
+    accumulatedReasoningToReasoningEvent = accumulatedReasoningToReasoningEvent;
+    functionCallToToolCallEvent = functionCallToToolCallEvent;
+    usageToTokenUsageEvent = usageToTokenUsageEvent;
+    streamErrorToErrorEvent = streamErrorToErrorEvent;
+  }
+
+  return WithOpenAIResponsesOutputConverter;
+}

--- a/front/lib/model_constructors/providers/openai/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/openai/converters/output/utils.ts
@@ -1,0 +1,454 @@
+import { APIConnectionError, APIError } from "openai";
+import type {
+  ResponseCreatedEvent,
+  ResponseOutputItem,
+  ResponseStreamEvent,
+  ResponseUsage,
+} from "openai/resources/responses/responses";
+
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ModelResponseEvent,
+  ReasoningDeltaEvent,
+  ReasoningEvent,
+  ResponseIdEvent,
+  TextDeltaEvent,
+  TextEvent,
+  TokenUsageEvent,
+  ToolCallDeltaEvent,
+  ToolCallEvent,
+  ToolCallStartedEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isRecord } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+// Parses tool-call arguments into an object, falling back to `{}` for malformed
+// or non-object JSON.
+function parseToolArguments(argumentsJson: string): Record<string, unknown> {
+  const parsed = safeParseJSON(argumentsJson);
+  if (parsed.isErr() || parsed.value === null || !isRecord(parsed.value)) {
+    return {};
+  }
+  return parsed.value;
+}
+
+// The per-signal leaf converters. Composites below take an object satisfying
+// this interface (`this`), so overriding one leaf on an endpoint changes how
+// every composite uses it.
+export interface OutputEventConverters {
+  responseCreatedToResponseIdEvent(
+    metadata: EndpointMetadata,
+    event: ResponseCreatedEvent
+  ): ResponseIdEvent;
+  textDeltaToTextDeltaEvent(
+    metadata: EndpointMetadata,
+    delta: string
+  ): TextDeltaEvent;
+  reasoningSummaryDeltaToReasoningDeltaEvent(
+    metadata: EndpointMetadata,
+    delta: string
+  ): ReasoningDeltaEvent;
+  functionCallToToolCallStartedEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    index: number,
+    name: string
+  ): ToolCallStartedEvent;
+  argumentsDeltaToToolCallDeltaEvent(
+    metadata: EndpointMetadata
+  ): ToolCallDeltaEvent;
+  accumulatedTextToTextEvent(
+    metadata: EndpointMetadata,
+    text: string
+  ): TextEvent;
+  accumulatedReasoningToReasoningEvent(
+    metadata: EndpointMetadata,
+    text: string
+  ): ReasoningEvent;
+  functionCallToToolCallEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    name: string,
+    argumentsJson: string
+  ): ToolCallEvent;
+  usageToTokenUsageEvent(
+    metadata: EndpointMetadata,
+    usage: ResponseUsage
+  ): TokenUsageEvent;
+  streamErrorToErrorEvent(
+    metadata: EndpointMetadata,
+    error: unknown
+  ): ErrorEvent;
+}
+
+// -- Leaf converters: one unified event per Responses stream signal --
+
+export function responseCreatedToResponseIdEvent(
+  metadata: EndpointMetadata,
+  event: ResponseCreatedEvent
+): ResponseIdEvent {
+  return {
+    type: "response_id",
+    content: { responseId: event.response.id },
+    metadata,
+  };
+}
+
+export function textDeltaToTextDeltaEvent(
+  metadata: EndpointMetadata,
+  delta: string
+): TextDeltaEvent {
+  return { type: "text_delta", content: { value: delta }, metadata };
+}
+
+export function reasoningSummaryDeltaToReasoningDeltaEvent(
+  metadata: EndpointMetadata,
+  delta: string
+): ReasoningDeltaEvent {
+  return { type: "reasoning_delta", content: { value: delta }, metadata };
+}
+
+export function functionCallToToolCallStartedEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  index: number,
+  name: string
+): ToolCallStartedEvent {
+  return { type: "tool_call_started", content: { id, index, name }, metadata };
+}
+
+export function argumentsDeltaToToolCallDeltaEvent(
+  metadata: EndpointMetadata
+): ToolCallDeltaEvent {
+  return { type: "tool_call_delta", metadata };
+}
+
+export function accumulatedTextToTextEvent(
+  metadata: EndpointMetadata,
+  text: string
+): TextEvent {
+  return { type: "text", content: { value: text }, metadata };
+}
+
+export function accumulatedReasoningToReasoningEvent(
+  metadata: EndpointMetadata,
+  text: string
+): ReasoningEvent {
+  return { type: "reasoning", content: { value: text }, metadata };
+}
+
+export function functionCallToToolCallEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  name: string,
+  argumentsJson: string
+): ToolCallEvent {
+  return {
+    type: "tool_call",
+    content: { id, name, arguments: parseToolArguments(argumentsJson) },
+    metadata,
+  };
+}
+
+export function usageToTokenUsageEvent(
+  metadata: EndpointMetadata,
+  usage: ResponseUsage
+): TokenUsageEvent {
+  const cacheHit = usage.input_tokens_details?.cached_tokens ?? 0;
+  const reasoning = usage.output_tokens_details?.reasoning_tokens ?? 0;
+  return {
+    type: "token_usage",
+    content: {
+      // OpenAI prompt caching has no separate creation cost.
+      cacheCreated: 0,
+      cacheHit,
+      // input_tokens includes cached; subtract to get the uncached portion.
+      standardInput: usage.input_tokens - cacheHit,
+      standardOutput: usage.output_tokens - reasoning,
+      reasoning,
+    },
+    metadata,
+  };
+}
+
+function isApiConnectionError(err: unknown): err is APIConnectionError {
+  return err instanceof APIConnectionError;
+}
+
+function isApiError(err: unknown): err is APIError {
+  return err instanceof APIError;
+}
+
+// A stream error classified into the categories we surface. `APIConnectionError`
+// is checked before `APIError` since the former extends the latter.
+type ClassifiedStreamError =
+  | { kind: "connection"; error: APIConnectionError }
+  | { kind: "api"; error: APIError }
+  | { kind: "unknown" };
+
+function classifyStreamError(error: unknown): ClassifiedStreamError {
+  if (isApiConnectionError(error)) {
+    return { kind: "connection", error };
+  }
+  if (isApiError(error)) {
+    return { kind: "api", error };
+  }
+  return { kind: "unknown" };
+}
+
+// HTTP status is a number, not a union, so the 5xx range stays an `if` in the
+// default branch.
+function apiErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: APIError
+): ErrorEvent {
+  const status = error.status;
+  switch (status) {
+    case 400:
+    case 422:
+      return buildErrorEvent({
+        metadata,
+        type: "invalid_request_error",
+        message: `Invalid request to OpenAI: ${error.message}`,
+        originalError: error,
+      });
+    case 401:
+      return buildErrorEvent({
+        metadata,
+        type: "authentication_error",
+        message: `Authentication failed for OpenAI: ${error.message}`,
+        originalError: error,
+      });
+    case 403:
+      return buildErrorEvent({
+        metadata,
+        type: "permission_error",
+        message: `Permission denied for OpenAI: ${error.message}`,
+        originalError: error,
+      });
+    case 404:
+      return buildErrorEvent({
+        metadata,
+        type: "not_found_error",
+        message: `Resource not found for OpenAI: ${error.message}`,
+        originalError: error,
+      });
+    case 429:
+      return buildErrorEvent({
+        metadata,
+        type: "rate_limit_error",
+        message: `Rate limit exceeded for OpenAI/${metadata.modelId}: ${error.message}`,
+        originalError: error,
+      });
+    default:
+      if (status !== undefined && status >= 500 && status < 600) {
+        return buildErrorEvent({
+          metadata,
+          type: "server_error",
+          message: `Server error from OpenAI (${status}): ${error.message}`,
+          originalError: error,
+        });
+      }
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Error from OpenAI (${status}): ${error.message}`,
+        originalError: error,
+      });
+  }
+}
+
+// Maps any error thrown by the OpenAI SDK while streaming into a unified
+// `ErrorEvent`, so everything leaving the endpoint is an event, not an exception.
+export function streamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  const classified = classifyStreamError(error);
+  switch (classified.kind) {
+    case "connection":
+      return buildErrorEvent({
+        metadata,
+        type: "network_error",
+        message: `Network error connecting to OpenAI: ${classified.error.message}`,
+        originalError: error,
+      });
+    case "api":
+      return apiErrorToErrorEvent(metadata, classified.error);
+    case "unknown":
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Unknown error from OpenAI`,
+        originalError: error,
+      });
+    default:
+      assertNever(classified);
+  }
+}
+
+// -- Composite: a completed output item → unified events --
+
+// Returns the events to emit for a finished output item; the caller decides
+// which are aggregated into the success summary.
+export function outputItemToEvents(
+  item: ResponseOutputItem,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): ModelResponseEvent[] {
+  switch (item.type) {
+    case "message":
+      return item.content.flatMap((part) => {
+        switch (part.type) {
+          case "output_text":
+            return [converters.accumulatedTextToTextEvent(metadata, part.text)];
+          case "refusal":
+            return [
+              buildErrorEvent({
+                metadata,
+                type: "refusal_error",
+                message: part.refusal,
+              }),
+            ];
+          default:
+            return [];
+        }
+      });
+    case "reasoning": {
+      const text = item.summary.map((summary) => summary.text).join("\n\n");
+      // Skip empty reasoning items (no summary emitted, e.g. effort "none").
+      return text
+        ? [converters.accumulatedReasoningToReasoningEvent(metadata, text)]
+        : [];
+    }
+    case "function_call":
+      return [
+        converters.functionCallToToolCallEvent(
+          metadata,
+          item.call_id,
+          item.name,
+          item.arguments
+        ),
+      ];
+    // Output item types we don't surface (server tools, image gen, etc.).
+    default:
+      return [];
+  }
+}
+
+// -- Entry point: drive the raw stream into unified events --
+
+export async function* rawOutputToEvents(
+  stream: AsyncGenerator<ResponseStreamEvent>,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): AsyncGenerator<ModelResponseEvent> {
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  let usage: ResponseUsage | null = null;
+
+  while (true) {
+    let result: IteratorResult<ResponseStreamEvent>;
+    try {
+      result = await stream.next();
+    } catch (err) {
+      // Everything leaving the endpoint is an event: map any SDK error to a
+      // unified error event and terminate rather than throwing.
+      yield converters.streamErrorToErrorEvent(metadata, err);
+      return;
+    }
+    if (result.done) {
+      break;
+    }
+
+    const event = result.value;
+    let outputEvents: ModelResponseEvent[] = [];
+    switch (event.type) {
+      case "response.created":
+        outputEvents = [
+          converters.responseCreatedToResponseIdEvent(metadata, event),
+        ];
+        break;
+      case "response.output_text.delta":
+        outputEvents = [
+          converters.textDeltaToTextDeltaEvent(metadata, event.delta),
+        ];
+        break;
+      case "response.reasoning_summary_text.delta":
+        outputEvents = [
+          converters.reasoningSummaryDeltaToReasoningDeltaEvent(
+            metadata,
+            event.delta
+          ),
+        ];
+        break;
+      case "response.output_item.added":
+        if (event.item.type === "function_call") {
+          outputEvents = [
+            converters.functionCallToToolCallStartedEvent(
+              metadata,
+              event.item.call_id,
+              event.output_index,
+              event.item.name
+            ),
+          ];
+        }
+        break;
+      case "response.function_call_arguments.delta":
+        outputEvents = [converters.argumentsDeltaToToolCallDeltaEvent(metadata)];
+        break;
+      case "response.output_item.done":
+        outputEvents = outputItemToEvents(event.item, metadata, converters);
+        break;
+      case "response.completed":
+        usage = event.response.usage ?? null;
+        break;
+      case "response.failed":
+        yield converters.streamErrorToErrorEvent(
+          metadata,
+          event.response.error
+        );
+        return;
+      case "response.incomplete":
+        yield buildErrorEvent({
+          metadata,
+          type: "stop_error",
+          message:
+            event.response.incomplete_details?.reason ??
+            "The response was incomplete.",
+        });
+        return;
+      case "error":
+        yield buildErrorEvent({
+          metadata,
+          type: "stream_error",
+          message: event.message,
+          originalError: event,
+        });
+        return;
+      // Other Responses stream signals (audio, web search, mcp, etc.) are not
+      // surfaced; ignore rather than crash if OpenAI adds more.
+      default:
+        outputEvents = [];
+    }
+
+    for (const outputEvent of outputEvents) {
+      if (
+        outputEvent.type === "text" ||
+        outputEvent.type === "reasoning" ||
+        outputEvent.type === "tool_call"
+      ) {
+        aggregated.push(outputEvent);
+      }
+      yield outputEvent;
+    }
+  }
+
+  if (usage !== null) {
+    yield converters.usageToTokenUsageEvent(metadata, usage);
+  }
+
+  yield { type: "success", content: { aggregated }, metadata };
+}

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four.ts
@@ -1,0 +1,48 @@
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { GPT_5_4_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+const CONTEXT_SIZE = 1_000_000;
+const MAX_OUTPUT_TOKENS = 128_000;
+
+// gpt-5.4 accepts none/low/medium/high/xhigh natively; the universal "maximal"
+// maps onto xhigh in the converter. "minimal" is rejected by the API.
+const GPT_5_4_REASONING_EFFORTS = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "maximal",
+] as const;
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.enum(GPT_5_4_REASONING_EFFORTS) })
+    .optional(),
+  // gpt-5.4 is a reasoning model; the Responses API rejects an explicit
+  // temperature, so drop it.
+  temperature: temperatureSchema.optional().transform(() => undefined),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithOpenAIGptFiveDotFourConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class OpenAIGptFiveDotFour extends Base {
+    static readonly modelId = GPT_5_4_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return OpenAIGptFiveDotFour;
+}

--- a/front/lib/model_constructors/providers/openai/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_efforts.ts
@@ -1,0 +1,24 @@
+import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
+
+// Reasoning efforts the OpenAI Responses API accepts verbatim (its
+// `ReasoningEffort` enum minus the non-OpenAI "maximal"). The strings match
+// OpenAI's, so mapping a supported effort is the identity.
+export const OPENAI_SUPPORTED_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const satisfies readonly ReasoningEffort[];
+
+export type OpenAISupportedReasoningEffort =
+  (typeof OPENAI_SUPPORTED_REASONING_EFFORTS)[number];
+
+export function isOpenAISupportedReasoningEffort(
+  effort: string
+): effort is OpenAISupportedReasoningEffort {
+  return OPENAI_SUPPORTED_REASONING_EFFORTS.some(
+    (supported) => supported === effort
+  );
+}

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -1,0 +1,59 @@
+import OpenAI from "openai";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseCreateParamsStreaming,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+
+import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/providers/openai/converters/input";
+import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/providers/openai/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/openai/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { OPENAI_RESPONSES_API } from "@app/lib/model_constructors/types/provider_apis";
+import { OPENAI_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+
+export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConverter(
+  WithOpenAIResponsesOutputConverter(
+    StreamEndpoint<ResponseCreateParamsNonStreaming, ResponseStreamEvent>
+  )
+) {
+  static readonly providerId = OPENAI_PROVIDER_ID;
+  static readonly api = OPENAI_RESPONSES_API;
+
+  static readonly configSchema = inputConfigSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ OPENAI_API_KEY, OPENAI_BASE_URL }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      apiKey: OPENAI_API_KEY,
+      baseURL: OPENAI_BASE_URL,
+    });
+  }
+
+  async *streamRaw(
+    input: ResponseCreateParamsNonStreaming
+  ): AsyncGenerator<ResponseStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ResponseCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = await this.client.responses.create(streamingInput);
+
+    // Deep-copy each event in case the SDK reuses objects.
+    for await (const event of stream) {
+      yield structuredClone(event);
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ResponseStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four.ts
@@ -1,0 +1,21 @@
+import { WithOpenAIGptFiveDotFourConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesGlobalGptFiveDotFourStream extends WithOpenAIGptFiveDotFourConfig(
+  OpenAIResponsesStream
+) {
+  // https://openai.com/api/pricing
+  static readonly tokenPricing = {
+    cacheHit: 0.25,
+    standardInput: 2.5,
+    standardOutput: 15.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+OpenAIResponsesGlobalGptFiveDotFourStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesGlobalGptFiveDotFourStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four.test.ts
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourStream, setup);


### PR DESCRIPTION
## Description

Adds the OpenAI Responses provider to the `model_constructors` framework — input/output converters, reasoning-effort mapping, the `OpenAIResponsesStream` client, the GPT-5.5 model config, and the global GPT-5.5 stream endpoint with its integration tests.

Branched off `main`; depends on the `model_constructors` stream framework (StreamEndpoint, converters base, test harness) currently on `pierre/new-llm/int-test`. Will rebase onto that once it lands — CI will be red until then.

## Tests

Integration harness (`lib/model_constructors/test/`), gated on `NODE_ENV=test` + `RUN_LLM_TEST=true` so CI never burns tokens. The GPT-5.5 contract was characterized against the live Responses API (widest schema → narrow): `minimal` effort is rejected by the API, `temperature` is stripped (reasoning model), `maximal` maps to `xhigh`, and a forced tool does not require reasoning "none". 39/39 cases pass locally.

## Risk

Low. New, self-contained provider code under `model_constructors`; nothing existing is rewired.

## Deploy Plan

Standard deploy, no migration needed.
