### PR TITLE
Introduce conversation sandbox ownership link

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -120,7 +120,10 @@ import {
   RunModel,
   RunUsageModel,
 } from "@app/lib/resources/storage/models/runs";
-import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import {
+  ConversationSandboxModel,
+  SandboxModel,
+} from "@app/lib/resources/storage/models/sandbox";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import {
   TakeawaySourcesModel,
@@ -252,6 +255,7 @@ export function loadAllModels() {
     AcademyQuizAttemptModel,
     AcademyChapterVisitModel,
     SandboxModel,
+    ConversationSandboxModel,
     ConversationBranchModel,
     ConversationForkModel,
     ProjectTaskModel,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6838,6 +6838,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "conversation_mcp_server_view",
   "conversation_participant",
   "conversation_selected_spaces",
+  "conversation_sandbox",
   "conversation_skills",
   "data_source",
   "message",

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -52,7 +52,10 @@ vi.mock("@app/lib/lock", () => ({
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
-import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import {
+  ConversationSandboxModel,
+  SandboxModel,
+} from "@app/lib/resources/storage/models/sandbox";
 import { WorkspaceSandboxEnvVarModel } from "@app/lib/resources/storage/models/workspace_sandbox_env_var";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -680,6 +683,14 @@ describe("SandboxResource.ensureActive", () => {
     );
     expect(persisted?.baseImage).toBe("test-image");
     expect(persisted?.version).toBe("0.0.1");
+
+    const link = await ConversationSandboxModel.findOne({
+      where: {
+        conversationId: conversation.id,
+        workspaceId: authenticator.getNonNullableWorkspace().id,
+      },
+    });
+    expect(link?.sandboxId).toBe(persisted?.id);
   });
 
   it("refreshes baseImage and version when recreating from a deleted row", async () => {

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -21,12 +21,16 @@ import { executeWithLock } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxStatus } from "@app/lib/resources/storage/models/sandbox";
-import { SandboxModel } from "@app/lib/resources/storage/models/sandbox";
+import {
+  ConversationSandboxModel,
+  SandboxModel,
+} from "@app/lib/resources/storage/models/sandbox";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -113,15 +117,32 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     { transaction }: { transaction?: Transaction } = {}
   ) {
     const now = new Date();
-    const sandbox = await this.model.create(
-      {
-        ...blob,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        lastActivityAt: now,
-        statusChangedAt: now,
-      },
-      { transaction }
-    );
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const createSandbox = async (t: Transaction) => {
+      const sandbox = await this.model.create(
+        {
+          ...blob,
+          workspaceId,
+          lastActivityAt: now,
+          statusChangedAt: now,
+        },
+        { transaction: t }
+      );
+
+      await ConversationSandboxModel.create(
+        {
+          workspaceId,
+          conversationId: blob.conversationId,
+          sandboxId: sandbox.id,
+        },
+        { transaction: t }
+      );
+
+      return sandbox;
+    };
+
+    const sandbox = await withTransaction(createSandbox, transaction);
 
     recordLifecycleOperation("create", {
       workspaceId: auth.getNonNullableWorkspace().sId,
@@ -250,13 +271,26 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<number, Error>> {
-    const deletedCount = await SandboxModel.destroy({
-      where: {
-        id: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      transaction,
-    });
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const deleteSandbox = async (t: Transaction) => {
+      await ConversationSandboxModel.destroy({
+        where: {
+          sandboxId: this.id,
+          workspaceId,
+        },
+        transaction: t,
+      });
+
+      return SandboxModel.destroy({
+        where: {
+          id: this.id,
+          workspaceId,
+        },
+        transaction: t,
+      });
+    };
+
+    const deletedCount = await withTransaction(deleteSandbox, transaction);
 
     return new Ok(deletedCount);
   }
@@ -293,11 +327,22 @@ export class SandboxResource extends BaseResource<SandboxModel> {
         }
       }
 
-      await SandboxModel.destroy({
-        where: {
-          id: sandbox.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        },
+      await withTransaction(async (transaction) => {
+        await ConversationSandboxModel.destroy({
+          where: {
+            conversationId: conversation.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+        });
+
+        await SandboxModel.destroy({
+          where: {
+            id: sandbox.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction,
+        });
       });
 
       return new Ok(undefined);

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -14,6 +14,8 @@ export class SandboxModel extends WorkspaceAwareModel<SandboxModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
+  // TODO(2026-06-17 SANDBOX): Drop this legacy owner column once
+  // conversation_sandboxes fully replaces it.
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare providerId: string;
   declare status: SandboxStatus;
@@ -116,4 +118,78 @@ ConversationModel.hasMany(SandboxModel, {
 
 SandboxModel.belongsTo(ConversationModel, {
   foreignKey: "conversationId",
+});
+
+export class ConversationSandboxModel extends WorkspaceAwareModel<ConversationSandboxModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]>;
+  declare sandboxId: ForeignKey<SandboxModel["id"]>;
+
+  declare conversation: NonAttribute<ConversationModel>;
+  declare sandbox: NonAttribute<SandboxModel>;
+}
+
+ConversationSandboxModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    sandboxId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "conversation_sandbox",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "conversationId"],
+        name: "conversation_sandboxes_workspace_conversation_idx",
+        concurrently: true,
+      },
+      {
+        unique: true,
+        fields: ["workspaceId", "sandboxId"],
+        name: "conversation_sandboxes_workspace_sandbox_idx",
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ConversationSandboxModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "conversation",
+});
+
+ConversationModel.hasMany(ConversationSandboxModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  as: "sandboxLinks",
+});
+
+ConversationSandboxModel.belongsTo(SandboxModel, {
+  foreignKey: { name: "sandboxId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "sandbox",
+});
+
+SandboxModel.hasOne(ConversationSandboxModel, {
+  foreignKey: { name: "sandboxId", allowNull: false },
+  as: "conversationLink",
 });

--- a/front/migrations/20260624_backfill_conversation_sandboxes.ts
+++ b/front/migrations/20260624_backfill_conversation_sandboxes.ts
@@ -1,0 +1,77 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+type CountRow = { count: number };
+
+async function countRows(sql: string) {
+  const [{ count }] = await frontSequelize.query<CountRow>(sql, {
+    type: QueryTypes.SELECT,
+  });
+  return count;
+}
+
+async function countMissingConversationSandboxes() {
+  return countRows(`
+    SELECT COUNT(*)::int AS "count"
+    FROM "sandboxes" s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "conversation_sandboxes" cs
+      WHERE cs."workspaceId" = s."workspaceId"
+        AND cs."conversationId" = s."conversationId"
+        AND cs."sandboxId" = s."id"
+    )
+  `);
+}
+
+async function countExtraConversationSandboxes() {
+  return countRows(`
+    SELECT COUNT(*)::int AS "count"
+    FROM "conversation_sandboxes" cs
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "sandboxes" s
+      WHERE s."workspaceId" = cs."workspaceId"
+        AND s."conversationId" = cs."conversationId"
+        AND s."id" = cs."sandboxId"
+    )
+  `);
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const missingBefore = await countMissingConversationSandboxes();
+  const extraBefore = await countExtraConversationSandboxes();
+
+  logger.info(
+    { missingBefore, extraBefore },
+    "Checked sandbox ownership drift"
+  );
+
+  if (execute) {
+    await countRows(`
+      WITH inserted AS (
+        INSERT INTO "conversation_sandboxes"
+          ("createdAt", "updatedAt", "conversationId", "sandboxId", "workspaceId")
+        SELECT s."createdAt", NOW(), s."conversationId", s."id", s."workspaceId"
+        FROM "sandboxes" s
+        WHERE NOT EXISTS (
+          SELECT 1 FROM "conversation_sandboxes" cs
+          WHERE cs."workspaceId" = s."workspaceId"
+            AND cs."conversationId" = s."conversationId"
+            AND cs."sandboxId" = s."id"
+        )
+        ON CONFLICT DO NOTHING RETURNING 1
+      )
+      SELECT COUNT(*)::int AS "count" FROM inserted
+    `);
+  }
+
+  const missingAfter = await countMissingConversationSandboxes();
+  const extraAfter = await countExtraConversationSandboxes();
+
+  if (execute && (missingAfter > 0 || extraAfter > 0)) {
+    throw new Error(
+      `conversation_sandboxes is not ISO with sandboxes: missing=${missingAfter} extra=${extraAfter}`
+    );
+  }
+});

--- a/front/migrations/pre-deploy/20260617103000_create_conversation_sandboxes.sql
+++ b/front/migrations/pre-deploy/20260617103000_create_conversation_sandboxes.sql
@@ -1,0 +1,19 @@
+-- Move conversation ownership out of sandboxes before adding other sandbox owners.
+SET lock_timeout = '5s';
+
+CREATE TABLE "public"."conversation_sandboxes"
+(
+  "createdAt"      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "updatedAt"      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  "conversationId" BIGINT                   NOT NULL REFERENCES "public"."conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "sandboxId"      BIGINT                   NOT NULL REFERENCES "public"."sandboxes" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "workspaceId"    BIGINT                   NOT NULL REFERENCES "public"."workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "id"             BIGSERIAL,
+  PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "conversation_sandboxes_workspace_conversation_idx"
+  ON "public"."conversation_sandboxes" ("workspaceId", "conversationId");
+
+CREATE UNIQUE INDEX CONCURRENTLY "conversation_sandboxes_workspace_sandbox_idx"
+  ON "public"."conversation_sandboxes" ("workspaceId", "sandboxId");


### PR DESCRIPTION
## Description

Shared Computer S1 refactor slice. Context: [Shared Computer v0](https://app.notion.com/p/38128599d9418127b78ff7285cb722e4).

This PR moves existing conversation sandbox ownership toward a join-table model instead of adding more ownership fields directly to `sandboxes`.

The schema/model changes are:

- add `conversation_sandboxes` as the conversation-to-sandbox ownership table;
- add a standalone data migration script to backfill `conversation_sandboxes` from existing `sandboxes.conversationId` rows and verify both models are ISO;
- add uniqueness for one sandbox per conversation and one conversation owner per sandbox;
- keep writing the legacy `sandboxes.conversationId` column for deploy compatibility until a later PR drops it.

The runtime changes are limited to existing conversation sandboxes:

- `SandboxResource.makeNew` writes both `sandboxes.conversationId` and `conversation_sandboxes`;
- sandbox deletion paths delete the `conversation_sandboxes` row alongside the legacy sandbox row;
- reads remain on the legacy `sandboxes.conversationId` model in this PR;
- no Pod-scoped sandbox creation/fetch path is introduced in this PR.

## Follow-ups

- Switch conversation sandbox reads to `conversation_sandboxes`.
- Introduce the Pod/space sandbox ownership table and model.
- Update Pod-scoped runtime paths to use that table.
- Remove the legacy fallback once all writers use ownership tables.
- Drop `sandboxes.conversationId` in a later post-deploy migration.

## Tests

- `npm run format:changed`
- `source ~/.dust-hive/envs/shared-computer-s1/env.sh && cd front && FRONT_DATABASE_URI="$TEST_FRONT_DATABASE_URI" REDIS_URI="$TEST_REDIS_URI" REDIS_CACHE_URI="$TEST_REDIS_URI" NODE_ENV=test npx tsx admin/db.ts`
- `source ~/.dust-hive/envs/shared-computer-s1/env.sh && cd front && FRONT_DATABASE_URI="$TEST_FRONT_DATABASE_URI" NODE_ENV=test npx tsx migrations/20260624_backfill_conversation_sandboxes.ts`
- `source ~/.dust-hive/envs/shared-computer-s1/env.sh && cd front && FRONT_DATABASE_URI="$TEST_FRONT_DATABASE_URI" NODE_ENV=test npx tsx migrations/20260624_backfill_conversation_sandboxes.ts --execute`
- `source ~/.dust-hive/envs/shared-computer-s1/env.sh && cd front && NODE_ENV=test npm test -- lib/resources/sandbox_resource.test.ts lib/resources/conversation_resource.test.ts`
- `source ~/.dust-hive/envs/shared-computer-s1/env.sh && cd front && NODE_ENV=test npm test -- lib/resources/space_resource.test.ts -t "should detect any new models with space relationships"`

Local checks not attributable to this PR:

- `npm -w front run tsgo -- --noEmit` currently fails on existing frontend/Sparkle type mismatches such as missing `StarFilled`, `SheetViewportProvider`, and `AdomikLogo` exports.
- `FRONT_DATABASE_URI="$TEST_FRONT_DATABASE_URI" npm run migration:check:pre-deploy` currently reports seven unrelated pending pre-deploy migrations in the Hive test DB; this PR's migration is not listed as pending.

## Risk

Additive schema change with dual writes/deletes to the new join table and the legacy `sandboxes.conversationId` column. Reads remain on the legacy column in this PR. Rollback is code-only safe because the new table can remain unused and the legacy column remains authoritative until the follow-up cleanup PRs.

## Deploy Plan

- [x] From a local checkout at the repository root, authenticate with gcloud if needed and check production migration state across regions: `./scripts/run-migrations.sh status front`.
- [x] Before deploying this SHA, run the additive front pre-deploy schema migration across all production regions: `./scripts/run-migrations.sh pre-deploy front`. This wraps `npm run migration:apply:pre-deploy` in each region's prodbox pod and should finish with all regions complete.
- [x] Deploy front only after the pre-deploy migration is applied in all regions. The deploy gate runs `npm run migration:check:pre-deploy` in Kubernetes and aborts the release if any pre-deploy migration is still pending. Deployed code writes both `sandboxes.conversationId` and `conversation_sandboxes`.
- [ ] After the deploy is stable in every region, run the standalone data migration from each production front prodbox: `npx tsx migrations/20260624_backfill_conversation_sandboxes.ts` first as a dry run, then `npx tsx migrations/20260624_backfill_conversation_sandboxes.ts --execute`. The execute run backfills missing rows and exits non-zero unless `missingAfter=0` and `extraAfter=0`, proving `conversation_sandboxes` and `sandboxes.conversationId` are ISO at completion. Because deployed code dual-writes creates/deletes, they remain ISO after this step.
- [ ] Monitor sandbox lifecycle/reaper errors after deploy and after the data migration. Rollback is code-only safe because the schema/data changes are additive, reads remain on the legacy model, and deployed code dual-writes.
- [ ] No post-deploy schema migration is part of this PR. The follow-up PR that drops `sandboxes.conversationId` must deploy the code first, wait until it is stable in all regions, then run `./scripts/run-migrations.sh post-deploy front`.

