### PR TITLE
Make gracefully stopped messages non-resumable

### DIFF
--- a/front/lib/api/assistant/conversation/answer_user_question.ts
+++ b/front/lib/api/assistant/conversation/answer_user_question.ts
@@ -86,8 +86,8 @@ export async function registerUserAnswer(
   }
 
   // A blocked action is only actionable while its agent message can still resume: answering one
-  // left behind by an interrupted, cancelled or failed message would relaunch an agent loop that
-  // was already terminated.
+  // left behind by a non-resumable terminal message would relaunch an agent loop that was already
+  // terminated.
   if (!(await action.canAgentMessageResume(auth))) {
     return new Err(
       new DustError(

--- a/front/lib/api/assistant/conversation/blocked_actions.test.ts
+++ b/front/lib/api/assistant/conversation/blocked_actions.test.ts
@@ -384,7 +384,7 @@ describe("blocked actions resolution", () => {
       expect(await getActionRequired()).toBe(false);
     });
 
-    it("leaves blocked actions untouched when the message is gracefully stopped", async () => {
+    it("denies blocked actions when the message is gracefully stopped", async () => {
       const { agentMessage, action } =
         await AgentMCPActionFactory.createWithAgentMessage(auth, {
           workspace,
@@ -399,13 +399,12 @@ describe("blocked actions resolution", () => {
         status: "gracefully_stopped",
       });
 
-      // A graceful stop keeps pending approvals actionable.
       const reloadedAction = await AgentMCPActionResource.fetchById(
         auth,
         action.sId
       );
-      expect(reloadedAction?.status).toBe("blocked_validation_required");
-      expect(await getActionRequired()).toBe(true);
+      expect(reloadedAction?.status).toBe("denied");
+      expect(await getActionRequired()).toBe(false);
     });
   });
 });

--- a/front/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front/lib/api/assistant/conversation/resolve_authentication.ts
@@ -121,8 +121,8 @@ export async function resolveAuthentication(
   }
 
   // A blocked action is only actionable while its agent message can still resume: resolving one
-  // left behind by an interrupted, cancelled or failed message would relaunch an agent loop that
-  // was already terminated.
+  // left behind by a non-resumable terminal message would relaunch an agent loop that was already
+  // terminated.
   if (!(await action.canAgentMessageResume(auth))) {
     return new Err(
       new DustError(

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -73,9 +73,9 @@ async function findUserMessageForRetry(
     return new Err(new Error("No blocked actions found"));
   }
 
-  // Blocked actions of a message that can no longer resume (interrupted, cancelled, failed) are
-  // stale leftovers: retrying them would relaunch an agent loop that was already terminated. All
-  // blocked actions belong to the same agent message, so checking the first one is enough.
+  // Blocked actions of a message that can no longer resume are stale leftovers: retrying them
+  // would relaunch an agent loop that was already terminated. All blocked actions belong to the
+  // same agent message, so checking the first one is enough.
   if (!(await blockedActions[0].canAgentMessageResume(auth))) {
     return new Err(new Error("Agent message can no longer resume"));
   }

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -1259,7 +1259,10 @@ describe("validateAction", () => {
       }
     });
 
-    it("rejects resolving an action whose agent message can no longer resume", async () => {
+    it.each([
+      "interrupted",
+      "gracefully_stopped",
+    ] as const)("rejects resolving an action whose agent message is %s", async (status) => {
       const agentConfig = await AgentConfigurationFactory.createTestAgent(
         auth,
         { name: "Test Agent" }
@@ -1289,12 +1292,12 @@ describe("validateAction", () => {
         agentMessageModelId: messageRow.agentMessageId!,
       });
 
-      // Legacy stuck conversation: the message was interrupted while its blocked action was
-      // left pending. A stale approval (e.g. an old email link) must not resume the loop.
+      // Legacy stuck conversation: the message reached a non-resumable terminal status while its
+      // blocked action was left pending. A stale approval must not resume the loop.
       await ConversationFactory.setAgentMessageStatus({
         workspace,
         agentMessageModelId: messageRow.agentMessageId!,
-        status: "interrupted",
+        status,
       });
 
       const conversationResource = await ConversationResource.fetchById(
@@ -1324,10 +1327,12 @@ describe("validateAction", () => {
 
     it("rejects resolving authentication or file authorization whose agent message can no longer resume", async () => {
       async function expectResolveAuthenticationRejected({
+        agentMessageStatus,
         status,
         kind,
         rank,
       }: {
+        agentMessageStatus: "interrupted" | "gracefully_stopped";
         status:
           | "blocked_authentication_required"
           | "blocked_file_authorization_required";
@@ -1361,7 +1366,7 @@ describe("validateAction", () => {
         await ConversationFactory.setAgentMessageStatus({
           workspace,
           agentMessageModelId: agentMessageMessage.agentMessageId!,
-          status: "interrupted",
+          status: agentMessageStatus,
         });
 
         const conversationResource = await ConversationResource.fetchById(
@@ -1390,15 +1395,24 @@ describe("validateAction", () => {
         expect(action.status).toBe(status);
       }
 
-      await expectResolveAuthenticationRejected({
-        status: "blocked_authentication_required",
-        rank: 1,
-      });
-      await expectResolveAuthenticationRejected({
-        status: "blocked_file_authorization_required",
-        kind: "file_authorization",
-        rank: 3,
-      });
+      for (const agentMessageStatus of [
+        "interrupted",
+        "gracefully_stopped",
+      ] as const) {
+        const rankOffset = agentMessageStatus === "interrupted" ? 0 : 10;
+
+        await expectResolveAuthenticationRejected({
+          agentMessageStatus,
+          status: "blocked_authentication_required",
+          rank: 1 + rankOffset,
+        });
+        await expectResolveAuthenticationRejected({
+          agentMessageStatus,
+          status: "blocked_file_authorization_required",
+          kind: "file_authorization",
+          rank: 3 + rankOffset,
+        });
+      }
     });
   });
 

--- a/front/lib/api/assistant/email/validate_tool_from_email.test.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.test.ts
@@ -40,7 +40,10 @@ describe("validateActionFromEmail", () => {
     });
   });
 
-  it("rejects resolving an action whose agent message can no longer resume", async () => {
+  it.each([
+    "interrupted",
+    "gracefully_stopped",
+  ] as const)("rejects resolving an action whose agent message is %s", async (status) => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",
     });
@@ -68,7 +71,7 @@ describe("validateActionFromEmail", () => {
     await ConversationFactory.setAgentMessageStatus({
       workspace,
       agentMessageModelId: messageRow.agentMessageId!,
-      status: "interrupted",
+      status,
     });
 
     const result = await validateActionFromEmail(auth, {

--- a/front/lib/api/assistant/email/validate_tool_from_email.ts
+++ b/front/lib/api/assistant/email/validate_tool_from_email.ts
@@ -229,8 +229,8 @@ export async function validateActionFromEmail(
   }
 
   // A blocked action is only actionable while its agent message can still resume: resolving one
-  // from a stale email link after interruption, cancellation or failure would relaunch an agent
-  // loop that was already terminated.
+  // from a stale email link after a non-resumable terminal status would relaunch an agent loop
+  // that was already terminated.
   if (!(await action.canAgentMessageResume(auth))) {
     return new Err(
       new DustError(

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -212,7 +212,10 @@ describe("listBlockedActionsForConversation", () => {
     expect(result[0].status).toBe("blocked_validation_required");
   });
 
-  it("should not return blocked actions whose agent message can no longer resume", async () => {
+  it.each([
+    "interrupted",
+    "gracefully_stopped",
+  ] as const)("should not return blocked actions whose agent message is %s", async (status) => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",
     });
@@ -241,11 +244,12 @@ describe("listBlockedActionsForConversation", () => {
       agentMessageModelId: agentMessageRow.agentMessageId!,
     });
 
-    // Interrupt the agent message (e.g. the user skipped it), leaving the blocked action behind.
+    // Finalize the agent message while leaving the blocked action behind, as can happen for stale
+    // historical rows.
     await ConversationFactory.setAgentMessageStatus({
       workspace,
       agentMessageModelId: agentMessageRow.agentMessageId!,
-      status: "interrupted",
+      status,
     });
 
     const conversationResource = await ConversationResource.fetchById(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -346,7 +346,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
 
     // A blocked action is only actionable while its agent message can still resume: exclude
-    // actions left behind by messages that were interrupted, cancelled or failed before their
+    // actions left behind by messages that reached a non-resumable terminal status before their
     // blocked tools got resolved. Filtered application-side: agent_messages has no index on
     // status, and the rows are already narrowed to the conversation's latest agent messages.
     const blockedActions = blockedActionRows.filter(
@@ -807,10 +807,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
-   * Whether the agent message owning this action can still resume, i.e. has not reached a
-   * terminal status (interrupted, cancelled, failed). Resolving a blocked action (approving,
-   * denying, answering, retrying) is only allowed while the message can resume: otherwise it
-   * would relaunch an agent loop that was already terminated.
+   * Whether the agent message owning this action can still resume. Resolving a blocked action
+   * (approving, denying, answering, retrying) is only allowed while the message can resume:
+   * otherwise it would relaunch an agent loop that was already terminated.
    */
   async canAgentMessageResume(auth: Authenticator): Promise<boolean> {
     const agentMessage = await AgentMessageModel.findOne({

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -252,12 +252,15 @@ export const AGENT_MESSAGE_STATUSES_TO_TRACK: AgentMessageStatus[] = [
 
 // Terminal statuses from which an agent message can never resume. Tools of such a message that
 // are still blocked on user input (e.g. a manual tool approval that was skipped when the message
-// got interrupted) are not actionable anymore. "gracefully_stopped" is not included: a graceful
-// stop keeps pending approvals actionable and approving them resumes the loop.
+// got interrupted or gracefully stopped) are not actionable anymore. "gracefully_stopped" is
+// treated like "succeeded" in most places, but it belongs here for resumption: a graceful stop
+// ends the loop in place, so resolving a leftover approval would relaunch a direction the loop
+// already stopped (and that steering, if any, has since superseded via a newly promoted message).
 export const UNRESUMABLE_AGENT_MESSAGE_STATUSES: AgentMessageStatus[] = [
   "failed",
   "cancelled",
   "interrupted",
+  "gracefully_stopped",
 ];
 
 export function isTerminalAgentMessageStatus(


### PR DESCRIPTION
## Description

This PR treats `gracefully_stopped` agent messages as non-resumable for blocked tool actions. Once an agent message is gracefully stopped, stale approvals, auth resolutions, user answers, email approvals, and blocked-action retries no longer relaunch that old agent loop.

This aligns blocked-action handling with steering semantics, where the stopped message is finalized and any continuation happens through a newly promoted user message and a new agent message.

 
## Tests

 Tested with:
```
  NODE_ENV=test npm test -- ./lib/api/assistant/conversation/blocked_actions.test.ts ./lib/resources/agent_mcp_action_resource.test.ts ./lib/api/assistant/conversation/validate_actions.test.ts ./lib/api/assistant/email/validate_tool_from_email.test.ts ./temporal/agent_loop/activities/common.test.ts
```

## Risk

Code can be rolled back. 

## Deploy Plan

Deploy front. 