### PR TITLE
Make Computer skill opt-in by default

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -529,6 +529,56 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(text).not.toContain("## AVAILABLE SKILLS");
   });
 
+  it("should point agents to the Computer for uploaded files when sandbox tools are available", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      systemSkills: [],
+      enabledSkills: [],
+      equippedSkills: [],
+      isNewFileExplorer: true,
+      hasSandboxTools: true,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    expect(text).toContain(
+      "Files attached as `<file>` tags are mounted under `/files/conversation` when using the Computer."
+    );
+    expect(text).toContain(
+      "You must enable the Computer skill proactively as soon as the user uploads files"
+    );
+    expect(text).toContain("especially PDFs");
+  });
+
+  it("should not mention the Computer file mount when sandbox tools are unavailable", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      systemSkills: [],
+      enabledSkills: [],
+      equippedSkills: [],
+      isNewFileExplorer: true,
+      hasSandboxTools: false,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    expect(text).not.toContain("Computer skill");
+    expect(text).not.toContain("/files/conversation");
+    expect(text).toContain(
+      "Tabular files (CSV, spreadsheets) are queryable via the query tables tool"
+    );
+  });
+
   it("should keep system skill instructions in the system prompt", async () => {
     const discoverSkills = await SkillResource.fetchById(
       authenticator1,

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -555,6 +555,31 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(text).toContain("especially PDFs");
   });
 
+  it("should point legacy attachment prompts to the Computer when sandbox tools are available", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      systemSkills: [],
+      enabledSkills: [],
+      equippedSkills: [],
+      isNewFileExplorer: false,
+      hasSandboxTools: true,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    expect(text).toContain(
+      "When using the Computer, conversation files are mounted under `/files/conversation`."
+    );
+    expect(text).toContain(
+      "You must enable the Computer skill proactively as soon as the user uploads files"
+    );
+  });
+
   it("should not mention the Computer file mount when sandbox tools are unavailable", () => {
     const params = {
       userMessage: userMessage1,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -242,8 +242,25 @@ function constructSkillsSection({
   return skillsSection;
 }
 
+function constructComputerEnableForFilesPrompt(): string {
+  return (
+    "You must enable the Computer skill proactively as soon as the user uploads files, " +
+    "especially PDFs, spreadsheets, archives, or other files that require inspection, " +
+    "text extraction, code execution, or file manipulation."
+  );
+}
+
 // TODO(20260504 FILE SYSTEM): Remove in favor of constructAttachmentsSectionNewFileExplorer.
-function constructAttachmentsSection(): string {
+function constructAttachmentsSection({
+  hasSandboxTools,
+}: {
+  hasSandboxTools: boolean;
+}): string {
+  const sandboxFilesPrompt = hasSandboxTools
+    ? "When using the Computer, conversation files are mounted under `/files/conversation`. " +
+      `${constructComputerEnableForFilesPrompt()}\n`
+    : "";
+
   return (
     "# ATTACHMENTS\n" +
     'The conversation history may contain file attachments, indicated by attachment tags of the form <attachment id="{FILE_ID}" type="{MIME_TYPE}" title="{TITLE}" version="{VERSION}" isIncludable="{IS_INCLUDABLE}" isQueryable="{IS_QUERYABLE}" isSearchable="{IS_SEARCHABLE}" sourceUrl="{SOURCE_URL}"> . ' +
@@ -254,6 +271,7 @@ function constructAttachmentsSection(): string {
     `- isQueryable: attachment contents are tabular data that can be queried alongside other queryable conversation files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`;\n` +
     `- isSearchable: attachment contents are available for semantic search, i.e. when semantically searching conversation files' content, using \`${getPrefixedToolName(CONVERSATION_FILES_SERVER_NAME, CONVERSATION_SEARCH_FILES_ACTION_NAME)}\`,` +
     " contents of this attachment will be considered in the search.\n" +
+    sandboxFilesPrompt +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files' types to decide which tool to use on which file.\n"
   );
 }
@@ -264,7 +282,7 @@ function constructAttachmentsSectionNewFileExplorer({
   hasSandboxTools: boolean;
 }): string {
   const tabularFilesLine = hasSandboxTools
-    ? '- Files attached as `<file>` tags are mounted under `/files/conversation` when using the Computer. You must enable the Computer skill proactively as soon as the user uploads files, especially PDFs, spreadsheets, archives, or other files that require inspection, text extraction, code execution, or file manipulation. Tabular files attached as `<attachment isQueryable="true">` tags (for example tool-generated CSVs) remain queryable via the query tables tool;\n'
+    ? `- Files attached as \`<file>\` tags are mounted under \`/files/conversation\` when using the Computer. ${constructComputerEnableForFilesPrompt()} Tabular files attached as \`<attachment isQueryable="true">\` tags (for example tool-generated CSVs) remain queryable via the query tables tool;\n`
     : "- Tabular files (CSV, spreadsheets) are queryable via the query tables tool;\n";
 
   return (
@@ -459,7 +477,7 @@ export function constructPromptMultiActions(
   });
   const attachmentsSection = isNewFileExplorer
     ? constructAttachmentsSectionNewFileExplorer({ hasSandboxTools })
-    : constructAttachmentsSection();
+    : constructAttachmentsSection({ hasSandboxTools });
   const pastedContentSection = constructPastedContentSection();
   const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -264,7 +264,7 @@ function constructAttachmentsSectionNewFileExplorer({
   hasSandboxTools: boolean;
 }): string {
   const tabularFilesLine = hasSandboxTools
-    ? '- Tabular files (CSV, spreadsheets) attached as `<file>` tags are mounted under /files/conversation; analyze them with code via the sandbox. Tabular files attached as `<attachment isQueryable="true">` tags (for example tool-generated CSVs) remain queryable via the query tables tool;\n'
+    ? '- Files attached as `<file>` tags are mounted under `/files/conversation` when using the Computer. You must enable the Computer skill proactively as soon as the user uploads files, especially PDFs, spreadsheets, archives, or other files that require inspection, text extraction, code execution, or file manipulation. Tabular files attached as `<attachment isQueryable="true">` tags (for example tool-generated CSVs) remain queryable via the query tables tool;\n'
     : "- Tabular files (CSV, spreadsheets) are queryable via the query tables tool;\n";
 
   return (

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -601,7 +601,7 @@ export function _getDeepDiveGlobalAgent(
     ...deepAgent,
     status,
     actions,
-    // The "sandbox" (Computer) skill is auto-enabled for all agents when the
+    // The "sandbox" (Computer) skill is auto-equipped for all agents when the
     // `sandbox_tools` feature flag is on (see SkillResource.listForAgentLoop),
     // so it no longer needs to be listed here.
     skills: ["frames", "discover_skills", "skill-authoring"],

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -263,41 +263,66 @@ describe("getJITServers", () => {
     });
   });
 
-  describe("sandbox (Computer) auto-enable", () => {
-    it("auto-enables the sandbox system skill for any agent when sandbox_tools is on", async () => {
+  describe("sandbox (Computer) availability", () => {
+    it("auto-equips the sandbox skill for any agent when sandbox_tools is on", async () => {
       await FeatureFlagFactory.basic(auth, "sandbox_tools");
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
       // The test agent does not list the sandbox skill in its configuration.
-      const { systemSkills } = await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-      });
-
-      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(true);
-    });
-
-    it("does not enable the sandbox skill when sandbox_tools is off", async () => {
-      const { systemSkills } = await SkillResource.listForAgentLoop(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-      });
+      const { enabledSkills, systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
 
       expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(false);
+      expect(enabledSkills.some((s) => s.sId === "sandbox")).toBe(false);
+      const computerSkill = equippedSkills.find((s) => s.sId === "sandbox");
+      expect(computerSkill).toBeDefined();
+      expect(computerSkill?.instructions).toBe("");
     });
 
-    it("keeps the sandbox skill enabled for nested sub-agent conversations", async () => {
+    it("does not equip or enable the sandbox skill when sandbox_tools is off", async () => {
+      const { enabledSkills, systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
+
+      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(false);
+      expect(enabledSkills.some((s) => s.sId === "sandbox")).toBe(false);
+      expect(equippedSkills.some((s) => s.sId === "sandbox")).toBe(false);
+    });
+
+    it("keeps the sandbox skill available for nested sub-agent conversations", async () => {
       await FeatureFlagFactory.basic(auth, "sandbox_tools");
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
       // run_agent sub-agents run in a child conversation (depth > 0); they get
       // their own Computer too.
-      const { systemSkills } = await SkillResource.listForAgentLoop(auth, {
+      const { systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation: { ...conversation, depth: 1 },
+        });
+
+      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(false);
+      expect(equippedSkills.some((s) => s.sId === "sandbox")).toBe(true);
+    });
+
+    it("includes skill_management so agents can enable the sandbox skill", async () => {
+      await FeatureFlagFactory.basic(auth, "sandbox_tools");
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
-        conversation: { ...conversation, depth: 1 },
+        conversation,
+        attachments: [],
       });
 
-      expect(systemSkills.some((s) => s.sId === "sandbox")).toBe(true);
+      expect(
+        jitServers.some((server) => server.name === "skill_management")
+      ).toBe(true);
     });
   });
 

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -354,8 +354,10 @@ export const sandboxSkill = {
   userFacingDescription:
     "Run code, scripts, and shell commands in the conversation's Computer (a sandboxed Linux environment).",
   agentFacingDescription:
-    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
-    "process data, install packages, manipulate files, or perform any task requiring shell access. " +
+    "You must enable this skill proactively as soon as the user uploads files or you need to work with files, " +
+    "including PDFs, spreadsheets, archives, or generated artifacts. Use it to extract text from files, " +
+    "parse lengthy tool outputs, run code and shell commands, process data, manipulate files, or perform " +
+    "any computer-related task. " +
     "Always call this environment 'the Computer' in any text you send to the user.",
   fetchInstructions: async (
     auth: Authenticator,
@@ -378,9 +380,9 @@ export const sandboxSkill = {
   mcpServers: [{ name: "sandbox" }],
   version: 1,
   icon: "CommandLineIcon",
-  // Auto-enabled for every agent when the `sandbox_tools` flag is on (the flag gate lives in
-  // isRestricted), so agents do not need to opt in.
-  isAutoEnabledForAgentLoop: () => true,
+  // Auto-equipped for every agent when the `sandbox_tools` flag is on (the flag gate lives in
+  // isRestricted), but not enabled until the agent decides to use it.
+  isAutoEquippedForAgentLoop: () => true,
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -354,6 +354,8 @@ export const sandboxSkill = {
   userFacingDescription:
     "Run code, scripts, and shell commands in the conversation's Computer (a sandboxed Linux environment).",
   agentFacingDescription:
+    "Execute code and commands in an isolated Linux sandbox. Useful to parse lengthy tool outputs, run code, " +
+    "process data, install packages, manipulate files, or perform any task requiring shell access. " +
     "You must enable this skill proactively as soon as the user uploads files or you need to work with files, " +
     "including PDFs, spreadsheets, archives, or generated artifacts. Use it to extract text from files, " +
     "parse lengthy tool outputs, run code and shell commands, process data, manipulate files, or perform " +

--- a/front/lib/resources/skill/code_defined/shared.ts
+++ b/front/lib/resources/skill/code_defined/shared.ts
@@ -24,10 +24,16 @@ interface BaseSkillDefinition {
   readonly mcpServers?: MCPServerDefinition[];
   readonly inheritAgentConfigurationDataSources?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
+  // Optional callback to auto-equip a code-defined skill for an agent loop (subject to
+  // isRestricted), without enabling it. Return true to make the skill available through
+  // skill_management__enable_skill.
+  readonly isAutoEquippedForAgentLoop?: (params: {
+    agentConfiguration: AgentConfigurationType;
+    conversation: ConversationWithoutContentType;
+  }) => boolean;
   // Optional callback to auto-enable a code-defined skill for an agent loop (subject to
   // isRestricted), without it being added to the agent configuration. Return true to enable.
-  // Used for skills that are on by default, either always (e.g. the Computer) or for a given
-  // context (e.g. Pods in a Pod conversation).
+  // Used for skills that are on by default for a given context (e.g. Pods in a Pod conversation).
   readonly isAutoEnabledForAgentLoop?: (params: {
     agentConfiguration: AgentConfigurationType;
     conversation: ConversationWithoutContentType;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1435,10 +1435,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     // System skills are always treated as enabled when present in the agent configuration.
     const configSystemSkills = allAgentSkills.filter((s) => s.isSystemSkill);
 
-    // Code-defined skills can opt into being auto-enabled for the agent loop without being
-    // added to the agent configuration, either always (e.g. the Computer) or for a given
-    // context (e.g. Pods in a Pod conversation). `findAll` already drops restricted skills, so
-    // a flag-gated skill only shows up once its feature flag is on.
+    // Code-defined skills can opt into being auto-equipped or auto-enabled for the agent loop
+    // without being added to the agent configuration. `findAll` already drops restricted skills,
+    // so a flag-gated skill only shows up once its feature flag is on.
     const enabledGlobalSkillIds = new Set(
       removeNulls([
         ...configSystemSkills.map((s) => s.globalSId),
@@ -1464,6 +1463,30 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         })
       : [];
 
+    const equippedGlobalSkillIds = new Set(
+      removeNulls([
+        ...allAgentSkills.map((s) => s.globalSId),
+        ...conversationEnabledSkills.map((s) => s.globalSId),
+        ...autoEnabledSkills.map((s) => s.globalSId),
+      ])
+    );
+    const autoEquippedRefs = codeDefinedDefs
+      .filter(
+        (def) =>
+          def.isAutoEquippedForAgentLoop?.({
+            agentConfiguration,
+            conversation,
+          }) && !equippedGlobalSkillIds.has(def.sId)
+      )
+      .map((def) => ({ globalSkillId: def.sId, customSkillId: null }));
+    const autoEquippedSkills = autoEquippedRefs.length
+      ? await this.fetchBySkillReferences(auth, autoEquippedRefs, {
+          agentLoopData,
+          withInstructions: false,
+          withTools: false,
+        })
+      : [];
+
     // System skills land in `systemSkills` (always enabled); auto-enabled global skills join
     // the conversation-enabled skills.
     const systemSkills = [
@@ -1481,13 +1504,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       enabledSkills
     );
 
-    // Compute the equipped skills: all non-system agent skills plus
-    // discoverable skills that are not already equipped. Keep this list stable
+    // Compute the equipped skills: all non-system agent skills, auto-equipped skills,
+    // plus discoverable skills that are not already equipped. Keep this list stable
     // even after a skill is enabled.
     const agentEquippedSkills = allAgentSkills.filter((s) => !s.isSystemSkill);
 
     const agentEquippedSkillIds = new Set(
-      agentEquippedSkills.map((s) => s.sId)
+      [...agentEquippedSkills, ...autoEquippedSkills].map((s) => s.sId)
     );
     const discoveredSkills = discoverableSkills.filter(
       (s) => !agentEquippedSkillIds.has(s.sId)
@@ -1495,6 +1518,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const equippedSkills = removeNulls([
       ...agentEquippedSkills.sort(sortByName),
+      ...autoEquippedSkills.sort(sortByName),
       ...discoveredSkills.sort(sortByName),
     ]);
 


### PR DESCRIPTION
## Description

Make the Computer skill auto-available when sandbox tools are flagged, without loading its instructions or tools until the agent enables it. The file prompt still tells agents to enable Computer proactively for uploaded files, especially PDFs and other files that need extraction or processing.

## Tests

- `NODE_ENV=test npm run test -- ./lib/api/assistant/jit_actions.test.ts ./lib/api/assistant/generation.test.ts`
- `npm run tsgo`

## Risk

Low. This changes skill routing for the sandbox flag and keeps the existing enable_skill path for activating the Computer.

## Deploy Plan

Standard deploy.