### PR TITLE
Add generatedByUserId FK to authorized file access with double-write.

### DIFF
--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -48,6 +48,7 @@ function makeAllowlist(
 ): AuthorizedFileAccessAllowlist {
   return {
     computedByUserId: "usr_test",
+    generatedByUserId: 123,
     frameContentHash: "hash",
     refs: [],
     ...overrides,
@@ -203,6 +204,7 @@ describe("computeAuthorizedFileAccess", () => {
     ]);
     expect(result.unverifiableRefs).toEqual(["fil_ZZZZZZZZZZ"]);
     expect(result.computedByUserId).toBe(auth.user()!.sId);
+    expect(result.generatedByUserId).toBe(auth.user()!.id);
     expect(result.frameContentHash).toBe(computeFrameContentHash(frameContent));
   });
 
@@ -447,6 +449,7 @@ describe("computeAuthorizedFileAccess", () => {
     });
 
     expect(result.computedByUserId).toBe(user.sId);
+    expect(result.generatedByUserId).toBe(user.id);
   });
 
   it("marks file_id refs without conversation or space metadata as unverifiable", async () => {
@@ -870,6 +873,8 @@ describe("ensureAuthorizedFileAccessForShare", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.shareScope).toBe("public");
     expect(rows[0]?.ref).toBe(dataFile.sId);
+    expect(rows[0]?.computedByUserId).toBe(auth.user()!.sId);
+    expect(rows[0]?.generatedByUserId).toBe(auth.user()!.id);
     expect(rows[0]?.frameContentHash).toBe(
       computeFrameContentHash(frameContent)
     );

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1303,6 +1303,50 @@ describe("FileResource", () => {
       expect(rows[0]?.kind).toBe("file_id");
       expect(rows[0]?.ref).toBe(dataFile.sId);
       expect(rows[0]?.fileName).toBe("data.txt");
+      expect(rows[0]?.generatedByUserId).toBe(auth.user()!.id);
+    });
+
+    it("getActiveAuthorizedFileAccessAllowlist prefers generatedByUserId FK over legacy sId column", async () => {
+      const { authenticator: auth } = await createResourceTest({});
+
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const frameFile = await FileFactory.create(auth, null, {
+        contentType: frameContentType,
+        fileName: "Frame.tsx",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: conversation.sId },
+      });
+
+      const shareableFile = await FileResource.shareableFileModel.findOne({
+        where: { fileId: frameFile.id, workspaceId: frameFile.workspaceId },
+      });
+      expect(shareableFile).not.toBeNull();
+
+      await AuthorizedFileAccessModel.create({
+        workspaceId: frameFile.workspaceId,
+        shareableFileId: shareableFile!.id,
+        kind: "file_id",
+        ref: "fil_PLACEHOLDER",
+        fileName: null,
+        legacyPath: null,
+        shareScope: shareableFile!.shareScope,
+        computedByUserId: "usr_deleted_user",
+        generatedByUserId: auth.user()!.id,
+        frameContentHash: "hash123",
+        allowedAt: new Date(),
+        revokedAt: null,
+      });
+
+      const allowlist =
+        await frameFile.getActiveAuthorizedFileAccessAllowlist();
+
+      expect(allowlist?.computedByUserId).toBe(auth.user()!.sId);
     });
 
     it("setShareScope updates share scope without recomputing the allowlist", async () => {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1792,6 +1792,7 @@ export class FileResource extends BaseResource<FileModel> {
         visited: new Set(),
       });
 
+    let generatedByUserId = auth.user()?.id ?? null;
     let computedByUserId = auth.user()?.sId;
     if (!computedByUserId) {
       // Temporary: API keys carry a userId FK to their owner, fall back to it
@@ -1800,6 +1801,7 @@ export class FileResource extends BaseResource<FileModel> {
       if (keyUserModelId) {
         const keyUser = await UserResource.fetchByModelId(keyUserModelId);
         computedByUserId = keyUser?.sId;
+        generatedByUserId = keyUserModelId;
       }
     }
     if (!computedByUserId) {
@@ -1808,6 +1810,7 @@ export class FileResource extends BaseResource<FileModel> {
 
     return {
       computedByUserId,
+      generatedByUserId,
       frameContentHash: computeFrameContentHash(frameContent),
       refs,
       ...(unverifiableRefs.length > 0 ? { unverifiableRefs } : {}),
@@ -1838,9 +1841,9 @@ export class FileResource extends BaseResource<FileModel> {
     }
   }
 
-  private static allowlistFromActiveRows(
+  private static async allowlistFromActiveRows(
     rows: AuthorizedFileAccessModel[]
-  ): AuthorizedFileAccessAllowlist | null {
+  ): Promise<AuthorizedFileAccessAllowlist | null> {
     if (rows.length === 0) {
       return null;
     }
@@ -1850,9 +1853,22 @@ export class FileResource extends BaseResource<FileModel> {
       return ref ? [ref] : [];
     });
 
+    const firstRow = rows[0]!;
+    let computedByUserId = firstRow.computedByUserId;
+    if (firstRow.generatedByUserId) {
+      const user = await UserResource.fetchByModelId(
+        firstRow.generatedByUserId
+      );
+      if (user) {
+        computedByUserId = user.sId;
+      }
+    }
+    const generatedByUserId = firstRow.generatedByUserId;
+
     return {
-      computedByUserId: rows[0]!.computedByUserId,
-      frameContentHash: rows[0]!.frameContentHash,
+      computedByUserId,
+      generatedByUserId,
+      frameContentHash: firstRow.frameContentHash,
       refs,
     };
   }
@@ -1885,7 +1901,7 @@ export class FileResource extends BaseResource<FileModel> {
       },
     });
 
-    return FileResource.allowlistFromActiveRows(rows);
+    return await FileResource.allowlistFromActiveRows(rows);
   }
 
   async getActiveAuthorizedFileAccessShareScope(): Promise<FileShareScope | null> {
@@ -1918,6 +1934,7 @@ export class FileResource extends BaseResource<FileModel> {
       shareableFileId: shareableFile.id,
       shareScope: shareableFile.shareScope,
       computedByUserId: computed.computedByUserId,
+      generatedByUserId: computed.generatedByUserId,
       frameContentHash: computed.frameContentHash,
       allowedAt,
       revokedAt: null,

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -310,6 +310,7 @@ export class AuthorizedFileAccessModel extends WorkspaceAwareModel<AuthorizedFil
   declare legacyPath: string | null;
   declare shareScope: FileShareScope;
   declare computedByUserId: string;
+  declare generatedByUserId: ForeignKey<UserModel["id"]> | null;
   declare frameContentHash: string;
   declare allowedAt: Date;
   declare revokedAt: Date | null;
@@ -317,6 +318,7 @@ export class AuthorizedFileAccessModel extends WorkspaceAwareModel<AuthorizedFil
   declare shareableFileId: ForeignKey<ShareableFileModel["id"]>;
 
   declare shareableFile?: NonAttribute<ShareableFileModel>;
+  declare generatedByUser?: NonAttribute<UserModel | null>;
 }
 
 AuthorizedFileAccessModel.init(
@@ -377,6 +379,7 @@ AuthorizedFileAccessModel.init(
     indexes: [
       { fields: ["workspaceId"], concurrently: true },
       { fields: ["shareableFileId"], concurrently: true },
+      { fields: ["generatedByUserId"], concurrently: true },
       {
         fields: ["shareableFileId"],
         where: { revokedAt: null },
@@ -393,6 +396,16 @@ ShareableFileModel.hasMany(AuthorizedFileAccessModel, {
 });
 AuthorizedFileAccessModel.belongsTo(ShareableFileModel, {
   foreignKey: { name: "shareableFileId", allowNull: false },
+});
+
+UserModel.hasMany(AuthorizedFileAccessModel, {
+  foreignKey: { name: "generatedByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});
+AuthorizedFileAccessModel.belongsTo(UserModel, {
+  as: "generatedByUser",
+  foreignKey: { name: "generatedByUserId", allowNull: true },
+  onDelete: "SET NULL",
 });
 
 /**

--- a/front/migrations/20260617_backfill_authorized_file_access_generated_by_user_id.ts
+++ b/front/migrations/20260617_backfill_authorized_file_access_generated_by_user_id.ts
@@ -1,0 +1,85 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { AuthorizedFileAccessModel } from "@app/lib/resources/storage/models/files";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 500;
+
+type BackfillRow = {
+  id: number;
+  computedByUserId: string;
+};
+
+/**
+ * Backfills generatedByUserId from legacy computedByUserId user sIds.
+ * Run after deploying the FK column migration and double-write code.
+ */
+makeScript({}, async ({ execute }, logger) => {
+  let lastId = 0;
+  let backfilledCount = 0;
+  let unresolvedCount = 0;
+
+  for (;;) {
+    const rows = await frontSequelize.query<BackfillRow>(
+      `
+        SELECT afa."id", afa."computedByUserId"
+        FROM "authorized_file_accesses" afa
+        WHERE afa."generatedByUserId" IS NULL
+          AND afa."id" > :lastId
+        ORDER BY afa."id" ASC
+        LIMIT :batchSize
+      `,
+      {
+        replacements: { lastId, batchSize: BATCH_SIZE },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      lastId = row.id;
+
+      const [user] = await frontSequelize.query<{ id: number }>(
+        `SELECT "id" FROM "users" WHERE "sId" = :sId LIMIT 1`,
+        {
+          replacements: { sId: row.computedByUserId },
+          type: QueryTypes.SELECT,
+        }
+      );
+
+      if (!user) {
+        unresolvedCount += 1;
+        logger.warn(
+          { rowId: row.id, computedByUserId: row.computedByUserId },
+          "Could not resolve user for authorized file access row"
+        );
+        continue;
+      }
+
+      if (execute) {
+        await AuthorizedFileAccessModel.update(
+          { generatedByUserId: user.id },
+          { where: { id: row.id } }
+        );
+      }
+
+      backfilledCount += 1;
+    }
+
+    logger.info(
+      { backfilledCount, unresolvedCount, lastId },
+      execute ? "Backfill progress" : "Dry run progress"
+    );
+  }
+
+  logger.info(
+    { backfilledCount, unresolvedCount, execute },
+    execute
+      ? "Completed authorized file access generatedByUserId backfill"
+      : "Dry run completed for authorized file access generatedByUserId backfill"
+  );
+});

--- a/front/migrations/pre-deploy/20260617133202_add_generated_by_user_id_to_authorized_file_accesses.sql
+++ b/front/migrations/pre-deploy/20260617133202_add_generated_by_user_id_to_authorized_file_accesses.sql
@@ -1,0 +1,18 @@
+/*
+Adds a nullable FK from authorized_file_accesses to users for the authoring user.
+Legacy computedByUserId (user sId string) is kept during the double-write phase.
+ */
+SET
+    SESSION statement_timeout = '2s';
+
+SET
+    SESSION lock_timeout = '2s';
+
+ALTER TABLE "public"."authorized_file_accesses"
+ADD COLUMN "generatedByUserId" BIGINT;
+
+ALTER TABLE "public"."authorized_file_accesses" ADD CONSTRAINT "authorized_file_accesses_generatedByUserId_fkey" FOREIGN KEY ("generatedByUserId") REFERENCES "users" ("id") ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+ALTER TABLE "public"."authorized_file_accesses" VALIDATE CONSTRAINT "authorized_file_accesses_generatedByUserId_fkey";
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "authorized_file_accesses_generatedByUserId_idx" ON "public"."authorized_file_accesses" ("generatedByUserId");

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -208,6 +208,7 @@ export function entryToAuthorizedFileRef(
 /** Active allowlist view derived from non-revoked DB rows. */
 export type AuthorizedFileAccessAllowlist = {
   computedByUserId: string;
+  generatedByUserId: number | null;
   frameContentHash: string;
   refs: AuthorizedFileRef[];
 };


### PR DESCRIPTION
## Description

Adds a nullable `generatedByUserId` FK (`BIGINT`, `ON DELETE SET NULL`) to `authorized_file_accesses` pointing at `users.id`, replacing the legacy `computedByUserId` sId string as the authoritative user reference. The legacy column is kept during the transition.

- `computeAuthorizedFileAccess` now resolves and persists both `computedByUserId` (sId) and `generatedByUserId` (model id), including the API-key owner fallback path.
- `getActiveAuthorizedFileAccessAllowlist` joins `UserModel as generatedByUser` and prefers `generatedByUser.sId` over the raw `computedByUserId` string when the FK is populated.
- Pre-deploy SQL migration adds the column + `NOT VALID` FK constraint + validate step (2 s timeouts, no table lock).
- Backfill script iterates `authorized_file_accesses` where `generatedByUserId IS NULL`, resolves `users.id` from `computedByUserId` sId, and updates in batches of 500.

## Tests

- Updated existing tests for `computeAuthorizedFileAccess` and `ensureAuthorizedFileAccessForShare` to assert `generatedByUserId` is populated.
- New test in `file_resource.test.ts`: inserts a row with `computedByUserId = "usr_deleted_user"` and a valid `generatedByUserId`, asserts `getActiveAuthorizedFileAccessAllowlist` returns the FK-resolved sId, not the stale string.
- Tested locally.

## Risk

Low. Column is nullable — existing rows and read paths continue to work via `computedByUserId` until the backfill completes. Old code ignores the new column. Rollback is safe: dropping the FK column requires a migration, but the app functions without it since all writes still populate the legacy string column.

## Deploy Plan

1. Run pre-deploy SQL migration `20260617133202_add_generated_by_user_id_to_authorized_file_accesses.sql` on the front DB.
2. Deploy front (enables double-write and FK-prefer reads).
3. Run backfill script `20260617_backfill_authorized_file_access_generated_by_user_id.ts --execute` to populate `generatedByUserId` on existing rows.
