### PR TITLE
fix: attachment citation file preview uses canonical path when available

### DIFF
--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -48,16 +48,16 @@ export function FilePreviewProvider({
 
   const openFilePreview = useCallback(
     (file: PreviewableFile) => {
-      const fileUrl = file.fileId
-        ? getFileViewUrl(owner, file.fileId)
-        : file.filePath
-          ? getFilePathViewUrl(owner, file.filePath)
+      const fileUrl = file.filePath
+        ? getFilePathViewUrl(owner, file.filePath)
+        : file.fileId
+          ? getFileViewUrl(owner, file.fileId)
           : null;
 
-      const downloadUrl = file.fileId
-        ? getFileDownloadUrl(owner, file.fileId)
-        : file.filePath
-          ? getFilePathDownloadUrl(owner, file.filePath)
+      const downloadUrl = file.filePath
+        ? getFilePathDownloadUrl(owner, file.filePath)
+        : file.fileId
+          ? getFileDownloadUrl(owner, file.fileId)
           : null;
 
       if (!fileUrl || !downloadUrl) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When a file attachment citation is clicked in a user or agent message, the preview dialog was picking up the legacy identifier-based URL over the canonical path, even when the canonical path was available in the content fragment data. The legacy URL already carries a query parameter that conflicts with the ones the viewer needs to append, and it does not support on-the-fly Office-to-PDF conversion. Flipping the priority so the canonical path is preferred when present fixes preview for PDFs and Office documents clicked from conversation citations.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
