### PR TITLE
Fix wake-up banner not dismissing after wake-up executes

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -265,7 +265,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             !nextData && "mb-10"
           )}
         >
-          <WakeUpMessage message={data} />
+          <WakeUpMessage
+            message={data}
+            owner={context.owner}
+            conversationId={context.conversation?.sId ?? null}
+          />
         </div>
       );
     }

--- a/front/components/assistant/conversation/WakeUpMessage.tsx
+++ b/front/components/assistant/conversation/WakeUpMessage.tsx
@@ -1,11 +1,32 @@
+import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type { UserMessageTypeWithContentFragments } from "@app/types/assistant/conversation";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useEffect } from "react";
 
 interface WakeUpMessageProps {
   message: UserMessageTypeWithContentFragments;
+  owner: LightWorkspaceType;
+  conversationId: string | null;
 }
 
-export function WakeUpMessage({ message }: WakeUpMessageProps) {
+export function WakeUpMessage({
+  message,
+  owner,
+  conversationId,
+}: WakeUpMessageProps) {
+  const { mutateWakeUps } = useConversationWakeUps({
+    owner,
+    conversationId: conversationId ?? "",
+    disabled: !conversationId,
+  });
+
+  useEffect(() => {
+    if (message.visibility !== "pending") {
+      void mutateWakeUps();
+    }
+  }, [message.visibility, mutateWakeUps]);
+
   const label =
     message.visibility === "pending" ? "Wake-up pending" : "Wake-up executed";
 


### PR DESCRIPTION
## Description

When a wake-up executed, the wake-up banner was not dismissing from the conversation UI. We needed to refresh the page for it to disappear. This was because the WakeUpMessage component had no way to trigger a revalidation of the wake-ups list when the message transitioned from pending to executed.

This PR passes owner and conversationId down to WakeUpMessage and adds a useEffect that calls mutateWakeUps() whenever message.visibility changes away from "pending", causing the banner to dismiss immediately after execution.

Before: 
<img width="1512" height="982" alt="Screenshot 2026-06-16 at 16 07 13" src="https://github.com/user-attachments/assets/62f6bba6-5c7f-430a-b75a-74dd8dc4f784" />

After:
<img width="1512" height="982" alt="Screenshot 2026-06-16 at 16 24 08" src="https://github.com/user-attachments/assets/bcc9d4c7-0cfa-4418-ada8-d82801ad4ce9" />

## Tests

Tested a wake-up and verified the banner dismisses once the wake-up executes.

## Risk

Low since the change is limited to the WakeUpMessage component 

## Deploy Plan


