### PR TITLE
feat(file-explorer): Office and PDF file preview via Gotenberg + react-pdf

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -157,7 +157,7 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
         "Content-Type": "application/pdf",
         "Content-Disposition": `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`,
         "Content-Length": String(pdfBuffer.length),
-        "Cache-Control": "private, max-age=300",
+        "Cache-Control": "private, max-age=3600",
       },
     });
   }

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { DustFileSystemError } from "@app/lib/api/file_system/types";
 import {
@@ -7,7 +8,6 @@ import {
   renameCanonicalFile,
   streamThumbnail,
 } from "@app/lib/api/files/file_system_ops";
-import config from "@app/lib/api/config";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -1,11 +1,13 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { DustFileSystemError } from "@app/lib/api/file_system/types";
 import {
+  convertCanonicalFileToPdf,
   deleteCanonicalFile,
   moveCanonicalFile,
   renameCanonicalFile,
   streamThumbnail,
 } from "@app/lib/api/files/file_system_ops";
+import config from "@app/lib/api/config";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
@@ -90,6 +92,75 @@ app.get("/:canonicalPath{.+}", validate("param", ParamsSchema), async (ctx) => {
 
   const thumbnail = ctx.req.query("thumbnail");
   const download = ctx.req.query("download");
+  const previewPdf = ctx.req.query("preview") === "pdf";
+
+  // ?preview=pdf converts Office files to PDF via Gotenberg's LibreOffice route.
+  if (previewPdf) {
+    const rendererUrl = config.getDocumentRendererUrl();
+    if (!rendererUrl) {
+      return apiError(ctx, {
+        status_code: 503,
+        api_error: {
+          type: "internal_server_error",
+          message: "PDF preview is not configured.",
+        },
+      });
+    }
+
+    const conversionResult = await convertCanonicalFileToPdf(
+      dustFs,
+      canonicalPath,
+      rendererUrl
+    );
+    if (conversionResult.isErr()) {
+      const e = conversionResult.error;
+
+      switch (e.code) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: { type: "file_not_found", message: e.message },
+          });
+
+        case "too_large":
+          return apiError(ctx, {
+            status_code: 413,
+            api_error: { type: "invalid_request_error", message: e.message },
+          });
+
+        case "unsupported_type":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: { type: "invalid_request_error", message: e.message },
+          });
+
+        case "conversion_failed":
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: { type: "internal_server_error", message: e.message },
+          });
+
+        default:
+          assertNever(e.code);
+      }
+    }
+
+    const { pdfBuffer, pdfFileName } = conversionResult.value;
+    // RFC 5987: filename= must be ASCII-safe; filename*= carries the UTF-8 encoded name.
+    const asciiFallback = pdfFileName.replace(/[^\x20-\x7E]/g, "_");
+    const encodedName = encodeURIComponent(pdfFileName);
+
+    return new Response(new Uint8Array(pdfBuffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `inline; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`,
+        "Content-Length": String(pdfBuffer.length),
+        "Cache-Control": "private, max-age=300",
+      },
+    });
+  }
 
   // ?thumbnail=1 serves the resized/processed version (images only).
   if (thumbnail && thumbnail !== "0") {

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -181,10 +181,14 @@ function FilePreviewDialogContent({
       );
 
     case "pdf":
-      return <PDFViewer url={fileUrl} />;
+      return <PDFViewer url={`${fileUrl}?v=${entry.lastModifiedMs}`} />;
 
     case "viewer":
-      return <PDFViewer url={`${fileUrl}?preview=pdf`} />;
+      return (
+        <PDFViewer
+          url={`${fileUrl}?preview=pdf&v=${entry.lastModifiedMs}`}
+        />
+      );
 
     case "audio":
       return (

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,4 +1,5 @@
 import type { FileEntry } from "@app/components/file_explorer/types";
+import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
 import { useFileContent } from "@app/hooks/useFileContent";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
@@ -180,23 +181,10 @@ function FilePreviewDialogContent({
       );
 
     case "pdf":
-      return (
-        <iframe
-          src={`${fileUrl}#navpanes=0`}
-          className="h-[70vh] w-full rounded-lg border-0"
-          title={entry.fileName}
-        />
-      );
+      return <PDFViewer url={fileUrl} />;
 
     case "viewer":
-      // TODO(20260504 FILE_SYSTEM): add Office viewer preview support.
-      return (
-        <div className="flex h-48 items-center justify-center">
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Cannot preview this file type. You can download it instead.
-          </p>
-        </div>
-      );
+      return <PDFViewer url={`${fileUrl}?preview=pdf`} />;
 
     case "audio":
       return (

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,5 +1,5 @@
-import type { FileEntry } from "@app/components/file_explorer/types";
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
+import type { FileEntry } from "@app/components/file_explorer/types";
 import { getFilePreviewConfig } from "@app/components/spaces/FilePreviewSheet";
 import { useFileContent } from "@app/hooks/useFileContent";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
@@ -181,11 +181,14 @@ function FilePreviewDialogContent({
       );
 
     case "pdf":
-      return <PDFViewer url={`${fileUrl}?v=${entry.lastModifiedMs}`} />;
+      return (
+        <PDFViewer key={fileUrl} url={`${fileUrl}?v=${entry.lastModifiedMs}`} />
+      );
 
     case "viewer":
       return (
         <PDFViewer
+          key={fileUrl}
           url={`${fileUrl}?preview=pdf&v=${entry.lastModifiedMs}`}
         />
       );

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -1,0 +1,192 @@
+import { clientFetch } from "@app/lib/egress/client";
+import { Button, Spinner } from "@dust-tt/sparkle";
+import { useEffect, useRef, useState } from "react";
+import { Document, Page, pdfjs } from "react-pdf";
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url
+).toString();
+
+const ZOOM_LEVELS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
+const DEFAULT_ZOOM_IDX = 2;
+const BASE_PAGE_WIDTH = 680;
+
+interface PDFViewerProps {
+  url: string;
+}
+
+export function PDFViewer({ url }: PDFViewerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [zoomIdx, setZoomIdx] = useState(DEFAULT_ZOOM_IDX);
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [isFetching, setIsFetching] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let createdObjectUrl: string | null = null;
+
+    setIsFetching(true);
+    setObjectUrl(null);
+    setHasError(false);
+    setNumPages(null);
+    setCurrentPage(1);
+    setZoomIdx(DEFAULT_ZOOM_IDX);
+
+    void (async () => {
+      try {
+        const res = await clientFetch(url);
+        if (cancelled) {
+          return;
+        }
+        if (!res.ok) {
+          setHasError(true);
+          return;
+        }
+
+        const blob = await res.blob();
+        if (cancelled) {
+          return;
+        }
+
+        createdObjectUrl = URL.createObjectURL(blob);
+        setObjectUrl(createdObjectUrl);
+      } catch {
+        if (!cancelled) {
+          setHasError(true);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsFetching(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+
+      if (createdObjectUrl) {
+        URL.revokeObjectURL(createdObjectUrl);
+      }
+    };
+  }, [url]);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container || !numPages) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const topVisible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+          .at(0);
+
+        if (topVisible && topVisible.target instanceof HTMLElement) {
+          const pageNum = Number(topVisible.target.dataset.pageNumber);
+          if (!isNaN(pageNum)) {
+            setCurrentPage(pageNum);
+          }
+        }
+      },
+      { root: container, threshold: 0.1 }
+    );
+
+    container
+      .querySelectorAll("[data-page-number]")
+      .forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [numPages]);
+
+  const zoom = ZOOM_LEVELS[zoomIdx] ?? 1.0;
+  const pageWidth = Math.round(BASE_PAGE_WIDTH * zoom);
+
+  const isLoading = isFetching || (!hasError && numPages === null);
+
+  return (
+    <div className="flex h-full flex-col gap-2">
+      {isLoading && (
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </div>
+      )}
+      {hasError && (
+        <div className="flex flex-1 items-center justify-center px-4">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Unable to load file. You can download it instead.
+          </p>
+        </div>
+      )}
+      {!isFetching && !hasError && (
+        <>
+          {numPages !== null && (
+            <div className="flex items-center justify-between rounded-lg bg-muted-background px-3 py-1.5 dark:bg-muted-background-night">
+              <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                Page {currentPage} of {numPages}
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  label="-"
+                  disabled={zoomIdx <= 0}
+                  onClick={() => setZoomIdx((i) => i - 1)}
+                  tooltip="Zoom out"
+                />
+                <span className="w-10 text-center text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {Math.round(zoom * 100)}%
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  label="+"
+                  disabled={zoomIdx >= ZOOM_LEVELS.length - 1}
+                  onClick={() => setZoomIdx((i) => i + 1)}
+                  tooltip="Zoom in"
+                />
+              </div>
+            </div>
+          )}
+          <div
+            ref={scrollRef}
+            className={
+              numPages !== null
+                ? "flex-1 min-h-0 overflow-y-auto rounded-lg"
+                : "hidden"
+            }
+          >
+            <Document
+              file={objectUrl}
+              onLoadSuccess={({ numPages: n }) => setNumPages(n)}
+              onLoadError={() => setHasError(true)}
+              loading={null}
+              error={null}
+            >
+              <div className="flex flex-col items-center gap-4 py-4">
+                {Array.from({ length: numPages ?? 0 }, (_, i) => (
+                  <div key={i + 1} data-page-number={i + 1}>
+                    <Page
+                      pageNumber={i + 1}
+                      width={pageWidth}
+                      renderTextLayer={true}
+                      renderAnnotationLayer={true}
+                      className="shadow-md"
+                    />
+                  </div>
+                ))}
+              </div>
+            </Document>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -34,11 +34,11 @@ type Action =
   | { type: "zoom_out" };
 
 const initialState: State = {
-  isFetching: true,
-  hasError: false,
-  objectUrl: null,
-  numPages: null,
   currentPage: 1,
+  hasError: false,
+  isFetching: true,
+  numPages: null,
+  objectUrl: null,
   zoomIdx: DEFAULT_ZOOM_IDX,
 };
 

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -1,6 +1,7 @@
 import { clientFetch } from "@app/lib/egress/client";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { Button, Spinner } from "@dust-tt/sparkle";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -14,29 +15,78 @@ const ZOOM_LEVELS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
 const DEFAULT_ZOOM_IDX = 2;
 const BASE_PAGE_WIDTH = 680;
 
+type State = {
+  isFetching: boolean;
+  hasError: boolean;
+  objectUrl: string | null;
+  numPages: number | null;
+  currentPage: number;
+  zoomIdx: number;
+};
+
+type Action =
+  | { type: "fetch_success"; objectUrl: string }
+  | { type: "fetch_error" }
+  | { type: "document_loaded"; numPages: number }
+  | { type: "document_error" }
+  | { type: "set_current_page"; page: number }
+  | { type: "zoom_in" }
+  | { type: "zoom_out" };
+
+const initialState: State = {
+  isFetching: true,
+  hasError: false,
+  objectUrl: null,
+  numPages: null,
+  currentPage: 1,
+  zoomIdx: DEFAULT_ZOOM_IDX,
+};
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "fetch_success":
+      return { ...state, isFetching: false, objectUrl: action.objectUrl };
+
+    case "fetch_error":
+      return { ...state, isFetching: false, hasError: true };
+
+    case "document_loaded":
+      return { ...state, numPages: action.numPages };
+
+    case "document_error":
+      return { ...state, hasError: true };
+
+    case "set_current_page":
+      return { ...state, currentPage: action.page };
+
+    case "zoom_in":
+      return {
+        ...state,
+        zoomIdx: Math.min(state.zoomIdx + 1, ZOOM_LEVELS.length - 1),
+      };
+
+    case "zoom_out":
+      return { ...state, zoomIdx: Math.max(state.zoomIdx - 1, 0) };
+
+    default:
+      assertNeverAndIgnore(action);
+      return state;
+  }
+}
+
 interface PDFViewerProps {
   url: string;
 }
 
 export function PDFViewer({ url }: PDFViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [numPages, setNumPages] = useState<number | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [zoomIdx, setZoomIdx] = useState(DEFAULT_ZOOM_IDX);
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [isFetching, setIsFetching] = useState(true);
-  const [hasError, setHasError] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isFetching, hasError, objectUrl, numPages, currentPage, zoomIdx } =
+    state;
 
   useEffect(() => {
     let cancelled = false;
     let createdObjectUrl: string | null = null;
-
-    setIsFetching(true);
-    setObjectUrl(null);
-    setHasError(false);
-    setNumPages(null);
-    setCurrentPage(1);
-    setZoomIdx(DEFAULT_ZOOM_IDX);
 
     void (async () => {
       try {
@@ -45,7 +95,7 @@ export function PDFViewer({ url }: PDFViewerProps) {
           return;
         }
         if (!res.ok) {
-          setHasError(true);
+          dispatch({ type: "fetch_error" });
           return;
         }
 
@@ -55,14 +105,10 @@ export function PDFViewer({ url }: PDFViewerProps) {
         }
 
         createdObjectUrl = URL.createObjectURL(blob);
-        setObjectUrl(createdObjectUrl);
+        dispatch({ type: "fetch_success", objectUrl: createdObjectUrl });
       } catch {
         if (!cancelled) {
-          setHasError(true);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsFetching(false);
+          dispatch({ type: "fetch_error" });
         }
       }
     })();
@@ -92,7 +138,7 @@ export function PDFViewer({ url }: PDFViewerProps) {
         if (topVisible && topVisible.target instanceof HTMLElement) {
           const pageNum = Number(topVisible.target.dataset.pageNumber);
           if (!isNaN(pageNum)) {
-            setCurrentPage(pageNum);
+            dispatch({ type: "set_current_page", page: pageNum });
           }
         }
       },
@@ -138,7 +184,7 @@ export function PDFViewer({ url }: PDFViewerProps) {
                   size="sm"
                   label="-"
                   disabled={zoomIdx <= 0}
-                  onClick={() => setZoomIdx((i) => i - 1)}
+                  onClick={() => dispatch({ type: "zoom_out" })}
                   tooltip="Zoom out"
                 />
                 <span className="w-10 text-center text-xs text-muted-foreground dark:text-muted-foreground-night">
@@ -149,7 +195,7 @@ export function PDFViewer({ url }: PDFViewerProps) {
                   size="sm"
                   label="+"
                   disabled={zoomIdx >= ZOOM_LEVELS.length - 1}
-                  onClick={() => setZoomIdx((i) => i + 1)}
+                  onClick={() => dispatch({ type: "zoom_in" })}
                   tooltip="Zoom in"
                 />
               </div>
@@ -165,8 +211,10 @@ export function PDFViewer({ url }: PDFViewerProps) {
           >
             <Document
               file={objectUrl}
-              onLoadSuccess={({ numPages: n }) => setNumPages(n)}
-              onLoadError={() => setHasError(true)}
+              onLoadSuccess={({ numPages: n }) =>
+                dispatch({ type: "document_loaded", numPages: n })
+              }
+              onLoadError={() => dispatch({ type: "document_error" })}
               loading={null}
               error={null}
             >

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -17,6 +17,9 @@ import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import { isSupportedImageContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { DocumentRenderer } from "@app/types/shared/document_renderer";
+import logger from "@app/logger/logger";
+import path from "path";
 import type { Readable } from "stream";
 
 // ---------------------------------------------------------------------------
@@ -333,6 +336,130 @@ export async function moveCanonicalFile(
   }
 
   return moveResult;
+}
+
+// ---------------------------------------------------------------------------
+// Office → PDF conversion
+// ---------------------------------------------------------------------------
+
+const OFFICE_PREVIEW_CONTENT_TYPES = new Set([
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+async function readableToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+const OFFICE_PDF_MAX_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+const OFFICE_PDF_CONVERSION_TIMEOUT_MS = 60_000;
+
+export type OfficePdfErrorCode =
+  | "not_found"
+  | "too_large"
+  | "unsupported_type"
+  | "conversion_failed"
+  | "internal";
+
+export class OfficePdfError extends Error {
+  constructor(
+    readonly code: OfficePdfErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "OfficePdfError";
+  }
+}
+
+export type OfficePdfResult = {
+  pdfBuffer: Buffer;
+  pdfFileName: string;
+};
+
+/**
+ * Read an Office file at `canonicalPath` from GCS and convert it to PDF using
+ * Gotenberg's LibreOffice route. `rendererUrl` is the Gotenberg base URL; the
+ * caller is responsible for checking it is configured before calling this.
+ */
+export async function convertCanonicalFileToPdf(
+  dustFs: DustFileSystem,
+  canonicalPath: string,
+  rendererUrl: string
+): Promise<Result<OfficePdfResult, OfficePdfError>> {
+  const statResult = await dustFs.stat(canonicalPath);
+  if (statResult.isErr()) {
+    return new Err(new OfficePdfError("internal", statResult.error.message));
+  }
+
+  if (!statResult.value) {
+    return new Err(
+      new OfficePdfError("not_found", `File not found: \`${canonicalPath}\`.`)
+    );
+  }
+
+  const { contentType, sizeBytes } = statResult.value;
+
+  if (sizeBytes > OFFICE_PDF_MAX_SIZE_BYTES) {
+    return new Err(
+      new OfficePdfError(
+        "too_large",
+        `File exceeds the ${OFFICE_PDF_MAX_SIZE_BYTES / 1024 / 1024} MB limit for PDF preview.`
+      )
+    );
+  }
+
+  if (!OFFICE_PREVIEW_CONTENT_TYPES.has(contentType)) {
+    return new Err(
+      new OfficePdfError(
+        "unsupported_type",
+        "PDF preview is only supported for Office file types."
+      )
+    );
+  }
+
+  // TODO: Consider streaming the GCS read directly into Gotenberg's multipart body and piping its
+  // response back to the client to avoid buffering the full file in memory.
+  const readResult = await dustFs.read(canonicalPath);
+  if (readResult.isErr()) {
+    return new Err(new OfficePdfError("internal", readResult.error.message));
+  }
+
+  if (!readResult.value) {
+    return new Err(
+      new OfficePdfError("not_found", `File not found: \`${canonicalPath}\`.`)
+    );
+  }
+
+  const fileBuffer = await readableToBuffer(readResult.value);
+  const fileName = path.posix.basename(canonicalPath);
+
+  const renderer = new DocumentRenderer(rendererUrl, logger, {
+    timeoutMs: OFFICE_PDF_CONVERSION_TIMEOUT_MS,
+  });
+
+  const conversionResult = await renderer.convertOfficeToPdf(
+    fileBuffer,
+    fileName
+  );
+  if (conversionResult.isErr()) {
+    return new Err(
+      new OfficePdfError("conversion_failed", conversionResult.error.message)
+    );
+  }
+
+  return new Ok({
+    pdfBuffer: conversionResult.value,
+    pdfFileName: fileName.replace(/\.[^.]+$/, ".pdf"),
+  });
 }
 
 /**

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -13,12 +13,12 @@ import {
 } from "@app/lib/api/file_system/types";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import logger from "@app/logger/logger";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import { isSupportedImageContentType } from "@app/types/files";
+import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { DocumentRenderer } from "@app/types/shared/document_renderer";
-import logger from "@app/logger/logger";
 import path from "path";
 import type { Readable } from "stream";
 

--- a/front/package.json
+++ b/front/package.json
@@ -198,6 +198,7 @@
     "react-image-crop": "^10.1.8",
     "react-intersection-observer": "^9.13.1",
     "react-markdown": "^8.0.7",
+    "react-pdf": "^10.4.1",
     "react-phone-number-input": "^3.4.14",
     "react-resizable-panels": "^2.1.7",
     "react-svg-credit-card-payment-icons": "^5.1.2",

--- a/front/types/shared/document_renderer/index.ts
+++ b/front/types/shared/document_renderer/index.ts
@@ -160,6 +160,55 @@ export class DocumentRenderer {
   }
 
   /**
+   * Convert an Office document (DOCX, XLSX, PPTX, …) to PDF using Gotenberg's
+   * LibreOffice route. The file name extension tells LibreOffice the source format.
+   */
+  async convertOfficeToPdf(
+    fileBuffer: Buffer,
+    fileName: string
+  ): Promise<Result<Buffer, DocumentRendererError>> {
+    const formData = new FormData();
+    formData.append("files", new Blob([new Uint8Array(fileBuffer)]), fileName);
+
+    try {
+      // eslint-disable-next-line no-restricted-globals
+      const response = await fetch(
+        `${this.serviceUrl}/forms/libreoffice/convert`,
+        {
+          method: "POST",
+          body: formData,
+          signal: AbortSignal.timeout(this.timeoutMs),
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        this.logger.error(
+          { status: response.status, error: errorText },
+          "Office PDF conversion failed"
+        );
+        return new Err(
+          new DocumentRendererError(
+            "render_failed",
+            `Office PDF conversion failed: ${errorText}`,
+            response.status
+          )
+        );
+      }
+
+      return new Ok(Buffer.from(await response.arrayBuffer()));
+    } catch (error) {
+      this.logger.error({ error }, "Office PDF conversion network error");
+      return new Err(
+        new DocumentRendererError(
+          "network_error",
+          normalizeError(error).message
+        )
+      );
+    }
+  }
+
+  /**
    * Capture a screenshot of a self-contained HTML string.
    * The HTML is uploaded directly to Gotenberg so no public URL is required.
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -656,6 +656,7 @@
         "react-image-crop": "^10.1.8",
         "react-intersection-observer": "^9.13.1",
         "react-markdown": "^8.0.7",
+        "react-pdf": "^10.4.1",
         "react-phone-number-input": "^3.4.14",
         "react-resizable-panels": "^2.1.7",
         "react-svg-credit-card-payment-icons": "^5.1.2",
@@ -8438,6 +8439,271 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -36704,12 +36970,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-2.0.0.tgz",
+      "integrity": "sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/make-event-props": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+      "integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
     },
     "node_modules/map-stream": {
       "version": "0.1.0",
@@ -38063,6 +38347,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-2.0.0.tgz",
+      "integrity": "sha512-3+B21mYK2IqUWnd2EivABLT7ueDhb0b8/dGK8LoFQPrU61YITeCMn14F7y7qZafWNZhUEKb24cJdiT5Wxs3prg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge-stream": {
@@ -44105,6 +44406,18 @@
         "through": "~2.3"
       }
     },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
     "node_modules/peberminta": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
@@ -46248,6 +46561,35 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-pdf": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
+      "integrity": "sha512-kS/35staVCBqS29verTQJQZXw7RfsRCPO3fdJoW1KXylcv7A9dw6DZ3vJXC2w+bIBgLw5FN4pOFvKSQtkQhPfA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^2.0.0",
+        "make-event-props": "^2.0.0",
+        "merge-refs": "^2.0.0",
+        "pdfjs-dist": "5.4.296",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-phone-number-input": {
       "version": "3.4.16",
@@ -55718,6 +56060,15 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The file explorer previously had no preview capability for Office documents and relied on the browser's native iframe renderer for PDFs, which is inconsistent across browsers and visually rough. This change adds a "polished" preview experience for both, leveraging infrastructure that was already in place.

For Office documents (e.g. Word, Excel, and PowerPoint in both legacy and Open XML formats) the preview works by routing the file through Gotenberg's LibreOffice conversion endpoint, which was already wired into the codebase for other rendering tasks. Gotenberg delegates to LibreOffice, using the file's extension to determine the source format, and returns a PDF. That PDF is then served back to the client inline with a five-minute private browser cache window, so reopening the same file within that period costs nothing on the server side. A 50 MB size guard is enforced at stat time, before any reading or conversion happens, to keep memory pressure predictable.

For native PDFs the same viewer is used directly, without the conversion step. The viewer itself is built on `react-pdf`, which is backed by Mozilla's PDF.js. All pages are rendered in a single vertical scroll, with an `IntersectionObserver` tracking the topmost visible page to keep a live "Page X of Y" indicator accurate without polling. Zoom controls adjust page width in discrete steps.

The fetch path deserves a note: react-pdf's internal loader does not carry session credentials, which caused 401s. The fix is to pre-fetch the file with the auth-aware client, turn the response into a blob URL, and hand that local URL to the renderer. 

An alternative renderer, `EmbedPDF`, backed by PDFium (Chrome's renderer), was considered. PDFium produces marginally sharper output because it is the same engine as Chrome's built-in viewer, but it ships a 4.6 MB WASM binary that compresses poorly over the wire (WASM's binary format resists deflate significantly more than JavaScript). For a productivity tool with returning users on corporate connections the one-time cost is acceptable, but the visual improvement over PDF.js is subtle enough that it does not justify the payload.

https://github.com/user-attachments/assets/89223add-6e61-4354-a4fc-a1f1c69d8db6


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
