### PR TITLE
chore(deps): upgrade @typescript/native-preview to 7.0.0-dev.20260609.1

### DIFF
--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "isolatedModules": true,
     "outDir": "./build",
-    "rootDir": "./",
+    "rootDir": "../",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       ],
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
-        "@typescript/native-preview": "^7.0.0-dev.20260420.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260608.1",
         "knip": "^5.80.0",
         "lefthook": "2.1.8",
         "react-doctor": "^0.4.2",
@@ -21281,28 +21281,31 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-XYMYZ1OAvO1OWJMntCGW5yoJvJjdrsgmNJxXEPO3Za2kFmQ69TdHOAzg9adurMgAXNpaDWtf28bfEveMRnvpZA==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-1HOuH/u/451O3hx4Z9fesNqarpeit6UfkgwK96sCVWi5p69F0N3v+6bI969lLIjF7K9dbYQNiWUaZ6Wik87iKg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsgo": "bin/tsgo.js"
       },
+      "engines": {
+        "node": ">=16.20.0"
+      },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260420.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260420.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260420.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260420.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260420.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260420.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260420.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260609.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260609.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260609.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260609.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260609.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260609.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260609.1"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-WMVphWuSmPuDzdutP2OM7ZhvlgdrBQ6ufQia+cJz6jqLd2MjPaYlS+/ACEcTgf6+PsTXygUOUvcqv9j5s7QC8w==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-Yf/zHEadP/yUiWUdM/mZVfEVFJuGMf6nhRSFif0vp+FwtfGU4jmlpNF7BTJJdOHrrcWkwEJKzAoMCtEtyxhuyQ==",
       "cpu": [
         "arm64"
       ],
@@ -21311,12 +21314,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-ChRf5ZpdM5CmplmtfCHGFd/UjYDkld9Z27h5HeC41NGxkbe7NeNQYjwPcbZynca2swISZvFr8Wwlo4nNZG/51A==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-z4dYWI57CPHs0wV/FWFth8fWmqYH7iOm7THOfZ5Fv0jo/SWK6kE1kEUIqIAExqo7ueRNqSrCw0I8U1J4TJszAw==",
       "cpu": [
         "x64"
       ],
@@ -21325,12 +21331,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-8+Ey5WZ1jiJXFuN8oQxu3N6pTi6UvigNXTWmB/e+2q6cu6ytFNgiVic6xXtcxOqBpqYMKwXzTZkECjs3NtT6og==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-mEtN8BbAgVtBu/5MVomYquXNvgok2C0KG6V0D4SV1jfBJNtlcqbp0WuIqT0bnM9DA4TgzcHvnFMpwGSK/dqI5A==",
       "cpu": [
         "arm"
       ],
@@ -21339,12 +21348,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-AmRuZ5R1TTrBNMInIACxd3AGvXS8X0PCAheftIMSa/1YOsNbfvPCbzZTleSaIx0ETabPeKQArur0uTPwnKjJbg==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-OxNVWH9IhrMAzNlDyDit1dPO64GFIDPOUKoruIkJ9A1ZEONfIHXG5f+V3si9jtuNmuomiz9FjpbzOqLsgaxt+w==",
       "cpu": [
         "arm64"
       ],
@@ -21353,12 +21365,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-zk6y0AX1+SjuYXZfIRTkpRttp+gfpnz6ELFDWLuhtTJtnxgm8BRSKPup2rcm4xkfpRrVv9dhPGSjJYGNR9z9tg==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-KO8WO1gBIC09T3255RlTY42TGu8en5mEkLPQu2wkMn+dX2T8KYL64zXrCeLeUWa0NvmVdJUeyWu3pFOn3zKemw==",
       "cpu": [
         "x64"
       ],
@@ -21367,12 +21382,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-TopcWdHwUGaocYuoj0qEZmZa1SLFm9hY0jKrzi5Xa9Xt/gvUnSLJYRBVblibM+/s8S9ZaV94Gc+CUn9EeSsJ9A==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-+8q19LWjnMKK6SF3PLeMEalbfWDYWHs0AU8kSFCBCke/RLoDG4FjQzVtLgUo+KWhsmZMosiEyqEnZmSlED2tIQ==",
       "cpu": [
         "arm64"
       ],
@@ -21381,12 +21399,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260420.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260420.1.tgz",
-      "integrity": "sha512-9P6DDMOCncgXGbFfxRpZE0sWzjyymRON67T9J1u885NLp+AmIdns8e91nzD6ipB0EdZimyR4ZjdSZfqetAQSrQ==",
+      "version": "7.0.0-dev.20260609.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260609.1.tgz",
+      "integrity": "sha512-qNPcss+6yRoNFfFIKQbPwJWYxDfOZwyL8JBJh4J+yMLOad/+/AOjsO4EtZsIpv5PMCjpnD75coBoDkw+5NkItw==",
       "cpu": [
         "x64"
       ],
@@ -21395,7 +21416,10 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
-    "@typescript/native-preview": "^7.0.0-dev.20260420.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260608.1",
     "knip": "^5.80.0",
     "lefthook": "2.1.8",
     "react-doctor": "^0.4.2",


### PR DESCRIPTION
## Description

Upgrades `@typescript/native-preview` (tsgo) from `7.0.0-dev.20260420.1` to `7.0.0-dev.20260609.1` (~7 weeks of nightly builds).

**Main gains:**
- **Crash fixes**: two stack overflow crashes in the type checker on complex recursive/generic types, a panic in auto-import resolution, and a panic on private identifiers in class analysis
- **macOS native file watcher**: LSP now uses OS-native watchers instead of polling — better editor responsiveness on large repos
- **Type checker correctness**: false positives fixed for late-bound members, auto-accessors, `exactOptionalPropertyTypes` mismatches, and `this` type inference
- **JSDoc/emit fixes**: `@typedef` emission bugs, `@private`/`@protected` on constructors, CJS export and modifier-order emit

**Extension tsconfig fix:** the new tsgo build is stricter about TS6059 (`rootDir` enforcement). Since the extension imports `front/` files via `@app/*` path aliases, the previous `rootDir: "./"` caused a type error. Changed to `rootDir: "../"` so both `extension/` and `front/` fall within it. This is safe since `noEmit: true` is set — `rootDir` has no effect on output.

Note: pinned to `^7.0.0-dev.20260608.1` per the repo's `min-release-age=7` policy; npm resolved to the June 9 build.

## Tests

No business logic changed — dependency version bump and tsconfig adjustment only. Existing CI type-check runs validate both.

## Risk

Low. tsgo is used for `--noEmit` type-checking only, not for emit. The `rootDir` change in the extension tsconfig has no effect on the build output.
