### PR TITLE
Drop legacy authorized file access columns and stop double-write.

### DIFF
--- a/front/lib/api/viz/authorized_file_access.test.ts
+++ b/front/lib/api/viz/authorized_file_access.test.ts
@@ -47,8 +47,7 @@ function makeAllowlist(
   overrides: Partial<AuthorizedFileAccessAllowlist> = {}
 ): AuthorizedFileAccessAllowlist {
   return {
-    computedByUserId: "usr_test",
-    generatedByUserId: 123,
+    generatedByUserId: null,
     frameContentHash: "hash",
     refs: [],
     ...overrides,
@@ -203,7 +202,6 @@ describe("computeAuthorizedFileAccess", () => {
       },
     ]);
     expect(result.unverifiableRefs).toEqual(["fil_ZZZZZZZZZZ"]);
-    expect(result.computedByUserId).toBe(auth.user()!.sId);
     expect(result.generatedByUserId).toBe(auth.user()!.id);
     expect(result.frameContentHash).toBe(computeFrameContentHash(frameContent));
   });
@@ -448,7 +446,6 @@ describe("computeAuthorizedFileAccess", () => {
       frameContent,
     });
 
-    expect(result.computedByUserId).toBe(user.sId);
     expect(result.generatedByUserId).toBe(user.id);
   });
 
@@ -798,7 +795,6 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       where: {
         shareableFileId: shareableFile!.id,
         workspaceId: frameFile.workspaceId,
-        revokedAt: null,
       },
     });
     expect(rows).toHaveLength(0);
@@ -847,10 +843,9 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       fileName: "data.txt",
       legacyPath: null,
       shareScope: initialShareScope,
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       frameContentHash: computeFrameContentHash(frameContent),
       allowedAt: new Date(),
-      revokedAt: null,
     });
 
     await frameFile.setShareScope(auth, "public");
@@ -867,13 +862,11 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       where: {
         shareableFileId: shareableFile!.id,
         workspaceId: frameFile.workspaceId,
-        revokedAt: null,
       },
     });
     expect(rows).toHaveLength(1);
     expect(rows[0]?.shareScope).toBe("public");
     expect(rows[0]?.ref).toBe(dataFile.sId);
-    expect(rows[0]?.computedByUserId).toBe(auth.user()!.sId);
     expect(rows[0]?.generatedByUserId).toBe(auth.user()!.id);
     expect(rows[0]?.frameContentHash).toBe(
       computeFrameContentHash(frameContent)
@@ -899,7 +892,7 @@ describe("ensureAuthorizedFileAccessForShare", () => {
     });
 
     const activeSnapshot = makeAllowlist({
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       frameContentHash: computeFrameContentHash(frameContent),
       refs: [],
     });
@@ -916,10 +909,9 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       fileName: null,
       legacyPath: null,
       shareScope: shareableFile!.shareScope,
-      computedByUserId: activeSnapshot.computedByUserId,
+      generatedByUserId: auth.user()!.id,
       frameContentHash: activeSnapshot.frameContentHash,
       allowedAt: new Date(),
-      revokedAt: null,
     });
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -933,8 +925,8 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       expect(result.value.frameContentHash).toBe(
         activeSnapshot.frameContentHash
       );
-      expect(result.value.computedByUserId).toBe(
-        activeSnapshot.computedByUserId
+      expect(result.value.generatedByUserId).toBe(
+        activeSnapshot.generatedByUserId
       );
     }
 
@@ -942,7 +934,6 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       where: {
         shareableFileId: shareableFile!.id,
         workspaceId: frameFile.workspaceId,
-        revokedAt: null,
       },
     });
     expect(rows).toHaveLength(1);
@@ -979,10 +970,9 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       fileName: null,
       legacyPath: null,
       shareScope: shareableFile!.shareScope,
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       frameContentHash: "stale-hash",
       allowedAt: new Date(),
-      revokedAt: null,
     });
 
     vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -1001,7 +991,6 @@ describe("ensureAuthorizedFileAccessForShare", () => {
       where: {
         shareableFileId: shareableFile!.id,
         workspaceId: frameFile.workspaceId,
-        revokedAt: null,
       },
     });
     expect(rows).toHaveLength(1);
@@ -1042,7 +1031,7 @@ describe("readAllowlistedScopedVizFile", () => {
 
     const canonicalPath = "pod-vlt_otherPod/chart.png";
     const allowlist = makeAllowlist({
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       refs: [
         { kind: "canonical_path", ref: canonicalPath, fileName: "chart.png" },
       ],
@@ -1154,7 +1143,7 @@ describe("assertVizFileAuthorized", () => {
 
     const frameContent = `useFile("${dataFile.sId}");`;
     const allowlist = makeAllowlist({
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       frameContentHash: computeFrameContentHash(frameContent),
       refs: [{ kind: "file_id", ref: dataFile.sId, fileName: "data.txt" }],
     });
@@ -1189,7 +1178,7 @@ describe("reverifyAuthorAccess", () => {
     });
 
     const allowlist = makeAllowlist({
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       refs: [{ kind: "file_id", ref: dataFile.sId, fileName: "data.txt" }],
     });
 
@@ -1218,7 +1207,7 @@ describe("reverifyAuthorAccess", () => {
 
     const canonicalPath = `conversation-${conversation.sId}/report.csv`;
     const allowlist = makeAllowlist({
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       refs: [
         {
           kind: "canonical_path",
@@ -1346,10 +1335,9 @@ describe("public share referenced files change notice", () => {
       fileName: "data.txt",
       legacyPath: null,
       shareScope: shareableFile!.shareScope,
-      computedByUserId: auth.user()!.sId,
+      generatedByUserId: auth.user()!.id,
       frameContentHash: "hash",
       allowedAt: new Date(),
-      revokedAt: null,
     });
 
     const state = await fetchShareableFileAllowlistState(frameFile);

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -7,6 +7,7 @@ import {
 } from "@app/lib/api/viz/authorized_file_access_policy";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import {
@@ -176,10 +177,17 @@ export async function readAllowlistedScopedVizFile({
   canonicalScopedPath: string;
   workspace: LightWorkspaceType;
 }): Promise<Result<AllowlistedScopedVizFile, void>> {
-  const userId = authorizedFileAccess.computedByUserId;
+  const userId = authorizedFileAccess.generatedByUserId;
+  if (!userId) {
+    return new Err(undefined);
+  }
+  const user = await UserResource.fetchByModelId(userId);
+  if (!user) {
+    return new Err(undefined);
+  }
 
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
-    userId,
+    user.sId,
     workspace.sId
   );
 
@@ -250,10 +258,17 @@ export async function reverifyAuthorAccess(
     return false;
   }
 
-  const userId = authorizedFileAccess.computedByUserId;
+  const userId = authorizedFileAccess.generatedByUserId;
+  if (!userId) {
+    return false;
+  }
+  const user = await UserResource.fetchByModelId(userId);
+  if (!user) {
+    return false;
+  }
 
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
-    userId,
+    user.sId,
     workspace.sId
   );
 

--- a/front/lib/api/viz/share_frame_viewer_files.ts
+++ b/front/lib/api/viz/share_frame_viewer_files.ts
@@ -150,7 +150,6 @@ export async function getShareFrameViewerFilesForFrame(
     where: {
       shareableFileId: shareableFile.id,
       workspaceId: frameFile.workspaceId,
-      revokedAt: null,
     },
   });
 
@@ -159,7 +158,6 @@ export async function getShareFrameViewerFilesForFrame(
       kind: entry.kind,
       ref: entry.ref,
       shareScope: entry.shareScope,
-      computedByUserId: entry.computedByUserId,
       frameContentHash: entry.frameContentHash,
       allowedAt: entry.allowedAt.toISOString(),
       ...(entry.fileName ? { fileName: entry.fileName } : {}),

--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -1181,10 +1181,9 @@ describe("FileResource", () => {
         fileName: null,
         legacyPath: null,
         shareScope: shareableFile!.shareScope,
-        computedByUserId: auth.user()!.sId,
+        generatedByUserId: auth.user()!.id,
         frameContentHash: "old-hash",
         allowedAt: existingAllowedAt,
-        revokedAt: null,
       });
 
       vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
@@ -1207,7 +1206,6 @@ describe("FileResource", () => {
       });
 
       expect(rows).toHaveLength(1);
-      expect(rows[0]?.revokedAt).toBeNull();
       expect(rows[0]?.kind).toBe("unverifiable");
       expect(rows[0]?.ref).toBe("fil_ABCDEFGHIJ");
     });
@@ -1251,7 +1249,6 @@ describe("FileResource", () => {
         where: {
           shareableFileId: shareableFile!.id,
           workspaceId: frameFile.workspaceId,
-          revokedAt: null,
         },
       });
       expect(rows).toHaveLength(0);
@@ -1296,7 +1293,6 @@ describe("FileResource", () => {
         where: {
           shareableFileId: shareableFile!.id,
           workspaceId: frameFile.workspaceId,
-          revokedAt: null,
         },
       });
       expect(rows).toHaveLength(1);
@@ -1306,7 +1302,7 @@ describe("FileResource", () => {
       expect(rows[0]?.generatedByUserId).toBe(auth.user()!.id);
     });
 
-    it("getActiveAuthorizedFileAccessAllowlist prefers generatedByUserId FK over legacy sId column", async () => {
+    it("getActiveAuthorizedFileAccessAllowlist resolves computedByUserId from generatedByUserId FK", async () => {
       const { authenticator: auth } = await createResourceTest({});
 
       const conversation = await ConversationFactory.create(auth, {
@@ -1336,17 +1332,15 @@ describe("FileResource", () => {
         fileName: null,
         legacyPath: null,
         shareScope: shareableFile!.shareScope,
-        computedByUserId: "usr_deleted_user",
         generatedByUserId: auth.user()!.id,
         frameContentHash: "hash123",
         allowedAt: new Date(),
-        revokedAt: null,
       });
 
       const allowlist =
         await frameFile.getActiveAuthorizedFileAccessAllowlist();
 
-      expect(allowlist?.computedByUserId).toBe(auth.user()!.sId);
+      expect(allowlist?.generatedByUserId).toBe(auth.user()!.id);
     });
 
     it("setShareScope updates share scope without recomputing the allowlist", async () => {
@@ -1379,7 +1373,6 @@ describe("FileResource", () => {
         where: {
           shareableFileId: shareableFile!.id,
           workspaceId: frameFile.workspaceId,
-          revokedAt: null,
         },
       });
       expect(rows).toHaveLength(0);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1792,24 +1792,19 @@ export class FileResource extends BaseResource<FileModel> {
         visited: new Set(),
       });
 
-    let generatedByUserId = auth.user()?.id ?? null;
-    let computedByUserId = auth.user()?.sId;
-    if (!computedByUserId) {
-      // Temporary: API keys carry a userId FK to their owner, fall back to it
-      // until authorized file access is reworked to not require a user identity.
-      const keyUserModelId = auth.key()?.userModelId;
-      if (keyUserModelId) {
-        const keyUser = await UserResource.fetchByModelId(keyUserModelId);
-        computedByUserId = keyUser?.sId;
-        generatedByUserId = keyUserModelId;
-      }
+    const generatedByUserId =
+      auth.user()?.id ?? auth.key()?.userModelId ?? null;
+    if (!generatedByUserId) {
+      throw new Error("Cannot compute authorized file access without a user");
     }
-    if (!computedByUserId) {
+
+    const generatedByUser =
+      auth.user() ?? (await UserResource.fetchByModelId(generatedByUserId));
+    if (!generatedByUser) {
       throw new Error("Cannot compute authorized file access without a user");
     }
 
     return {
-      computedByUserId,
       generatedByUserId,
       frameContentHash: computeFrameContentHash(frameContent),
       refs,
@@ -1854,20 +1849,13 @@ export class FileResource extends BaseResource<FileModel> {
     });
 
     const firstRow = rows[0]!;
-    let computedByUserId = firstRow.computedByUserId;
-    if (firstRow.generatedByUserId) {
-      const user = await UserResource.fetchByModelId(
-        firstRow.generatedByUserId
-      );
-      if (user) {
-        computedByUserId = user.sId;
-      }
-    }
     const generatedByUserId = firstRow.generatedByUserId;
+    if (!generatedByUserId) {
+      return null;
+    }
 
     return {
-      computedByUserId,
-      generatedByUserId,
+      generatedByUserId: firstRow.generatedByUserId,
       frameContentHash: firstRow.frameContentHash,
       refs,
     };
@@ -1897,7 +1885,6 @@ export class FileResource extends BaseResource<FileModel> {
       where: {
         shareableFileId: shareableFile.id,
         workspaceId: this.workspaceId,
-        revokedAt: null,
       },
     });
 
@@ -1910,7 +1897,6 @@ export class FileResource extends BaseResource<FileModel> {
       where: {
         shareableFileId: shareableFile.id,
         workspaceId: this.workspaceId,
-        revokedAt: null,
       },
       attributes: ["shareScope"],
     });
@@ -1933,11 +1919,9 @@ export class FileResource extends BaseResource<FileModel> {
       workspaceId: this.workspaceId,
       shareableFileId: shareableFile.id,
       shareScope: shareableFile.shareScope,
-      computedByUserId: computed.computedByUserId,
       generatedByUserId: computed.generatedByUserId,
       frameContentHash: computed.frameContentHash,
       allowedAt,
-      revokedAt: null,
     };
 
     const rows = [

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -309,11 +309,9 @@ export class AuthorizedFileAccessModel extends WorkspaceAwareModel<AuthorizedFil
   declare fileName: string | null;
   declare legacyPath: string | null;
   declare shareScope: FileShareScope;
-  declare computedByUserId: string;
   declare generatedByUserId: ForeignKey<UserModel["id"]> | null;
   declare frameContentHash: string;
   declare allowedAt: Date;
-  declare revokedAt: Date | null;
 
   declare shareableFileId: ForeignKey<ShareableFileModel["id"]>;
 
@@ -355,10 +353,6 @@ AuthorizedFileAccessModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    computedByUserId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
     frameContentHash: {
       type: DataTypes.STRING,
       allowNull: false,
@@ -366,11 +360,6 @@ AuthorizedFileAccessModel.init(
     allowedAt: {
       type: DataTypes.DATE,
       allowNull: false,
-    },
-    revokedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: null,
     },
   },
   {
@@ -380,12 +369,6 @@ AuthorizedFileAccessModel.init(
       { fields: ["workspaceId"], concurrently: true },
       { fields: ["shareableFileId"], concurrently: true },
       { fields: ["generatedByUserId"], concurrently: true },
-      {
-        fields: ["shareableFileId"],
-        where: { revokedAt: null },
-        name: "authorized_file_accesses_shareable_file_id_non_revoked",
-        concurrently: true,
-      },
     ],
   }
 );

--- a/front/migrations/20260606_backfill_frame_authorized_file_access.ts
+++ b/front/migrations/20260606_backfill_frame_authorized_file_access.ts
@@ -1,3 +1,4 @@
+/*
 import type { Logger } from "pino";
 import { Op, QueryTypes } from "sequelize";
 
@@ -643,3 +644,4 @@ makeScript(
     );
   }
 );
+*/

--- a/front/migrations/post-deploy/20260617140000_drop_legacy_authorized_file_access_columns.sql
+++ b/front/migrations/post-deploy/20260617140000_drop_legacy_authorized_file_access_columns.sql
@@ -1,0 +1,11 @@
+/*
+Post-deploy: drop legacy authorized_file_access columns after FK backfill.
+Requires PR1 cleanup + PR2 backfill to have run before this migration.
+ */
+DROP INDEX CONCURRENTLY IF EXISTS "authorized_file_accesses_shareable_file_id_non_revoked";
+
+ALTER TABLE "public"."authorized_file_accesses"
+DROP COLUMN "computedByUserId";
+
+ALTER TABLE "public"."authorized_file_accesses"
+DROP COLUMN "revokedAt";

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -1,8 +1,6 @@
-import type { AuthorizedFileAccessEntry } from "@app/types/files";
 import {
   authorizedFileAccessEntrySchema,
   ensureFileSize,
-  getActiveAuthorizedFileAccessEntries,
   getAuthorizedFileRefLabel,
   parseAuthorizedFileAccessEntry,
   resolveFileContentType,
@@ -54,7 +52,6 @@ describe("resolveMaxFileSizes", () => {
 describe("authorizedFileAccessEntrySchema", () => {
   const baseEntry = {
     shareScope: "workspace" as const,
-    computedByUserId: "usr_abc",
     frameContentHash: "hash123",
     allowedAt: "2026-06-05T12:00:00.000Z",
   };
@@ -85,17 +82,6 @@ describe("authorizedFileAccessEntrySchema", () => {
     }
   });
 
-  it("accepts a revoked entry", () => {
-    const entry = {
-      kind: "file_id" as const,
-      ref: "fil_abc",
-      ...baseEntry,
-      revokedAt: "2026-06-05T13:00:00.000Z",
-    };
-
-    expect(authorizedFileAccessEntrySchema.parse(entry)).toEqual(entry);
-  });
-
   it("rejects legacyPath on file_id entries", () => {
     expect(() =>
       authorizedFileAccessEntrySchema.parse({
@@ -116,34 +102,6 @@ describe("authorizedFileAccessEntrySchema", () => {
         ...baseEntry,
       })
     ).toThrow();
-  });
-});
-
-describe("getActiveAuthorizedFileAccessEntries", () => {
-  const baseEntry = {
-    shareScope: "workspace" as const,
-    computedByUserId: "usr_abc",
-    frameContentHash: "hash_v1",
-    allowedAt: "2026-06-05T12:00:00.000Z",
-  } satisfies Omit<AuthorizedFileAccessEntry, "kind" | "ref">;
-
-  it("returns only entries with revokedAt = null", () => {
-    const active = {
-      kind: "file_id" as const,
-      ref: "fil_active",
-      ...baseEntry,
-    };
-    const revoked = {
-      kind: "file_id" as const,
-      ref: "fil_revoked",
-      ...baseEntry,
-      revokedAt: "2026-06-05T13:00:00.000Z",
-    };
-
-    expect(getActiveAuthorizedFileAccessEntries([active, revoked])).toEqual([
-      active,
-    ]);
-    expect(getActiveAuthorizedFileAccessEntries([])).toEqual([]);
   });
 });
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -104,10 +104,8 @@ export type AuthorizedFileAccessKind = z.infer<
 
 const authorizedFileAccessEntryBaseSchema = {
   shareScope: fileShareScopeSchema,
-  computedByUserId: z.string(),
   frameContentHash: z.string(),
   allowedAt: z.string(),
-  revokedAt: z.string().nullable().optional(),
 };
 
 const authorizedFileIdAccessEntrySchema = z
@@ -207,7 +205,6 @@ export function entryToAuthorizedFileRef(
 
 /** Active allowlist view derived from non-revoked DB rows. */
 export type AuthorizedFileAccessAllowlist = {
-  computedByUserId: string;
   generatedByUserId: number | null;
   frameContentHash: string;
   refs: AuthorizedFileRef[];
@@ -222,12 +219,6 @@ export function parseAuthorizedFileAccessEntry(
   data: unknown
 ): AuthorizedFileAccessEntry {
   return authorizedFileAccessEntrySchema.parse(data);
-}
-
-export function getActiveAuthorizedFileAccessEntries(
-  entries: AuthorizedFileAccessEntry[]
-): AuthorizedFileAccessEntry[] {
-  return entries.filter((entry) => entry.revokedAt == null);
 }
 
 export type AuthorizedFileAccessShareError = Omit<DustError, "code"> & {


### PR DESCRIPTION
## Description

Completes the `authorized_file_accesses` FK migration by dropping `computedByUserId` (string sId) and `revokedAt` columns from both the Sequelize model and application code. All reads and writes now exclusively use `generatedByUserId` (integer FK). The `revokedAt: null` soft-delete filter is removed from all queries — rows are hard-replaced on revoke via `persistAuthorizedFileAccess`, so the filter was redundant. `readAllowlistedScopedVizFile` and `reverifyAuthorAccess` now resolve the integer FK to a `UserResource` before constructing the `Authenticator`. The backfill script (`20260606_backfill_frame_authorized_file_access.ts`) is commented out, and `getActiveAuthorizedFileAccessEntries` is removed as a dead helper.

## Tests

Updated unit tests in `authorized_file_access.test.ts`, `file_resource.test.ts`, and `files.test.ts` to reflect the removed fields. Tested locally.

## Risk

Low. This is a post-backfill cleanup — `generatedByUserId` is fully populated before this lands. Dropping `revokedAt` is safe because `persistAuthorizedFileAccess` hard-deletes and re-inserts rows on revoke; no "stale revoked" rows exist in the table. Rollback before the SQL migration is safe: the app code would still function (old FK reads were already in place).

## Deploy Plan

1. Deploy `front`
2. Run post-deploy SQL migration `20260617140000_drop_legacy_authorized_file_access_columns.sql`:
   - Drops partial index `authorized_file_accesses_shareable_file_id_non_revoked` (`DROP INDEX CONCURRENTLY`)
   - Drops columns `computedByUserId` and `revokedAt` from `authorized_file_accesses`
