### PR TITLE
Add: audit log for frame's file access update.

### DIFF
--- a/front/admin/audit_log_schemas/frame.authorized_files_updated.json
+++ b/front/admin/audit_log_schemas/frame.authorized_files_updated.json
@@ -1,0 +1,17 @@
+{
+  "action": "frame.authorized_files_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    }
+  ],
+  "metadata": {
+    "frame_file_id": "string",
+    "frame_file_name": "string",
+    "share_scope": "string",
+    "authorized_ref_count": "string",
+    "authorized_refs": "string",
+    "unverifiable_ref_count": "string",
+    "frame_content_hash": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -28,6 +28,7 @@
   "dsync.connection_deleted": 3,
   "dust_mcp_server.settings_updated": 1,
   "file.moved": 1,
+  "frame.authorized_files_updated": 1,
   "invitation.revoked": 3,
   "invitation.role_updated": 3,
   "mcp_connection.created": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -133,6 +133,7 @@ export const AUDIT_ACTIONS = [
   "datasource.reauthorized",
   // Files.
   "file.moved",
+  "frame.authorized_files_updated",
   // Audit Logs.
   "audit_log.viewed",
   "audit_log.export_configured",

--- a/front/lib/api/viz/authorized_file_access.ts
+++ b/front/lib/api/viz/authorized_file_access.ts
@@ -5,6 +5,7 @@ import {
   isAllowlistStale,
   isAuthorizedFileRef,
 } from "@app/lib/api/viz/authorized_file_access_policy";
+import { emitFrameAuthorizedFilesUpdatedAuditLog } from "@app/lib/api/viz/frame_authorized_files_audit";
 import { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -153,6 +154,13 @@ export async function ensureAuthorizedFileAccessForShare(
   }
 
   await frameFile.persistAuthorizedFileAccess(authorized);
+
+  emitFrameAuthorizedFilesUpdatedAuditLog(
+    auth,
+    frameFile,
+    authorized,
+    currentShareScope
+  );
 
   return new Ok(authorized);
 }

--- a/front/lib/api/viz/frame_authorized_files_audit.ts
+++ b/front/lib/api/viz/frame_authorized_files_audit.ts
@@ -1,0 +1,35 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import type { Authenticator } from "@app/lib/auth";
+import type { FileResource } from "@app/lib/resources/file_resource";
+import type {
+  ComputedAuthorizedFileAccess,
+  FileShareScope,
+} from "@app/types/files";
+import { getAuthorizedFileRefLabel } from "@app/types/files";
+
+export function emitFrameAuthorizedFilesUpdatedAuditLog(
+  auth: Authenticator,
+  frameFile: FileResource,
+  computed: ComputedAuthorizedFileAccess,
+  shareScope: FileShareScope
+): void {
+  void emitAuditLogEvent({
+    auth,
+    action: "frame.authorized_files_updated",
+    targets: [buildAuditLogTarget("workspace", auth.getNonNullableWorkspace())],
+    context: getAuditLogContext(auth),
+    metadata: {
+      frame_file_id: frameFile.sId,
+      frame_file_name: frameFile.fileName,
+      share_scope: shareScope,
+      authorized_ref_count: String(computed.refs.length),
+      authorized_refs: computed.refs.map(getAuthorizedFileRefLabel).join(", "),
+      unverifiable_ref_count: String(computed.unverifiableRefs?.length ?? 0),
+      frame_content_hash: computed.frameContentHash,
+    },
+  });
+}

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -1795,12 +1795,27 @@ export class FileResource extends BaseResource<FileModel> {
     const generatedByUserId =
       auth.user()?.id ?? auth.key()?.userModelId ?? null;
     if (!generatedByUserId) {
-      throw new Error("Cannot compute authorized file access without a user");
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          hasApiKey: auth.key() != null,
+        },
+        "Cannot compute authorized file access without a userId"
+      );
+
+      throw new Error("Cannot compute authorized file access without a userId");
     }
 
     const generatedByUser =
       auth.user() ?? (await UserResource.fetchByModelId(generatedByUserId));
     if (!generatedByUser) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          hasApiKey: auth.key() != null,
+        },
+        "Cannot compute authorized file access without a user"
+      );
       throw new Error("Cannot compute authorized file access without a user");
     }
 


### PR DESCRIPTION
## Description

Emits a `frame.authorized_files_updated` WorkOS audit event every time `ensureAuthorizedFileAccessForShare` persists a new authorized file access allowlist for a Frame. The new `emitFrameAuthorizedFilesUpdatedAuditLog` helper (fire-and-forget via `void`) records the frame file ID/name, share scope, authorized ref count, and unverifiable ref count. Registered in `AUDIT_ACTIONS`, `schema_versions.json` (v1), and backed by a new audit log schema JSON.

Also adds structured `logger.error` calls in `FileResource.computeAuthorizedFileAccess` before both user-resolution throws, surfacing `workspaceId` and `hasApiKey` in logs to ease future debugging.

## Tests

Tested manually by triggering a frame share flow and confirming the audit event appears in WorkOS.

## Risk

Low. The audit emit is fire-and-forget (`void`) — failure to emit has no impact on the share response. Logger additions are purely additive.

## Deploy Plan

Deploy `front`.
