### PR TITLE
Hide empty message bubble when user sends file without text

### DIFF
--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -240,6 +240,9 @@ export function UserMessage({
     .filter((m) => isUserMessage(m) && m.visibility === "pending").length;
   const isEmpty = !message.content;
   const isCurrentUser = message.user?.sId === currentUserId;
+  const hasCitations = (citations?.length ?? 0) > 0;
+  const shouldHideMessageContent =
+    isEmpty && hasCitations && !isDeleted && !isPending;
   const canDelete =
     (isCurrentUser || isAdmin) && !isDeleted && !isProjectArchived;
   const canEdit = isCurrentUser && !isDeleted && !isProjectArchived;
@@ -398,6 +401,7 @@ export function UserMessage({
                 type="user"
                 className={cn(shouldShowBiggerUserMessage && "@sm:min-w-100")}
                 reversed={isCurrentUser}
+                showContent={!shouldHideMessageContent}
               >
                 <div
                   className={cn(

--- a/sparkle/src/components/ConversationMessages.tsx
+++ b/sparkle/src/components/ConversationMessages.tsx
@@ -61,37 +61,53 @@ interface ConversationMessageContentProps
   type: ConversationMessageType;
   infoChip?: React.ReactNode;
   reversed?: boolean;
+  showContent?: boolean;
 }
 
 export const ConversationMessageContent = React.forwardRef<
   HTMLDivElement,
   ConversationMessageContentProps
->(({ children, citations, className, type, reversed, ...props }, ref) => {
-  return (
-    <>
-      {type === "user" && citations && citations.length > 0 && (
-        <CitationGrid reversed={reversed}>{citations}</CitationGrid>
-      )}
-      <div
-        ref={ref}
-        className={cn(
-          "s-flex s-min-w-0 s-flex-col s-gap-1",
-          type === "user" &&
-            "s-rounded-2xl s-bg-muted-background dark:s-bg-muted-background-night s-px-4 s-py-3",
-          className
+>(
+  (
+    {
+      children,
+      citations,
+      className,
+      type,
+      reversed,
+      showContent = true,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <>
+        {type === "user" && citations && citations.length > 0 && (
+          <CitationGrid reversed={reversed}>{citations}</CitationGrid>
         )}
-        {...props}
-      >
-        <div className="s-text-base s-text-foreground dark:s-text-foreground-night">
-          {children}
-        </div>
-        {type === "agent" && citations && citations.length > 0 && (
-          <CitationGrid>{citations}</CitationGrid>
+        {showContent && (
+          <div
+            ref={ref}
+            className={cn(
+              "s-flex s-min-w-0 s-flex-col s-gap-1",
+              type === "user" &&
+                "s-rounded-2xl s-bg-muted-background dark:s-bg-muted-background-night s-px-4 s-py-3",
+              className
+            )}
+            {...props}
+          >
+            <div className="s-text-base s-text-foreground dark:s-text-foreground-night">
+              {children}
+            </div>
+            {type === "agent" && citations && citations.length > 0 && (
+              <CitationGrid>{citations}</CitationGrid>
+            )}
+          </div>
         )}
-      </div>
-    </>
-  );
-});
+      </>
+    );
+  }
+);
 
 ConversationMessageContent.displayName = "ConversationMessageContent";
 


### PR DESCRIPTION
## Description
Hide empty message bubble when user sends a file without any text content.
Previously, starting a conversation by attaching a file with no accompanying text would display a "no message" label and an empty grey bubble in the conversation below the file. This looked strange.

Fixes #8494
Changes made:
- front/components/assistant/conversation/UserMessage.tsx --> removed the "no message" text and stopped rendering the empty text container div when message content is empty
- sparkle/src/components/ConversationMessages.tsx --> skip rendering the grey rounded bubble for user messages when there is no text content

Before:
<img width="925" height="493" alt="Screenshot 2026-06-16 at 15 17 44" src="https://github.com/user-attachments/assets/8820be7b-8334-414f-95aa-bf393da8fa22" />

After:
<img width="901" height="419" alt="Screenshot 2026-06-16 at 15 17 56" src="https://github.com/user-attachments/assets/0a9ae904-a143-4b50-9e51-b4ad485882f7" />

## Tests
Tested manually in my dust-hive environment:
- Sent a message with only a file attachment (no text) → no "no message" label + no empty grey box
- Sent a message with both text and a file --> looks the same as before 
- Sent a text-only message --> looks the same as before 
- Verified deleted messages and pending messages --> looks the same as before 

## Risk
Low since only changes visual appearance. 

## Deploy Plan

