### PR TITLE
Cancel wake-up when the triggering message is deleted

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -153,6 +153,7 @@ import {
   isUserMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
+import { ACTIVE_WAKE_UP_STATUSES } from "@app/types/assistant/wakeups";
 import type {
   ContentFragmentContextType,
   ContentFragmentType,
@@ -2317,6 +2318,27 @@ export async function softDeleteUserMessageAndReplies(
       messageIds: runningOrphans.map((m) => m.sId),
       conversationId: conversation.sId,
     });
+  }
+
+  // Cancel active wake-ups owned by the message author when their message is deleted.
+  if (message.user) {
+    const activeWakeUps = await WakeUpResource.listByConversation(
+      auth,
+      conversation,
+      { status: ACTIVE_WAKE_UP_STATUSES }
+    );
+    const authorWakeUps = activeWakeUps.filter(
+      (w) => w.userId === message.user!.id
+    );
+    for (const wakeUp of authorWakeUps) {
+      const cancelResult = await wakeUp.cancel(auth);
+      if (cancelResult.isErr()) {
+        logger.error(
+          { wakeUpId: wakeUp.sId, err: cancelResult.error },
+          "Failed to cancel wake-up on message deletion"
+        );
+      }
+    }
   }
 
   auditLog(


### PR DESCRIPTION
## Description

When a user deletes the message that triggered a wake-up, the wake-up was still executing even though the message was gone. This fix cancels any active wake-ups owned by the message author when their message is deleted.

Change: front/lib/api/assistant/conversation.ts — in softDeleteUserMessageAndReplies, after stopping orphaned agent loops, cancel active wake-ups for the conversation that are owned by the deleted message's author.

Before: 
<img width="1978" height="1710" alt="Screenshot 2026-06-16 at 16 39 45" src="https://github.com/user-attachments/assets/d4cb8f73-8201-46e1-827f-c75abbc60537" />

After: 
<img width="1512" height="982" alt="Screenshot 2026-06-16 at 18 36 34" src="https://github.com/user-attachments/assets/a867dab2-38c8-4ed1-9226-f7196df6d2c4" />


## Tests
Tested manually in my dust-hive environment:
- Set up a wake-up via an agent, then deleted the triggering message --> wake-up banner disappeared and wake-up did not fire
- Deleted a regular message in a conversation with no active wake-up → no side effects

## Risk
Low since just applies when delete a wake up call. 

## Deploy Plan

