### PR TITLE
Store the programmatic monthly cap in credit_usage_configurations

### DIFF
--- a/front/lib/api/credits/programmatic_usage_limit.test.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.test.ts
@@ -1,5 +1,8 @@
 import * as workosAudit from "@app/lib/api/audit/workos_audit";
-import { syncProgrammaticUsageLimit } from "@app/lib/api/credits/programmatic_usage_limit";
+import {
+  getProgrammaticUsageLimit,
+  syncProgrammaticUsageLimit,
+} from "@app/lib/api/credits/programmatic_usage_limit";
 import { Authenticator } from "@app/lib/auth";
 import * as programmaticCap from "@app/lib/metronome/alerts/programmatic_cap";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -12,7 +15,6 @@ vi.mock("@app/lib/metronome/alerts/programmatic_cap", async () => {
   );
   return {
     ...actual,
-    getMetronomeProgrammaticCap: vi.fn(),
     upsertMetronomeProgrammaticCapAlerts: vi.fn(),
     clearMetronomeProgrammaticCapAlerts: vi.fn(),
   };
@@ -32,9 +34,6 @@ const METRONOME_CUSTOMER_ID = "cust_test_xxx";
 const AUDIT_CONTEXT = { location: "127.0.0.1" };
 
 beforeEach(() => {
-  vi.mocked(programmaticCap.getMetronomeProgrammaticCap).mockResolvedValue(
-    new Ok(null)
-  );
   vi.mocked(
     programmaticCap.upsertMetronomeProgrammaticCapAlerts
   ).mockResolvedValue(new Ok(undefined));
@@ -44,15 +43,67 @@ beforeEach(() => {
   vi.mocked(workosAudit.emitAuditLogEvent).mockResolvedValue(undefined);
 });
 
+describe("syncProgrammaticUsageLimit persistence", () => {
+  it("persists the cap to the configuration as the source of truth", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 500 });
+
+    const read = await getProgrammaticUsageLimit(auth);
+    expect(read.isOk() && read.value).toBe(500);
+    expect(
+      programmaticCap.upsertMetronomeProgrammaticCapAlerts
+    ).toHaveBeenCalled();
+  });
+
+  it("persists 0 as a hard cap rather than clearing it", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 0 });
+
+    const read = await getProgrammaticUsageLimit(auth);
+    expect(read.isOk() && read.value).toBe(0);
+    expect(
+      programmaticCap.upsertMetronomeProgrammaticCapAlerts
+    ).toHaveBeenCalled();
+    expect(
+      programmaticCap.clearMetronomeProgrammaticCapAlerts
+    ).not.toHaveBeenCalled();
+  });
+
+  it("clears the cap and the alerts when set to null", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 500 });
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: null });
+
+    const read = await getProgrammaticUsageLimit(auth);
+    expect(read.isOk() && read.value).toBe(null);
+    expect(
+      programmaticCap.clearMetronomeProgrammaticCapAlerts
+    ).toHaveBeenCalled();
+  });
+});
+
 describe("syncProgrammaticUsageLimit audit", () => {
   it("emits an audit event with previous and new cap", async () => {
     const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    vi.mocked(programmaticCap.getMetronomeProgrammaticCap).mockResolvedValue(
-      new Ok(200)
-    );
+
+    // Seed a previous cap, then ignore its audit emission.
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 200 });
+    vi.mocked(workosAudit.emitAuditLogEvent).mockClear();
 
     await syncProgrammaticUsageLimit({
       auth,
@@ -98,9 +149,9 @@ describe("syncProgrammaticUsageLimit audit", () => {
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-    vi.mocked(programmaticCap.getMetronomeProgrammaticCap).mockResolvedValue(
-      new Ok(500)
-    );
+
+    await syncProgrammaticUsageLimit({ auth, monthlyCapCredits: 500 });
+    vi.mocked(workosAudit.emitAuditLogEvent).mockClear();
 
     await syncProgrammaticUsageLimit({
       auth,

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -6,9 +6,9 @@ import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeProgrammaticCapAlerts,
-  getMetronomeProgrammaticCap,
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -24,9 +24,9 @@ export type PutProgrammaticUsageLimitResponseBody = {
 /**
  * Read the workspace's programmatic usage monthly cap.
  *
- * Metronome is the source of truth: the cap is the threshold of the
- * workspace's programmatic cap alert. Returns `null` when no cap is
- * configured.
+ * The cap is persisted on `credit_usage_configurations` (the source of truth);
+ * the Metronome programmatic alerts are derived enforcement. Returns `null`
+ * when no cap is configured.
  */
 export async function getProgrammaticUsageLimit(
   auth: Authenticator
@@ -38,25 +38,19 @@ export async function getProgrammaticUsageLimit(
     );
   }
 
-  const result = await getMetronomeProgrammaticCap({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  if (result.isErr()) {
-    return new Err(
-      new Error(
-        `Failed to read programmatic cap from Metronome: ${result.error.message}`
-      )
-    );
-  }
-  return new Ok(result.value);
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  return new Ok(config?.programmaticMonthlyCapAwuCredits ?? null);
 }
 
 /**
  * Set or clear the workspace's programmatic usage monthly cap.
  *
- * A strictly positive `monthlyCapCredits` upserts the three programmatic cap
- * alerts (cap, low balance, critical balance); `null` clears them.
+ * Persists the cap on `credit_usage_configurations` (the source of truth),
+ * then derives the four Metronome programmatic alerts (cap, warning, low,
+ * critical) from it. A non-negative `monthlyCapCredits` upserts the alerts
+ * (0 included, as a hard cap); `null` or a negative value clears both the
+ * stored cap and the alerts.
  */
 export async function syncProgrammaticUsageLimit({
   auth,
@@ -86,21 +80,38 @@ export async function syncProgrammaticUsageLimit({
     );
   }
 
-  // Read previous cap for audit metadata (best-effort).
-  const previousResult = await getMetronomeProgrammaticCap({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  const previousCapCredits = previousResult.isOk()
-    ? previousResult.value
-    : null;
+  // Persist the admin's intent first: the credit-usage configuration column is
+  // the source of truth; the Metronome alerts below are derived enforcement (a
+  // failed sync can be retried and re-derives from this value). The config row
+  // is created lazily, so upsert it. A normalized cap stores `null` (no cap)
+  // for any negative/absent value and the value itself otherwise (0 included,
+  // as a hard cap).
+  const normalizedCapCredits =
+    monthlyCapCredits !== null && monthlyCapCredits >= 0
+      ? monthlyCapCredits
+      : null;
+  const existingConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const previousCapCredits =
+    existingConfig?.programmaticMonthlyCapAwuCredits ?? null;
+  if (existingConfig) {
+    await existingConfig.updateConfiguration(auth, {
+      programmaticMonthlyCapAwuCredits: normalizedCapCredits,
+    });
+  } else {
+    await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      programmaticMonthlyCapAwuCredits: normalizedCapCredits,
+    });
+  }
 
   const alertResult =
-    monthlyCapCredits !== null && monthlyCapCredits >= 0
+    normalizedCapCredits !== null
       ? await upsertMetronomeProgrammaticCapAlerts({
           metronomeCustomerId: workspace.metronomeCustomerId,
           workspaceId: workspace.sId,
-          monthlyCapCredits,
+          monthlyCapCredits: normalizedCapCredits,
         })
       : await clearMetronomeProgrammaticCapAlerts({
           metronomeCustomerId: workspace.metronomeCustomerId,
@@ -123,7 +134,7 @@ export async function syncProgrammaticUsageLimit({
       previous_monthly_cap_credits:
         previousCapCredits !== null ? String(previousCapCredits) : "unset",
       new_monthly_cap_credits:
-        monthlyCapCredits !== null ? String(monthlyCapCredits) : "unset",
+        normalizedCapCredits !== null ? String(normalizedCapCredits) : "unset",
     },
   });
 

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -3,7 +3,6 @@ import { recalculatePerUserCapAlertForSeatChange } from "@app/lib/api/membership
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
-import { getMetronomeProgrammaticCap } from "@app/lib/metronome/alerts/programmatic_cap";
 import { getNetBalance } from "@app/lib/metronome/client";
 import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balance";
@@ -710,11 +709,12 @@ async function notifyAdminsProgrammaticCapAboutStatus({
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const lightWorkspace = renderLightWorkspaceType({ workspace });
 
-    const capResult = await getMetronomeProgrammaticCap({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-    });
-    const monthlyCapCredits = capResult.isOk() ? capResult.value : null;
+    const creditUsageConfig =
+      await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+        workspace.id
+      );
+    const monthlyCapCredits =
+      creditUsageConfig?.programmaticMonthlyCapAwuCredits ?? null;
 
     const { members: admins } = await getMembers(auth, {
       roles: ["admin"],

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_monthly_cap.ts
@@ -1,14 +1,9 @@
 import {
-  buildAuditLogTarget,
-  emitAuditLogEvent,
-} from "@app/lib/api/audit/workos_audit";
+  getProgrammaticUsageLimit,
+  syncProgrammaticUsageLimit,
+} from "@app/lib/api/credits/programmatic_usage_limit";
 import { dispatchProgrammaticCapReset } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { createPlugin } from "@app/lib/api/poke/types";
-import {
-  clearMetronomeProgrammaticCapAlerts,
-  getMetronomeProgrammaticCap,
-  upsertMetronomeProgrammaticCapAlerts,
-} from "@app/lib/metronome/alerts/programmatic_cap";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
@@ -58,7 +53,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     return plan !== null && isCreditPricedPlan(plan);
   },
 
-  populateAsyncArgs: async (_auth, workspace) => {
+  populateAsyncArgs: async (auth, workspace) => {
     if (!workspace) {
       return new Ok({
         enabled: false,
@@ -76,10 +71,7 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
       });
     }
 
-    const capResult = await getMetronomeProgrammaticCap({
-      metronomeCustomerId: workspaceResource.metronomeCustomerId,
-      workspaceId: workspace.sId,
-    });
+    const capResult = await getProgrammaticUsageLimit(auth);
     if (capResult.isErr()) {
       return new Err(capResult.error);
     }
@@ -137,69 +129,27 @@ export const manageProgrammaticMonthlyCapPlugin = createPlugin({
     }
     const { enabled, monthlyCapAwu } = parsed.data;
 
-    // Read previous cap for audit metadata (best-effort).
-    const previousResult = await getMetronomeProgrammaticCap({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-    });
-    const previousCapCredits = previousResult.isOk()
-      ? previousResult.value
-      : null;
-
-    if (enabled && monthlyCapAwu) {
-      const result = await upsertMetronomeProgrammaticCapAlerts({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-        monthlyCapCredits: monthlyCapAwu,
-      });
-      if (result.isErr()) {
-        return new Err(result.error);
-      }
-
-      // Reset the state machine — thresholds may have changed.
-      await dispatchProgrammaticCapReset({ workspace: workspaceResource });
-
-      void emitAuditLogEvent({
-        auth,
-        action: "workspace.programmatic_usage_limit_updated",
-        targets: [buildAuditLogTarget("workspace", workspace)],
-        metadata: {
-          previous_monthly_cap_credits:
-            previousCapCredits !== null ? String(previousCapCredits) : "unset",
-          new_monthly_cap_credits: String(monthlyCapAwu),
-        },
-      });
-
-      return new Ok({
-        display: "text",
-        value: `Programmatic monthly cap set to ${monthlyCapAwu} AWU for workspace "${workspace.name}".`,
-      });
-    }
-
-    // Disable: clear alerts and reset state.
-    const clearResult = await clearMetronomeProgrammaticCapAlerts({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-    });
-    if (clearResult.isErr()) {
-      return new Err(clearResult.error);
-    }
-    await dispatchProgrammaticCapReset({ workspace: workspaceResource });
-
-    void emitAuditLogEvent({
+    // `syncProgrammaticUsageLimit` persists the cap (DB source of truth),
+    // derives the Metronome alerts, and emits the audit event with the
+    // operator as actor. `null` clears the cap.
+    const monthlyCapCredits = enabled && monthlyCapAwu ? monthlyCapAwu : null;
+    const syncResult = await syncProgrammaticUsageLimit({
       auth,
-      action: "workspace.programmatic_usage_limit_updated",
-      targets: [buildAuditLogTarget("workspace", workspace)],
-      metadata: {
-        previous_monthly_cap_credits:
-          previousCapCredits !== null ? String(previousCapCredits) : "unset",
-        new_monthly_cap_credits: "unset",
-      },
+      monthlyCapCredits,
     });
+    if (syncResult.isErr()) {
+      return new Err(syncResult.error);
+    }
+
+    // Reset the state machine — thresholds may have changed.
+    await dispatchProgrammaticCapReset({ workspace: workspaceResource });
 
     return new Ok({
       display: "text",
-      value: `Programmatic monthly cap removed for workspace "${workspace.name}".`,
+      value:
+        monthlyCapCredits !== null
+          ? `Programmatic monthly cap set to ${monthlyCapCredits} AWU for workspace "${workspace.name}".`
+          : `Programmatic monthly cap removed for workspace "${workspace.name}".`,
     });
   },
 });

--- a/front/lib/metronome/alerts/programmatic_cap.ts
+++ b/front/lib/metronome/alerts/programmatic_cap.ts
@@ -1,6 +1,5 @@
 import {
   clearMetronomeAlert,
-  findMetronomeAlert,
   upsertMetronomeAlert,
 } from "@app/lib/metronome/alerts";
 import { listMetronomeAlerts } from "@app/lib/metronome/client";
@@ -63,27 +62,6 @@ export const PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME =
 export const PROGRAMMATIC_LOW_BALANCE_ALERT_NAME = "Programmatic low balance";
 export const PROGRAMMATIC_CRITICAL_BALANCE_ALERT_NAME =
   "Programmatic critical balance";
-
-/**
- * Read the current programmatic monthly cap from Metronome. Returns the cap
- * alert threshold (in Programmatic USD credits), or null if no cap is set.
- */
-export async function getMetronomeProgrammaticCap({
-  metronomeCustomerId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  workspaceId: string;
-}): Promise<Result<number | null, Error>> {
-  const result = await findMetronomeAlert({
-    metronomeCustomerId,
-    uniquenessKey: programmaticCapUniquenessKey(workspaceId),
-  });
-  if (result.isErr()) {
-    return new Err(result.error);
-  }
-  return new Ok(result.value?.alert.threshold ?? null);
-}
 
 export type ProgrammaticCapAlertState = {
   id: string;

--- a/front/lib/metronome/programmatic_awu_usage.ts
+++ b/front/lib/metronome/programmatic_awu_usage.ts
@@ -1,5 +1,4 @@
 import type { Authenticator } from "@app/lib/auth";
-import { getMetronomeProgrammaticCap } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
   ceilToMidnightUTC,
   floorToMidnightUTC,
@@ -16,6 +15,7 @@ import {
   isToolCategory,
   TOOL_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -40,22 +40,13 @@ export async function getRemainingProgrammaticUsageFromMetronome(
     return Infinity;
   }
 
-  const programmaticCapRes = await getMetronomeProgrammaticCap({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  if (programmaticCapRes.isErr()) {
-    logger.warn(
-      { workspaceId: workspace.sId, error: programmaticCapRes.error },
-      "[Metronome] Failed to fetch the programmatic cap — treating the programmatic headroom as unlimited"
-    );
-    return Infinity;
-  }
-  if (programmaticCapRes.value === null) {
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if (config?.programmaticMonthlyCapAwuCredits == null) {
     // No programmatic cap configured.
     return Infinity;
   }
-  const programmaticCapAwuCredits = programmaticCapRes.value;
+  const programmaticCapAwuCredits = config.programmaticMonthlyCapAwuCredits;
 
   const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
   if (!metronomeContractId) {

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -125,6 +125,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       allowMemberUpgradeRequests: boolean;
       upgradeRequestEmailEnabled: boolean;
       defaultPoolCapAwuCredits: number | null;
+      programmaticMonthlyCapAwuCredits: number | null;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -187,6 +188,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       allowMemberUpgradeRequests: this.allowMemberUpgradeRequests,
       upgradeRequestEmailEnabled: this.upgradeRequestEmailEnabled,
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
+      programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
     };
   }
 
@@ -200,6 +202,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       allowMemberUpgradeRequests: String(this.allowMemberUpgradeRequests),
       upgradeRequestEmailEnabled: String(this.upgradeRequestEmailEnabled),
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
+      programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -29,6 +29,10 @@ import type { CreationOptional } from "sequelize";
  *   workspace-pool AWU consumption, in AWU credits, excluding the seat
  *   allowance. NULL means no default is configured (the plan-tier default
  *   applies).
+ * - programmaticMonthlyCapAwuCredits: Workspace monthly cap on programmatic
+ *   (API) AWU consumption, in AWU credits. Source of truth for the cap; the
+ *   four Metronome programmatic alerts (cap/warning/low/critical) are derived
+ *   from it. NULL means no cap is configured; 0 is a meaningful hard cap.
  *
  * The credit-cap-warning notification settings (whether to warn, and at which
  * balance) are NOT stored here: they are derived from the workspace's Metronome
@@ -44,6 +48,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare allowMemberUpgradeRequests: CreationOptional<boolean>;
   declare upgradeRequestEmailEnabled: CreationOptional<boolean>;
   declare defaultPoolCapAwuCredits: number | null;
+  declare programmaticMonthlyCapAwuCredits: number | null;
 }
 
 CreditUsageConfigurationModel.init(
@@ -97,6 +102,11 @@ CreditUsageConfigurationModel.init(
       defaultValue: true,
     },
     defaultPoolCapAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    programmaticMonthlyCapAwuCredits: {
       type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,

--- a/front/migrations/20260616_backfill_programmatic_monthly_caps.ts
+++ b/front/migrations/20260616_backfill_programmatic_monthly_caps.ts
@@ -1,0 +1,104 @@
+import { Authenticator } from "@app/lib/auth";
+import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+
+/**
+ * Backfill `credit_usage_configurations.programmaticMonthlyCapAwuCredits` from
+ * the existing Metronome programmatic cap alert. Unlike the per-user pool cap,
+ * the cap alert threshold is the cap value itself (no seat-allowance math), so
+ * we copy it directly. The credit-usage configuration row is created lazily, so
+ * upsert it.
+ *
+ * Idempotent: workspaces already carrying the expected value are skipped.
+ *
+ * Pass `--wId <workspaceId>` to run on a single workspace.
+ */
+makeScript(
+  {
+    wId: {
+      type: "string",
+      required: false,
+      description: "Run on a single workspace (sId).",
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    let updated = 0;
+    let alreadySet = 0;
+    let skipped = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const { metronomeCustomerId } = workspace;
+        if (!metronomeCustomerId) {
+          return;
+        }
+
+        const statesResult = await getMetronomeProgrammaticCapAlertStates({
+          metronomeCustomerId,
+          workspaceId: workspace.sId,
+        });
+        if (statesResult.isErr()) {
+          logger.error(
+            { workspaceId: workspace.sId, err: statesResult.error },
+            "Failed to read programmatic cap alerts; skipping workspace."
+          );
+          skipped++;
+          return;
+        }
+
+        const programmaticMonthlyCapAwuCredits =
+          statesResult.value.cap?.threshold ?? null;
+        if (programmaticMonthlyCapAwuCredits === null) {
+          // No programmatic cap configured for this workspace.
+          return;
+        }
+
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const config =
+          await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+        if (
+          config?.programmaticMonthlyCapAwuCredits ===
+          programmaticMonthlyCapAwuCredits
+        ) {
+          alreadySet++;
+          return;
+        }
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            programmaticMonthlyCapAwuCredits,
+            previous: config?.programmaticMonthlyCapAwuCredits ?? null,
+          },
+          execute
+            ? "Backfilling programmatic monthly cap."
+            : "Would backfill programmatic monthly cap."
+        );
+        if (execute) {
+          if (config) {
+            await config.updateConfiguration(auth, {
+              programmaticMonthlyCapAwuCredits,
+            });
+          } else {
+            await CreditUsageConfigurationResource.makeNew(auth, {
+              defaultDiscountPercent: 0,
+              usageCapCredits: null,
+              programmaticMonthlyCapAwuCredits,
+            });
+          }
+        }
+        updated++;
+      },
+      { wId }
+    );
+
+    logger.info(
+      { updated, alreadySet, skipped },
+      execute ? "Backfill completed." : "Dry run completed."
+    );
+  }
+);

--- a/front/migrations/db/migration_682.sql
+++ b/front/migrations/db/migration_682.sql
@@ -1,0 +1,8 @@
+-- Migration created on Jun 16, 2026
+-- Workspace monthly cap on programmatic (API) AWU consumption, in AWU credits.
+-- Stored on credit_usage_configurations as the source of truth; the four
+-- Metronome programmatic alerts (cap/warning/low/critical) are derived from it.
+-- NULL means no cap is configured; 0 is a meaningful hard cap at zero.
+SET statement_timeout = '2s';
+SET lock_timeout = '2s';
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "programmaticMonthlyCapAwuCredits" INTEGER;


### PR DESCRIPTION
## Description

Persist the workspace programmatic monthly cap on credit_usage_configurations as the source of truth; the four Metronome programmatic alerts (cap/warning/low/critical) are derived from it. getProgrammaticUsageLimit and the dispatcher/headroom read paths now read the DB column instead of the alert threshold. The poke plugin routes through syncProgrammaticUsageLimit. 0 persists as a hard cap; NULL means no cap.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

1. Merge
2. Run migration
3. Run `npx tsx migrations/20260616_backfill_programmatic_monthly_caps.ts --wId <wId> --execute` on Metronome workspaces
