### PR TITLE
Add linter for useFile() to enforce string literrals.

### DIFF
--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -2,6 +2,7 @@ import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import {
   validateTailwindCode,
   validateTypeScriptSyntax,
+  validateUseFileCalls,
 } from "@app/lib/api/files/content_validation";
 import {
   getFileContent,
@@ -87,6 +88,14 @@ export async function createClientExecutableFile(
   if (syntaxValidation.isErr()) {
     return new Err({
       message: syntaxValidation.error.message,
+      tracked: false,
+    });
+  }
+
+  const useFileValidation = validateUseFileCalls(content);
+  if (useFileValidation.isErr()) {
+    return new Err({
+      message: useFileValidation.error.message,
       tracked: false,
     });
   }
@@ -244,6 +253,14 @@ export async function editClientExecutableFile(
       if (syntaxValidation.isErr()) {
         return new Err({
           message: syntaxValidation.error.message,
+          tracked: false,
+        });
+      }
+
+      const useFileValidation = validateUseFileCalls(updatedContent);
+      if (useFileValidation.isErr()) {
+        return new Err({
+          message: useFileValidation.error.message,
           tracked: false,
         });
       }

--- a/front/lib/api/files/content_validation.test.ts
+++ b/front/lib/api/files/content_validation.test.ts
@@ -3,6 +3,7 @@ import {
   formatValidationWarningsForLLM,
   validateTailwindCode,
   validateTypeScriptSyntax,
+  validateUseFileCalls,
 } from "@app/lib/api/files/content_validation";
 import { describe, expect, it } from "vitest";
 
@@ -426,6 +427,114 @@ const MyComponent = () => {
         "TypeScript syntax errors detected"
       );
       expect(result.error.message).toContain("error TS");
+    }
+  });
+});
+
+describe("validateUseFileCalls", () => {
+  it("should pass code without useFile calls", () => {
+    const code = `
+      const MyComponent = () => {
+        return <div>Hello</div>;
+      };
+    `;
+    const result = validateUseFileCalls(code);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("should pass useFile with a string literal file ID", () => {
+    const code = `
+      const MyComponent = () => {
+        const file = useFile("fil_ABCDEFGHIJ");
+        return <div>{file?.name}</div>;
+      };
+    `;
+    const result = validateUseFileCalls(code);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("should pass useFile with a scoped path string literal", () => {
+    const code = `const file = useFile("conversation-conv_123/report.csv");`;
+    const result = validateUseFileCalls(code);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("should pass useFile with a no-substitution template literal", () => {
+    const code = "const file = useFile(`fil_ABCDEFGHIJ`);";
+    const result = validateUseFileCalls(code);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("should reject useFile with a variable argument", () => {
+    const code = `
+      const MyComponent = ({ fileId }) => {
+        const file = useFile(fileId);
+        return <div>{file?.name}</div>;
+      };
+    `;
+    const result = validateUseFileCalls(code);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Invalid useFile() calls detected"
+      );
+      expect(result.error.message).toContain("useFile(fileId)");
+      expect(result.error.message).toContain("string literal");
+    }
+  });
+
+  it("should reject useFile with string concatenation", () => {
+    const code = `const file = useFile("fil_" + fileSuffix);`;
+    const result = validateUseFileCalls(code);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain('useFile("fil_" + fileSuffix)');
+    }
+  });
+
+  it("should reject useFile with a template literal containing substitutions", () => {
+    const code =
+      "const file = useFile(`conversation-${conversationId}/report.csv`);";
+    const result = validateUseFileCalls(code);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("${...}");
+    }
+  });
+
+  it("should reject useFile with no arguments", () => {
+    const code = `const file = useFile();`;
+    const result = validateUseFileCalls(code);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("useFile()");
+      expect(result.error.message).toContain(
+        "requires a string literal file ID or scoped path"
+      );
+    }
+  });
+
+  it("should reject multiple invalid useFile calls", () => {
+    const code = `
+      const a = useFile(fileId);
+      const b = useFile(getPath());
+    `;
+    const result = validateUseFileCalls(code);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("useFile(fileId)");
+      expect(result.error.message).toContain("useFile(getPath())");
+    }
+  });
+
+  it("should mention shared frame authorization in the error message", () => {
+    const code = `const file = useFile(dynamicPath);`;
+    const result = validateUseFileCalls(code);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "authorized when the Frame is shared"
+      );
     }
   });
 });

--- a/front/lib/api/files/content_validation.ts
+++ b/front/lib/api/files/content_validation.ts
@@ -102,6 +102,109 @@ export function validateTailwindCode(
  * - transpileModule API: https://github.com/microsoft/TypeScript/blob/main/src/services/transpile.ts
  * - Limitation discussion: https://github.com/microsoft/TypeScript/issues/4864
  */
+function isConstantStringExpression(node: ts.Expression): boolean {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node);
+}
+
+function formatSourceLocation(
+  sourceFile: ts.SourceFile,
+  node: ts.Node
+): string {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(sourceFile)
+  );
+  return `Line ${line + 1}, Column ${character + 1}`;
+}
+
+/**
+ * Validates that every useFile() call uses a string literal as its first argument.
+ *
+ * Static analysis of useFile() references is required to authorize file access when
+ * a Frame is shared. Dynamic arguments (variables, expressions, template literals
+ * with substitutions) cannot be resolved at validation time.
+ */
+export function validateUseFileCalls(code: string): Result<undefined, Error> {
+  const invalidCalls: {
+    callText: string;
+    lineColumn: string;
+    reason: string;
+  }[] = [];
+
+  try {
+    const sourceFile = ts.createSourceFile(
+      "frame.tsx",
+      code,
+      ts.ScriptTarget.Latest,
+      false,
+      ts.ScriptKind.TSX
+    );
+
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "useFile"
+      ) {
+        const callText = node.getText(sourceFile);
+        const lineColumn = formatSourceLocation(sourceFile, node);
+
+        if (node.arguments.length === 0) {
+          invalidCalls.push({
+            callText,
+            lineColumn,
+            reason:
+              "useFile() requires a string literal file ID or scoped path as its first argument.",
+          });
+        } else if (!isConstantStringExpression(node.arguments[0])) {
+          invalidCalls.push({
+            callText,
+            lineColumn,
+            reason:
+              'The first argument must be a string literal such as useFile("fil_abc123") ' +
+              'or useFile("conversation-{conversationId}/report.csv"). Variables, ' +
+              "expressions, concatenation, and template literals with ${...} are not allowed.",
+          });
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+  } catch (error) {
+    return new Err(
+      new Error(`Failed to validate useFile() calls: ${normalizeError(error)}`)
+    );
+  }
+
+  if (invalidCalls.length > 0) {
+    const formattedErrors = invalidCalls
+      .slice(0, MAX_DISPLAYED_ERRORS)
+      .map(
+        ({ lineColumn, callText, reason }) =>
+          `${lineColumn}: ${callText}\n  ${reason}`
+      )
+      .join("\n\n");
+
+    const additionalErrors =
+      invalidCalls.length > MAX_DISPLAYED_ERRORS
+        ? ` (and ${invalidCalls.length - MAX_DISPLAYED_ERRORS} more invalid useFile() calls)`
+        : "";
+
+    return new Err(
+      new Error(
+        `Invalid useFile() calls detected${additionalErrors}:\n\n${formattedErrors}\n\n` +
+          `useFile() must be called with a string literal so referenced files can be detected ` +
+          `and authorized when the Frame is shared. Replace dynamic arguments with a literal ` +
+          `file ID (e.g. "fil_abc123") or scoped path (e.g. "conversation-{conversationId}/report.csv"). ` +
+          `Please fix these errors and try again.`
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
 export function validateTypeScriptSyntax(
   code: string
 ): Result<undefined, Error> {


### PR DESCRIPTION
## Description

The idea is to ensure that the model always uses string literrals as argument so we can easily audit them so they can be vetted for Frame sharing.

Today models can be very creative and we do not catch everything, we have seen stuff like:
```ts
const fileId = (id):string => `fil_${id}`;
const fileA = "fil_XXXX";

useFile(fileId('XXXX));
useFile(fileA);
```

Our code to detect files used is not picking the `fileId()` pattern, and detecting "fil_XXX" is also flimsy.

The proposal is to enforce only using string litteral for useFile() calls, with a clear error message so the models work around it. That way, we can easily extract all files used without doubt.

## Tests

Local
<img width="1425" height="820" alt="image" src="https://github.com/user-attachments/assets/5e0eb289-5d8c-487a-a280-502bd2bbafa1" />

## Risk

Low, existing Frames will not be affected, new Frame will catch the error and auto-adapt.

## Deploy Plan

Deploy front