### PR TITLE
[front] read mcp tool usage data from replica 

### DIFF
--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -38,14 +38,14 @@ async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
  */
 async function buildVisibilityFilter(auth: Authenticator): Promise<{
   clause: string;
-  replacements: Record<string, unknown>;
+  params: Record<string, unknown>;
 }> {
   const workspaceId = auth.getNonNullableWorkspace().id;
 
   if (auth.isAdmin()) {
     return {
       clause: `ac."status" = 'active' AND ac."workspaceId" = :workspace_id`,
-      replacements: { workspace_id: workspaceId },
+      params: { workspace_id: workspaceId },
     };
   }
 
@@ -55,7 +55,7 @@ async function buildVisibilityFilter(auth: Authenticator): Promise<{
     clause: `ac."status" = 'active'
         AND ac."workspaceId" = :workspace_id
         AND (ac."scope" = 'visible' OR ac."id" IN (:agent_ids))`,
-    replacements: {
+    params: {
       workspace_id: workspaceId,
       agent_ids: agentIds.length > 0 ? agentIds : [-1],
     },
@@ -104,7 +104,7 @@ export async function getToolsUsage(
 
   const replicaDb = getFrontReplicaDbConnection();
 
-  const { clause, replacements } = await buildVisibilityFilter(auth);
+  const { clause, params } = await buildVisibilityFilter(auth);
 
 
 
@@ -125,7 +125,7 @@ export async function getToolsUsage(
     WHERE ${clause}
     GROUP BY msv."internalMCPServerId", msv."remoteMCPServerId"
     `,
-    { replacements, type: QueryTypes.SELECT }
+    { replacements: params, type: QueryTypes.SELECT }
   );
 
   const result: MCPServersUsageByAgent = {};

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -1,18 +1,90 @@
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
-import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
-import { Op, Sequelize } from "sequelize";
+import { QueryTypes } from "sequelize";
 
 // To use in case of heavy db load emergency with these usages queries
 // If it is a problem, let's add caching
 const DISABLE_QUERIES = false;
 
 export type MCPServersUsageByAgent = Record<string, AgentsUsageType>;
+
+interface MCPServerUsageRow {
+  internalMCPServerId: string | null;
+  remoteMCPServerId: ModelId | null;
+  names: string[];
+  sIds: string[];
+  pictureUrls: string[];
+}
+
+/**
+ * Returns the list of agent IDs visible to the current user (used for
+ * non-admin visibility filtering).
+ */
+async function getVisibleAgentIds(auth: Authenticator): Promise<ModelId[]> {
+  const groups = await GroupResource.findAgentIdsForGroups(
+    auth,
+    auth.groupModelIds()
+  );
+  return groups.map((g) => g.agentConfigurationId);
+}
+
+/**
+ * Builds the visibility WHERE clause and query replacements depending on
+ * whether the caller is an admin or a regular user.
+ */
+async function buildVisibilityFilter(auth: Authenticator): Promise<{
+  clause: string;
+  replacements: Record<string, unknown>;
+}> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
+  if (auth.isAdmin()) {
+    return {
+      clause: `ac."status" = 'active' AND ac."workspaceId" = :workspace_id`,
+      replacements: { workspace_id: workspaceId },
+    };
+  }
+
+  const agentIds = await getVisibleAgentIds(auth);
+
+  return {
+    clause: `ac."status" = 'active'
+        AND ac."workspaceId" = :workspace_id
+        AND (ac."scope" = 'visible' OR ac."id" IN (:agent_ids))`,
+    replacements: {
+      workspace_id: workspaceId,
+      agent_ids: agentIds.length > 0 ? agentIds : [-1],
+    },
+  };
+}
+
+function rowToUsageEntry(
+  row: MCPServerUsageRow,
+  workspaceId: ModelId
+): { key: string; usage: AgentsUsageType } {
+  const key =
+    row.internalMCPServerId ||
+    remoteMCPServerNameToSId({
+      remoteMCPServerId: row.remoteMCPServerId!,
+      workspaceId,
+    });
+
+  return {
+    key,
+    usage: {
+      count: row.sIds.length,
+      agents: row.sIds.map((sId, index) => ({
+        sId,
+        name: row.names[index],
+        pictureUrl: row.pictureUrls[index],
+      })),
+    },
+  };
+}
 
 export async function getToolsUsage(
   auth: Authenticator
@@ -30,111 +102,36 @@ export async function getToolsUsage(
     return {};
   }
 
-  const getAgentsForUser = async () =>
-    (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
-      (g) => g.agentConfigurationId
-    );
+  const replicaDb = getFrontReplicaDbConnection();
 
-  const getAgentWhereClauseAdmin = () => ({
-    status: "active",
-    workspaceId: owner.id,
-  });
+  const { clause, replacements } = await buildVisibilityFilter(auth);
 
-  const getAgentWhereClauseNonAdmin = async () => ({
-    status: "active",
-    workspaceId: owner.id,
-    // If user is non-admin, only include agents that either they have access to or are published.
-    [Op.or]: [
-      {
-        scope: "visible",
-      },
-      {
-        id: {
-          [Op.in]: await getAgentsForUser(),
-        },
-      },
-    ],
-  });
 
-  const res = (await AgentConfigurationModel.findAll({
-    raw: true,
-    group: [
-      "mcpServerConfigurations->mcpServerView.internalMCPServerId",
-      "mcpServerConfigurations->mcpServerView.remoteMCPServerId",
-    ],
-    where: auth.isAdmin()
-      ? getAgentWhereClauseAdmin()
-      : await getAgentWhereClauseNonAdmin(),
-    attributes: [
-      "mcpServerConfigurations->mcpServerView.internalMCPServerId",
-      "mcpServerConfigurations->mcpServerView.remoteMCPServerId",
-      [
-        Sequelize.fn(
-          "array_agg",
-          Sequelize.literal(
-            '"agent_configuration"."name" ORDER BY "agent_configuration"."name"'
-          )
-        ),
-        "names",
-      ],
-      [
-        Sequelize.fn(
-          "array_agg",
-          Sequelize.literal(
-            '"agent_configuration"."sId" ORDER BY "agent_configuration"."name"'
-          )
-        ),
-        "sIds",
-      ],
-      [
-        Sequelize.fn(
-          "array_agg",
-          Sequelize.literal(
-            '"agent_configuration"."pictureUrl" ORDER BY "agent_configuration"."name"'
-          )
-        ),
-        "pictureUrls",
-      ],
-    ],
-    include: [
-      {
-        model: AgentMCPServerConfigurationModel,
-        as: "mcpServerConfigurations",
-        attributes: [],
-        required: true,
-        include: [
-          {
-            model: MCPServerViewModel,
-            as: "mcpServerView",
-            attributes: [],
-            required: true,
-          },
-        ],
-      },
-    ],
-  })) as unknown as {
-    internalMCPServerId: string;
-    remoteMCPServerId: ModelId;
-    names: string[];
-    sIds: string[];
-    pictureUrls: string[];
-  }[];
 
-  return res.reduce<MCPServersUsageByAgent>((acc, mcpServerViewConfig) => {
-    acc[
-      mcpServerViewConfig.internalMCPServerId ||
-        remoteMCPServerNameToSId({
-          remoteMCPServerId: mcpServerViewConfig.remoteMCPServerId,
-          workspaceId: owner.id,
-        })
-    ] = {
-      count: mcpServerViewConfig.sIds.length,
-      agents: mcpServerViewConfig.sIds.map((sId, index) => ({
-        sId,
-        name: mcpServerViewConfig.names[index],
-        pictureUrl: mcpServerViewConfig.pictureUrls[index],
-      })),
-    };
-    return acc;
-  }, {});
+  // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
+  const rows = await replicaDb.query<MCPServerUsageRow>(
+    `
+    SELECT
+      msv."internalMCPServerId",
+      msv."remoteMCPServerId",
+      array_agg(ac."name" ORDER BY ac."name")       AS "names",
+      array_agg(ac."sId" ORDER BY ac."name")         AS "sIds",
+      array_agg(ac."pictureUrl" ORDER BY ac."name")  AS "pictureUrls"
+    FROM agent_configurations ac
+    INNER JOIN agent_mcp_server_configurations amsc
+      ON amsc."agentConfigurationId" = ac."id"
+    INNER JOIN mcp_server_views msv
+      ON msv."id" = amsc."mcpServerViewId"
+    WHERE ${clause}
+    GROUP BY msv."internalMCPServerId", msv."remoteMCPServerId"
+    `,
+    { replacements, type: QueryTypes.SELECT }
+  );
+
+  const result: MCPServersUsageByAgent = {};
+  for (const row of rows) {
+    const { key, usage } = rowToUsageEntry(row, owner.id);
+    result[key] = usage;
+  }
+  return result;
 }

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -106,8 +106,6 @@ export async function getToolsUsage(
 
   const { clause, params } = await buildVisibilityFilter(auth);
 
-
-
   // biome-ignore lint/plugin/noRawSql: Read-only analytics query on replica.
   const rows = await replicaDb.query<MCPServerUsageRow>(
     `


### PR DESCRIPTION
## Description
This PR is to read the data about MCP tool usage we show for admins in spaces (e.g. https://app.dust.tt/w/0ec9852c2f/spaces/vlt_z2c3w2KRm0Oy/categories/actions) . 

This query seems to be [slow](ttps://console.cloud.google.com/sql/instances/cell-00001-front-db/insights;database=front;duration=PT1H;trace=05b68d069153b197921ec3f1afb3c3a7;span=02092fdd57801eb4;query_hash=748718500892308015;sort_by=TOTAL_EXEC_TIME/executed?project=prj-dust-europe-west1) and flavien suggested to read it from replica instead of main db. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested it on front edge

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
