### PR TITLE
[LLM] Use EU multi-region Vertex endpoint for agent platform

### DIFF
--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -79,6 +79,7 @@ export async function getLlmCredentials(
     OPENAI_USE_EU_ENDPOINT:
       config.getRegion() === "europe-west1" ? "true" : "false",
     OPENAI_BASE_URL: env("DUST_MANAGED_OPENAI_BASE_URL"),
+    AGENT_PLATFORM_PROJECT_ID: config.getVertexAiProjectId(),
   };
 
   if (!plan.isByok) {

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -19,7 +19,7 @@ import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provide
 import { z } from "zod";
 
 // Can be extended later (e.g. "us", "asia-east1"...)
-type AgentPlatformRegionalEndpoint = "global" | "europe-west1";
+export type AgentPlatformRegionalEndpoint = "global" | "eu";
 
 const configSchema = inputConfigSchema.extend({
   reasoning: z
@@ -44,6 +44,8 @@ export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
 
   static readonly providerId = ANTHROPIC_PROVIDER_ID;
   static readonly api = AGENT_PLATFORM_API;
+
+  static readonly regionalEndpoint: AgentPlatformRegionalEndpoint;
 
   static readonly configSchema: z.ZodType<z.infer<typeof configSchema>> =
     configSchema;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -13,7 +13,7 @@ export class AgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithAnthrop
     standardOutput: 16.5,
   };
   static readonly region = "eu";
-  static readonly regionalEndpoint = "europe-west1";
+  static readonly regionalEndpoint = "eu";
 
   static readonly id = this.buildId();
 }

--- a/front/types/provider_credential.ts
+++ b/front/types/provider_credential.ts
@@ -22,6 +22,7 @@ export type LLMCredentialsType = {
   COHERE_API_KEY?: string;
   AI21_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
+  AGENT_PLATFORM_PROJECT_ID?: string;
 };
 
 export type ProviderCredentialType = {


### PR DESCRIPTION
## Description

Route the agent platform Anthropic-on-Vertex endpoints through the `eu` multi-region endpoint and pass the Dust-managed GCP project id (`VERTEX_AI_PROJECT_ID`) through `LLMCredentialsType` so the `AnthropicVertex` client is constructed with a defined `projectId`.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`