### PR TITLE
fix: block binary documents from being indexed in conversation data source

### DIFF
--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -234,14 +234,16 @@ async function createConversationFile(
     conversationId,
     fileName,
     snippet = null,
+    contentType = "text/plain",
   }: {
     conversationId: string;
     fileName: string;
     snippet?: string | null;
+    contentType?: "text/plain" | "text/csv";
   }
 ): Promise<FileResource> {
   return FileFactory.create(auth, auth.getNonNullableUser(), {
-    contentType: "text/plain",
+    contentType,
     fileName,
     fileSize: 16,
     status: "ready",
@@ -907,8 +909,9 @@ describe("createConversationFork", () => {
 
     const sourceFile = await createConversationFile(auth, {
       conversationId: parentConversation.sId,
-      fileName: "notes.txt",
+      fileName: "notes.csv",
       snippet: "fork me",
+      contentType: "text/csv",
     });
 
     let parentConversationWithContent = await fetchConversationOrThrow(
@@ -966,7 +969,7 @@ describe("createConversationFork", () => {
     const childFileAttachments = childAttachments.filter(isFileAttachmentType);
 
     expect(childFileAttachments).toHaveLength(1);
-    expect(childFileAttachments[0]?.title).toBe("notes.txt");
+    expect(childFileAttachments[0]?.title).toBe("notes.csv");
     expect(childFileAttachments[0]?.fileId).not.toBe(sourceFile.sId);
 
     const copiedFiles = await FileResource.fetchByIds(auth, [
@@ -1023,6 +1026,7 @@ describe("createConversationFork", () => {
       conversationId: parentConversation.sId,
       fileName: "data.csv",
       snippet: "data",
+      contentType: "text/csv",
     });
     const frameFile = await FileFactory.create(
       auth,

--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -55,8 +55,8 @@ describe("maybeUpsertFileAttachment", () => {
 
   it("stamps conversationId on files without useCaseMetadata and attempts upsert", async () => {
     const file = await FileFactory.create(auth, null, {
-      contentType: "text/plain",
-      fileName: "attachment.txt",
+      contentType: "text/csv",
+      fileName: "attachment.csv",
       fileSize: 100,
       status: "ready",
       useCase: "conversation",

--- a/front/lib/api/files/processing/index.test.ts
+++ b/front/lib/api/files/processing/index.test.ts
@@ -22,287 +22,404 @@ vi.mock("@app/lib/api/config", async (importOriginal) => {
   };
 });
 
-describe("hasProcessedVersion", () => {
-  it("should return false for plain text files", () => {
-    expect(hasProcessedVersion("text/plain")).toBe(false);
+// Types whose processing does not vary by use case.
+describe("use-case-independent types", () => {
+  describe("hasProcessedVersion", () => {
+    it("plain text has no processed version", () => {
+      expect(hasProcessedVersion("text/plain")).toBe(false);
+    });
+
+    it("Python files have no processed version", () => {
+      expect(hasProcessedVersion("text/x-python")).toBe(false);
+    });
+
+    it("JSON has no processed version", () => {
+      expect(hasProcessedVersion("application/json")).toBe(false);
+    });
+
+    it("CSV has no processed version", () => {
+      expect(hasProcessedVersion("text/csv")).toBe(false);
+    });
+
+    it("raster images have a processed version (resize)", () => {
+      expect(hasProcessedVersion("image/png")).toBe(true);
+      expect(hasProcessedVersion("image/jpeg")).toBe(true);
+      expect(hasProcessedVersion("image/webp")).toBe(true);
+    });
+
+    it("SVG has a processed version (rasterized to PNG)", () => {
+      expect(hasProcessedVersion("image/svg+xml")).toBe(true);
+    });
+
+    it("audio has a processed version (transcription)", () => {
+      expect(hasProcessedVersion("audio/mpeg")).toBe(true);
+    });
+
+    it("Excel has a processed version (text extraction for table upsert)", () => {
+      expect(
+        hasProcessedVersion(
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+      ).toBe(true);
+      expect(hasProcessedVersion("application/vnd.ms-excel")).toBe(true);
+    });
   });
 
-  it("should return false for Python files", () => {
-    expect(hasProcessedVersion("text/x-python")).toBe(false);
-  });
+  describe("getProcessedContentType", () => {
+    it("plain text and JSON return undefined", () => {
+      expect(getProcessedContentType("text/plain")).toBeUndefined();
+      expect(getProcessedContentType("application/json")).toBeUndefined();
+    });
 
-  it("should return false for JSON files", () => {
-    expect(hasProcessedVersion("application/json")).toBe(false);
-  });
+    it("audio returns text/plain", () => {
+      expect(getProcessedContentType("audio/mpeg")).toBe("text/plain");
+    });
 
-  it("should return false for CSV files", () => {
-    expect(hasProcessedVersion("text/csv")).toBe(false);
-  });
+    it("raster images return their original content type", () => {
+      expect(getProcessedContentType("image/png")).toBe("image/png");
+      expect(getProcessedContentType("image/jpeg")).toBe("image/jpeg");
+    });
 
-  it("should return true for SVG files (rasterized to PNG)", () => {
-    expect(hasProcessedVersion("image/svg+xml")).toBe(true);
-  });
-
-  it("should return false for PDF files (lazy extraction via extract_text tool)", () => {
-    expect(hasProcessedVersion("application/pdf")).toBe(false);
-  });
-
-  it("should return false for Word documents (lazy extraction via extract_text tool)", () => {
-    expect(
-      hasProcessedVersion(
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-      )
-    ).toBe(false);
-  });
-
-  it("should return true for image files (resize)", () => {
-    expect(hasProcessedVersion("image/png")).toBe(true);
-  });
-
-  it("should return true for Excel files (text extraction required for table upsert)", () => {
-    expect(
-      hasProcessedVersion(
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      )
-    ).toBe(true);
-  });
-
-  it("should return true for audio files (transcription)", () => {
-    expect(hasProcessedVersion("audio/mpeg")).toBe(true);
-  });
-});
-
-describe("getProcessedContentType", () => {
-  it("should return undefined for content types without processing", () => {
-    expect(getProcessedContentType("text/plain")).toBeUndefined();
-    expect(getProcessedContentType("application/json")).toBeUndefined();
-  });
-
-  it("should return undefined for PDFs (no pre-processing; use extract_text tool)", () => {
-    expect(getProcessedContentType("application/pdf")).toBeUndefined();
-  });
-
-  it("should return undefined for Word documents (no pre-processing; use extract_text tool)", () => {
-    expect(
-      getProcessedContentType(
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-      )
-    ).toBeUndefined();
-  });
-
-  it("should return text/plain for audio files", () => {
-    expect(getProcessedContentType("audio/mpeg")).toBe("text/plain");
-  });
-
-  it("should return the same content type for raster images", () => {
-    expect(getProcessedContentType("image/png")).toBe("image/png");
-    expect(getProcessedContentType("image/jpeg")).toBe("image/jpeg");
-  });
-
-  it("should return image/png for SVG files (rasterized)", () => {
-    expect(getProcessedContentType("image/svg+xml")).toBe("image/png");
+    it("SVG returns image/png (rasterized)", () => {
+      expect(getProcessedContentType("image/svg+xml")).toBe("image/png");
+    });
   });
 });
 
-describe("isUploadSupportedForContentType", () => {
-  it("should return true for plain text files (uploadable without processing)", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "text/plain",
-        useCase: "conversation",
-      })
-    ).toBe(true);
+// For conversation, only tabular files (Excel/CSV) are processed and indexed in the data source.
+// Binary documents (PDF, DOCX, PPTX) are uploaded as-is and never text-extracted.
+describe("conversation use case", () => {
+  describe("hasProcessedVersion", () => {
+    it("PDF has no processed version", () => {
+      expect(hasProcessedVersion("application/pdf", "conversation")).toBe(
+        false
+      );
+    });
+
+    it("DOCX has no processed version", () => {
+      expect(
+        hasProcessedVersion(
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "conversation"
+        )
+      ).toBe(false);
+    });
+
+    it("PPTX has no processed version", () => {
+      expect(
+        hasProcessedVersion(
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "conversation"
+        )
+      ).toBe(false);
+    });
+
+    it("DOC (legacy Word) has no processed version", () => {
+      expect(
+        hasProcessedVersion("application/msword", "conversation")
+      ).toBe(false);
+    });
+
+    it("PPT (legacy PowerPoint) has no processed version", () => {
+      expect(
+        hasProcessedVersion("application/vnd.ms-powerpoint", "conversation")
+      ).toBe(false);
+    });
   });
 
-  it("should return true for Python files (uploadable without processing)", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "text/x-python",
-        useCase: "conversation",
-      })
-    ).toBe(true);
+  describe("getProcessedContentType", () => {
+    it("PDF returns undefined", () => {
+      expect(
+        getProcessedContentType("application/pdf", "conversation")
+      ).toBeUndefined();
+    });
+
+    it("DOCX returns undefined", () => {
+      expect(
+        getProcessedContentType(
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "conversation"
+        )
+      ).toBeUndefined();
+    });
   });
 
-  it("should return true for CSV files (uploadable without processing)", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "text/csv",
-        useCase: "conversation",
-      })
-    ).toBe(true);
-  });
-
-  it("should return true for PDF files (uploadable with processing)", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "application/pdf",
-        useCase: "conversation",
-      })
-    ).toBe(true);
-  });
-
-  it("should return true for SVG files in conversation", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "image/svg+xml",
-        useCase: "conversation",
-      })
-    ).toBe(true);
-  });
-
-  it("should return true for image files as skill_attachment", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "image/png",
-        useCase: "skill_attachment",
-      })
-    ).toBe(true);
-  });
-
-  it("should return true for Slack thread attachments", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "text/vnd.dust.attachment.slack.thread",
-        useCase: "conversation",
-      })
-    ).toBe(true);
-  });
-
-  it("should return true for section JSON as tool_output", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "application/vnd.dust.section.json",
-        useCase: "tool_output",
-      })
-    ).toBe(true);
-  });
-
-  it("should return false for unsupported content type / use case combo", () => {
-    expect(
-      isUploadSupportedForContentType({
-        contentType: "image/png",
-        useCase: "upsert_table",
-      })
-    ).toBe(false);
-  });
-
-  it("should return true for supported image types with workspace_branding", () => {
-    for (const contentType of [
-      "image/jpeg",
-      "image/png",
-      "image/svg+xml",
-      "image/webp",
-    ] as const) {
+  describe("isUploadSupportedForContentType", () => {
+    it("plain text is supported", () => {
       expect(
         isUploadSupportedForContentType({
-          contentType,
-          useCase: "workspace_branding",
+          contentType: "text/plain",
+          useCase: "conversation",
         })
       ).toBe(true);
-    }
+    });
+
+    it("Python files are supported", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "text/x-python",
+          useCase: "conversation",
+        })
+      ).toBe(true);
+    });
+
+    it("CSV is supported", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "text/csv",
+          useCase: "conversation",
+        })
+      ).toBe(true);
+    });
+
+    it("PDF is supported (uploaded as-is, not indexed)", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "application/pdf",
+          useCase: "conversation",
+        })
+      ).toBe(true);
+    });
+
+    it("SVG is supported", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "image/svg+xml",
+          useCase: "conversation",
+        })
+      ).toBe(true);
+    });
+
+    it("Slack thread attachment is supported", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "text/vnd.dust.attachment.slack.thread",
+          useCase: "conversation",
+        })
+      ).toBe(true);
+    });
   });
 
-  it("should return false for non-image types with workspace_branding", () => {
-    expect(
-      isUploadSupportedForContentType({
+  describe("processAndStoreFile", () => {
+    it("PDF is stored as original only, no text extraction for conversation", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
+        contentType: "application/pdf",
+        fileName: "document.pdf",
+        fileSize: 1000,
+        status: "created",
+        useCase: "conversation",
+      });
+
+      const result = await processAndStoreFile(auth, {
+        file,
+        content: { type: "string", value: "fake pdf bytes" },
+      });
+
+      assert(
+        result.isOk(),
+        `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+      );
+
+      const writes = fileStorageMock.writeStreamCalls;
+      expect(writes).toHaveLength(1);
+      expect(writes[0].contentType).toBe("application/pdf");
+    });
+
+    it("plain text is stored as original only", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const file = await FileFactory.create(auth, null, {
         contentType: "text/plain",
-        useCase: "workspace_branding",
-      })
-    ).toBe(false);
+        fileName: "readme.txt",
+        fileSize: 100,
+        status: "created",
+        useCase: "conversation",
+      });
+
+      const result = await processAndStoreFile(auth, {
+        file,
+        content: { type: "string", value: "hello world" },
+      });
+
+      assert(
+        result.isOk(),
+        `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+      );
+
+      const writes = fileStorageMock.writeStreamCalls;
+      expect(writes).toHaveLength(1);
+      expect(writes[0].contentType).toBe("text/plain");
+    });
+
+    it("raw sandbox spreadsheets skip processing when skipFileProcessing is set", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const contentType =
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+      const file = await FileFactory.create(auth, null, {
+        contentType,
+        fileName: "large.xlsx",
+        fileSize: 100,
+        status: "created",
+        useCase: "conversation",
+        useCaseMetadata: {
+          conversationId: "conv-raw",
+          skipDataSourceIndexing: true,
+          skipFileProcessing: true,
+        },
+      });
+
+      const result = await processAndStoreFile(auth, {
+        file,
+        content: { type: "string", value: "fake xlsx bytes" },
+      });
+
+      assert(
+        result.isOk(),
+        `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+      );
+
+      const writes = fileStorageMock.writeStreamCalls;
+      expect(writes).toHaveLength(1);
+      expect(writes[0].contentType).toBe(contentType);
+    });
   });
 });
 
-describe("processAndStoreFile", () => {
-  it("should store PDF as original only (no pre-processing; extraction is lazy via extract_text tool)", async () => {
-    const { authenticator: auth } = await createResourceTest({
-      role: "admin",
+// For non-conversation use cases (upsert_document, folders_document, etc.), binary documents
+// are text-extracted via Tika and their processed version is text/plain.
+describe("upsert_document / folders_document use cases", () => {
+  describe("hasProcessedVersion", () => {
+    it("PDF has a processed version", () => {
+      expect(hasProcessedVersion("application/pdf", "upsert_document")).toBe(
+        true
+      );
+      expect(hasProcessedVersion("application/pdf", "folders_document")).toBe(
+        true
+      );
     });
 
-    const file = await FileFactory.create(auth, null, {
-      contentType: "application/pdf",
-      fileName: "document.pdf",
-      fileSize: 1000,
-      status: "created",
-      useCase: "conversation",
+    it("DOCX has a processed version", () => {
+      expect(
+        hasProcessedVersion(
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "upsert_document"
+        )
+      ).toBe(true);
     });
 
-    const result = await processAndStoreFile(auth, {
-      file,
-      content: { type: "string", value: "fake pdf bytes" },
+    it("PPTX has a processed version", () => {
+      expect(
+        hasProcessedVersion(
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "upsert_document"
+        )
+      ).toBe(true);
     });
 
-    assert(
-      result.isOk(),
-      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
-    );
+    it("DOC (legacy Word) has a processed version", () => {
+      expect(
+        hasProcessedVersion("application/msword", "upsert_document")
+      ).toBe(true);
+    });
 
-    // Only one write: original (application/pdf). No processed version is created at upload time.
-    const writes = fileStorageMock.writeStreamCalls;
-    expect(writes).toHaveLength(1);
-    expect(writes[0].contentType).toBe("application/pdf");
+    it("PPT (legacy PowerPoint) has a processed version", () => {
+      expect(
+        hasProcessedVersion("application/vnd.ms-powerpoint", "upsert_document")
+      ).toBe(true);
+    });
   });
 
-  it("should not create a processed version for plain text files", async () => {
-    const { authenticator: auth } = await createResourceTest({
-      role: "admin",
+  describe("getProcessedContentType", () => {
+    it("PDF returns text/plain", () => {
+      expect(
+        getProcessedContentType("application/pdf", "upsert_document")
+      ).toBe("text/plain");
+      expect(
+        getProcessedContentType("application/pdf", "folders_document")
+      ).toBe("text/plain");
     });
 
-    const file = await FileFactory.create(auth, null, {
-      contentType: "text/plain",
-      fileName: "readme.txt",
-      fileSize: 100,
-      status: "created",
-      useCase: "conversation",
+    it("DOCX returns text/plain", () => {
+      expect(
+        getProcessedContentType(
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "upsert_document"
+        )
+      ).toBe("text/plain");
     });
 
-    const result = await processAndStoreFile(auth, {
-      file,
-      content: { type: "string", value: "hello world" },
+    it("PPTX returns text/plain", () => {
+      expect(
+        getProcessedContentType(
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "upsert_document"
+        )
+      ).toBe("text/plain");
     });
-
-    assert(
-      result.isOk(),
-      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
-    );
-
-    // Only one write: the original. No processed version created.
-    const writes = fileStorageMock.writeStreamCalls;
-    expect(writes).toHaveLength(1);
-    expect(writes[0].contentType).toBe("text/plain");
   });
+});
 
-  it("should skip processed version creation for raw sandbox spreadsheets", async () => {
-    const { authenticator: auth } = await createResourceTest({
-      role: "admin",
+describe("other use cases", () => {
+  describe("isUploadSupportedForContentType", () => {
+    it("section JSON is supported for tool_output", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "application/vnd.dust.section.json",
+          useCase: "tool_output",
+        })
+      ).toBe(true);
     });
 
-    const contentType =
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-    const file = await FileFactory.create(auth, null, {
-      contentType,
-      fileName: "large.xlsx",
-      fileSize: 100,
-      status: "created",
-      useCase: "conversation",
-      useCaseMetadata: {
-        conversationId: "conv-raw",
-        skipDataSourceIndexing: true,
-        skipFileProcessing: true,
-      },
+    it("images are supported for skill_attachment", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "image/png",
+          useCase: "skill_attachment",
+        })
+      ).toBe(true);
     });
 
-    const result = await processAndStoreFile(auth, {
-      file,
-      content: { type: "string", value: "fake xlsx bytes" },
+    it("supported image types are accepted for workspace_branding", () => {
+      for (const contentType of [
+        "image/jpeg",
+        "image/png",
+        "image/svg+xml",
+        "image/webp",
+      ] as const) {
+        expect(
+          isUploadSupportedForContentType({
+            contentType,
+            useCase: "workspace_branding",
+          })
+        ).toBe(true);
+      }
     });
 
-    assert(
-      result.isOk(),
-      `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
-    );
+    it("non-image types are rejected for workspace_branding", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "text/plain",
+          useCase: "workspace_branding",
+        })
+      ).toBe(false);
+    });
 
-    const writes = fileStorageMock.writeStreamCalls;
-    expect(writes).toHaveLength(1);
-    expect(writes[0].contentType).toBe(contentType);
+    it("images are rejected for upsert_table", () => {
+      expect(
+        isUploadSupportedForContentType({
+          contentType: "image/png",
+          useCase: "upsert_table",
+        })
+      ).toBe(false);
+    });
   });
 });

--- a/front/lib/api/files/processing/index.test.ts
+++ b/front/lib/api/files/processing/index.test.ts
@@ -115,9 +115,9 @@ describe("conversation use case", () => {
     });
 
     it("DOC (legacy Word) has no processed version", () => {
-      expect(
-        hasProcessedVersion("application/msword", "conversation")
-      ).toBe(false);
+      expect(hasProcessedVersion("application/msword", "conversation")).toBe(
+        false
+      );
     });
 
     it("PPT (legacy PowerPoint) has no processed version", () => {
@@ -326,9 +326,9 @@ describe("upsert_document / folders_document use cases", () => {
     });
 
     it("DOC (legacy Word) has a processed version", () => {
-      expect(
-        hasProcessedVersion("application/msword", "upsert_document")
-      ).toBe(true);
+      expect(hasProcessedVersion("application/msword", "upsert_document")).toBe(
+        true
+      );
     });
 
     it("PPT (legacy PowerPoint) has a processed version", () => {

--- a/front/lib/api/files/processing/index.ts
+++ b/front/lib/api/files/processing/index.ts
@@ -210,8 +210,8 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
 interface ProcessingEntry {
   process: ProcessingFunction;
   processedContentType: AllSupportedFileContentType;
-  // When set, this entry only applies for matching use cases. Omit to apply for all use cases.
-  useCases?: (useCase: FileUseCase) => boolean;
+  // When set, this entry only applies when the predicate returns true. Omit to apply for all use cases.
+  appliesTo?: (useCase: FileUseCase) => boolean;
 }
 
 const PROCESSING_BY_CONTENT_TYPE = new Map<
@@ -310,7 +310,7 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
     {
       process: extractTextFromFileAndUpload,
       processedContentType: "text/plain",
-      useCases: (uc) => uc !== "conversation",
+      appliesTo: (uc) => uc !== "conversation",
     },
   ],
   [
@@ -318,7 +318,7 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
     {
       process: extractTextFromFileAndUpload,
       processedContentType: "text/plain",
-      useCases: (uc) => uc !== "conversation",
+      appliesTo: (uc) => uc !== "conversation",
     },
   ],
   [
@@ -326,7 +326,7 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
     {
       process: extractTextFromFileAndUpload,
       processedContentType: "text/plain",
-      useCases: (uc) => uc !== "conversation",
+      appliesTo: (uc) => uc !== "conversation",
     },
   ],
   [
@@ -334,7 +334,7 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
     {
       process: extractTextFromFileAndUpload,
       processedContentType: "text/plain",
-      useCases: (uc) => uc !== "conversation",
+      appliesTo: (uc) => uc !== "conversation",
     },
   ],
   [
@@ -342,7 +342,7 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
     {
       process: extractTextFromFileAndUpload,
       processedContentType: "text/plain",
-      useCases: (uc) => uc !== "conversation",
+      appliesTo: (uc) => uc !== "conversation",
     },
   ],
 ]);
@@ -358,7 +358,7 @@ function getProcessingEntry(
     return undefined;
   }
 
-  if (entry.useCases && useCase !== undefined && !entry.useCases(useCase)) {
+  if (entry.appliesTo && useCase !== undefined && !entry.appliesTo(useCase)) {
     return undefined;
   }
 

--- a/front/lib/api/files/processing/index.ts
+++ b/front/lib/api/files/processing/index.ts
@@ -210,6 +210,8 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
 interface ProcessingEntry {
   process: ProcessingFunction;
   processedContentType: AllSupportedFileContentType;
+  // When set, this entry only applies for matching use cases. Omit to apply for all use cases.
+  useCases?: (useCase: FileUseCase) => boolean;
 }
 
 const PROCESSING_BY_CONTENT_TYPE = new Map<
@@ -300,16 +302,67 @@ const PROCESSING_BY_CONTENT_TYPE = new Map<
       processedContentType: "text/plain",
     },
   ],
+
+  // Binary documents: Tika text extraction for all use cases except conversation (only tabular
+  // data is indexed in the data source for conversation).
+  [
+    "application/pdf",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+      useCases: (uc) => uc !== "conversation",
+    },
+  ],
+  [
+    "application/msword",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+      useCases: (uc) => uc !== "conversation",
+    },
+  ],
+  [
+    "application/vnd.ms-powerpoint",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+      useCases: (uc) => uc !== "conversation",
+    },
+  ],
+  [
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+      useCases: (uc) => uc !== "conversation",
+    },
+  ],
+  [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    {
+      process: extractTextFromFileAndUpload,
+      processedContentType: "text/plain",
+      useCases: (uc) => uc !== "conversation",
+    },
+  ],
 ]);
 
-// Returns the processing entry for a content type (processing function + output content type).
-// Returns undefined when no transformation is needed. The original file is used as-is. Processing
-// is purely content-type-driven. Upload support per use case is handled separately by the
-// per-use-case files.
+// Returns the processing entry for a content type and use case.
+// Returns undefined when no transformation is needed. The original file is used as-is.
 function getProcessingEntry(
-  contentType: AllSupportedFileContentType
+  contentType: AllSupportedFileContentType,
+  useCase?: FileUseCase
 ): ProcessingEntry | undefined {
-  return PROCESSING_BY_CONTENT_TYPE.get(contentType);
+  const entry = PROCESSING_BY_CONTENT_TYPE.get(contentType);
+  if (!entry) {
+    return undefined;
+  }
+
+  if (entry.useCases && useCase !== undefined && !entry.useCases(useCase)) {
+    return undefined;
+  }
+
+  return entry;
 }
 
 // Whether uploading this content type for this use case is supported. Dispatches to per-use-case
@@ -356,23 +409,25 @@ export function isUploadSupportedForContentType({
 
 /**
  * Whether a file with this content type has a meaningful processed version (e.g., text extraction,
- * image resize, audio transcription). When false, readers should use the "original" version
- * directly. Purely content-type-driven — no use-case branching.
+ * image resize, audio transcription) for the given use case. When false, readers should use the
+ * "original" version directly.
  */
 export function hasProcessedVersion(
-  contentType: AllSupportedFileContentType
+  contentType: AllSupportedFileContentType,
+  useCase?: FileUseCase
 ): boolean {
-  return getProcessingEntry(contentType) !== undefined;
+  return getProcessingEntry(contentType, useCase) !== undefined;
 }
 
 /**
- * Returns the content type of the processed version for a given original content type.
- * Returns undefined when there is no processed version.
+ * Returns the content type of the processed version for a given original content type and use
+ * case. Returns undefined when there is no processed version.
  */
 export function getProcessedContentType(
-  contentType: AllSupportedFileContentType
+  contentType: AllSupportedFileContentType,
+  useCase?: FileUseCase
 ): AllSupportedFileContentType | undefined {
-  return getProcessingEntry(contentType)?.processedContentType;
+  return getProcessingEntry(contentType, useCase)?.processedContentType;
 }
 
 const maybeApplyProcessing = async (
@@ -383,7 +438,7 @@ const maybeApplyProcessing = async (
     return new Ok(undefined);
   }
 
-  const entry = getProcessingEntry(file.contentType);
+  const entry = getProcessingEntry(file.contentType, file.useCase);
   if (!entry) {
     // No processing needed. The original file is used as-is.
     return new Ok(undefined);

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -620,13 +620,19 @@ describe("isFileTypeUpsertableForUseCase", () => {
   it("only indexes tabular files for the conversation use case", () => {
     for (const contentType of TABULAR_TYPES) {
       expect(
-        isFileTypeUpsertableForUseCase({ contentType, useCase: "conversation" }),
+        isFileTypeUpsertableForUseCase({
+          contentType,
+          useCase: "conversation",
+        }),
         `expected ${contentType} to be upsertable for conversation`
       ).toBe(true);
     }
     for (const contentType of NON_TABULAR_TYPES) {
       expect(
-        isFileTypeUpsertableForUseCase({ contentType, useCase: "conversation" }),
+        isFileTypeUpsertableForUseCase({
+          contentType,
+          useCase: "conversation",
+        }),
         `expected ${contentType} to NOT be upsertable for conversation`
       ).toBe(false);
     }
@@ -655,7 +661,10 @@ describe("isFileTypeUpsertableForUseCase", () => {
 
     for (const contentType of binaryTypes) {
       expect(
-        isFileTypeUpsertableForUseCase({ contentType, useCase: "conversation" }),
+        isFileTypeUpsertableForUseCase({
+          contentType,
+          useCase: "conversation",
+        }),
         `expected ${contentType} to NOT be upsertable for conversation`
       ).toBe(false);
     }
@@ -669,10 +678,7 @@ describe("isFileTypeUpsertableForUseCase", () => {
     ] as const;
 
     for (const contentType of binaryTypes) {
-      for (const useCase of [
-        "upsert_document",
-        "folders_document",
-      ] as const) {
+      for (const useCase of ["upsert_document", "folders_document"] as const) {
         expect(
           isFileTypeUpsertableForUseCase({ contentType, useCase }),
           `expected ${contentType} to be upsertable for ${useCase}`

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -4,7 +4,10 @@ import {
   upsertTable,
 } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/processing";
-import { processAndUpsertToDataSource } from "@app/lib/api/files/upsert";
+import {
+  isFileTypeUpsertableForUseCase,
+  processAndUpsertToDataSource,
+} from "@app/lib/api/files/upsert";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -107,10 +110,14 @@ describe("processAndUpsertToDataSource", () => {
       getNonNullableWorkspace: () => workspace,
     } as unknown as Authenticator;
 
-    // Reset mocks
+    // Reset mocks. vi.clearAllMocks() only clears call history, not implementations,
+    // so explicitly restore default implementations that some tests override.
     vi.clearAllMocks();
     vi.mocked(getFileContent).mockReset();
     vi.mocked(upsertDocument).mockReset();
+    vi.mocked(upsertTable).mockResolvedValue(
+      new Ok({ table: { table_id: "test-table-id" } })
+    );
   });
 
   it("should skip all processing for tool_output files with skipDataSourceIndexing", async () => {
@@ -142,23 +149,22 @@ describe("processAndUpsertToDataSource", () => {
     expect(createDataSourceFolder).not.toHaveBeenCalled();
   });
 
-  it("should keep over-quota text conversation files without indexing them", async () => {
-    const file = await FileFactory.create(auth, null, {
-      contentType: "text/plain",
-      fileName: "large-conversation-file.txt",
+  it("should keep over-quota CSV conversation files without indexing them", async () => {
+    const file = await FileFactory.csv(auth, null, {
+      fileName: "large-conversation-file.csv",
       fileSize: overQuotaFileSizeBytes,
       status: "ready",
       useCase: "conversation",
       useCaseMetadata: {
         conversationId: "test-conversation-id",
+        generatedTables: [],
       },
     });
 
     const space = await SpaceFactory.global(workspace);
     const datasourceView = await DataSourceViewFactory.folder(workspace, space);
 
-    vi.mocked(getFileContent).mockResolvedValue("large text content");
-    vi.mocked(upsertDocument).mockResolvedValue(
+    vi.mocked(upsertTable).mockResolvedValue(
       new Err(new DustError("data_source_quota_error", "File is too large."))
     );
 
@@ -176,7 +182,6 @@ describe("processAndUpsertToDataSource", () => {
       "test-conversation-id"
     );
     expect(updatedFile?.useCaseMetadata?.skipDataSourceIndexing).toBe(true);
-    expect(updatedFile?.snippet).toBe("Mocked snippet");
   });
 
   it("should keep data source quota errors fatal for non-conversation files", async () => {
@@ -209,22 +214,21 @@ describe("processAndUpsertToDataSource", () => {
   });
 
   it("should keep unrelated conversation indexing errors fatal", async () => {
-    const file = await FileFactory.create(auth, null, {
-      contentType: "text/plain",
-      fileName: "conversation-file.txt",
+    const file = await FileFactory.csv(auth, null, {
+      fileName: "conversation-file.csv",
       fileSize: 1000,
       status: "ready",
       useCase: "conversation",
       useCaseMetadata: {
         conversationId: "test-conversation-id",
+        generatedTables: [],
       },
     });
 
     const space = await SpaceFactory.global(workspace);
     const datasourceView = await DataSourceViewFactory.folder(workspace, space);
 
-    vi.mocked(getFileContent).mockResolvedValue("text content");
-    vi.mocked(upsertDocument).mockResolvedValue(
+    vi.mocked(upsertTable).mockResolvedValue(
       new Err(
         new DustError("invalid_request_error", "Missing embedding API key.")
       )
@@ -239,6 +243,45 @@ describe("processAndUpsertToDataSource", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.code).toBe("invalid_request_error");
+    }
+  });
+
+  it("should reject non-tabular files for conversation use case", async () => {
+    const nonTabularTypes = [
+      { contentType: "text/plain" as const, fileName: "notes.txt" },
+      {
+        contentType:
+          "application/vnd.openxmlformats-officedocument.presentationml.presentation" as const,
+        fileName: "slides.pptx",
+      },
+      { contentType: "application/pdf" as const, fileName: "doc.pdf" },
+    ];
+
+    const space = await SpaceFactory.global(workspace);
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+
+    for (const { contentType, fileName } of nonTabularTypes) {
+      const file = await FileFactory.create(auth, null, {
+        contentType,
+        fileName,
+        fileSize: 1000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "test-conversation-id" },
+      });
+
+      const result = await processAndUpsertToDataSource(
+        auth,
+        datasourceView.dataSource,
+        { file }
+      );
+
+      expect(result.isErr(), `${contentType} should not be upsertable`).toBe(
+        true
+      );
+      if (result.isErr()) {
+        expect(result.error.code).toBe("invalid_file");
+      }
     }
   });
 
@@ -549,6 +592,92 @@ id,category,description
       expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
       expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);
       expect(generatedTables.length).toBe(2);
+    }
+  });
+});
+
+describe("isFileTypeUpsertableForUseCase", () => {
+  const TABULAR_TYPES = [
+    "text/csv",
+    "text/comma-separated-values",
+    "text/tsv",
+    "text/tab-separated-values",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+  ] as const;
+
+  const NON_TABULAR_TYPES = [
+    "text/plain",
+    "text/markdown",
+    "application/json",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/pdf",
+    "image/png",
+    "audio/mpeg",
+  ] as const;
+
+  it("only indexes tabular files for the conversation use case", () => {
+    for (const contentType of TABULAR_TYPES) {
+      expect(
+        isFileTypeUpsertableForUseCase({ contentType, useCase: "conversation" }),
+        `expected ${contentType} to be upsertable for conversation`
+      ).toBe(true);
+    }
+    for (const contentType of NON_TABULAR_TYPES) {
+      expect(
+        isFileTypeUpsertableForUseCase({ contentType, useCase: "conversation" }),
+        `expected ${contentType} to NOT be upsertable for conversation`
+      ).toBe(false);
+    }
+  });
+
+  it("indexes plain-text files for non-conversation use cases", () => {
+    for (const useCase of [
+      "upsert_document",
+      "folders_document",
+      "tool_output",
+      "project_context",
+    ] as const) {
+      expect(
+        isFileTypeUpsertableForUseCase({ contentType: "text/plain", useCase }),
+        `expected text/plain to be upsertable for ${useCase}`
+      ).toBe(true);
+    }
+  });
+
+  it("does not index binary office formats for the conversation use case", () => {
+    const binaryTypes = [
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/pdf",
+    ] as const;
+
+    for (const contentType of binaryTypes) {
+      expect(
+        isFileTypeUpsertableForUseCase({ contentType, useCase: "conversation" }),
+        `expected ${contentType} to NOT be upsertable for conversation`
+      ).toBe(false);
+    }
+  });
+
+  it("indexes binary office formats for non-conversation use cases after text extraction", () => {
+    const binaryTypes = [
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/pdf",
+    ] as const;
+
+    for (const contentType of binaryTypes) {
+      for (const useCase of [
+        "upsert_document",
+        "folders_document",
+      ] as const) {
+        expect(
+          isFileTypeUpsertableForUseCase({ contentType, useCase }),
+          `expected ${contentType} to be upsertable for ${useCase}`
+        ).toBe(true);
+      }
     }
   });
 });

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -505,6 +505,11 @@ const getProcessingFunction = ({
       }
   }
 
+  // For conversation, only tabular files (CSV, TSV, XLSX, XLS dispatched above) are indexed.
+  if (useCase === "conversation") {
+    return undefined;
+  }
+
   if (isSupportedAudioContentType(contentType)) {
     if (useCase === "upsert_document" || useCase === "project_context") {
       return upsertDocumentToDatasource;
@@ -512,21 +517,8 @@ const getProcessingFunction = ({
     return undefined;
   }
 
-  if (
-    isSupportedPlainTextContentType(contentType) &&
-    [
-      "conversation",
-      "tool_output",
-      "upsert_document",
-      "folders_document",
-      "project_context",
-    ].includes(useCase)
-  ) {
-    return upsertDocumentToDatasource;
-  }
-
   if (isSupportedPlainTextContentType(contentType)) {
-    return undefined;
+    return upsertDocumentToDatasource;
   }
 
   // Processing is assumed to be irrelevant for internal mime types.
@@ -534,7 +526,7 @@ const getProcessingFunction = ({
     return undefined;
   }
 
-  // Fonts are binary assets used as-is — no processing needed.
+  // Fonts are binary assets with no processing needed.
   if (isSupportedFontContentType(contentType)) {
     return undefined;
   }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -659,7 +659,7 @@ export class FileResource extends BaseResource<FileModel> {
       return "original";
     }
 
-    return hasProcessedVersion(this.contentType) ? "processed" : "original";
+    return hasProcessedVersion(this.contentType, this.useCase) ? "processed" : "original";
   }
 
   /**
@@ -1322,7 +1322,7 @@ export class FileResource extends BaseResource<FileModel> {
 
     if (
       this.useCaseMetadata?.skipFileProcessing === true ||
-      !hasProcessedVersion(this.contentType)
+      !hasProcessedVersion(this.contentType, this.useCase)
     ) {
       return;
     }
@@ -1330,7 +1330,7 @@ export class FileResource extends BaseResource<FileModel> {
     // Only delete processed mount file if this file type has real processing.
     const processedMountPath = makeProcessedMountFileName({
       mountFilePath: gcsMountFilePath,
-      processedContentType: getProcessedContentType(this.contentType),
+      processedContentType: getProcessedContentType(this.contentType, this.useCase),
     });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -659,7 +659,9 @@ export class FileResource extends BaseResource<FileModel> {
       return "original";
     }
 
-    return hasProcessedVersion(this.contentType, this.useCase) ? "processed" : "original";
+    return hasProcessedVersion(this.contentType, this.useCase)
+      ? "processed"
+      : "original";
   }
 
   /**
@@ -1330,7 +1332,10 @@ export class FileResource extends BaseResource<FileModel> {
     // Only delete processed mount file if this file type has real processing.
     const processedMountPath = makeProcessedMountFileName({
       mountFilePath: gcsMountFilePath,
-      processedContentType: getProcessedContentType(this.contentType, this.useCase),
+      processedContentType: getProcessedContentType(
+        this.contentType,
+        this.useCase
+      ),
     });
     await bucket.delete(processedMountPath, { ignoreNotFound: true });
 

--- a/front/lib/utils/files.ts
+++ b/front/lib/utils/files.ts
@@ -30,7 +30,7 @@ export async function copyContent(
   if (
     !includeProcessedVersion ||
     sourceFile.useCaseMetadata?.skipFileProcessing === true ||
-    !hasProcessedVersion(sourceFile.contentType)
+    !hasProcessedVersion(sourceFile.contentType, sourceFile.useCase)
   ) {
     return;
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

When a user attaches a PDF, Word document, or PowerPoint to a conversation, the file was being sent to the data source for indexing. Because no text-extracted version existed at that point, the raw binary bytes were forwarded to Core, causing a `core_api_error`.

The fix introduces the concept of use-case-aware processing. For conversation, only tabular files (CSV, TSV, Excel) produce a processed version and get indexed. Everything else is stored as uploaded and left out of the data source entirely. For folder and document upload use cases, binary office formats now go through text extraction as before, so search and retrieval over uploaded documents continue to work.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
