### PR TITLE
Add agents insights

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -1,7 +1,11 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { GetAgentOverviewResponseBody } from "@app/lib/api/assistant/observability/overview";
-import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
+import {
+  fetchAgentCostStats,
+  fetchAgentOverview,
+  getAgentCostStats,
+} from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -55,7 +59,18 @@ app.get(
       version,
     });
 
-    const overview = await fetchAgentOverview(baseQuery, days);
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const [overview, costStatsMap] = await Promise.all([
+      fetchAgentOverview(baseQuery, days),
+      fetchAgentCostStats(
+        owner,
+        [assistant.sId],
+        cutoff,
+        version !== undefined ? Number(version) : undefined
+      ),
+    ]);
+    const costs = getAgentCostStats(costStatsMap, assistant.sId);
+
     if (overview.isErr()) {
       return apiError(ctx, {
         status_code: 500,
@@ -86,6 +101,7 @@ app.get(
         negativeFeedbacks,
         timePeriodSec: days * 24 * 60 * 60,
       },
+      costs,
     });
   }
 );

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -1,5 +1,6 @@
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { TabContentChildSectionLayout } from "@app/components/agent_builder/observability/TabContentChildSectionLayout";
+import { formatCreditsCompact } from "@app/lib/client/credits";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import {
   useAgentAnalytics,
@@ -186,7 +187,7 @@ export function AgentObservability({
             <Spinner />
           </div>
         ) : (
-          <CardGrid adaptColumns>
+          <CardGrid>
             <ValueCard
               title="Active Users"
               className="h-24"
@@ -216,6 +217,53 @@ export function AgentObservability({
                 </div>
               }
             />
+            <div className="hidden @[40rem]:contents">
+              <div></div>
+            </div>
+
+            <div className="hidden @[24rem]:contents">
+              <ValueCard
+                title="Total cost"
+                className="h-24"
+                content={
+                  <div className="flex flex-col gap-1 text-2xl">
+                    <div className="truncate text-foreground dark:text-foreground-night">
+                      {agentAnalytics?.costs?.totalCostCredits != null
+                        ? `${formatCreditsCompact(agentAnalytics.costs.totalCostCredits)} credits`
+                        : "-"}
+                    </div>
+                  </div>
+                }
+              />
+            </div>
+            <ValueCard
+              title="Avg. cost / msg"
+              className="h-24"
+              content={
+                <div className="flex flex-col gap-1 text-2xl">
+                  <div className="truncate text-foreground dark:text-foreground-night">
+                    {agentAnalytics?.costs?.avgCostCredits != null
+                      ? `${formatCreditsCompact(agentAnalytics.costs.avgCostCredits)} credits`
+                      : "-"}
+                  </div>
+                </div>
+              }
+            />
+            <div className="hidden @[40rem]:contents">
+              <ValueCard
+                title="Median cost / msg"
+                className="h-24"
+                content={
+                  <div className="flex flex-col gap-1 text-2xl">
+                    <div className="truncate text-foreground dark:text-foreground-night">
+                      {agentAnalytics?.costs?.medianCostCredits != null
+                        ? `${formatCreditsCompact(agentAnalytics.costs.medianCostCredits)} credits`
+                        : "-"}
+                    </div>
+                  </div>
+                }
+              />
+            </div>
           </CardGrid>
         )}
       </TabContentChildSectionLayout>

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -1,6 +1,7 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
+import { formatCreditsCompact } from "@app/lib/client/credits";
 import { LinkWrapper } from "@app/lib/platform";
 import { useWorkspaceTopAgents } from "@app/lib/swr/workspaces";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
@@ -15,6 +16,7 @@ interface TopAgentRowData {
   pictureUrl: string | null;
   messageCount: number;
   userCount: number;
+  totalCostCredits: number | null;
   onClick?: () => void;
   onDoubleClick?: () => void;
 }
@@ -77,6 +79,22 @@ function makeColumns(workspaceId: string): ColumnDef<TopAgentRowData>[] {
         />
       ),
     },
+    {
+      id: "totalCostCredits",
+      accessorKey: "totalCostCredits",
+      header: "Total cost",
+      meta: {
+        sizeRatio: 15,
+      },
+      cell: (info: TopAgentInfo) => {
+        const cost = info.row.original.totalCostCredits;
+        return (
+          <DataTable.BasicCellContent
+            label={cost != null ? `${formatCreditsCompact(cost)} credits` : "-"}
+          />
+        );
+      },
+    },
   ];
 }
 
@@ -106,6 +124,7 @@ export function WorkspaceTopAgentsTable({
       pictureUrl: agent.pictureUrl,
       messageCount: agent.messageCount,
       userCount: agent.userCount,
+      totalCostCredits: agent.totalCostCredits,
     }));
   }, [topAgents]);
 

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -1,7 +1,16 @@
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { frontSequelize } from "@app/lib/resources/storage";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
+import { QueryTypes } from "sequelize";
+
+export type AgentCostStats = {
+  totalCostCredits: number | null;
+  avgCostCredits: number | null;
+  medianCostCredits: number | null;
+};
 
 export type AgentOverview = {
   activeUsers: number;
@@ -9,6 +18,7 @@ export type AgentOverview = {
   messageCount: number;
   positiveFeedbacks: number;
   negativeFeedbacks: number;
+  costs: AgentCostStats;
 };
 
 type OverviewAggs = {
@@ -70,7 +80,83 @@ export async function fetchAgentOverview(
     negativeFeedbacks: Math.round(
       aggs?.feedbacks?.recent?.down?.doc_count ?? 0
     ),
+    costs: {
+      totalCostCredits: null,
+      avgCostCredits: null,
+      medianCostCredits: null,
+    },
   });
+}
+
+const EMPTY_COST_STATS: AgentCostStats = {
+  totalCostCredits: null,
+  avgCostCredits: null,
+  medianCostCredits: null,
+};
+
+// Returns cost stats (total, avg, median credits) per agent for the given time
+// window. Accepts a list so the same query backs both the single-agent Insights
+// tab and the multi-agent Top Agents table.
+export async function fetchAgentCostStats(
+  workspace: LightWorkspaceType,
+  agentIds: string[],
+  cutoff: Date,
+  version?: number
+): Promise<Map<string, AgentCostStats>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const versionClause =
+    version !== undefined ? `AND "agentConfigurationVersion" = :version` : "";
+
+  // biome-ignore lint/plugin/noRawSql: PERCENTILE_CONT with GROUP BY has no Sequelize aggregate equivalent.
+  const rows = await frontSequelize.query<{
+    agent_configuration_id: string;
+    total_cost_credits: number | null;
+    avg_cost_credits: number | null;
+    median_cost_credits: number | null;
+  }>(
+    `SELECT
+      "agentConfigurationId" AS agent_configuration_id,
+      SUM("costCredits")::float AS total_cost_credits,
+      AVG("costCredits")::float AS avg_cost_credits,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY "costCredits")::float AS median_cost_credits
+    FROM agent_messages
+    WHERE "workspaceId" = :workspaceId
+      AND "agentConfigurationId" IN (:agentIds)
+      AND "createdAt" >= :cutoff
+      AND "costCredits" IS NOT NULL
+      ${versionClause}
+    GROUP BY "agentConfigurationId"`,
+    {
+      type: QueryTypes.SELECT,
+      replacements: {
+        workspaceId: workspace.id,
+        agentIds,
+        cutoff,
+        version,
+      },
+    }
+  );
+
+  return new Map(
+    rows.map((row) => [
+      row.agent_configuration_id,
+      {
+        totalCostCredits: row.total_cost_credits,
+        avgCostCredits: row.avg_cost_credits,
+        medianCostCredits: row.median_cost_credits,
+      },
+    ])
+  );
+}
+
+export function getAgentCostStats(
+  map: Map<string, AgentCostStats>,
+  agentId: string
+): AgentCostStats {
+  return map.get(agentId) ?? EMPTY_COST_STATS;
 }
 
 export type GetAgentOverviewResponseBody = {
@@ -85,4 +171,5 @@ export type GetAgentOverviewResponseBody = {
     negativeFeedbacks: number;
     timePeriodSec: number;
   };
+  costs: AgentCostStats;
 };

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -1,4 +1,9 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import {
+  fetchAgentCostStats,
+  getAgentCostStats,
+} from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
@@ -82,13 +87,24 @@ export async function fetchTopAgents(
   );
 
   const bucketAgentIds = buckets.map((bucket) => String(bucket.key));
-  const agents =
-    bucketAgentIds.length > 0
-      ? await getAgentConfigurations(auth, {
-          agentIds: bucketAgentIds,
-          variant: "extra_light",
-        })
-      : [];
+  if (bucketAgentIds.length === 0) {
+    return new Ok([]);
+  }
+
+  const cutoff = startDate
+    ? new Date(startDate)
+    : new Date(
+        Date.now() - (days ?? DEFAULT_PERIOD_DAYS) * 24 * 60 * 60 * 1000
+      );
+
+  const [agents, costStatsMap] = await Promise.all([
+    getAgentConfigurations(auth, {
+      agentIds: bucketAgentIds,
+      variant: "extra_light",
+    }),
+    fetchAgentCostStats(owner, bucketAgentIds, cutoff),
+  ]);
+
   const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
 
   const rows = buckets.map((bucket) => {
@@ -100,6 +116,8 @@ export async function fetchTopAgents(
       pictureUrl: agent?.pictureUrl ?? null,
       messageCount: bucket.doc_count ?? 0,
       userCount: Math.round(bucket.unique_users?.value ?? 0),
+      totalCostCredits: getAgentCostStats(costStatsMap, agentId)
+        .totalCostCredits,
     };
   });
 

--- a/front/lib/api/workspace/analytics.ts
+++ b/front/lib/api/workspace/analytics.ts
@@ -9,6 +9,7 @@ export type WorkspaceTopAgentRow = {
   pictureUrl: string | null;
   messageCount: number;
   userCount: number;
+  totalCostCredits: number | null;
 };
 
 export type GetWorkspaceTopAgentsResponse = {


### PR DESCRIPTION
## Description

<img width="704" height="836" alt="Screenshot 2026-06-16 at 14 14 09" src="https://github.com/user-attachments/assets/93913e97-287f-4592-98c1-528b8e737069" />

<img width="1030" height="365" alt="Screenshot 2026-06-16 at 14 22 06" src="https://github.com/user-attachments/assets/48ca73d6-7cb8-45b2-ace2-20620d4f1180" />


Adds credit cost insights in two places:

**Agent Insights tab** — three new metric cards below the existing "Active Users" and "Messages / active user" cards:
- **Total cost** — sum of `costCredits` across all messages for the selected period
- **Avg. cost / msg** — average `costCredits` per message (excludes messages with no cost)
- **Median cost / msg** — median `costCredits` per message via `PERCENTILE_CONT(0.5)` (excludes messages with no cost)

All three metrics respect the selected time range (7/14/30/90 days) and the selected version when in version mode (same behaviour as the existing ES-backed cards). The cards are responsive using CSS container queries that match CardGrid's own breakpoints: only "Avg. cost / msg" shows at 1-col width, Total + Avg at 2-col, all three at 3-col.

**Analytics — Top Agents table** — new **Total cost** column backed by a single batched `SUM(costCredits)` query against `agent_messages`, grouped by agent and scoped to the same time window as the ES aggregation. Shows `-` for agents with no cost data.

Both features read directly from the `agent_messages` table rather than Elasticsearch, since `costCredits` is the authoritative cost field on that model.

## Tests

Tested manually:
- Verified cost cards appear/disappear at the correct container widths in the agent builder Insights tab
- Verified values match expected sums/averages from the DB for a test workspace
- Verified the Top Agents table loads without errors and shows cost totals

## Risk

Low. Read-only queries on `agent_messages` with existing indexes (`workspaceId`, `agentConfigurationId`). No schema changes. The cost stats query runs in parallel with the existing ES overview fetch so it does not add latency on the critical path. Falls back to `-` gracefully when no cost data is available (non-credit plans).

## Deploy Plan

Standard deploy — no migrations, no feature flags needed.