### PR TITLE
Favorite star icon remained empty for favorited agents

### DIFF
--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -90,18 +90,6 @@ export function AgentDetailsButtonBar({
           disabled={isFavoriteDisabled}
           onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
         />
-
-        <Button
-          icon={Star01}
-          tooltip={
-            agentIsFavorite ? "Remove from favorites" : "Add to favorites"
-          }
-          size="sm"
-          className="hidden group-hover:block"
-          variant={agentIsFavorite ? "outline" : "highlight-secondary"}
-          disabled={isFavoriteDisabled}
-          onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
-        />
       </div>
 
       {canShowAgentConversationActions(agentConfiguration.sId) && (

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -67,6 +67,8 @@ export function AgentDetailsButtonBar({
   const isFavoriteDisabled =
     isAgentConfigurationValidating || isUpdatingFavorite;
 
+  const agentIsFavorite = agentConfiguration.userFavorite || isFavoriteDisabled;
+
   const handleNewConversation = async () => {
     onClose();
     await router.push(
@@ -78,19 +80,13 @@ export function AgentDetailsButtonBar({
     <div className="flex flex-row items-center gap-2 px-1.5">
       <div className="group">
         <Button
-          icon={
-            agentConfiguration.userFavorite || isFavoriteDisabled
-              ? Star01
-              : Star01
-          }
+          icon={Star01}
           tooltip={
-            agentConfiguration.userFavorite || isFavoriteDisabled
-              ? "Remove from favorites"
-              : "Add to favorites"
+            agentIsFavorite ? "Remove from favorites" : "Add to favorites"
           }
           size="sm"
           className="group-hover:hidden"
-          variant="outline"
+          variant={agentIsFavorite ? "highlight-secondary" : "outline"}
           disabled={isFavoriteDisabled}
           onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
         />
@@ -98,13 +94,11 @@ export function AgentDetailsButtonBar({
         <Button
           icon={Star01}
           tooltip={
-            agentConfiguration.userFavorite || isFavoriteDisabled
-              ? "Remove from favorites"
-              : "Add to favorites"
+            agentIsFavorite ? "Remove from favorites" : "Add to favorites"
           }
           size="sm"
           className="hidden group-hover:block"
-          variant="outline"
+          variant={agentIsFavorite ? "outline" : "highlight-secondary"}
           disabled={isFavoriteDisabled}
           onClick={() => updateUserFavorite(!agentConfiguration.userFavorite)}
         />


### PR DESCRIPTION
## Description

Fixes a visual bug where the favorite star icon in the agent details button bar always appeared empty (outline), even when an agent was marked as a favorite. The root cause was that the icon variant was always the same (`outline`) so the filled/active state was never rendered.

## Tests

Can be tested manually by opening an agent's details panel, toggling the favorite star, and verifying that the icon correctly reflects the favorited state (filled) vs unfavorited state (empty) both before and during the update.

## Risk

Low — cosmetic-only change confined to a single component.

## Deploy Plan

Deploy front.