### PR TITLE
Martin/marketing ebook pdf

### DIFF
--- a/marketing/components/home/content/Product/HeroOfficeSection.tsx
+++ b/marketing/components/home/content/Product/HeroOfficeSection.tsx
@@ -130,34 +130,6 @@ export function HeroOfficeSection() {
       <div className="relative mx-auto flex w-full max-w-[1600px] flex-col-reverse items-stretch gap-10 px-6 pt-16 lg:flex-row lg:items-center lg:gap-0 lg:px-10 lg:pt-24">
         <div className="z-10 flex w-full flex-col items-start gap-6 lg:w-[42%] lg:pr-8">
           <HomeReveal>
-            <Link
-              href="/landing/ebook"
-              onClick={withTracking(TRACKING_AREAS.HOME, "hero_ebook_pill")}
-              className="group inline-flex items-center gap-2 rounded-full border border-gray-100 bg-white py-1.5 pl-3 pr-3 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50"
-            >
-              <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
-              <span className="whitespace-nowrap">
-                <span className="font-semibold">New</span> · The AI Enterprise
-                Playbook
-              </span>
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.6"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="flex-shrink-0 transition-transform duration-200 ease-out group-hover:translate-x-0.5 motion-reduce:transform-none motion-reduce:transition-none"
-                aria-hidden="true"
-              >
-                <line x1="3" y1="8" x2="13" y2="8" />
-                <polyline points="9 4 13 8 9 12" />
-              </svg>
-            </Link>
-          </HomeReveal>
-          <HomeReveal>
             <h1
               className="m-0 text-balance text-[clamp(40px,4.8vw,76px)] font-semibold leading-[90%] tracking-[-0.04em] text-foreground"
               style={{ fontFamily: "var(--font-sans, inherit)" }}


### PR DESCRIPTION
## Description

Fixes two issues with the gated ebook PDF download flow on the marketing site:

1. **Missing PDF file**: The `/api/home/ebook/download` endpoint streams `assets/gated/Dust_AI_Enterprise_Playbook.pdf` via `process.cwd()`, but the file was never committed to the repo — valid tokens were hitting `ENOENT` and the browser received `ERR_INVALID_RESPONSE`. The PDF is now added under `marketing/assets/gated/` (intentionally outside `public/` to keep it behind the token-gated endpoint).
2. **Missing Docker layer**: The marketing `Dockerfile` never copied the `assets/` directory into the runtime image, so the file would have been absent in production regardless. A `COPY` step is added after the `public/` copy.

Additionally removes the "New · The AI Enterprise Playbook" promotional pill from the homepage hero section (`HeroOfficeSection.tsx`).

## Tests

Manually verify: submit the ebook form, receive a download token, and confirm the PDF streams correctly. Also confirm the hero pill is no longer visible on the homepage.

## Risk

Binary PDF is committed to the repository (increases repo size). Low risk overall — the change is additive for the PDF/Dockerfile fix and purely subtractive for the hero UI.

## Deploy Plan

Deploy marketing.