### PR TITLE
Add: poke plugin to manage members and editors of pods.

### DIFF
--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -38,7 +38,17 @@ export function EnumSelect({
 }: EnumSelectProps) {
   const [open, setOpen] = React.useState(false);
 
-  let title = values?.length ? values.sort().join(", ") : placeholder;
+  const optionLabelByValue = React.useMemo(
+    () => new Map(options.map((option) => [option.value, option.label])),
+    [options]
+  );
+
+  let title = values?.length
+    ? values
+        .map((value) => optionLabelByValue.get(value) ?? value)
+        .sort()
+        .join(", ")
+    : placeholder;
 
   if (title.length > 80) {
     title = `${values?.length} items selected`;

--- a/front/lib/api/poke/plugins/spaces/index.ts
+++ b/front/lib/api/poke/plugins/spaces/index.ts
@@ -1,2 +1,3 @@
 export * from "./force_run_task_generation";
 export * from "./import_app";
+export * from "./update_pod_members";

--- a/front/lib/api/poke/plugins/spaces/update_pod_members.test.ts
+++ b/front/lib/api/poke/plugins/spaces/update_pod_members.test.ts
@@ -1,0 +1,123 @@
+import { updatePodMembersPlugin } from "@app/lib/api/poke/plugins/spaces/update_pod_members";
+import { Authenticator } from "@app/lib/auth";
+import { GroupSpaceEditorResource } from "@app/lib/resources/group_space_editor_resource";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { describe, expect, it } from "vitest";
+
+describe("updatePodMembersPlugin", () => {
+  it("restores members and editors on an orphaned pod", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+    const pod = await SpaceFactory.project(workspace);
+    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+      space: pod,
+      filterOnManagementMode: true,
+    });
+    const editorGroupSpaces = await GroupSpaceEditorResource.fetchBySpace({
+      space: pod,
+      filterOnManagementMode: true,
+    });
+
+    const memberGroup = memberGroupSpaces[0].group;
+    const editorGroup = editorGroupSpaces[0].group;
+
+    const activeMemberGroupMembers =
+      await memberGroup.getActiveMembers(adminAuth);
+    for (const member of activeMemberGroupMembers) {
+      await memberGroup.dangerouslyRemoveMembers(adminAuth, {
+        users: [member.toJSON()],
+      });
+    }
+
+    const activeEditorGroupMembers =
+      await editorGroup.getActiveMembers(adminAuth);
+    for (const member of activeEditorGroupMembers) {
+      await editorGroup.dangerouslyRemoveMembers(adminAuth, {
+        users: [member.toJSON()],
+      });
+    }
+
+    const reloadedPod = await SpaceResource.fetchById(adminAuth, pod.sId);
+    expect(reloadedPod).not.toBeNull();
+    expect(updatePodMembersPlugin.isApplicableTo(adminAuth, reloadedPod)).toBe(
+      true
+    );
+
+    const result = await updatePodMembersPlugin.execute(
+      adminAuth,
+      reloadedPod,
+      {
+        members: [user.sId],
+        editors: [user.sId],
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.value).toContain("Successfully updated pod access");
+    }
+
+    const updatedMemberGroupMembers =
+      await memberGroup.getActiveMembers(adminAuth);
+    const updatedEditorGroupMembers =
+      await editorGroup.getActiveMembers(adminAuth);
+
+    expect(updatedMemberGroupMembers.map((member) => member.sId)).toEqual([
+      user.sId,
+    ]);
+    expect(updatedEditorGroupMembers.map((member) => member.sId)).toEqual([
+      user.sId,
+    ]);
+  });
+
+  it("returns a no-op message when membership is already correct", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+      space: pod,
+      filterOnManagementMode: true,
+    });
+    const editorGroupSpaces = await GroupSpaceEditorResource.fetchBySpace({
+      space: pod,
+      filterOnManagementMode: true,
+    });
+
+    await memberGroupSpaces[0].group.dangerouslyAddMembers(adminAuth, {
+      users: [user.toJSON()],
+    });
+
+    const reloadedPod = await SpaceResource.fetchById(adminAuth, pod.sId);
+    const currentEditors =
+      await editorGroupSpaces[0].group.getActiveMembers(adminAuth);
+
+    const result = await updatePodMembersPlugin.execute(
+      adminAuth,
+      reloadedPod,
+      {
+        members: [user.sId],
+        editors: currentEditors.map((editor) => editor.sId),
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.value).toContain("No changes needed");
+    }
+  });
+});

--- a/front/lib/api/poke/plugins/spaces/update_pod_members.ts
+++ b/front/lib/api/poke/plugins/spaces/update_pod_members.ts
@@ -1,0 +1,301 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { getMembers } from "@app/lib/api/workspace";
+import type { Authenticator } from "@app/lib/auth";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupSpaceEditorResource } from "@app/lib/resources/group_space_editor_resource";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { UserType } from "@app/types/user";
+
+const updatePodMembersLogger = logger.child({
+  activity: "update-pod-members",
+});
+
+function formatMemberLabel(member: {
+  fullName: string | null;
+  email: string | null;
+}): string {
+  return member.fullName
+    ? `${member.fullName} (${member.email})`
+    : (member.email ?? member.fullName ?? "Unknown user");
+}
+
+async function syncGroupMembers(
+  auth: Authenticator,
+  group: GroupResource,
+  selectedMemberIds: string[]
+): Promise<
+  Result<
+    { added: string[]; removed: string[]; userMap: Map<string, UserType> },
+    Error
+  >
+> {
+  const currentMembers = await group.getActiveMembers(auth);
+  const currentMemberIds = new Set(currentMembers.map((member) => member.sId));
+
+  const newMemberIds = new Set(selectedMemberIds);
+  const usersToAdd = selectedMemberIds.filter(
+    (id) => !currentMemberIds.has(id)
+  );
+  const usersToRemove = Array.from(currentMemberIds).filter(
+    (id) => !newMemberIds.has(id)
+  );
+
+  if (usersToAdd.length === 0 && usersToRemove.length === 0) {
+    return new Ok({ added: [], removed: [], userMap: new Map() });
+  }
+
+  const allUserIds = [...usersToAdd, ...usersToRemove];
+  const userResources =
+    allUserIds.length > 0 ? await UserResource.fetchByIds(allUserIds) : [];
+  const userMap = new Map(
+    userResources.map((user) => [user.sId, user.toJSON()])
+  );
+
+  if (usersToAdd.length > 0) {
+    const usersToAddTypes = removeNulls(
+      usersToAdd.map((id) => userMap.get(id))
+    );
+    const addResult = await group.dangerouslyAddMembers(auth, {
+      users: usersToAddTypes,
+    });
+    if (addResult.isErr()) {
+      return new Err(
+        new Error(`Failed to add members: ${addResult.error.message}`)
+      );
+    }
+  }
+
+  if (usersToRemove.length > 0) {
+    const usersToRemoveTypes = removeNulls(
+      usersToRemove.map((id) => userMap.get(id))
+    );
+    const removeResult = await group.dangerouslyRemoveMembers(auth, {
+      users: usersToRemoveTypes,
+    });
+    if (removeResult.isErr()) {
+      return new Err(
+        new Error(`Failed to remove members: ${removeResult.error.message}`)
+      );
+    }
+  }
+
+  return new Ok({ added: usersToAdd, removed: usersToRemove, userMap });
+}
+
+async function getManualMemberGroup(
+  space: SpaceResource
+): Promise<GroupResource | null> {
+  const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+    space,
+    filterOnManagementMode: true,
+  });
+  if (memberGroupSpaces.length !== 1) {
+    return null;
+  }
+  return memberGroupSpaces[0].group;
+}
+
+async function getManualEditorGroup(
+  space: SpaceResource
+): Promise<GroupResource | null> {
+  const editorGroupSpaces = await GroupSpaceEditorResource.fetchBySpace({
+    space,
+    filterOnManagementMode: true,
+  });
+  if (editorGroupSpaces.length !== 1) {
+    return null;
+  }
+  return editorGroupSpaces[0].group;
+}
+
+export const updatePodMembersPlugin = createPlugin({
+  manifest: {
+    id: "update-pod-members",
+    name: "Update Pod Members & Editors",
+    description:
+      "Select which workspace members should be in this pod's member and editor groups. Uncheck to remove, check to add.",
+    warning:
+      "WARNING: This plugin must not be used without the explicit approval of the customer.",
+    resourceTypes: ["spaces"],
+    args: {
+      members: {
+        type: "enum",
+        label: "Members",
+        description: "Select members who should have access to this pod",
+        async: true,
+        values: [],
+        multiple: true,
+      },
+      editors: {
+        type: "enum",
+        label: "Editors",
+        description: "Select members who should be editors of this pod",
+        async: true,
+        values: [],
+        multiple: true,
+      },
+    },
+  },
+  populateAsyncArgs: async (auth, resource) => {
+    if (!resource) {
+      return new Ok({ members: [], editors: [] });
+    }
+
+    const { members: allMembers } = await getMembers(auth, {
+      activeOnly: true,
+    });
+
+    const memberGroup = await getManualMemberGroup(resource);
+    const editorGroup = await getManualEditorGroup(resource);
+
+    const currentMembers = memberGroup
+      ? await memberGroup.getActiveMembers(auth)
+      : [];
+    const currentEditors = editorGroup
+      ? await editorGroup.getActiveMembers(auth)
+      : [];
+
+    const memberIds = new Set(currentMembers.map((member) => member.sId));
+    const editorIds = new Set(currentEditors.map((editor) => editor.sId));
+
+    return new Ok({
+      members: allMembers.map((member) => ({
+        label: formatMemberLabel(member),
+        value: member.sId,
+        checked: memberIds.has(member.sId),
+      })),
+      editors: allMembers.map((member) => ({
+        label: formatMemberLabel(member),
+        value: member.sId,
+        checked: editorIds.has(member.sId),
+      })),
+    });
+  },
+  execute: async (auth, resource, args) => {
+    if (!resource) {
+      return new Err(new Error("Pod not found"));
+    }
+
+    if (!resource.isProject()) {
+      return new Err(new Error("This plugin only applies to pods"));
+    }
+
+    if (resource.managementMode !== "manual") {
+      return new Err(
+        new Error(
+          "This plugin only applies to pods with manual member management"
+        )
+      );
+    }
+
+    const memberGroup = await getManualMemberGroup(resource);
+    if (!memberGroup) {
+      return new Err(new Error("Pod does not have a member group"));
+    }
+
+    const editorGroup = await getManualEditorGroup(resource);
+    if (!editorGroup) {
+      return new Err(new Error("Pod does not have an editor group"));
+    }
+
+    const selectedMemberIds = args.members ?? [];
+    const selectedEditorIds = args.editors ?? [];
+
+    const memberSyncResult = await syncGroupMembers(
+      auth,
+      memberGroup,
+      selectedMemberIds
+    );
+    if (memberSyncResult.isErr()) {
+      return new Err(
+        new Error(`Failed to update members: ${memberSyncResult.error.message}`)
+      );
+    }
+
+    const editorSyncResult = await syncGroupMembers(
+      auth,
+      editorGroup,
+      selectedEditorIds
+    );
+    if (editorSyncResult.isErr()) {
+      return new Err(
+        new Error(`Failed to update editors: ${editorSyncResult.error.message}`)
+      );
+    }
+
+    const {
+      added: membersAdded,
+      removed: membersRemoved,
+      userMap: memberUserMap,
+    } = memberSyncResult.value;
+    const {
+      added: editorsAdded,
+      removed: editorsRemoved,
+      userMap: editorUserMap,
+    } = editorSyncResult.value;
+
+    if (
+      membersAdded.length === 0 &&
+      membersRemoved.length === 0 &&
+      editorsAdded.length === 0 &&
+      editorsRemoved.length === 0
+    ) {
+      return new Ok({
+        display: "text",
+        value:
+          "No changes needed - member and editor lists are already up to date.",
+      });
+    }
+
+    const userMap = new Map([...memberUserMap, ...editorUserMap]);
+    const formatNames = (userIds: string[]) =>
+      removeNulls(userIds.map((id) => userMap.get(id))).map(
+        (user) => user.fullName || user.email
+      );
+
+    let message = "Successfully updated pod access:";
+    if (membersAdded.length > 0) {
+      message += `\n- Members added: ${formatNames(membersAdded).join(", ")}`;
+    }
+    if (membersRemoved.length > 0) {
+      message += `\n- Members removed: ${formatNames(membersRemoved).join(", ")}`;
+    }
+    if (editorsAdded.length > 0) {
+      message += `\n- Editors added: ${formatNames(editorsAdded).join(", ")}`;
+    }
+    if (editorsRemoved.length > 0) {
+      message += `\n- Editors removed: ${formatNames(editorsRemoved).join(", ")}`;
+    }
+
+    updatePodMembersLogger.info(
+      {
+        action: "update_pod_members",
+        spaceId: resource.sId,
+        spaceName: resource.name,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        membersAdded: membersAdded.map((userId) => ({ userId })),
+        membersRemoved: membersRemoved.map((userId) => ({ userId })),
+        editorsAdded: editorsAdded.map((userId) => ({ userId })),
+        editorsRemoved: editorsRemoved.map((userId) => ({ userId })),
+      },
+      "Pod members and editors updated via poke"
+    );
+
+    return new Ok({
+      display: "text",
+      value: message,
+    });
+  },
+  isApplicableTo: (_auth, resource) => {
+    if (!resource) {
+      return false;
+    }
+    return resource.isProject() && resource.managementMode === "manual";
+  },
+});


### PR DESCRIPTION
## Description

New poke plugin `updatePodMembersPlugin` that lets support engineers manage the member and editor groups of a pod directly from the Poke UI. 

## Tests

- Added vitest unit tests in `update_pod_members.test.ts` covering two scenarios: restoring members/editors on an orphaned pod, and verifying no-op when membership is already correct.
- Tested manually in Poke against a pod with `managementMode === 'manual'`.

<img width="938" height="669" alt="image" src="https://github.com/user-attachments/assets/6dd3187f-8d08-4fc0-84ca-190f9da1b8db" />


## Risk

Low. Poke-only plugin

## Deploy Plan

Deploy `front`.
