### PR TITLE
Show usage chart if ff is enabled

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -10,7 +10,7 @@ import { WorkspaceToolUsageChart } from "@app/components/workspace/analytics/Wor
 import { WorkspaceTopAgentsTable } from "@app/components/workspace/analytics/WorkspaceTopAgentsTable";
 import { WorkspaceTopUsersTable } from "@app/components/workspace/analytics/WorkspaceTopUsersTable";
 import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useCreditPurchaseInfo } from "@app/lib/swr/credits";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
@@ -23,6 +23,7 @@ import { useState } from "react";
 
 export function AnalyticsPage() {
   const owner = useWorkspace();
+  const { hasFeature } = useFeatureFlags();
   const canSeeAnalytics = hasPermission(owner.role, "workspace:view_analytics");
   const [downloadingMonth, setDownloadingMonth] = useState<string | null>(null);
   const [includeInactive, setIncludeInactive] = useState(true);
@@ -178,13 +179,14 @@ export function AnalyticsPage() {
         period={period}
       />
       <div className="flex flex-col pb-8 gap-8">
-        {billingCycleStartDay !== null &&
+        {(billingCycleStartDay !== null ||
+          hasFeature("usage_page_read_only")) &&
           (isCreditPurchaseInfoLoading ? (
             <div className="h-64 animate-pulse rounded bg-muted-foreground/20" />
           ) : (
             <AwuUsageChart
               workspaceId={owner.sId}
-              billingCycleStartDay={billingCycleStartDay}
+              billingCycleStartDay={billingCycleStartDay ?? 1}
             />
           ))}
         <WorkspaceUsageChart workspaceId={owner.sId} period={period} />


### PR DESCRIPTION
## Description

Show the AWU usage chart (`AwuUsageChart`) on the Analytics page for workspaces with the `usage_page_read_only` feature flag.

Previously the chart was only rendered when `billingCycleStartDay` was non-null (i.e. credit-priced workspaces). Legacy-contract workspaces with the `usage_page_read_only` flag have no billing cycle day, so the chart was hidden for them. This PR extends the condition to also show the chart when the feature flag is active, falling back to day `1` (same default used in `UsagePage` for the same audience).

## Tests

Tested manually.

## Risk

Low — additive change behind an existing feature flag. No new endpoints or data fetching paths introduced.

## Deploy Plan

No special deploy steps required.