### PR TITLE
Reset AWU User fair usage limit

### DIFF
--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -10,6 +10,7 @@ import type {
   MaxAwuCreditsTimeframeType,
   MaxMessagesTimeframeType,
 } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
 export type GetTrialMessageUsageResponseType = {
@@ -95,6 +96,40 @@ export async function resetMessageRateLimitForWorkspace(auth: Authenticator) {
       workspace,
       plan.limits.assistant.maxMessagesTimeframe
     ),
+  });
+}
+
+export async function resetFairUseAwuCreditsRateLimitForUser({
+  auth,
+  user,
+}: {
+  auth: Authenticator;
+  user: UserType;
+}) {
+  const workspace = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
+
+  const { maxAwuCredits, maxAwuCreditsTimeframe } = plan.limits.assistant;
+
+  if (maxAwuCredits === -1) {
+    return new Err(new Error("The workspace plan has no AWU fair-use limit."));
+  }
+
+  const resetResult = await expireRateLimiterKey({
+    key: makeFairUseAwuCreditsRateLimitKeyForUser(
+      workspace,
+      user,
+      maxAwuCreditsTimeframe
+    ),
+  });
+  if (resetResult.isErr()) {
+    return resetResult;
+  }
+
+  return new Ok({
+    didResetExistingKey: resetResult.value,
+    limit: maxAwuCredits,
+    timeframe: maxAwuCreditsTimeframe,
   });
 }
 

--- a/front/lib/api/poke/plugins/workspaces/reset_message_rate_limit.ts
+++ b/front/lib/api/poke/plugins/workspaces/reset_message_rate_limit.ts
@@ -1,18 +1,57 @@
-import { resetMessageRateLimitForWorkspace } from "@app/lib/api/assistant/rate_limits";
+import {
+  resetFairUseAwuCreditsRateLimitForUser,
+  resetMessageRateLimitForWorkspace,
+} from "@app/lib/api/assistant/rate_limits";
 import { createPlugin } from "@app/lib/api/poke/types";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { mapToEnumValues } from "@app/types/poke/plugins";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
+
+const RESET_TARGETS = ["workspace_rate_limit", "user_awu_fair_use"] as const;
+
+const ResetMessageRateLimitArgsSchema = z
+  .object({
+    resetTarget: z.array(z.enum(RESET_TARGETS)).length(1),
+    userEmail: z.string().trim().optional(),
+  })
+  .refine(
+    (args) =>
+      args.resetTarget[0] !== "user_awu_fair_use" ||
+      (args.userEmail !== undefined && args.userEmail.length > 0),
+    {
+      message: "User email is required to reset fair-use AWU credits.",
+      path: ["userEmail"],
+    }
+  );
 
 export const resetMessageRateLimitPlugin = createPlugin({
   manifest: {
     id: "reset-message-rate-limit",
-    name: "Reset Message Rate Limit",
-    description: "Reset the message rate limit for the workspace.",
+    name: "Reset Message Rate Limits",
+    description:
+      "Reset the workspace message rate limit or a user's AWU fair-use limit.",
     resourceTypes: ["workspaces"],
     args: {
-      confirmReset: {
-        type: "boolean",
-        label: "Confirm Reset",
-        description: "Confirm you want to reset the message rate limit",
+      resetTarget: {
+        type: "enum",
+        label: "Reset Target",
+        description: "Choose which limit to reset.",
+        values: mapToEnumValues(RESET_TARGETS, (value) => ({
+          label: value,
+          value,
+          checked: value === "workspace_rate_limit",
+        })),
+        multiple: false,
+      },
+      userEmail: {
+        type: "string",
+        label: "User Email",
+        description:
+          "Email of the workspace user whose AWU fair-use counter should be reset.",
+        dependsOn: { field: "resetTarget", value: "user_awu_fair_use" },
       },
     },
   },
@@ -24,15 +63,78 @@ export const resetMessageRateLimitPlugin = createPlugin({
       return new Err(new Error("The workspace does not have a subscription."));
     }
 
-    if (!args.confirmReset) {
-      return new Err(new Error("Rate limit reset not confirmed."));
+    const parseResult = ResetMessageRateLimitArgsSchema.safeParse(args);
+    if (!parseResult.success) {
+      return new Err(
+        new Error(
+          `Invalid arguments: ${parseResult.error.errors
+            .map((e) => `${e.path.join(".")}: ${e.message}`)
+            .join(", ")}`
+        )
+      );
     }
 
-    await resetMessageRateLimitForWorkspace(auth);
+    const resetTarget = parseResult.data.resetTarget[0];
+    if (!resetTarget) {
+      return new Err(new Error("Please select a reset target."));
+    }
 
-    return new Ok({
-      display: "text",
-      value: `Message rate limit reset for workspace ${resource?.sId}.`,
-    });
+    switch (resetTarget) {
+      case "workspace_rate_limit": {
+        await resetMessageRateLimitForWorkspace(auth);
+
+        return new Ok({
+          display: "text",
+          value: `Workspace message rate limit reset for workspace ${resource?.sId}.`,
+        });
+      }
+
+      case "user_awu_fair_use": {
+        const { userEmail } = parseResult.data;
+        if (!userEmail) {
+          return new Err(new Error("User email is required."));
+        }
+
+        const user = await UserResource.fetchByEmail(userEmail);
+        if (!user) {
+          return new Err(
+            new Error(`Could not find user with email ${userEmail}.`)
+          );
+        }
+
+        const workspace = auth.getNonNullableWorkspace();
+        const membership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace,
+          });
+        if (!membership) {
+          return new Err(
+            new Error(
+              `User ${user.email} is not an active member of workspace ${workspace.sId}.`
+            )
+          );
+        }
+
+        const resetResult = await resetFairUseAwuCreditsRateLimitForUser({
+          auth,
+          user: user.toJSON(),
+        });
+        if (resetResult.isErr()) {
+          return resetResult;
+        }
+
+        const keyStatus = resetResult.value.didResetExistingKey
+          ? "existing counter cleared"
+          : "no existing counter found";
+        return new Ok({
+          display: "text",
+          value: `AWU fair-use limit reset for ${user.email} (${keyStatus}; limit ${resetResult.value.limit} credits per ${resetResult.value.timeframe}).`,
+        });
+      }
+
+      default:
+        return assertNever(resetTarget);
+    }
   },
 });


### PR DESCRIPTION
## Description

Poke plugin to reset AWU fair use limit per user (by email). Piggy backs the existing poke plugin to reset message limits.

<img width="626" height="330" alt="Screenshot 2026-06-17 at 13 25 38" src="https://github.com/user-attachments/assets/760e58b3-7d7d-426d-b0e8-e1a900b5550e" />
<img width="608" height="456" alt="Screenshot 2026-06-17 at 13 25 41" src="https://github.com/user-attachments/assets/25669183-8a3a-44b3-be22-5827e92c9366" />

## Tests

Tested locally

## Risk

None

## Deploy Plan

- deploy `front`