### PR TITLE
Store the pool credit-balance threshold in credit_usage_configurations

### DIFF
--- a/front/lib/api/credits/balance_threshold_alert.test.ts
+++ b/front/lib/api/credits/balance_threshold_alert.test.ts
@@ -1,0 +1,117 @@
+import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
+import { getUsageConfiguration } from "@app/lib/api/credits/usage_configuration";
+import { Authenticator } from "@app/lib/auth";
+import * as balanceThreshold from "@app/lib/metronome/alerts/balance_threshold";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/alerts/balance_threshold", async () => {
+  const actual = await vi.importActual<typeof balanceThreshold>(
+    "@app/lib/metronome/alerts/balance_threshold"
+  );
+  return {
+    ...actual,
+    upsertMetronomeBalanceThresholdAlert: vi.fn(),
+    clearMetronomeBalanceThresholdAlert: vi.fn(),
+  };
+});
+
+const METRONOME_CUSTOMER_ID = "cust_test_xxx";
+
+beforeEach(() => {
+  vi.mocked(
+    balanceThreshold.upsertMetronomeBalanceThresholdAlert
+  ).mockResolvedValue(new Ok({ alertId: "alert_xxx" }));
+  vi.mocked(
+    balanceThreshold.clearMetronomeBalanceThresholdAlert
+  ).mockResolvedValue(new Ok(undefined));
+});
+
+describe("syncMetronomeBalanceThresholdAlert persistence", () => {
+  it("persists the threshold to the configuration and upserts the alert", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits: 500,
+    });
+
+    expect((await getUsageConfiguration(auth)).balanceThresholdCredits).toBe(
+      500
+    );
+    expect(
+      balanceThreshold.upsertMetronomeBalanceThresholdAlert
+    ).toHaveBeenCalled();
+  });
+
+  it("normalizes 0 to null and clears the alert", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits: 0,
+    });
+
+    expect((await getUsageConfiguration(auth)).balanceThresholdCredits).toBe(
+      null
+    );
+    expect(
+      balanceThreshold.clearMetronomeBalanceThresholdAlert
+    ).toHaveBeenCalled();
+    expect(
+      balanceThreshold.upsertMetronomeBalanceThresholdAlert
+    ).not.toHaveBeenCalled();
+  });
+
+  it("clears the stored threshold and the alert when set to null", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits: 500,
+    });
+    await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits: null,
+    });
+
+    expect((await getUsageConfiguration(auth)).balanceThresholdCredits).toBe(
+      null
+    );
+    expect(
+      balanceThreshold.clearMetronomeBalanceThresholdAlert
+    ).toHaveBeenCalled();
+  });
+
+  it("returns an error but keeps the persisted threshold when the alert sync fails", async () => {
+    const workspace = await WorkspaceFactory.creditPriced({
+      metronomeCustomerId: METRONOME_CUSTOMER_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    vi.mocked(
+      balanceThreshold.upsertMetronomeBalanceThresholdAlert
+    ).mockResolvedValue(new Err(new Error("metronome down")));
+
+    const result = await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits: 500,
+    });
+
+    expect(result.isErr()).toBe(true);
+    // Persist-first: the threshold is the source of truth, so it stays written
+    // even when deriving the Metronome alert fails — the sync can be retried.
+    expect((await getUsageConfiguration(auth)).balanceThresholdCredits).toBe(
+      500
+    );
+  });
+});

--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -11,40 +11,20 @@ import {
 } from "@app/lib/metronome/user_block";
 import { notifyAdminsBalanceThresholdReached } from "@app/lib/notifications/workflows/balance-threshold-reached";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 /**
- * Read the workspace's credit-balance-threshold notification setting.
+ * Persist the workspace's credit-balance-threshold notification setting.
  *
- * Metronome is the source of truth: the setting is the threshold of the
- * workspace's balance-threshold alert (cached in Redis). Returns `null` when no
- * threshold is configured, or when the workspace has no Metronome customer.
- */
-export async function getWorkspaceBalanceThreshold(
-  auth: Authenticator
-): Promise<number | null> {
-  const workspace = auth.getNonNullableWorkspace();
-  if (!workspace.metronomeCustomerId) {
-    return null;
-  }
-
-  const { threshold } = await getCachedWorkspaceBalanceThreshold({
-    metronomeCustomerId: workspace.metronomeCustomerId,
-    workspaceId: workspace.sId,
-  });
-  return threshold;
-}
-
-/**
- * Persist the workspace's credit-balance-threshold notification setting to its
- * Metronome customer.
- *
- * A strictly positive `balanceThresholdCredits` upserts the balance-threshold
- * alert; 0 or null clears it (the warning is "off"). No-op when the workspace
- * has no Metronome customer. The underlying Metronome calls are idempotent.
+ * The threshold is stored on `credit_usage_configurations` (the source of
+ * truth), then the Metronome balance-threshold alert is derived from it: a
+ * strictly positive value upserts the alert; 0 or null clears it (the warning
+ * is "off") and is stored as NULL. No-op when the workspace has no Metronome
+ * customer. The underlying Metronome calls are idempotent.
  */
 export async function syncMetronomeBalanceThresholdAlert({
   auth,
@@ -60,6 +40,34 @@ export async function syncMetronomeBalanceThresholdAlert({
 
   const shouldAlert =
     balanceThresholdCredits !== null && balanceThresholdCredits > 0;
+  // Normalize 0 to null — both mean "no threshold / warning off".
+  const normalizedThresholdAwuCredits = shouldAlert
+    ? balanceThresholdCredits
+    : null;
+
+  // Persist the admin's intent first: the credit-usage configuration column is
+  // the source of truth; the Metronome alert below is derived enforcement (a
+  // failed sync can be retried and re-derives from this value). The config row
+  // is created lazily, so upsert it.
+  const existingConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if (existingConfig) {
+    const updateResult = await existingConfig.updateConfiguration(auth, {
+      balanceThresholdAwuCredits: normalizedThresholdAwuCredits,
+    });
+    if (updateResult.isErr()) {
+      return new Err(updateResult.error);
+    }
+  } else {
+    const createResult = await CreditUsageConfigurationResource.makeNew(auth, {
+      defaultDiscountPercent: 0,
+      usageCapCredits: null,
+      balanceThresholdAwuCredits: normalizedThresholdAwuCredits,
+    });
+    if (createResult.isErr()) {
+      return new Err(createResult.error);
+    }
+  }
 
   const alertResult = shouldAlert
     ? await upsertMetronomeBalanceThresholdAlert({

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,7 +1,4 @@
-import {
-  getWorkspaceBalanceThreshold,
-  syncMetronomeBalanceThresholdAlert,
-} from "@app/lib/api/credits/balance_threshold_alert";
+import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
 import type { Authenticator } from "@app/lib/auth";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import type { Result } from "@app/types/shared/result";
@@ -9,9 +6,9 @@ import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
 // Combined workspace-level usage configuration surfaced to admins on the Usage
-// page. `balanceThresholdCredits` is derived from the workspace's Metronome
-// balance-threshold alert (see `balance_threshold_alert.ts`); the upgrade-request
-// toggles are stored on the `credit_usage_configurations` row.
+// page. All fields are stored on the `credit_usage_configurations` row:
+// `balanceThresholdCredits` is the source of truth from which the Metronome
+// balance-threshold alert is derived (see `balance_threshold_alert.ts`).
 export type CreditUsageConfigurationBody = {
   // Credit balance (in AWU credits) below which workspace admins are emailed.
   // `null` means no threshold is configured (the warning is off).
@@ -51,20 +48,18 @@ const DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED = true;
 const DEFAULT_AUTO_SEAT_UPGRADE_ENABLED = false;
 
 /**
- * Read the full usage configuration for a workspace: the Metronome-derived
- * balance threshold plus the upgrade-request toggles. Toggles fall back to their
- * defaults when no configuration row exists yet.
+ * Read the full usage configuration for a workspace: the balance threshold plus
+ * the upgrade-request toggles, all read from the credit-usage configuration row.
+ * Toggles fall back to their defaults when no configuration row exists yet.
  */
 export async function getUsageConfiguration(
   auth: Authenticator
 ): Promise<CreditUsageConfigurationBody> {
-  const [balanceThresholdCredits, config] = await Promise.all([
-    getWorkspaceBalanceThreshold(auth),
-    CreditUsageConfigurationResource.fetchByWorkspaceId(auth),
-  ]);
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
   return {
-    balanceThresholdCredits,
+    balanceThresholdCredits: config?.balanceThresholdAwuCredits ?? null,
     allowMemberUpgradeRequests:
       config?.allowMemberUpgradeRequests ??
       DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS,

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -127,6 +127,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultPoolCapAwuCredits: number | null;
       programmaticMonthlyCapAwuCredits: number | null;
       autoSeatUpgradeEnabled: boolean;
+      balanceThresholdAwuCredits: number | null;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -190,6 +191,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       upgradeRequestEmailEnabled: this.upgradeRequestEmailEnabled,
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
       programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
+      balanceThresholdAwuCredits: this.balanceThresholdAwuCredits,
     };
   }
 
@@ -204,6 +206,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       upgradeRequestEmailEnabled: String(this.upgradeRequestEmailEnabled),
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
       programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
+      balanceThresholdAwuCredits: this.balanceThresholdAwuCredits,
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -37,11 +37,15 @@ import type { CreationOptional } from "sequelize";
  *   are automatically bumped to the next entitled seat tier (free→pro, pro→max,
  *   none→workspace) instead of being blocked. May increase the bill. Defaults to
  *   false.
+ * - balanceThresholdAwuCredits: Credit balance (in AWU credits) below which
+ *   workspace admins are emailed. Source of truth for the threshold value; the
+ *   Metronome balance-threshold alert (see
+ *   `lib/metronome/alerts/balance_threshold.ts`) is derived from it. NULL means
+ *   no threshold is configured (the warning is off); 0 is normalized to NULL.
  *
- * The credit-cap-warning notification settings (whether to warn, and at which
- * balance) are NOT stored here: they are derived from the workspace's Metronome
- * balance-threshold alert (see `lib/metronome/alerts/balance_threshold.ts`),
- * with reads cached in Redis.
+ * The Metronome balance-threshold alert id (used by the webhook to match the
+ * firing alert) is NOT stored here: it is a Metronome-generated value resolved
+ * from the alert, with reads cached in Redis.
  */
 export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsageConfigurationModel> {
   declare createdAt: CreationOptional<Date>;
@@ -54,6 +58,7 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare defaultPoolCapAwuCredits: number | null;
   declare programmaticMonthlyCapAwuCredits: number | null;
   declare autoSeatUpgradeEnabled: CreationOptional<boolean>;
+  declare balanceThresholdAwuCredits: number | null;
 }
 
 CreditUsageConfigurationModel.init(
@@ -120,6 +125,11 @@ CreditUsageConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    balanceThresholdAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/20260617_backfill_balance_thresholds.ts
+++ b/front/migrations/20260617_backfill_balance_thresholds.ts
@@ -1,0 +1,108 @@
+import { Authenticator } from "@app/lib/auth";
+import { getCachedWorkspaceBalanceThreshold } from "@app/lib/metronome/alerts/balance_threshold";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Backfill `credit_usage_configurations.balanceThresholdAwuCredits` from the
+ * existing Metronome balance-threshold alert. The alert threshold is the value
+ * the admin entered (in AWU credits), so we copy it directly. The credit-usage
+ * configuration row is created lazily, so upsert it.
+ *
+ * Idempotent: workspaces already carrying the expected value are skipped.
+ *
+ * Pass `--wId <workspaceId>` to run on a single workspace.
+ */
+makeScript(
+  {
+    wId: {
+      type: "string",
+      required: false,
+      description: "Run on a single workspace (sId).",
+    },
+  },
+  async ({ execute, wId }, logger) => {
+    let updated = 0;
+    let alreadySet = 0;
+    let skipped = 0;
+
+    await runOnAllWorkspaces(
+      async (workspace) => {
+        const { metronomeCustomerId } = workspace;
+        if (!metronomeCustomerId) {
+          return;
+        }
+
+        let balanceThresholdAwuCredits: number | null;
+        try {
+          const { threshold } = await getCachedWorkspaceBalanceThreshold({
+            metronomeCustomerId,
+            workspaceId: workspace.sId,
+          });
+          balanceThresholdAwuCredits = threshold;
+        } catch (err) {
+          logger.error(
+            { workspaceId: workspace.sId, err: normalizeError(err) },
+            "Failed to read balance threshold alert; skipping workspace."
+          );
+          skipped++;
+          return;
+        }
+
+        if (balanceThresholdAwuCredits === null) {
+          // No balance threshold configured for this workspace.
+          return;
+        }
+
+        const auth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        const config =
+          await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+        if (config?.balanceThresholdAwuCredits === balanceThresholdAwuCredits) {
+          alreadySet++;
+          return;
+        }
+
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            balanceThresholdAwuCredits,
+            previous: config?.balanceThresholdAwuCredits ?? null,
+          },
+          execute
+            ? "Backfilling balance threshold."
+            : "Would backfill balance threshold."
+        );
+        if (execute) {
+          const writeResult = config
+            ? await config.updateConfiguration(auth, {
+                balanceThresholdAwuCredits,
+              })
+            : await CreditUsageConfigurationResource.makeNew(auth, {
+                defaultDiscountPercent: 0,
+                usageCapCredits: null,
+                balanceThresholdAwuCredits,
+              });
+          if (writeResult.isErr()) {
+            logger.error(
+              { workspaceId: workspace.sId, err: writeResult.error },
+              "Failed to persist balance threshold; skipping workspace."
+            );
+            skipped++;
+            return;
+          }
+        }
+        updated++;
+      },
+      { wId }
+    );
+
+    logger.info(
+      { updated, alreadySet, skipped },
+      execute ? "Backfill completed." : "Dry run completed."
+    );
+  }
+);

--- a/front/migrations/pre-deploy/20260617142734_add_balance_threshold_awu_credits.sql
+++ b/front/migrations/pre-deploy/20260617142734_add_balance_threshold_awu_credits.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "balanceThresholdAwuCredits" integer;


### PR DESCRIPTION
## Description

Persist the workspace credit-balance-threshold notification setting on credit_usage_configurations as the source of truth; the Metronome balance-threshold alert is derived from it. The admin read path (getUsageConfiguration) now reads the DB column instead of the cached Metronome alert; syncMetronomeBalanceThresholdAlert persists the value first, then derives the alert. The webhook handlers keep resolving the Metronome alert id (for firing-alert matching). 0 is normalized to NULL (warning off).

## Tests

local

## Risk

Low

## Deploy Plan

1. merge
2. run pre-deploy migration
3. run `npx tsx front/migrations/20260617_backfill_balance_thresholds.ts --wId <wid> --execute` on Metronome-billed workspaces