### PR TITLE
Skip text extraction for plain-text files

### DIFF
--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -317,7 +317,7 @@ const EXTRACT_TEXT_TOOL = {
     "Returns the scoped path of the extracted file. " +
     `Use this before \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` or \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_GREP_ACTION_NAME)}\` ` +
     "on binary documents that cannot be read as text. " +
-    "Do NOT use on plain-text files (.txt, .md, .csv, etc.) — read those directly.",
+    "Do NOT use on plain-text files (.txt, .md, .csv, etc.), read those directly.",
   schema: {
     path: z
       .string()

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -316,7 +316,8 @@ const EXTRACT_TEXT_TOOL = {
     "and save the result as a plain-text file next to the source. " +
     "Returns the scoped path of the extracted file. " +
     `Use this before \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_CAT_ACTION_NAME)}\` or \`${getPrefixedToolName(FILES_SERVER_NAME, FILES_GREP_ACTION_NAME)}\` ` +
-    "on binary documents that cannot be read as text.",
+    "on binary documents that cannot be read as text. " +
+    "Do NOT use on plain-text files (.txt, .md, .csv, etc.) — read those directly.",
   schema: {
     path: z
       .string()


### PR DESCRIPTION
## Description

Agents were incorrectly calling the `extract_text` tool on plain-text files (`.md`, `.txt`, `.csv`, etc.), triggering the error `text/plain is not supported for text extraction`. This happened because the tool description wasn't explicit enough that it should only be used for binary documents requiring Tika processing. This PR adds a one-line clarification to the tool description: _"Do NOT use on plain-text files (.txt, .md, .csv, etc.) — read those directly."_

## Tests

Manual

## Risk

_None_ — description-only change, no logic modified.

## Deploy Plan

Deploy front.