### PR TITLE
Fix agent builder save on repeated clicks

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -376,10 +376,8 @@ export default function AgentBuilder({
 
   const handleSubmit = async (formData: AgentBuilderFormData) => {
     try {
-      setIsSaving(true);
       const confirmed = await showDialog();
       if (!confirmed) {
-        setIsSaving(false);
         return;
       }
 
@@ -410,7 +408,6 @@ export default function AgentBuilder({
           description: result.error.message,
           type: "error",
         });
-        setIsSaving(false);
         return;
       }
 
@@ -457,13 +454,10 @@ export default function AgentBuilder({
           keepValues: true,
         });
       }
-
-      setIsSaving(false);
     } catch (error) {
       datadogLogger.error("Unexpected error:", {
         error: normalizeError(error),
       });
-      setIsSaving(false);
     }
   };
 
@@ -500,15 +494,18 @@ export default function AgentBuilder({
       description: "There was an error validating the form.",
       type: "error",
     });
-    setIsSaving(false);
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (isSaving) {
       return;
     }
     setIsSaving(true);
-    void form.handleSubmit(handleSubmit, handleFormErrors)();
+    try {
+      await form.handleSubmit(handleSubmit, handleFormErrors)();
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleCancel = () => {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -122,9 +122,6 @@ export default function AgentBuilder({
   const [isCreatedDialogOpen, setIsCreatedDialogOpen] = useState(false);
   const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
   const hasPendingCreationRef = useRef(false);
-  // Synchronous guard: React state batching means isSaving won't disable the button before
-  // a second rapid click fires. This ref is checked/set synchronously in handleSave.
-  const isSavingRef = useRef(false);
 
   const { actions, isActionsLoading, mutateActions } =
     useAgentConfigurationActions(
@@ -382,6 +379,7 @@ export default function AgentBuilder({
       setIsSaving(true);
       const confirmed = await showDialog();
       if (!confirmed) {
+        setIsSaving(false);
         return;
       }
 
@@ -412,6 +410,7 @@ export default function AgentBuilder({
           description: result.error.message,
           type: "error",
         });
+        setIsSaving(false);
         return;
       }
 
@@ -458,12 +457,12 @@ export default function AgentBuilder({
           keepValues: true,
         });
       }
+
+      setIsSaving(false);
     } catch (error) {
       datadogLogger.error("Unexpected error:", {
         error: normalizeError(error),
       });
-    } finally {
-      isSavingRef.current = false;
       setIsSaving(false);
     }
   };
@@ -501,15 +500,14 @@ export default function AgentBuilder({
       description: "There was an error validating the form.",
       type: "error",
     });
-    isSavingRef.current = false;
     setIsSaving(false);
   };
 
   const handleSave = () => {
-    if (isSavingRef.current) {
+    if (isSaving) {
       return;
     }
-    isSavingRef.current = true;
+    setIsSaving(true);
     void form.handleSubmit(handleSubmit, handleFormErrors)();
   };
 
@@ -528,7 +526,7 @@ export default function AgentBuilder({
 
   const isSaveDisabled = duplicateAgentId
     ? false
-    : isSaving || isSubmitting || isActionsLoading || isTriggersLoading;
+    : isSubmitting || isActionsLoading || isTriggersLoading;
 
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -122,6 +122,9 @@ export default function AgentBuilder({
   const [isCreatedDialogOpen, setIsCreatedDialogOpen] = useState(false);
   const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
   const hasPendingCreationRef = useRef(false);
+  // Synchronous guard: React state batching means isSaving won't disable the button before
+  // a second rapid click fires. This ref is checked/set synchronously in handleSave.
+  const isSavingRef = useRef(false);
 
   const { actions, isActionsLoading, mutateActions } =
     useAgentConfigurationActions(
@@ -379,7 +382,6 @@ export default function AgentBuilder({
       setIsSaving(true);
       const confirmed = await showDialog();
       if (!confirmed) {
-        setIsSaving(false);
         return;
       }
 
@@ -410,7 +412,6 @@ export default function AgentBuilder({
           description: result.error.message,
           type: "error",
         });
-        setIsSaving(false);
         return;
       }
 
@@ -457,12 +458,12 @@ export default function AgentBuilder({
           keepValues: true,
         });
       }
-
-      setIsSaving(false);
     } catch (error) {
       datadogLogger.error("Unexpected error:", {
         error: normalizeError(error),
       });
+    } finally {
+      isSavingRef.current = false;
       setIsSaving(false);
     }
   };
@@ -500,10 +501,15 @@ export default function AgentBuilder({
       description: "There was an error validating the form.",
       type: "error",
     });
+    isSavingRef.current = false;
     setIsSaving(false);
   };
 
   const handleSave = () => {
+    if (isSavingRef.current) {
+      return;
+    }
+    isSavingRef.current = true;
     void form.handleSubmit(handleSubmit, handleFormErrors)();
   };
 
@@ -522,7 +528,7 @@ export default function AgentBuilder({
 
   const isSaveDisabled = duplicateAgentId
     ? false
-    : isSubmitting || isActionsLoading || isTriggersLoading;
+    : isSaving || isSubmitting || isActionsLoading || isTriggersLoading;
 
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 


### PR DESCRIPTION
## Description

The agent builder Save button could trigger multiple concurrent save requests when clicked rapidly. React's state batching means `isSaving` (a `useState`) is not yet `true` when a second click fires within the same render cycle, so the existing state-based guard was insufficient. This PR adds a `isSavingRef` (`useRef`) that is checked and set synchronously at the top of `handleSave`, providing a true single-entry guard. It also consolidates the scattered `setIsSaving(false)` early-returns into a single `finally` block, and adds `isSaving` to the `isSaveDisabled` condition so the button visually disables once a save is in flight.

## Tests

Manually tested by clicking the Save button multiple times in quick succession and confirming only one API request is fired.

## Risk

Low. The change is limited to `AgentBuilder.tsx` and only affects the save-button click guard logic. No schema or API changes.

## Deploy Plan

Deploy front.