### PR TITLE
chore(docker): copy dist/migrate.js explicitly in all runtime images

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -99,6 +99,8 @@ WORKDIR /app/front
 
 # Copy worker assets from workers-specific build
 COPY --from=workers-build /app/front/dist ./dist
+# Ensure migrate.js is present (workers-build may clean dist before building)
+COPY --from=base-deps /app/front/dist/migrate.js ./dist/migrate.js
 # Copy front's package.json and local node_modules (non-hoisted deps)
 COPY --from=base-deps /app/front/package.json ./package.json
 COPY --from=base-deps /app/front/node_modules ./node_modules
@@ -234,6 +236,8 @@ COPY --from=front-api-build /app/package.json ./package.json
 COPY --from=front-api-build /app/package-lock.json ./package-lock.json
 
 COPY --from=front-api-build /app/front ./front
+# Ensure migrate.js is present explicitly
+COPY --from=base-deps /app/front/dist/migrate.js ./front/dist/migrate.js
 
 # front-api workspace (server.ts, app.ts, routes/, middleware/).
 COPY --from=front-api-build /app/front-api ./front-api


### PR DESCRIPTION
## Description

The `workers-build` stage in the front Dockerfile copies its output into `front/dist`, which can overwrite or drop `migrate.js` that was compiled in the `base-deps` stage. This adds explicit `COPY --from=base-deps` steps to restore `migrate.js` after the workers build, for both the `front` and `front-api` runtime images.

Needed so that `npm run migration:apply` works correctly inside the deployed container.
