### PR TITLE
[front] VerifyPage: call verify automatically on full code input

### DIFF
--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -168,68 +168,103 @@ export function VerifyPage() {
       return;
     }
 
+    lastAutoSubmittedCodeRef.current = null;
+    setCode(Array(CODE_LENGTH).fill(""));
     setResendCooldown(RESEND_COOLDOWN_SECONDS);
     setStep("code");
   };
 
-  const handleVerifyCode = async () => {
-    const fullCode = code.join("");
-    if (fullCode.length !== CODE_LENGTH) {
-      setPhoneError("Please enter the full 6-digit code.");
+  const lastAutoSubmittedCodeRef = useRef<string | null>(null);
+
+  const verifyCode = useCallback(
+    async (fullCode: string) => {
+      if (fullCode.length !== CODE_LENGTH) {
+        setPhoneError("Please enter the full 6-digit code.");
+        return;
+      }
+
+      setIsLoading(true);
+      setPhoneError(null);
+      try {
+        const e164Phone = phoneNumber;
+
+        const verifyResponse = await clientFetch(
+          `/api/w/${workspace.sId}/verification/validate`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ phoneNumber: e164Phone, code: fullCode }),
+          }
+        );
+
+        if (!verifyResponse.ok) {
+          const data = await verifyResponse.json();
+          setPhoneError(data.error?.message ?? "Invalid code");
+          return;
+        }
+
+        const trialResponse = await clientFetch(
+          `/api/w/${workspace.sId}/trial/start`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+
+        if (!trialResponse.ok) {
+          const data = await trialResponse.json();
+          setPhoneError(data.api_error?.message ?? "Failed to start trial");
+          return;
+        }
+
+        // Revalidate the auth context so the SPA picks up the new subscription
+        // (canUseProduct is now true) and doesn't redirect back to /trial.
+        await mutateAuthContext();
+
+        // With the credit-priced checkout flow we show a welcome screen before
+        // entering the workspace instead of redirecting there directly.
+        if (isMetronomeCheckout) {
+          setStep("done");
+        } else {
+          goToWorkspace();
+        }
+      } catch {
+        setPhoneError("Network error. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      phoneNumber,
+      workspace.sId,
+      mutateAuthContext,
+      isMetronomeCheckout,
+      goToWorkspace,
+    ]
+  );
+
+  const handleVerifyCode = useCallback(() => {
+    void verifyCode(code.join(""));
+  }, [code, verifyCode]);
+
+  useEffect(() => {
+    if (step !== "code" || isLoading) {
       return;
     }
 
-    setIsLoading(true);
-    setPhoneError(null);
-    try {
-      const e164Phone = phoneNumber;
+    const fullCode = code.join("");
 
-      const verifyResponse = await clientFetch(
-        `/api/w/${workspace.sId}/verification/validate`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ phoneNumber: e164Phone, code: fullCode }),
-        }
-      );
-
-      if (!verifyResponse.ok) {
-        const data = await verifyResponse.json();
-        setPhoneError(data.error?.message ?? "Invalid code");
-        return;
-      }
-
-      const trialResponse = await clientFetch(
-        `/api/w/${workspace.sId}/trial/start`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        }
-      );
-
-      if (!trialResponse.ok) {
-        const data = await trialResponse.json();
-        setPhoneError(data.api_error?.message ?? "Failed to start trial");
-        return;
-      }
-
-      // Revalidate the auth context so the SPA picks up the new subscription
-      // (canUseProduct is now true) and doesn't redirect back to /trial.
-      await mutateAuthContext();
-
-      // With the credit-priced checkout flow we show a welcome screen before
-      // entering the workspace instead of redirecting there directly.
-      if (isMetronomeCheckout) {
-        setStep("done");
-      } else {
-        goToWorkspace();
-      }
-    } catch {
-      setPhoneError("Network error. Please try again.");
-    } finally {
-      setIsLoading(false);
+    if (fullCode.length !== CODE_LENGTH) {
+      return;
     }
-  };
+
+    if (lastAutoSubmittedCodeRef.current === fullCode) {
+      return;
+    }
+
+    lastAutoSubmittedCodeRef.current = fullCode;
+    void verifyCode(fullCode);
+  }, [code, step, isLoading, verifyCode]);
 
   const handleCodeChange = useCallback((index: number, value: string) => {
     const digit = value.replace(/\D/g, "").slice(-1);
@@ -293,6 +328,7 @@ export function VerifyPage() {
   const handleBack = () => {
     setStep("phone");
     setCode(Array(CODE_LENGTH).fill(""));
+    lastAutoSubmittedCodeRef.current = null;
     setPhoneError(null);
   };
 
@@ -544,7 +580,7 @@ function CodeVerificationStep({
                     variant="primary"
                     label={isLoading ? "Verifying..." : "Verify now"}
                     onClick={onVerify}
-                    disabled={isLoading}
+                    disabled={isLoading || code.join("").length !== CODE_LENGTH}
                   />
                 </div>
               </div>

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -62,6 +62,7 @@ export function VerifyPage() {
   const [code, setCode] = useState<string[]>(Array(CODE_LENGTH).fill(""));
   const [resendCooldown, setResendCooldown] = useState(0);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const lastAutoSubmittedCodeRef = useRef<string | null>(null);
 
   // Initialize countryCode once data is loaded.
   useEffect(() => {
@@ -173,8 +174,6 @@ export function VerifyPage() {
     setResendCooldown(RESEND_COOLDOWN_SECONDS);
     setStep("code");
   };
-
-  const lastAutoSubmittedCodeRef = useRef<string | null>(null);
 
   const verifyCode = useCallback(
     async (fullCode: string) => {


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8956

* Auto-submit: a useEffect watches code, and when all 6 digits are filled it calls verifyCode automatically — guarded by lastAutoSubmittedCodeRef to prevent retrying on invalid codes.
* No retry loop: the ref records the last auto-submitted code, so a failed attempt (wrong code error) won't re-fire unless the user changes the input.
* Reset on resend/back: both handleSendCode and handleBack clear the ref and wipe the code boxes, so the next full entry triggers auto-submit again.
* Button disabled when incomplete: the Verify button now requires all 6 digits before becoming clickable, consistent with the auto-submit behavior.

## Tests

Tested locally

## Risk

Medium, impacts the current free trial flow and future free plan flow

## Deploy Plan

Deploy front