### PR TITLE
Update free credits amount

### DIFF
--- a/front/components/pages/onboarding/SubscriptionPlans.tsx
+++ b/front/components/pages/onboarding/SubscriptionPlans.tsx
@@ -3,12 +3,12 @@ import {
   getSeatIconColorClass,
 } from "@app/components/workspace/seat_styles";
 import {
-  CP_FREE_PLAN_CREDITS,
   CP_MAX_SEAT_COST_MONTHLY,
   CP_MAX_SEAT_COST_YEARLY,
   CP_PRO_SEAT_COST_MONTHLY,
   CP_PRO_SEAT_COST_YEARLY,
 } from "@app/lib/client/subscription";
+import { FREE_SEAT_LIFETIME_AWU_CREDITS } from "@app/lib/metronome/constants";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { BillingPeriod } from "@app/types/plan";
@@ -158,7 +158,7 @@ export function FreePlanCard({ onStartFree }: FreePlanCardProps) {
       icon={LayerSingle}
       seatType="free"
       name="Free"
-      credits={CP_FREE_PLAN_CREDITS.toLocaleString()}
+      credits={FREE_SEAT_LIFETIME_AWU_CREDITS.toLocaleString()}
       creditsLabel="credits"
       priceLabel="One-time · never expires"
       features={["Credits never reset", "Full access to every Dust feature"]}

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -2,11 +2,9 @@ import { PhoneNumberCodeInput } from "@app/components/trial/PhoneNumberCodeInput
 import { PhoneNumberInput } from "@app/components/trial/PhoneNumberInput";
 import config from "@app/lib/api/config";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import {
-  CP_FREE_PLAN_CREDITS,
-  useIsMetronomeCheckout,
-} from "@app/lib/client/subscription";
+import { useIsMetronomeCheckout } from "@app/lib/client/subscription";
 import { clientFetch } from "@app/lib/egress/client";
+import { FREE_SEAT_LIFETIME_AWU_CREDITS } from "@app/lib/metronome/constants";
 import {
   CODE_LENGTH,
   isValidPhoneNumber,
@@ -324,7 +322,7 @@ export function VerifyPage() {
     case "done":
       return (
         <WelcomeStep
-          credits={CP_FREE_PLAN_CREDITS}
+          credits={FREE_SEAT_LIFETIME_AWU_CREDITS}
           onStartBuilding={goToWorkspace}
         />
       );

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -20,12 +20,6 @@ export const CP_PRO_SEAT_COST_YEARLY = 24;
 export const CP_MAX_SEAT_COST_MONTHLY = 150;
 export const CP_MAX_SEAT_COST_YEARLY = 120;
 
-// Lifetime AWU credits granted once per seat on the credit-priced Free plan.
-// Mirrors the server-side source of truth `FREE_SEAT_LIFETIME_AWU_CREDITS` in
-// `front/lib/metronome/setup_new_pricing.ts` (that module is server-only and
-// cannot be imported client-side).
-export const CP_FREE_PLAN_CREDITS = 300;
-
 /**
  * Client-side mirror of the server-side `isMetronomeBillingEnabled` gate: the
  * credit-priced checkout flow follows Metronome billing, which is enabled by

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -288,7 +288,7 @@ export const AWU_PRIORITY_PURCHASED_COMMIT = 300;
 // than via a recurring credit, so this constant is also the authoritative
 // source for the free seat's displayed allowance (see
 // `getAwuAllocationInfoForSeatType`).
-export const FREE_SEAT_LIFETIME_AWU_CREDITS = 300;
+export const FREE_SEAT_LIFETIME_AWU_CREDITS = 500;
 
 // Seat commit/credit priorities
 export const SEAT_PRIORITY_SUBSCRIPTION_COMMIT = 300;

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -1,3 +1,4 @@
+import { FREE_SEAT_LIFETIME_AWU_CREDITS } from "@app/lib/metronome/constants";
 import {
   MAX_SEAT_MONTHLY_AWU_CREDITS,
   PRO_SEAT_MONTHLY_AWU_CREDITS,
@@ -724,8 +725,8 @@ describe("UserCreditStateMachine — seat_balance_resolved", () => {
         ...baseCtx,
         seatType: "free",
         liveBalance: {
-          seatBalanceAwu: 300,
-          seatStartingBalanceAwu: 300,
+          seatBalanceAwu: FREE_SEAT_LIFETIME_AWU_CREDITS,
+          seatStartingBalanceAwu: FREE_SEAT_LIFETIME_AWU_CREDITS,
           perUserCapAwuCredits: null,
           consumedAwuCredits: null,
         },
@@ -747,7 +748,7 @@ describe("UserCreditStateMachine — seat_balance_resolved", () => {
         seatType: "free",
         liveBalance: {
           seatBalanceAwu: 40,
-          seatStartingBalanceAwu: 300,
+          seatStartingBalanceAwu: FREE_SEAT_LIFETIME_AWU_CREDITS,
           perUserCapAwuCredits: null,
           consumedAwuCredits: null,
         },


### PR DESCRIPTION
## Description

Increases the lifetime AWU credits granted to free-plan users from 300 to 500.

- Updates `FREE_SEAT_LIFETIME_AWU_CREDITS` (the single source of truth) in `front/lib/metronome/constants.ts` from 300 to 500
- Removes the now-redundant `CP_FREE_PLAN_CREDITS` alias from `front/lib/client/subscription.ts` — all consumers import `FREE_SEAT_LIFETIME_AWU_CREDITS` directly
- Updates hardcoded `300` values in tests to use the constant

## Tests

Existing tests updated to use `FREE_SEAT_LIFETIME_AWU_CREDITS` instead of hardcoded `300`. No new tests needed — this is a constant change.

## Risk

Low. Display-only and credit-grant change. Rollback is a one-line revert.

## Deploy Plan

Standard deploy — no migration required.