### PR TITLE
Fix redirect of legacy conversation paths

### DIFF
--- a/front-spa/src/app/routes.tsx
+++ b/front-spa/src/app/routes.tsx
@@ -12,7 +12,10 @@ import {
   builderFullPageRoutes,
   builderRedirectRoutes,
 } from "@spa/app/routes/builderRoutes";
-import { conversationRoutes } from "@spa/app/routes/conversationRoutes";
+import {
+  conversationRedirectRoutes,
+  conversationRoutes,
+} from "@spa/app/routes/conversationRoutes";
 import { labsRoutes } from "@spa/app/routes/labsRoutes";
 import {
   loginAuthenticatedRoutes,
@@ -73,6 +76,7 @@ export const routes: RouteObject[] = [
           ...adminFullPageRoutes,
           ...builderFullPageRoutes,
           ...builderRedirectRoutes,
+          ...conversationRedirectRoutes,
           ...onboardingRoutes,
         ],
       },

--- a/front-spa/src/app/routes/conversationRoutes.tsx
+++ b/front-spa/src/app/routes/conversationRoutes.tsx
@@ -1,11 +1,26 @@
 import { ConversationRouterLayout } from "@spa/app/layouts/ConversationRouterLayout";
 import { withSuspense } from "@spa/app/routes/withSuspense";
 import type { RouteObject } from "react-router-dom";
-import { Navigate, useLocation } from "react-router-dom";
+import { Navigate, useLocation, useParams } from "react-router-dom";
 
 function RedirectWithSearchParams({ to }: { to: string }) {
   const location = useLocation();
   return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
+}
+
+// Redirect legacy conversation URLs (/w/:wId/assistant/:cId and /w/:wId/agent/:cId) to the current
+// /w/:wId/conversation/:cId, preserving query params and hash. The deployed Cloudflare worker
+// issues a real 301 for these paths, but the worker does not run under the Vite dev/preview server,
+// so this client-side redirect guarantees the behavior in every environment.
+function ConversationRedirect() {
+  const { wId, cId } = useParams();
+  const location = useLocation();
+  return (
+    <Navigate
+      to={`/w/${wId}/conversation/${cId}${location.search}${location.hash}`}
+      replace
+    />
+  );
 }
 
 const ConversationPage = withSuspense(
@@ -23,5 +38,17 @@ export const conversationRoutes: RouteObject[] = [
     path: "conversation",
     element: <ConversationRouterLayout />,
     children: [{ path: ":cId", element: <ConversationPage /> }],
+  },
+];
+
+// Legacy conversation URL redirects: /assistant/:cId and /agent/:cId -> /conversation/:cId.
+export const conversationRedirectRoutes: RouteObject[] = [
+  {
+    path: "assistant/:cId",
+    element: <ConversationRedirect />,
+  },
+  {
+    path: "agent/:cId",
+    element: <ConversationRedirect />,
   },
 ];

--- a/front-spa/worker/app.ts
+++ b/front-spa/worker/app.ts
@@ -10,17 +10,27 @@
  * 1. Return 404 for missing assets under /assets/ (prevent SPA fallback
  *    from serving index.html with a 200 for broken JS/CSS imports).
  *
- * 2. Route sub-app paths to their dedicated index.html:
+ * 2. Permanently redirect legacy conversation URLs to their current path:
+ *    - /w/:wId/assistant/:cId → /w/:wId/conversation/:cId (301)
+ *    - /w/:wId/agent/:cId     → /w/:wId/conversation/:cId (301)
+ *
+ * 3. Route sub-app paths to their dedicated index.html:
  *    - /share/*                → share/index.html
  *    - /oauth/*, /w/* /oauth/* → oauth/index.html
  *    - /email/*                → email/index.html
  *
- * 3. Fall back to the main index.html for all other paths (SPA routing).
+ * 4. Fall back to the main index.html for all other paths (SPA routing).
  */
 
 interface Env {
   ASSETS: Fetcher;
 }
+
+// Legacy conversation URLs (/w/:wId/assistant/:cId and /w/:wId/agent/:cId) renamed to
+// /w/:wId/conversation/:cId. The query string is preserved here; the URL fragment never reaches
+// the server but is reapplied by the browser on a 301.
+const LEGACY_CONVERSATION_PATH_REGEX =
+  /^\/w\/([^/]+)\/(?:assistant|agent)\/([^/]+)\/?$/;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -29,6 +39,15 @@ export default {
 
     if (path.startsWith("/assets/")) {
       return new Response("Not Found", { status: 404 });
+    }
+
+    const legacyConversationMatch = LEGACY_CONVERSATION_PATH_REGEX.exec(path);
+    if (legacyConversationMatch) {
+      const [, wId, cId] = legacyConversationMatch;
+      return Response.redirect(
+        `${url.origin}/w/${wId}/conversation/${cId}${url.search}`,
+        301
+      );
     }
 
     let fallback: string;

--- a/front-spa/worker/app.ts
+++ b/front-spa/worker/app.ts
@@ -10,27 +10,17 @@
  * 1. Return 404 for missing assets under /assets/ (prevent SPA fallback
  *    from serving index.html with a 200 for broken JS/CSS imports).
  *
- * 2. Permanently redirect legacy conversation URLs to their current path:
- *    - /w/:wId/assistant/:cId → /w/:wId/conversation/:cId (301)
- *    - /w/:wId/agent/:cId     → /w/:wId/conversation/:cId (301)
- *
- * 3. Route sub-app paths to their dedicated index.html:
+ * 2. Route sub-app paths to their dedicated index.html:
  *    - /share/*                → share/index.html
  *    - /oauth/*, /w/* /oauth/* → oauth/index.html
  *    - /email/*                → email/index.html
  *
- * 4. Fall back to the main index.html for all other paths (SPA routing).
+ * 3. Fall back to the main index.html for all other paths (SPA routing).
  */
 
 interface Env {
   ASSETS: Fetcher;
 }
-
-// Legacy conversation URLs (/w/:wId/assistant/:cId and /w/:wId/agent/:cId) renamed to
-// /w/:wId/conversation/:cId. The query string is preserved here; the URL fragment never reaches
-// the server but is reapplied by the browser on a 301.
-const LEGACY_CONVERSATION_PATH_REGEX =
-  /^\/w\/([^/]+)\/(?:assistant|agent)\/([^/]+)\/?$/;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -39,15 +29,6 @@ export default {
 
     if (path.startsWith("/assets/")) {
       return new Response("Not Found", { status: 404 });
-    }
-
-    const legacyConversationMatch = LEGACY_CONVERSATION_PATH_REGEX.exec(path);
-    if (legacyConversationMatch) {
-      const [, wId, cId] = legacyConversationMatch;
-      return Response.redirect(
-        `${url.origin}/w/${wId}/conversation/${cId}${url.search}`,
-        301
-      );
     }
 
     let fallback: string;


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1781623904519679
Legacy redirects were broken 5d ago with https://github.com/dust-tt/dust/pull/27248

This fixes them.

r? @tdraier is that the best way to do it? Claude argues that we need both layers

```
 ┌─────────────────────────────────────┬───────────────────────┬──────────────────────────────────────────────────┐
  │                Diff                 │         Layer         │                      Covers                      │
  ├─────────────────────────────────────┼───────────────────────┼──────────────────────────────────────────────────┤
  │ conversationRoutes.tsx + routes.tsx │ client (react-router) │ dev, preview, prod — runs in browser             │
  ├─────────────────────────────────────┼───────────────────────┼──────────────────────────────────────────────────┤
  │ worker/app.ts                       │ Cloudflare worker     │ prod only — upgrades to a true 301 (no SPA load) │
  └─────────────────────────────────────┴───────────────────────┴──────────────────────────────────────────────────┘
```

wdyt?

cc @davidebbo 
cc @id13 (OOO)

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`