### PR TITLE
chore(front-api): add phased migration scripts

### DIFF
--- a/front-api/create_db_migration_file.sh
+++ b/front-api/create_db_migration_file.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo ""
+echo "ERROR: migrations/db/ is frozen. Do not add files here."
+echo ""
+echo "Use the new phased migration system instead:"
+echo ""
+echo "  Safe schema additions (add column, table, index):"
+echo "    npm run migration:generate:pre-deploy <description words>"
+echo ""
+echo "  Breaking schema changes (drop column, tighten constraint):"
+echo "    npm run migration:generate:post-deploy <description words>"
+echo ""
+echo "See the runbook for full instructions:"
+echo "  https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
+echo ""
+
+exit 1

--- a/front-api/esbuild.shared.ts
+++ b/front-api/esbuild.shared.ts
@@ -45,6 +45,7 @@ export interface BuildTarget {
 // server.ts is the Hono-only runtime target (`npm start` in this workspace).
 export const BUILD_TARGETS: BuildTarget[] = [
   { name: "server", entry: "server.ts", outfile: "dist/server.js" },
+  { name: "migrate", entry: "scripts/migrate.ts", outfile: "dist/migrate.js" },
 ];
 
 // Options shared by dev and production builds. Mode-specific options

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -10,6 +10,16 @@
     "lint:swagger-annotations": "BAD_FILES=$(grep -rlE 'app\\.(get|post|patch|put|delete)\\(' routes --include='*.ts' | grep -v '\\.test\\.ts$' | xargs grep -rL '@swagger\\|@ignoreswagger'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: The following API route files register a handler but are missing the @swagger or @ignoreswagger annotation:\"; echo \"$BAD_FILES\"; exit 1; else echo \"Swagger annotation check: OK.\"; exit 0; fi",
     "docs": "tsx scripts/generate-swagger.ts 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
+    "create-db-migration": "./create_db_migration_file.sh",
+    "migration:generate:pre-deploy": "./scripts/generate-migration.sh pre-deploy",
+    "migration:generate:post-deploy": "./scripts/generate-migration.sh post-deploy",
+    "migration:apply:pre-deploy": "node scripts/run-migrate.cjs --command pre-deploy --execute",
+    "migration:apply:post-deploy": "node scripts/run-migrate.cjs --command post-deploy --execute",
+    "migration:apply": "npm run migration:apply:pre-deploy && npm run migration:apply:post-deploy",
+    "migration:status": "node scripts/run-migrate.cjs --command status --execute",
+    "migration:check": "node scripts/run-migrate.cjs --command check --execute",
+    "migration:check:pre-deploy": "node scripts/run-migrate.cjs --command check-pre-deploy --execute",
+    "migration:check:post-deploy": "node scripts/run-migrate.cjs --command check-post-deploy --execute",
     "tsgo": "tsgo"
   },
   "dependencies": {

--- a/front-api/scripts/generate-migration.sh
+++ b/front-api/scripts/generate-migration.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure NODE_ENV is not set to production.
+if [ "${NODE_ENV:-}" == "production" ]; then
+  echo "Error: NODE_ENV is set to production. Aborting script."
+  exit 1
+fi
+
+# Check that pg-schema-diff is installed.
+if ! command -v pg-schema-diff >/dev/null 2>&1; then
+  echo "Error: 'pg-schema-diff' is not installed or not in PATH."
+  echo ""
+  echo "Install it from https://github.com/stripe/pg-schema-diff:"
+  echo "  brew install pg-schema-diff"
+  exit 1
+fi
+
+# Check that psql is installed.
+if ! command -v psql >/dev/null 2>&1; then
+  echo "Error: 'psql' is not installed or not in PATH."
+  echo "Install the PostgreSQL client tools (e.g. 'brew install postgresql')."
+  exit 1
+fi
+
+if [ -z "${FRONT_DATABASE_URI:-}" ]; then
+  echo "Error: FRONT_DATABASE_URI must be set."
+  exit 1
+fi
+
+usage() {
+  echo "Usage: $0 <pre-deploy|post-deploy> <description words...>"
+  echo ""
+  echo "  pre-deploy   Schema change that old code can survive (add column, add table, add index)."
+  echo "  post-deploy  Schema change that requires new code to be live (drop column, tighten constraint)."
+  echo ""
+  echo "  Description words are joined with '_' (e.g. 'add email column' -> 'add_email_column')."
+  exit 1
+}
+
+PHASE="${1:-}"
+shift || true
+DESC="${*:-}"
+DESC="${DESC// /_}"
+
+if [ -z "${PHASE}" ] || [ -z "${DESC}" ]; then
+  usage
+fi
+
+case "${PHASE}" in
+  pre-deploy|post-deploy) ;;
+  *)
+    echo "Error: phase must be 'pre-deploy' or 'post-deploy', got '${PHASE}'."
+    usage
+    ;;
+esac
+
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+OUT_DIR="migrations/${PHASE}"
+FILENAME="${OUT_DIR}/${TIMESTAMP}_${DESC}.sql"
+
+mkdir -p "${OUT_DIR}"
+
+# The current FRONT_DATABASE_URI is the baseline (already at production schema).
+# We only need one shadow DB to materialize the current branch's models.
+BASE_DSN="${FRONT_DATABASE_URI%/*}"
+ADMIN_DSN="${BASE_DSN}/postgres"
+
+SHADOW_TO="dust_front_shadow_to_$$"
+TO_DSN="${BASE_DSN}/${SHADOW_TO}"
+
+cleanup() {
+  set +e
+  psql "${ADMIN_DSN}" -c "DROP DATABASE IF EXISTS \"${SHADOW_TO}\"" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+echo "Building target schema from current branch..."
+psql "${ADMIN_DSN}" -c "CREATE DATABASE \"${SHADOW_TO}\"" >/dev/null
+FRONT_DATABASE_URI="${TO_DSN}" npx tsx ../front/admin/db.ts
+
+echo "Computing diff..."
+pg-schema-diff plan \
+  --from-dsn "${FRONT_DATABASE_URI}" \
+  --to-dsn "${TO_DSN}" \
+  --disable-plan-validation \
+  --output-format sql \
+  > "${FILENAME}"
+
+if [ ! -s "${FILENAME}" ]; then
+  rm "${FILENAME}"
+  echo "No schema changes detected."
+  exit 0
+fi
+
+echo ""
+echo "✅ Migration generated:"
+echo "   ${FILENAME}"

--- a/front-api/scripts/migrate.ts
+++ b/front-api/scripts/migrate.ts
@@ -1,0 +1,200 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { dbConfig } from "@app/lib/resources/storage/config";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { execFileSync } from "child_process";
+import { QueryTypes } from "sequelize";
+import type { MigrationParams } from "umzug";
+import { Umzug } from "umzug";
+
+const PHASES = ["pre-deploy", "post-deploy"] as const;
+type Phase = (typeof PHASES)[number];
+type Command =
+  | Phase
+  | "status"
+  | "check"
+  | "check-pre-deploy"
+  | "check-post-deploy";
+
+async function ensureSchemaMigrationsTable(): Promise<void> {
+  // biome-ignore lint/plugin/noRawSql: migration runner bootstraps its own table.
+  await frontSequelize.query(
+    `CREATE TABLE IF NOT EXISTS "schema_migrations" (
+      "name"       VARCHAR(255) PRIMARY KEY,
+      "phase"      VARCHAR(20)  NOT NULL,
+      "applied_at" TIMESTAMP    NOT NULL DEFAULT NOW(),
+      UNIQUE ("name", "phase")
+    )`
+  );
+}
+
+// Custom Umzug storage that writes both the migration name and its phase, so
+// pre-deploy and post-deploy migrations can be counted independently (used by
+// the deploy gate).
+class PhasedSequelizeStorage {
+  constructor(private readonly phase: Phase) {}
+
+  async logMigration({ name }: { name: string }): Promise<void> {
+    // biome-ignore lint/plugin/noRawSql: schema_migrations is the migration runner's own ledger.
+    await frontSequelize.query(
+      `INSERT INTO "schema_migrations" ("name", "phase") VALUES (:name, :phase)`,
+      {
+        replacements: { name, phase: this.phase },
+        type: QueryTypes.INSERT,
+      }
+    );
+  }
+
+  async unlogMigration(_: { name: string }): Promise<void> {
+    throw new Error("Rolling back migrations is not supported.");
+  }
+
+  async executed(): Promise<string[]> {
+    // biome-ignore lint/plugin/noRawSql: schema_migrations is the migration runner's own ledger.
+    const rows = await frontSequelize.query<{ name: string }>(
+      `SELECT "name" FROM "schema_migrations" WHERE "phase" = :phase ORDER BY "name"`,
+      {
+        replacements: { phase: this.phase },
+        type: QueryTypes.SELECT,
+      }
+    );
+    return rows.map((r) => r.name);
+  }
+}
+
+function createUmzug(phase: Phase) {
+  return new Umzug({
+    migrations: {
+      glob: `migrations/${phase}/*.sql`,
+      resolve: ({ name, path: filePath }: MigrationParams<unknown>) => ({
+        // Prefix with phase so pre- and post-deploy migrations never collide on
+        // a same filename.
+        name: `${phase}/${name}`,
+        up: async () => {
+          if (!filePath) {
+            throw new Error(`Missing path for migration ${name}.`);
+          }
+          // Use psql -f so the file runs in a single direct PostgreSQL session,
+          // bypassing pgbouncer. This is required because pg-schema-diff emits
+          // files that mix SET SESSION, regular DDL, and CREATE/DROP INDEX
+          // CONCURRENTLY — the latter two require autocommit, which pgbouncer's
+          // transaction-pooling mode would break if we used a library client.
+          try {
+            execFileSync("psql", ["--version"], { stdio: "pipe" });
+          } catch {
+            throw new Error(
+              "psql is not available — install the PostgreSQL client tools."
+            );
+          }
+          execFileSync(
+            "psql",
+            [
+              dbConfig.getRequiredFrontDatabaseURI(),
+              "-v",
+              "ON_ERROR_STOP=1",
+              "-f",
+              filePath,
+            ],
+            { stdio: "inherit" }
+          );
+        },
+        // Down migrations are intentionally not supported. The expand/contract
+        // pattern means rolling back a schema change is a new forward migration.
+        down: async () => {
+          throw new Error("Down migrations are not supported.");
+        },
+      }),
+    },
+    context: frontSequelize.getQueryInterface(),
+    storage: new PhasedSequelizeStorage(phase),
+    logger: {
+      debug: (msg: unknown) => logger.debug(msg as Record<string, unknown>),
+      info: (msg: unknown) => logger.info(msg as Record<string, unknown>),
+      warn: (msg: unknown) => logger.warn(msg as Record<string, unknown>),
+      error: (msg: unknown) => logger.error(msg as Record<string, unknown>),
+    },
+  });
+}
+
+async function runUp(phase: Phase): Promise<void> {
+  const umzug = createUmzug(phase);
+  const applied = await umzug.up();
+  if (applied.length === 0) {
+    logger.info({ phase }, "No pending migrations.");
+    return;
+  }
+  logger.info(
+    { phase, count: applied.length, names: applied.map((m) => m.name) },
+    "Migrations applied."
+  );
+}
+
+async function runStatus(): Promise<void> {
+  for (const phase of PHASES) {
+    const pending = await createUmzug(phase).pending();
+    logger.info(
+      { phase, count: pending.length, names: pending.map((m) => m.name) },
+      "Pending migrations."
+    );
+  }
+}
+
+async function runCheckPhase(phase: Phase): Promise<void> {
+  const pending = await createUmzug(phase).pending();
+  if (pending.length > 0) {
+    logger.error(
+      { phase, count: pending.length, names: pending.map((m) => m.name) },
+      "Pending migrations found — deploy blocked."
+    );
+    process.exit(1);
+  }
+  logger.info({ phase }, "All migrations applied.");
+}
+
+makeScript(
+  {
+    command: {
+      type: "string",
+      choices: [
+        "pre-deploy",
+        "post-deploy",
+        "status",
+        "check",
+        "check-pre-deploy",
+        "check-post-deploy",
+      ],
+      demandOption: true,
+      describe: "Migration command to run.",
+    },
+  },
+  async ({ command, execute }) => {
+    if (!execute) {
+      return;
+    }
+
+    await ensureSchemaMigrationsTable();
+
+    const typedCommand = command as Command;
+    switch (typedCommand) {
+      case "pre-deploy":
+      case "post-deploy":
+        await runUp(typedCommand);
+        break;
+      case "status":
+        await runStatus();
+        break;
+      case "check":
+      case "check-pre-deploy":
+        await runCheckPhase("pre-deploy");
+        break;
+      case "check-post-deploy":
+        await runCheckPhase("post-deploy");
+        break;
+      default:
+        assertNever(typedCommand);
+    }
+
+    await frontSequelize.close();
+  }
+);

--- a/front-api/scripts/run-migrate.cjs
+++ b/front-api/scripts/run-migrate.cjs
@@ -1,0 +1,12 @@
+'use strict';
+const { existsSync } = require('fs');
+const { spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+const compiled = 'dist/migrate.js';
+
+const result = existsSync(compiled)
+  ? spawnSync('node', [compiled, ...args], { stdio: 'inherit' })
+  : spawnSync('tsx', ['scripts/migrate.ts', ...args], { stdio: 'inherit' });
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Description

Adds phased migration scripts to `front-api` to match the setup in `front`. This is a copy of the existing tooling — a refactor to share the implementation will follow.

- `scripts/migrate.ts` — Umzug-based runner for pre/post-deploy SQL migrations
- `scripts/run-migrate.cjs` — launcher that uses `dist/migrate.js` when built, falls back to `tsx`
- `scripts/generate-migration.sh` — generates migration SQL via pg-schema-diff (references `../front/admin/db.ts` since `front-api` shares `front`'s Sequelize models)
- `create_db_migration_file.sh` — error guard redirecting away from the frozen `migrations/db/` path
- `esbuild.shared.ts` — adds `migrate` to `BUILD_TARGETS` so `npm run build` produces `dist/migrate.js`
- `package.json` — exposes all `migration:*` and `create-db-migration` scripts

## Tests

Manual: scripts wired up and executable, build target added.

## Risk

Low — additive only.

## Deploy Plan

None.
