### PR TITLE
[intercom] strip null byte

### DIFF
--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -238,7 +238,7 @@ export async function syncConversation({
   const source = conversation.source?.type ?? null;
   const firstMessageAuthor = conversation.source?.author ?? null;
   const firstMessageContent = conversation.source?.body
-    ? stripNullBytes(htmlToMarkdown(conversation.source.body))
+    ? htmlToMarkdown(stripNullBytes(conversation.source.body))
     : null;
 
   markdown += `# ${convoTitle}\n\n`;
@@ -255,7 +255,7 @@ export async function syncConversation({
     (part: ConversationPartType) => {
       const messageAuthor = part.author;
       const messageContent = part.body
-        ? stripNullBytes(htmlToMarkdown(part.body))
+        ? htmlToMarkdown(stripNullBytes(part.body))
         : null;
       const type = part.part_type === "note" ? "Internal note" : "Message";
 

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -244,7 +244,7 @@ export async function syncConversation({
   markdown += `# ${convoTitle}\n\n`;
   markdown += `**TAGS: ${tagsAsString ?? "no tags"}**\n`;
   markdown += `**SOURCE: ${source || "unknown"}**\n`;
-  markdown += `**CUSTOM ATTRIBUTES: ${stripNullBytes(JSON.stringify(customAttributes))}**\n\n`;
+  markdown += `**CUSTOM ATTRIBUTES: ${JSON.stringify(customAttributes)}**\n\n`;
 
   if (firstMessageAuthor && firstMessageContent) {
     markdown += `**[Message] ${stripNullBytes(firstMessageAuthor.name)} (${firstMessageAuthor.type})**\n`;

--- a/connectors/src/connectors/intercom/temporal/sync_conversation.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_conversation.ts
@@ -29,7 +29,7 @@ import {
 } from "@connectors/lib/models/intercom";
 import logger from "@connectors/logger/logger";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
-import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES, stripNullBytes } from "@connectors/types";
 export async function deleteTeamAndConversations({
   connectorId,
   dataSourceConfig,
@@ -218,7 +218,9 @@ export async function syncConversation({
 
   // Building the markdown content for the conversation
   let markdown = "";
-  let convoTitle = conversation.title;
+  let convoTitle = conversation.title
+    ? stripNullBytes(conversation.title)
+    : null;
 
   if (!convoTitle) {
     const formattedDate = createdAtDate.toLocaleDateString("en-US", {
@@ -230,34 +232,38 @@ export async function syncConversation({
   }
   const customAttributes = conversation.custom_attributes;
   const tags = conversation.tags?.tags ?? [];
-  const tagsAsString = tags.map((tag: IntercomTagType) => tag.name).join(", ");
+  const tagsAsString = tags
+    .map((tag: IntercomTagType) => stripNullBytes(tag.name))
+    .join(", ");
   const source = conversation.source?.type ?? null;
   const firstMessageAuthor = conversation.source?.author ?? null;
   const firstMessageContent = conversation.source?.body
-    ? htmlToMarkdown(conversation.source.body)
+    ? stripNullBytes(htmlToMarkdown(conversation.source.body))
     : null;
 
   markdown += `# ${convoTitle}\n\n`;
   markdown += `**TAGS: ${tagsAsString ?? "no tags"}**\n`;
   markdown += `**SOURCE: ${source || "unknown"}**\n`;
-  markdown += `**CUSTOM ATTRIBUTES: ${JSON.stringify(customAttributes)}**\n\n`;
+  markdown += `**CUSTOM ATTRIBUTES: ${stripNullBytes(JSON.stringify(customAttributes))}**\n\n`;
 
   if (firstMessageAuthor && firstMessageContent) {
-    markdown += `**[Message] ${firstMessageAuthor.name} (${firstMessageAuthor.type})**\n`;
+    markdown += `**[Message] ${stripNullBytes(firstMessageAuthor.name)} (${firstMessageAuthor.type})**\n`;
     markdown += `${firstMessageContent}\n\n`;
   }
 
   conversation.conversation_parts.conversation_parts.forEach(
     (part: ConversationPartType) => {
       const messageAuthor = part.author;
-      const messageContent = part.body ? htmlToMarkdown(part.body) : null;
+      const messageContent = part.body
+        ? stripNullBytes(htmlToMarkdown(part.body))
+        : null;
       const type = part.part_type === "note" ? "Internal note" : "Message";
 
       const shouldSync =
         part.part_type !== "note" || intercomWorkspace.shouldSyncNotes;
 
       if (messageContent && shouldSync) {
-        markdown += `**[${type}] ${messageAuthor.name} (${messageAuthor.type})**\n`;
+        markdown += `**[${type}] ${stripNullBytes(messageAuthor.name)} (${messageAuthor.type})**\n`;
         markdown += `${messageContent}\n\n`;
       }
     }
@@ -270,7 +276,7 @@ export async function syncConversation({
 
   const renderedPage = await renderDocumentTitleAndContent({
     dataSourceConfig,
-    title: conversation.title,
+    title: convoTitle,
     content: renderedMarkdown,
     createdAt: createdAtDate,
     updatedAt: updatedAtDate,
@@ -295,13 +301,13 @@ export async function syncConversation({
       typeof value === "number" ||
       typeof value === "boolean"
     ) {
-      systemTags.push(`attribute:${name}:${value}`);
+      systemTags.push(stripNullBytes(`attribute:${name}:${value}`));
     }
   });
 
   const customTags: string[] = [];
   tags.forEach((tag) => {
-    customTags.push(`tag:${tag.name}`);
+    customTags.push(stripNullBytes(`tag:${tag.name}`));
   });
 
   const datasourceTags = [

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -369,7 +369,7 @@ export async function upsertArticle({
 
   let articleContentInMarkdown =
     typeof article.body === "string"
-      ? stripNullBytes(htmlToMarkdown(article.body))
+      ? htmlToMarkdown(stripNullBytes(article.body))
       : "";
 
   if (!articleContentInMarkdown) {

--- a/connectors/src/connectors/intercom/temporal/sync_help_center.ts
+++ b/connectors/src/connectors/intercom/temporal/sync_help_center.ts
@@ -36,6 +36,7 @@ import {
   concurrentExecutor,
   INTERNAL_MIME_TYPES,
   safeSubstring,
+  stripNullBytes,
 } from "@connectors/types";
 
 /**
@@ -367,7 +368,9 @@ export async function upsertArticle({
       : "";
 
   let articleContentInMarkdown =
-    typeof article.body === "string" ? htmlToMarkdown(article.body) : "";
+    typeof article.body === "string"
+      ? stripNullBytes(htmlToMarkdown(article.body))
+      : "";
 
   if (!articleContentInMarkdown) {
     logger.warn(
@@ -390,7 +393,7 @@ export async function upsertArticle({
   );
   const renderedPage = await renderDocumentTitleAndContent({
     dataSourceConfig,
-    title: article.title,
+    title: stripNullBytes(article.title),
     content: renderedMarkdown,
     createdAt: createdAtDate,
     updatedAt: updatedAtDate,
@@ -412,7 +415,7 @@ export async function upsertArticle({
     documentUrl: articleUrl,
     timestampMs: updatedAtDate.getTime(),
     tags: [
-      `title:${article.title}`,
+      `title:${stripNullBytes(article.title)}`,
       `createdAt:${createdAtDate.getTime()}`,
       `updatedAt:${updatedAtDate.getTime()}`,
     ],
@@ -425,7 +428,7 @@ export async function upsertArticle({
     upsertContext: {
       sync_type: "batch",
     },
-    title: article.title,
+    title: stripNullBytes(article.title),
     mimeType: INTERNAL_MIME_TYPES.INTERCOM.ARTICLE,
     async: true,
   });


### PR DESCRIPTION
## Description
This PR is to fix this error in intercom connector: 
```
Upsert error: Failed to upsert document (error: db error: ERROR: invalid byte sequence for encoding \"UTF8\": 0x00\n\nCaused by:\n    ERROR: invalid byte sequence for encoding \"UTF8\": 0x00)",
```

I checked the document causing this, and actually it contains a literal null byte because it's about somebody asking an agent on how to fix a problem of null byte 🙃

This won't fix for the stucked one so I need to pause and restart if I understand it correctly. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
