### PR TITLE
[LLM] Route streaming through new model-router endpoint behind a feature flag

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -262,8 +262,8 @@ function getProviderIdFilter(auth: Authenticator): ValueFilter<ProviderId> {
   );
   const byok = auth.getNonNullablePlan().isByok;
   const providerIds = byok
-    ? whitelistedProviderIds
-    : intersection(whitelistedProviderIds, BYOK_MODEL_PROVIDER_IDS);
+    ? intersection(whitelistedProviderIds, BYOK_MODEL_PROVIDER_IDS)
+    : whitelistedProviderIds;
 
   return { in: providerIds };
 }

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -283,11 +283,11 @@ const REGION_MAPPING: Record<RegionType, Region> = {
   "us-central1": GLOBAL,
 };
 
-async function getStreamEndpointLLM(
+function getStreamEndpointLLM(
   auth: Authenticator,
   featureFlags: WhitelistableFeature[],
   llmParameters: LLMParameters
-): Promise<LLM | null> {
+): LLM | null {
   // llmParameters.modelId is ModelIdType — narrow before filtering.
   if (!isModelId(llmParameters.modelId)) {
     return null;

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,3 +1,4 @@
+import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import {
@@ -17,14 +18,40 @@ import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/op
 import { XaiLLM } from "@app/lib/api/llm/clients/xai";
 import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
+import { StreamEndpointTransition } from "@app/lib/api/llm/transitionLLM";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
-import { config as regionConfig } from "@app/lib/api/regions/config";
+import {
+  config as multiRegionsConfig,
+  config as regionConfig,
+} from "@app/lib/api/regions/config";
+import { isEnterpriseOrDust } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { getStreamEndpoints } from "@app/lib/llms/stream";
+import type {
+  ValueFilter,
+  Where,
+  WorkspaceFilter,
+} from "@app/lib/llms/stream/types/filter";
+import { isModelId } from "@app/lib/model_constructors/types/model_ids";
+import {
+  isProviderId,
+  type ProviderId,
+} from "@app/lib/model_constructors/types/provider_ids";
+import {
+  EUROPE,
+  GLOBAL,
+  type Region,
+} from "@app/lib/model_constructors/types/regions";
 import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
+import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
+import type { RegionType } from "@app/types/region";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import intersection from "lodash/intersection";
+import sortBy from "lodash/sortBy";
 
 // EAP (Early Access Program) models are served through a dedicated Anthropic
 // workspace key (ANTHROPIC_EAP_API_KEY) rather than the workspace's
@@ -46,7 +73,9 @@ function withEapAnthropicKey(
   return { ...credentials, ANTHROPIC_API_KEY: eapApiKey };
 }
 
-export async function getLLM(
+// Legacy router: dispatches to the per-provider client classes, which implement
+// both the streaming and batch surfaces on the returned instance.
+export async function getLegacyLLM(
   auth: Authenticator,
   {
     credentials,
@@ -158,7 +187,7 @@ export async function getLLM(
       featureFlags.includes("use_vertex_for_supported_models"));
 
   if (isAnthropicWhitelistedModelId(modelId)) {
-    const useEapKey = modelConfig.useEapKey ?? false;
+    const useEapKey = getModelConfigByModelId(modelId)?.useEapKey ?? false;
 
     // EAP models must hit the Anthropic API directly with the EAP key. Vertex
     // authenticates via GCP project creds and ignores ANTHROPIC_API_KEY, so
@@ -188,4 +217,109 @@ export async function getLLM(
   }
 
   return null;
+}
+
+// Resolves an LLM for the streaming surface: the new `StreamEndpoint`-backed
+// router when enabled, falling back to the legacy per-provider clients.
+export async function getLLM(
+  auth: Authenticator,
+  llmParameters: LLMParameters
+): Promise<LLM | null> {
+  const modelConfig = getModelConfigByModelId(llmParameters.modelId);
+  if (!modelConfig) {
+    return null;
+  }
+  const featureFlags = await getFeatureFlags(auth);
+
+  const streamEndpointLLM = getStreamEndpointLLM(
+    auth,
+    featureFlags,
+    llmParameters
+  );
+
+  if (featureFlags.includes("use_new_llm_router") && streamEndpointLLM) {
+    return streamEndpointLLM;
+  }
+
+  const legacyLLM = await getLegacyLLM(auth, llmParameters);
+
+  return legacyLLM;
+}
+
+function getRegionFilter(auth: Authenticator): ValueFilter<Region> | undefined {
+  const dustRegion = multiRegionsConfig.getCurrentRegion();
+  const regionalModelsOnly = auth.getNonNullableWorkspace().regionalModelsOnly;
+  if (dustRegion === "us-central1" || !regionalModelsOnly) {
+    return undefined;
+  }
+
+  return { eq: EUROPE };
+}
+
+function getProviderIdFilter(auth: Authenticator): ValueFilter<ProviderId> {
+  const whitelistedProviderIds = [...getWhitelistedProviders(auth)].filter(
+    isProviderId
+  );
+  const byok = auth.getNonNullablePlan().isByok;
+  const providerIds = byok
+    ? whitelistedProviderIds
+    : intersection(whitelistedProviderIds, BYOK_MODEL_PROVIDER_IDS);
+
+  return { in: providerIds };
+}
+
+// Temporary helper while we have both systems
+export function getWorkspaceFilter(
+  auth: Authenticator
+): Where<WorkspaceFilter> {
+  return {
+    providerId: getProviderIdFilter(auth),
+    region: getRegionFilter(auth),
+  };
+}
+
+const REGION_MAPPING: Record<RegionType, Region> = {
+  "europe-west1": EUROPE,
+  "us-central1": GLOBAL,
+};
+
+async function getStreamEndpointLLM(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[],
+  llmParameters: LLMParameters
+): Promise<LLM | null> {
+  // llmParameters.modelId is ModelIdType — narrow before filtering.
+  if (!isModelId(llmParameters.modelId)) {
+    return null;
+  }
+
+  const workspaceFilter = getWorkspaceFilter(auth);
+
+  const endpoints = getStreamEndpoints(
+    {
+      featureFlags,
+      enterprise: isEnterpriseOrDust(auth.getNonNullablePlan()),
+    },
+    {
+      ...workspaceFilter,
+      modelId: {
+        eq: llmParameters.modelId,
+      },
+    }
+  );
+
+  const preferredRegion = REGION_MAPPING[multiRegionsConfig.getCurrentRegion()];
+
+  const sortedEndpoints = sortBy(
+    endpoints,
+    (endpoint) => endpoint.region === preferredRegion
+  );
+
+  const endpoint = sortedEndpoints[0];
+
+  if (!endpoint) {
+    return null;
+  }
+
+  return new StreamEndpointTransition(auth, llmParameters, endpoint);
 }

--- a/front/lib/api/llm/tests/batch_llm_store.test.ts
+++ b/front/lib/api/llm/tests/batch_llm_store.test.ts
@@ -1,4 +1,4 @@
-import { getLLM } from "@app/lib/api/llm";
+import { getLegacyLLM, getLLM } from "@app/lib/api/llm";
 import type { LlmConversationOptions } from "@app/lib/api/llm/batch_llm";
 import {
   downloadBatchResultFromLlm,
@@ -59,7 +59,7 @@ function makeConversationOptions(
   };
 }
 
-async function setupTest(): Promise<{
+async function setupTest(surface: "stream" | "batch" = "batch"): Promise<{
   authenticator: Authenticator;
   workspace: LightWorkspaceType;
   llm: LLM;
@@ -73,11 +73,15 @@ async function setupTest(): Promise<{
     skipEmbeddingApiKeyRequirement: true,
   });
 
-  const llm = await getLLM(authenticator, {
+  const llmParameters = {
     modelId: CLAUDE_SONNET_4_6_MODEL_ID,
     bypassFeatureFlag: true,
     credentials,
-  });
+  };
+  const llm =
+    surface === "batch"
+      ? await getLegacyLLM(authenticator, llmParameters)
+      : await getLLM(authenticator, llmParameters);
   if (!llm) {
     throw new Error("Failed to create LLM");
   }
@@ -243,7 +247,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
       "writeBatchUserMessages + storeLlmResult stores data for a streamed call",
       async () => {
         const { authenticator, workspace, llm, agentConfigurationId } =
-          await setupTest();
+          await setupTest("stream");
 
         // Create conversation and user message.
         const writeResult = await writeBatchUserMessages(

--- a/front/lib/api/llm/tests/llmBatch.test.ts
+++ b/front/lib/api/llm/tests/llmBatch.test.ts
@@ -1,6 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { getLLM } from "@app/lib/api/llm";
+import { getLegacyLLM } from "@app/lib/api/llm";
 import { MODELS } from "@app/lib/api/llm/tests/models";
 import type { ResponseChecker } from "@app/lib/api/llm/tests/types";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -277,7 +277,7 @@ describe.skipIf(!RUN_LLM_BATCH_TEST || modelsWithBatchSupport.length === 0)(
           const credentials = await getLlmCredentials(authenticator, {
             skipEmbeddingApiKeyRequirement: true,
           });
-          const llm = await getLLM(authenticator, {
+          const llm = await getLegacyLLM(authenticator, {
             modelId: modelId as ModelIdType,
             bypassFeatureFlag: true,
             credentials,

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -1,0 +1,544 @@
+import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
+import { LLM } from "@app/lib/api/llm/llm";
+import {
+  handleGenericError,
+  type LLMErrorType,
+} from "@app/lib/api/llm/types/errors";
+import type {
+  LLMEvent,
+  LLMOutputItem,
+  ToolCallEvent as OldToolCallEvent,
+  ReasoningGeneratedEvent,
+  TextGeneratedEvent,
+} from "@app/lib/api/llm/types/events";
+import { EventError } from "@app/lib/api/llm/types/events";
+import type {
+  LLMClientMetadata,
+  LLMParameters,
+  LLMStreamParameters,
+} from "@app/lib/api/llm/types/options";
+import { normalizePrompt } from "@app/lib/api/llm/types/options";
+import {
+  extractEncryptedContentFromMetadata,
+  parseResponseFormatSchema,
+} from "@app/lib/api/llm/utils";
+import type { Authenticator } from "@app/lib/auth";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type {
+  InputConfig,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseMessage,
+  Payload,
+  SystemTextMessage,
+  ToolCallResultPart,
+} from "@app/lib/model_constructors/types/input/messages";
+import type {
+  ErrorType,
+  ModelResponseEvent,
+  ReasoningEvent as NewReasoningEvent,
+  TextEvent as NewTextEvent,
+  ToolCallEvent as NewToolCallEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import type {
+  AgentFunctionCallContentType,
+  AgentReasoningContentType,
+  AgentTextContentType,
+} from "@app/types/assistant/agent_message_content";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+/**
+ * Maps old reasoning effort values to the new model's effort values.
+ */
+function mapReasoningEffort(
+  effort: ReasoningEffort | null
+): "none" | "low" | "medium" | "high" | "maximal" {
+  switch (effort) {
+    case null:
+    case "none":
+      return "none";
+    case "light":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    default:
+      assertNever(effort);
+  }
+}
+
+/**
+ * Converts an old-system message to new BaseMessage(s).
+ */
+function toBaseMessages(
+  message: ModelMessageTypeMultiActionsWithoutContentFragment
+): BaseMessage[] {
+  switch (message.role) {
+    case "user":
+      return message.content.map((c): BaseMessage => {
+        switch (c.type) {
+          case "text":
+            return { role: "user", type: "text", content: { value: c.text } };
+          case "image_url":
+            return {
+              role: "user",
+              type: "image_url",
+              content: { url: c.image_url.url },
+            };
+          default:
+            assertNever(c);
+        }
+      });
+    case "function": {
+      const parts: ToolCallResultPart[] =
+        typeof message.content === "string"
+          ? [{ type: "text", text: message.content }]
+          : message.content.map((c) =>
+              c.type === "text"
+                ? { type: "text", text: c.text }
+                : { type: "image_url", url: c.image_url.url }
+            );
+      return [
+        {
+          role: "user",
+          type: "tool_call_result",
+          content: {
+            callId: message.function_call_id,
+            parts,
+            isError: false,
+          },
+        },
+      ];
+    }
+    case "assistant":
+      return message.contents.flatMap(
+        (
+          c:
+            | AgentTextContentType
+            | AgentReasoningContentType
+            | AgentFunctionCallContentType
+        ): BaseMessage[] => {
+          switch (c.type) {
+            case "text_content":
+              return [
+                {
+                  role: "assistant",
+                  type: "text",
+                  content: { value: c.value },
+                },
+              ];
+            case "reasoning":
+              if (!c.value.reasoning) {
+                return [];
+              }
+              return [
+                {
+                  role: "assistant",
+                  type: "reasoning",
+                  content: { value: c.value.reasoning },
+                  signature: extractEncryptedContentFromMetadata(
+                    c.value.metadata
+                  ),
+                },
+              ];
+            case "function_call":
+              return [
+                {
+                  role: "assistant",
+                  type: "tool_call_request",
+                  content: {
+                    callId: c.value.id,
+                    toolName: c.value.name,
+                    arguments: c.value.arguments,
+                  },
+                  signature: c.value.metadata?.thoughtSignature,
+                },
+              ];
+            default:
+              assertNever(c);
+          }
+        }
+      );
+    case "compaction":
+      return [
+        {
+          role: "user",
+          type: "text",
+          content: { value: message.content },
+        },
+      ];
+    default:
+      assertNever(message);
+  }
+}
+
+/**
+ * Converts a new model aggregated item to the old LLMOutputItem format.
+ */
+function convertAggregatedItem(
+  item: NewTextEvent | NewReasoningEvent | NewToolCallEvent,
+  metadata: LLMClientMetadata
+): LLMOutputItem {
+  switch (item.type) {
+    case "text":
+      return {
+        type: "text_generated",
+        content: { text: item.content.value },
+        metadata,
+      };
+    case "reasoning":
+      return {
+        type: "reasoning_generated",
+        content: { text: item.content.value },
+        metadata: {
+          ...metadata,
+          ...(typeof item.metadata.content?.signature === "string"
+            ? { encrypted_content: item.metadata.content.signature }
+            : {}),
+        },
+      };
+    case "tool_call":
+      return {
+        type: "tool_call",
+        content: {
+          id: item.content.id,
+          name: item.content.name,
+          arguments: item.content.arguments,
+        },
+        metadata: {
+          ...metadata,
+          ...(typeof item.metadata.content?.signature === "string"
+            ? { thoughtSignature: item.metadata.content.signature }
+            : {}),
+        },
+      };
+    default:
+      assertNever(item);
+  }
+}
+
+/**
+ * Maps new model ErrorType to old LLMErrorType with correct retryability.
+ */
+function mapErrorType(errorType: ErrorType): {
+  type: LLMErrorType;
+  isRetryable: boolean;
+} {
+  switch (errorType) {
+    case "input_configuration_error":
+      return { type: "invalid_request_error", isRetryable: false };
+    case "stop_error":
+      return { type: "stop_error", isRetryable: true };
+    case "refusal_error":
+      return { type: "refusal_error", isRetryable: false };
+    case "model_output_error":
+      return { type: "invalid_request_error", isRetryable: true };
+    case "rate_limit_error":
+      return { type: "rate_limit_error", isRetryable: true };
+    case "overloaded_error":
+      return { type: "overloaded_error", isRetryable: true };
+    case "invalid_request_error":
+      return { type: "invalid_request_error", isRetryable: false };
+    case "authentication_error":
+      return { type: "authentication_error", isRetryable: false };
+    case "permission_error":
+      return { type: "permission_error", isRetryable: false };
+    case "not_found_error":
+      return { type: "not_found_error", isRetryable: false };
+    case "network_error":
+      return { type: "network_error", isRetryable: true };
+    case "timeout_error":
+      return { type: "timeout_error", isRetryable: true };
+    case "server_error":
+      return { type: "server_error", isRetryable: true };
+    case "stream_error":
+      return { type: "stream_error", isRetryable: true };
+    case "unknown_error":
+      return { type: "unknown_error", isRetryable: false };
+    default:
+      assertNever(errorType);
+  }
+}
+
+/**
+ * Converts a single new model event to its old LLM event equivalent.
+ */
+function convertToOldEvent(
+  event: ModelResponseEvent,
+  metadata: LLMClientMetadata
+): LLMEvent {
+  switch (event.type) {
+    case "response_id":
+      return {
+        type: "interaction_id",
+        content: { modelInteractionId: event.content.responseId },
+        metadata,
+      };
+
+    case "text_delta":
+      return {
+        type: "text_delta",
+        content: { delta: event.content.value },
+        metadata,
+      };
+
+    case "text":
+      return {
+        type: "text_generated",
+        content: { text: event.content.value },
+        metadata,
+      };
+
+    case "reasoning_delta":
+      return {
+        type: "reasoning_delta",
+        content: { delta: event.content.value },
+        metadata,
+      };
+
+    case "reasoning":
+      return {
+        type: "reasoning_generated",
+        content: { text: event.content.value },
+        metadata: {
+          ...metadata,
+          ...(typeof event.metadata.content?.signature === "string"
+            ? { encrypted_content: event.metadata.content.signature }
+            : {}),
+        },
+      };
+
+    case "tool_call_started":
+      return {
+        type: "tool_call_started",
+        content: event.content,
+        metadata,
+      };
+
+    case "tool_call_delta":
+      return {
+        type: "tool_call_delta",
+        metadata,
+      };
+
+    case "tool_call":
+      return {
+        type: "tool_call",
+        content: {
+          id: event.content.id,
+          name: event.content.name,
+          arguments: event.content.arguments,
+        },
+        metadata: {
+          ...metadata,
+          ...(typeof event.metadata.content?.signature === "string"
+            ? { thoughtSignature: event.metadata.content.signature }
+            : {}),
+        },
+      };
+
+    case "token_usage": {
+      const {
+        standardInput,
+        standardOutput,
+        cacheHit,
+        cacheCreated,
+        reasoning,
+      } = event.content;
+      const inputTokens = standardInput + cacheHit + cacheCreated;
+      return {
+        type: "token_usage",
+        content: {
+          inputTokens,
+          outputTokens: standardOutput,
+          reasoningTokens: reasoning,
+          totalTokens: inputTokens + standardOutput + reasoning,
+          cachedTokens: cacheHit,
+          cacheCreationTokens: cacheCreated,
+          uncachedInputTokens: standardInput,
+        },
+        metadata,
+      };
+    }
+
+    case "success": {
+      const aggregated = event.content.aggregated.map((item) =>
+        convertAggregatedItem(item, metadata)
+      );
+      const textGenerated = aggregated.find(
+        (item): item is TextGeneratedEvent => item.type === "text_generated"
+      );
+      const reasoningGenerated = aggregated.find(
+        (item): item is ReasoningGeneratedEvent =>
+          item.type === "reasoning_generated"
+      );
+      const toolCalls = aggregated.filter(
+        (item): item is OldToolCallEvent => item.type === "tool_call"
+      );
+      return {
+        type: "success",
+        aggregated,
+        textGenerated,
+        reasoningGenerated,
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        metadata,
+      };
+    }
+
+    case "error": {
+      const { type: errorType, isRetryable } = mapErrorType(event.content.type);
+      return new EventError(
+        {
+          type: errorType,
+          message: event.content.message,
+          isRetryable,
+          originalError: event.content.originalError,
+        },
+        metadata
+      );
+    }
+
+    default:
+      assertNever(event);
+  }
+}
+
+/**
+ * Converts a stream of new model events to old LLM events.
+ */
+async function* convertToOldEvents(
+  newEvents: AsyncGenerator<ModelResponseEvent>,
+  metadata: LLMClientMetadata
+): AsyncGenerator<LLMEvent> {
+  for await (const event of newEvents) {
+    yield convertToOldEvent(event, metadata);
+  }
+}
+
+/**
+ * Shared base bridging the old LLM system with the new model_constructors one.
+ *
+ * It extends the old LLM base class (used by the existing agent pipeline) and
+ * owns the surface-agnostic conversion: old message types -> `BaseMessage`,
+ * LLM parameters -> the new `InputConfig`. The concrete subclasses bind a single
+ * inference surface — `StreamEndpointTransition` for streaming,
+ * `BatchEndpointTransition` for batch — mirroring `StreamEndpoint`/`BatchEndpoint`.
+ */
+abstract class BaseTransition extends LLM {
+  // Builds the provider-agnostic conversation payload (system + messages) shared
+  // by both the streaming and batch surfaces.
+  protected buildPayload(streamParameters: LLMStreamParameters): Payload {
+    const { conversation, hasConditionalJITTools, prompt } = streamParameters;
+
+    const baseMessages = conversation.messages.flatMap(toBaseMessages);
+
+    // Cache breakpoint on the last user-role message so the conversation
+    // prefix is reused across turns. Mirrors the legacy cache_control:
+    // ephemeral marker on the last user content block, and the request-level
+    // cache_control that acted as a default trailing breakpoint for
+    // tool-result turns.
+    for (let i = baseMessages.length - 1; i >= 0; i--) {
+      const msg = baseMessages[i];
+      if (msg.role === "user") {
+        baseMessages[i] = { ...msg, cache: "short" };
+        break;
+      }
+    }
+
+    const { instructions, sharedContext, ephemeralContext } =
+      normalizePrompt(prompt);
+
+    const system: SystemTextMessage[] = [];
+
+    const instructionsText = instructions.map((s) => s.content).join("\n");
+    if (instructionsText) {
+      system.push({
+        role: "system",
+        type: "text",
+        content: { value: instructionsText },
+        cache: hasConditionalJITTools ? "short" : "long",
+      });
+    }
+
+    const sharedText = sharedContext.map((s) => s.content).join("\n");
+    if (sharedText) {
+      system.push({
+        role: "system",
+        type: "text",
+        content: { value: sharedText },
+        cache: "short",
+      });
+    }
+
+    const ephemeralText = ephemeralContext.map((s) => s.content).join("\n");
+    if (ephemeralText) {
+      system.push({
+        role: "system",
+        type: "text",
+        content: { value: ephemeralText },
+      });
+    }
+
+    return { conversation: { system, messages: baseMessages } };
+  }
+
+  // Builds the request config from the LLM parameters, parsed by the surface's
+  // own `configSchema` (stream and batch own theirs independently).
+  protected buildConfig(
+    streamParameters: LLMStreamParameters,
+    configSchema: BaseEndpointConfiguration["configSchema"]
+  ): InputConfig {
+    const { specifications, forceToolCall } = streamParameters;
+
+    return configSchema.parse({
+      tools: specifications as ToolSpecification[],
+      temperature: this.temperature ?? undefined,
+      reasoning: { effort: mapReasoningEffort(this.reasoningEffort) },
+      forceTool: forceToolCall,
+      outputFormat: parseResponseFormatSchema(
+        this.responseFormat,
+        ANTHROPIC_PROVIDER_ID
+      ),
+    });
+  }
+}
+
+/**
+ * Streaming transition: wraps a new `StreamEndpoint` and delegates streaming and
+ * event parsing to it. Returned by `getLLM` for the streaming surface.
+ */
+export class StreamEndpointTransition extends BaseTransition {
+  private model: StreamEndpoint;
+
+  constructor(
+    auth: Authenticator,
+    llmParameters: LLMParameters,
+    modelConstructor: StreamEndpointConstructor
+  ) {
+    super(auth, ANTHROPIC_PROVIDER_ID, llmParameters);
+    this.model = new modelConstructor(llmParameters.credentials);
+  }
+
+  protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
+    return this.model.buildRequestPayload(
+      this.buildPayload(streamParameters),
+      this.buildConfig(streamParameters, this.model.constructor.configSchema)
+    );
+  }
+
+  protected async *sendRequest(payload: unknown): AsyncGenerator<LLMEvent> {
+    try {
+      const rawStream = this.model.streamRaw(payload);
+      const newEvents = this.model.rawStreamOutputToEvents(rawStream);
+      yield* convertToOldEvents(newEvents, this.metadata);
+    } catch (err) {
+      yield handleGenericError(err, this.metadata);
+    }
+  }
+}

--- a/front/lib/llms/configuration.ts
+++ b/front/lib/llms/configuration.ts
@@ -1,13 +1,13 @@
-import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { EndpointFilter, Where } from "@app/lib/llms/stream/types/filter";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 type ReasoningEffortOf<C extends InputConfig> = NonNullable<
   C["reasoning"]
 >["effort"];
 
-export type DustModelConfiguration<C extends InputConfig> =
-  BaseModelConfiguration<C> & {
+export type DustEndpointConfiguration<C extends InputConfig> =
+  BaseEndpointConfiguration<C> & {
     // Description
     displayName: string;
     description: string;
@@ -15,7 +15,6 @@ export type DustModelConfiguration<C extends InputConfig> =
     // Behavior
     defaultReasoningEffort: ReasoningEffortOf<C>;
 
-    // Filters
-    byok: boolean;
-    featureFlags: WhitelistableFeature[];
+    // Filter
+    endpointFilter: Where<EndpointFilter>;
   };

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,5 +1,3 @@
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-
 export function WithDustClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
     ...args: any[]
@@ -11,7 +9,7 @@ export function WithDustClaudeSonnetFourDotSixConfig<
       "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (200k context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
-    static readonly featureFlags: WhitelistableFeature[] = [];
+    static readonly endpointFilter = {};
   }
 
   return DustClaudeSonnetFourDotSix;

--- a/front/lib/llms/stream/dust_stream_endpoint.ts
+++ b/front/lib/llms/stream/dust_stream_endpoint.ts
@@ -1,4 +1,4 @@
-import type { DustModelConfiguration } from "@app/lib/llms/configuration";
+import type { DustEndpointConfiguration } from "@app/lib/llms/configuration";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
@@ -9,10 +9,10 @@ export abstract class DustStreamEndpoint<
   O = unknown,
   C extends InputConfig = InputConfig,
 > extends StreamEndpoint<I, O> {
-  declare ["constructor"]: DustModelConfiguration<C>;
+  declare ["constructor"]: DustEndpointConfiguration<C>;
 }
 
-// Like `StreamEndpointConstructor`, but with `DustModelConfiguration`.
+// Like `StreamEndpointConstructor`, but with `DustEndpointConfiguration`.
 export type DustStreamEndpointConstructor<
   I = unknown,
   O = unknown,
@@ -20,7 +20,7 @@ export type DustStreamEndpointConstructor<
 > = (new (
   credentials: Credentials
 ) => StreamEndpoint<I, O>) &
-  DustModelConfiguration<C>;
+  DustEndpointConfiguration<C>;
 
 // Infers `C` from the class's `configSchema` so `defaultReasoningEffort` is
 // checked against the endpoint's supported efforts. Returns the class unchanged.

--- a/front/lib/llms/stream/dust_stream_endpoint.ts
+++ b/front/lib/llms/stream/dust_stream_endpoint.ts
@@ -1,4 +1,4 @@
-import type { DustEndpointConfiguration } from "@app/lib/llms/configuration";
+import type { DustStreamEndpointConfiguration } from "@app/lib/llms/stream/types/configuration";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
@@ -9,10 +9,10 @@ export abstract class DustStreamEndpoint<
   O = unknown,
   C extends InputConfig = InputConfig,
 > extends StreamEndpoint<I, O> {
-  declare ["constructor"]: DustEndpointConfiguration<C>;
+  declare ["constructor"]: DustStreamEndpointConfiguration<C>;
 }
 
-// Like `StreamEndpointConstructor`, but with `DustEndpointConfiguration`.
+// Like `StreamEndpointConstructor`, but with `DustStreamEndpointConfiguration`.
 export type DustStreamEndpointConstructor<
   I = unknown,
   O = unknown,
@@ -20,7 +20,7 @@ export type DustStreamEndpointConstructor<
 > = (new (
   credentials: Credentials
 ) => StreamEndpoint<I, O>) &
-  DustEndpointConfiguration<C>;
+  DustStreamEndpointConfiguration<C>;
 
 // Infers `C` from the class's `configSchema` so `defaultReasoningEffort` is
 // checked against the endpoint's supported efforts. Returns the class unchanged.

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,7 +1,10 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import type { Where, WorkspaceFilter } from "@app/lib/llms/stream/types/filter";
+import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export const DUST_STREAM_ENDPOINTS = {
   [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
@@ -9,3 +12,15 @@ export const DUST_STREAM_ENDPOINTS = {
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
+
+export function getStreamEndpoints(
+  workspaceConfiguration: {
+    featureFlags: WhitelistableFeature[];
+    enterprise: boolean;
+  },
+  inputCondition: Where<WorkspaceFilter>
+) {
+  return Object.values(DUST_STREAM_ENDPOINTS).filter((constructor) =>
+    isEndpointAvailable(constructor, workspaceConfiguration, inputCondition)
+  );
+}

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -6,7 +6,7 @@ type ReasoningEffortOf<C extends InputConfig> = NonNullable<
   C["reasoning"]
 >["effort"];
 
-export type DustEndpointConfiguration<C extends InputConfig> =
+export type DustStreamEndpointConfiguration<C extends InputConfig> =
   BaseEndpointConfiguration<C> & {
     // Description
     displayName: string;

--- a/front/lib/llms/stream/types/filter.ts
+++ b/front/lib/llms/stream/types/filter.ts
@@ -10,10 +10,10 @@ export type EndpointFilter = {
 };
 
 export type WorkspaceFilter = {
-  regions: Region[];
-  providerIds: ProviderId[];
-  modelIds: ModelId[];
-  providerApis: ProviderApi[];
+  region: Region[];
+  providerId: ProviderId[];
+  modelId: ModelId[];
+  providerApi: ProviderApi[];
 };
 
 export type ArrayValueFilter<T> = {

--- a/front/lib/llms/stream/types/filter.ts
+++ b/front/lib/llms/stream/types/filter.ts
@@ -1,0 +1,53 @@
+import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
+import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
+import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export type EndpointFilter = {
+  featureFlags: WhitelistableFeature[];
+  enterprise: boolean;
+};
+
+export type WorkspaceFilter = {
+  regions: Region[];
+  providerIds: ProviderId[];
+  modelIds: ModelId[];
+  providerApis: ProviderApi[];
+};
+
+export type ArrayValueFilter<T> = {
+  contains?: T;
+  containsAny?: T[];
+  containsAll?: T[];
+  isEmpty?: boolean;
+};
+
+export type ScalarValueFilter<T> = {
+  eq?: T;
+  neq?: T;
+  in?: T[];
+};
+
+export type ValueFilter<T> = T extends readonly (infer U)[]
+  ? ArrayValueFilter<U>
+  : ScalarValueFilter<T>;
+
+// Combined set of operators supported for a single field. The runtime matcher branches on the
+// shape of the value rather than the filter, so it needs a type accepted by both the array and
+// scalar matchers. Since every operator is optional, every `ValueFilter<T>` is assignable to it.
+export type AnyValueFilter = ArrayValueFilter<unknown> & ScalarValueFilter<unknown>;
+
+export type LogicalFilters<T> = {
+  and?: Where<T>[];
+  or?: Where<T>[];
+  not?: Where<T>;
+};
+
+export type FieldFilters<T> = {
+  [K in Exclude<keyof T, "and" | "or" | "not">]?: ValueFilter<
+    NonNullable<T[K]>
+  >;
+};
+
+export type Where<T> = LogicalFilters<T> & FieldFilters<T>;

--- a/front/lib/llms/stream/types/filter.ts
+++ b/front/lib/llms/stream/types/filter.ts
@@ -10,26 +10,28 @@ export type EndpointFilter = {
 };
 
 export type WorkspaceFilter = {
-  region: Region[];
-  providerId: ProviderId[];
-  modelId: ModelId[];
-  providerApi: ProviderApi[];
+  region: Region;
+  providerId: ProviderId;
+  modelId: ModelId;
+  providerApi: ProviderApi;
 };
 
 export type ArrayValueFilter<T> = {
   contains?: T;
   containsAny?: T[];
   containsAll?: T[];
-  isEmpty?: boolean;
 };
 
 export type ScalarValueFilter<T> = {
   eq?: T;
-  neq?: T;
   in?: T[];
 };
 
-export type ValueFilter<T> = T extends readonly (infer U)[]
+// Wrap both sides in a tuple to prevent distribution over union types: a naked
+// conditional would turn `ValueFilter<ProviderId>` into a union of
+// `ScalarValueFilter<"openai"> | ScalarValueFilter<"anthropic"> | ...`, forcing
+// `in` to be a homogeneous single-provider array instead of `ProviderId[]`.
+export type ValueFilter<T> = [T] extends [readonly (infer U)[]]
   ? ArrayValueFilter<U>
   : ScalarValueFilter<T>;
 

--- a/front/lib/llms/stream/types/filter.ts
+++ b/front/lib/llms/stream/types/filter.ts
@@ -36,7 +36,8 @@ export type ValueFilter<T> = T extends readonly (infer U)[]
 // Combined set of operators supported for a single field. The runtime matcher branches on the
 // shape of the value rather than the filter, so it needs a type accepted by both the array and
 // scalar matchers. Since every operator is optional, every `ValueFilter<T>` is assignable to it.
-export type AnyValueFilter = ArrayValueFilter<unknown> & ScalarValueFilter<unknown>;
+export type AnyValueFilter = ArrayValueFilter<unknown> &
+  ScalarValueFilter<unknown>;
 
 export type LogicalFilters<T> = {
   and?: Where<T>[];

--- a/front/lib/llms/stream/utils/is_endpoint_available.ts
+++ b/front/lib/llms/stream/utils/is_endpoint_available.ts
@@ -1,0 +1,30 @@
+import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
+import type { Where, WorkspaceFilter } from "@app/lib/llms/stream/types/filter";
+import { matchesWhere } from "@app/lib/llms/stream/utils/matches_where";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+export function isEndpointAvailable(
+  endpointConstructor: DustStreamEndpointConstructor,
+  workspaceConfiguration: {
+    featureFlags: WhitelistableFeature[];
+    enterprise: boolean;
+  },
+  inputCondition: Where<WorkspaceFilter>
+) {
+  // Availability is decided by matching a `where` condition from both sides:
+  //
+  // - The input condition (`inputCondition`): the filter the caller wants to retrieve, evaluated
+  //   against the endpoint's own properties. It expresses what the call site is looking for — e.g.
+  //   a workspace-level constraint, whitelisting some provider ids, or simply the code base
+  //   requiring a specific modelId.
+  //
+  // - The endpoint condition (`endpoint.constructor.endpointFilter`): the filter the endpoint
+  //   declares about which workspaces it is available to, evaluated against the workspace
+  //   configuration we receive. This side is fixed by the endpoint and is not tweakable at runtime.
+  //
+  // The endpoint is available only when both conditions match.
+  return (
+    matchesWhere(endpointConstructor, inputCondition) &&
+    matchesWhere(workspaceConfiguration, endpointConstructor.endpointFilter)
+  );
+}

--- a/front/lib/llms/stream/utils/matches_where.test.ts
+++ b/front/lib/llms/stream/utils/matches_where.test.ts
@@ -233,36 +233,36 @@ describe("matchesWhere", () => {
     // Mimics an endpoint description that exposes the WorkspaceFilter shape:
     // which providers / regions / models / apis it covers.
     const description: WorkspaceFilter = {
-      regions: ["eu", "global"],
-      providerIds: ["anthropic"],
-      modelIds: ["claude-sonnet-4-6"],
-      providerApis: ["anthropic", "agent-platform"],
+      region: ["eu", "global"],
+      providerId: ["anthropic"],
+      modelId: ["claude-sonnet-4-6"],
+      providerApi: ["anthropic", "agent-platform"],
     };
 
     it("matches provider and region membership", () => {
       expect(
-        matchesWhere(description, { providerIds: { contains: "anthropic" } })
+        matchesWhere(description, { providerId: { contains: "anthropic" } })
       ).toBe(true);
       expect(
-        matchesWhere(description, { regions: { containsAny: ["us", "eu"] } })
+        matchesWhere(description, { region: { containsAny: ["us", "eu"] } })
       ).toBe(true);
       expect(
-        matchesWhere(description, { regions: { contains: "us" } })
+        matchesWhere(description, { region: { contains: "us" } })
       ).toBe(false);
     });
 
     it("matches multiple list fields together", () => {
       expect(
         matchesWhere(description, {
-          providerIds: { contains: "anthropic" },
-          providerApis: { containsAll: ["anthropic", "agent-platform"] },
-          regions: { containsAny: ["eu"] },
+          providerId: { contains: "anthropic" },
+          providerApi: { containsAll: ["anthropic", "agent-platform"] },
+          region: { containsAny: ["eu"] },
         })
       ).toBe(true);
       expect(
         matchesWhere(description, {
-          providerIds: { contains: "anthropic" },
-          providerApis: { contains: "openai-responses" },
+          providerId: { contains: "anthropic" },
+          providerApi: { contains: "openai-responses" },
         })
       ).toBe(false);
     });

--- a/front/lib/llms/stream/utils/matches_where.test.ts
+++ b/front/lib/llms/stream/utils/matches_where.test.ts
@@ -278,10 +278,7 @@ describe("matchesWhere", () => {
     it("or requires at least one child to match", () => {
       expect(
         matchesWhere(freeWorkspace, {
-          or: [
-            { enterprise: { eq: true } },
-            { enterprise: { eq: false } },
-          ],
+          or: [{ enterprise: { eq: true } }, { enterprise: { eq: false } }],
         })
       ).toBe(true);
       expect(

--- a/front/lib/llms/stream/utils/matches_where.test.ts
+++ b/front/lib/llms/stream/utils/matches_where.test.ts
@@ -1,14 +1,16 @@
-import { describe, expect, it } from "vitest";
-
 import type {
   EndpointFilter,
   Where,
   WorkspaceFilter,
 } from "@app/lib/llms/stream/types/filter";
 import { matchesWhere } from "@app/lib/llms/stream/utils/matches_where";
+import { describe, expect, it } from "vitest";
 
 const enterpriseWorkspace: EndpointFilter = {
-  featureFlags: ["use_vertex_for_supported_models", "anthropic_vertex_fallback"],
+  featureFlags: [
+    "use_vertex_for_supported_models",
+    "anthropic_vertex_fallback",
+  ],
   enterprise: true,
 };
 
@@ -46,22 +48,13 @@ describe("matchesWhere", () => {
       );
     });
 
-    it("neq excludes a matching value", () => {
-      expect(
-        matchesWhere(enterpriseWorkspace, { enterprise: { neq: false } })
-      ).toBe(true);
-      expect(
-        matchesWhere(enterpriseWorkspace, { enterprise: { neq: true } })
-      ).toBe(false);
-    });
-
     it("in matches when the value is included", () => {
       expect(
         matchesWhere(enterpriseWorkspace, { enterprise: { in: [true] } })
       ).toBe(true);
-      expect(
-        matchesWhere(freeWorkspace, { enterprise: { in: [true] } })
-      ).toBe(false);
+      expect(matchesWhere(freeWorkspace, { enterprise: { in: [true] } })).toBe(
+        false
+      );
       // `enterprise: true` is not in `[false]`, so this excludes it.
       expect(
         matchesWhere(enterpriseWorkspace, { enterprise: { in: [false] } })
@@ -69,7 +62,7 @@ describe("matchesWhere", () => {
     });
 
     it("combines multiple scalar conditions (all must pass)", () => {
-      // Combining eq/neq/in is only meaningful on a non-boolean field, since
+      // Combining eq/in is only meaningful on a non-boolean field, since
       // `ValueFilter<boolean>` distributes into `ScalarValueFilter<true> |
       // ScalarValueFilter<false>` and cannot mix the two literals.
       const item = { providerId: "anthropic" };
@@ -77,7 +70,6 @@ describe("matchesWhere", () => {
         matchesWhere(item, {
           providerId: {
             eq: "anthropic",
-            neq: "openai",
             in: ["anthropic", "google_ai_studio"],
           },
         })
@@ -101,9 +93,9 @@ describe("matchesWhere", () => {
     };
 
     it("eq matches the providerId and region", () => {
-      expect(
-        matchesWhere(endpoint, { providerId: { eq: "anthropic" } })
-      ).toBe(true);
+      expect(matchesWhere(endpoint, { providerId: { eq: "anthropic" } })).toBe(
+        true
+      );
       expect(matchesWhere(endpoint, { providerId: { eq: "openai" } })).toBe(
         false
       );
@@ -163,7 +155,9 @@ describe("matchesWhere", () => {
     it("containsAny matches when at least one flag is present", () => {
       expect(
         matchesWhere(enterpriseWorkspace, {
-          featureFlags: { containsAny: ["audit_logs", "anthropic_vertex_fallback"] },
+          featureFlags: {
+            containsAny: ["audit_logs", "anthropic_vertex_fallback"],
+          },
         })
       ).toBe(true);
       expect(
@@ -193,36 +187,20 @@ describe("matchesWhere", () => {
       ).toBe(false);
     });
 
-    it("isEmpty distinguishes empty and non-empty flag lists", () => {
-      expect(
-        matchesWhere(freeWorkspace, { featureFlags: { isEmpty: true } })
-      ).toBe(true);
-      expect(
-        matchesWhere(freeWorkspace, { featureFlags: { isEmpty: false } })
-      ).toBe(false);
-      expect(
-        matchesWhere(enterpriseWorkspace, { featureFlags: { isEmpty: false } })
-      ).toBe(true);
-      expect(
-        matchesWhere(enterpriseWorkspace, { featureFlags: { isEmpty: true } })
-      ).toBe(false);
-    });
-
     it("combines multiple array conditions (all must pass)", () => {
       expect(
         matchesWhere(enterpriseWorkspace, {
           featureFlags: {
             contains: "anthropic_vertex_fallback",
             containsAny: ["use_vertex_for_supported_models", "audit_logs"],
-            isEmpty: false,
           },
         })
       ).toBe(true);
       expect(
         matchesWhere(enterpriseWorkspace, {
           featureFlags: {
-            contains: "anthropic_vertex_fallback",
-            isEmpty: true,
+            contains: "audit_logs",
+            containsAny: ["use_vertex_for_supported_models"],
           },
         })
       ).toBe(false);
@@ -230,9 +208,14 @@ describe("matchesWhere", () => {
   });
 
   describe("array filters on WorkspaceFilter lists", () => {
-    // Mimics an endpoint description that exposes the WorkspaceFilter shape:
-    // which providers / regions / models / apis it covers.
-    const description: WorkspaceFilter = {
+    // Mimics an endpoint description that covers several values per
+    // WorkspaceFilter field: the set of providers / regions / models / apis it
+    // exposes. `WorkspaceFilter` itself is scalar (one value per field on a real
+    // endpoint), so the coverage shape arrays each field.
+    type WorkspaceFilterCoverage = {
+      [K in keyof WorkspaceFilter]: WorkspaceFilter[K][];
+    };
+    const description: WorkspaceFilterCoverage = {
       region: ["eu", "global"],
       providerId: ["anthropic"],
       modelId: ["claude-sonnet-4-6"],
@@ -246,9 +229,9 @@ describe("matchesWhere", () => {
       expect(
         matchesWhere(description, { region: { containsAny: ["us", "eu"] } })
       ).toBe(true);
-      expect(
-        matchesWhere(description, { region: { contains: "us" } })
-      ).toBe(false);
+      expect(matchesWhere(description, { region: { contains: "us" } })).toBe(
+        false
+      );
     });
 
     it("matches multiple list fields together", () => {
@@ -297,7 +280,7 @@ describe("matchesWhere", () => {
         matchesWhere(freeWorkspace, {
           or: [
             { enterprise: { eq: true } },
-            { featureFlags: { isEmpty: true } },
+            { enterprise: { eq: false } },
           ],
         })
       ).toBe(true);

--- a/front/lib/llms/stream/utils/matches_where.test.ts
+++ b/front/lib/llms/stream/utils/matches_where.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  EndpointFilter,
+  Where,
+  WorkspaceFilter,
+} from "@app/lib/llms/stream/types/filter";
+import { matchesWhere } from "@app/lib/llms/stream/utils/matches_where";
+
+const enterpriseWorkspace: EndpointFilter = {
+  featureFlags: ["use_vertex_for_supported_models", "anthropic_vertex_fallback"],
+  enterprise: true,
+};
+
+// A representative non-enterprise workspace with no flags.
+const freeWorkspace: EndpointFilter = {
+  featureFlags: [],
+  enterprise: false,
+};
+
+describe("matchesWhere", () => {
+  describe("empty and no-op filters", () => {
+    it("matches everything with an empty where", () => {
+      expect(matchesWhere(enterpriseWorkspace, {})).toBe(true);
+      expect(matchesWhere(freeWorkspace, {})).toBe(true);
+    });
+
+    it("ignores a field whose filter is not an object (undefined)", () => {
+      // `enterprise: undefined` is a no-op, not a falsy match.
+      const where: Where<EndpointFilter> = { enterprise: undefined };
+      expect(matchesWhere(enterpriseWorkspace, where)).toBe(true);
+      expect(matchesWhere(freeWorkspace, where)).toBe(true);
+    });
+  });
+
+  describe("scalar filters (enterprise)", () => {
+    it("eq matches the enterprise boolean", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, { enterprise: { eq: true } })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, { enterprise: { eq: false } })
+      ).toBe(false);
+      expect(matchesWhere(freeWorkspace, { enterprise: { eq: false } })).toBe(
+        true
+      );
+    });
+
+    it("neq excludes a matching value", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, { enterprise: { neq: false } })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, { enterprise: { neq: true } })
+      ).toBe(false);
+    });
+
+    it("in matches when the value is included", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, { enterprise: { in: [true] } })
+      ).toBe(true);
+      expect(
+        matchesWhere(freeWorkspace, { enterprise: { in: [true] } })
+      ).toBe(false);
+      // `enterprise: true` is not in `[false]`, so this excludes it.
+      expect(
+        matchesWhere(enterpriseWorkspace, { enterprise: { in: [false] } })
+      ).toBe(false);
+    });
+
+    it("combines multiple scalar conditions (all must pass)", () => {
+      // Combining eq/neq/in is only meaningful on a non-boolean field, since
+      // `ValueFilter<boolean>` distributes into `ScalarValueFilter<true> |
+      // ScalarValueFilter<false>` and cannot mix the two literals.
+      const item = { providerId: "anthropic" };
+      expect(
+        matchesWhere(item, {
+          providerId: {
+            eq: "anthropic",
+            neq: "openai",
+            in: ["anthropic", "google_ai_studio"],
+          },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(item, {
+          providerId: { eq: "anthropic", in: ["openai"] },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("scalar filters on endpoint identity fields", () => {
+    // Mimics matching an endpoint's singular identity fields, e.g. an Anthropic
+    // global Sonnet 4.6 stream endpoint.
+    const endpoint = {
+      providerId: "anthropic",
+      api: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      region: "global",
+    };
+
+    it("eq matches the providerId and region", () => {
+      expect(
+        matchesWhere(endpoint, { providerId: { eq: "anthropic" } })
+      ).toBe(true);
+      expect(matchesWhere(endpoint, { providerId: { eq: "openai" } })).toBe(
+        false
+      );
+      expect(matchesWhere(endpoint, { region: { eq: "global" } })).toBe(true);
+      expect(matchesWhere(endpoint, { region: { eq: "eu" } })).toBe(false);
+    });
+
+    it("in matches against an allowed provider list", () => {
+      expect(
+        matchesWhere(endpoint, {
+          providerId: { in: ["anthropic", "openai"] },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(endpoint, {
+          providerId: { in: ["openai", "google_ai_studio"] },
+        })
+      ).toBe(false);
+    });
+
+    it("matches across several identity fields at once", () => {
+      expect(
+        matchesWhere(endpoint, {
+          providerId: { eq: "anthropic" },
+          api: { eq: "anthropic" },
+          region: { in: ["global", "us"] },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(endpoint, {
+          providerId: { eq: "anthropic" },
+          region: { in: ["eu", "us"] },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("array filters (featureFlags)", () => {
+    it("contains matches a single required flag", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: { contains: "use_vertex_for_supported_models" },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: { contains: "audit_logs" },
+        })
+      ).toBe(false);
+      expect(
+        matchesWhere(freeWorkspace, {
+          featureFlags: { contains: "use_vertex_for_supported_models" },
+        })
+      ).toBe(false);
+    });
+
+    it("containsAny matches when at least one flag is present", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: { containsAny: ["audit_logs", "anthropic_vertex_fallback"] },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: { containsAny: ["audit_logs", "deepseek_feature"] },
+        })
+      ).toBe(false);
+    });
+
+    it("containsAll requires every flag to be present", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: {
+            containsAll: [
+              "use_vertex_for_supported_models",
+              "anthropic_vertex_fallback",
+            ],
+          },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: {
+            containsAll: ["use_vertex_for_supported_models", "audit_logs"],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("isEmpty distinguishes empty and non-empty flag lists", () => {
+      expect(
+        matchesWhere(freeWorkspace, { featureFlags: { isEmpty: true } })
+      ).toBe(true);
+      expect(
+        matchesWhere(freeWorkspace, { featureFlags: { isEmpty: false } })
+      ).toBe(false);
+      expect(
+        matchesWhere(enterpriseWorkspace, { featureFlags: { isEmpty: false } })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, { featureFlags: { isEmpty: true } })
+      ).toBe(false);
+    });
+
+    it("combines multiple array conditions (all must pass)", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: {
+            contains: "anthropic_vertex_fallback",
+            containsAny: ["use_vertex_for_supported_models", "audit_logs"],
+            isEmpty: false,
+          },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          featureFlags: {
+            contains: "anthropic_vertex_fallback",
+            isEmpty: true,
+          },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("array filters on WorkspaceFilter lists", () => {
+    // Mimics an endpoint description that exposes the WorkspaceFilter shape:
+    // which providers / regions / models / apis it covers.
+    const description: WorkspaceFilter = {
+      regions: ["eu", "global"],
+      providerIds: ["anthropic"],
+      modelIds: ["claude-sonnet-4-6"],
+      providerApis: ["anthropic", "agent-platform"],
+    };
+
+    it("matches provider and region membership", () => {
+      expect(
+        matchesWhere(description, { providerIds: { contains: "anthropic" } })
+      ).toBe(true);
+      expect(
+        matchesWhere(description, { regions: { containsAny: ["us", "eu"] } })
+      ).toBe(true);
+      expect(
+        matchesWhere(description, { regions: { contains: "us" } })
+      ).toBe(false);
+    });
+
+    it("matches multiple list fields together", () => {
+      expect(
+        matchesWhere(description, {
+          providerIds: { contains: "anthropic" },
+          providerApis: { containsAll: ["anthropic", "agent-platform"] },
+          regions: { containsAny: ["eu"] },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(description, {
+          providerIds: { contains: "anthropic" },
+          providerApis: { contains: "openai-responses" },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("logical operators", () => {
+    it("and requires every child to match", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          and: [
+            { enterprise: { eq: true } },
+            { featureFlags: { contains: "anthropic_vertex_fallback" } },
+          ],
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          and: [
+            { enterprise: { eq: true } },
+            { featureFlags: { contains: "audit_logs" } },
+          ],
+        })
+      ).toBe(false);
+    });
+
+    it("an empty `and` array is a no-op (matches)", () => {
+      expect(matchesWhere(enterpriseWorkspace, { and: [] })).toBe(true);
+    });
+
+    it("or requires at least one child to match", () => {
+      expect(
+        matchesWhere(freeWorkspace, {
+          or: [
+            { enterprise: { eq: true } },
+            { featureFlags: { isEmpty: true } },
+          ],
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(freeWorkspace, {
+          or: [
+            { enterprise: { eq: true } },
+            { featureFlags: { contains: "audit_logs" } },
+          ],
+        })
+      ).toBe(false);
+    });
+
+    it("an empty `or` array never matches", () => {
+      // `[].some(...)` is false, so an empty `or` excludes everything.
+      expect(matchesWhere(enterpriseWorkspace, { or: [] })).toBe(false);
+    });
+
+    it("not inverts its child", () => {
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          not: { enterprise: { eq: false } },
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          not: { enterprise: { eq: true } },
+        })
+      ).toBe(false);
+    });
+
+    it("supports nested logical operators", () => {
+      // (enterprise AND (vertex flag OR audit flag)) AND NOT(deepseek flag)
+      const where: Where<EndpointFilter> = {
+        and: [
+          { enterprise: { eq: true } },
+          {
+            or: [
+              { featureFlags: { contains: "use_vertex_for_supported_models" } },
+              { featureFlags: { contains: "audit_logs" } },
+            ],
+          },
+        ],
+        not: { featureFlags: { contains: "deepseek_feature" } },
+      };
+      expect(matchesWhere(enterpriseWorkspace, where)).toBe(true);
+      expect(matchesWhere(freeWorkspace, where)).toBe(false);
+    });
+
+    it("combines logical operators with sibling field filters", () => {
+      // Field filters and logical operators in the same `where` must all pass.
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          enterprise: { eq: true },
+          or: [
+            { featureFlags: { contains: "anthropic_vertex_fallback" } },
+            { featureFlags: { contains: "audit_logs" } },
+          ],
+        })
+      ).toBe(true);
+      expect(
+        matchesWhere(enterpriseWorkspace, {
+          enterprise: { eq: false },
+          or: [{ featureFlags: { contains: "anthropic_vertex_fallback" } }],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("realistic endpoint availability scenarios", () => {
+    // A gated endpoint: only available to enterprise workspaces that have the
+    // vertex routing flag enabled.
+    const gatedEndpointFilter: Where<EndpointFilter> = {
+      enterprise: { eq: true },
+      featureFlags: { contains: "use_vertex_for_supported_models" },
+    };
+
+    it("allows an eligible enterprise workspace", () => {
+      expect(matchesWhere(enterpriseWorkspace, gatedEndpointFilter)).toBe(true);
+    });
+
+    it("rejects a non-enterprise workspace", () => {
+      const enterpriseFlagOnly: EndpointFilter = {
+        featureFlags: ["use_vertex_for_supported_models"],
+        enterprise: false,
+      };
+      expect(matchesWhere(enterpriseFlagOnly, gatedEndpointFilter)).toBe(false);
+    });
+
+    it("rejects an enterprise workspace missing the flag", () => {
+      const enterpriseNoFlag: EndpointFilter = {
+        featureFlags: ["anthropic_vertex_fallback"],
+        enterprise: true,
+      };
+      expect(matchesWhere(enterpriseNoFlag, gatedEndpointFilter)).toBe(false);
+    });
+
+    it("an empty endpoint filter is available to all workspaces", () => {
+      // Matches the default `endpointFilter = {}` on the Dust Sonnet 4.6 config.
+      expect(matchesWhere(enterpriseWorkspace, {})).toBe(true);
+      expect(matchesWhere(freeWorkspace, {})).toBe(true);
+    });
+  });
+});

--- a/front/lib/llms/stream/utils/matches_where.ts
+++ b/front/lib/llms/stream/utils/matches_where.ts
@@ -1,0 +1,110 @@
+import type {
+  AnyValueFilter,
+  ArrayValueFilter,
+  LogicalFilters,
+  ScalarValueFilter,
+  Where,
+} from "@app/lib/llms/stream/types/filter";
+import { isRecord } from "@app/types/shared/utils/general";
+import isObject from "lodash/isObject";
+
+export function matchesWhere<T extends object>(
+  item: T,
+  where: Where<T>
+): boolean {
+  const { and, or, not, ...fieldFilters } = where;
+
+  if (and?.some((child) => !matchesWhere(item, child))) {
+    return false;
+  }
+
+  if (or && !or.some((child) => matchesWhere(item, child))) {
+    return false;
+  }
+
+  if (not && matchesWhere(item, not)) {
+    return false;
+  }
+
+  return matchesFieldFilters(item, fieldFilters);
+}
+
+function matchesFieldFilters<T extends object>(
+  item: T,
+  fieldFilters: Omit<Where<T>, keyof LogicalFilters<T>>
+): boolean {
+  const keys = Object.keys(fieldFilters) as Array<keyof typeof fieldFilters>;
+  for (const key of keys) {
+    const value = item[key];
+    const filter = fieldFilters[key];
+
+    if (!matchesValueFilter(value, filter)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function matchesValueFilter(
+  value: unknown,
+  filter: AnyValueFilter | undefined
+): boolean {
+  if (!isObject(filter) || !isRecord(filter)) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return matchesArrayFilter(value, filter);
+  }
+
+  return matchesScalarFilter(value, filter);
+}
+
+function matchesArrayFilter(
+  value: unknown[],
+  filter: ArrayValueFilter<unknown>
+): boolean {
+  if (filter.contains !== undefined && !value.includes(filter.contains)) {
+    return false;
+  }
+
+  if (
+    filter.containsAny !== undefined &&
+    !filter.containsAny.some((candidate) => value.includes(candidate))
+  ) {
+    return false;
+  }
+
+  if (
+    filter.containsAll !== undefined &&
+    !filter.containsAll.every((candidate) => value.includes(candidate))
+  ) {
+    return false;
+  }
+
+  if (filter.isEmpty !== undefined && (value.length === 0) !== filter.isEmpty) {
+    return false;
+  }
+
+  return true;
+}
+
+function matchesScalarFilter(
+  value: unknown,
+  filter: ScalarValueFilter<unknown>
+): boolean {
+  if (filter.eq !== undefined && value !== filter.eq) {
+    return false;
+  }
+
+  if (filter.neq !== undefined && value === filter.neq) {
+    return false;
+  }
+
+  if (filter.in !== undefined && !filter.in.includes(value)) {
+    return false;
+  }
+
+  return true;
+}

--- a/front/lib/llms/stream/utils/matches_where.ts
+++ b/front/lib/llms/stream/utils/matches_where.ts
@@ -83,10 +83,6 @@ function matchesArrayFilter(
     return false;
   }
 
-  if (filter.isEmpty !== undefined && (value.length === 0) !== filter.isEmpty) {
-    return false;
-  }
-
   return true;
 }
 
@@ -95,10 +91,6 @@ function matchesScalarFilter(
   filter: ScalarValueFilter<unknown>
 ): boolean {
   if (filter.eq !== undefined && value !== filter.eq) {
-    return false;
-  }
-
-  if (filter.neq !== undefined && value === filter.neq) {
     return false;
   }
 

--- a/front/lib/model_constructors/batch/configuration.ts
+++ b/front/lib/model_constructors/batch/configuration.ts
@@ -1,8 +1,8 @@
 import type { BatchEndpoint } from "@app/lib/model_constructors/batch/endpoint";
-import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 
-export type BatchModelConfiguration = BaseModelConfiguration;
+export type BatchModelConfiguration = BaseEndpointConfiguration;
 
 export type BatchEndpointConstructor = (new (
   credentials: Credentials

--- a/front/lib/model_constructors/client.ts
+++ b/front/lib/model_constructors/client.ts
@@ -1,4 +1,4 @@
-import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
@@ -8,7 +8,7 @@ import type { Region } from "@app/lib/model_constructors/types/regions";
 export abstract class Client {
   // Re-type `this.constructor` (typed as `Function` by default) so the concrete
   // subclass's static config is visible at the type level.
-  declare ["constructor"]: BaseModelConfiguration;
+  declare ["constructor"]: BaseEndpointConfiguration;
 
   metadata(): EndpointMetadata {
     return {

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -6,7 +6,7 @@ import type { Region } from "@app/lib/model_constructors/types/regions";
 import type { TokenPricing } from "@app/lib/model_constructors/types/token_pricing";
 import type { z } from "zod";
 
-export type BaseModelConfiguration<C extends InputConfig = InputConfig> = {
+export type BaseEndpointConfiguration<C extends InputConfig = InputConfig> = {
   // Identity
   id: `${ProviderId}/${ProviderApi}/${Region}/${ModelId}`;
   providerId: ProviderId;

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -4,7 +4,7 @@ import type {
   RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import AnthropicVertex from "@anthropic-ai/vertex-sdk";
-import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
 import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
 import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
@@ -38,7 +38,7 @@ export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
   )
 ) {
   // Narrow `this.constructor` so the per-endpoint static below is visible.
-  declare ["constructor"]: BaseModelConfiguration & {
+  declare ["constructor"]: BaseEndpointConfiguration & {
     regionalEndpoint: AgentPlatformRegionalEndpoint;
   };
 

--- a/front/lib/model_constructors/stream/configuration.ts
+++ b/front/lib/model_constructors/stream/configuration.ts
@@ -1,8 +1,8 @@
-import type { BaseModelConfiguration } from "@app/lib/model_constructors/configuration";
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 
-export type StreamModelConfiguration = BaseModelConfiguration;
+export type StreamModelConfiguration = BaseEndpointConfiguration;
 
 export type StreamEndpointConstructor = (new (
   credentials: Credentials

--- a/front/lib/reinforcement/run_reinforced_analysis.ts
+++ b/front/lib/reinforcement/run_reinforced_analysis.ts
@@ -1,6 +1,5 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
-import { getLLM } from "@app/lib/api/llm";
+import { getLegacyLLM } from "@app/lib/api/llm";
 import { writeBatchUserMessages } from "@app/lib/api/llm/batch_llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -263,24 +262,22 @@ export async function createReinforcedSkillsConversation(
  */
 export async function getReinforcedSkillsLLM(
   auth: Authenticator,
-  operationType: ReinforcedSkillsOperationType,
-  { forBatch }: { forBatch?: boolean } = {}
+  operationType: ReinforcedSkillsOperationType
 ): Promise<LLM | null> {
   const owner = auth.workspace();
   if (!owner) {
     return null;
   }
 
-  const model = forBatch
-    ? await getLargeWhitelistedModelWithBatchMode(auth)
-    : getLargeWhitelistedModel(auth);
+  const model = await getLargeWhitelistedModelWithBatchMode(auth);
   if (!model) {
     return null;
   }
+
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  return getLLM(auth, {
+  const llmParameters = {
     modelId: model.modelId,
     credentials,
     context: {
@@ -288,7 +285,11 @@ export async function getReinforcedSkillsLLM(
       workspaceId: owner.sId,
       userId: auth.user()?.sId,
     },
-  });
+  };
+
+  const batchLLM = await getLegacyLLM(auth, llmParameters);
+
+  return batchLLM;
 }
 
 /**

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -218,7 +218,7 @@ async function runReinforcedSkillsStep({
   if (!model) {
     logger.error(
       { contextId, workspaceId: owner.sId },
-      "ReinforcedSkills: no model confiuguration available for step activity"
+      "ReinforcedSkills: no model configuration available for step activity"
     );
     return {
       isTerminal: true,

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -1,6 +1,8 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationAsTextWithFeedback } from "@app/lib/api/assistant/conversation/render_conversation_with_feedback";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { getLargeWhitelistedModel } from "@app/lib/api/assistant/models";
+import { getLLM } from "@app/lib/api/llm";
 import type { LlmConversationOptions } from "@app/lib/api/llm/batch_llm";
 import {
   downloadBatchResultFromLlm,
@@ -13,6 +15,7 @@ import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
 import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { intelligenceAwuFromRunUsages } from "@app/lib/metronome/events";
 import { getRemainingProgrammaticUsageFromMetronome } from "@app/lib/metronome/programmatic_awu_usage";
@@ -200,12 +203,47 @@ async function runReinforcedSkillsStep({
   approvedSourceSuggestionIds: string[];
   toolActionInfo?: ReinforcedToolActionInfo;
 }> {
-  const llm = await getReinforcedSkillsLLM(auth, operationType, {
-    forBatch: false,
+  const owner = auth.workspace();
+  if (!owner) {
+    logger.error({ contextId }, "ReinforcedSkills: no Workspace found");
+    return {
+      isTerminal: true,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
+  }
+
+  const model = getLargeWhitelistedModel(auth);
+
+  if (!model) {
+    logger.error(
+      { contextId, workspaceId: owner.sId },
+      "ReinforcedSkills: no model confiuguration available for step activity"
+    );
+    return {
+      isTerminal: true,
+      suggestionsCreated: 0,
+      approvedSourceSuggestionIds: [],
+    };
+  }
+
+  const credentials = await getLlmCredentials(auth, {
+    skipEmbeddingApiKeyRequirement: true,
   });
+  const llmParameters = {
+    modelId: model.modelId,
+    credentials,
+    context: {
+      operationType,
+      workspaceId: owner.sId,
+      userId: auth.user()?.sId,
+    },
+  };
+
+  const llm = await getLLM(auth, llmParameters);
   if (!llm) {
     logger.error(
-      { contextId, workspaceId: auth.getNonNullableWorkspace().sId },
+      { contextId, workspaceId: owner.sId },
       "ReinforcedSkills: no LLM available for step activity"
     );
     return {
@@ -1012,8 +1050,7 @@ export async function checkBatchStatusActivity({
 
   const llm = await getReinforcedSkillsLLM(
     auth,
-    "reinforcement_analyze_conversation",
-    { forBatch: true }
+    "reinforcement_analyze_conversation"
   );
   if (!llm) {
     throw ApplicationFailure.nonRetryable(
@@ -1051,8 +1088,7 @@ export async function startSkillConversationAnalysisBatchActivity({
 
   const llm = await getReinforcedSkillsLLM(
     auth,
-    "reinforcement_analyze_conversation",
-    { forBatch: true }
+    "reinforcement_analyze_conversation"
   );
   if (!llm) {
     logger.warn(
@@ -1184,8 +1220,7 @@ export async function processSkillConversationAnalysisBatchResultActivity({
 
   const llm = await getReinforcedSkillsLLM(
     auth,
-    "reinforcement_analyze_conversation",
-    { forBatch: true }
+    "reinforcement_analyze_conversation"
   );
   if (!llm) {
     return [];
@@ -1348,8 +1383,7 @@ export async function startSkillAggregationBatchActivity({
 
   const llm = await getReinforcedSkillsLLM(
     auth,
-    "reinforcement_aggregate_suggestions",
-    { forBatch: true }
+    "reinforcement_aggregate_suggestions"
   );
   if (!llm) {
     logger.warn(
@@ -1459,8 +1493,7 @@ export async function processSkillAggregationBatchResultActivity({
 
   const llm = await getReinforcedSkillsLLM(
     auth,
-    "reinforcement_aggregate_suggestions",
-    { forBatch: true }
+    "reinforcement_aggregate_suggestions"
   );
   if (!llm) {
     return {

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -2,7 +2,7 @@ import {
   formatAvailableTools,
   formatMcpDescription,
 } from "@app/lib/api/assistant/global_agents/sidekick_context";
-import { getLLM } from "@app/lib/api/llm";
+import { getLegacyLLM, getLLM } from "@app/lib/api/llm";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { BatchResultWithRunIds } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
@@ -302,15 +302,22 @@ async function executeMultiStep(
   return { toolCalls: allToolCalls, responseText: lastResponseText };
 }
 
-async function getLLMInstance(auth: Authenticator): Promise<LLM> {
+async function getLLMInstance(
+  auth: Authenticator,
+  surface: "stream" | "batch" = "stream"
+): Promise<LLM> {
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
   });
-  const llm = await getLLM(auth, {
+  const llmParameters = {
     credentials,
     modelId: MODEL_ID,
     bypassFeatureFlag: true,
-  });
+  };
+  const llm =
+    surface === "batch"
+      ? await getLegacyLLM(auth, llmParameters)
+      : await getLLM(auth, llmParameters);
   if (!llm) {
     throw new Error(
       `Failed to initialize LLM for reinforcement eval (model: ${MODEL_ID})`
@@ -365,7 +372,7 @@ export async function executeBatch(
   auth: Authenticator,
   testCases: CategorizedTestCase[]
 ): Promise<Map<string, ExecutionResult>> {
-  const llm = await getLLMInstance(auth);
+  const llm = await getLLMInstance(auth, "batch");
 
   const testCaseById = new Map<string, CategorizedTestCase>();
   for (const tc of testCases) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -320,6 +320,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to admin governance features, including assigning the business_admin role from the UI",
     stage: "dust_only",
   },
+  use_new_llm_router: {
+    description: "Use the new LLM router for model selection and routing",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -776,6 +776,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "metronome_billing_usage_page"
   | "user_settings_v2"
   | "admin_governance"
+  | "use_new_llm_router"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Introduces a `use_new_llm_router` feature flag and a `StreamEndpointTransition` bridge that routes streaming LLM calls through the new model-router endpoint (with availability/where-clause filtering) while falling back to the legacy `getLLM` path when the flag is off.

## Tests

Tested locally; added unit tests for `matchesWhere` and endpoint-availability filtering, and updated LLM/reinforcement tests to select the legacy or new `getLLM` per surface.

## Risk

Low — new routing is gated behind the `use_new_llm_router` flag and defaults to the legacy path.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`