### PR TITLE
Log expected workspace_in_different_region API errors at info level

### DIFF
--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -7,6 +7,7 @@ import type {
   APIErrorType,
   APIErrorWithContentfulStatusCode,
 } from "@app/types/error";
+import { EXPECTED_API_ERROR_TYPES } from "@app/types/error";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { getClientIpFromContext } from "@front-api/lib/request";
 import type { Context, ErrorHandler, TypedResponse } from "hono";
@@ -42,7 +43,14 @@ export function apiError(
     stack: error?.stack ?? callstack,
   };
 
-  logger.error(
+  // Some error types are expected outcomes of normal operation (e.g. a region
+  // redirect) rather than failures. Log those at `info` so they don't pollute
+  // error monitoring.
+  const logLevel = EXPECTED_API_ERROR_TYPES.has(err.api_error.type)
+    ? "info"
+    : "error";
+
+  logger[logLevel](
     {
       method: ctx.req.method,
       url: ctx.req.path,

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -179,6 +179,13 @@ export type RegionRedirectError = {
 
 export type APIErrorType = (typeof API_ERROR_TYPES)[number];
 
+// Error types that are expected outcomes of normal operation rather than
+// failures (e.g. a region redirect). Callers can use this to log them at a
+// lower level so they don't pollute error monitoring.
+export const EXPECTED_API_ERROR_TYPES: ReadonlySet<APIErrorType> = new Set([
+  "workspace_in_different_region",
+]);
+
 export type APIError = {
   type: APIErrorType;
   message: string;


### PR DESCRIPTION
  ## Description

  The `front-api` `apiError` helper logs every API error at `error` level. This includes `workspace_in_different_region`, which is not a failure — it's an expected region redirect (the response carries a `redirect` payload telling the client to go to the correct region, e.g. `https://eu.dust.tt`).

  These were polluting error monitoring with noise like:

  ```json
  {"level":"error","apiError":{"api_error":{"redirect":{"region":"europe-west1","url":"https://eu.dust.tt"},"type":"workspace_in_different_region",...},"status_code":400},"url":"/api/auth-context"}
```

  Changes

  - Add an EXPECTED_API_ERROR_TYPES set in front/types/error.ts containing
  workspace_in_different_region.
  - apiError (front-api/middlewares/utils.ts) now selects the log level from
  that set: expected types log at info, everything else stays at error.

  This is centralized so it covers all routes that return the error
  (auth-context, poke/workspaces, join, share frame, w/[wId]) at once, and any
  future expected-but-non-failure type just needs to be added to the set.

  Notes

  - Only the log severity changes. The HTTP status code, response body,
  api_errors.count statsd metric, and tracing tags are all unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front