### PR TITLE
fix: handle gong invalid credentials messages

### DIFF
--- a/connectors/src/connectors/gong/lib/errors.ts
+++ b/connectors/src/connectors/gong/lib/errors.ts
@@ -17,6 +17,30 @@ function isGongAPIErrorBody(body: unknown): body is {
   );
 }
 
+export function parseGongAPIErrorBody(body: string): {
+  errors: string[];
+  requestId?: string;
+} {
+  const bodyParsedRes = safeParseJSON(body);
+
+  if (bodyParsedRes.isErr()) {
+    return {
+      errors: [
+        `Failed to parse error response: ${bodyParsedRes.error.message}`,
+      ],
+    };
+  }
+
+  if (isGongAPIErrorBody(bodyParsedRes.value)) {
+    return {
+      errors: bodyParsedRes.value.errors,
+      requestId: bodyParsedRes.value.requestId,
+    };
+  }
+
+  return { errors: [body] };
+}
+
 export class GongAPIError extends Error {
   readonly type: GongAPIErrorType;
   readonly connectorId: ModelId;
@@ -77,21 +101,7 @@ export class GongAPIError extends Error {
       retryAfterSeconds?: number;
     }
   ) {
-    // Attempt to parse the body as JSON.
-    const bodyParsedRes = safeParseJSON(body);
-    let errors: string[] = [];
-    let requestId: string | undefined;
-
-    if (bodyParsedRes.isErr()) {
-      errors = [
-        `Failed to parse error response: ${bodyParsedRes.error.message}`,
-      ];
-    } else if (isGongAPIErrorBody(bodyParsedRes.value)) {
-      errors = bodyParsedRes.value.errors;
-      requestId = bodyParsedRes.value.requestId;
-    } else {
-      errors = [body];
-    }
+    const { errors, requestId } = parseGongAPIErrorBody(body);
 
     return new this(
       `Gong API responded with status: ${response.status} on ${endpoint}`,

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -1,4 +1,7 @@
-import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
+import {
+  GongAPIError,
+  parseGongAPIErrorBody,
+} from "@connectors/connectors/gong/lib/errors";
 import {
   ExternalOAuthTokenError,
   HTTPError,
@@ -244,6 +247,11 @@ const GongPermissionProfilesResponseCodec = t.intersection([
 const RETRY_AFTER_FLOOR_SECONDS = 10;
 const RETRY_AFTER_CEILING_SECONDS = 3600;
 
+const GONG_INVALID_CREDENTIALS_MESSAGES = [
+  "Validate credentials failed. Please check your credentials and try again.",
+  "Your access token has been revoked. Please generate a new access token.",
+];
+
 export function clampRetryAfterSeconds(
   raw: number | undefined
 ): number | undefined {
@@ -273,19 +281,24 @@ export class GongClient {
     codec: t.Type<T>
   ): Promise<T> {
     if (!response.ok) {
+      // Don't attempt to parse the body in JSON.
+      const body = await response.text();
+
       if (response.status === 403 && response.statusText === "Forbidden") {
         throw new ExternalOAuthTokenError();
       }
-      if (
-        response.status === 401 &&
-        (response.statusText.includes(
-          "Validate credentials failed. Please check your credentials and try again."
-        ) ||
-          response.statusText.includes(
-            "Your access token has been revoked. Please generate a new access token."
-          ))
-      ) {
-        throw new ExternalOAuthTokenError();
+
+      if (response.status === 401) {
+        const { errors } = parseGongAPIErrorBody(body);
+        const candidates = [...errors, response.statusText];
+        const isInvalidCredentials = candidates.some((candidate) =>
+          GONG_INVALID_CREDENTIALS_MESSAGES.some((message) =>
+            candidate.includes(message)
+          )
+        );
+        if (isInvalidCredentials) {
+          throw new ExternalOAuthTokenError();
+        }
       }
 
       // Handle rate limiting
@@ -321,9 +334,6 @@ export class GongClient {
           `provider:gong`,
         ]);
 
-        // Don't attempt to parse the body in JSON.
-        const body = await response.text();
-
         throw GongAPIError.fromAPIError(response, {
           body,
           connectorId: this.connectorId,
@@ -335,9 +345,6 @@ export class GongClient {
       if (response.status === 404) {
         throw new HTTPError(response.statusText, response.status);
       }
-
-      // Don't attempt to parse the body in JSON.
-      const body = await response.text();
 
       throw GongAPIError.fromAPIError(response, {
         endpoint,


### PR DESCRIPTION
## Description

This PR fixes the Gong connector's handling of invalid credentials errors by also inspecting the response body (not just `statusText`) when detecting 401 unauthorized responses.

We have a stuck connector here https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aeurope-west1%20%40level%3Aerror%20%40workflowId%3A%2A&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ7VOsUnt9agcwAAABhBWjdWT3RxVkFBQ3BWazQyZDIwWXdnQUUAAAAkMDE5ZWQ1M2MtZTQwMC00NWQ3LTk4MDAtY2Y2NWY4ZjAwZjQ2AABEXg&fromUser=false&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40workflowId%3A%5C%22gong-sync-274877923250-workflow-2026-06-16T20%3A00%3A00Z%5C%22%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22workflowId%22%2C%22value%22%3A%22gong-sync-274877923250-workflow-2026-06-16T20%3A00%3A00Z%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1781680462000%2C%22to%22%3A1781694862000%2C%22live%22%3Atrue%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1781679242000&to_ts=1781693642000&live=true

- Extracts the body parsing logic from `GongAPIError` into a new exported `parseGongAPIErrorBody` helper function in `errors.ts`.
- On 401 responses, parses the response body and checks both the parsed error messages and `statusText` against the known invalid-credentials messages before throwing an `ExternalOAuthTokenError`.

## Tests

Manually.

## Risks

Low — the change broadens the detection of invalid credential errors to also look inside the response body, reducing the risk of missed credential revocation signals. Existing behavior is preserved for other error cases.

## Deploy Plan

Standard deployment.
