### PR TITLE
feat(credits): auto-upgrade member seat on credit limit hit

### DIFF
--- a/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.test.ts
@@ -8,8 +8,10 @@ function upgradeRequestsUrl(wId: string) {
   return `/api/w/${wId}/credits/upgrade-requests`;
 }
 
-async function metronomeWorkspace(): Promise<WorkspaceType> {
-  return WorkspaceFactory.metronome({ metronomeCustomerId: "cust_test_xxx" });
+async function creditPricedWorkspace(): Promise<WorkspaceType> {
+  return WorkspaceFactory.creditPriced({
+    metronomeCustomerId: "cust_test_xxx",
+  });
 }
 
 async function createMemberRequest(workspace: WorkspaceType) {
@@ -29,7 +31,7 @@ async function createMemberRequest(workspace: WorkspaceType) {
 describe("/api/w/[wId]/credits/upgrade-requests", () => {
   describe("auth", () => {
     it("GET returns 403 when caller is not an admin", async () => {
-      const workspace = await metronomeWorkspace();
+      const workspace = await creditPricedWorkspace();
       await createPrivateApiMockRequest({
         method: "GET",
         role: "user",
@@ -64,7 +66,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
     });
 
     it("creates a pending request for a member", async () => {
-      const workspace = await metronomeWorkspace();
+      const workspace = await creditPricedWorkspace();
       const { user, response } = await createMemberRequest(workspace);
 
       expect(response.status).toBe(200);
@@ -75,7 +77,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
     });
 
     it("is idempotent — a second request reuses the pending one", async () => {
-      const workspace = await metronomeWorkspace();
+      const workspace = await creditPricedWorkspace();
       const { membership, response: first } =
         await createMemberRequest(workspace);
       const firstSId = (await first.json()).request.sId;
@@ -95,7 +97,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
 
   describe("GET + PATCH (admin)", () => {
     it("lists pending requests and resolves them", async () => {
-      const workspace = await metronomeWorkspace();
+      const workspace = await creditPricedWorkspace();
       const { user: member } = await createMemberRequest(workspace);
 
       // Re-authenticate as an admin of the same workspace.
@@ -133,7 +135,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
     });
 
     it("PATCH returns 404 for an unknown request id", async () => {
-      const workspace = await metronomeWorkspace();
+      const workspace = await creditPricedWorkspace();
       await createPrivateApiMockRequest({
         method: "GET",
         role: "admin",
@@ -153,7 +155,7 @@ describe("/api/w/[wId]/credits/upgrade-requests", () => {
     });
 
     it("PATCH returns 403 when caller is not an admin", async () => {
-      const workspace = await metronomeWorkspace();
+      const workspace = await creditPricedWorkspace();
       await createPrivateApiMockRequest({
         method: "GET",
         role: "user",

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -53,6 +53,7 @@ import {
   deriveAgentTriggerType,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import {
@@ -2484,6 +2485,13 @@ async function checkMessagesLimit(
         ? ("credits_exhausted" as const)
         : null;
     if (blockedReason === "no_seat") {
+      // If the workspace opted into auto-upgrades, try to assign a seat
+      // (none → workspace) so the member is unblocked on their next attempt.
+      // Fire-and-forget: it no-ops unless eligible, and we don't block this
+      // request on the Metronome seat sync.
+      if (user) {
+        void maybeAutoUpgradeSeat({ workspaceId: owner.sId, userId: user.sId });
+      }
       return new Err({
         status_code: 403,
         api_error: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2486,11 +2486,18 @@ async function checkMessagesLimit(
         : null;
     if (blockedReason === "no_seat") {
       // If the workspace opted into auto-upgrades, try to assign a seat
-      // (none → workspace) so the member is unblocked on their next attempt.
-      // Fire-and-forget: it no-ops unless eligible, and we don't block this
-      // request on the Metronome seat sync.
+      // (none → workspace) so the member can proceed with this very message.
+      // We await the result (it no-ops unless eligible): on success the user
+      // is no longer seat-less, so we fall through instead of rejecting a
+      // message we just unblocked.
       if (user) {
-        void maybeAutoUpgradeSeat({ workspaceId: owner.sId, userId: user.sId });
+        const upgrade = await maybeAutoUpgradeSeat({
+          workspaceId: owner.sId,
+          userId: user.sId,
+        });
+        if (upgrade.isOk() && upgrade.value.upgraded) {
+          return new Ok(undefined);
+        }
       }
       return new Err({
         status_code: 403,

--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -226,7 +226,6 @@ describe("maybeAutoUpgradeSeat", () => {
       expect.objectContaining({
         newSeatType: "max",
         author: "no-author",
-        skipSeatLimitCheck: true,
       })
     );
     expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledWith(

--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -1,0 +1,323 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+
+import {
+  maybeAutoUpgradeSeat,
+  resolveAutoUpgradeTarget,
+} from "@app/lib/api/credits/auto_seat_upgrade";
+import * as membershipApi from "@app/lib/api/membership";
+import * as workspaceApi from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
+import * as seatUpgradeNotif from "@app/lib/notifications/workflows/seat-auto-upgraded";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `maybeAutoUpgradeSeat` always returns `Ok` (it swallows failures into a no-op),
+// so tests assert on the resolved value directly.
+function expectOk<T>(result: Result<T, Error>): T {
+  expect(result.isOk()).toBe(true);
+  if (!result.isOk()) {
+    throw new Error("expected Ok result");
+  }
+  return result.value;
+}
+
+// We mock the Metronome boundary (the live contract read + product/seat-type
+// catalog) so the entitlement resolution runs against deterministic data, and
+// the seat-mutation + side effects (audit, admin notification) so we can assert
+// on them without touching Metronome or WorkOS. The pure helper
+// `getSeatSubscriptionsFromContract` is intentionally left un-mocked so the real
+// entitlement logic is exercised.
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return { ...actual, getActiveContract: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return { ...actual, getProductSeatTypes: vi.fn() };
+});
+
+vi.mock("@app/lib/api/membership", async () => {
+  const actual = await vi.importActual<typeof membershipApi>(
+    "@app/lib/api/membership"
+  );
+  return { ...actual, updateMembershipSeatAndTrack: vi.fn() };
+});
+
+vi.mock("@app/lib/api/workspace", async () => {
+  const actual = await vi.importActual<typeof workspaceApi>(
+    "@app/lib/api/workspace"
+  );
+  return { ...actual, getMembers: vi.fn() };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return { ...actual, emitAuditLogEventDirect: vi.fn() };
+});
+
+vi.mock("@app/lib/notifications/workflows/seat-auto-upgraded", async () => {
+  const actual = await vi.importActual<typeof seatUpgradeNotif>(
+    "@app/lib/notifications/workflows/seat-auto-upgraded"
+  );
+  return { ...actual, notifyAdminsSeatAutoUpgraded: vi.fn() };
+});
+
+// Build a fake Metronome contract entitling exactly the given seat types, plus a
+// matching product→seat-type catalog. Mirrors the contract shape used in
+// `seat_types.test.ts`.
+function setupEntitledSeats(seatTypeList: MembershipSeatType[]): void {
+  const contract = {
+    subscriptions: seatTypeList.map((seatType) => ({
+      subscription_rate: {
+        product: { id: `${seatType}-product`, name: seatType },
+      },
+    })),
+    overrides: seatTypeList.map((seatType) => ({
+      entitled: true,
+      product: { id: `${seatType}-product` },
+    })),
+  } as unknown as CachedContract;
+
+  const catalog = new Map<string, MembershipSeatType>(
+    seatTypeList.map((seatType) => [`${seatType}-product`, seatType])
+  );
+
+  vi.mocked(planType.getActiveContract).mockResolvedValue(contract);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(catalog);
+}
+
+async function setup({
+  autoSeatUpgradeEnabled,
+  seatType,
+}: {
+  autoSeatUpgradeEnabled: boolean;
+  seatType: MembershipSeatType;
+}) {
+  const workspace = await WorkspaceFactory.creditPriced();
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, {
+    role: "user",
+    seatType,
+  });
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  await CreditUsageConfigurationResource.makeNew(auth, {
+    autoSeatUpgradeEnabled,
+    defaultDiscountPercent: 0,
+    usageCapCredits: null,
+  });
+
+  return { workspace, user };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(workspaceApi.getMembers).mockResolvedValue({
+    members: [],
+    total: 0,
+  });
+  vi.mocked(workosAudit.emitAuditLogEventDirect).mockResolvedValue(undefined);
+});
+
+describe("resolveAutoUpgradeTarget", () => {
+  it("resolves pro to max when max is entitled", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    setupEntitledSeats(["pro", "max"]);
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, "pro");
+
+    expect(target).toBe("max");
+  });
+
+  it("resolves free to pro when pro is entitled", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    setupEntitledSeats(["free", "pro"]);
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, "free");
+
+    expect(target).toBe("pro");
+  });
+
+  it("returns null at the top tier (max has no higher tier)", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    setupEntitledSeats(["pro", "max"]);
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, "max");
+
+    expect(target).toBeNull();
+  });
+
+  it("returns null when the target tier is not entitled", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    // pro would target max, but max is not entitled by the contract.
+    setupEntitledSeats(["pro"]);
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, "pro");
+
+    expect(target).toBeNull();
+  });
+
+  it("prefers the monthly cadence over the yearly variant", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    setupEntitledSeats(["pro", "max_yearly", "max"]);
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, "pro");
+
+    expect(target).toBe("max");
+  });
+
+  it("returns null when there is no active contract", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+    vi.mocked(planType.getActiveContract).mockResolvedValue(null);
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, "pro");
+
+    expect(target).toBeNull();
+  });
+
+  it("returns null for a null seat type", async () => {
+    const workspace = await WorkspaceFactory.creditPriced();
+
+    const target = await resolveAutoUpgradeTarget(workspace.sId, null);
+
+    expect(target).toBeNull();
+  });
+});
+
+describe("maybeAutoUpgradeSeat", () => {
+  it("upgrades a pro member to max, emits audit, and notifies admins", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+    vi.mocked(membershipApi.updateMembershipSeatAndTrack).mockResolvedValue(
+      new Ok({
+        previousSeatType: "pro",
+        newSeatType: "max",
+        scheduledSeatChangeAt: undefined,
+      })
+    );
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: true });
+
+    expect(membershipApi.updateMembershipSeatAndTrack).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newSeatType: "max",
+        author: "no-author",
+        skipSeatLimitCheck: true,
+      })
+    );
+    expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "membership.seat_auto_upgraded",
+        metadata: { previous_seat_type: "pro", new_seat_type: "max" },
+      })
+    );
+    expect(seatUpgradeNotif.notifyAdminsSeatAutoUpgraded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousSeatType: "pro",
+        newSeatType: "max",
+      })
+    );
+  });
+
+  it("no-ops when the workspace toggle is off", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: false,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: false });
+    expect(membershipApi.updateMembershipSeatAndTrack).not.toHaveBeenCalled();
+    expect(workosAudit.emitAuditLogEventDirect).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the member is already at the top entitled tier", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "max",
+    });
+    setupEntitledSeats(["pro", "max"]);
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: false });
+    expect(membershipApi.updateMembershipSeatAndTrack).not.toHaveBeenCalled();
+  });
+
+  it("no-ops without audit/notify when the seat update fails", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+    vi.mocked(membershipApi.updateMembershipSeatAndTrack).mockResolvedValue(
+      new Err({ type: "metronome_error" })
+    );
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: false });
+    expect(workosAudit.emitAuditLogEventDirect).not.toHaveBeenCalled();
+    expect(
+      seatUpgradeNotif.notifyAdminsSeatAutoUpgraded
+    ).not.toHaveBeenCalled();
+  });
+
+  it("no-ops without audit/notify when the applied seat is unchanged", async () => {
+    const { workspace, user } = await setup({
+      autoSeatUpgradeEnabled: true,
+      seatType: "pro",
+    });
+    setupEntitledSeats(["pro", "max"]);
+    vi.mocked(membershipApi.updateMembershipSeatAndTrack).mockResolvedValue(
+      new Ok({
+        previousSeatType: "pro",
+        newSeatType: "pro",
+        scheduledSeatChangeAt: undefined,
+      })
+    );
+
+    const result = await maybeAutoUpgradeSeat({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+    });
+
+    expect(expectOk(result)).toEqual({ upgraded: false });
+    expect(workosAudit.emitAuditLogEventDirect).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -1,0 +1,305 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
+import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import { getActiveContract } from "@app/lib/metronome/plan_type";
+import {
+  getProductSeatTypes,
+  getSeatSubscriptionsFromContract,
+} from "@app/lib/metronome/seat_types";
+import { notifyAdminsSeatAutoUpgraded } from "@app/lib/notifications/workflows/seat-auto-upgraded";
+import { isCreditPricedFreePlan } from "@app/lib/plans/plan_codes";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { toBaseSeatType } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Allowed auto-upgrade transitions, keyed on the *base* seat tier of the
+// member's current seat. The value is the base tier we try to move them to,
+// constrained to seats the workspace's contract actually offers (see
+// `resolveAutoUpgradeTarget`). Anything not listed here (already at `max` or
+// `workspace`) is a no-op.
+const AUTO_UPGRADE_TARGET_BASE_TIER: Partial<
+  Record<MembershipSeatType, MembershipSeatType>
+> = {
+  none: "workspace",
+  free: "pro",
+  pro: "max",
+};
+
+/**
+ * Whether the workspace's subscription allows auto-upgrades to incur cost:
+ * Metronome-billed on a non-free credit-priced plan. (The same gate the member
+ * upgrade-request flow uses, plus the explicit non-free check.)
+ */
+function passesBillingGate(subscription: SubscriptionResource): boolean {
+  if (!subscription.isMetronomeOnlyBilled) {
+    return false;
+  }
+  return !isCreditPricedFreePlan(subscription.getPlan().code);
+}
+
+/**
+ * Resolve the concrete seat type a member should be auto-upgraded to, or `null`
+ * when no upgrade applies. The target base tier comes from
+ * `AUTO_UPGRADE_TARGET_BASE_TIER`; the concrete seat type must be entitled by
+ * the workspace's active contract ("stay in the allowed seats"). When both the
+ * monthly and yearly cadence of the target tier are entitled, the monthly
+ * variant is preferred.
+ */
+export async function resolveAutoUpgradeTarget(
+  workspaceId: string,
+  currentSeatType: MembershipSeatType | null | undefined
+): Promise<MembershipSeatType | null> {
+  if (!currentSeatType) {
+    return null;
+  }
+
+  const targetBaseTier =
+    AUTO_UPGRADE_TARGET_BASE_TIER[toBaseSeatType(currentSeatType)];
+  if (!targetBaseTier) {
+    return null;
+  }
+
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    return null;
+  }
+
+  const productSeatTypes = await getProductSeatTypes();
+  const entitledSeats = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+
+  // Find an entitled seat whose base tier matches the target, preferring the
+  // monthly cadence (the base tier itself) over the `_yearly` variant.
+  let fallback: MembershipSeatType | null = null;
+  for (const seatType of entitledSeats.keys()) {
+    if (toBaseSeatType(seatType) !== targetBaseTier) {
+      continue;
+    }
+    if (seatType === targetBaseTier) {
+      return seatType;
+    }
+    fallback = seatType;
+  }
+  return fallback;
+}
+
+/**
+ * Whether the given workspace+member is currently eligible for an automatic
+ * seat upgrade: the toggle is on, the billing gate passes, and the member's
+ * seat has an entitled higher tier. Used to suppress the member "request
+ * upgrade" CTA (an eligible member will be auto-upgraded rather than needing to
+ * ask). Read-only; returns `false` on any missing prerequisite.
+ */
+export async function isEligibleForAutoSeatUpgrade(
+  auth: Authenticator
+): Promise<boolean> {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if (!config?.autoSeatUpgradeEnabled) {
+    return false;
+  }
+
+  const subscription = auth.subscriptionResource();
+  if (!subscription || !passesBillingGate(subscription)) {
+    return false;
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return false;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return false;
+  }
+
+  const target = await resolveAutoUpgradeTarget(
+    workspace.sId,
+    membership.seatType
+  );
+  return target !== null;
+}
+
+/**
+ * Auto-upgrade a member's seat one tier when they hit their credit limit, if
+ * the workspace has opted in. No-ops unless: the toggle is on, the workspace is
+ * Metronome-billed on a non-free plan, and the member's seat has an entitled
+ * higher tier. The seat-count limit is intentionally bypassed (the upgrade may
+ * make the subscription more expensive). On success, notifies admins and emits
+ * an audit event.
+ *
+ * Fire-and-forget at the call sites; returns a `Result` for testability but
+ * swallows Metronome failures into an `Ok` no-op so the credit-state path is
+ * never broken by an upgrade attempt.
+ */
+export async function maybeAutoUpgradeSeat({
+  workspaceId,
+  userId,
+}: {
+  workspaceId: string;
+  userId: string;
+}): Promise<Result<{ upgraded: boolean }, Error>> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if (!config?.autoSeatUpgradeEnabled) {
+    return new Ok({ upgraded: false });
+  }
+
+  const subscription = auth.subscriptionResource();
+  if (!subscription || !passesBillingGate(subscription)) {
+    return new Ok({ upgraded: false });
+  }
+
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    return new Ok({ upgraded: false });
+  }
+
+  const lightWorkspace = auth.getNonNullableWorkspace();
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace: lightWorkspace,
+    });
+  if (!membership) {
+    return new Ok({ upgraded: false });
+  }
+
+  const newSeatType = await resolveAutoUpgradeTarget(
+    workspaceId,
+    membership.seatType
+  );
+  if (!newSeatType) {
+    return new Ok({ upgraded: false });
+  }
+
+  const result = await updateMembershipSeatAndTrack({
+    user,
+    workspace: lightWorkspace,
+    newSeatType,
+    author: "no-author",
+    skipSeatLimitCheck: true,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      {
+        workspaceId,
+        userId,
+        currentSeatType: membership.seatType,
+        newSeatType,
+        error: result.error.type,
+      },
+      "[AutoSeatUpgrade] Failed to upgrade member seat"
+    );
+    return new Ok({ upgraded: false });
+  }
+
+  const { previousSeatType, newSeatType: appliedSeatType } = result.value;
+  if (previousSeatType === appliedSeatType) {
+    return new Ok({ upgraded: false });
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      userId,
+      previousSeatType,
+      newSeatType: appliedSeatType,
+    },
+    "[AutoSeatUpgrade] Upgraded member seat after credit limit hit"
+  );
+
+  void emitAuditLogEventDirect({
+    workspace: lightWorkspace,
+    action: "membership.seat_auto_upgraded",
+    actor: { type: "system", id: "auto-seat-upgrade", name: "Dust" },
+    targets: [
+      buildAuditLogTarget("workspace", lightWorkspace),
+      buildAuditLogTarget("user", {
+        sId: user.sId,
+        name: user.fullName() || "unknown",
+      }),
+    ],
+    context: { location: "internal" },
+    metadata: {
+      previous_seat_type: previousSeatType,
+      new_seat_type: appliedSeatType,
+    },
+  });
+
+  void notifyAdmins({
+    auth,
+    workspace: lightWorkspace,
+    member: {
+      sId: user.sId,
+      name: user.fullName() || user.username,
+      email: user.email,
+    },
+    previousSeatType,
+    newSeatType: appliedSeatType,
+  });
+
+  return new Ok({ upgraded: true });
+}
+
+async function notifyAdmins({
+  auth,
+  workspace,
+  member,
+  previousSeatType,
+  newSeatType,
+}: {
+  auth: Authenticator;
+  workspace: LightWorkspaceType;
+  member: { sId: string; name: string; email: string | null };
+  previousSeatType: MembershipSeatType;
+  newSeatType: MembershipSeatType;
+}): Promise<void> {
+  try {
+    const { members: admins } = await getMembers(auth, {
+      roles: ["admin"],
+      activeOnly: true,
+    });
+    notifyAdminsSeatAutoUpgraded({
+      admins: admins.map((admin) => ({
+        sId: admin.sId,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+      })),
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      memberId: member.sId,
+      memberName: member.name,
+      memberEmail: member.email,
+      previousSeatType,
+      newSeatType,
+    });
+  } catch (err) {
+    logger.error(
+      { err, workspaceId: workspace.sId, memberId: member.sId },
+      "[AutoSeatUpgrade] Failed to notify admins of seat auto-upgrade"
+    );
+  }
+}

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -199,7 +199,6 @@ export async function maybeAutoUpgradeSeat({
     workspace: lightWorkspace,
     newSeatType,
     author: "no-author",
-    skipSeatLimitCheck: true,
   });
   if (result.isErr()) {
     logger.warn(

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -11,7 +11,10 @@ import {
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
 import { notifyAdminsSeatAutoUpgraded } from "@app/lib/notifications/workflows/seat-auto-upgraded";
-import { isCreditPricedFreePlan } from "@app/lib/plans/plan_codes";
+import {
+  isCreditPricedFreePlan,
+  isCreditPricedPlanPrefix,
+} from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -45,7 +48,11 @@ function passesBillingGate(subscription: SubscriptionResource): boolean {
   if (!subscription.isMetronomeOnlyBilled) {
     return false;
   }
-  return !isCreditPricedFreePlan(subscription.getPlan().code);
+  const planCode = subscription.getPlan().code;
+  if (!isCreditPricedPlanPrefix(planCode)) {
+    return false;
+  }
+  return !isCreditPricedFreePlan(planCode);
 }
 
 /**
@@ -158,7 +165,9 @@ export async function maybeAutoUpgradeSeat({
   workspaceId: string;
   userId: string;
 }): Promise<Result<{ upgraded: boolean }, Error>> {
-  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  // The caller's auth can't mutate seats (member, or no user at all). This only
+  // reads workspace data, we can take a builder only.
+  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
 
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -6,6 +6,7 @@ import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { notifyAdminsUpgradeRequested } from "@app/lib/notifications/workflows/upgrade-request-created";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipUpgradeRequestResource } from "@app/lib/resources/membership_upgrade_request_resource";
@@ -106,7 +107,11 @@ export async function createUpgradeRequest(
   auth: Authenticator,
   { auditContext }: { auditContext?: AuditLogContext } = {}
 ): Promise<Result<MembershipUpgradeRequestType, UpgradeRequestError>> {
-  if (!auth.getNonNullableSubscriptionResource().isMetronomeOnlyBilled) {
+  const subscription = auth.getNonNullableSubscriptionResource();
+  if (
+    !subscription.isMetronomeOnlyBilled ||
+    !isCreditPricedPlanPrefix(subscription.getPlan().code)
+  ) {
     return new Err(
       new UpgradeRequestError(
         "workspace_not_metronome_billed",

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -592,6 +592,7 @@ export async function updateMembershipSeatAndTrack({
   newSeatType,
   author,
   immediate = false,
+  skipSeatLimitCheck = false,
 }: {
   user: UserResource;
   workspace: LightWorkspaceType;
@@ -599,6 +600,10 @@ export async function updateMembershipSeatAndTrack({
   author: UserType | "no-author";
   // When true, skip billing-period scheduling and apply the change right now.
   immediate?: boolean;
+  // When true, bypass the per-seat-type hard cap. Used by the auto-seat-upgrade
+  // flow, which intentionally exceeds committed seat counts (making the
+  // subscription more expensive) to keep a capped member unblocked.
+  skipSeatLimitCheck?: boolean;
 }): Promise<
   Result<
     {
@@ -644,8 +649,13 @@ export async function updateMembershipSeatAndTrack({
   }
 
   // Enforce the per-seat-type hard cap. Assigning to `none` (removing a seat)
-  // is always allowed. Same-type noops are also allowed (no net change).
-  if (newSeatType !== "none" && newSeatType !== previousSeatType) {
+  // is always allowed. Same-type noops are also allowed (no net change). The
+  // auto-seat-upgrade flow skips this check on purpose.
+  if (
+    !skipSeatLimitCheck &&
+    newSeatType !== "none" &&
+    newSeatType !== previousSeatType
+  ) {
     const seatLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
       workspace,
     });

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -592,7 +592,6 @@ export async function updateMembershipSeatAndTrack({
   newSeatType,
   author,
   immediate = false,
-  skipSeatLimitCheck = false,
 }: {
   user: UserResource;
   workspace: LightWorkspaceType;
@@ -600,10 +599,6 @@ export async function updateMembershipSeatAndTrack({
   author: UserType | "no-author";
   // When true, skip billing-period scheduling and apply the change right now.
   immediate?: boolean;
-  // When true, bypass the per-seat-type hard cap. Used by the auto-seat-upgrade
-  // flow, which intentionally exceeds committed seat counts (making the
-  // subscription more expensive) to keep a capped member unblocked.
-  skipSeatLimitCheck?: boolean;
 }): Promise<
   Result<
     {
@@ -648,14 +643,11 @@ export async function updateMembershipSeatAndTrack({
     return new Err({ type: "free_seat_not_allowed" });
   }
 
-  // Enforce the per-seat-type hard cap. Assigning to `none` (removing a seat)
-  // is always allowed. Same-type noops are also allowed (no net change). The
-  // auto-seat-upgrade flow skips this check on purpose.
-  if (
-    !skipSeatLimitCheck &&
-    newSeatType !== "none" &&
-    newSeatType !== previousSeatType
-  ) {
+  // Enforce the per-seat-type hard cap (`maxSeats`). Assigning to `none`
+  // (removing a seat) is always allowed. Same-type noops are also allowed (no
+  // net change). This cap is never bypassed — committed seat counts (`minSeats`)
+  // are not enforced here, so exceeding the commitment is already permitted.
+  if (newSeatType !== "none" && newSeatType !== previousSeatType) {
     const seatLimits = await WorkspaceSeatLimitResource.fetchByWorkspace({
       workspace,
     });

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -1,3 +1,4 @@
+import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { fetchRemainingCapCreditsPercentageForUser } from "@app/lib/api/credits/members_usage";
 import { recalculatePerUserCapAlertForSeatChange } from "@app/lib/api/membership";
 import { getMembers } from "@app/lib/api/workspace";
@@ -146,6 +147,15 @@ export async function dispatchSeatBalanceExhausted({
       },
       "[CreditStateDispatcher] dispatchSeatBalanceExhausted: transition skipped"
     );
+    return;
+  }
+
+  // Free seats have no pool fallback, so an exhausted balance lands them in
+  // `capped`. If the workspace opted into auto-upgrades, bump their seat one
+  // tier (free → pro) so they stay unblocked. Pro/max seats fall back to the
+  // pool (`on_pool`) instead and are left alone here.
+  if (result.value === "capped") {
+    void maybeAutoUpgradeSeat({ workspaceId: workspace.sId, userId });
   }
 }
 
@@ -260,6 +270,13 @@ export async function dispatchPerUserCapReached({
   if (result.isErr()) {
     return result;
   }
+
+  // The member just hit their per-user cap. If the workspace opted into
+  // auto-upgrades, bump their seat one tier so they stay unblocked.
+  if (result.value === "capped") {
+    void maybeAutoUpgradeSeat({ workspaceId: workspace.sId, userId });
+  }
+
   return new Ok(undefined);
 }
 


### PR DESCRIPTION
## Description

big PR but I promise half is tests

Part of the **auto-upgrade seats** stack (builds on #27421 and #27422). This is the engine that turns the feature on.

When a member hits their per-user credit limit and the workspace opted in (`autoSeatUpgradeEnabled`), bump the member to the next seat tier instead of leaving them blocked:

- **Transitions:** `free → pro`, `pro → max`, `none → workspace` — only to a tier the workspace's Metronome contract actually entitles ("stay in the allowed seats").
- **Gate:** only on Metronome-billed, non-free credit-priced plans.
- **Seat-count limit bypassed** (`skipSeatLimitCheck` on `updateMembershipSeatAndTrack`) — the upgrade is intentionally allowed to exceed committed seats and potentially make the subscription more expensive.
- On success, notifies admins (Novu) and emits the `membership.seat_auto_upgraded` audit event (both from #27422).

**Triggers:**
- Capped members (`free → pro`, `pro → max`) via the Metronome credit-state dispatchers (`dispatchPerUserCapReached`, free-seat `dispatchSeatBalanceExhausted`).
- Seat-less members (`none → workspace`) at the `no_seat` block in the message-send path.

## Tests

Type-checked (`front` + `front-api`). The credit-state dispatcher unit tests cover the trigger guards. A full end-to-end test of `maybeAutoUpgradeSeat` requires a Metronome contract fixture (entitled seats), verified manually: enable the toggle on a credit-priced workspace, drive a member to `capped`, confirm the seat bumps, the admin email fires, and the audit event is emitted.

## Risk

The new logic runs on the Metronome credit-state path and the message-send `no_seat` path. All calls are fire-and-forget and no-op unless the toggle is on, so default-off workspaces (all of them at launch) are unaffected. Metronome failures during the upgrade are swallowed into a no-op so the credit-state path is never broken by an upgrade attempt.
