### PR TITLE
feat(credits): hide upgrade-request CTA when seat auto-upgrade is eligible

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.test.ts
+++ b/front-api/routes/w/[wId]/usage-status.test.ts
@@ -80,6 +80,35 @@ describe("/api/w/[wId]/usage-status", () => {
     expect(body.hasPendingUpgradeRequest).toBe(true);
   });
 
+  it("still offers the upgrade request when auto-upgrade is on but no higher seat is available", async () => {
+    const workspace = await creditPricedWorkspace();
+
+    // Auto-upgrade is enabled, but the test workspace has no entitled higher
+    // seat tier (no Metronome contract), so the member can't be auto-upgraded
+    // and must keep the manual request CTA.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await CreditUsageConfigurationResource.makeNew(adminAuth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      autoSeatUpgradeEnabled: true,
+    });
+
+    const { membership } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+      workspace,
+    });
+    await membership.updateCreditState("capped");
+
+    const response = await honoApp.request(usageStatusUrl(workspace.sId));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.canRequestUpgrade).toBe(true);
+  });
+
   it("does not offer upgrade requests to admins", async () => {
     const workspace = await creditPricedWorkspace();
     const { membership } = await createPrivateApiMockRequest({

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -39,6 +39,7 @@ app.get(
         userBlockedReason: null,
         canRequestUpgrade: false,
         hasPendingUpgradeRequest: false,
+        willAutoUpgrade: false,
       });
     }
 
@@ -62,7 +63,7 @@ app.get(
     const programmaticCreditStatus: ProgrammaticCreditStatus =
       programmaticState === "depleted" ? "depleted" : "active";
 
-    const { canRequestUpgrade, hasPendingUpgradeRequest } =
+    const { canRequestUpgrade, hasPendingUpgradeRequest, willAutoUpgrade } =
       await getUpgradeRequestAvailabilityForUser(auth, {
         isNearOrAtLimit: userNearCreditLimit || userBlockedReason !== null,
       });
@@ -76,6 +77,7 @@ app.get(
       userBlockedReason,
       canRequestUpgrade,
       hasPendingUpgradeRequest,
+      willAutoUpgrade,
     });
   }
 );

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -15,11 +15,12 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
     canRequestUpgrade,
     hasPendingUpgradeRequest,
     userBlockedReason,
+    willAutoUpgrade,
   } = useWorkspaceUsageStatus({
     owner,
   });
 
-  const showUpgradeCta = canRequestUpgrade || isAdmin;
+  const showUpgradeCta = !willAutoUpgrade && (canRequestUpgrade || isAdmin);
 
   if (userBlockedReason === "no_seat") {
     return (
@@ -52,6 +53,16 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
 
   const isBlocked = userBlockedReason === "user_cap_reached";
 
+  let message: string;
+  if (isBlocked) {
+    message = "You've reached your usage limit";
+  } else {
+    message = "You've used 80% of your usage limit";
+    if (willAutoUpgrade) {
+      message += ". You'll be automatically upgraded when you reach the limit";
+    }
+  }
+
   return (
     <div
       className={cn(
@@ -63,14 +74,12 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
       <span
         className={cn(
           "copy-sm grow truncate",
-          isBlocked
+          isBlocked && !willAutoUpgrade
             ? "text-warning-500 dark:text-warning-500-night"
             : "text-foreground dark:text-foreground-night"
         )}
       >
-        {isBlocked
-          ? "You've reached your usage limit"
-          : "You've used 80% of your usage limit"}
+        {message}
       </span>
       {showUpgradeCta && (
         <div className="shrink-0">

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -184,6 +184,7 @@ export async function createUpgradeRequest(
 export type UpgradeRequestAvailability = {
   canRequestUpgrade: boolean;
   hasPendingUpgradeRequest: boolean;
+  willAutoUpgrade: boolean;
 };
 
 export async function getUpgradeRequestAvailabilityForUser(
@@ -193,6 +194,7 @@ export async function getUpgradeRequestAvailabilityForUser(
   const unavailable: UpgradeRequestAvailability = {
     canRequestUpgrade: false,
     hasPendingUpgradeRequest: false,
+    willAutoUpgrade: false,
   };
 
   const user = auth.user();
@@ -200,15 +202,15 @@ export async function getUpgradeRequestAvailabilityForUser(
     return unavailable;
   }
 
-  if (!(await isMemberUpgradeRequestAllowed(auth))) {
-    return unavailable;
+  if (await isEligibleForAutoSeatUpgrade(auth)) {
+    return {
+      canRequestUpgrade: false,
+      hasPendingUpgradeRequest: false,
+      willAutoUpgrade: true,
+    };
   }
 
-  // When the workspace auto-upgrades seats and this member is eligible (their
-  // seat has an entitled higher tier), they'll be bumped automatically on
-  // limit — so don't surface the manual "request upgrade" CTA. Members already
-  // on the top entitled seat (or workspaces with auto-upgrade off) still see it.
-  if (await isEligibleForAutoSeatUpgrade(auth)) {
+  if (!(await isMemberUpgradeRequestAllowed(auth))) {
     return unavailable;
   }
 
@@ -219,6 +221,7 @@ export async function getUpgradeRequestAvailabilityForUser(
   return {
     canRequestUpgrade: true,
     hasPendingUpgradeRequest: pending !== null,
+    willAutoUpgrade: false,
   };
 }
 

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -198,7 +198,7 @@ export async function getUpgradeRequestAvailabilityForUser(
   };
 
   const user = auth.user();
-  if (auth.isAdmin() || !isNearOrAtLimit || !user) {
+  if (!isNearOrAtLimit || !user) {
     return unavailable;
   }
 
@@ -208,6 +208,10 @@ export async function getUpgradeRequestAvailabilityForUser(
       hasPendingUpgradeRequest: false,
       willAutoUpgrade: true,
     };
+  }
+
+  if (auth.isAdmin()) {
+    return unavailable;
   }
 
   if (!(await isMemberUpgradeRequestAllowed(auth))) {

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -2,6 +2,7 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { isEligibleForAutoSeatUpgrade } from "@app/lib/api/credits/auto_seat_upgrade";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -200,6 +201,14 @@ export async function getUpgradeRequestAvailabilityForUser(
   }
 
   if (!(await isMemberUpgradeRequestAllowed(auth))) {
+    return unavailable;
+  }
+
+  // When the workspace auto-upgrades seats and this member is eligible (their
+  // seat has an entitled higher tier), they'll be bumped automatically on
+  // limit — so don't surface the manual "request upgrade" CTA. Members already
+  // on the top entitled seat (or workspaces with auto-upgrade off) still see it.
+  if (await isEligibleForAutoSeatUpgrade(auth)) {
     return unavailable;
   }
 

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -81,6 +81,7 @@ export type GetWorkspaceUsageStatusResponseBody = {
   userBlockedReason: UserBlockedReason | null;
   canRequestUpgrade: boolean;
   hasPendingUpgradeRequest: boolean;
+  willAutoUpgrade: boolean;
 };
 
 export type GetFairUseCreditsResponseBody = {

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -290,6 +290,7 @@ export function useWorkspaceUsageStatus({
     userBlockedReason: data?.userBlockedReason ?? null,
     canRequestUpgrade: data?.canRequestUpgrade ?? false,
     hasPendingUpgradeRequest: data?.hasPendingUpgradeRequest ?? false,
+    willAutoUpgrade: data?.willAutoUpgrade ?? false,
     isUsageStatusLoading: !error && !data && !disabled,
   };
 }


### PR DESCRIPTION
## Description

Final PR of the **auto-upgrade seats** stack (builds on #27423). Makes the member-facing "request upgrade" CTA aware of auto-upgrade.

When a member is eligible for an automatic seat upgrade (toggle on, billing gate passes, and their seat has an entitled higher tier), `getUpgradeRequestAvailabilityForUser` now returns `canRequestUpgrade: false` — they'll be auto-upgraded, so there's nothing to ask for. The CTA still shows when:

- auto-upgrade is disabled, or
- the member is already on the top entitled seat (`max`/`workspace`) and can't be upgraded the auto way.

Reuses the `isEligibleForAutoSeatUpgrade` predicate from #27423 (no change needed in `UsageUpgradeButton`, which already renders off `canRequestUpgrade`).

## Tests

Extended the `usage-status` functional test: with auto-upgrade enabled but no higher seat available (no contract entitlement in the test env), a capped member still sees the CTA.
