### PR TITLE
fix(temporal): remove @dust-tt/client import from error_utils to fix Buffer not defined in workflow sandbox

### DIFF
--- a/front/types/shared/utils/error_utils.ts
+++ b/front/types/shared/utils/error_utils.ts
@@ -1,9 +1,21 @@
 import { DustError } from "@app/lib/error";
-// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
-import { errorToString } from "@dust-tt/client";
 
-// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
-export { errorToString, normalizeError } from "@dust-tt/client";
+export function errorToString(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = "cause" in error ? errorToString(error.cause) : null;
+    return `${error.message}${cause ? `\n- Cause: ${cause}` : ""}`;
+  } else if (typeof error === "string") {
+    return error;
+  }
+  return JSON.stringify(error);
+}
+
+export function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(errorToString(error));
+}
 
 export function normalizeAsInternalDustError(
   error: unknown


### PR DESCRIPTION
## Description

`front/types/shared/utils/error_utils.ts` was re-exporting `normalizeError` and `errorToString` from `@dust-tt/client`. Importing the full SDK entry point causes `sdks/js/src/types.ts` to be evaluated, which contains `z.instanceof(Buffer)` — a module-level expression that throws `ReferenceError: Buffer is not defined` in Temporal's sandboxed V8 workflow environment.

The import chain was: `temporal/relocation/workflows.ts` → `lib/utils/async_utils.ts` → `types/shared/utils/error_utils.ts` → `@dust-tt/client` → `types.ts:3025` → crash.

Fixed by implementing `normalizeError` and `errorToString` locally in `error_utils.ts` (identical logic to the SDK's own `sdks/js/src/error_utils.ts`), removing the dependency on the full SDK entry point entirely.

## Tests

Verify the relocation worker starts without the crash. The bundle build can be used as a smoke test:
```
cd front && NODE_OPTIONS=--max_old_space_size=8192 npm run build:temporal-bundles
```

## Risk

Low. The two functions are pure, dependency-free utilities. The local implementations are byte-for-byte identical to the SDK source they replace.
