### PR TITLE
Allow scheduled commits

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -32,6 +32,7 @@ type SelectFieldProps<T extends FieldValues> = {
   control: Control<T>;
   name: Path<T>;
   title?: string;
+  hideLabel?: boolean;
   mountPortalContainer?: HTMLElement;
 } & (
   | { options: SelectFieldOption[]; groups?: never }
@@ -42,6 +43,7 @@ export function SelectField<T extends FieldValues>({
   control,
   name,
   title,
+  hideLabel,
   options,
   groups,
   mountPortalContainer,
@@ -60,9 +62,11 @@ export function SelectField<T extends FieldValues>({
 
         return (
           <PokeFormItem>
-            <PokeFormLabel className="capitalize">
-              {title ?? name}
-            </PokeFormLabel>
+            {!hideLabel && (
+              <PokeFormLabel className="capitalize">
+                {title ?? name}
+              </PokeFormLabel>
+            )}
             <PokeFormControl>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -110,6 +114,7 @@ interface InputFieldProps<T extends FieldValues> {
   control: Control<T>;
   name: Path<T>;
   title?: string;
+  hideLabel?: boolean;
   type?: "text" | "number" | "datetime-local";
   placeholder?: string;
   /** Native `min` attribute, useful for `number` and `datetime-local`. */
@@ -126,6 +131,7 @@ export function InputField<T extends FieldValues>({
   control,
   name,
   title,
+  hideLabel,
   type,
   placeholder,
   min,
@@ -140,7 +146,11 @@ export function InputField<T extends FieldValues>({
       name={name}
       render={({ field }) => (
         <PokeFormItem>
-          <PokeFormLabel className="capitalize">{title ?? name}</PokeFormLabel>
+          {!hideLabel && (
+            <PokeFormLabel className="capitalize">
+              {title ?? name}
+            </PokeFormLabel>
+          )}
           <PokeFormControl>
             <Input
               placeholder={placeholder ?? name}

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -43,69 +43,111 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-const SwitchContractFormSchema = z.object({
-  metronomePackageId: z.string().min(1, "Required"),
-  planCode: z.string().min(1, "Required"),
-  startingAt: z.string().optional(),
-  // How the enterprise contract's start moment is resolved:
-  //  - "immediately": swap at the current hour (no startingAt sent).
-  //  - "retroactive_first_of_month": backdate to the 1st of the current month,
-  //    00:00 UTC.
-  //  - "select": use the operator-chosen `startingAt` (the only mode that
-  //    surfaces the date picker).
-  startMode: z
-    .enum(["immediately", "retroactive_first_of_month", "select"])
-    .default("select"),
-  stripeCustomerId: z.string(),
-  stripeCollectionMethod: z
-    .enum(["charge_automatically", "send_invoice"])
-    .default("charge_automatically"),
-  // Net payment terms in days (e.g. 30 for "Net 30"). Only relevant for
-  // `send_invoice`; empty leaves Metronome's account default in place.
-  netPaymentTermsDays: z
-    .number()
-    .int("Net payment terms must be a whole number of days")
-    .min(0, "Net payment terms must be ≥ 0")
-    .max(365, "Net payment terms must be ≤ 365")
-    .optional(),
-  paygEnabled: z.boolean().default(false),
-  usageCapCredits: z
-    .number()
-    .int("Usage cap must be an integer number of credits")
-    .min(1, "Usage cap must be at least 1 credit")
-    .optional(),
-  // One-off initial credits (contract-level prepaid commit). Toggled on via
-  // `showInitialCredits`; both fields are then required together and assembled
-  // into `initialCredits` on submit.
-  showInitialCredits: z.boolean().default(false),
-  initialCreditsAmount: z
-    .number()
-    .int("Initial credits must be an integer number of credits")
-    .min(1, "Initial credits must be at least 1 credit")
-    .optional(),
-  initialCreditsInvoiceAmount: z
-    .number()
-    .min(0, "Invoice amount must be zero or more")
-    .optional(),
-  // Per-seat-type settings, keyed by seat type. Every seat type the selected
-  // package knows about is shown; only `selected` ones are submitted. `selected`
-  // is pre-checked for the seats the package entitles by default, and can be
-  // toggled to opt into entitling additional seats. `minSeats` is the billing
-  // floor (0 = none); `rate` is the per-seat rate, prefilled from the package
-  // override default; `commitmentPrice` (optional) creates a prepaid commit of
-  // `minSeats * rate` invoiced at that price.
-  seats: z
-    .record(
-      z.string(),
-      z.object({
-        selected: z.boolean().default(false),
-        minSeats: z.number().int().min(0),
-        rate: z.number().min(0),
-        commitmentPrice: z.number().min(0).optional(),
-      })
-    )
-    .default({}),
-});
+const SwitchContractFormSchema = z
+  .object({
+    metronomePackageId: z.string().min(1, "Required"),
+    planCode: z.string().min(1, "Required"),
+    startingAt: z.string().optional(),
+    // How the enterprise contract's start moment is resolved:
+    //  - "immediately": swap at the current hour (no startingAt sent).
+    //  - "retroactive_first_of_month": backdate to the 1st of the current month,
+    //    00:00 UTC.
+    //  - "select": use the operator-chosen `startingAt` (the only mode that
+    //    surfaces the date picker).
+    startMode: z
+      .enum(["immediately", "retroactive_first_of_month", "select"])
+      .default("select"),
+    stripeCustomerId: z.string(),
+    stripeCollectionMethod: z
+      .enum(["charge_automatically", "send_invoice"])
+      .default("charge_automatically"),
+    // Net payment terms in days (e.g. 30 for "Net 30"). Only relevant for
+    // `send_invoice`; empty leaves Metronome's account default in place.
+    netPaymentTermsDays: z
+      .number()
+      .int("Net payment terms must be a whole number of days")
+      .min(0, "Net payment terms must be ≥ 0")
+      .max(365, "Net payment terms must be ≤ 365")
+      .optional(),
+    paygEnabled: z.boolean().default(false),
+    usageCapCredits: z
+      .number()
+      .int("Usage cap must be an integer number of credits")
+      .min(1, "Usage cap must be at least 1 credit")
+      .optional(),
+    // One-off initial credits (contract-level prepaid commit). Toggled on via
+    // `showInitialCredits`; both fields are then required together and assembled
+    // into `initialCredits` on submit.
+    showInitialCredits: z.boolean().default(false),
+    initialCreditsAmount: z
+      .number()
+      .int("Initial credits must be an integer number of credits")
+      .min(1, "Initial credits must be at least 1 credit")
+      .optional(),
+    initialCreditsInvoiceAmount: z
+      .number()
+      .min(0, "Invoice amount must be zero or more")
+      .optional(),
+    initialCreditsFrequency: z
+      .enum(["one_time", "monthly", "quarterly", "semi_annually", "annually"])
+      .default("one_time"),
+    initialCreditsPeriods: z
+      .number()
+      .int("Number of periods must be a whole number")
+      .min(2, "Number of periods must be at least 2")
+      .max(60, "Number of periods must be at most 60")
+      .optional(),
+    // Per-seat-type settings, keyed by seat type. Every seat type the selected
+    // package knows about is shown; only `selected` ones are submitted. `selected`
+    // is pre-checked for the seats the package entitles by default, and can be
+    // toggled to opt into entitling additional seats. `minSeats` is the billing
+    // floor (0 = none); `rate` is the per-seat rate, prefilled from the package
+    // override default; `commitmentPrice` (optional) creates a prepaid commit of
+    // `minSeats * rate` invoiced at that price.
+    seats: z
+      .record(
+        z.string(),
+        z
+          .object({
+            selected: z.boolean().default(false),
+            minSeats: z.number().int().min(0),
+            rate: z.number().min(0),
+            commitmentPrice: z.number().min(0).optional(),
+            paymentFrequency: z
+              .enum([
+                "one_time",
+                "monthly",
+                "quarterly",
+                "semi_annually",
+                "annually",
+              ])
+              .default("one_time"),
+            paymentPeriods: z
+              .number()
+              .int("Number of periods must be a whole number")
+              .min(2, "Number of periods must be at least 2")
+              .max(60, "Number of periods must be at most 60")
+              .optional(),
+          })
+          .refine(
+            (s) =>
+              s.paymentFrequency === "one_time" ||
+              s.paymentPeriods !== undefined,
+            { message: "Periods required when frequency is not one-time" }
+          )
+      )
+      .default({}),
+  })
+  .refine(
+    (s) =>
+      !s.showInitialCredits ||
+      s.initialCreditsFrequency === "one_time" ||
+      s.initialCreditsPeriods !== undefined,
+    {
+      message: "Periods required when frequency is not one-time",
+      path: ["initialCreditsPeriods"],
+    }
+  );
 type SwitchContractFormValues = z.infer<typeof SwitchContractFormSchema>;
 
 type SwitchContractBodyInput = z.input<typeof SwitchContractBodySchema>;
@@ -188,6 +230,8 @@ export default function SwitchContractDialog({
       showInitialCredits: false,
       initialCreditsAmount: undefined,
       initialCreditsInvoiceAmount: undefined,
+      initialCreditsFrequency: "one_time",
+      initialCreditsPeriods: undefined,
       seats: {},
     },
   });
@@ -255,14 +299,24 @@ export default function SwitchContractDialog({
   useEffect(() => {
     const next: Record<
       string,
-      { selected: boolean; minSeats: number; rate: number }
+      {
+        selected: boolean;
+        minSeats: number;
+        rate: number;
+        paymentFrequency: "one_time";
+      }
     > = {};
     for (const seat of selectedSeats) {
       const rate =
         seat.defaultRate != null && resolvedCurrency
           ? amountCents(seat.defaultRate, resolvedCurrency) / 100
           : (seat.defaultRate ?? 0);
-      next[seat.seatType] = { selected: seat.entitled, minSeats: 0, rate };
+      next[seat.seatType] = {
+        selected: seat.entitled,
+        minSeats: 0,
+        rate,
+        paymentFrequency: "one_time",
+      };
     }
     form.setValue("seats", next);
   }, [selectedSeats, form, resolvedCurrency]);
@@ -364,6 +418,7 @@ export default function SwitchContractDialog({
     selectedTier !== null && isPaygEligibleTier(selectedTier);
 
   const showInitialCredits = form.watch("showInitialCredits");
+  const initialCreditsFrequency = form.watch("initialCreditsFrequency");
   const stripeCollectionMethod = form.watch("stripeCollectionMethod");
   const watchedSeats = form.watch("seats");
 
@@ -405,9 +460,26 @@ export default function SwitchContractDialog({
           setError("Initial credits require a Stripe customer to invoice.");
           return;
         }
+        if (
+          values.initialCreditsFrequency !== "one_time" &&
+          (values.initialCreditsPeriods === undefined ||
+            values.initialCreditsPeriods < 2)
+        ) {
+          setError(
+            "Scheduled payments require a number of periods of at least 2."
+          );
+          return;
+        }
         cleaned.initialCredits = {
           amountCredits: values.initialCreditsAmount,
           invoiceAmount: values.initialCreditsInvoiceAmount,
+          paymentSchedule: {
+            frequency: values.initialCreditsFrequency,
+            periods:
+              values.initialCreditsFrequency !== "one_time"
+                ? values.initialCreditsPeriods
+                : undefined,
+          },
         };
       }
       // Resolve the start moment for enterprise. "immediately" leaves
@@ -440,6 +512,8 @@ export default function SwitchContractDialog({
           entry.commitmentPrice > 0
             ? entry.commitmentPrice
             : undefined;
+        const paymentFrequency = entry?.paymentFrequency ?? "one_time";
+        const paymentPeriods = entry?.paymentPeriods;
         if (selected && !entitled && seatType !== "free" && !(rate > 0)) {
           setError(
             `Seat "${seatType}" is not entitled by the selected package and ` +
@@ -447,7 +521,29 @@ export default function SwitchContractDialog({
           );
           return;
         }
-        seats.push({ seatType, selected, minSeats, rate, commitmentPrice });
+        if (
+          commitmentPrice !== undefined &&
+          paymentFrequency !== "one_time" &&
+          (paymentPeriods === undefined || paymentPeriods < 2)
+        ) {
+          setError(
+            `Seat "${seatType}" has a scheduled payment frequency but no valid ` +
+              "number of periods (minimum 2)."
+          );
+          return;
+        }
+        seats.push({
+          seatType,
+          selected,
+          minSeats,
+          rate,
+          commitmentPrice,
+          paymentSchedule: {
+            frequency: paymentFrequency,
+            periods:
+              paymentFrequency !== "one_time" ? paymentPeriods : undefined,
+          },
+        });
       }
       if (seats.length > 0) {
         cleaned.seats = seats;
@@ -652,7 +748,7 @@ export default function SwitchContractDialog({
                   </div>
                 )}
                 {selectedSeats.length > 0 && (
-                  <div className="space-y-3 border-t pt-4">
+                  <div className="space-y-2 border-t pt-4">
                     <Label className="text-sm">
                       Seats configuration{" "}
                       {resolvedCurrency
@@ -665,12 +761,34 @@ export default function SwitchContractDialog({
                       one to entitle it (a non-zero rate is required, except for
                       the free seat).
                     </div>
+                    {/* Header row */}
+                    <div className="flex items-center gap-3 pb-1 text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+                      <div className="w-32 shrink-0" />
+                      <div className="flex-1">Min seats</div>
+                      <div className="flex-1">
+                        Seat rate
+                        {resolvedCurrency
+                          ? ` (${resolvedCurrency.toUpperCase()})`
+                          : ""}
+                      </div>
+                      <div className="flex-1">
+                        Commitment price
+                        {resolvedCurrency
+                          ? ` (${resolvedCurrency.toUpperCase()})`
+                          : ""}
+                      </div>
+                      <div className="flex-1">Payment schedule</div>
+                      <div className="flex-1">Periods</div>
+                    </div>
                     {selectedSeats.map(({ seatType, entitled }) => {
                       const isSelected =
                         watchedSeats?.[seatType]?.selected ?? false;
+                      const seatPaymentFrequency =
+                        watchedSeats?.[seatType]?.paymentFrequency ??
+                        "one_time";
                       return (
-                        <div key={seatType} className="flex items-end gap-3">
-                          <div className="flex w-32 shrink-0 items-center gap-2 pb-2">
+                        <div key={seatType} className="flex items-center gap-3">
+                          <div className="flex w-32 shrink-0 items-center gap-2">
                             <Checkbox
                               checked={isSelected}
                               onCheckedChange={(checked) =>
@@ -693,7 +811,7 @@ export default function SwitchContractDialog({
                             <InputField
                               control={form.control}
                               name={`seats.${seatType}.minSeats`}
-                              title="Min seats"
+                              hideLabel
                               type="number"
                               placeholder="0"
                               disabled={!isSelected}
@@ -703,11 +821,7 @@ export default function SwitchContractDialog({
                             <InputField
                               control={form.control}
                               name={`seats.${seatType}.rate`}
-                              title={
-                                resolvedCurrency
-                                  ? `Seat rate (${resolvedCurrency.toUpperCase()})`
-                                  : "Seat rate"
-                              }
+                              hideLabel
                               type="number"
                               placeholder="0"
                               disabled={!isSelected}
@@ -717,15 +831,40 @@ export default function SwitchContractDialog({
                             <InputField
                               control={form.control}
                               name={`seats.${seatType}.commitmentPrice`}
-                              title={
-                                resolvedCurrency
-                                  ? `Commitment price (${resolvedCurrency.toUpperCase()})`
-                                  : "Commitment price"
-                              }
+                              hideLabel
                               type="number"
                               placeholder="optional"
                               disabled={!isSelected}
                             />
+                          </div>
+                          <div className="flex-1">
+                            <SelectField
+                              control={form.control}
+                              name={`seats.${seatType}.paymentFrequency`}
+                              hideLabel
+                              mountPortalContainer={portalContainer}
+                              options={[
+                                { value: "one_time", display: "One-time" },
+                                { value: "monthly", display: "Monthly" },
+                                { value: "quarterly", display: "Quarterly" },
+                                {
+                                  value: "semi_annually",
+                                  display: "Semi-annually",
+                                },
+                                { value: "annually", display: "Annually" },
+                              ]}
+                            />
+                          </div>
+                          <div className="flex-1">
+                            {seatPaymentFrequency !== "one_time" && (
+                              <InputField
+                                control={form.control}
+                                name={`seats.${seatType}.paymentPeriods`}
+                                hideLabel
+                                type="number"
+                                placeholder="e.g., 4"
+                              />
+                            )}
                           </div>
                         </div>
                       );
@@ -745,7 +884,7 @@ export default function SwitchContractDialog({
                         }
                       />
                       <Label className="text-sm">
-                        Initial credits (one-off prepaid commit)
+                        Initial credits (prepaid commit)
                       </Label>
                     </div>
                     {showInitialCredits && (
@@ -760,10 +899,47 @@ export default function SwitchContractDialog({
                         <InputField
                           control={form.control}
                           name="initialCreditsInvoiceAmount"
-                          title={`Amount to Invoice (${resolvedCurrency.toUpperCase()})`}
+                          title={`Total Amount to Invoice (${resolvedCurrency.toUpperCase()})`}
                           type="number"
-                          placeholder="e.g., 5000 — amount billed to the customer"
+                          placeholder="e.g., 5000 — total billed to the customer"
                         />
+                        <SelectField
+                          control={form.control}
+                          name="initialCreditsFrequency"
+                          title="Payment schedule"
+                          mountPortalContainer={portalContainer}
+                          options={[
+                            {
+                              value: "one_time",
+                              display: "One-time (single invoice)",
+                            },
+                            {
+                              value: "monthly",
+                              display: "Monthly",
+                            },
+                            {
+                              value: "quarterly",
+                              display: "Quarterly (every 3 months)",
+                            },
+                            {
+                              value: "semi_annually",
+                              display: "Semi-annually (every 6 months)",
+                            },
+                            {
+                              value: "annually",
+                              display: "Annually",
+                            },
+                          ]}
+                        />
+                        {initialCreditsFrequency !== "one_time" && (
+                          <InputField
+                            control={form.control}
+                            name="initialCreditsPeriods"
+                            title="Number of periods"
+                            type="number"
+                            placeholder="e.g., 4 for 4 quarterly installments"
+                          />
+                        )}
                       </>
                     )}
                   </div>

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -60,6 +60,19 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { z } from "zod";
 
+const paymentScheduleSchema = z
+  .object({
+    frequency: z
+      .enum(["one_time", "monthly", "quarterly", "semi_annually", "annually"])
+      .default("one_time"),
+    periods: z.number().int().min(2).max(60).optional(),
+  })
+  .refine(
+    (s) => s.frequency === "one_time" || s.periods !== undefined,
+    "periods is required when frequency is not one_time"
+  )
+  .default({ frequency: "one_time" });
+
 export const SwitchContractBodySchema = z.object({
   planCode: z.string().min(1),
   metronomePackageId: z.string().min(1),
@@ -100,6 +113,7 @@ export const SwitchContractBodySchema = z.object({
         .int("Initial credits must be an integer number of credits")
         .min(1, "Initial credits must be at least 1 credit"),
       invoiceAmount: z.number().min(0, "Invoice amount must be zero or more"),
+      paymentSchedule: paymentScheduleSchema,
     })
     .optional(),
   // Optional per-seat-type settings for the new contract. `minSeats` is the
@@ -126,6 +140,7 @@ export const SwitchContractBodySchema = z.object({
           .number()
           .min(0, "Commitment price must be ≥ 0")
           .optional(),
+        paymentSchedule: paymentScheduleSchema,
       })
     )
     .optional(),
@@ -217,6 +232,79 @@ function firstPeriodProration(
   );
   const fraction = Math.max(0, Math.min(1, remainingHours / totalHours));
   return { fraction, periodEnd: new Date(periodEndMs) };
+}
+
+const MONTHS_PER_PAYMENT_FREQUENCY: Record<
+  "monthly" | "quarterly" | "semi_annually" | "annually",
+  number
+> = {
+  monthly: 1,
+  quarterly: 3,
+  semi_annually: 6,
+  annually: 12,
+};
+
+function buildInvoiceScheduleItems({
+  invoiceAmountCents,
+  resolvedCurrency,
+  alignedStart,
+  paymentSchedule,
+}: {
+  invoiceAmountCents: number;
+  resolvedCurrency: SupportedCurrency;
+  alignedStart: Date;
+  paymentSchedule: {
+    frequency:
+      | "one_time"
+      | "monthly"
+      | "quarterly"
+      | "semi_annually"
+      | "annually";
+    periods?: number;
+  };
+}): { unitPrice: number; quantity: number; timestamp: Date }[] {
+  const { frequency, periods } = paymentSchedule;
+  if (frequency === "one_time" || !periods || periods <= 1) {
+    return [
+      {
+        unitPrice: metronomeAmount(invoiceAmountCents, resolvedCurrency),
+        quantity: 1,
+        timestamp: alignedStart,
+      },
+    ];
+  }
+  const monthsPerPeriod = MONTHS_PER_PAYMENT_FREQUENCY[frequency];
+  const perPeriodCents = Math.floor(invoiceAmountCents / periods);
+  const remainderCents = invoiceAmountCents - perPeriodCents * periods;
+  return Array.from({ length: periods }, (_, i) => {
+    const totalMonths = alignedStart.getUTCMonth() + i * monthsPerPeriod;
+    const targetYear =
+      alignedStart.getUTCFullYear() + Math.floor(totalMonths / 12);
+    const targetMonth = ((totalMonths % 12) + 12) % 12;
+    const lastDayOfMonth = new Date(
+      Date.UTC(targetYear, targetMonth + 1, 0)
+    ).getUTCDate();
+    const day =
+      i === 0 ? Math.min(alignedStart.getUTCDate(), lastDayOfMonth) : 1;
+    const ts = new Date(
+      Date.UTC(
+        targetYear,
+        targetMonth,
+        day,
+        alignedStart.getUTCHours(),
+        alignedStart.getUTCMinutes(),
+        alignedStart.getUTCSeconds(),
+        alignedStart.getUTCMilliseconds()
+      )
+    );
+    const amountCents =
+      i === 0 ? perPeriodCents + remainderCents : perPeriodCents;
+    return {
+      unitPrice: metronomeAmount(amountCents, resolvedCurrency),
+      quantity: 1,
+      timestamp: ts,
+    };
+  });
 }
 
 /**
@@ -534,10 +622,12 @@ export async function switchContract({
     const invoiceAmountCents = Math.round(
       body.initialCredits.invoiceAmount * 100
     );
-    const invoiceUnitPrice = metronomeAmount(
+    const invoiceScheduleItems = buildInvoiceScheduleItems({
       invoiceAmountCents,
-      resolvedCurrency
-    );
+      resolvedCurrency,
+      alignedStart,
+      paymentSchedule: body.initialCredits.paymentSchedule,
+    });
 
     const commitResult = await addPrepaidCommitToContract({
       metronomeCustomerId,
@@ -547,10 +637,8 @@ export async function switchContract({
       accessCreditTypeId: getCreditTypeAwuId(),
       accessStartingAt: alignedStart,
       accessEndingBefore: FOREVER_ENDING_BEFORE,
-      invoiceUnitPrice,
-      invoiceQuantity: 1,
+      invoiceScheduleItems,
       invoiceCreditTypeId: CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency],
-      invoiceTimestamp: alignedStart,
       priority: AWU_PRIORITY_PURCHASED_COMMIT,
       applicableProductTags: ["usage"],
       name: `Initial credits: ${body.initialCredits.amountCredits.toLocaleString()} credits`,
@@ -694,10 +782,12 @@ export async function switchContract({
         // units for EUR — the unit the fiat credit type expects).
         const accessAmountNative =
           Math.round(seat.minSeats * rateNative * fraction * 100) / 100;
-        const commitmentPriceNative = metronomeAmount(
-          Math.round(seat.commitmentPrice * 100),
-          resolvedCurrency
-        );
+        const seatInvoiceScheduleItems = buildInvoiceScheduleItems({
+          invoiceAmountCents: Math.round(seat.commitmentPrice * 100),
+          resolvedCurrency,
+          alignedStart,
+          paymentSchedule: seat.paymentSchedule,
+        });
         const commitResult = await addPrepaidCommitToContract({
           metronomeCustomerId,
           metronomeContractId,
@@ -706,10 +796,8 @@ export async function switchContract({
           accessCreditTypeId: fiatCreditTypeId,
           accessStartingAt: alignedStart,
           accessEndingBefore: periodEnd,
-          invoiceUnitPrice: commitmentPriceNative,
-          invoiceQuantity: 1,
+          invoiceScheduleItems: seatInvoiceScheduleItems,
           invoiceCreditTypeId: fiatCreditTypeId,
-          invoiceTimestamp: alignedStart,
           priority: AWU_PRIORITY_PURCHASED_COMMIT,
           // Draw only against this seat's product, not all `usage`.
           applicableProductIds: [pkgSeat.productId],

--- a/front/lib/metronome/client.test.ts
+++ b/front/lib/metronome/client.test.ts
@@ -384,10 +384,14 @@ const BASE_PREPAID_COMMIT_PARAMS = {
   accessCreditTypeId: "credit-type-awu",
   accessStartingAt: new Date("2026-04-01T00:00:00.000Z"),
   accessEndingBefore: new Date("2027-04-01T00:00:00.000Z"),
-  invoiceUnitPrice: 5_000,
-  invoiceQuantity: 1,
+  invoiceScheduleItems: [
+    {
+      unitPrice: 5_000,
+      quantity: 1,
+      timestamp: new Date("2026-04-01T00:00:00.000Z"),
+    },
+  ],
   invoiceCreditTypeId: "credit-type-usd",
-  invoiceTimestamp: new Date("2026-04-01T00:00:00.000Z"),
   priority: 2,
   name: "Test commit",
   uniquenessKey: "commit-key-1",
@@ -419,6 +423,9 @@ describe("addPrepaidCommitToContract", () => {
 describe("addPaymentGatedCommitToContract", () => {
   const BASE_PAYMENT_GATED_PARAMS = {
     ...BASE_PREPAID_COMMIT_PARAMS,
+    invoiceUnitPrice: 5_000,
+    invoiceQuantity: 1,
+    invoiceTimestamp: new Date("2026-04-01T00:00:00.000Z"),
     applicableProducTags: ["usage"],
     stripeInvoiceMetadata: { workspace_id: "ws-1" },
   };

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1917,10 +1917,8 @@ export async function addPrepaidCommitToContract({
   accessCreditTypeId,
   accessStartingAt,
   accessEndingBefore,
-  invoiceUnitPrice,
-  invoiceQuantity,
+  invoiceScheduleItems,
   invoiceCreditTypeId,
-  invoiceTimestamp,
   priority,
   name,
   uniquenessKey,
@@ -1935,10 +1933,12 @@ export async function addPrepaidCommitToContract({
   accessCreditTypeId: string;
   accessStartingAt: Date;
   accessEndingBefore: Date;
-  invoiceUnitPrice: number;
-  invoiceQuantity: number;
+  invoiceScheduleItems: {
+    unitPrice: number;
+    quantity: number;
+    timestamp: Date;
+  }[];
   invoiceCreditTypeId: string;
-  invoiceTimestamp: Date;
   priority: number;
   name: string;
   uniquenessKey: string;
@@ -1976,13 +1976,11 @@ export async function addPrepaidCommitToContract({
           },
           invoice_schedule: {
             credit_type_id: invoiceCreditTypeId,
-            schedule_items: [
-              {
-                unit_price: invoiceUnitPrice,
-                quantity: invoiceQuantity,
-                timestamp: floorToHourISO(invoiceTimestamp),
-              },
-            ],
+            schedule_items: invoiceScheduleItems.map((item) => ({
+              unit_price: item.unitPrice,
+              quantity: item.quantity,
+              timestamp: floorToHourISO(item.timestamp),
+            })),
           },
         },
       ],
@@ -1994,8 +1992,7 @@ export async function addPrepaidCommitToContract({
         metronomeContractId,
         editId: response.data.id,
         accessAmount,
-        invoiceUnitPrice,
-        invoiceQuantity,
+        invoiceScheduleItemsCount: invoiceScheduleItems.length,
       },
       "[Metronome] Prepaid commit added to contract"
     );
@@ -2017,8 +2014,7 @@ export async function addPrepaidCommitToContract({
         metronomeCustomerId,
         metronomeContractId,
         accessAmount,
-        invoiceUnitPrice,
-        invoiceQuantity,
+        invoiceScheduleItemsCount: invoiceScheduleItems.length,
       },
       "[Metronome] Failed to add prepaid commit to contract"
     );


### PR DESCRIPTION
Add split payment schedules to the switch-contract poke plugin.

<img width="837" height="438" alt="Screenshot 2026-06-16 at 23 54 21" src="https://github.com/user-attachments/assets/58612f7c-6447-4e24-ad85-d33963c734be" />

When adding a prepaid commit (initial credits or seat commitment), operators can now choose a payment frequency (one-time, monthly, quarterly, semi-annually, annually) and a number of periods. The total invoice amount is divided equally across periods, each invoiced at the chosen interval.