### PR TITLE
ci(deploy): trigger and wait for dust-infra workflow to complete

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -237,7 +237,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: dust-infra
 
-      - name: Trigger dust-infra workflow
+      - name: Trigger and wait for dust-infra workflow
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           OWNER: ${{ github.repository_owner }}
@@ -292,12 +292,70 @@ jobs:
               });
             }
 
+            // Record the time just before dispatch so we can identify the triggered run.
+            const beforeDispatch = new Date().toISOString();
+
             await github.rest.repos.createDispatchEvent({
               owner: process.env.OWNER,
               repo: 'dust-infra',
               event_type: 'trigger-component-deploy',
               client_payload: payload,
             });
+
+            core.info(`Dispatched to dust-infra at ${beforeDispatch}. Waiting for workflow run to appear...`);
+
+            // Poll until the workflow run appears in dust-infra (up to 5 minutes).
+            // Requires the INFRA_DISPATCH_APP to have actions:read on dust-infra.
+            let infraRunId = null;
+            for (let i = 0; i < 30; i++) {
+              await new Promise(r => setTimeout(r, 10000));
+
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: process.env.OWNER,
+                repo: 'dust-infra',
+                event: 'repository_dispatch',
+                created: `>=${beforeDispatch}`,
+                per_page: 5,
+              });
+
+              if (data.workflow_runs.length > 0) {
+                infraRunId = data.workflow_runs[0].id;
+                core.info(`Found dust-infra workflow run #${infraRunId}: ${data.workflow_runs[0].html_url}`);
+                break;
+              }
+
+              core.info(`Waiting for workflow run to appear... (${(i + 1) * 10}s elapsed)`);
+            }
+
+            if (!infraRunId) {
+              core.setFailed('Could not find dust-infra workflow run after 5 minutes.');
+              return;
+            }
+
+            // Poll until the run completes (up to 90 minutes).
+            for (let i = 0; i < 540; i++) {
+              await new Promise(r => setTimeout(r, 10000));
+
+              const { data: run } = await github.rest.actions.getWorkflowRun({
+                owner: process.env.OWNER,
+                repo: 'dust-infra',
+                run_id: infraRunId,
+              });
+
+              if (run.status === 'completed') {
+                core.info(`dust-infra workflow completed with conclusion: ${run.conclusion}`);
+                if (run.conclusion !== 'success') {
+                  core.setFailed(`Deployment failed in dust-infra (conclusion: ${run.conclusion}). See: ${run.html_url}`);
+                }
+                return;
+              }
+
+              if (i % 6 === 0) {
+                core.info(`dust-infra workflow status: ${run.status} (${Math.floor((i + 1) * 10 / 60)}m elapsed)`);
+              }
+            }
+
+            core.setFailed('Timed out waiting for dust-infra workflow to complete (90 minutes).');
 
       - name: Notify Failure
         if: failure()

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -99,6 +99,8 @@ WORKDIR /app/front
 
 # Copy worker assets from workers-specific build
 COPY --from=workers-build /app/front/dist ./dist
+# Ensure migrate.js is present (workers-build may clean dist before building)
+COPY --from=base-deps /app/front/dist/migrate.js ./dist/migrate.js
 # Copy front's package.json and local node_modules (non-hoisted deps)
 COPY --from=base-deps /app/front/package.json ./package.json
 COPY --from=base-deps /app/front/node_modules ./node_modules
@@ -234,6 +236,8 @@ COPY --from=front-api-build /app/package.json ./package.json
 COPY --from=front-api-build /app/package-lock.json ./package-lock.json
 
 COPY --from=front-api-build /app/front ./front
+# Ensure migrate.js is present explicitly
+COPY --from=base-deps /app/front/dist/migrate.js ./front/dist/migrate.js
 
 # front-api workspace (server.ts, app.ts, routes/, middleware/).
 COPY --from=front-api-build /app/front-api ./front-api


### PR DESCRIPTION
## Description

The `deploy` job dispatched to `dust-infra` via `createDispatchEvent` and immediately succeeded — a fire-and-forget call that returns 204 with no indication of what happens next. This meant that if `dust-infra` failed (e.g. a migration error), the GitHub deploy job stayed green and there was no signal in the UI.

The step now records the timestamp before dispatch, then polls `dust-infra`'s workflow runs until it finds the triggered run (up to 5 min), then polls that run's status until it completes (up to 90 min). If the conclusion is anything other than `success`, it calls `core.setFailed()` — which turns the job red and triggers the existing `Notify Failure` Slack step.

**Prerequisite**: `INFRA_DISPATCH_APP` needs `Actions: Read` permission on `dust-infra`. Without it the polling calls will 403 and the job fails with "Could not find dust-infra workflow run after 5 minutes." which is still better than silently going green, but the permission should be added for correct behavior.

## Tests

Manual verification: the next deployment that fails in dust-infra should show the `deploy` job as red in GitHub.

## Deploy Plan

Add `Actions: Read` permission to the `INFRA_DISPATCH_APP` GitHub App on the `dust-infra` repository before merging.
