### PR TITLE
Remove unique index on conversationId for Pod

### DIFF
--- a/connectors/migrations/pre-deploy/20260616150709_remove_unique_index_on_conversationId.sql
+++ b/connectors/migrations/pre-deploy/20260616150709_remove_unique_index_on_conversationId.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."dust_project_conversations_conversation_id";

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -92,7 +92,6 @@ DustProjectConversationModel.init(
   {
     sequelize: connectorsSequelize,
     indexes: [
-      { fields: ["conversationId"], unique: true },
       { fields: ["connectorId", "conversationId"], unique: true },
       { fields: ["connectorId", "sourceUpdatedAt"] },
       {


### PR DESCRIPTION
## Description

Drops the single-column unique index on `conversationId` from `DustProjectConversationModel`, keeping only the composite unique index on `(connectorId, conversationId)`. A Pod can be managed by multiple connectors, so uniqueness constrained to `conversationId` alone is too strict and would block valid insertions where different connectors reference the same conversation.

## Tests

Tested that the composite unique index `(connectorId, conversationId)` still enforces the right constraint. Migration runs with `DROP INDEX CONCURRENTLY` — safe for production with no table lock.

## Risk

Low. Relaxing a unique index cannot cause data corruption; it only permits rows that were previously rejected. The composite index retains the meaningful uniqueness constraint. `DROP INDEX CONCURRENTLY` avoids any lock contention.

## Deploy Plan

1. Run pre-deploy migration `20260616150709_remove_unique_index_on_conversationId.sql` on the connectors DB.
2. Deploy connectors.
