### PR TITLE
[LLM] Include providerApi and region in LLM interaction logs

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -202,6 +202,7 @@ export abstract class LLM<TPayload = unknown> {
       `model_id:${this.modelId}`,
       `client_id:${this.metadata.clientId}`,
       `inference_provider:${this.metadata.inferenceProvider}`,
+      ...(this.metadata.region ? [`region:${this.metadata.region}`] : []),
       `operation_type:${this.context.operationType}`,
     ];
 
@@ -249,6 +250,7 @@ export abstract class LLM<TPayload = unknown> {
               errorContent: currentEvent.content,
               modelId: this.modelId,
               inferenceProvider: this.metadata.inferenceProvider,
+              region: this.metadata.region,
               context: this.context,
               traceId: this.traceId,
             },
@@ -265,6 +267,7 @@ export abstract class LLM<TPayload = unknown> {
               llmEventType: "success",
               modelId: this.modelId,
               inferenceProvider: this.metadata.inferenceProvider,
+              region: this.metadata.region,
               context: this.context,
               traceId: this.traceId,
             },
@@ -578,6 +581,7 @@ export abstract class LLM<TPayload = unknown> {
         `model_id:${this.modelId}`,
         `client_id:${this.metadata.clientId}`,
         `inference_provider:${this.metadata.inferenceProvider}`,
+        ...(this.metadata.region ? [`region:${this.metadata.region}`] : []),
         `operation_type:${this.context!.operationType}`,
       ];
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -523,6 +523,13 @@ export class StreamEndpointTransition extends BaseTransition {
   ) {
     super(auth, ANTHROPIC_PROVIDER_ID, llmParameters);
     this.model = new modelConstructor(llmParameters.credentials);
+
+    const { api, region } = this.model.metadata();
+    this.metadata = {
+      ...this.metadata,
+      inferenceProvider: api,
+      region,
+    };
   }
 
   protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -4,6 +4,7 @@ import type {
   LLMTraceContext,
   LLMTraceCustomization,
 } from "@app/lib/api/llm/traces/types";
+import type { Region } from "@app/lib/model_constructors/types/regions";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type {
   ModelIdType,
@@ -117,8 +118,11 @@ export type LLMParameterOverwrites = Partial<
 
 export type LLMClientMetadata = {
   clientId: ModelProviderIdType;
+  // Holds the inference provider for legacy clients (e.g. "google_vertex_ai")
+  // and the new router's `providerApi` value (e.g. "agent-platform").
   inferenceProvider: string;
   inferenceRegion: InferenceRegionType;
+  region?: Region;
   modelId: ModelIdType;
 };
 


### PR DESCRIPTION
## Description

Surface the new router's `providerApi` (via `inferenceProvider`, e.g. `agent-platform`) and a new optional `region` in LLM interaction success/error logs and StatsD metric tags; populated by `StreamEndpointTransition` and left undefined for legacy clients.

## Tests

Tested locally.

## Risk

Low. The StatsD `inference_provider` tag now also emits `agent-platform` for new-router traffic — update any alerts that filter on `inference_provider:anthropic`.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`