### PR TITLE
Rank title matches above description matches in capabilities search

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -438,6 +438,19 @@ export function CapabilitiesPicker({
       }
     }
 
+    const getSearchRank = (item: CapabilityPickerItem): number => {
+      if (normalizedSearchText.length === 0) {
+        return 0;
+      }
+      if (item.sortName.startsWith(normalizedSearchText)) {
+        return 0;
+      }
+      if (item.sortName.includes(normalizedSearchText)) {
+        return 1;
+      }
+      return 2;
+    };
+
     return items.toSorted((a, b) => {
       const aGroupOrder = a.kind === "uninstalled_tool" ? 1 : 0;
       const bGroupOrder = b.kind === "uninstalled_tool" ? 1 : 0;
@@ -445,6 +458,11 @@ export function CapabilitiesPicker({
 
       if (groupComparison !== 0) {
         return groupComparison;
+      }
+
+      const rankComparison = getSearchRank(a) - getSearchRank(b);
+      if (rankComparison !== 0) {
+        return rankComparison;
       }
 
       return a.sortName.localeCompare(b.sortName);

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -1,4 +1,8 @@
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
+import {
+  matchesSlashCommandCapabilityQuery,
+  sortSlashCommandCapabilityMatches,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import { CapabilityDetailsSheets } from "@app/components/shared/CapabilityDetailsSheets";
 import {
   getMcpServerViewDescription,
@@ -65,25 +69,6 @@ type CapabilityPickerItem = CapabilityPickerItemBase &
         server: MCPServerType;
       }
   );
-
-function matchesCapabilityPickerSearchQuery({
-  description,
-  label,
-  normalizedQuery,
-}: {
-  description?: string;
-  label: string;
-  normalizedQuery: string;
-}) {
-  if (normalizedQuery.length === 0) {
-    return true;
-  }
-
-  return (
-    label.toLowerCase().includes(normalizedQuery) ||
-    (description?.toLowerCase().includes(normalizedQuery) ?? false)
-  );
-}
 
 function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
   return (
@@ -357,10 +342,10 @@ export function CapabilitiesPicker({
         const description = skill.userFacingDescription;
 
         if (
-          !matchesCapabilityPickerSearchQuery({
+          !matchesSlashCommandCapabilityQuery({
             description,
             label: skill.name,
-            normalizedQuery: normalizedSearchText,
+            query: normalizedSearchText,
           })
         ) {
           continue;
@@ -384,10 +369,10 @@ export function CapabilitiesPicker({
         if (
           !isJITMCPServerView(serverView) ||
           selectedMCPServerViewIds.has(serverView.sId) ||
-          !matchesCapabilityPickerSearchQuery({
+          !matchesSlashCommandCapabilityQuery({
             description,
             label,
-            normalizedQuery: normalizedSearchText,
+            query: normalizedSearchText,
           })
         ) {
           continue;
@@ -417,10 +402,10 @@ export function CapabilitiesPicker({
         if (
           installedServerNames.has(server.name) ||
           server.availability !== "manual" ||
-          !matchesCapabilityPickerSearchQuery({
+          !matchesSlashCommandCapabilityQuery({
             description,
             label,
-            normalizedQuery: normalizedSearchText,
+            query: normalizedSearchText,
           })
         ) {
           continue;
@@ -438,35 +423,18 @@ export function CapabilitiesPicker({
       }
     }
 
-    const getSearchRank = (item: CapabilityPickerItem): number => {
-      if (normalizedSearchText.length === 0) {
-        return 0;
-      }
-      if (item.sortName.startsWith(normalizedSearchText)) {
-        return 0;
-      }
-      if (item.sortName.includes(normalizedSearchText)) {
-        return 1;
-      }
-      return 2;
-    };
-
-    return items.toSorted((a, b) => {
-      const aGroupOrder = a.kind === "uninstalled_tool" ? 1 : 0;
-      const bGroupOrder = b.kind === "uninstalled_tool" ? 1 : 0;
-      const groupComparison = aGroupOrder - bGroupOrder;
-
-      if (groupComparison !== 0) {
-        return groupComparison;
-      }
-
-      const rankComparison = getSearchRank(a) - getSearchRank(b);
-      if (rankComparison !== 0) {
-        return rankComparison;
-      }
-
-      return a.sortName.localeCompare(b.sortName);
-    });
+    const installedItems = items.filter((i) => i.kind !== "uninstalled_tool");
+    const uninstalledItems = items.filter((i) => i.kind === "uninstalled_tool");
+    return [
+      ...sortSlashCommandCapabilityMatches({
+        items: installedItems,
+        normalizedQuery: normalizedSearchText,
+      }),
+      ...sortSlashCommandCapabilityMatches({
+        items: uninstalledItems,
+        normalizedQuery: normalizedSearchText,
+      }),
+    ];
   })();
 
   const hasNoVisibleItems =

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -88,6 +88,25 @@ describe("matchesSlashCommandCapabilityQuery", () => {
       })
     ).toBe(false);
   });
+
+  it("matches against description when label does not match", () => {
+    expect(
+      matchesSlashCommandCapabilityQuery({
+        description: "Search and retrieve documents",
+        label: "Linear",
+        query: "docs",
+      })
+    ).toBe(true);
+  });
+
+  it("does not match against description when description is absent", () => {
+    expect(
+      matchesSlashCommandCapabilityQuery({
+        label: "Linear",
+        query: "docs",
+      })
+    ).toBe(false);
+  });
 });
 
 describe("sortSlashCommandCapabilityMatches", () => {
@@ -113,6 +132,26 @@ describe("sortSlashCommandCapabilityMatches", () => {
     });
 
     expect(result.map((item) => item.id)).toEqual(["longtest", "testlonger"]);
+  });
+
+  it("ranks title matches above description-only matches", () => {
+    const result = sortSlashCommandCapabilityMatches({
+      normalizedQuery: "docs",
+      items: [
+        {
+          id: "desc-only",
+          sortName: "linear",
+          description: "Search and retrieve docs",
+        },
+        {
+          id: "title-match",
+          sortName: "docs viewer",
+          description: "View files",
+        },
+      ],
+    });
+
+    expect(result.map((item) => item.id)).toEqual(["title-match", "desc-only"]);
   });
 });
 

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -60,9 +60,11 @@ export function isToolSlashCommand(
 }
 
 export function matchesSlashCommandCapabilityQuery({
+  description,
   label,
   query,
 }: {
+  description?: string;
   label: string;
   query: string;
 }) {
@@ -70,20 +72,37 @@ export function matchesSlashCommandCapabilityQuery({
     return true;
   }
 
-  return subFilter(query, label.toLowerCase());
+  return (
+    subFilter(query, label.toLowerCase()) ||
+    (description !== undefined && subFilter(query, description.toLowerCase()))
+  );
 }
 
 export function sortSlashCommandCapabilityMatches<
-  T extends { sortName: string },
+  T extends { description?: string; sortName: string },
 >({ items, normalizedQuery }: { items: T[]; normalizedQuery: string }): T[] {
   return items.toSorted((a, b) => {
-    if (normalizedQuery.length > 0) {
+    if (normalizedQuery.length === 0) {
+      return a.sortName.localeCompare(b.sortName);
+    }
+
+    const aTitleMatch = subFilter(normalizedQuery, a.sortName);
+    const bTitleMatch = subFilter(normalizedQuery, b.sortName);
+
+    // Title matches rank above description-only matches.
+    if (aTitleMatch !== bTitleMatch) {
+      return aTitleMatch ? -1 : 1;
+    }
+
+    // Within title matches, use fuzzy sort on the title.
+    if (aTitleMatch) {
       return (
         compareForFuzzySort(normalizedQuery, a.sortName, b.sortName) ||
         a.sortName.localeCompare(b.sortName)
       );
     }
 
+    // Both are description-only matches: sort alphabetically by title.
     return a.sortName.localeCompare(b.sortName);
   });
 }


### PR DESCRIPTION
## Description

When searching in the capabilities picker dropdown, items whose name _starts with_ the query are now ranked first, followed by items whose name _contains_ the query anywhere, and finally items that only match via their description. Previously, all filtered items were sorted purely alphabetically regardless of where the match occurred, causing description-only matches to appear mixed in with direct title matches.

This is implemented via a small `getSearchRank` helper that returns 0/1/2 based on match position, applied as the primary sort key before the existing alphabetical `localeCompare` tie-breaker.

## Tests

Manually verified in the capabilities picker by typing a partial query and confirming that prefix-matching items bubble to the top.

## Risk

Low — purely a client-side sort order change in the capabilities picker dropdown.

## Deploy Plan

Deploy front.