### PR TITLE
Tim outlook refactor

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -459,7 +459,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   "outlook": {
     "create_contact": "high",
     "create_draft": "medium",
-    "create_reply_draft": "medium",
     "delete_draft": "low",
     "get_attachments": "never_ask",
     "get_contacts": "never_ask",

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -135,32 +135,71 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_draft: {
-    description: `Create a new email draft in Outlook.
+    description: `Create a new email draft in Outlook, or a reply draft to an existing message.
 - The draft will be saved in the user's Outlook account and can be reviewed and sent later.
-- The draft will include proper email headers and formatting`,
+- The draft will include proper email headers and formatting.`,
     schema: {
-      to: z.array(z.string()).describe("The email addresses of the recipients"),
-      cc: z.array(z.string()).optional().describe("The email addresses to CC"),
+      to: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
+        ),
+      cc: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "The CC email addresses (optional, acts as override if replyToMessageId is set)."
+        ),
       bcc: z
         .array(z.string())
         .optional()
-        .describe("The email addresses to BCC"),
+        .describe(
+          "The BCC email addresses (optional, acts as override if replyToMessageId is set)."
+        ),
       replyTo: z
         .array(z.string())
         .optional()
         .describe(
           "Reply-to email addresses. Replies will go to these addresses instead of the sender."
         ),
-      subject: z.string().describe("The subject line of the email"),
-      contentType: z
-        .string()
-        .default("text")
-        .describe("The content type of the email (text or html)."),
-      body: z.string().describe("The body of the email"),
-      importance: z
+      subject: z
         .string()
         .optional()
-        .describe("The importance level of the email"),
+        .describe(
+          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
+        ),
+      contentType: z
+        .enum(["text", "html"])
+        .optional()
+        .describe(
+          "The content type of the email body (required if replyToMessageId is not set, must be omitted if replyToMessageId is set (forced to html for replies))."
+        ),
+      body: z.string().describe("The body of the email"),
+      importance: z
+        .enum(["low", "normal", "high"])
+        .optional()
+        .describe("The importance level of the email."),
+      replyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The ID of the message to reply to. If provided, the draft will be created as a reply in the existing thread, with proper threading headers and the original message quoted."
+        ),
+      replyAll: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to reply to all recipients. Only used when replyToMessageId is set. Defaults to false."
+        ),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox to create the draft in (e.g. 'support@company.com'). " +
+            "Leave empty to create the draft in your own mailbox. " +
+            "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
     },
     stake: "medium",
     displayLabels: {
@@ -174,48 +213,17 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
       messageId: z.string().describe("The ID of the draft to delete"),
       subject: z.string().describe("The subject of the draft to delete"),
       to: z.array(z.string()).describe("The email addresses of the recipients"),
+      sharedMailboxAddress: z
+        .string()
+        .optional()
+        .describe(
+          "The email address of the shared mailbox containing the draft. Omit to use the authenticated user's mailbox."
+        ),
     },
     stake: "low",
     displayLabels: {
       running: "Deleting draft",
       done: "Delete draft",
-    },
-  },
-  create_reply_draft: {
-    description: `Create a reply draft to an existing email in Outlook.
-- The draft will be saved in the user's Outlook account and can be reviewed and sent later.
-- The reply will be properly formatted with the original message quoted.
-- The draft will include proper email headers and threading information.`,
-    schema: {
-      messageId: z.string().describe("The ID of the message to reply to"),
-      body: z.string().describe("The body of the reply email"),
-      contentType: z
-        .string()
-        .optional()
-        .describe(
-          "The content type of the email (text or html). Defaults to html."
-        ),
-      replyAll: z
-        .boolean()
-        .optional()
-        .describe("Whether to reply to all recipients. Defaults to false."),
-      to: z
-        .array(z.string())
-        .optional()
-        .describe("Override the To recipients for the reply."),
-      cc: z
-        .array(z.string())
-        .optional()
-        .describe("Override the CC recipients for the reply."),
-      bcc: z
-        .array(z.string())
-        .optional()
-        .describe("Override the BCC recipients for the reply."),
-    },
-    stake: "medium",
-    displayLabels: {
-      running: "Creating reply draft",
-      done: "Create reply draft",
     },
   },
   send_mail: {
@@ -225,8 +233,10 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     schema: {
       to: z
         .array(z.string())
-        .min(1)
-        .describe("The email addresses of the recipients"),
+        .optional()
+        .describe(
+          "The email addresses of the recipients (optional if replyToMessageId is set, acts as override)."
+        ),
       cc: z.array(z.string()).optional().describe("The email addresses to CC"),
       bcc: z
         .array(z.string())
@@ -238,17 +248,29 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Reply-to email addresses. Replies will go to these addresses instead of the sender."
         ),
-      subject: z.string().describe("The subject line of the email"),
+      subject: z
+        .string()
+        .optional()
+        .describe(
+          "The subject line of the email (required if replyToMessageId is not set, must be omitted if replyToMessageId is set)."
+        ),
       contentType: z
         .enum(["text", "html"])
-        .default("text")
-        .describe("The content type of the email body (text or html)."),
+        .optional()
+        .describe(
+          "The content type of the email body (text or html). Required when replyToMessageId is not set. Must be omitted when replyToMessageId is set."
+        ),
       body: z.string().describe("The body of the email"),
+      importance: z
+        .enum(["low", "normal", "high"])
+        .optional()
+        .describe("The importance level of the email."),
       saveToSentItems: z
         .boolean()
         .optional()
         .describe(
-          "Whether to save the sent email to the Sent Items folder. Defaults to true."
+          "Whether to save the sent email to the Sent Items folder. Defaults to true. " +
+            "Note: this option is ignored when replyToMessageId is set — the email will always be saved to Sent Items in that case."
         ),
       sharedMailboxAddress: z
         .string()
@@ -257,6 +279,18 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
           "The email address of the shared mailbox to send from (e.g. 'support@company.com'). " +
             "Leave empty to send from your own mailbox. " +
             "Note: the shared mailbox address must be known in advance — there is no API to auto-discover it."
+        ),
+      replyToMessageId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The ID of the message to reply to. If provided, the email will be sent as a reply in the existing thread, with proper threading headers and the original message quoted."
+        ),
+      replyAll: z
+        .boolean()
+        .optional()
+        .describe(
+          "Whether to reply to all recipients. Only used when replyToMessageId is set. Defaults to false."
         ),
     },
     stake: "high",

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -614,9 +614,10 @@ async function sendReply({
   bcc?: string[];
   replyTo?: string[];
 }): Promise<Ok<null> | Err<MCPError>> {
-  const endpoint = (replyAll ?? false)
-    ? `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/replyAll`
-    : `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/reply`;
+  const endpoint =
+    (replyAll ?? false)
+      ? `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/replyAll`
+      : `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/reply`;
 
   const message: Record<string, unknown> = {
     body: { contentType: "html", content: sanitizeHtml(body) },

--- a/front/lib/api/actions/servers/outlook/tools/mail.ts
+++ b/front/lib/api/actions/servers/outlook/tools/mail.ts
@@ -352,6 +352,370 @@ const findFolderByPath = async (
   return { folderId: parentFolderId };
 };
 
+async function createOutlookDraft({
+  basePath,
+  accessToken,
+  replyToMessageId,
+  replyAll,
+  subject,
+  contentType,
+  body,
+  importance,
+  to,
+  cc,
+  bcc,
+  replyTo,
+  sharedMailboxAddress,
+}: {
+  basePath: string;
+  accessToken: string;
+  replyToMessageId?: string;
+  replyAll?: boolean;
+  subject?: string;
+  contentType?: string;
+  body: string;
+  importance?: string;
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  sharedMailboxAddress?: string;
+}): Promise<Ok<{ draftId: string; conversationId?: string }> | Err<MCPError>> {
+  let draftId: string;
+  let conversationId: string | undefined;
+
+  if (replyToMessageId) {
+    const endpoint =
+      (replyAll ?? false)
+        ? `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/createReplyAll`
+        : `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/createReply`;
+
+    const createDraftResponse = await fetchFromOutlook(endpoint, accessToken, {
+      method: "POST",
+    });
+
+    if (!createDraftResponse.ok) {
+      const errorText = await getErrorText(createDraftResponse);
+      if (createDraftResponse.status === 404) {
+        return new Err(
+          new MCPError(`Message not found: ${replyToMessageId}`, {
+            tracked: false,
+          })
+        );
+      }
+      return new Err(
+        new MCPError(
+          `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
+        )
+      );
+    }
+
+    const createDraftResult = await createDraftResponse.json();
+    draftId = createDraftResult.id;
+    conversationId = createDraftResult.conversationId;
+
+    const existingBody = createDraftResult.body?.content ?? "";
+    const sanitizedBody = sanitizeHtml(body);
+    const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
+
+    const updatePayload: Record<string, unknown> = {
+      body: { contentType: "html", content: combinedBody },
+      importance,
+    };
+    if (to && to.length > 0) {
+      updatePayload.toRecipients = to.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (cc && cc.length > 0) {
+      updatePayload.ccRecipients = cc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (bcc && bcc.length > 0) {
+      updatePayload.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (replyTo && replyTo.length > 0) {
+      updatePayload.replyTo = replyTo.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    const encodedDraftId = encodeURIComponent(draftId);
+
+    const updateDraftResponse = await fetchFromOutlook(
+      `${basePath}/messages/${encodedDraftId}`,
+      accessToken,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updatePayload),
+      }
+    );
+
+    if (!updateDraftResponse.ok) {
+      void fetchFromOutlook(
+        `${basePath}/messages/${encodedDraftId}`,
+        accessToken,
+        { method: "DELETE" }
+      );
+      const errorText = await getErrorText(updateDraftResponse);
+      return new Err(
+        new MCPError(`Failed to update reply draft: ${errorText}`)
+      );
+    }
+  } else {
+    const message: Record<string, unknown> = {
+      subject,
+      importance,
+      body: { contentType, content: body },
+      toRecipients: (to ?? []).map((email) => ({
+        emailAddress: { address: email },
+      })),
+      isDraft: true,
+    };
+
+    if (sharedMailboxAddress) {
+      message.from = { emailAddress: { address: sharedMailboxAddress } };
+    }
+    if (cc && cc.length > 0) {
+      message.ccRecipients = cc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (bcc && bcc.length > 0) {
+      message.bccRecipients = bcc.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+    if (replyTo && replyTo.length > 0) {
+      message.replyTo = replyTo.map((email) => ({
+        emailAddress: { address: email },
+      }));
+    }
+
+    const response = await fetchFromOutlook(
+      `${basePath}/messages`,
+      accessToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(message),
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return new Err(new MCPError(`Failed to create draft: ${errorText}`));
+    }
+
+    const result = await response.json();
+    draftId = result.id;
+    conversationId = result.conversationId;
+  }
+
+  return new Ok({ draftId, conversationId });
+}
+
+async function sendDirectMail({
+  basePath,
+  accessToken,
+  to,
+  cc,
+  bcc,
+  replyTo,
+  subject,
+  contentType,
+  body,
+  importance,
+  saveToSentItems,
+  sharedMailboxAddress,
+}: {
+  basePath: string;
+  accessToken: string;
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  subject?: string;
+  contentType?: string;
+  body: string;
+  importance?: string;
+  saveToSentItems: boolean;
+  sharedMailboxAddress?: string;
+}): Promise<Ok<null> | Err<MCPError>> {
+  const message: Record<string, unknown> = {
+    subject,
+    importance,
+    body: { contentType: contentType ?? "text", content: body },
+    toRecipients: (to ?? []).map((email) => ({
+      emailAddress: { address: email },
+    })),
+  };
+  if (sharedMailboxAddress) {
+    message.from = { emailAddress: { address: sharedMailboxAddress } };
+  }
+  if (cc && cc.length > 0) {
+    message.ccRecipients = cc.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (bcc && bcc.length > 0) {
+    message.bccRecipients = bcc.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (replyTo && replyTo.length > 0) {
+    message.replyTo = replyTo.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+
+  const response = await fetchFromOutlook(`${basePath}/sendMail`, accessToken, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message, saveToSentItems }),
+  });
+
+  if (!response.ok) {
+    const errorText = await getErrorText(response);
+    return new Err(
+      new MCPError(
+        `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
+      )
+    );
+  }
+
+  return new Ok(null);
+}
+
+async function sendReply({
+  basePath,
+  accessToken,
+  replyToMessageId,
+  replyAll,
+  body,
+  importance,
+  to,
+  cc,
+  bcc,
+  replyTo,
+}: {
+  basePath: string;
+  accessToken: string;
+  replyToMessageId: string;
+  replyAll?: boolean;
+  body: string;
+  importance?: string;
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+}): Promise<Ok<null> | Err<MCPError>> {
+  const endpoint = (replyAll ?? false)
+    ? `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/replyAll`
+    : `${basePath}/messages/${encodeURIComponent(replyToMessageId)}/reply`;
+
+  const message: Record<string, unknown> = {
+    body: { contentType: "html", content: sanitizeHtml(body) },
+    importance,
+  };
+  if (to && to.length > 0) {
+    message.toRecipients = to.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (cc && cc.length > 0) {
+    message.ccRecipients = cc.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (bcc && bcc.length > 0) {
+    message.bccRecipients = bcc.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+  if (replyTo && replyTo.length > 0) {
+    message.replyTo = replyTo.map((email) => ({
+      emailAddress: { address: email },
+    }));
+  }
+
+  const response = await fetchFromOutlook(endpoint, accessToken, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+
+  if (!response.ok) {
+    const errorText = await getErrorText(response);
+    if (response.status === 404) {
+      return new Err(
+        new MCPError(`Message not found: ${replyToMessageId}`, {
+          tracked: false,
+        })
+      );
+    }
+    return new Err(
+      new MCPError(
+        `Failed to send reply: ${response.status} ${response.statusText} - ${errorText}`
+      )
+    );
+  }
+
+  return new Ok(null);
+}
+
+function validateMailParams({
+  replyToMessageId,
+  subject,
+  contentType,
+  to,
+}: {
+  replyToMessageId?: string;
+  subject?: string;
+  contentType?: string;
+  to?: string[];
+}): Err<MCPError> | null {
+  if (replyToMessageId) {
+    if (subject) {
+      return new Err(
+        new MCPError("subject must be omitted when replyToMessageId is set.")
+      );
+    }
+    if (contentType) {
+      return new Err(
+        new MCPError(
+          "contentType must be omitted when replyToMessageId is set."
+        )
+      );
+    }
+  } else {
+    if (!to || to.length === 0) {
+      return new Err(
+        new MCPError(
+          "At least one recipient is required when replyToMessageId is not set."
+        )
+      );
+    }
+    if (!subject?.trim()) {
+      return new Err(
+        new MCPError("subject is required when replyToMessageId is not set.")
+      );
+    }
+    if (!contentType) {
+      return new Err(
+        new MCPError(
+          "contentType is required when replyToMessageId is not set."
+        )
+      );
+    }
+  }
+  return null;
+}
+
 const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   get_messages: async (
     { search, folderName, top = 10, skip = 0, select, sharedMailboxAddress },
@@ -827,7 +1191,19 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
   },
 
   create_draft: async (
-    { to, cc, bcc, replyTo, subject, contentType, body, importance = "normal" },
+    {
+      to,
+      cc,
+      bcc,
+      replyTo,
+      subject,
+      contentType,
+      body,
+      importance = "normal",
+      replyToMessageId,
+      replyAll = false,
+      sharedMailboxAddress,
+    },
     { authInfo }
   ) => {
     const accessToken = authInfo?.token;
@@ -835,53 +1211,36 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       return new Err(new MCPError("Authentication required"));
     }
 
-    // Create the email message object for Microsoft Graph API
-    const message: Record<string, unknown> = {
+    const validationError = validateMailParams({
+      replyToMessageId,
       subject,
-      importance,
-      body: {
-        contentType,
-        content: body,
-      },
-      toRecipients: to.map((email) => ({
-        emailAddress: { address: email },
-      })),
-      isDraft: true,
-    };
-
-    if (cc && cc.length > 0) {
-      message.ccRecipients = cc.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    if (bcc && bcc.length > 0) {
-      message.bccRecipients = bcc.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    if (replyTo && replyTo.length > 0) {
-      message.replyTo = replyTo.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    // Make the API call to create the draft in Outlook
-    const response = await fetchFromOutlook("/me/messages", accessToken, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(message),
+      contentType,
+      to,
     });
-
-    if (!response.ok) {
-      const errorText = await getErrorText(response);
-      return new Err(new MCPError(`Failed to create draft: ${errorText}`));
+    if (validationError) {
+      return validationError;
     }
 
-    const result = await response.json();
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
+
+    const result = await createOutlookDraft({
+      basePath,
+      accessToken,
+      replyToMessageId,
+      replyAll,
+      subject,
+      contentType,
+      body,
+      importance,
+      to,
+      cc,
+      bcc,
+      replyTo,
+      sharedMailboxAddress,
+    });
+    if (result.isErr()) {
+      return result;
+    }
 
     return new Ok([
       { type: "text" as const, text: "Draft created successfully" },
@@ -889,8 +1248,8 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
         type: "text" as const,
         text: JSON.stringify(
           {
-            messageId: result.id,
-            conversationId: result.conversationId,
+            messageId: result.value.draftId,
+            conversationId: result.value.conversationId,
           },
           null,
           2
@@ -899,7 +1258,10 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     ]);
   },
 
-  delete_draft: async ({ messageId, subject, to }, { authInfo }) => {
+  delete_draft: async (
+    { messageId, subject, to, sharedMailboxAddress },
+    { authInfo }
+  ) => {
     const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("Authentication required"));
@@ -912,8 +1274,10 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       );
     }
 
+    const basePath = getMailboxBasePath(sharedMailboxAddress);
+
     const response = await fetchFromOutlook(
-      `/me/messages/${messageId}`,
+      `${basePath}/messages/${messageId}`,
       accessToken,
       { method: "DELETE" }
     );
@@ -927,125 +1291,6 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
     ]);
   },
 
-  create_reply_draft: async (
-    { messageId, body, contentType = "html", replyAll = false, to, cc, bcc },
-    { authInfo }
-  ) => {
-    const accessToken = authInfo?.token;
-    if (!accessToken) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    // Create the reply draft
-    const endpoint = replyAll
-      ? `/me/messages/${messageId}/createReplyAll`
-      : `/me/messages/${messageId}/createReply`;
-
-    const replyMessage: Record<string, unknown> = {
-      message: {
-        body: {
-          contentType,
-          content: body,
-        },
-      },
-    };
-
-    // Add recipients if overriding
-    if (to && to.length > 0) {
-      (replyMessage.message as Record<string, unknown>).toRecipients = to.map(
-        (email) => ({
-          emailAddress: { address: email },
-        })
-      );
-    }
-
-    if (cc && cc.length > 0) {
-      (replyMessage.message as Record<string, unknown>).ccRecipients = cc.map(
-        (email) => ({
-          emailAddress: { address: email },
-        })
-      );
-    }
-
-    if (bcc && bcc.length > 0) {
-      (replyMessage.message as Record<string, unknown>).bccRecipients = bcc.map(
-        (email) => ({
-          emailAddress: { address: email },
-        })
-      );
-    }
-
-    // Create the empty draft
-    const createDraftResponse = await fetchFromOutlook(endpoint, accessToken, {
-      method: "POST",
-    });
-
-    if (!createDraftResponse.ok) {
-      const errorText = await getErrorText(createDraftResponse);
-      if (createDraftResponse.status === 404) {
-        return new Err(
-          new MCPError(`Message not found: ${messageId}`, {
-            tracked: false,
-          })
-        );
-      }
-      return new Err(
-        new MCPError(
-          `Failed to create reply draft: ${createDraftResponse.status} ${createDraftResponse.statusText} - ${errorText}`
-        )
-      );
-    }
-
-    const createDraftResult = await createDraftResponse.json();
-
-    // Get the existing body content from the created draft (includes quoted original message)
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const existingBody = createDraftResult.body?.content || "";
-
-    // Prepend the new body to the existing HTML content
-    const sanitizedBody = sanitizeHtml(body);
-    const combinedBody = `<div>${sanitizedBody}</div><br><br>${existingBody}`;
-
-    const updateDraftResponse = await fetchFromOutlook(
-      `/me/messages/${createDraftResult.id}`,
-      accessToken,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          body: {
-            contentType: "html",
-            content: combinedBody,
-          },
-        }),
-      }
-    );
-
-    if (!updateDraftResponse.ok) {
-      const errorText = await getErrorText(updateDraftResponse);
-      return new Err(new MCPError(`Failed to update the draft: ${errorText}`));
-    }
-
-    return new Ok([
-      { type: "text" as const, text: "Reply draft created successfully" },
-      {
-        type: "text" as const,
-        text: JSON.stringify(
-          {
-            messageId: createDraftResult.id,
-            conversationId: createDraftResult.conversationId,
-            originalMessageId: messageId,
-            subject: createDraftResult.subject,
-          },
-          null,
-          2
-        ),
-      },
-    ]);
-  },
-
   send_mail: async (
     {
       to,
@@ -1053,10 +1298,13 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       bcc,
       replyTo,
       subject,
-      contentType = "text",
+      contentType,
       body,
+      importance,
       saveToSentItems = true,
       sharedMailboxAddress,
+      replyToMessageId,
+      replyAll = false,
     },
     { authInfo }
   ) => {
@@ -1065,67 +1313,56 @@ const handlers: ToolHandlers<typeof OUTLOOK_TOOLS_METADATA> = {
       return new Err(new MCPError("Authentication required"));
     }
 
+    const validationError = validateMailParams({
+      replyToMessageId,
+      subject,
+      contentType,
+      to,
+    });
+    if (validationError) {
+      return validationError;
+    }
+
     const basePath = getMailboxBasePath(sharedMailboxAddress);
 
-    const message: Record<string, unknown> = {
-      subject,
-      body: {
+    if (!replyToMessageId) {
+      const result = await sendDirectMail({
+        basePath,
+        accessToken,
+        to,
+        cc,
+        bcc,
+        replyTo,
+        subject,
         contentType,
-        content: body,
-      },
-      toRecipients: to.map((email) => ({
-        emailAddress: { address: email },
-      })),
-    };
-
-    if (sharedMailboxAddress) {
-      message.from = {
-        emailAddress: { address: sharedMailboxAddress },
-      };
-    }
-
-    if (cc && cc.length > 0) {
-      message.ccRecipients = cc.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    if (bcc && bcc.length > 0) {
-      message.bccRecipients = bcc.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    if (replyTo && replyTo.length > 0) {
-      message.replyTo = replyTo.map((email) => ({
-        emailAddress: { address: email },
-      }));
-    }
-
-    const response = await fetchFromOutlook(
-      `${basePath}/sendMail`,
-      accessToken,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          message,
-          saveToSentItems,
-        }),
+        body,
+        importance,
+        saveToSentItems,
+        sharedMailboxAddress,
+      });
+      if (result.isErr()) {
+        return result;
       }
-    );
-
-    if (!response.ok) {
-      const errorText = await getErrorText(response);
-      return new Err(
-        new MCPError(
-          `Failed to send email: ${response.status} ${response.statusText} - ${errorText}`
-        )
-      );
+      return new Ok([
+        { type: "text" as const, text: "Email sent successfully" },
+      ]);
     }
 
+    const result = await sendReply({
+      basePath,
+      accessToken,
+      replyToMessageId,
+      replyAll,
+      body,
+      importance,
+      to,
+      cc,
+      bcc,
+      replyTo,
+    });
+    if (result.isErr()) {
+      return result;
+    }
     return new Ok([{ type: "text" as const, text: "Email sent successfully" }]);
   },
 


### PR DESCRIPTION
## Description

Refactor of the Outlook MCP mail tools:
- Merged create_reply_draft into create_draft (which now accepts replyToMessageId and replyAll params)
- Replaced the send_mail reply path (createDraft -> PATCH -> send, 3 API calls) with a direct call to the /messages/{id}/reply endpoint (I realized that the api supported direct reply)

## Tests

tested manually.

## Risk

Low. The reply behavior in send_mail changes slightly: body quoting is now handled by the Graph API instead of manually. 

## Deploy Plan

