### PR TITLE
fix(upsert-queue): use decodeBuffer for encoding-aware JSON parsing

### DIFF
--- a/front/temporal/upsert_queue/activities.test.ts
+++ b/front/temporal/upsert_queue/activities.test.ts
@@ -1,0 +1,51 @@
+import { cleanUtf8Content } from "@app/temporal/upsert_queue/activities";
+import { describe, expect, it } from "vitest";
+
+describe("cleanUtf8Content", () => {
+  it("returns plain strings unchanged", () => {
+    expect(cleanUtf8Content("hello world")).toBe("hello world");
+    expect(cleanUtf8Content("")).toBe("");
+    expect(cleanUtf8Content('{"key": "value"}')).toBe('{"key": "value"}');
+  });
+
+  it("strips null bytes", () => {
+    expect(cleanUtf8Content("hello\0world")).toBe("helloworld");
+    expect(cleanUtf8Content("\0\0\0")).toBe("");
+    expect(cleanUtf8Content('{"key": "val\0ue"}')).toBe('{"key": "value"}');
+  });
+
+  it("returns early when no actual surrogate code points are present", () => {
+    // \\uD800 here is the 6-char ASCII sequence \uD800, not an actual surrogate code point.
+    // The early-exit regex sees no surrogates → returns unchanged.
+    expect(cleanUtf8Content("\\uD800")).toBe("\\uD800");
+    expect(cleanUtf8Content("\\uDC00")).toBe("\\uDC00");
+  });
+
+  it("replaces lone high surrogates in escaped form when actual surrogates trigger processing", () => {
+    // \uD800 (actual code point U+D800) triggers the early-exit guard.
+    // The following \\uD800 is the 6-char escaped form — lone, so it gets replaced.
+    expect(cleanUtf8Content("\uD800\\uD800")).toBe("\uD800\\u003F");
+    expect(cleanUtf8Content("\uD800\\uDBFF")).toBe("\uD800\\u003F");
+
+    // \\uD800\\uDC00 is a valid surrogate pair in escaped form — preserved.
+    expect(cleanUtf8Content("\uD800\\uD800\\uDC00")).toBe(
+      "\uD800\\uD800\\uDC00"
+    );
+  });
+
+  it("replaces lone low surrogates in escaped form when actual surrogates trigger processing", () => {
+    // \\uDC00 alone (no preceding high surrogate) is invalid — replaced.
+    expect(cleanUtf8Content("\uD800\\uDC00")).toBe("\uD800\\u003F");
+    expect(cleanUtf8Content("\uD800\\uDFFF")).toBe("\uD800\\u003F");
+
+    // \\uD800\\uDC00 valid pair — preserved.
+    expect(cleanUtf8Content("\uD800\\uD83D\\uDE00")).toBe(
+      "\uD800\\uD83D\\uDE00"
+    );
+  });
+
+  it("strips null bytes independently of the surrogate path", () => {
+    // Null bytes are stripped first; the remaining string has no actual surrogates → early exit.
+    expect(cleanUtf8Content("\0\\uD800\0")).toBe("\\uD800");
+  });
+});

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -1,4 +1,5 @@
 import config from "@app/lib/api/config";
+import { decodeBuffer } from "@app/lib/api/files/utils";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -14,7 +15,10 @@ import { fromError } from "zod-validation-error";
 
 const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
-function cleanUtf8Content(content: string): string {
+export function cleanUtf8Content(content: string): string {
+  // Strip null bytes (invalid in PostgreSQL text columns and JSON strings per RFC4627)
+  content = content.replace(/\0/g, "");
+
   // Early exit if no \uD sequences found.
   if (!/[\uD800-\uDFFF]/.test(content)) {
     return content;
@@ -39,9 +43,11 @@ export async function upsertDocumentActivity(
 
   const storage = new Storage({ keyFilename: SERVICE_ACCOUNT });
   const bucket = storage.bucket(DUST_UPSERT_QUEUE_BUCKET);
-  const content = await bucket.file(`${upsertQueueId}.json`).download();
-
-  const upsertDocument = JSON.parse(cleanUtf8Content(content.toString()));
+  // GCS bucket.file().download() returns a `DownloadResponse = [Buffer]` — it's defined as a tuple with exactly one element.
+  // It's a quirk of the GCS SDK's callback-style API converted to a promise
+  // There's never more than one Buffer => destructuring is fine
+  const [fileBuffer] = await bucket.file(`${upsertQueueId}.json`).download();
+  const upsertDocument = JSON.parse(cleanUtf8Content(decodeBuffer(fileBuffer)));
 
   const documentItemValidation =
     EnqueueUpsertDocument.safeParse(upsertDocument);


### PR DESCRIPTION
## Description

`bucket.file().download()` returns a `[Buffer]` tuple (GCS SDK quirk). The previous `content.toString()` decoded the buffer as plain UTF-8, silently misreading UTF-16 files (e.g. from Windows tools like Excel or Notepad) into interleaved NUL bytes that PostgreSQL later rejects.

- Replace `content.toString()` with `decodeBuffer(fileBuffer)` from `@app/lib/api/files/utils`, which already detects UTF-16 LE/BE/UTF-8 BOMs and falls back to UTF-8.
- Destructure `const [fileBuffer] = ...download()` instead of `content[0]` to make the SDK's fixed-size tuple obvious.
- Null-byte stripping added to `cleanUtf8Content` as an additional guard (NUL bytes are invalid in both PostgreSQL text columns and JSON per RFC 4627).
- Export `cleanUtf8Content` and add unit tests covering the null-byte, surrogate, and fast-path behaviours.

## Tests

Unit tests added in `front/temporal/upsert_queue/activities.test.ts` (6 cases, all green).
