### PR TITLE
feat(analytics): add credit-cost breakdown and sub-agent cost rollup to agent message analytics

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -15,6 +15,9 @@
     "agent_version": {
       "type": "keyword"
     },
+    "ancestor_message_ids": {
+      "type": "keyword"
+    },
     "user_id": {
       "type": "keyword"
     },
@@ -57,6 +60,20 @@
         }
       }
     },
+    "cost": {
+      "type": "object",
+      "properties": {
+        "full_awu": {
+          "type": "integer"
+        },
+        "llm_awu": {
+          "type": "integer"
+        },
+        "tool_awu": {
+          "type": "integer"
+        }
+      }
+    },
     "tools_used": {
       "type": "nested",
       "properties": {
@@ -77,6 +94,9 @@
         },
         "status": {
           "type": "keyword"
+        },
+        "cost_awu": {
+          "type": "integer"
         }
       }
     },

--- a/front/lib/analytics/migrations/20260618_add_cost_breakdown_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260618_add_cost_breakdown_to_agent_message_analytics_2.http
@@ -1,0 +1,30 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "ancestor_message_ids": {
+      "type": "keyword"
+    },
+    "cost": {
+      "type": "object",
+      "properties": {
+        "full_awu": {
+          "type": "integer"
+        },
+        "llm_awu": {
+          "type": "integer"
+        },
+        "tool_awu": {
+          "type": "integer"
+        }
+      }
+    },
+    "tools_used": {
+      "type": "nested",
+      "properties": {
+        "cost_awu": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -216,6 +216,44 @@ async function resolveGroupNames(
   }
 }
 
+type SubAgentCostAggs = {
+  sub_agent_cost?: estypes.AggregationsSumAggregate;
+};
+
+// Total credit cost of every sub-agent (run_agent) spawned, recursively, by a
+// single agent message. Aggregated at query time from the analytics index:
+// every sub-agent message carries its ancestor chain in `ancestor_message_ids`,
+// so summing `cost.full_awu` over the docs that list this message as an ancestor
+// rolls up the whole tree at any depth without a recursive query. This is the
+// Elasticsearch counterpart of `ConversationResource.sumSubAgentCostCreditsByMessageId`.
+export async function fetchSubAgentCreditCost(
+  auth: Authenticator,
+  { agentMessageId }: { agentMessageId: string }
+): Promise<Result<number, ElasticsearchError>> {
+  const result = await searchAnalytics<never, SubAgentCostAggs>(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: auth.getNonNullableWorkspace().sId } },
+          { term: { ancestor_message_ids: agentMessageId } },
+        ],
+      },
+    },
+    {
+      aggregations: {
+        sub_agent_cost: { sum: { field: "cost.full_awu" } },
+      },
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  return new Ok(result.value.aggregations?.sub_agent_cost?.value ?? 0);
+}
+
 // Estimates AWU credit consumption from the analytics index, reusing the same
 // conversion as the Metronome billing pipeline: LLM credits from
 // tokens.cost_micro_usd (markup baked in) and tool credits from per-category

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -216,44 +216,6 @@ async function resolveGroupNames(
   }
 }
 
-type SubAgentCostAggs = {
-  sub_agent_cost?: estypes.AggregationsSumAggregate;
-};
-
-// Total credit cost of every sub-agent (run_agent) spawned, recursively, by a
-// single agent message. Aggregated at query time from the analytics index:
-// every sub-agent message carries its ancestor chain in `ancestor_message_ids`,
-// so summing `cost.full_awu` over the docs that list this message as an ancestor
-// rolls up the whole tree at any depth without a recursive query. This is the
-// Elasticsearch counterpart of `ConversationResource.sumSubAgentCostCreditsByMessageId`.
-export async function fetchSubAgentCreditCost(
-  auth: Authenticator,
-  { agentMessageId }: { agentMessageId: string }
-): Promise<Result<number, ElasticsearchError>> {
-  const result = await searchAnalytics<never, SubAgentCostAggs>(
-    {
-      bool: {
-        filter: [
-          { term: { workspace_id: auth.getNonNullableWorkspace().sId } },
-          { term: { ancestor_message_ids: agentMessageId } },
-        ],
-      },
-    },
-    {
-      aggregations: {
-        sub_agent_cost: { sum: { field: "cost.full_awu" } },
-      },
-      size: 0,
-    }
-  );
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  return new Ok(result.value.aggregations?.sub_agent_cost?.value ?? 0);
-}
-
 // Estimates AWU credit consumption from the analytics index, reusing the same
 // conversion as the Metronome billing pipeline: LLM credits from
 // tokens.cost_micro_usd (markup baked in) and tool credits from per-category

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -236,6 +236,164 @@ describe("ConversationResource", () => {
     });
   });
 
+  describe("listAncestorAgentMessageIds", () => {
+    // Creates a sub-agent: a user message in `conversation` whose
+    // agenticOriginMessageId points at `originSid`, plus its agent reply.
+    // Returns the reply's sId (the origin for any deeper sub-agents).
+    async function createSubAgent({
+      auth,
+      conversation,
+      agentConfigurationId,
+      originSid,
+    }: {
+      auth: Authenticator;
+      conversation: ConversationWithoutContentType;
+      agentConfigurationId: string;
+      originSid: string;
+    }): Promise<string> {
+      const workspace = auth.getNonNullableWorkspace();
+      const { messageRow: userMessageRow } =
+        await ConversationFactory.createUserMessage({
+          auth,
+          workspace,
+          conversation,
+          content: "sub-agent trigger",
+          agenticMessageType: "run_agent",
+          agenticOriginMessageId: originSid,
+        });
+
+      const replyRow = await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: 1,
+        agentConfigurationId,
+        parentId: userMessageRow.id,
+      });
+
+      return replyRow.sId;
+    }
+
+    // Builds origin -> child -> grandchild sub-agent chain and returns their
+    // sIds.
+    async function createAncestorChain(
+      auth: Authenticator,
+      agentConfigurationId: string
+    ): Promise<{ originSid: string; childSid: string; grandChildSid: string }> {
+      const workspace = auth.getNonNullableWorkspace();
+
+      const parentConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId,
+        messagesCreatedAt: [new Date("2026-01-01T00:00:00.000Z")],
+      });
+      const originMessage = await MessageModel.findOne({
+        where: {
+          conversationId: parentConversation.id,
+          workspaceId: workspace.id,
+          rank: 1,
+        },
+      });
+      assert(originMessage, "Origin agent message not found");
+
+      const childConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId,
+        messagesCreatedAt: [],
+      });
+      const childSid = await createSubAgent({
+        auth,
+        conversation: childConversation,
+        agentConfigurationId,
+        originSid: originMessage.sId,
+      });
+
+      const grandChildConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId,
+        messagesCreatedAt: [],
+      });
+      const grandChildSid = await createSubAgent({
+        auth,
+        conversation: grandChildConversation,
+        agentConfigurationId,
+        originSid: childSid,
+      });
+
+      return { originSid: originMessage.sId, childSid, grandChildSid };
+    }
+
+    it("returns the ancestor chain ordered from nearest to furthest", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Ancestor Chain",
+        description: "agent",
+      });
+
+      const { originSid, childSid, grandChildSid } = await createAncestorChain(
+        auth,
+        agent.sId
+      );
+
+      const ancestors = await ConversationResource.listAncestorAgentMessageIds(
+        auth,
+        { agentMessageId: grandChildSid }
+      );
+
+      expect(ancestors).toEqual([childSid, originSid]);
+    });
+
+    it("returns [] for a top-level (non sub-agent) message", async () => {
+      const { workspace, authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Top Level",
+        description: "agent",
+      });
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date("2026-01-01T00:00:00.000Z")],
+      });
+      const originMessage = await MessageModel.findOne({
+        where: {
+          conversationId: conversation.id,
+          workspaceId: workspace.id,
+          rank: 1,
+        },
+      });
+      assert(originMessage, "Origin agent message not found");
+
+      const ancestors = await ConversationResource.listAncestorAgentMessageIds(
+        auth,
+        { agentMessageId: originMessage.sId }
+      );
+
+      expect(ancestors).toEqual([]);
+    });
+
+    it("stops walking at maxDepth", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Max Depth",
+        description: "agent",
+      });
+
+      const { childSid, grandChildSid } = await createAncestorChain(
+        auth,
+        agent.sId
+      );
+
+      const ancestors = await ConversationResource.listAncestorAgentMessageIds(
+        auth,
+        { agentMessageId: grandChildSid, maxDepth: 1 }
+      );
+
+      // Only the nearest ancestor is returned; the chain is truncated.
+      expect(ancestors).toEqual([childSid]);
+    });
+  });
+
   describe("fetchByModelIds", () => {
     it("should fetch by model ids within workspace", async () => {
       const workspace = await WorkspaceFactory.basic();

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -860,6 +860,95 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return row.total_credits;
   }
 
+  /**
+   * Walks UP the sub-agent tree from a single agent message and returns the
+   * sIds of every ancestor agent message (the message that spawned it, the one
+   * that spawned that, ...), `maxDepth`-bounded. Mirrors the linkage used by
+   * `sumSubAgentCostCreditsByMessageId` (only `run_agent` agentic origins; not
+   * `agent_handover`). Returns `[]` for a top-level (non sub-agent) message.
+   *
+   * Used to denormalize the ancestor chain onto each agent-message analytics
+   * document so sub-agent cost can be aggregated at query time in Elasticsearch
+   * (which has no recursive query).
+   */
+  static async listAncestorAgentMessageIds(
+    auth: Authenticator,
+    {
+      agentMessageId,
+      maxDepth = 10,
+    }: { agentMessageId: string; maxDepth?: number }
+  ): Promise<string[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const query = `
+      WITH RECURSIVE ancestors AS (
+        -- The agent message that spawned the starting agent message.
+        SELECT
+          um."agenticOriginMessageId" AS ancestor_sid,
+          1                           AS depth
+        FROM messages reply
+        JOIN messages user_msg
+          ON user_msg.id = reply."parentId"
+         AND user_msg."workspaceId" = reply."workspaceId"
+        JOIN user_messages um
+          ON um.id = user_msg."userMessageId"
+         AND um."workspaceId" = user_msg."workspaceId"
+        WHERE reply."workspaceId" = :workspaceId
+          AND reply."sId" = :agentMessageId
+          AND reply."agentMessageId" IS NOT NULL
+          AND um."agenticMessageType" = 'run_agent'
+          AND um."agenticOriginMessageId" IS NOT NULL
+
+        UNION ALL
+
+        -- The agent message that spawned a previously found ancestor.
+        SELECT
+          um."agenticOriginMessageId",
+          a.depth + 1
+        FROM ancestors a
+        JOIN messages reply
+          ON reply."sId" = a.ancestor_sid
+         AND reply."workspaceId" = :workspaceId
+         AND reply."agentMessageId" IS NOT NULL
+        JOIN messages user_msg
+          ON user_msg.id = reply."parentId"
+         AND user_msg."workspaceId" = :workspaceId
+        JOIN user_messages um
+          ON um.id = user_msg."userMessageId"
+         AND um."workspaceId" = :workspaceId
+         AND um."agenticMessageType" = 'run_agent'
+         AND um."agenticOriginMessageId" IS NOT NULL
+        WHERE a.depth < :maxDepth
+      )
+      SELECT DISTINCT ancestor_sid, MAX(depth) AS depth
+      FROM ancestors
+      GROUP BY ancestor_sid
+      ORDER BY depth
+    `;
+
+    // biome-ignore lint/plugin/noRawSql: recursive CTE has no Sequelize equivalent.
+    const rows = await frontSequelize.query<{
+      ancestor_sid: string;
+      depth: number;
+    }>(query, {
+      type: QueryTypes.SELECT,
+      replacements: { workspaceId, agentMessageId, maxDepth },
+    });
+
+    if (rows.length > 0 && rows[rows.length - 1].depth >= maxDepth) {
+      logger.warn(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          agentMessageId,
+          maxDepth,
+        },
+        "[Analytics] Sub-agent ancestor walk hit the depth cap; chain may be truncated."
+      );
+    }
+
+    return rows.map((row) => row.ancestor_sid);
+  }
+
   private static getOptions(
     options?: FetchConversationOptions
   ): ResourceFindOptions<ConversationModel> {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -878,7 +878,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       maxDepth = 10,
     }: { agentMessageId: string; maxDepth?: number }
   ): Promise<string[]> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
 
     const query = `
       WITH RECURSIVE ancestors AS (
@@ -893,7 +893,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         JOIN user_messages um
           ON um.id = user_msg."userMessageId"
          AND um."workspaceId" = user_msg."workspaceId"
-        WHERE reply."workspaceId" = :workspaceId
+        WHERE reply."workspaceId" = :workspaceModelId
           AND reply."sId" = :agentMessageId
           AND reply."agentMessageId" IS NOT NULL
           AND um."agenticMessageType" = 'run_agent'
@@ -908,14 +908,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         FROM ancestors a
         JOIN messages reply
           ON reply."sId" = a.ancestor_sid
-         AND reply."workspaceId" = :workspaceId
+         AND reply."workspaceId" = :workspaceModelId
          AND reply."agentMessageId" IS NOT NULL
         JOIN messages user_msg
           ON user_msg.id = reply."parentId"
-         AND user_msg."workspaceId" = :workspaceId
+         AND user_msg."workspaceId" = :workspaceModelId
         JOIN user_messages um
           ON um.id = user_msg."userMessageId"
-         AND um."workspaceId" = :workspaceId
+         AND um."workspaceId" = :workspaceModelId
          AND um."agenticMessageType" = 'run_agent'
          AND um."agenticOriginMessageId" IS NOT NULL
         WHERE a.depth < :maxDepth
@@ -932,7 +932,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       depth: number;
     }>(query, {
       type: QueryTypes.SELECT,
-      replacements: { workspaceId, agentMessageId, maxDepth },
+      replacements: { workspaceModelId, agentMessageId, maxDepth },
     });
 
     if (rows.length > 0 && rows[rows.length - 1].depth >= maxDepth) {

--- a/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
+++ b/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
@@ -212,6 +212,9 @@ async function backfillMcpServerConfigurationSidForWorkspace(
           mcp_server_configuration_sid: sid,
           execution_time_ms: action.executionDurationMs,
           status: action.status,
+          // This historical backfill predates per-tool cost tracking; cost_awu
+          // is populated by the live analytics activity going forward.
+          cost_awu: 0,
         });
       }
 

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -1,5 +1,6 @@
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
+import { awuFromMicroUsd } from "@app/lib/metronome/events";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Logger } from "@app/logger/logger";
@@ -99,7 +100,13 @@ async function seedProgrammaticUsage(
     const document: AgentMessageAnalyticsData = {
       agent_id: `seed-agent-${i % AGENT_COUNT}`,
       agent_version: "1",
+      ancestor_message_ids: [],
       conversation_id: `seed-conv-${i}`,
+      cost: {
+        full_awu: awuFromMicroUsd(costMicroUsd),
+        llm_awu: awuFromMicroUsd(costMicroUsd),
+        tool_awu: 0,
+      },
       context_origin: "api",
       latency_ms: randomInt(LATENCY_MS_RANGE.min, LATENCY_MS_RANGE.max),
       message_id: messageId,

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -120,7 +120,13 @@ export async function seedAnalytics(
     const document: AgentMessageAnalyticsData = {
       agent_id: agentMessage.agentConfigurationId,
       agent_version: agentMessage.agentConfigurationVersion.toString(),
+      ancestor_message_ids: [],
       conversation_id: conversationId,
+      cost: {
+        full_awu: 0,
+        llm_awu: 0,
+        tool_awu: 0,
+      },
       context_origin: "web",
       latency_ms: agentMessage.modelInteractionDurationMs ?? 0,
       message_id: message.sId,

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -6,6 +6,7 @@ import {
   SEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { updateAnalyticsFeedback } from "@app/lib/analytics/feedback";
 import {
@@ -17,6 +18,13 @@ import { addTraceToLangfuseDataset } from "@app/lib/api/instrumentation/langfuse
 import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import {
+  getToolCategory,
+  intelligenceAwuFromRunUsages,
+  isFreeOrigin,
+  isFreeToolServer,
+  TOOL_CATEGORY_AWU_WEIGHTS,
+} from "@app/lib/metronome/events";
 import type { AgentMessageFeedbackModel } from "@app/lib/models/agent/conversation";
 import {
   AgentMessageModel,
@@ -29,9 +37,11 @@ import { AgentMessageSkillModel } from "@app/lib/models/skill/conversation_skill
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentMCPServerConfigurationResource } from "@app/lib/resources/agent_mcp_server_configuration_resource";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/global_registry";
 import type { SkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
@@ -169,8 +179,12 @@ export async function storeAgentAnalytics(
     agentAgentMessageRow.id,
   ]);
 
+  const isFreeUsage = contextOrigin !== null && isFreeOrigin(contextOrigin);
+
+  const runUsages = await fetchRunUsagesForMessage(auth, agentAgentMessageRow);
+
   // Collect token usage from run data.
-  const tokens = await collectTokenUsage(auth, agentAgentMessageRow);
+  const tokens = aggregateTokenUsage(runUsages);
 
   // Collect skills usage data.
   const skillsUsed = await collectSkillsUsageFromMessage(
@@ -178,8 +192,28 @@ export async function storeAgentAnalytics(
     agentAgentMessageRow.id
   );
 
-  // Collect tool usage data.
-  const toolsUsed = await collectToolUsageFromMessage(auth, actions);
+  // Collect tool usage data (with per-tool credit cost).
+  const toolsUsed = await collectToolUsageFromMessage(auth, actions, {
+    isFreeUsage,
+  });
+
+  const llmAwu = isFreeUsage ? 0 : intelligenceAwuFromRunUsages(runUsages);
+  const toolAwu = toolsUsed.reduce((sum, tool) => sum + tool.cost_awu, 0);
+  const cost = {
+    full_awu: llmAwu + toolAwu,
+    llm_awu: llmAwu,
+    tool_awu: toolAwu,
+  };
+
+  // Denormalize the sub-agent ancestor chain so a sub-agent's cost can be rolled
+  // up to its ancestors via a query-time aggregation (ES has no recursive query).
+  // Only run_agent replies have ancestors — skip the recursive query otherwise.
+  const ancestorMessageIds =
+    userMessageModel.agenticMessageType === "run_agent"
+      ? await ConversationResource.listAncestorAgentMessageIds(auth, {
+          agentMessageId: agentMessageRow.sId,
+        })
+      : [];
 
   // Collect feedback from the agent message.
   const feedbacks = agentAgentMessageRow.feedbacks
@@ -199,7 +233,9 @@ export async function storeAgentAnalytics(
   const document: AgentMessageAnalyticsData = {
     agent_id: agentAgentMessageRow.agentConfigurationId,
     agent_version: agentAgentMessageRow.agentConfigurationVersion.toString(),
+    ancestor_message_ids: ancestorMessageIds,
     conversation_id: conversationRow.sId,
+    cost,
     context_origin: contextOrigin,
     latency_ms: agentAgentMessageRow.modelInteractionDurationMs ?? 0,
     message_id: agentMessageRow.sId,
@@ -231,30 +267,30 @@ export async function storeAgentAnalytics(
 }
 
 /**
- * Collect token usage from runs associated with this agent message.
+ * Fetch the run usages for all runs associated with this agent message.
  */
-async function collectTokenUsage(
+async function fetchRunUsagesForMessage(
   auth: Authenticator,
   agentMessage: AgentMessageModel
-): Promise<AgentMessageAnalyticsTokens> {
+): Promise<RunUsageType[]> {
   if (!agentMessage.runIds || agentMessage.runIds.length === 0) {
-    return {
-      prompt: 0,
-      completion: 0,
-      reasoning: 0,
-      cached: 0,
-      cost_micro_usd: 0,
-    };
+    return [];
   }
 
-  // Get run usages for all runs associated with this agent message.
   const runResources = await RunResource.listByDustRunIds(auth, {
     dustRunIds: agentMessage.runIds,
   });
-  const runUsages = await RunResource.listRunUsagesForRuns(auth, {
+  return RunResource.listRunUsagesForRuns(auth, {
     runs: runResources,
   });
+}
 
+/**
+ * Aggregate token usage from a set of run usages.
+ */
+function aggregateTokenUsage(
+  runUsages: RunUsageType[]
+): AgentMessageAnalyticsTokens {
   return runUsages.reduce(
     (acc, usage) => {
       return {
@@ -280,7 +316,8 @@ async function collectTokenUsage(
  */
 async function collectToolUsageFromMessage(
   auth: Authenticator,
-  actionResources: AgentMCPActionResource[]
+  actionResources: AgentMCPActionResource[],
+  { isFreeUsage }: { isFreeUsage: boolean }
 ): Promise<AgentMessageAnalyticsToolUsed[]> {
   const uniqueConfigIds = Array.from(
     new Set(actionResources.map((a) => a.mcpServerConfigurationId))
@@ -323,6 +360,13 @@ async function collectToolUsageFromMessage(
       mcpServerId ??
       "unknown";
 
+    const cost_awu =
+      !isFreeUsage &&
+      isToolExecutionStatusFinal(actionResource.status) &&
+      !isFreeToolServer(internalMCPServerName)
+        ? TOOL_CATEGORY_AWU_WEIGHTS[getToolCategory(internalMCPServerName)]
+        : 0;
+
     return {
       step_index: actionResource.stepContent.step,
       server_name: serverName,
@@ -333,6 +377,7 @@ async function collectToolUsageFromMessage(
         configIdToSId.get(actionResource.mcpServerConfigurationId) ?? undefined,
       execution_time_ms: actionResource.executionDurationMs,
       status: actionResource.status,
+      cost_awu,
     };
   });
 }

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -23,6 +23,13 @@ export interface AgentMessageAnalyticsToolUsed {
   mcp_server_configuration_sid?: string;
   execution_time_ms: number | null;
   status: string;
+  cost_awu: number;
+}
+
+export interface AgentMessageAnalyticsCost {
+  full_awu: number;
+  llm_awu: number;
+  tool_awu: number;
 }
 
 export interface AgentMessageAnalyticsFeedback {
@@ -45,7 +52,9 @@ export interface AgentMessageAnalyticsSkillUsed {
 export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   agent_id: string;
   agent_version: string;
+  ancestor_message_ids: string[];
   conversation_id: string;
+  cost: AgentMessageAnalyticsCost;
   feedbacks: AgentMessageAnalyticsFeedback[];
   context_origin: UserMessageOrigin | null;
   latency_ms: number;


### PR DESCRIPTION
## Description

First PR to move cost data in ES -- next one will be the backfill <3



Adds credit-cost data to the agent-message Elasticsearch analytics document so cost can be sliced and aggregated in analytics, alongside the existing Postgres `cost_credits` written at finalize time.

**Per-message cost breakdown** — every analytics doc now carries a `cost` object and a per-tool cost:
- `cost.full_awu` — total AWU credits (= llm + tool)
- `cost.llm_awu` — intelligence (LLM) AWU
- `cost.tool_awu` — tool AWU
- `tools_used[].cost_awu` — AWU billed per tool invocation (enables breakdown by tool)

The math reuses the exact same helpers as the Metronome billing pipeline (`intelligenceAwuFromRunUsages`, `toolAwuFromActions` building blocks, `getToolCategory`, `isFreeToolServer`, `isFreeOrigin`), mirroring `credit_cost.ts` so the ES value matches the billed `cost_credits`: free origins are zeroed, only final-status tool actions are billed, free tool servers contribute 0. Run usages are fetched once and reused for both token aggregation and the LLM cost.

**Sub-agent cost rollup** — sub-agent (`run_agent`) messages now denormalize their ancestor chain into `ancestor_message_ids` (a new `keyword` field), computed by a bounded recursive CTE (`ConversationResource.listAncestorAgentMessageIds`). This lets `fetchSubAgentCreditCost` roll up the cost of an entire sub-agent tree at query time with a single ES `sum` aggregation, since Elasticsearch has no recursive query.

The new ES fields are additive (no index version bump).

## Tests

- `npx tsgo --noEmit` passes; biome clean (pre-commit hooks green).
- Functional check: for a message with one advanced final tool + LLM usage, `cost.tool_awu = 3`, `cost.full_awu = llm + 3`, the single `tools_used` entry has `cost_awu = 3`, and `cost.full_awu` equals the Postgres `cost_credits`. Free-origin messages (e.g. `agent_sidekick`) → all cost fields and per-tool `cost_awu` are `0`.

## Deploy Plan

The new fields rely on Elasticsearch dynamic mapping (same as the existing `auth_method` / `api_key_name` fields), so no reindex is required. Optionally, apply the additive mapping to the live `front.agent_message_analytics_2` index per region (`PUT /front.agent_message_analytics_2/_mapping` with the `cost`, `tools_used.cost_awu`, and `ancestor_message_ids` blocks) to pin explicit field types instead of relying on dynamic inference.
