### PR TITLE
refacto: avoid conversation join when fetching sandbox

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -33,7 +33,10 @@ app.get(
       });
     }
 
-    const sandbox = await SandboxResource.fetchByConversationId(auth, cId);
+    const sandbox = await SandboxResource.fetchByConversation(
+      auth,
+      conversation.toJSON()
+    );
 
     return ctx.json({
       sandboxStatus: sandbox?.status ?? null,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -308,7 +308,7 @@ export async function destroyConversation(
     where: { workspaceId: owner.id, sourceId: conversation.sId },
   });
 
-  await SandboxResource.deleteByConversationId(auth, conversation.sId);
+  await SandboxResource.deleteByConversation(auth, conversation);
 
   // TODO(2026-03-09 SANDBOX): Implement proper file deletion.
   // FileResource records associated with this conversation (via

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -8,7 +8,10 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import type {
+  ConversationWithoutContentType,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
 
 /**
  * Called when a sandbox-child action enters a blocked state. Flips the
@@ -22,7 +25,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 export async function pauseSandboxBashForBlockedChild(
   auth: Authenticator,
   action: AgentMCPActionResource,
-  conversation: { sId: string }
+  conversation: ConversationWithoutContentType
 ): Promise<void> {
   const info = action.stepContext.sandboxChildActionInfo;
   if (!isSandboxChildActionInfo(info)) {
@@ -57,7 +60,7 @@ export async function pauseSandboxBashForBlockedChild(
 
   const pauseResult = await SandboxResource.pauseForApproval(
     auth,
-    conversation.sId
+    conversation
   );
   if (pauseResult.isErr()) {
     logger.error(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -263,12 +263,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     {
       transaction,
       excludeTest,
+      includeDeleted,
       updatedAfter,
       includeForkingData,
       loadSpaces,
     }: {
       transaction?: Transaction;
       excludeTest?: boolean;
+      includeDeleted?: boolean;
       updatedAfter?: Date;
       includeForkingData?: boolean;
       loadSpaces?: boolean;
@@ -280,7 +282,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const workspace = auth.getNonNullableWorkspace();
 
-    const excludedVisibilities: ConversationVisibility[] = ["deleted"];
+    const excludedVisibilities: ConversationVisibility[] = [];
+
+    if (!includeDeleted) {
+      excludedVisibilities.push("deleted");
+    }
     if (excludeTest) {
       excludedVisibilities.push("test");
     }
@@ -289,7 +295,9 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       where: {
         workspaceId: workspace.id,
         id: ids,
-        visibility: { [Op.notIn]: excludedVisibilities },
+        ...(excludedVisibilities.length > 0
+          ? { visibility: { [Op.notIn]: excludedVisibilities } }
+          : {}),
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
       ...(includeForkingData ? { include: this.getForkedFromInclude() } : {}),

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -263,14 +263,12 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     {
       transaction,
       excludeTest,
-      includeDeleted,
       updatedAfter,
       includeForkingData,
       loadSpaces,
     }: {
       transaction?: Transaction;
       excludeTest?: boolean;
-      includeDeleted?: boolean;
       updatedAfter?: Date;
       includeForkingData?: boolean;
       loadSpaces?: boolean;
@@ -282,11 +280,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const workspace = auth.getNonNullableWorkspace();
 
-    const excludedVisibilities: ConversationVisibility[] = [];
+    const excludedVisibilities: ConversationVisibility[] = ["deleted"];
 
-    if (!includeDeleted) {
-      excludedVisibilities.push("deleted");
-    }
     if (excludeTest) {
       excludedVisibilities.push("test");
     }
@@ -295,9 +290,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       where: {
         workspaceId: workspace.id,
         id: ids,
-        ...(excludedVisibilities.length > 0
-          ? { visibility: { [Op.notIn]: excludedVisibilities } }
-          : {}),
+        visibility: { [Op.notIn]: excludedVisibilities },
         ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
       } as WhereOptions<ConversationModel>,
       ...(includeForkingData ? { include: this.getForkedFromInclude() } : {}),
@@ -327,6 +320,33 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           : null
       )
     );
+  }
+
+  /**
+   * Fetch conversations by ModelId across all workspaces (no auth scoping).
+   * Used by the sandbox reaper, which operates across every workspace and only
+   * needs the conversation rows to drive sandbox lifecycle transitions.
+   *
+   * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
+   */
+  static async dangerouslyFetchByModelIds(
+    ids: ModelId[]
+  ): Promise<ConversationResource[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    // The reaper needs to drive sandbox lifecycle transitions even for deleted
+    // conversations, so we include every visibility here.
+    const conversations = await this.model.findAll({
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+      where: {
+        id: ids,
+      },
+    });
+
+    return conversations.map((c) => this.fromModel(c, null));
   }
 
   get forkingData(): ConversationForkingDataType | undefined {

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -50,6 +50,7 @@ vi.mock("@app/lib/lock", () => ({
 }));
 
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
@@ -135,9 +136,9 @@ describe("SandboxResource.updateStatus", () => {
 
     expect(mockDistribution).not.toHaveBeenCalled();
 
-    const reloaded = await SandboxResource.fetchByConversationId(
+    const reloaded = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversation
     );
     expect(reloaded?.statusChangedAt?.getTime()).toBe(
       originalStatusChangedAt?.getTime()
@@ -156,9 +157,9 @@ describe("SandboxResource.updateStatus", () => {
     await sandbox.updateStatus("sleeping", { ctx });
     const afterTransition = Date.now();
 
-    const reloaded = await SandboxResource.fetchByConversationId(
+    const reloaded = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversation
     );
     expect(reloaded?.status).toBe("sleeping");
     expect(reloaded?.statusChangedAt?.getTime()).toBeGreaterThanOrEqual(
@@ -172,7 +173,7 @@ describe("SandboxResource.updateStatus", () => {
 
 describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
   let authenticator: Authenticator;
-  let conversation: ConversationType;
+  let conversationResource: ConversationResource;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -191,20 +192,32 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
 
     const agentConfig =
       await AgentConfigurationFactory.createTestAgent(authenticator);
-    conversation = await ConversationFactory.create(authenticator, {
+    const conversation = await ConversationFactory.create(authenticator, {
       agentConfigurationId: agentConfig.sId,
       messagesCreatedAt: [new Date()],
     });
+    const fetched = await ConversationResource.fetchById(
+      authenticator,
+      conversation.sId
+    );
+    if (!fetched) {
+      throw new Error("Conversation not found.");
+    }
+    conversationResource = fetched;
   });
 
   it("deletes the sandbox egress policy after provider destroy succeeds", async () => {
-    const sandbox = await SandboxFactory.create(authenticator, conversation, {
-      status: "sleeping",
-    });
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON(),
+      {
+        status: "sleeping",
+      }
+    );
 
     const result = await SandboxResource.dangerouslyDestroyIfSleeping(
       authenticator,
-      conversation.sId
+      conversationResource
     );
 
     expect(result.isOk()).toBe(true);
@@ -213,9 +226,9 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
     });
     expect(mockDeleteSandboxPolicy).toHaveBeenCalledWith(sandbox.providerId);
 
-    const reloaded = await SandboxResource.fetchByConversationId(
+    const reloaded = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversationResource.toJSON()
     );
     expect(reloaded?.status).toBe("deleted");
   });
@@ -223,7 +236,7 @@ describe("SandboxResource.dangerouslyDestroyIfSleeping", () => {
 
 describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
   let authenticator: Authenticator;
-  let conversation: ConversationType;
+  let conversationResource: ConversationResource;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -242,10 +255,18 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
 
     const agentConfig =
       await AgentConfigurationFactory.createTestAgent(authenticator);
-    conversation = await ConversationFactory.create(authenticator, {
+    const conversation = await ConversationFactory.create(authenticator, {
       agentConfigurationId: agentConfig.sId,
       messagesCreatedAt: [new Date()],
     });
+    const fetched = await ConversationResource.fetchById(
+      authenticator,
+      conversation.sId
+    );
+    if (!fetched) {
+      throw new Error("Conversation not found.");
+    }
+    conversationResource = fetched;
   });
 
   it.each([
@@ -253,14 +274,18 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
     "sleeping",
     "pending_approval",
   ] as const)("destroys at the provider and marks deleted regardless of status (%s)", async (status) => {
-    const sandbox = await SandboxFactory.create(authenticator, conversation, {
-      status,
-      killRequestedAt: new Date(),
-    });
+    const sandbox = await SandboxFactory.create(
+      authenticator,
+      conversationResource.toJSON(),
+      {
+        status,
+        killRequestedAt: new Date(),
+      }
+    );
 
     const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
       authenticator,
-      conversation.sId
+      conversationResource
     );
 
     expect(result.isOk()).toBe(true);
@@ -268,42 +293,42 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
       workspaceId: authenticator.getNonNullableWorkspace().sId,
     });
 
-    const reloaded = await SandboxResource.fetchByConversationId(
+    const reloaded = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversationResource.toJSON()
     );
     expect(reloaded?.status).toBe("deleted");
   });
 
   it("is a no-op when killRequestedAt is not set", async () => {
-    await SandboxFactory.create(authenticator, conversation, {
+    await SandboxFactory.create(authenticator, conversationResource.toJSON(), {
       status: "running",
     });
 
     const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
       authenticator,
-      conversation.sId
+      conversationResource
     );
 
     expect(result.isOk()).toBe(true);
     expect(mockProviderDestroy).not.toHaveBeenCalled();
 
-    const reloaded = await SandboxResource.fetchByConversationId(
+    const reloaded = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversationResource.toJSON()
     );
     expect(reloaded?.status).toBe("running");
   });
 
   it("is a no-op when the sandbox is already deleted", async () => {
-    await SandboxFactory.create(authenticator, conversation, {
+    await SandboxFactory.create(authenticator, conversationResource.toJSON(), {
       status: "deleted",
       killRequestedAt: new Date(),
     });
 
     const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
       authenticator,
-      conversation.sId
+      conversationResource
     );
 
     expect(result.isOk()).toBe(true);
@@ -311,7 +336,7 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested", () => {
   });
 });
 
-describe("SandboxResource.dangerouslyGetKillRequestedConversationIds", () => {
+describe("SandboxResource.dangerouslyGetKillRequestedSandboxes", () => {
   let authenticator: Authenticator;
   let conversation: ConversationType;
 
@@ -334,13 +359,12 @@ describe("SandboxResource.dangerouslyGetKillRequestedConversationIds", () => {
       killRequestedAt: new Date(),
     });
 
-    const rows =
-      await SandboxResource.dangerouslyGetKillRequestedConversationIds({
-        limit: 10,
-      });
+    const rows = await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+      limit: 10,
+    });
 
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.conversationId).toBe(conversation.sId);
+    expect(rows[0]?.conversationId).toBe(conversation.id);
   });
 
   it("skips deleted rows even when killRequestedAt is set", async () => {
@@ -349,10 +373,9 @@ describe("SandboxResource.dangerouslyGetKillRequestedConversationIds", () => {
       killRequestedAt: new Date(),
     });
 
-    const rows =
-      await SandboxResource.dangerouslyGetKillRequestedConversationIds({
-        limit: 10,
-      });
+    const rows = await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+      limit: 10,
+    });
 
     expect(rows).toHaveLength(0);
   });
@@ -362,10 +385,9 @@ describe("SandboxResource.dangerouslyGetKillRequestedConversationIds", () => {
       status: "running",
     });
 
-    const rows =
-      await SandboxResource.dangerouslyGetKillRequestedConversationIds({
-        limit: 10,
-      });
+    const rows = await SandboxResource.dangerouslyGetKillRequestedSandboxes({
+      limit: 10,
+    });
 
     expect(rows).toHaveLength(0);
   });
@@ -415,9 +437,9 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(2);
-    const stillUnmarked = await SandboxResource.fetchByConversationId(
+    const stillUnmarked = await SandboxResource.fetchByConversation(
       authenticator,
-      other.sId
+      other
     );
     expect(stillUnmarked?.killRequestedAt).toBeNull();
   });
@@ -452,9 +474,9 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(2);
-    const matched = await SandboxResource.fetchByConversationId(
+    const matched = await SandboxResource.fetchByConversation(
       authenticator,
-      cMatch.sId
+      cMatch
     );
     expect(matched?.killRequestedAt).toBeNull();
   });
@@ -482,9 +504,9 @@ describe("SandboxResource.dangerouslyRequestKillForBaseImage", () => {
     });
 
     expect(affected).toBe(1);
-    const alreadyMarked = await SandboxResource.fetchByConversationId(
+    const alreadyMarked = await SandboxResource.fetchByConversation(
       authenticator,
-      cAlreadyMarked.sId
+      cAlreadyMarked
     );
     expect(alreadyMarked?.killRequestedAt?.toISOString()).toBe(
       new Date("2020-01-01").toISOString()
@@ -652,9 +674,9 @@ describe("SandboxResource.ensureActive", () => {
 
     expect(result.isOk()).toBe(true);
 
-    const persisted = await SandboxResource.fetchByConversationId(
+    const persisted = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversation
     );
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
@@ -674,9 +696,9 @@ describe("SandboxResource.ensureActive", () => {
 
     expect(result.isOk()).toBe(true);
 
-    const persisted = await SandboxResource.fetchByConversationId(
+    const persisted = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversation
     );
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
@@ -703,9 +725,9 @@ describe("SandboxResource.ensureActive", () => {
     });
     expect(mockProviderCreate).toHaveBeenCalled();
 
-    const persisted = await SandboxResource.fetchByConversationId(
+    const persisted = await SandboxResource.fetchByConversation(
       authenticator,
-      conversation.sId
+      conversation
     );
     expect(persisted?.providerId).toBe("provider-id");
     expect(persisted?.baseImage).toBe("test-image");

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -18,8 +18,8 @@ import type { RootCommand } from "@app/lib/api/sandbox/root_command";
 import { SANDBOX_TRUST_ENV_VARS } from "@app/lib/api/sandbox/trust_env";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
-import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -28,7 +28,7 @@ import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import logger from "@app/logger/logger";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -147,17 +147,17 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
-   * Return conversation sIds and workspace ModelIds for sandboxes with the given `status`
-   * whose `lastActivityAt` is older than `olderThanMs`. Used by the reaper
-   * workflow to identify candidates for sleep/destroy.
+   * Return sandboxes with the given `status` whose `lastActivityAt` is older
+   * than `olderThanMs`. Used by the reaper workflow to identify candidates for
+   * sleep/destroy.
    *
    * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
-  static async dangerouslyGetStaleConversationIds(opts: {
+  static async dangerouslyGetStaleSandboxes(opts: {
     status: SandboxStatus;
     olderThanMs: number;
     limit: number;
-  }): Promise<Array<{ conversationId: string; workspaceModelId: ModelId }>> {
+  }): Promise<SandboxResource[]> {
     const rows = await this.model.findAll({
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
@@ -167,21 +167,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
           [Op.lt]: new Date(Date.now() - opts.olderThanMs),
         },
       },
-      include: [
-        {
-          model: ConversationModel,
-          attributes: ["sId", "workspaceId"],
-          required: true,
-        },
-      ],
       order: [["lastActivityAt", "ASC"]],
       limit: opts.limit,
     });
 
-    return rows.map((r) => ({
-      conversationId: r.conversation.sId,
-      workspaceModelId: r.conversation.workspaceId,
-    }));
+    return rows.map((r) => new this(this.model, r.get()));
   }
 
   /**
@@ -190,42 +180,35 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    *
    * / WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
-  private static async dangerouslyFetchByConversationId(
-    conversationId: string
+  private static async dangerouslyFetchByConversation(
+    conversation: ConversationResource
   ): Promise<SandboxResource | null> {
     const row = await this.model.findOne({
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
-      include: [
-        {
-          model: ConversationModel,
-          attributes: [],
-          required: true,
-          where: { sId: conversationId },
-        },
-      ],
+      where: {
+        conversationId: conversation.id,
+      },
     });
 
     return row ? new this(this.model, row.get()) : null;
   }
 
-  static async fetchByConversationId(
+  static async fetchByConversation(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationWithoutContentType
   ): Promise<SandboxResource | null> {
-    const row = await this.model.findOne({
-      where: { workspaceId: auth.getNonNullableWorkspace().id },
-      include: [
-        {
-          model: ConversationModel,
-          attributes: [],
-          required: true,
-          where: { sId: conversationId },
-        },
-      ],
+    const sandboxes = await this.baseFetch(auth, {
+      where: {
+        conversationId: conversation.id,
+      },
     });
 
-    return row ? new this(this.model, row.get()) : null;
+    if (sandboxes.length === 0) {
+      return null;
+    }
+
+    return sandboxes[0];
   }
 
   async updateStatus(
@@ -282,14 +265,14 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    * Full cleanup under the lifecycle lock: best-effort destroy at the provider,
    * then delete the DB row.
    */
-  static async deleteByConversationId(
+  static async deleteByConversation(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationResource
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversationId, async (provider) => {
-      const sandbox = await SandboxResource.fetchByConversationId(
+    return this.withLifecycleLock(conversation.sId, async (provider) => {
+      const sandbox = await SandboxResource.fetchByConversation(
         auth,
-        conversationId
+        conversation.toJSON()
       );
       if (!sandbox) {
         return new Ok(undefined);
@@ -348,7 +331,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   // cannot shadow a system var like CONVERSATION_ID.
   private static async buildSandboxEnvVars(
     auth: Authenticator,
-    conversation: ConversationType,
+    conversation: ConversationWithoutContentType,
     imageEnvVars: Record<string, string> | undefined
   ): Promise<Result<Record<string, string>, Error>> {
     const workspaceEnvResult =
@@ -387,7 +370,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async ensureActive(
     auth: Authenticator,
-    conversation: ConversationType
+    conversation: ConversationWithoutContentType
   ): Promise<Result<EnsureSandboxResult, Error>> {
     assert(
       auth.getNonNullableWorkspace().id !== undefined,
@@ -397,9 +380,9 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     return this.withLifecycleLock(conversation.sId, async (provider) => {
       const ctx = { workspaceId: auth.getNonNullableWorkspace().sId };
       const tracingOpts = { workspaceId: auth.getNonNullableWorkspace().sId };
-      const existing = await SandboxResource.fetchByConversationId(
+      const existing = await SandboxResource.fetchByConversation(
         auth,
-        conversation.sId
+        conversation
       );
 
       if (!existing) {
@@ -597,11 +580,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslySleepIfRunning(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationResource
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversationId, async (provider) => {
+    return this.withLifecycleLock(conversation.sId, async (provider) => {
       const sandbox =
-        await SandboxResource.dangerouslyFetchByConversationId(conversationId);
+        await SandboxResource.dangerouslyFetchByConversation(conversation);
       if (!sandbox || sandbox.status !== "running") {
         return new Ok(undefined);
       }
@@ -636,12 +619,12 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async pauseForApproval(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationWithoutContentType
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversationId, async (provider) => {
-      const sandbox = await SandboxResource.fetchByConversationId(
+    return this.withLifecycleLock(conversation.sId, async (provider) => {
+      const sandbox = await SandboxResource.fetchByConversation(
         auth,
-        conversationId
+        conversation
       );
       if (!sandbox || sandbox.status !== "running") {
         return new Ok(undefined);
@@ -688,11 +671,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslySleepIfPendingApproval(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationResource
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversationId, async () => {
+    return this.withLifecycleLock(conversation.sId, async () => {
       const sandbox =
-        await SandboxResource.dangerouslyFetchByConversationId(conversationId);
+        await SandboxResource.dangerouslyFetchByConversation(conversation);
       if (!sandbox || sandbox.status !== "pending_approval") {
         return new Ok(undefined);
       }
@@ -717,11 +700,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslyDestroyIfSleeping(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationResource
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversationId, async (provider) => {
+    return this.withLifecycleLock(conversation.sId, async (provider) => {
       const sandbox =
-        await SandboxResource.dangerouslyFetchByConversationId(conversationId);
+        await SandboxResource.dangerouslyFetchByConversation(conversation);
       if (!sandbox || sandbox.status !== "sleeping") {
         return new Ok(undefined);
       }
@@ -814,15 +797,15 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   }
 
   /**
-   * Return conversation sIds for sandboxes with `killRequestedAt` set and not
-   * yet deleted. The kill-requester workflow marks rows; the reaper (and the
-   * bash path) is responsible for actually destroying them.
+   * Return sandboxes with `killRequestedAt` set and not yet deleted. The
+   * kill-requester workflow marks rows; the reaper (and the bash path) is
+   * responsible for actually destroying them.
    *
    * WORKSPACE_ISOLATION_BYPASS: The reaper operates across all workspaces.
    */
-  static async dangerouslyGetKillRequestedConversationIds(opts: {
+  static async dangerouslyGetKillRequestedSandboxes(opts: {
     limit: number;
-  }): Promise<Array<{ conversationId: string; workspaceModelId: ModelId }>> {
+  }): Promise<SandboxResource[]> {
     const rows = await this.model.findAll({
       // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
       dangerouslyBypassWorkspaceIsolationSecurity: true,
@@ -830,21 +813,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         killRequestedAt: { [Op.ne]: null },
         status: { [Op.ne]: "deleted" },
       },
-      include: [
-        {
-          model: ConversationModel,
-          attributes: ["sId", "workspaceId"],
-          required: true,
-        },
-      ],
       order: [["killRequestedAt", "ASC"]],
       limit: opts.limit,
     });
 
-    return rows.map((r) => ({
-      conversationId: r.conversation.sId,
-      workspaceModelId: r.conversation.workspaceId,
-    }));
+    return rows.map((r) => new this(this.model, r.get()));
   }
 
   /**
@@ -857,11 +830,11 @@ export class SandboxResource extends BaseResource<SandboxModel> {
    */
   static async dangerouslyDestroyIfKillRequested(
     auth: Authenticator,
-    conversationId: string
+    conversation: ConversationResource
   ): Promise<Result<void, Error>> {
-    return this.withLifecycleLock(conversationId, async (provider) => {
+    return this.withLifecycleLock(conversation.sId, async (provider) => {
       const sandbox =
-        await SandboxResource.dangerouslyFetchByConversationId(conversationId);
+        await SandboxResource.dangerouslyFetchByConversation(conversation);
       if (
         !sandbox ||
         sandbox.status === "deleted" ||

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -7,7 +7,6 @@ import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { heartbeat } from "@temporalio/activity";
-import groupBy from "lodash/groupBy";
 
 import {
   BATCH_SIZE,
@@ -49,33 +48,17 @@ async function fetchAuthMap(
 
 /**
  * Fetch the ConversationResource for each sandbox, keyed by conversation
- * ModelId. `ConversationResource.fetchByModelIds` is workspace-scoped, so we
- * group the conversation ids by workspace and issue one scoped query per
- * workspace (batched — never one query per conversation).
+ * ModelId. The reaper spans every workspace, so we issue a single
+ * cross-workspace query instead of one scoped query per workspace.
  */
 async function fetchConversationMap(
-  sandboxes: SandboxResource[],
-  authMap: Map<ModelId, Authenticator>
+  sandboxes: SandboxResource[]
 ): Promise<Map<ModelId, ConversationResource>> {
-  const sandboxesByWorkspace = groupBy(sandboxes, (s) => s.workspaceId);
-  const conversationMap = new Map<ModelId, ConversationResource>();
+  const conversations = await ConversationResource.dangerouslyFetchByModelIds(
+    sandboxes.map((s) => s.conversationId)
+  );
 
-  for (const [workspaceModelId, auth] of authMap) {
-    const conversationModelIds = (
-      sandboxesByWorkspace[workspaceModelId] ?? []
-    ).map((s) => s.conversationId);
-
-    const conversations = await ConversationResource.fetchByModelIds(
-      auth,
-      conversationModelIds,
-      { includeDeleted: true }
-    );
-    for (const conversation of conversations) {
-      conversationMap.set(conversation.id, conversation);
-    }
-  }
-
-  return conversationMap;
+  return new Map(conversations.map((c) => [c.id, c]));
 }
 
 /**
@@ -93,7 +76,7 @@ async function processSandboxes(
   errorMessage: string
 ): Promise<void> {
   const authMap = await fetchAuthMap(sandboxes);
-  const conversationMap = await fetchConversationMap(sandboxes, authMap);
+  const conversationMap = await fetchConversationMap(sandboxes);
 
   await concurrentExecutor(
     sandboxes,

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -1,10 +1,13 @@
 import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
 import { heartbeat } from "@temporalio/activity";
+import groupBy from "lodash/groupBy";
 
 import {
   BATCH_SIZE,
@@ -16,241 +19,208 @@ import {
 const REAPER_CONCURRENCY = 16;
 
 /**
- * Batch-fetch workspaces for a list of conversations to avoid N+1 queries.
- * Returns a Map for O(1) lookup during concurrent processing.
+ * Build a workspace-scoped internal Authenticator for each workspace touched by
+ * the batch. One query for all workspaces, then one builder per workspace.
  */
-async function fetchWorkspaceMap(
-  conversations: Array<{ conversationId: string; workspaceModelId: ModelId }>
-): Promise<Map<ModelId, WorkspaceResource>> {
+async function fetchAuthMap(
+  sandboxes: SandboxResource[]
+): Promise<Map<ModelId, Authenticator>> {
   const uniqueWorkspaceModelIds = [
-    ...new Set(conversations.map((c) => c.workspaceModelId)),
+    ...new Set(sandboxes.map((s) => s.workspaceId)),
   ];
 
   const workspaces = await WorkspaceResource.fetchByModelIds(
     uniqueWorkspaceModelIds
   );
 
-  return new Map(workspaces.map((w) => [w.id, w]));
+  const entries = await concurrentExecutor(
+    workspaces,
+    async (w) => {
+      const authenticator = await Authenticator.internalBuilderForWorkspace(
+        w.sId
+      );
+      return [w.id, authenticator] as const;
+    },
+    { concurrency: REAPER_CONCURRENCY }
+  );
+
+  return new Map(entries);
 }
 
 /**
- * Process one batch of stale sandboxes. Returns `true` when either query
- * returned a full batch, signalling the workflow to loop for more.
+ * Fetch the ConversationResource for each sandbox, keyed by conversation
+ * ModelId. `ConversationResource.fetchByModelIds` is workspace-scoped, so we
+ * group the conversation ids by workspace and issue one scoped query per
+ * workspace (batched — never one query per conversation).
+ */
+async function fetchConversationMap(
+  sandboxes: SandboxResource[],
+  authMap: Map<ModelId, Authenticator>
+): Promise<Map<ModelId, ConversationResource>> {
+  const sandboxesByWorkspace = groupBy(sandboxes, (s) => s.workspaceId);
+  const conversationMap = new Map<ModelId, ConversationResource>();
+
+  for (const [workspaceModelId, auth] of authMap) {
+    const conversationModelIds = (
+      sandboxesByWorkspace[workspaceModelId] ?? []
+    ).map((s) => s.conversationId);
+
+    const conversations = await ConversationResource.fetchByModelIds(
+      auth,
+      conversationModelIds,
+      { includeDeleted: true }
+    );
+    for (const conversation of conversations) {
+      conversationMap.set(conversation.id, conversation);
+    }
+  }
+
+  return conversationMap;
+}
+
+/**
+ * Shared driver for every reaper phase: resolve the workspace auth and the
+ * ConversationResource for each sandbox, then run `action` concurrently. The
+ * lifecycle methods take the serialized conversation, so we pass
+ * `conversation.toJSON()`.
+ */
+async function processSandboxes(
+  sandboxes: SandboxResource[],
+  action: (
+    auth: Authenticator,
+    conversation: ConversationResource
+  ) => Promise<Result<void, Error>>,
+  errorMessage: string
+): Promise<void> {
+  const authMap = await fetchAuthMap(sandboxes);
+  const conversationMap = await fetchConversationMap(sandboxes, authMap);
+
+  await concurrentExecutor(
+    sandboxes,
+    async (sandbox) => {
+      const auth = authMap.get(sandbox.workspaceId);
+      const conversation = conversationMap.get(sandbox.conversationId);
+
+      if (!auth || !conversation) {
+        logger.warn(
+          {
+            conversationModelId: sandbox.conversationId,
+            workspaceModelId: sandbox.workspaceId,
+          },
+          "Reaper: workspace or conversation not found, skipping."
+        );
+        return;
+      }
+
+      const result = await action(auth, conversation);
+      if (result.isErr()) {
+        logger.error(
+          {
+            conversationModelId: sandbox.conversationId,
+            error: result.error.message,
+          },
+          errorMessage
+        );
+      }
+      heartbeat();
+    },
+    { concurrency: REAPER_CONCURRENCY }
+  );
+}
+
+/**
+ * Process one batch of stale sandboxes. Returns `true` when any query returned a
+ * full batch, signalling the workflow to loop for more.
  */
 export async function reapStaleSandboxesActivity(): Promise<boolean> {
   // Phase 0: Destroy sandboxes flagged with killRequestedAt. These bypass the
   // sleep→destroy cycle and are reaped immediately regardless of status/age.
-  const killRequestedConversations =
-    await SandboxResource.dangerouslyGetKillRequestedConversationIds({
+  const killRequestedSandboxes =
+    await SandboxResource.dangerouslyGetKillRequestedSandboxes({
       limit: BATCH_SIZE,
     });
 
-  if (killRequestedConversations.length > 0) {
+  if (killRequestedSandboxes.length > 0) {
     logger.info(
-      { count: killRequestedConversations.length },
+      { count: killRequestedSandboxes.length },
       "Reaper: kill-requested sandboxes found."
     );
 
-    const workspaceMap = await fetchWorkspaceMap(killRequestedConversations);
-
-    await concurrentExecutor(
-      killRequestedConversations,
-      async ({ conversationId, workspaceModelId }) => {
-        const workspace = workspaceMap.get(workspaceModelId);
-
-        if (!workspace) {
-          logger.warn(
-            { conversationId, workspaceModelId },
-            "Workspace not found, skipping"
-          );
-          return;
-        }
-
-        const auth = await Authenticator.internalBuilderForWorkspace(
-          workspace.sId
-        );
-        const result = await SandboxResource.dangerouslyDestroyIfKillRequested(
-          auth,
-          conversationId
-        );
-        if (result.isErr()) {
-          logger.error(
-            { conversationId, error: result.error.message },
-            "Reaper: failed to destroy kill-requested sandbox — continuing."
-          );
-        }
-        heartbeat();
-      },
-      { concurrency: REAPER_CONCURRENCY }
+    await processSandboxes(
+      killRequestedSandboxes,
+      (auth, conversation) =>
+        SandboxResource.dangerouslyDestroyIfKillRequested(auth, conversation),
+      "Reaper: failed to destroy kill-requested sandbox — continuing."
     );
   }
 
   // Phase 1: Sleep running sandboxes that have been idle > SLEEP_THRESHOLD_MS.
-  const runningConversations =
-    await SandboxResource.dangerouslyGetStaleConversationIds({
-      status: "running",
-      olderThanMs: SLEEP_THRESHOLD_MS,
-      limit: BATCH_SIZE,
-    });
+  const runningSandboxes = await SandboxResource.dangerouslyGetStaleSandboxes({
+    status: "running",
+    olderThanMs: SLEEP_THRESHOLD_MS,
+    limit: BATCH_SIZE,
+  });
 
-  if (runningConversations.length > 0) {
+  if (runningSandboxes.length > 0) {
     logger.info(
-      { count: runningConversations.length },
+      { count: runningSandboxes.length },
       "Reaper: stale running sandboxes found."
     );
 
-    // Batch-fetch all workspaces to avoid N queries inside the concurrent loop
-    const workspaceMap = await fetchWorkspaceMap(runningConversations);
-
-    logger.info(
-      {
-        conversationCount: runningConversations.length,
-        uniqueWorkspaceCount: workspaceMap.size,
-      },
-      "Batch-fetched workspaces for running sandboxes"
-    );
-
-    await concurrentExecutor(
-      runningConversations,
-      async ({ conversationId, workspaceModelId }) => {
-        const workspace = workspaceMap.get(workspaceModelId);
-
-        if (!workspace) {
-          logger.warn(
-            { conversationId, workspaceModelId },
-            "Workspace not found, skipping"
-          );
-          return;
-        }
-
-        const auth = await Authenticator.internalBuilderForWorkspace(
-          workspace.sId
-        );
-        const result = await SandboxResource.dangerouslySleepIfRunning(
-          auth,
-          conversationId
-        );
-        if (result.isErr()) {
-          logger.error(
-            { conversationId, error: result.error.message },
-            "Reaper: failed to sleep sandbox — continuing."
-          );
-        }
-        heartbeat();
-      },
-      { concurrency: REAPER_CONCURRENCY }
+    await processSandboxes(
+      runningSandboxes,
+      (auth, conversation) =>
+        SandboxResource.dangerouslySleepIfRunning(auth, conversation),
+      "Reaper: failed to sleep sandbox — continuing."
     );
   }
 
   // Phase 2: Transition abandoned pending_approval sandboxes to sleeping.
-  const pendingConversations =
-    await SandboxResource.dangerouslyGetStaleConversationIds({
-      status: "pending_approval",
-      olderThanMs: PENDING_APPROVAL_THRESHOLD_MS,
-      limit: BATCH_SIZE,
-    });
+  const pendingSandboxes = await SandboxResource.dangerouslyGetStaleSandboxes({
+    status: "pending_approval",
+    olderThanMs: PENDING_APPROVAL_THRESHOLD_MS,
+    limit: BATCH_SIZE,
+  });
 
-  if (pendingConversations.length > 0) {
+  if (pendingSandboxes.length > 0) {
     logger.info(
-      { count: pendingConversations.length },
+      { count: pendingSandboxes.length },
       "Reaper: stale pending_approval sandboxes found."
     );
 
-    const workspaceMap = await fetchWorkspaceMap(pendingConversations);
-
-    await concurrentExecutor(
-      pendingConversations,
-      async ({ conversationId, workspaceModelId }) => {
-        const workspace = workspaceMap.get(workspaceModelId);
-
-        if (!workspace) {
-          logger.warn(
-            { conversationId, workspaceModelId },
-            "Workspace not found, skipping"
-          );
-          return;
-        }
-
-        const auth = await Authenticator.internalBuilderForWorkspace(
-          workspace.sId
-        );
-        const result = await SandboxResource.dangerouslySleepIfPendingApproval(
-          auth,
-          conversationId
-        );
-        if (result.isErr()) {
-          logger.error(
-            { conversationId, error: result.error.message },
-            "Reaper: failed to transition pending_approval sandbox — continuing."
-          );
-        }
-        heartbeat();
-      },
-      { concurrency: REAPER_CONCURRENCY }
+    await processSandboxes(
+      pendingSandboxes,
+      (auth, conversation) =>
+        SandboxResource.dangerouslySleepIfPendingApproval(auth, conversation),
+      "Reaper: failed to transition pending_approval sandbox — continuing."
     );
   }
 
   // Phase 3: Destroy sleeping sandboxes that have been idle > DESTROY_THRESHOLD_MS.
-  const sleepingConversations =
-    await SandboxResource.dangerouslyGetStaleConversationIds({
-      status: "sleeping",
-      olderThanMs: DESTROY_THRESHOLD_MS,
-      limit: BATCH_SIZE,
-    });
+  const sleepingSandboxes = await SandboxResource.dangerouslyGetStaleSandboxes({
+    status: "sleeping",
+    olderThanMs: DESTROY_THRESHOLD_MS,
+    limit: BATCH_SIZE,
+  });
 
-  if (sleepingConversations.length > 0) {
+  if (sleepingSandboxes.length > 0) {
     logger.info(
-      { count: sleepingConversations.length },
+      { count: sleepingSandboxes.length },
       "Reaper: stale sleeping sandboxes found."
     );
 
-    // Batch-fetch all workspaces to avoid N queries inside the concurrent loop
-    const workspaceMap = await fetchWorkspaceMap(sleepingConversations);
-
-    logger.info(
-      {
-        conversationCount: sleepingConversations.length,
-        uniqueWorkspaceCount: workspaceMap.size,
-      },
-      "Batch-fetched workspaces for sleeping sandboxes"
-    );
-
-    await concurrentExecutor(
-      sleepingConversations,
-      async ({ conversationId, workspaceModelId }) => {
-        const workspace = workspaceMap.get(workspaceModelId);
-
-        if (!workspace) {
-          logger.warn(
-            { conversationId, workspaceModelId },
-            "Workspace not found, skipping"
-          );
-          return;
-        }
-
-        const auth = await Authenticator.internalBuilderForWorkspace(
-          workspace.sId
-        );
-        const result = await SandboxResource.dangerouslyDestroyIfSleeping(
-          auth,
-          conversationId
-        );
-        if (result.isErr()) {
-          logger.error(
-            { conversationId, error: result.error.message },
-            "Reaper: failed to destroy sandbox — continuing."
-          );
-        }
-        heartbeat();
-      },
-      { concurrency: REAPER_CONCURRENCY }
+    await processSandboxes(
+      sleepingSandboxes,
+      (auth, conversation) =>
+        SandboxResource.dangerouslyDestroyIfSleeping(auth, conversation),
+      "Reaper: failed to destroy sandbox — continuing."
     );
   }
 
   return (
-    killRequestedConversations.length >= BATCH_SIZE ||
-    runningConversations.length >= BATCH_SIZE ||
-    pendingConversations.length >= BATCH_SIZE ||
-    sleepingConversations.length >= BATCH_SIZE
+    killRequestedSandboxes.length >= BATCH_SIZE ||
+    runningSandboxes.length >= BATCH_SIZE ||
+    pendingSandboxes.length >= BATCH_SIZE ||
+    sleepingSandboxes.length >= BATCH_SIZE
   );
 }

--- a/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
+++ b/front/temporal/sandbox_reaper/kill_requester/activities.test.ts
@@ -52,10 +52,7 @@ describe("requestSandboxKillsActivity", () => {
     });
 
     expect(hasMore).toBe(false);
-    const marked = await SandboxResource.fetchByConversationId(
-      authenticator,
-      c1.sId
-    );
+    const marked = await SandboxResource.fetchByConversation(authenticator, c1);
     expect(marked?.killRequestedAt).not.toBeNull();
   });
 });

--- a/front/tests/utils/SandboxFactory.ts
+++ b/front/tests/utils/SandboxFactory.ts
@@ -2,12 +2,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
 import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
-import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 
 export class SandboxFactory {
   static async create(
     auth: Authenticator,
-    conversation: ConversationType,
+    conversation: ConversationWithoutContentType,
     opts?: {
       status?: SandboxStatus;
       statusChangedAt?: Date | null;
@@ -38,9 +38,9 @@ export class SandboxFactory {
       );
     }
 
-    const result = await SandboxResource.fetchByConversationId(
+    const result = await SandboxResource.fetchByConversation(
       auth,
-      conversation.sId
+      conversation
     );
     if (!result) {
       throw new Error("Sandbox not found after creation");


### PR DESCRIPTION



## Description

This PR refactors `SandboxResource` to eliminate slow SQL JOINs on the `ConversationModel` table when fetching sandboxes. The affected query was averaging **6s execution time** (p95: 15.9s) and called **~1,100 times/hour** in production, creating significant DB load. By accepting a conversation object instead of a conversation `sId` string, the lookup becomes a direct `WHERE conversationId = conversation.id` query with no JOIN needed.

- Renames `fetchByConversationId`, `deleteByConversationId`, `dangerouslyFetchByConversationId` and related methods to accept a `ConversationResource` or `ConversationWithoutContentType` directly.
- Renames `dangerouslyGetKillRequestedConversationIds` → `dangerouslyGetKillRequestedSandboxes` and `dangerouslyGetStaleConversationIds` → `dangerouslyGetStaleSandboxes`, now returning `SandboxResource[]` instead of raw `{conversationId, workspaceModelId}` tuples.
- Refactors the sandbox reaper activities to batch-fetch `ConversationResource` objects grouped by workspace (one query per workspace rather than one per sandbox) and pass them down to lifecycle methods.

See https://console.cloud.google.com/sql/instances/cell-00001-front-db/insights;database=front;duration=PT1H;trace=2a971327900d6257581e69dc331d3352;span=939cca6209db136d;query_hash=5258826220973045733;sort_by=TOTAL_EXEC_TIME/executed?project=prj-dust-europe-west1

## Tests

Existing unit tests updated.

## Risks

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. -->
