### PR TITLE
fix: include editedByUser when fetching single data source view

### DIFF
--- a/front-api/middlewares/with_data_source_view.ts
+++ b/front-api/middlewares/with_data_source_view.ts
@@ -9,6 +9,7 @@ interface WithDataSourceViewOptions {
   requireCanReadOrAdministrate?: boolean;
   requireCanRead?: boolean;
   requireCanWrite?: boolean;
+  includeEditedBy?: boolean;
 }
 
 function hasPermission(
@@ -51,7 +52,9 @@ export function withDataSourceView(options: WithDataSourceViewOptions) {
         },
       });
     }
-    const view = await DataSourceViewResource.fetchById(auth, dsvId);
+    const view = await DataSourceViewResource.fetchById(auth, dsvId, {
+      includeEditedBy: options.includeEditedBy,
+    });
     if (
       !view ||
       view.space.sId !== space.sId ||

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -165,7 +165,10 @@ const app = workspaceApp();
 app.get(
   "/",
   withSpace({ requireCanReadOrAdministrate: true }),
-  withDataSourceView({ requireCanReadOrAdministrate: true }),
+  withDataSourceView({
+    requireCanReadOrAdministrate: true,
+    includeEditedBy: true,
+  }),
   async (ctx): HandlerResult<GetDataSourceViewResponseBody> => {
     const dataSourceView = ctx.get("dataSourceView");
     let connector: ConnectorType | null = null;


### PR DESCRIPTION
## Description

When fetching a single data source view via `GET /w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]`, the `editedByUser` field was not included in the response because the `includeEditedBy` option was never forwarded to `DataSourceViewResource.fetchById`. This PR fixes the bug by:
1. Adding an `includeEditedBy` option to `WithDataSourceViewOptions` in the middleware.
2. Passing `includeEditedBy: true` when registering the middleware on the single-view GET route, so the user join is performed and the field is populated in the serialized response.

## Tests

Manually verified that the `editedByUser` field is present when fetching a single data source view.

## Risk

Low — this is an additive change (adds an optional JOIN) with no schema migration or API contract change. Only a SQL query slightly heavier for the affected endpoint.

## Deploy Plan

Deploy front.