### PR TITLE
Show error when user has no seat

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -73,7 +73,7 @@ app.get(
 
     const { canRequestUpgrade, hasPendingUpgradeRequest } =
       await getUpgradeRequestAvailabilityForUser(auth, {
-        isNearOrAtLimit: awuStatus !== "normal",
+        isNearOrAtLimit: awuStatus !== "normal" || noSeat,
       });
 
     return ctx.json({

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -96,7 +96,9 @@ export function ConversationContainerVirtuoso({
   // A seatless member can never send a message. We surface this up-front rather
   // than relying on the deferred background message-post failure, which lands
   // after navigation and would otherwise leave behind an empty conversation.
-  const { noSeat } = useWorkspaceUsageStatus({ owner });
+  const { noSeat, awuStatus, poolCreditState } = useWorkspaceUsageStatus({
+    owner,
+  });
 
   // Maps a message-send failure to the right surface: blocking limits (no seat,
   // credits, per-user cap, plan limit) open the dedicated popup, everything else
@@ -132,15 +134,31 @@ export function ConversationContainerVirtuoso({
         });
       }
 
-      // Block seatless members before creating the conversation: the backend
-      // would reject the message anyway, and doing it here shows the popup
-      // immediately without leaving an empty conversation behind.
+      // Pre-check blocking conditions before creating the conversation.
+      // With deferMessage:true the message posts after navigation, so backend
+      // errors arrive too late and leave an empty conversation behind.
       if (noSeat) {
         setLimitReachedCode("no_seat");
         return new Err({
           code: "internal_error",
           name: "NoSeat",
           message: "You don't have a seat in this workspace.",
+        });
+      }
+      if (awuStatus === "blocked") {
+        setLimitReachedCode("user_credits_exhausted");
+        return new Err({
+          code: "internal_error",
+          name: "UserCapReached",
+          message: "You have reached your personal usage cap.",
+        });
+      }
+      if (poolCreditState === "depleted") {
+        setLimitReachedCode("pool_credits_exhausted");
+        return new Err({
+          code: "internal_error",
+          name: "CreditsExhausted",
+          message: "Your workspace has run out of credits.",
         });
       }
 
@@ -196,6 +214,8 @@ export function ConversationContainerVirtuoso({
     [
       isSubmitting,
       noSeat,
+      awuStatus,
+      poolCreditState,
       mutateConversations,
       owner,
       router,

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -10,15 +10,39 @@ interface InputBarUsageBannerProps {
 
 export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
   const { isAdmin } = useAuth();
-  const { awuStatus, canRequestUpgrade, hasPendingUpgradeRequest } =
+  const { awuStatus, canRequestUpgrade, hasPendingUpgradeRequest, noSeat } =
     useWorkspaceUsageStatus({
       owner,
     });
 
-  const showAwuBanner = awuStatus !== "normal";
   const showUpgradeCta = canRequestUpgrade || isAdmin;
 
-  if (!showAwuBanner) {
+  if (noSeat) {
+    return (
+      <div
+        className={cn(
+          "mb-2 flex w-full items-center gap-2 rounded-2xl border px-4 py-3",
+          "border-warning-200 bg-warning-100",
+          "dark:border-warning-200-night dark:bg-warning-100-night"
+        )}
+      >
+        <span className="copy-sm grow truncate text-warning-900 dark:text-warning-900-night">
+          You don&apos;t have a seat in this workspace.
+        </span>
+        {showUpgradeCta && (
+          <div className="shrink-0">
+            <UsageUpgradeButton
+              owner={owner}
+              hasPendingUpgradeRequest={hasPendingUpgradeRequest}
+              isAdmin={isAdmin}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (awuStatus === "normal") {
     return null;
   }
 

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -208,12 +208,8 @@ interface WorkspaceUsageStatusBannerProps {
 function WorkspaceUsageStatusBanner({
   owner,
 }: WorkspaceUsageStatusBannerProps) {
-  const {
-    poolCreditState,
-    programmaticCreditStatus,
-    balanceThresholdReached,
-    noSeat,
-  } = useWorkspaceUsageStatus({ owner });
+  const { poolCreditState, programmaticCreditStatus, balanceThresholdReached } =
+    useWorkspaceUsageStatus({ owner });
 
   // The low/critical pool states are internal throttling signals and are not
   // surfaced. Admins are alerted when the pool is fully depleted (agents
@@ -258,17 +254,6 @@ function WorkspaceUsageStatusBanner({
   );
 
   const banner = ((): StatusBannerProps | null => {
-    // A seatless member cannot run agents at all, so this takes precedence over
-    // every credit-related banner.
-    if (noSeat) {
-      return {
-        variant: "danger",
-        title: "You don't have a seat in this workspace",
-        description:
-          "You can no longer run agents. Contact your admin to be assigned a seat.",
-      };
-    }
-
     if (showPoolBanner) {
       return {
         variant: isPoolDepleted ? "danger" : "warning",


### PR DESCRIPTION
## Description

Moves the \"no seat\" error from a workspace-wide sidebar banner to the input bar area, consistent with other per-user blocking states (usage cap, etc.). Also fixes a bug where blocked users could still create conversations from the new conversation screen.

<img width="796" height="203" alt="Screenshot 2026-06-16 at 15 41 58" src="https://github.com/user-attachments/assets/03ae244c-cf68-49c8-b5bf-ab06d8f70f2d" />


**Changes:**

- **`AppStatusBanner`**: removed the no-seat case — it was a per-user state shown as a workspace-wide alert, which was wrong
- **`InputBarUsageBanner`**: added no-seat handling above the input bar, matching the existing usage-cap banner pattern; includes the "Request upgrade" CTA (non-admins) / "Go to workspace usage" link (admins) — also fixed the API to include \`noSeat\` in the \`isNearOrAtLimit\` check so \`canRequestUpgrade\` is correctly set for seatless users
- **`ConversationContainer`**: pre-check \`awuStatus === \"blocked\"\` and \`poolCreditState === \"depleted\"\` before creating a new conversation — with \`deferMessage: true\` the message posts after navigation, so backend errors arrive too late and leave an empty conversation behind; pre-checking surfaces the correct popup immediately (fixes https://github.com/dust-tt/tasks/issues/8928)

## Tests

Tested manually:
- No-seat user sees warning banner above input bar on both new and existing conversation pages
- Non-admin no-seat user sees "Request an upgrade" CTA; admin sees "Go to workspace usage"
- Blocked user (usage cap reached) on new conversation page now sees the popup immediately without creating an empty conversation
- Existing conversation page popup behaviour unchanged

## Risk

Low. UI-only changes for the banner move; the pre-check in `ConversationContainer` is purely client-side and mirrors what the backend would reject anyway.

## Deploy Plan

Standard deploy, no migration needed.