### PR TITLE
Fixed user seats

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.test.ts
+++ b/front-api/routes/w/[wId]/usage-status.test.ts
@@ -29,7 +29,8 @@ describe("/api/w/[wId]/usage-status", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.awuStatus).toBe("normal");
+    expect(body.userNearCreditLimit).toBe(false);
+    expect(body.userBlockedReason).toBeNull();
     expect(body.canRequestUpgrade).toBe(false);
     expect(body.hasPendingUpgradeRequest).toBe(false);
   });
@@ -47,7 +48,7 @@ describe("/api/w/[wId]/usage-status", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.awuStatus).toBe("blocked");
+    expect(body.userBlockedReason).toBe("user_cap_reached");
     expect(body.canRequestUpgrade).toBe(true);
     expect(body.hasPendingUpgradeRequest).toBe(false);
   });

--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -30,11 +30,11 @@ app.get(
     // Workspaces not on Metronome billing have no usage status to report.
     if (!workspace.metronomeCustomerId || !isCreditPriced) {
       return ctx.json({
-        awuStatus: "normal",
+        userNearCreditLimit: false,
         poolCreditState: "active",
         programmaticCreditStatus: "active",
         balanceThresholdReached: false,
-        noSeat: false,
+        userBlockedReason: null,
         canRequestUpgrade: false,
         hasPendingUpgradeRequest: false,
       });
@@ -42,7 +42,7 @@ app.get(
 
     const [
       poolCreditState,
-      blockedReason,
+      userBlockedReason,
       programmaticState,
       balanceThresholdReached,
     ] = await Promise.all([
@@ -52,14 +52,8 @@ app.get(
       isWorkspaceBalanceThresholdReached(workspace.sId),
     ]);
 
-    let awuStatus: GetWorkspaceUsageStatusResponseBody["awuStatus"] = "normal";
-    if (blockedReason === "user_cap_reached") {
-      awuStatus = "blocked";
-    } else if (await isUserAwuWarned(workspace.sId, user.sId)) {
-      awuStatus = "warned";
-    }
-
-    const noSeat = blockedReason === "no_seat";
+    const userNearCreditLimit =
+      !userBlockedReason && (await isUserAwuWarned(workspace.sId, user.sId));
 
     let programmaticCreditStatus: ProgrammaticCreditStatus = "active";
     if (programmaticState === "depleted") {
@@ -73,15 +67,15 @@ app.get(
 
     const { canRequestUpgrade, hasPendingUpgradeRequest } =
       await getUpgradeRequestAvailabilityForUser(auth, {
-        isNearOrAtLimit: awuStatus !== "normal" || noSeat,
+        isNearOrAtLimit: userNearCreditLimit || userBlockedReason !== null,
       });
 
     return ctx.json({
-      awuStatus,
+      userNearCreditLimit,
       poolCreditState,
       programmaticCreditStatus,
       balanceThresholdReached,
-      noSeat,
+      userBlockedReason,
       canRequestUpgrade,
       hasPendingUpgradeRequest,
     });

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -17,7 +17,7 @@ import {
   Hoverable,
   Page,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export type WorkspaceLimit =
   | "cant_invite_no_seats_available"
@@ -28,6 +28,25 @@ export type WorkspaceLimit =
   | "pool_credits_exhausted"
   | "user_credits_exhausted"
   | "no_seat";
+
+// Maps a raw API error.type string (from retry/edit endpoints) to the blocking
+// popup code, or null when it's a non-limit error.
+export function getWorkspaceLimitFromApiErrorType(
+  type: string
+): WorkspaceLimit | null {
+  switch (type) {
+    case "plan_message_limit_exceeded":
+      return "message_limit";
+    case "credits_exhausted":
+      return "pool_credits_exhausted";
+    case "user_cap_reached":
+      return "user_credits_exhausted";
+    case "no_seat":
+      return "no_seat";
+    default:
+      return null;
+  }
+}
 
 // Maps a message-send failure to the blocking popup it should open, or null when
 // the failure is transient and should be surfaced as a notification instead.
@@ -331,11 +350,19 @@ export function ReachedLimitPopup({
 }) {
   const [isFairUsageModalOpened, setIsFairUsageModalOpened] = useState(false);
 
+  // Keep the last code that was shown while open so the closing animation
+  // doesn't flash the fallback content when the parent nulls limitReachedCode.
+  const activeCodeRef = useRef(code);
+  if (isOpened) {
+    activeCodeRef.current = code;
+  }
+  const activeCode = activeCodeRef.current;
+
   const router = useAppRouter();
   const limitPrompt = getLimitPromptForCode(
     router,
     owner,
-    code,
+    activeCode,
     subscription,
     () => setIsFairUsageModalOpened(true),
     isAdmin

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1,4 +1,5 @@
 import { ToolGeneratedFileDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { AgentMessageMarkdown } from "@app/components/assistant/AgentMessageMarkdown";
 import { AgentHandle } from "@app/components/assistant/conversation/AgentHandle";
 import { AgentMessageInteractiveContentGeneratedFiles } from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
@@ -216,6 +217,7 @@ interface AgentMessageProps {
   additionalMarkdownPlugins?: PluggableList;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
   isProjectArchived?: boolean;
+  setLimitReachedCode?: (code: WorkspaceLimit) => void;
 }
 
 export function AgentMessage({
@@ -235,6 +237,7 @@ export function AgentMessage({
   additionalMarkdownPlugins,
   isAutoScrollEnabledRef,
   isProjectArchived = false,
+  setLimitReachedCode,
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
   const [streamId, setStreamId] = useState<string>(`message-${sId}`);
@@ -779,14 +782,17 @@ export function AgentMessage({
       blockedOnly?: boolean;
     }) => {
       setIsRetryHandlerProcessing(true);
-      await retryMessage({
+      const result = await retryMessage({
         conversationId,
         messageId,
         blockedOnly,
       });
       setIsRetryHandlerProcessing(false);
+      if (result.isErr()) {
+        setLimitReachedCode?.(result.error);
+      }
     },
-    [retryMessage]
+    [retryMessage, setLimitReachedCode]
   );
 
   const reloadMessage = useCallback(

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -32,6 +32,7 @@ import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { SubscriptionType } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
@@ -96,7 +97,7 @@ export function ConversationContainerVirtuoso({
   // A seatless member can never send a message. We surface this up-front rather
   // than relying on the deferred background message-post failure, which lands
   // after navigation and would otherwise leave behind an empty conversation.
-  const { noSeat, awuStatus, poolCreditState } = useWorkspaceUsageStatus({
+  const { userBlockedReason } = useWorkspaceUsageStatus({
     owner,
   });
 
@@ -137,28 +138,30 @@ export function ConversationContainerVirtuoso({
       // Pre-check blocking conditions before creating the conversation.
       // With deferMessage:true the message posts after navigation, so backend
       // errors arrive too late and leave an empty conversation behind.
-      if (noSeat) {
-        setLimitReachedCode("no_seat");
+      // userBlockedReason comes directly from isUserBlocked on the server —
+      // no blocking logic lives here.
+      if (userBlockedReason) {
+        let limitCode: WorkspaceLimit;
+        switch (userBlockedReason) {
+          case "no_seat":
+            limitCode = "no_seat";
+            break;
+          case "user_cap_reached":
+            limitCode = "user_credits_exhausted";
+            break;
+          case "credits_exhausted":
+            limitCode = "pool_credits_exhausted";
+            break;
+          default:
+            assertNeverAndIgnore(userBlockedReason);
+            limitCode = "pool_credits_exhausted";
+            break;
+        }
+        setLimitReachedCode(limitCode);
         return new Err({
           code: "internal_error",
-          name: "NoSeat",
-          message: "You don't have a seat in this workspace.",
-        });
-      }
-      if (awuStatus === "blocked") {
-        setLimitReachedCode("user_credits_exhausted");
-        return new Err({
-          code: "internal_error",
-          name: "UserCapReached",
-          message: "You have reached your personal usage cap.",
-        });
-      }
-      if (poolCreditState === "depleted") {
-        setLimitReachedCode("pool_credits_exhausted");
-        return new Err({
-          code: "internal_error",
-          name: "CreditsExhausted",
-          message: "Your workspace has run out of credits.",
+          name: "UserBlocked",
+          message: "You are not allowed to send messages.",
         });
       }
 
@@ -213,9 +216,7 @@ export function ConversationContainerVirtuoso({
     },
     [
       isSubmitting,
-      noSeat,
-      awuStatus,
-      poolCreditState,
+      userBlockedReason,
       mutateConversations,
       owner,
       router,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1424,6 +1424,7 @@ export const ConversationViewer = ({
       setBranchIdToApprove,
       isAutoScrollEnabledRef,
       isNoSeat: limitReachedCode === "no_seat",
+      setLimitReachedCode,
     };
   }, [
     user,
@@ -1442,6 +1443,7 @@ export const ConversationViewer = ({
     spaceInfo?.name,
     branchIdToApprove,
     limitReachedCode,
+    setLimitReachedCode,
   ]);
 
   return (

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -343,6 +343,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               owner={context.owner}
               onReactionToggle={(emoji: string) => onReactionToggle({ emoji })}
               isProjectArchived={context.isProjectArchived}
+              setLimitReachedCode={context.setLimitReachedCode}
             />
           )}
           {isAgentMessageWithStreaming(data) && (
@@ -365,6 +366,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               additionalMarkdownPlugins={context.additionalMarkdownPlugins}
               isAutoScrollEnabledRef={context.isAutoScrollEnabledRef}
               isProjectArchived={context.isProjectArchived}
+              setLimitReachedCode={context.setLimitReachedCode}
             />
           )}
           {data.visibility !== "deleted" &&

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,3 +1,4 @@
+import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { MessageEmojiPicker } from "@app/components/assistant/conversation/MessageEmojiPicker";
@@ -134,6 +135,7 @@ interface UserMessageProps {
   owner: WorkspaceType;
   onReactionToggle: (emoji: string) => void;
   isProjectArchived?: boolean;
+  setLimitReachedCode?: (code: WorkspaceLimit) => void;
 }
 
 export function UserMessage({
@@ -146,6 +148,7 @@ export function UserMessage({
   owner,
   onReactionToggle,
   isProjectArchived = false,
+  setLimitReachedCode,
 }: UserMessageProps) {
   const [shouldShowEditor, setShouldShowEditor] = useState(false);
   const { ref: userMessageHoveredRef, isHovering: isUserMessageHovered } =
@@ -186,11 +189,19 @@ export function UserMessage({
         .trim();
     }
 
-    await editMessage({
+    const result = await editMessage({
       messageId: message.sId,
       content,
       mentions: filteredMentions,
     });
+
+    if (!result) {
+      return;
+    }
+    if (result.isErr()) {
+      setLimitReachedCode?.(result.error);
+      return;
+    }
 
     setShouldShowEditor(false);
   };

--- a/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarUsageBanner.tsx
@@ -10,14 +10,18 @@ interface InputBarUsageBannerProps {
 
 export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
   const { isAdmin } = useAuth();
-  const { awuStatus, canRequestUpgrade, hasPendingUpgradeRequest, noSeat } =
-    useWorkspaceUsageStatus({
-      owner,
-    });
+  const {
+    userNearCreditLimit,
+    canRequestUpgrade,
+    hasPendingUpgradeRequest,
+    userBlockedReason,
+  } = useWorkspaceUsageStatus({
+    owner,
+  });
 
   const showUpgradeCta = canRequestUpgrade || isAdmin;
 
-  if (noSeat) {
+  if (userBlockedReason === "no_seat") {
     return (
       <div
         className={cn(
@@ -42,11 +46,11 @@ export function InputBarUsageBanner({ owner }: InputBarUsageBannerProps) {
     );
   }
 
-  if (awuStatus === "normal") {
+  if (!userNearCreditLimit && userBlockedReason !== "user_cap_reached") {
     return null;
   }
 
-  const isBlocked = awuStatus === "blocked";
+  const isBlocked = userBlockedReason === "user_cap_reached";
 
   return (
     <div

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -1,3 +1,4 @@
+import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
 import type { InputBarContainerProps } from "@app/components/assistant/conversation/input_bar/InputBarContainer";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -142,6 +143,7 @@ export type VirtuosoMessageListContext = {
   setBranchIdToApprove?: (branchId: string | null) => void;
   isAutoScrollEnabledRef: MutableRefObject<boolean>;
   isNoSeat?: boolean;
+  setLimitReachedCode?: (code: WorkspaceLimit) => void;
 };
 
 export const areSameRankAndBranch = (

--- a/front/hooks/useEditUserMessage.ts
+++ b/front/hooks/useEditUserMessage.ts
@@ -1,8 +1,13 @@
+import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
+import { getWorkspaceLimitFromApiErrorType } from "@app/components/app/ReachedLimitPopup";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import type { RichMention } from "@app/types/assistant/mentions";
 import { toMentionType } from "@app/types/assistant/mentions";
+import { isAPIErrorResponse } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 export function useEditUserMessage({
   owner,
@@ -22,7 +27,7 @@ export function useEditUserMessage({
       messageId: string;
       content: string;
       mentions: RichMention[];
-    }) => {
+    }): Promise<Result<void, WorkspaceLimit>> => {
       const apiMentions = mentions.map(toMentionType);
 
       const res = await clientFetch(
@@ -40,12 +45,19 @@ export function useEditUserMessage({
       );
 
       if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        if (isAPIErrorResponse(body)) {
+          const limitCode = getWorkspaceLimitFromApiErrorType(body.error.type);
+          if (limitCode) {
+            return new Err(limitCode);
+          }
+        }
         sendNotification({
           title: "Failed to edit message",
           description: "Please try again.",
           type: "error",
         });
-        return;
+        return new Ok(undefined);
       }
 
       sendNotification({
@@ -53,6 +65,7 @@ export function useEditUserMessage({
         description: "Message has been edited successfully.",
         type: "success",
       });
+      return new Ok(undefined);
     }
   );
 

--- a/front/hooks/useRetryMessage.ts
+++ b/front/hooks/useRetryMessage.ts
@@ -1,4 +1,9 @@
+import type { WorkspaceLimit } from "@app/components/app/ReachedLimitPopup";
+import { getWorkspaceLimitFromApiErrorType } from "@app/components/app/ReachedLimitPopup";
 import { clientFetch } from "@app/lib/egress/client";
+import { isAPIErrorResponse } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
 
@@ -12,8 +17,8 @@ export function useRetryMessage({ owner }: { owner: LightWorkspaceType }) {
       conversationId: string;
       messageId: string;
       blockedOnly?: boolean;
-    }): Promise<void> => {
-      await clientFetch(
+    }): Promise<Result<void, WorkspaceLimit>> => {
+      const res = await clientFetch(
         `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/retry?blocked_only=${blockedOnly}`,
         {
           method: "POST",
@@ -22,6 +27,16 @@ export function useRetryMessage({ owner }: { owner: LightWorkspaceType }) {
           },
         }
       );
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        if (isAPIErrorResponse(body)) {
+          const limitCode = getWorkspaceLimitFromApiErrorType(body.error.type);
+          if (limitCode) {
+            return new Err(limitCode);
+          }
+        }
+      }
+      return new Ok(undefined);
     },
     [owner.sId]
   );

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -502,11 +502,10 @@ export async function reconcileWorkspaceUserCreditStates({
         effectiveCapAwuCredits !== null ? (usageByUser.get(userId) ?? 0) : null,
     });
 
-    if (normalizeUserCreditState(membership.creditState) === expectedState) {
-      continue;
-    }
-
     try {
+      // Always call setUserCreditStateReconciled even when DB state already
+      // matches: it skips the DB write but always refreshes the Redis cache,
+      // fixing stale "capped" entries that survive after the DB is corrected.
       await setUserCreditStateReconciled(membership, expectedState, {
         workspaceId,
         userId,

--- a/front/lib/client/utils.ts
+++ b/front/lib/client/utils.ts
@@ -1,20 +1,20 @@
 import { useCallback, useState } from "react";
 
-export function useSubmitFunction<T extends unknown[]>(
-  submitFn: (...data: T) => Promise<void>
+export function useSubmitFunction<T extends unknown[], R = void>(
+  submitFn: (...data: T) => Promise<R>
 ) {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const submit = useCallback(
-    async (...data: T) => {
+    async (...data: T): Promise<R | undefined> => {
       if (isSubmitting) {
-        return;
+        return undefined;
       }
 
       setIsSubmitting(true);
 
       try {
-        await submitFn(...data);
+        return await submitFn(...data);
       } finally {
         setIsSubmitting(false);
       }

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -67,13 +67,15 @@ const DEFAULT_FAIR_USE_AWU_CREDITS_STATUS: FairUseAwuCreditsStatus = {
 };
 
 export type GetWorkspaceUsageStatusResponseBody = {
-  awuStatus: "normal" | "warned" | "blocked";
+  // True when the user has consumed ≥ 80 % of their credit allowance (soft warning, not yet blocked).
+  userNearCreditLimit: boolean;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditStatus: ProgrammaticCreditStatus;
   balanceThresholdReached: boolean;
-  // True when the current user has no billable seat in the workspace and is
-  // therefore blocked from sending messages.
-  noSeat: boolean;
+  // Authoritative block reason from isUserBlocked — null means the user can
+  // send messages. Replaces the old client-side derivations (noSeat,
+  // awuStatus === "blocked", poolCreditState === "depleted").
+  userBlockedReason: UserBlockedReason | null;
   canRequestUpgrade: boolean;
   hasPendingUpgradeRequest: boolean;
 };

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -282,11 +282,11 @@ export function useWorkspaceUsageStatus({
   );
 
   return {
-    awuStatus: data?.awuStatus ?? "normal",
+    userNearCreditLimit: data?.userNearCreditLimit ?? false,
     poolCreditState: data?.poolCreditState ?? "active",
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
     balanceThresholdReached: data?.balanceThresholdReached ?? false,
-    noSeat: data?.noSeat ?? false,
+    userBlockedReason: data?.userBlockedReason ?? null,
     canRequestUpgrade: data?.canRequestUpgrade ?? false,
     hasPendingUpgradeRequest: data?.hasPendingUpgradeRequest ?? false,
     isUsageStatusLoading: !error && !data && !disabled,


### PR DESCRIPTION
## Description

Three bugs fixed:

**1. `user_seat` members incorrectly blocked by pool depletion**

The frontend was pre-checking `poolCreditState === "depleted"` before creating a new conversation, which blocked `user_seat` members (pro/max seats with personal credits) even though they should be unaffected by a depleted workspace pool. `isUserBlocked` on the server already correctly exempts `user_seat` members from pool depletion — the client just wasn't using it.

Fix: replaced all client-side blocking derivations (`noSeat`, `awuStatus === "blocked"`, `poolCreditState === "depleted"`) with a single `userBlockedReason: UserBlockedReason | null` field returned directly from `isUserBlocked` on the server. The client now has zero blocking logic — it maps the server's answer to the right popup.

Also renamed `awuStatus: "normal" | "warned" | "blocked"` to `userNearCreditLimit: boolean` (the `"blocked"` case is now covered by `userBlockedReason`; the warning-only flag is clearer as a boolean).

**2. Limit-reached modal not appearing on retry / edit errors**

`useRetryMessage` and `useEditUserMessage` returned `WorkspaceLimit | null`, where `null` was ambiguous between success and non-limit errors. In practice several error paths silently returned `null` (failed JSON parse, unexpected error shape) and dropped the error entirely without showing a notification or the modal. Callers used `if (limitCode)` which couldn't distinguish these cases.

Fix: both hooks now return `Result<void, WorkspaceLimit>` — `Err(limitCode)` when a limit error is returned by the server, `Ok(undefined)` otherwise (with a notification for non-limit failures). Callers use `result.isErr()` for unambiguous handling.

**3. Stale `"capped"` Redis key not cleared by reconciliation**

`reconcileWorkspaceUserCreditStates` skipped calling `setUserCreditStateReconciled` when the DB state already matched the expected state. This optimization prevented the Redis cache from being refreshed, so a stale `"capped"` entry in Redis would persist indefinitely even after the DB was corrected — causing `isUserBlocked` to block users who should be able to post.

Fix: removed the early `continue`. `setUserCreditStateReconciled` already skips the DB write when state matches but always fires the Redis update — so calling it unconditionally is correct and cheap.

## Tests

- Updated `usage-status.test.ts` to assert `userBlockedReason` / `userNearCreditLimit` instead of the removed `awuStatus` field
- Fixed GEN6 lint: replaced nested ternary with exhaustive `switch` + `assertNeverAndIgnore` for `userBlockedReason` mapping
- Fixed React Doctor warning: replaced derived `useState` with `useRef` in `ReachedLimitPopup`

## Risk

Low. The blocking logic is now purely server-driven (no client-side derivation). The reconciliation change is additive — it only adds Redis writes that were previously skipped, never removes them.

## Deploy Plan

Standard deploy. No migration required. The `usage-status` endpoint response shape changes (removes `noSeat`, `awuStatus`; adds `userBlockedReason`, `userNearCreditLimit`) but all consumers are updated in this PR.