### PR TITLE
fix(billing): show "Save 20%" on yearly toggle everywhere

### DIFF
--- a/front/components/pages/onboarding/SubscriptionPlans.tsx
+++ b/front/components/pages/onboarding/SubscriptionPlans.tsx
@@ -121,24 +121,29 @@ export function PlanCard({
 interface BillingPeriodSwitchProps {
   defaultValue?: BillingPeriod;
   onValueChange: (period: BillingPeriod) => void;
+  size?: React.ComponentProps<typeof ButtonsSwitchList>["size"];
 }
 
 export function BillingPeriodSwitch({
   defaultValue = "monthly",
   onValueChange,
+  size,
 }: BillingPeriodSwitchProps) {
   return (
     <ButtonsSwitchList
       defaultValue={defaultValue}
+      size={size}
       onValueChange={(value) =>
         onValueChange(value === "yearly" ? "yearly" : "monthly")
       }
     >
       <ButtonsSwitch value="monthly" label="Monthly" />
-      <div className="flex items-center gap-1.5">
-        <ButtonsSwitch value="yearly" label="Yearly" />
-        <Chip size="xs" color="blue" label="Save 20%" />
-      </div>
+      <ButtonsSwitch
+        value="yearly"
+        label="Yearly"
+        className="flex-row-reverse"
+        icon={<Chip size="xs" color="blue" label="Save 20%" />}
+      />
     </ButtonsSwitchList>
   );
 }

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -1,3 +1,4 @@
+import { BillingPeriodSwitch } from "@app/components/pages/onboarding/SubscriptionPlans";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { useSubscriptionContext } from "@app/components/workspace/billing/SubscriptionContext";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -23,8 +24,6 @@ import type { BillingPeriod } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import {
   Button,
-  ButtonsSwitch,
-  ButtonsSwitchList,
   Chip,
   ContentMessage,
   CreditCard01,
@@ -361,18 +360,11 @@ export function MetronomeSubscriptionPanel() {
             <Page.H variant="h5">Choose a plan</Page.H>
             <Page.P>Pick a plan that best suits your team.</Page.P>
           </div>
-          <ButtonsSwitchList
+          <BillingPeriodSwitch
             defaultValue={billingPeriod}
             size="xs"
-            onValueChange={(v) => {
-              if (v === "monthly" || v === "yearly") {
-                setBillingPeriod(v);
-              }
-            }}
-          >
-            <ButtonsSwitch value="monthly" label="Monthly billing" />
-            <ButtonsSwitch value="yearly" label="Yearly billing" />
-          </ButtonsSwitchList>
+            onValueChange={setBillingPeriod}
+          />
         </div>
         <div className="pt-4">
           <SubscriptionPlanCards

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -1,3 +1,4 @@
+import { BillingPeriodSwitch } from "@app/components/pages/onboarding/SubscriptionPlans";
 import { MetronomeSubscriptionPanel } from "@app/components/pages/workspace/subscription/MetronomeSubscriptionPanel";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { SubscriptionProvider } from "@app/components/workspace/billing/SubscriptionContext";
@@ -28,8 +29,6 @@ import type {
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import {
   Button,
-  ButtonsSwitch,
-  ButtonsSwitchList,
   Chip,
   ContentMessage,
   CreditCard01,
@@ -589,21 +588,11 @@ export function SubscriptionPage() {
                       <Page.P>Pick a plan that best suits your team.</Page.P>
                     </div>
                     {!isWorkspaceWhitelistedBusinessPlan && (
-                      <ButtonsSwitchList
+                      <BillingPeriodSwitch
                         defaultValue={billingPeriod}
                         size="xs"
-                        onValueChange={(v) => {
-                          if (v === "monthly" || v === "yearly") {
-                            setBillingPeriod(v);
-                          }
-                        }}
-                      >
-                        <ButtonsSwitch
-                          value="monthly"
-                          label="Monthly billing"
-                        />
-                        <ButtonsSwitch value="yearly" label="Yearly billing" />
-                      </ButtonsSwitchList>
+                        onValueChange={setBillingPeriod}
+                      />
                     )}
                   </div>
                   <div className="pt-4">

--- a/front/components/paywall/TrialPricingCard.tsx
+++ b/front/components/paywall/TrialPricingCard.tsx
@@ -1,16 +1,11 @@
+import { BillingPeriodSwitch } from "@app/components/pages/onboarding/SubscriptionPlans";
 import {
   PRO_PLAN_COST_MONTHLY,
   PRO_PLAN_COST_YEARLY,
   usePriceWithCurrency,
 } from "@app/lib/client/subscription";
 import type { BillingPeriod } from "@app/types/plan";
-import {
-  Button,
-  ButtonsSwitch,
-  ButtonsSwitchList,
-  Check,
-  Icon,
-} from "@dust-tt/sparkle";
+import { Button, Check, Icon } from "@dust-tt/sparkle";
 
 interface TrialPricingCardProps {
   billingPeriod: BillingPeriod;
@@ -53,14 +48,11 @@ export function TrialPricingCard({
         </div>
 
         {/* Billing toggle */}
-        <ButtonsSwitchList
+        <BillingPeriodSwitch
           defaultValue={billingPeriod}
           size="xs"
-          onValueChange={(v) => onBillingPeriodChange(v as BillingPeriod)}
-        >
-          <ButtonsSwitch value="monthly" label="Monthly" />
-          <ButtonsSwitch value="yearly" label="Yearly" />
-        </ButtonsSwitchList>
+          onValueChange={onBillingPeriodChange}
+        />
       </div>
 
       {/* Features list */}


### PR DESCRIPTION
## Description

- Add optional `size` prop to the shared BillingPeriodSwitch
- Reuse BillingPeriodSwitch (carries the "Save 20%" chip) in the Metronome subscription panel, the subscription page pricing table, and the trial paywall pricing card, replacing inline ButtonsSwitch toggles that lacked the chip

Ticket: https://github.com/dust-tt/tasks/issues/8915
<img width="436" height="425" alt="Screenshot 2026-06-16 at 12 06 17" src="https://github.com/user-attachments/assets/10d2ec44-1f44-410f-9d6a-6ae2390fe6d9" />
<img width="433" height="427" alt="Screenshot 2026-06-16 at 12 06 54" src="https://github.com/user-attachments/assets/13d9e522-0316-4e78-908d-e114da5838d9" />

## Tests

Local

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front
