### PR TITLE
Only allow https again when validating URL

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -262,7 +262,7 @@ const FILES_TOOLS_COMMON_METADATA = {
   },
   [FILES_UPLOAD_FROM_URL_ACTION_NAME]: {
     description:
-      "Download a file from a public HTTP(S) URL and store it in a conversation or Pod file system. " +
+      "Download a file from a public HTTPS URL and store it in a conversation or Pod file system. " +
       "Use this for binary files (PDF, images, spreadsheets, etc.) that cannot be created with " +
       `\`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CREATE_ACTION_NAME)}\`. ` +
       "If the file already exists it is silently overwritten. " +
@@ -277,7 +277,10 @@ const FILES_TOOLS_COMMON_METADATA = {
       url: z
         .string()
         .url()
-        .describe("Public HTTP(S) URL of the file to download and store"),
+        .refine((u) => u.startsWith("https://"), {
+          message: "Only public HTTPS URLs are supported.",
+        })
+        .describe("Public HTTPS URL of the file to download and store"),
       content_type: z
         .string()
         .optional()

--- a/front/lib/api/file_system/upload_from_url.test.ts
+++ b/front/lib/api/file_system/upload_from_url.test.ts
@@ -80,18 +80,12 @@ describe("uploadFileFromUrlToFileSystem", () => {
     }
   });
 
-  it("uploads a file from a public HTTP URL", async () => {
+  it("rejects non-HTTPS URLs", async () => {
     const { authenticator: auth } = await createResourceTest({ role: "admin" });
     const conversation = await createConversation(auth, {
       title: "Test",
       visibility: "unlisted",
       spaceId: null,
-    });
-
-    mockFetchResponse({
-      body: "hello from url",
-      contentType: "text/plain",
-      contentLength: "15",
     });
 
     const fsResult = await DustFileSystem.forConversation(auth, conversation);
@@ -100,19 +94,15 @@ describe("uploadFileFromUrlToFileSystem", () => {
       return;
     }
 
-    const path = `conversation-${conversation.sId}/imported-${Date.now()}.txt`;
     const result = await uploadFileFromUrlToFileSystem(fsResult.value, {
-      path,
-      url: "http://example.com/imported.txt",
+      path: `conversation-${conversation.sId}/notes.txt`,
+      url: "http://example.com/file.txt",
     });
 
-    expect(result.isOk()).toBe(true);
-    if (!result.isOk()) {
-      return;
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("HTTPS");
     }
-
-    expect(result.value.contentType).toBe("text/plain");
-    expect(result.value.sizeBytes).toBe(15);
   });
 
   it("uploads a file from a public HTTPS URL", async () => {

--- a/front/lib/api/file_system/upload_from_url.ts
+++ b/front/lib/api/file_system/upload_from_url.ts
@@ -86,6 +86,12 @@ export async function uploadFileFromUrlToFileSystem(
     return new Err({ message: "Invalid URL." });
   }
 
+  if (new URL(validUrl.standardized).protocol !== "https:") {
+    return new Err({
+      message: "Only public HTTPS URLs are supported.",
+    });
+  }
+
   const sanitizedUrl = sanitizeUrlForDisplay(validUrl.standardized);
 
   const urlSafetyError = await validateExternalUrl(validUrl.standardized);

--- a/front/lib/api/mcp_server/tools/files/upload_from_url.ts
+++ b/front/lib/api/mcp_server/tools/files/upload_from_url.ts
@@ -19,7 +19,10 @@ const inputSchema = {
   url: z
     .string()
     .url()
-    .describe("Public HTTP(S) URL of the file to download and store."),
+    .refine((u) => u.startsWith("https://"), {
+      message: "Only public HTTPS URLs are supported.",
+    })
+    .describe("Public HTTPS URL of the file to download and store."),
   content_type: z
     .string()
     .optional()
@@ -34,7 +37,7 @@ export function registerFilesUploadFromUrlTool(server: McpServer) {
     "files_upload_from_url",
     {
       description:
-        "Download a file from a public HTTP(S) URL and store it in a conversation or Pod file system. " +
+        "Download a file from a public HTTPS URL and store it in a conversation or Pod file system. " +
         "Supports binary files (PDF, images, spreadsheets, etc.) that cannot be created with `files_create`. " +
         "Overwrites existing files at the destination path. " +
         "Requires an explicit scope with conversation_id or pod_id.",

--- a/front/lib/api/url_safety.ts
+++ b/front/lib/api/url_safety.ts
@@ -34,7 +34,7 @@ function isPrivateIp(address: string, family: 4 | 6): boolean {
 }
 
 /**
- * Validates that a URL is safe to fetch server-side: must use HTTP(S) and must
+ * Validates that a URL is safe to fetch server-side: must use HTTPS and must
  * not resolve to a private/reserved IP. Returns an error message string on
  * failure, or null on success.
  *
@@ -50,8 +50,8 @@ export async function validateExternalUrl(url: string): Promise<string | null> {
     return "Invalid URL format.";
   }
 
-  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-    return "Only HTTP(S) URLs are allowed.";
+  if (parsed.protocol !== "https:") {
+    return "Only HTTPS URLs are allowed.";
   }
 
   const hostname = parsed.hostname;


### PR DESCRIPTION
## Description

Re-enforces HTTPS-only for external URL fetching across the files upload pipeline. `validateExternalUrl` in `url_safety.ts` was accepting both HTTP and HTTPS; it now rejects anything that isn't `https:`. `uploadFileFromUrlToFileSystem` gains an early protocol guard before even reaching `validateExternalUrl`. Both the internal agent-loop tool metadata (`FILES_TOOLS_COMMON_METADATA`) and the external MCP server tool (`registerFilesUploadFromUrlTool`) add a Zod `.refine()` so HTTP URLs are rejected at the schema level with a clear error message.

## Tests

Updated the existing `upload_from_url.test.ts` test that previously verified HTTP uploads succeed — it now asserts that HTTP URLs are rejected with an error message containing "HTTPS".

## Risk

Low. This is a security tightening, not a behavior change for legitimate callers — all production URL fetches are expected to use HTTPS. The only scenario affected is an HTTP URL being passed to `uploadFileFromUrlToFileSystem` or the MCP tool, which will now fail fast with a clear error instead of proceeding.

## Deploy Plan

Deploy `front`.
