### PR TITLE
chore: upgrade biome to 2.5.0

### DIFF
--- a/biome.editor.json
+++ b/biome.editor.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "extends": ["./biome.json"],
   "linter": {
     "rules": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "root": true,
   "plugins": [],
   "vcs": {
@@ -57,7 +57,7 @@
       "marketing/**"
     ],
     "rules": {
-      "recommended": false,
+      "preset": "none",
       "correctness": {
         "noUnusedImports": { "fix": "safe", "level": "error" },
         "noUnusedVariables": "error"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "sdks/js"
       ],
       "devDependencies": {
-        "@biomejs/biome": "^2.4.8",
+        "@biomejs/biome": "2.5.0",
         "@typescript/native-preview": "^7.0.0-dev.20260608.1",
         "knip": "^5.80.0",
         "lefthook": "2.1.8",
@@ -3032,9 +3032,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.8.tgz",
-      "integrity": "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.0.tgz",
+      "integrity": "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -3048,20 +3048,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.8",
-        "@biomejs/cli-darwin-x64": "2.4.8",
-        "@biomejs/cli-linux-arm64": "2.4.8",
-        "@biomejs/cli-linux-arm64-musl": "2.4.8",
-        "@biomejs/cli-linux-x64": "2.4.8",
-        "@biomejs/cli-linux-x64-musl": "2.4.8",
-        "@biomejs/cli-win32-arm64": "2.4.8",
-        "@biomejs/cli-win32-x64": "2.4.8"
+        "@biomejs/cli-darwin-arm64": "2.5.0",
+        "@biomejs/cli-darwin-x64": "2.5.0",
+        "@biomejs/cli-linux-arm64": "2.5.0",
+        "@biomejs/cli-linux-arm64-musl": "2.5.0",
+        "@biomejs/cli-linux-x64": "2.5.0",
+        "@biomejs/cli-linux-x64-musl": "2.5.0",
+        "@biomejs/cli-win32-arm64": "2.5.0",
+        "@biomejs/cli-win32-x64": "2.5.0"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.8.tgz",
-      "integrity": "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw==",
       "cpu": [
         "arm64"
       ],
@@ -3076,9 +3076,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
-      "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ==",
       "cpu": [
         "x64"
       ],
@@ -3093,13 +3093,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
-      "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.0.tgz",
+      "integrity": "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3110,13 +3113,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
-      "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3127,13 +3133,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
-      "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.0.tgz",
+      "integrity": "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3144,13 +3153,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
-      "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3161,9 +3173,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
-      "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==",
       "cpu": [
         "arm64"
       ],
@@ -3178,9 +3190,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
-      "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.0.tgz",
+      "integrity": "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "doctor:full": "npx react-doctor@latest --diff false"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.8",
+    "@biomejs/biome": "2.5.0",
     "@typescript/native-preview": "^7.0.0-dev.20260608.1",
     "knip": "^5.80.0",
     "lefthook": "2.1.8",

--- a/x/henry/dust-hive/package.json
+++ b/x/henry/dust-hive/package.json
@@ -16,7 +16,7 @@
     "check": "bun run typecheck && bun run lint && bun run test"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.0",
+    "@biomejs/biome": "2.5.0",
     "@types/bun": "latest",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
## Description

Upgrades `@biomejs/biome` from `^2.4.8` to `2.5.0` in the root workspace and from `^1.9.0` to `2.5.0` in `x/henry/dust-hive`. The install was forced via `--min-release-age=0` since 2.5.0 was published on June 12, within the project's 7-day hold window.

## Tests

Ran `biome lint` against source files — no new errors introduced.

## Risk

## Deploy Plan
