### PR TITLE
Make the web app installable as a PWA

### DIFF
--- a/front-spa/index.html
+++ b/front-spa/index.html
@@ -6,6 +6,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Dust</title>
+
+    <!-- PWA: web app manifest enables installation and standalone (no browser chrome) launch. -->
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#FBFAF9" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1C222D" media="(prefers-color-scheme: dark)" />
+
+    <!-- PWA: iOS Safari standalone support ("Add to Home Screen"). -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Dust" />
+    <link rel="apple-touch-icon" href="/static/AppIcon_180.png" />
     <link rel="preload" href="/static/fonts/GeistVariable.woff2" as="font" type="font/woff2" crossorigin />
     <!-- Datadog RUM (Real User Monitoring) -->
     <script>

--- a/front-spa/src/app/main.tsx
+++ b/front-spa/src/app/main.tsx
@@ -21,3 +21,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <App />
   </React.StrictMode>
 );
+
+// Register the PWA service worker so the app is installable and launches standalone. The worker
+// does no caching (see front/public/sw.js); failures are non-fatal and intentionally ignored.
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    void navigator.serviceWorker.register("/sw.js").catch(() => {});
+  });
+}

--- a/front/public/manifest.webmanifest
+++ b/front/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Dust",
+  "short_name": "Dust",
+  "description": "Build and operate AI agents for work.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#FBFAF9",
+  "theme_color": "#FBFAF9",
+  "icons": [
+    {
+      "src": "/static/AppIcon_192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/AppIcon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/front/public/manifest.webmanifest
+++ b/front/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Dust",
   "short_name": "Dust",
-  "description": "Build and operate AI agents for work.",
+  "description": "Multiplayer AI for human-agent collaboration",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",

--- a/front/public/sw.js
+++ b/front/public/sw.js
@@ -1,0 +1,19 @@
+// Minimal service worker for PWA installability.
+//
+// Chrome and other Chromium browsers only surface the "Install app" prompt when a service worker
+// with a `fetch` handler is registered. This worker intentionally does no caching: it forwards
+// every request straight to the network so we get installability and standalone launch without
+// taking on the risk of serving stale assets. Offline support can be layered on later.
+self.addEventListener("install", () => {
+  // Activate this worker as soon as it finishes installing, replacing any previous version.
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  // Take control of all open clients immediately so the active worker is always the latest one.
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", () => {
+  // Pass-through: let the browser handle the request normally (no caching).
+});


### PR DESCRIPTION
## Description

Makes the responsive web app (`front-spa`) installable as a Progressive Web App so it can be added to a phone/desktop home screen and launched in a standalone window with no browser chrome — a native-feeling experience.

Changes:
- **`front/public/manifest.webmanifest`** — web app manifest with `display: standalone`, name/icons/colors. Reuses the existing `AppIcon_192.png` (192×192) and `AppIcon.png` (512×512) under `front/public/static/`. Served at `/manifest.webmanifest` since `front-spa`'s Vite `publicDir` points at `front/public`.
- **`front-spa/index.html`** — links the manifest and adds `theme-color` (light/dark) plus the iOS Safari standalone meta tags (`apple-mobile-web-app-capable`, status-bar style, title, `apple-touch-icon`).
- **`front/public/sw.js`** — minimal, intentionally cache-free service worker. Chromium only surfaces the "Install app" prompt when a SW with a `fetch` handler is registered; this one forwards every request to the network so we get installability without the risk of serving stale assets.
- **`front-spa/src/app/main.tsx`** — registers the service worker on `load` (feature-detected, failures ignored).

How it behaves:
- **iOS Safari**: Share → "Add to Home Screen" launches standalone (no Safari chrome). No SW required.
- **Android/Chrome & desktop Chrome/Edge**: shows the install prompt and launches in a standalone window.

Deliberately out of scope (possible follow-ups): offline support / asset caching, `viewport-fit=cover` safe-area handling, and maskable-specific icons (current icons are declared `purpose: any`).

## Tests

N/A, tested locally. `tsgo --noEmit` passes for `front-spa`; manifest validated as JSON.

## Risk

Low. Purely additive: new static files plus additive `<head>` tags. The service worker does no caching (pure network pass-through), so there is no stale-asset risk; if registration fails it is silently ignored and the app behaves exactly as before.

## Deploy Plan

- deploy `front` (serves `front/public/*` static assets: manifest, `sw.js`)
- deploy `front-spa`