### PR TITLE
Slack: tool approval fixes

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -485,6 +485,19 @@ export async function botValidateToolExecution(
       }
     }
 
+    // The Slack click only performs the validation when the action is still
+    // blocked. If it was already resolved elsewhere (e.g. approved from the Dust
+    // web app), `validateAction` returns `action_not_blocked` and the click is a
+    // no-op: confirming "approved"/"rejected" here would be misleading.
+    let confirmationText: string;
+    if (res.isOk()) {
+      confirmationText = text;
+    } else if (String(res.error.type) === "action_not_blocked") {
+      confirmationText = "Request already handled in Dust";
+    } else {
+      confirmationText = "An error occurred while processing the request";
+    }
+
     reportSlackUsage({
       connectorId: connector.id,
       method: "chat.postEphemeral",
@@ -494,7 +507,7 @@ export async function botValidateToolExecution(
     await slackClient.chat.postEphemeral({
       channel: slackChannel,
       user: slackChatBotMessage.slackUserId,
-      text,
+      text: confirmationText,
       thread_ts: params.slackThreadTs ?? slackMessageTs,
     });
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -485,17 +485,16 @@ export async function botValidateToolExecution(
       }
     }
 
-    // The Slack click only performs the validation when the action is still
-    // blocked. If it was already resolved elsewhere (e.g. approved from the Dust
-    // web app), `validateAction` returns `action_not_blocked` and the click is a
-    // no-op: confirming "approved"/"rejected" here would be misleading.
+    // The Slack click only performs the validation when the action is still blocked. If it was
+    // already resolved elsewhere (e.g. approved from the Dust web app), `validateAction` returns
+    // `action_not_blocked` and the click is a no-op: surface that to the user.
     let confirmationText: string;
     if (res.isOk()) {
       confirmationText = text;
     } else if (String(res.error.type) === "action_not_blocked") {
-      confirmationText = "Request already handled in Dust";
+      confirmationText = "Tool validation was already handled in Dust.";
     } else {
-      confirmationText = "An error occurred while processing the request";
+      confirmationText = "An error occurred while validating the tool.";
     }
 
     reportSlackUsage({


### PR DESCRIPTION
## Description

In the context of validation of tools from Slack, when:
- A tool was already validated in Dust before the button was clicked in Slack
- The validation fails

We would still display the default validation text.

Note: we can't remove the ephemeral UI when validation happens in Slack.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`