### PR TITLE
Fix Open Graph previews for shared frames

### DIFF
--- a/front-spa/.gitignore
+++ b/front-spa/.gitignore
@@ -13,3 +13,6 @@ dist/
 # Cache
 .cache/
 .vite/
+
+# Wrangler local dev secrets
+.dev.vars

--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -22,7 +22,8 @@
     "@dust-tt/sparkle": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.0.0"
+    "react-router-dom": "^7.0.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@tailwindcss/container-queries": "^0.1.1",

--- a/front-spa/worker/app.ts
+++ b/front-spa/worker/app.ts
@@ -2,7 +2,7 @@
  * Worker for the main app SPA.
  *
  * Static assets (JS, CSS, images) are served directly by the Workers Static
- * Assets layer — this worker is NOT invoked for those requests.
+ * Assets layer. This worker is NOT invoked for those requests.
  *
  * This worker only runs when no static file matched the request path
  * (not_found_handling = "none" in wrangler config). Its job is to:
@@ -15,11 +15,93 @@
  *    - /oauth/*, /w/* /oauth/* → oauth/index.html
  *    - /email/*                → email/index.html
  *
- * 3. Fall back to the main index.html for all other paths (SPA routing).
+ * 3. For /share/frame/:token, inject Open Graph meta tags into the HTML
+ *    by fetching frame metadata from the API before serving.
+ *
+ * 4. Fall back to the main index.html for all other paths (SPA routing).
  */
 
 interface Env {
   ASSETS: Fetcher;
+  DUST_API_URL: string;
+}
+
+interface ShareFrameMetadata {
+  title: string;
+  workspaceName: string;
+  ogImageUrl: string | null;
+}
+
+interface RegionRedirectError {
+  error: {
+    type: "workspace_in_different_region";
+    redirect: { region: string; url: string };
+  };
+}
+
+const SHARE_FRAME_RE = /^\/share\/frame\/([^/]+)$/;
+
+function isShareFrameMetadata(value: unknown): value is ShareFrameMetadata {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.title === "string" &&
+    typeof v.workspaceName === "string" &&
+    (v.ogImageUrl === null || typeof v.ogImageUrl === "string")
+  );
+}
+
+function isRegionRedirectError(value: unknown): value is RegionRedirectError {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.error !== "object" || v.error === null) {
+    return false;
+  }
+  const err = v.error as Record<string, unknown>;
+  if (err.type !== "workspace_in_different_region") {
+    return false;
+  }
+  if (typeof err.redirect !== "object" || err.redirect === null) {
+    return false;
+  }
+  const redirect = err.redirect as Record<string, unknown>;
+  return typeof redirect.url === "string";
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function buildOgMetaTags(
+  meta: ShareFrameMetadata,
+  canonicalUrl: string,
+  fallbackImageUrl: string
+): string {
+  const title = `${meta.title} - ${meta.workspaceName}`;
+  const description = `Discover what ${meta.workspaceName} built with AI. Explore now.`;
+  const image = meta.ogImageUrl ?? fallbackImageUrl;
+
+  return [
+    `<title>${escapeHtml(title)}</title>`,
+    `<meta name="description" content="${escapeHtml(description)}">`,
+    `<meta property="og:type" content="website">`,
+    `<meta property="og:site_name" content="Dust">`,
+    `<meta property="og:title" content="${escapeHtml(title)}">`,
+    `<meta property="og:description" content="${escapeHtml(description)}">`,
+    `<meta property="og:url" content="${escapeHtml(canonicalUrl)}">`,
+    `<meta property="og:image" content="${escapeHtml(image)}">`,
+    `<meta property="og:image:width" content="1200">`,
+    `<meta property="og:image:height" content="630">`,
+    `<meta property="og:image:alt" content="${escapeHtml(`Preview of ${meta.title} created by ${meta.workspaceName}`)}">`,
+  ].join("\n    ");
 }
 
 export default {
@@ -46,6 +128,76 @@ export default {
       fallback = "/index.html";
     }
 
-    return env.ASSETS.fetch(new URL(fallback, url.origin));
+    const htmlResponse = env.ASSETS.fetch(new URL(fallback, url.origin));
+
+    const frameMatch = SHARE_FRAME_RE.exec(path);
+    if (frameMatch) {
+      const token = frameMatch[1];
+      return injectFrameOgTags(
+        await htmlResponse,
+        token,
+        url.href,
+        env.DUST_API_URL
+      );
+    }
+
+    return htmlResponse;
   },
 };
+
+async function fetchFrameMeta(
+  token: string,
+  apiBaseUrl: string
+): Promise<ShareFrameMetadata | null> {
+  const res = await fetch(`${apiBaseUrl}/api/share/frame/${token}`);
+
+  if (res.ok) {
+    const data: unknown = await res.json();
+    return isShareFrameMetadata(data) ? data : null;
+  }
+
+  // The frame may live in a different region; follow the redirect hint.
+  if (res.status === 400) {
+    const body: unknown = await res.json();
+    if (isRegionRedirectError(body)) {
+      const regionRes = await fetch(
+        `${body.error.redirect.url}/api/share/frame/${token}`
+      );
+      if (regionRes.ok) {
+        const regionData: unknown = await regionRes.json();
+        return isShareFrameMetadata(regionData) ? regionData : null;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function injectFrameOgTags(
+  htmlResponse: Response,
+  token: string,
+  canonicalUrl: string,
+  apiBaseUrl: string
+): Promise<Response> {
+  let meta: ShareFrameMetadata | null;
+  try {
+    meta = await fetchFrameMeta(token, apiBaseUrl);
+  } catch {
+    return htmlResponse;
+  }
+
+  if (!meta) {
+    return htmlResponse;
+  }
+
+  const fallbackImageUrl = `${apiBaseUrl}/static/og/ic.png`;
+  const ogTags = buildOgMetaTags(meta, canonicalUrl, fallbackImageUrl);
+
+  return new HTMLRewriter()
+    .on("head", {
+      element(el) {
+        el.prepend(ogTags, { html: true });
+      },
+    })
+    .transform(htmlResponse);
+}

--- a/front-spa/worker/app.ts
+++ b/front-spa/worker/app.ts
@@ -29,6 +29,7 @@ interface Env {
   DUST_API_URL: string;
 }
 
+// z.ZodType<Pick<...>> makes TS flag any drift with GetShareFrameMetadataResponseBody.
 const ShareFrameMetadataSchema: z.ZodType<
   Pick<
     GetShareFrameMetadataResponseBody,

--- a/front-spa/worker/app.ts
+++ b/front-spa/worker/app.ts
@@ -21,56 +21,38 @@
  * 4. Fall back to the main index.html for all other paths (SPA routing).
  */
 
+import type { GetShareFrameMetadataResponseBody } from "@dust-tt/front/lib/api/files/share";
+import { z } from "zod";
+
 interface Env {
   ASSETS: Fetcher;
   DUST_API_URL: string;
 }
 
-interface ShareFrameMetadata {
-  title: string;
-  workspaceName: string;
-  ogImageUrl: string | null;
-}
+const ShareFrameMetadataSchema: z.ZodType<
+  Pick<
+    GetShareFrameMetadataResponseBody,
+    "title" | "workspaceName" | "ogImageUrl"
+  >
+> = z.object({
+  title: z.string(),
+  workspaceName: z.string(),
+  ogImageUrl: z.string().nullable(),
+});
 
-interface RegionRedirectError {
-  error: {
-    type: "workspace_in_different_region";
-    redirect: { region: string; url: string };
-  };
-}
+type ShareFrameMetadata = z.infer<typeof ShareFrameMetadataSchema>;
+
+const RegionRedirectErrorSchema = z.object({
+  error: z.object({
+    type: z.literal("workspace_in_different_region"),
+    redirect: z.object({
+      region: z.string(),
+      url: z.string(),
+    }),
+  }),
+});
 
 const SHARE_FRAME_RE = /^\/share\/frame\/([^/]+)$/;
-
-function isShareFrameMetadata(value: unknown): value is ShareFrameMetadata {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const v = value as Record<string, unknown>;
-  return (
-    typeof v.title === "string" &&
-    typeof v.workspaceName === "string" &&
-    (v.ogImageUrl === null || typeof v.ogImageUrl === "string")
-  );
-}
-
-function isRegionRedirectError(value: unknown): value is RegionRedirectError {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const v = value as Record<string, unknown>;
-  if (typeof v.error !== "object" || v.error === null) {
-    return false;
-  }
-  const err = v.error as Record<string, unknown>;
-  if (err.type !== "workspace_in_different_region") {
-    return false;
-  }
-  if (typeof err.redirect !== "object" || err.redirect === null) {
-    return false;
-  }
-  const redirect = err.redirect as Record<string, unknown>;
-  return typeof redirect.url === "string";
-}
 
 function escapeHtml(s: string): string {
   return s
@@ -152,20 +134,22 @@ async function fetchFrameMeta(
   const res = await fetch(`${apiBaseUrl}/api/share/frame/${token}`);
 
   if (res.ok) {
-    const data: unknown = await res.json();
-    return isShareFrameMetadata(data) ? data : null;
+    const parsed = ShareFrameMetadataSchema.safeParse(await res.json());
+    return parsed.success ? parsed.data : null;
   }
 
   // The frame may live in a different region; follow the redirect hint.
   if (res.status === 400) {
-    const body: unknown = await res.json();
-    if (isRegionRedirectError(body)) {
+    const parsed = RegionRedirectErrorSchema.safeParse(await res.json());
+    if (parsed.success) {
       const regionRes = await fetch(
-        `${body.error.redirect.url}/api/share/frame/${token}`
+        `${parsed.data.error.redirect.url}/api/share/frame/${token}`
       );
       if (regionRes.ok) {
-        const regionData: unknown = await regionRes.json();
-        return isShareFrameMetadata(regionData) ? regionData : null;
+        const regionParsed = ShareFrameMetadataSchema.safeParse(
+          await regionRes.json()
+        );
+        return regionParsed.success ? regionParsed.data : null;
       }
     }
   }

--- a/front-spa/wrangler-app.toml
+++ b/front-spa/wrangler-app.toml
@@ -6,3 +6,6 @@ main = "./worker/app.ts"
 directory = "./dist/app"
 not_found_handling = "none"
 binding = "ASSETS"
+
+[vars]
+DUST_API_URL = "https://dust.tt"

--- a/package-lock.json
+++ b/package-lock.json
@@ -795,7 +795,8 @@
         "@dust-tt/sparkle": "*",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.0.0"
+        "react-router-dom": "^7.0.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@tailwindcss/container-queries": "^0.1.1",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Open Graph previews for shared frames have been broken since February 2026 when the share pages were migrated from Next.js to the SPA architecture. Before that migration, the share frame page was a fully server-rendered Next.js page: on every request, a `getServerSideProps` handler fetched the file and workspace metadata from the database, passed it as props to the page component, and Next.js rendered the complete HTML including the `<head>` with OG meta tags before sending any bytes to the client. Social media crawlers (e.g. Slack, LinkedIn) received a proper HTML document with `og:title`, `og:description`, `og:image`, and `og:url` already present, so link unfurling worked correctly.

The migration replaced the server-rendered page with a client-side React component that sets OG meta tags inside a `useEffect`. This is fundamentally broken for crawlers: they do not execute JavaScript, so they see the bare SPA shell. A nearly empty HTML document with no meaningful meta tags. The component was functionally identical from a user's perspective, which is why the regression went unnoticed, but every share link posted to Slack or any messaging platform has shown no preview since that date.

Before settling on the current fix, several approaches were considered.

The most obvious fix was to add the OG tags server-side in the Hono API server, which already handles traffic at the main API domain. The idea was to intercept share frame URL requests there, fetch the metadata, and return a minimal HTML page with proper OG tags plus a JavaScript redirect that would send browsers on to the SPA. This approach was implemented and tested locally via `ngrok`. It worked, the OG tags appeared correctly in the HTML. However it introduced a fundamental conflict: after the JavaScript redirect fires, the browser's address bar shows the SPA domain. If a user opens a shared link and then re-shares it by copying from the address bar, they get a URL that bypasses the server-side layer entirely and points back to the bare SPA with no OG tags. The approach also required changing the canonical share URL across the codebase to point to the API domain rather than the SPA domain, which felt like a leaky coupling between transport concerns and sharing logic.

The next direction explored was a full migration to React Router v7 framework mode with server-side rendering on Cloudflare Workers. React Router v7 has first-class Cloudflare support and would allow declaring meta tags in a route's meta export, running server-side per request, which is the clean and conventional solution. The blocker is that the Cloudflare Vite plugin does not support mixing SSR and SPA modes in the same project. Enabling SSR for the share sub-app would require either extracting it into a fully separate deployment or migrating the entire front-end application, both of which are substantial architectural changes well beyond the scope of fixing link previews.

Various prerendering and bot-detection approaches were also considered: serving a different HTML response based on crawler user-agents, using an external prerender service, or generating static OG HTML files at share time. All of these either introduce external dependencies, require maintaining fragile bot detection lists, or add a generation and invalidation pipeline that grows in complexity with branding changes.

The chosen solution uses the Cloudflare Worker that already handles every request to the SPA domain. The Worker's existing job is to route paths to the appropriate HTML entry point. For share frame URLs specifically, it now also fetches the frame metadata from the API, then uses Cloudflare's built-in HTMLRewriter API to inject OG meta tags into the HTML response stream before it reaches the client. This is the established industry pattern for exactly this stack: it requires no architectural changes, no new deployments, no redirects, and no user-agent detection. The URL in the browser never changes, so re-sharing from the address bar works correctly. The implementation degrades gracefully. Any API error or unrecognised token simply serves the unmodified HTML, so the page always loads. Cross-region frames are handled by following the region redirect hint the API returns when a token belongs to a different region, making a second request to the appropriate regional API before injecting.

Local development is "testable" by running the Worker with wrangler dev against a local API instance using a `.dev.vars` file.

```
npm run build && npx wrangler dev --config wrangler-app.toml

curl -s http://localhost:8787/share/frame/6eb3228b-d357-4ada-baba-fefb26c726ee | grep "og:"
    <meta property="og:type" content="website">
    <meta property="og:site_name" content="Dust">
    <meta property="og:title" content="SectionHeaderDemo.tsx - Flavien's workspace">
    <meta property="og:description" content="Discover what Flavien's workspace built with AI. Explore now.">
    <meta property="og:url" content="http://localhost:8787/share/frame/6eb3228b-d357-4ada-baba-fefb26c726ee">
    <meta property="og:image" content="http://localhost:3000/api/v1/public/branding/GLi86iOQbZ/og?v=1781546002644505">
    <meta property="og:image:width" content="1200">
    <meta property="og:image:height" content="630">
    <meta property="og:image:alt" content="Preview of SectionHeaderDemo.tsx created by Flavien's workspace">
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
