### PR TITLE
feat(credits): add seat auto-upgrade admin notification and audit event

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -5,6 +5,7 @@ import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/con
 import { podAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { programmaticCapReachedWorkflow } from "@app/lib/notifications/workflows/programmatic-cap-reached";
 import { providerCredentialsHealthUpdatedWorkflow } from "@app/lib/notifications/workflows/provider-credential-updated";
+import { seatAutoUpgradedWorkflow } from "@app/lib/notifications/workflows/seat-auto-upgraded";
 import { skillSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/skill-suggestions-ready";
 import { upgradeRequestCreatedWorkflow } from "@app/lib/notifications/workflows/upgrade-request-created";
 import { userAwuCapReachedWorkflow } from "@app/lib/notifications/workflows/user-awu-cap-reached";
@@ -36,6 +37,7 @@ const options: ServeHandlerOptions = {
     balanceThresholdReachedWorkflow,
     programmaticCapReachedWorkflow,
     upgradeRequestCreatedWorkflow,
+    seatAutoUpgradedWorkflow,
   ],
 };
 

--- a/front/admin/audit_log_schemas/membership.seat_auto_upgraded.json
+++ b/front/admin/audit_log_schemas/membership.seat_auto_upgraded.json
@@ -1,0 +1,15 @@
+{
+  "action": "membership.seat_auto_upgraded",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "user"
+    }
+  ],
+  "metadata": {
+    "previous_seat_type": "string",
+    "new_seat_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -40,6 +40,7 @@
   "membership.origin_updated": 5,
   "membership.revoked": 4,
   "membership.role_updated": 6,
+  "membership.seat_auto_upgraded": 1,
   "membership.upgrade_request_created": 1,
   "membership.upgrade_request_resolved": 1,
   "oauth.authorized": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -49,6 +49,7 @@ export const AUDIT_ACTIONS = [
   "member.spend_limit_updated",
   "membership.upgrade_request_created",
   "membership.upgrade_request_resolved",
+  "membership.seat_auto_upgraded",
   // Domains & SSO.
   "domain.verified",
   "domain.verification_failed",

--- a/front/lib/notifications/workflows/seat-auto-upgraded.ts
+++ b/front/lib/notifications/workflows/seat-auto-upgraded.ts
@@ -1,0 +1,137 @@
+import config from "@app/lib/api/config";
+import { renderEmail } from "@app/lib/notifications/email-templates/default";
+import { getNovuClient } from "@app/lib/notifications/novu-client";
+import logger from "@app/logger/logger";
+import {
+  SEAT_AUTO_UPGRADED_TAG,
+  SEAT_AUTO_UPGRADED_TRIGGER_ID,
+} from "@app/types/notification_preferences";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const SeatAutoUpgradedPayloadSchema = z.object({
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  memberName: z.string(),
+  memberEmail: z.string().nullable(),
+  previousSeatType: z.string(),
+  newSeatType: z.string(),
+});
+
+type SeatAutoUpgradedPayloadType = z.infer<
+  typeof SeatAutoUpgradedPayloadSchema
+>;
+
+function formatMember(payload: SeatAutoUpgradedPayloadType): string {
+  return payload.memberEmail
+    ? `${payload.memberName} (${payload.memberEmail})`
+    : payload.memberName;
+}
+
+export const seatAutoUpgradedWorkflow = workflow(
+  SEAT_AUTO_UPGRADED_TRIGGER_ID,
+  async ({ step, payload, subscriber }) => {
+    await step.email("seat-auto-upgraded-email", async () => {
+      const member = formatMember(payload);
+      const subject = `[Dust] ${member} was auto-upgraded to a ${payload.newSeatType} seat`;
+      const content = [
+        `${member} reached their credit limit and was automatically upgraded from a ${payload.previousSeatType} seat to a ${payload.newSeatType} seat so they can keep working.`,
+        `This increases your subscription cost. You can turn off automatic seat upgrades from your workspace usage settings.`,
+      ].join("\n\n");
+
+      const body = await renderEmail({
+        name: subscriber.firstName ?? "there",
+        workspace: {
+          id: payload.workspaceId,
+          name: payload.workspaceName,
+        },
+        content,
+        action: {
+          label: "Go to workspace usage",
+          url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+        },
+      });
+      return { subject, body };
+    });
+  },
+  {
+    payloadSchema: SeatAutoUpgradedPayloadSchema,
+    tags: [SEAT_AUTO_UPGRADED_TAG],
+  }
+);
+
+/**
+ * Email a workspace's admins that a member's seat was automatically upgraded
+ * after they hit their credit limit. One Novu event is triggered per admin
+ * (subscribed by their Dust user sId), deduped via a `transactionId` keyed on
+ * the member sId and the new seat type so redeliveries don't re-send.
+ * Fire-and-forget — errors are logged but don't block the caller.
+ */
+export function notifyAdminsSeatAutoUpgraded({
+  admins,
+  workspaceId,
+  workspaceName,
+  memberId,
+  memberName,
+  memberEmail,
+  previousSeatType,
+  newSeatType,
+}: {
+  admins: Array<{
+    sId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+  }>;
+  workspaceId: string;
+  workspaceName: string;
+  memberId: string;
+  memberName: string;
+  memberEmail: string | null;
+  previousSeatType: string;
+  newSeatType: string;
+}): void {
+  if (admins.length === 0) {
+    return;
+  }
+
+  const payload: SeatAutoUpgradedPayloadType = {
+    workspaceId,
+    workspaceName,
+    memberName,
+    memberEmail,
+    previousSeatType,
+    newSeatType,
+  };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: admins.map((admin) => ({
+          workflowId: SEAT_AUTO_UPGRADED_TRIGGER_ID,
+          to: {
+            subscriberId: admin.sId,
+            email: admin.email,
+            firstName: admin.firstName ?? undefined,
+            lastName: admin.lastName ?? undefined,
+          },
+          payload,
+          transactionId: `${SEAT_AUTO_UPGRADED_TRIGGER_ID}-${memberId}-${newSeatType}-${admin.sId}`,
+        })),
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, memberId },
+          "Failed to trigger seat auto-upgraded notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, memberId },
+        "Failed to trigger seat auto-upgraded notification"
+      );
+    });
+}

--- a/front/lib/notifications/workflows/seat-auto-upgraded.ts
+++ b/front/lib/notifications/workflows/seat-auto-upgraded.ts
@@ -6,8 +6,9 @@ import {
   SEAT_AUTO_UPGRADED_TAG,
   SEAT_AUTO_UPGRADED_TRIGGER_ID,
 } from "@app/types/notification_preferences";
+import { isDevelopment } from "@app/types/shared/env";
 import { workflow } from "@novu/framework";
-import z from "zod";
+import { z } from "zod";
 
 const SeatAutoUpgradedPayloadSchema = z.object({
   workspaceId: z.string(),
@@ -22,6 +23,11 @@ type SeatAutoUpgradedPayloadType = z.infer<
   typeof SeatAutoUpgradedPayloadSchema
 >;
 
+const isSeatAutoUpgradedPayload = (
+  payload: unknown
+): payload is SeatAutoUpgradedPayloadType =>
+  SeatAutoUpgradedPayloadSchema.safeParse(payload).success;
+
 function formatMember(payload: SeatAutoUpgradedPayloadType): string {
   return payload.memberEmail
     ? `${payload.memberName} (${payload.memberEmail})`
@@ -31,28 +37,71 @@ function formatMember(payload: SeatAutoUpgradedPayloadType): string {
 export const seatAutoUpgradedWorkflow = workflow(
   SEAT_AUTO_UPGRADED_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
-    await step.email("seat-auto-upgraded-email", async () => {
-      const member = formatMember(payload);
-      const subject = `[Dust] ${member} was auto-upgraded to a ${payload.newSeatType} seat`;
-      const content = [
-        `${member} reached their credit limit and was automatically upgraded from a ${payload.previousSeatType} seat to a ${payload.newSeatType} seat so they can keep working.`,
-        `This increases your subscription cost. You can turn off automatic seat upgrades from your workspace usage settings.`,
-      ].join("\n\n");
-
-      const body = await renderEmail({
-        name: subscriber.firstName ?? "there",
-        workspace: {
-          id: payload.workspaceId,
-          name: payload.workspaceName,
-        },
-        content,
-        action: {
-          label: "Go to workspace usage",
-          url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
-        },
-      });
-      return { subject, body };
+    const { events } = await step.digest("digest", async () => {
+      const digestKey = `${subscriber.subscriberId}-workspace-${payload.workspaceId}-seat-auto-upgrades`;
+      return isDevelopment()
+        ? { amount: 2, unit: "minutes", digestKey }
+        : { cron: "0 9 * * *", digestKey }; // Every day at 9:00 AM UTC.
     });
+
+    await step.email(
+      "seat-auto-upgraded-email",
+      async () => {
+        // Dedupe by member (a member could be upgraded more than once across
+        // the window) and keep insertion order so the email lists each once.
+        const memberByKey = new Map<string, SeatAutoUpgradedPayloadType>();
+        for (const event of events) {
+          if (!isSeatAutoUpgradedPayload(event.payload)) {
+            continue;
+          }
+          const key = event.payload.memberEmail ?? event.payload.memberName;
+          if (!memberByKey.has(key)) {
+            memberByKey.set(key, event.payload);
+          }
+        }
+        const members = Array.from(memberByKey.values());
+        const count = members.length;
+
+        const subject =
+          count > 1
+            ? `[Dust] ${count} members were auto-upgraded to higher seats`
+            : `[Dust] ${formatMember(members[0])} was auto-upgraded to a ${members[0].newSeatType} seat`;
+
+        const intro =
+          count > 1
+            ? `${count} members reached their credit limit and were automatically upgraded to higher seats so they can keep working:`
+            : `${formatMember(members[0])} reached their credit limit and was automatically upgraded from a ${members[0].previousSeatType} seat to a ${members[0].newSeatType} seat so they can keep working.`;
+        const list =
+          count > 1
+            ? members
+                .map(
+                  (m) =>
+                    `• ${formatMember(m)} — ${m.previousSeatType} → ${m.newSeatType}`
+                )
+                .join("\n")
+            : "";
+        const outro = `This might increase your subscription cost. You can turn off automatic seat upgrades from your workspace usage settings.`;
+        const content = [intro, list, outro].filter(Boolean).join("\n\n");
+
+        const body = await renderEmail({
+          name: subscriber.firstName ?? "there",
+          workspace: {
+            id: payload.workspaceId,
+            name: payload.workspaceName,
+          },
+          content,
+          action: {
+            label: "Go to workspace usage",
+            url: `${config.getAppUrl()}/w/${payload.workspaceId}/usage`,
+          },
+        });
+        return { subject, body };
+      },
+      {
+        skip: async () =>
+          !events.some((event) => isSeatAutoUpgradedPayload(event.payload)),
+      }
+    );
   },
   {
     payloadSchema: SeatAutoUpgradedPayloadSchema,

--- a/front/lib/notifications/workflows/seat-auto-upgraded.ts
+++ b/front/lib/notifications/workflows/seat-auto-upgraded.ts
@@ -41,7 +41,7 @@ export const seatAutoUpgradedWorkflow = workflow(
       const digestKey = `${subscriber.subscriberId}-workspace-${payload.workspaceId}-seat-auto-upgrades`;
       return isDevelopment()
         ? { amount: 2, unit: "minutes", digestKey }
-        : { cron: "0 9 * * *", digestKey }; // Every day at 9:00 AM UTC.
+        : { cron: "0 */5 * * *", digestKey }; // Every 5 hours
     });
 
     await step.email(

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -122,6 +122,9 @@ export const UPGRADE_REQUEST_CREATED_TRIGGER_ID =
   "upgrade-request-created" as const;
 export const UPGRADE_REQUEST_CREATED_TAG = "upgrade-request-created" as const;
 
+export const SEAT_AUTO_UPGRADED_TRIGGER_ID = "seat-auto-upgraded" as const;
+export const SEAT_AUTO_UPGRADED_TAG = "seat-auto-upgraded" as const;
+
 export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof POD_ADDED_AS_MEMBER_TRIGGER_ID
@@ -131,4 +134,5 @@ export type WorkflowTriggerId =
   | typeof USER_AWU_CAP_REACHED_TRIGGER_ID
   | typeof BALANCE_THRESHOLD_REACHED_TRIGGER_ID
   | typeof PROGRAMMATIC_CAP_REACHED_TRIGGER_ID
-  | typeof UPGRADE_REQUEST_CREATED_TRIGGER_ID;
+  | typeof UPGRADE_REQUEST_CREATED_TRIGGER_ID
+  | typeof SEAT_AUTO_UPGRADED_TRIGGER_ID;


### PR DESCRIPTION
## Description

Part of the **auto-upgrade seats** stack (builds on #27421). Adds the notification and audit plumbing the engine will use when a member's seat is auto-upgraded. Both are dormant until the engine (#27423) calls them.

- New Novu workflow `seat-auto-upgraded` (+ trigger id/tag, registered in the Novu serve route) that emails workspace admins when a member is auto-upgraded.
- New audit action `membership.seat_auto_upgraded` (union entry, schema file, schema version).

## Deploy Plan

- After merge, register the audit schema with WorkOS: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`.
- Ensure the new `seat-auto-upgraded` Novu workflow is synced to Novu.
