### PR TITLE
feat(credits): add workspace auto-seat-upgrade setting

### DIFF
--- a/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
@@ -35,6 +35,7 @@ describe("/api/w/[wId]/credits/usage-configuration", () => {
     const { configuration } = await response.json();
     expect(configuration.allowMemberUpgradeRequests).toBe(true);
     expect(configuration.upgradeRequestEmailEnabled).toBe(true);
+    expect(configuration.autoSeatUpgradeEnabled).toBe(false);
   });
 
   it("PATCH persists the upgrade-request toggles and GET reflects them", async () => {
@@ -74,6 +75,40 @@ describe("/api/w/[wId]/credits/usage-configuration", () => {
     const getBody = await getResponse.json();
     expect(getBody.configuration.allowMemberUpgradeRequests).toBe(false);
     expect(getBody.configuration.upgradeRequestEmailEnabled).toBe(false);
+  });
+
+  it("PATCH persists autoSeatUpgradeEnabled and GET reflects it", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const patchResponse = await honoApp.request(
+      usageConfigurationUrl(workspace.sId),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ autoSeatUpgradeEnabled: true }),
+      }
+    );
+
+    expect(patchResponse.status).toBe(200);
+    const { configuration } = await patchResponse.json();
+    expect(configuration.autoSeatUpgradeEnabled).toBe(true);
+    // Untouched toggles keep their defaults.
+    expect(configuration.allowMemberUpgradeRequests).toBe(true);
+
+    await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+      workspace,
+    });
+
+    const getResponse = await honoApp.request(
+      usageConfigurationUrl(workspace.sId)
+    );
+    const getBody = await getResponse.json();
+    expect(getBody.configuration.autoSeatUpgradeEnabled).toBe(true);
   });
 
   it("PATCH returns 403 when caller is not an admin", async () => {

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -40,6 +40,7 @@ export function UsageSettingsCard({
 
   const [isSavingAllowUpgradeRequest, setIsSavingAllowUpgradeRequest] =
     useState(false);
+  const [isSavingAutoSeatUpgrade, setIsSavingAutoSeatUpgrade] = useState(false);
 
   const handleToggleAllowUpgradeRequest = async () => {
     setIsSavingAllowUpgradeRequest(true);
@@ -49,6 +50,17 @@ export function UsageSettingsCard({
       });
     } finally {
       setIsSavingAllowUpgradeRequest(false);
+    }
+  };
+
+  const handleToggleAutoSeatUpgrade = async () => {
+    setIsSavingAutoSeatUpgrade(true);
+    try {
+      await doUpdateUsageSettings({
+        autoSeatUpgradeEnabled: !usageSettings.autoSeatUpgradeEnabled,
+      });
+    } finally {
+      setIsSavingAutoSeatUpgrade(false);
     }
   };
 
@@ -109,6 +121,19 @@ export function UsageSettingsCard({
                 isUsageSettingsLoading
               }
               onClick={() => void handleToggleAllowUpgradeRequest()}
+            />
+          }
+        />
+        <SettingsList.Row
+          title="Auto-upgrade seats"
+          description="When a member reaches their credit limit, automatically move them to the next seat tier available in your plan (free → pro, pro → max) instead of blocking them. This may increase your subscription cost."
+          action={
+            <SliderToggle
+              selected={usageSettings.autoSeatUpgradeEnabled}
+              disabled={
+                readOnly || isSavingAutoSeatUpgrade || isUsageSettingsLoading
+              }
+              onClick={() => void handleToggleAutoSeatUpgrade()}
             />
           }
         />

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -21,6 +21,9 @@ export type CreditUsageConfigurationBody = {
   allowMemberUpgradeRequests: boolean;
   // Whether workspace admins are emailed when a member requests an upgrade.
   upgradeRequestEmailEnabled: boolean;
+  // Whether members who hit their per-user credit limit are automatically bumped
+  // to the next entitled seat tier instead of being blocked.
+  autoSeatUpgradeEnabled: boolean;
 };
 
 export type GetCreditUsageConfigurationResponseBody = {
@@ -36,6 +39,7 @@ export const PatchCreditUsageConfigurationRequestBody = z.object({
   balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
   allowMemberUpgradeRequests: z.boolean().optional(),
   upgradeRequestEmailEnabled: z.boolean().optional(),
+  autoSeatUpgradeEnabled: z.boolean().optional(),
 });
 
 export type PatchCreditUsageConfigurationBody = z.infer<
@@ -44,6 +48,7 @@ export type PatchCreditUsageConfigurationBody = z.infer<
 
 const DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS = true;
 const DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED = true;
+const DEFAULT_AUTO_SEAT_UPGRADE_ENABLED = false;
 
 /**
  * Read the full usage configuration for a workspace: the Metronome-derived
@@ -66,14 +71,17 @@ export async function getUsageConfiguration(
     upgradeRequestEmailEnabled:
       config?.upgradeRequestEmailEnabled ??
       DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+    autoSeatUpgradeEnabled:
+      config?.autoSeatUpgradeEnabled ?? DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
   };
 }
 
-async function setUpgradeRequestToggles(
+async function setConfigurationToggles(
   auth: Authenticator,
   toggles: {
     allowMemberUpgradeRequests?: boolean;
     upgradeRequestEmailEnabled?: boolean;
+    autoSeatUpgradeEnabled?: boolean;
   }
 ): Promise<Result<undefined, Error>> {
   const config =
@@ -93,6 +101,8 @@ async function setUpgradeRequestToggles(
     upgradeRequestEmailEnabled:
       toggles.upgradeRequestEmailEnabled ??
       DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+    autoSeatUpgradeEnabled:
+      toggles.autoSeatUpgradeEnabled ?? DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
   });
   if (createResult.isErr()) {
     return new Err(createResult.error);
@@ -129,11 +139,13 @@ export async function updateUsageConfiguration(
 
   if (
     patch.allowMemberUpgradeRequests !== undefined ||
-    patch.upgradeRequestEmailEnabled !== undefined
+    patch.upgradeRequestEmailEnabled !== undefined ||
+    patch.autoSeatUpgradeEnabled !== undefined
   ) {
-    const toggleResult = await setUpgradeRequestToggles(auth, {
+    const toggleResult = await setConfigurationToggles(auth, {
       allowMemberUpgradeRequests: patch.allowMemberUpgradeRequests,
       upgradeRequestEmailEnabled: patch.upgradeRequestEmailEnabled,
+      autoSeatUpgradeEnabled: patch.autoSeatUpgradeEnabled,
     });
     if (toggleResult.isErr()) {
       return new Err(toggleResult.error);

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -126,6 +126,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       upgradeRequestEmailEnabled: boolean;
       defaultPoolCapAwuCredits: number | null;
       programmaticMonthlyCapAwuCredits: number | null;
+      autoSeatUpgradeEnabled: boolean;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -33,6 +33,10 @@ import type { CreationOptional } from "sequelize";
  *   (API) AWU consumption, in AWU credits. Source of truth for the cap; the
  *   four Metronome programmatic alerts (cap/warning/low/critical) are derived
  *   from it. NULL means no cap is configured; 0 is a meaningful hard cap.
+ * - autoSeatUpgradeEnabled: Whether members who hit their per-user credit limit
+ *   are automatically bumped to the next entitled seat tier (free→pro, pro→max,
+ *   none→workspace) instead of being blocked. May increase the bill. Defaults to
+ *   false.
  *
  * The credit-cap-warning notification settings (whether to warn, and at which
  * balance) are NOT stored here: they are derived from the workspace's Metronome
@@ -49,6 +53,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
   declare defaultPoolCapAwuCredits: number | null;
   declare programmaticMonthlyCapAwuCredits: number | null;
+  declare autoSeatUpgradeEnabled: CreationOptional<boolean>;
 }
 
 CreditUsageConfigurationModel.init(
@@ -110,6 +115,11 @@ CreditUsageConfigurationModel.init(
       type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,
+    },
+    autoSeatUpgradeEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -31,7 +31,7 @@ const PutDefaultUserSpendLimitResponseSchema = z.object({
 
 export interface UsageSettings {
   allowUpgradeRequest: boolean;
-  autoUpgradeFreeToPro: boolean;
+  autoSeatUpgradeEnabled: boolean;
 }
 
 export interface UsageNotifications {
@@ -42,7 +42,7 @@ export interface UsageNotifications {
 
 const DEFAULT_USAGE_SETTINGS: UsageSettings = {
   allowUpgradeRequest: true,
-  autoUpgradeFreeToPro: false,
+  autoSeatUpgradeEnabled: false,
 };
 
 const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
@@ -93,7 +93,10 @@ export function useUsageSettings({ workspaceId }: { workspaceId: string }) {
   const usageSettings: UsageSettings = {
     ...DEFAULT_USAGE_SETTINGS,
     ...(data
-      ? { allowUpgradeRequest: data.configuration.allowMemberUpgradeRequests }
+      ? {
+          allowUpgradeRequest: data.configuration.allowMemberUpgradeRequests,
+          autoSeatUpgradeEnabled: data.configuration.autoSeatUpgradeEnabled,
+        }
       : {}),
   };
 
@@ -121,7 +124,9 @@ export function useUpdateUsageSettings({
       if (patch.allowUpgradeRequest !== undefined) {
         body.allowMemberUpgradeRequests = patch.allowUpgradeRequest;
       }
-      // TODO: `autoUpgradeFreeToPro` is intentionally not persisted (out of scope).
+      if (patch.autoSeatUpgradeEnabled !== undefined) {
+        body.autoSeatUpgradeEnabled = patch.autoSeatUpgradeEnabled;
+      }
 
       if (Object.keys(body).length === 0) {
         return true;

--- a/front/migrations/db/migration_683.sql
+++ b/front/migrations/db/migration_683.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jun 16, 2026
+ALTER TABLE "public"."credit_usage_configurations"
+ADD COLUMN "autoSeatUpgradeEnabled" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Description

First PR of a stack adding a workspace-level **"Auto-upgrade seats"** capability: when a member hits their per-user credit limit, the workspace can opt to automatically move them to the next seat tier instead of blocking them.

This PR adds only the **setting and its admin surface** — it has no behavioral effect on its own (the engine that consumes the flag lands later in the stack, #27423):

- New `autoSeatUpgradeEnabled` column on `credit_usage_configurations` (default `false`).
- Plumbs the flag through the usage-configuration API (read body + PATCH), the `useUsageSettings` SWR hooks (replacing the unpersisted `autoUpgradeFreeToPro` placeholder), and a new toggle row in the workspace Usage settings card.

## Tests

Extended the `usage-configuration` functional test: defaults `autoSeatUpgradeEnabled` to `false`, and PATCH persists it (admin-only) while leaving the other toggles at their defaults.

## Deploy Plan

Run `front/migrations/db/migration_681.sql` (adds the `autoSeatUpgradeEnabled` column) before/with the deploy.
