### PR TITLE
fix(billing): suppress programmatic cap banner when cap is 0

### DIFF
--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -5,6 +5,7 @@ import {
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
+import { useProgrammaticUsageLimit } from "@app/lib/swr/usage_settings";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
 import { useMetronomeContract } from "@app/lib/swr/workspaces";
@@ -233,8 +234,20 @@ function WorkspaceUsageStatusBanner({
     poolStateWouldBanner &&
     !isMetronomeContractLoading &&
     !contract?.hasPersonalCreditSeats;
-  const showProgrammaticBanner =
+  // A cap of 0 is a deliberate hard block on programmatic API, not an
+  // exhausted budget, so its "cap reached" banner is suppressed. The cap is
+  // only fetched when the banner would otherwise show.
+  const programmaticStateWouldBanner =
     isAdmin(owner) && programmaticCreditStatus !== "active";
+  const { programmaticUsageLimit, isProgrammaticUsageLimitLoading } =
+    useProgrammaticUsageLimit({
+      workspaceId: owner.sId,
+      disabled: !programmaticStateWouldBanner,
+    });
+  const showProgrammaticBanner =
+    programmaticStateWouldBanner &&
+    !isProgrammaticUsageLimitLoading &&
+    programmaticUsageLimit?.monthlyCapCredits !== 0;
   // The admin-configured balance-threshold warning is only relevant before the
   // pool is depleted/overage — those states have their own (stronger) banner.
   const showBalanceThresholdBanner =

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -330,8 +330,10 @@ function programmaticUsageLimitUrl(workspaceId: string): string {
 
 export function useProgrammaticUsageLimit({
   workspaceId,
+  disabled,
 }: {
   workspaceId: string;
+  disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const limitFetcher: Fetcher<GetProgrammaticUsageLimitResponseBody> = async (
@@ -342,12 +344,13 @@ export function useProgrammaticUsageLimit({
   };
   const { data, error } = useSWRWithDefaults(
     programmaticUsageLimitUrl(workspaceId),
-    limitFetcher
+    limitFetcher,
+    { disabled }
   );
 
   return {
     programmaticUsageLimit: data,
-    isProgrammaticUsageLimitLoading: !error && !data,
+    isProgrammaticUsageLimitLoading: !error && !data && !disabled,
     isProgrammaticUsageLimitError: !!error,
   };
 }


### PR DESCRIPTION
## Description

A monthly programmatic cap of 0 is a deliberate hard block (per the DB source-of-truth semantics from #27460), not an exhausted budget. The threshold-0 Metronome alert fires immediately and drives the workspace to `depleted`, so the "Programmatic API cap reached" banner was shown even though nothing was actually used. Programmatic API stays blocked at 0; only the banner is suppressed.

- AppStatusBanner: fetch the programmatic cap (gated to when the banner would otherwise show) and hide the banner when the cap is exactly 0.
- useProgrammaticUsageLimit: accept a `disabled` flag so the banner does not trigger an extra API call when it would not render.

Ticket: https://github.com/dust-tt/tasks/issues/8817
## Tests

Local
## Risk

Low

## Deploy Plan

Front