### PR TITLE
feat(poke): reset all provisioned members when no directory is configured

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/reset_provisioned_members_not_in_directory.ts
+++ b/front/lib/api/poke/plugins/workspaces/reset_provisioned_members_not_in_directory.ts
@@ -81,12 +81,6 @@ export const resetProvisionedMembersNotInDirectoryPlugin = createPlugin({
     }
 
     const directories = directoriesResult.value;
-    if (directories.length === 0) {
-      return new Ok({
-        display: "text",
-        value: "No WorkOS directories found for this workspace.",
-      });
-    }
 
     if (directories.length > 1) {
       return new Err(
@@ -95,8 +89,6 @@ export const resetProvisionedMembersNotInDirectoryPlugin = createPlugin({
         )
       );
     }
-
-    const [directory] = directories;
 
     // Get all active memberships with users included
     const { memberships } = await MembershipResource.getActiveMemberships({
@@ -116,24 +108,35 @@ export const resetProvisionedMembersNotInDirectoryPlugin = createPlugin({
       });
     }
 
-    // List all users in the directory
-    const directoryUserEmails = await getDirectoryUserEmails(directory.id);
-
-    // Check which provisioned members are not in the directory
+    // When no directory exists, all provisioned members should be reset.
+    // When a directory exists, only reset members not present in it.
     const membersToReset: Array<{
       membership: MembershipResource;
       userEmail: string;
     }> = [];
 
-    for (const membership of provisionedMemberships) {
-      const user = membership.user;
-      if (!user || !user.email) {
-        continue;
-      }
-
-      const userEmail = user.email.toLowerCase();
-      if (!directoryUserEmails.has(userEmail)) {
+    if (directories.length === 0) {
+      for (const membership of provisionedMemberships) {
+        const user = membership.user;
+        if (!user || !user.email) {
+          continue;
+        }
         membersToReset.push({ membership, userEmail: user.email });
+      }
+    } else {
+      const [directory] = directories;
+      const directoryUserEmails = await getDirectoryUserEmails(directory.id);
+
+      for (const membership of provisionedMemberships) {
+        const user = membership.user;
+        if (!user || !user.email) {
+          continue;
+        }
+
+        const userEmail = user.email.toLowerCase();
+        if (!directoryUserEmails.has(userEmail)) {
+          membersToReset.push({ membership, userEmail: user.email });
+        }
       }
     }
 
@@ -149,7 +152,7 @@ export const resetProvisionedMembersNotInDirectoryPlugin = createPlugin({
         display: "json",
         value: {
           mode: "dry_run",
-          message: `Found ${membersToReset.length} provisioned member${pluralize(membersToReset.length)} not in directory that would be reset`,
+          message: `Found ${membersToReset.length} provisioned member${pluralize(membersToReset.length)} that would be reset`,
           members: membersToReset.map(({ membership, userEmail }) => ({
             email: userEmail,
             role: membership.role,


### PR DESCRIPTION
## Description

Fixes a case where a workspace had its WorkOS directory sync connection deleted after provisioning members. Previously, the `reset-provisioned-members-not-in-directory` plugin would bail out early with `"No WorkOS directories found for this workspace."` when no directory existed, leaving those members permanently orphaned (membership origin `"provisioned"` prevents admins from revoking them). The fix changes the logic so that when no directory is configured, **all** provisioned members are flagged for reset — since there is no directory to validate membership against, every provisioned member should have their origin reverted to `"invited"`. When a directory does exist, the original behavior is preserved (only reset members absent from the directory).

Fixes [#8831](https://github.com/dust-tt/tasks/issues/8831).

## Tests

Manually tested via the Poke plugin on the affected workspace. Dry-run mode now correctly lists all provisioned members when no directory is found, and execute mode resets their origins.

## Risk

Low. The change only affects the Poke admin plugin; no production code path is modified. The plugin already had an `execute` dry-run gate, so operators can verify the member list before committing.

## Deploy Plan

Deploy `front`.