### PR TITLE
[dust-hive] proxy: route /oauth/* to front-api

### DIFF
--- a/x/henry/dust-hive/src/proxy-daemon.ts
+++ b/x/henry/dust-hive/src/proxy-daemon.ts
@@ -30,6 +30,7 @@ type Target = "front-api" | "marketing";
 const ROUTES: ReadonlyArray<{ pattern: RegExp; target: Target }> = [
   { pattern: /^\/m\/api(\/.*)?$/, target: "marketing" }, // /m/api/*
   { pattern: /^\/api(\/.*)?$/, target: "front-api" }, //   /api/*
+  { pattern: /^\/oauth(\/.*)?$/, target: "front-api" }, // /oauth/*
 ];
 
 const DEFAULT_TARGET: Target = "marketing";


### PR DESCRIPTION
## Description
Adds a `/oauth/*` routing rule to the dust-hive proxy so OAuth requests reach `front-api` instead of defaulting to `marketing`. Fixes local MCP server connections (e.g. Outlook) that require OAuth.

## Tests
Bun run check and verified that I could connect to mcps.

## Risk
Low. Doesn't touch existing routes and prod.

## Deploy Plan

