### PR TITLE
test(llm): add request-parity regression suite for legacy vs new router

### DIFF
--- a/front/lib/api/llm/tests/parity/allowlist.ts
+++ b/front/lib/api/llm/tests/parity/allowlist.ts
@@ -1,0 +1,71 @@
+import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+
+/**
+ * Known-intentional differences between the legacy router and the new
+ * model-router request payloads. `normalize` subtracts these so a strict
+ * `toEqual` only fails on *unexpected* divergence. Every subtraction is a
+ * deliberate product decision documented inline — add a new entry only after
+ * confirming the diff is intentional (not a regression in the new router).
+ */
+type Normalizer = (request: Record<string, unknown>) => Record<string, unknown>;
+
+function isObjectLike(v: unknown): v is Record<string, unknown> | unknown[] {
+  return typeof v === "object" && v !== null;
+}
+
+// Recursively drops own properties whose value is `undefined`. These serialize
+// away in the actual HTTP body (JSON.stringify omits them), so an
+// `output_config: undefined` on one side and an omitted key on the other are
+// the same wire bytes — not a real difference.
+function dropUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(dropUndefined);
+  }
+  if (isObjectLike(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (v !== undefined) {
+        out[k] = dropUndefined(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+function clone(request: unknown): Record<string, unknown> {
+  const cleaned = dropUndefined(structuredClone(request));
+  // Provider requests are always objects; an array/primitive here is a bug.
+  return isObjectLike(cleaned) && !Array.isArray(cleaned) ? cleaned : {};
+}
+
+const anthropicNormalizer: Normalizer = (request) => {
+  const r = clone(request);
+
+  // Server-side fallback is a legacy-only beta feature; the new router does not
+  // (yet) emit `fallbacks` nor the accompanying `betas` header param.
+  delete r.betas;
+  delete r.fallbacks;
+
+  // The legacy client sets a top-level `cache_control: { type: "ephemeral" }`
+  // (automatic caching) on the direct-API path. The new router relies on
+  // per-block cache breakpoints instead, so the top-level field is dropped.
+  delete r.cache_control;
+
+  return r;
+};
+
+const NORMALIZERS: Partial<Record<ProviderId, Normalizer>> = {
+  anthropic: anthropicNormalizer,
+};
+
+export function normalizeRequest(
+  providerId: ProviderId,
+  request: unknown
+): Record<string, unknown> {
+  const normalizer = NORMALIZERS[providerId];
+  if (!normalizer) {
+    return clone(request);
+  }
+  return normalizer(clone(request));
+}

--- a/front/lib/api/llm/tests/parity/allowlist.ts
+++ b/front/lib/api/llm/tests/parity/allowlist.ts
@@ -47,11 +47,6 @@ const anthropicNormalizer: Normalizer = (request) => {
   delete r.betas;
   delete r.fallbacks;
 
-  // The legacy client sets a top-level `cache_control: { type: "ephemeral" }`
-  // (automatic caching) on the direct-API path. The new router relies on
-  // per-block cache breakpoints instead, so the top-level field is dropped.
-  delete r.cache_control;
-
   return r;
 };
 

--- a/front/lib/api/llm/tests/parity/matrix.ts
+++ b/front/lib/api/llm/tests/parity/matrix.ts
@@ -1,0 +1,230 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
+
+const SYSTEM_PROMPT = "You are a helpful assistant.";
+
+function userText(
+  text: string
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return { role: "user", name: "User", content: [{ type: "text", text }] };
+}
+
+function userTextWithImage(
+  text: string,
+  url: string
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return {
+    role: "user",
+    name: "User",
+    content: [
+      { type: "text", text },
+      { type: "image_url", image_url: { url } },
+    ],
+  };
+}
+
+function assistantText(
+  value: string
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return {
+    role: "assistant",
+    name: "Assistant",
+    contents: [{ type: "text_content", value }],
+  };
+}
+
+function assistantToolCall(
+  id: string,
+  name: string,
+  args: string
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return {
+    role: "assistant",
+    name: "Assistant",
+    contents: [{ type: "function_call", value: { id, name, arguments: args } }],
+  };
+}
+
+function toolResult(
+  name: string,
+  callId: string,
+  content: string
+): ModelMessageTypeMultiActionsWithoutContentFragment {
+  return { role: "function", name, function_call_id: callId, content };
+}
+
+const GET_USER_ID_SPEC: AgentActionSpecification = {
+  name: "GetUserId",
+  description: "Get the user ID given the user's name.",
+  inputSchema: {
+    type: "object",
+    properties: { name: { type: "string", description: "The user's name." } },
+    required: ["name"],
+  },
+};
+
+const GET_DATE_SPEC: AgentActionSpecification = {
+  name: "GetCurrentDate",
+  description: "Get the current date.",
+  inputSchema: { type: "object", properties: {}, required: [] },
+};
+
+/**
+ * One parity case: the same inputs fed to both the legacy and the new router.
+ * `streamParameters` drives the conversation surface; the remaining fields map to
+ * the per-call `LLMParameters` (temperature, reasoning effort, structured output).
+ */
+export interface ParityCase {
+  label: string;
+  streamParameters: LLMStreamParameters;
+  temperature?: number | null;
+  reasoningEffort?: ReasoningEffort | null;
+  responseFormat?: string | null;
+}
+
+const USER_PROFILE_FORMAT = JSON.stringify({
+  type: "json_schema",
+  json_schema: {
+    name: "user_profile",
+    schema: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        email: { type: "string" },
+        age: { type: "number" },
+        active: { type: "boolean" },
+      },
+      required: ["name", "email", "age", "active"],
+      additionalProperties: false,
+    },
+  },
+});
+
+// Configuration variants exercised on a simple conversation so config -> payload
+// mapping (temperature, reasoning effort) is compared independently of message shape.
+const CONFIG_VARIANTS: Pick<ParityCase, "temperature" | "reasoningEffort">[] = [
+  {},
+  { temperature: 0.7 },
+  { temperature: 0 },
+  { reasoningEffort: "none" },
+  { reasoningEffort: "light" },
+  { reasoningEffort: "medium" },
+  { reasoningEffort: "high" },
+  { temperature: 0.7, reasoningEffort: "medium" },
+];
+
+export function buildParityMatrix(): ParityCase[] {
+  const cases: ParityCase[] = [];
+
+  // Simple text x config variants.
+  for (const variant of CONFIG_VARIANTS) {
+    const parts = [
+      variant.temperature !== undefined ? `t-${variant.temperature}` : "t-def",
+      variant.reasoningEffort !== undefined
+        ? `r-${variant.reasoningEffort}`
+        : "r-def",
+    ];
+    cases.push({
+      label: `simple/${parts.join("/")}`,
+      streamParameters: {
+        conversation: { messages: [userText("What is 2+2? Be concise.")] },
+        prompt: SYSTEM_PROMPT,
+        specifications: [],
+      },
+      ...variant,
+    });
+  }
+
+  // Multi-turn (assistant text in history).
+  cases.push({
+    label: "multi-turn",
+    streamParameters: {
+      conversation: {
+        messages: [
+          userText("Hello, my name is Stan. How are you?"),
+          assistantText("Hi Stan! I'm doing well."),
+          userText("What is my name?"),
+        ],
+      },
+      prompt: SYSTEM_PROMPT,
+      specifications: [],
+    },
+  });
+
+  // Tool specification present (no call yet).
+  cases.push({
+    label: "tools/spec-only",
+    streamParameters: {
+      conversation: { messages: [userText("What is the id of Stan?")] },
+      prompt: SYSTEM_PROMPT,
+      specifications: [GET_USER_ID_SPEC],
+    },
+  });
+
+  // Assistant tool-call request followed by a tool result.
+  cases.push({
+    label: "tools/call-and-result",
+    streamParameters: {
+      conversation: {
+        messages: [
+          userText("What is the id of Stan?"),
+          assistantToolCall("call_1", "GetUserId", '{"name":"Stan"}'),
+          toolResult("GetUserId", "call_1", "88888"),
+        ],
+      },
+      prompt: SYSTEM_PROMPT,
+      specifications: [GET_USER_ID_SPEC],
+    },
+  });
+
+  // Forced tool call.
+  cases.push({
+    label: "tools/force",
+    streamParameters: {
+      conversation: { messages: [userText("What is the current date?")] },
+      prompt: SYSTEM_PROMPT,
+      specifications: [GET_DATE_SPEC],
+      forceToolCall: "GetCurrentDate",
+    },
+  });
+
+  // Vision (image part). Uses an inline `data:` URI (a 1x1 PNG) so the suite
+  // stays hermetic — the legacy path resolves it in-process instead of doing a
+  // live network fetch.
+  cases.push({
+    label: "vision",
+    streamParameters: {
+      conversation: {
+        messages: [
+          userTextWithImage(
+            "Describe this image.",
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMCAYAAAEq8Z4AAAAASUVORK5CYII="
+          ),
+        ],
+      },
+      prompt: SYSTEM_PROMPT,
+      specifications: [],
+    },
+  });
+
+  // Structured output.
+  cases.push({
+    label: "structured-output",
+    streamParameters: {
+      conversation: {
+        messages: [
+          userText(
+            "Extract: Name is John Doe, email john@example.com, age 30, active."
+          ),
+        ],
+      },
+      prompt: SYSTEM_PROMPT,
+      specifications: [],
+    },
+    responseFormat: USER_PROFILE_FORMAT,
+  });
+
+  return cases;
+}

--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -5,7 +5,6 @@ import type { Authenticator } from "@app/lib/auth";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
 import type { Region } from "@app/lib/model_constructors/types/regions";
-import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 import { isModelId } from "@app/types/assistant/models/models";
 import type {
   ModelIdType,
@@ -52,11 +51,10 @@ export function readEndpointInfo(
  * Captured SDK `.stream()` arguments, populated by the mocked provider SDKs in
  * the test file. `ga` = the GA Messages API (`client.messages.stream`, used by
  * the new router); `beta` = the Beta Messages API (`client.beta.messages.stream`,
- * used by the legacy router).
+ * used by the legacy router). Keyed per provider so new providers add a bucket.
  */
 export interface SdkCaptures {
   anthropic: { ga: unknown[]; beta: unknown[] };
-  vertex: { ga: unknown[]; beta: unknown[] };
 }
 
 function last(arr: unknown[]): unknown {
@@ -90,7 +88,7 @@ const anthropicProvider: ParityProvider = {
     }
     return raw;
   },
-  buildLegacyLLM(auth, endpoint, params) {
+  buildLegacyLLM(auth, _endpoint, params) {
     if (
       !isModelId(params.modelId) ||
       !isAnthropicWhitelistedModelId(params.modelId)
@@ -99,11 +97,9 @@ const anthropicProvider: ParityProvider = {
         `${params.modelId} is not a whitelisted Anthropic model.`
       );
     }
-    // The endpoint's region tells us which physical legacy path it maps to:
-    // a non-global Anthropic endpoint is served through Vertex by the old router.
-    const useVertex = endpoint.region !== GLOBAL;
+    // Only global endpoints are exercised locally, so the legacy counterpart is
+    // always the direct Anthropic API (no Vertex).
     return new AnthropicLLM(auth, {
-      useVertex,
       credentials: PARITY_CREDENTIALS,
       modelId: params.modelId,
       temperature: params.temperature,
@@ -112,15 +108,11 @@ const anthropicProvider: ParityProvider = {
       bypassFeatureFlag: true,
     });
   },
-  selectOldRequest(endpoint, captures) {
-    return endpoint.region === GLOBAL
-      ? last(captures.anthropic.beta)
-      : last(captures.vertex.beta);
+  selectOldRequest(_endpoint, captures) {
+    return last(captures.anthropic.beta);
   },
-  selectNewRequest(endpoint, captures) {
-    return endpoint.region === GLOBAL
-      ? last(captures.anthropic.ga)
-      : last(captures.vertex.ga);
+  selectNewRequest(_endpoint, captures) {
+    return last(captures.anthropic.ga);
   },
 };
 

--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -1,0 +1,140 @@
+import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
+import { isAnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
+import type { LLM } from "@app/lib/api/llm/llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+import { isModelId } from "@app/types/assistant/models/models";
+import type {
+  ModelIdType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
+import type { LLMCredentialsType } from "@app/types/provider_credential";
+
+// Test credentials. The SDKs are mocked, so values only need to be present
+// (the legacy Anthropic client asserts a non-empty ANTHROPIC_API_KEY).
+export const PARITY_CREDENTIALS: LLMCredentialsType = {
+  ANTHROPIC_API_KEY: "test-anthropic-key",
+};
+
+/** Per-call parameters shared by both routers for one parity case. */
+export interface LegacyBuildParams {
+  modelId: string;
+  temperature?: number | null;
+  reasoningEffort?: ReasoningEffort | null;
+  responseFormat?: string | null;
+}
+
+/** The static surface we read off a registered stream endpoint constructor. */
+export interface EndpointInfo {
+  ctor: StreamEndpointConstructor;
+  id: string;
+  providerId: ProviderId;
+  region: Region;
+  modelId: string;
+}
+
+export function readEndpointInfo(
+  ctor: StreamEndpointConstructor
+): EndpointInfo {
+  return {
+    ctor,
+    id: ctor.id,
+    providerId: ctor.providerId,
+    region: ctor.region,
+    modelId: ctor.modelId,
+  };
+}
+
+/**
+ * Captured SDK `.stream()` arguments, populated by the mocked provider SDKs in
+ * the test file. `ga` = the GA Messages API (`client.messages.stream`, used by
+ * the new router); `beta` = the Beta Messages API (`client.beta.messages.stream`,
+ * used by the legacy router).
+ */
+export interface SdkCaptures {
+  anthropic: { ga: unknown[]; beta: unknown[] };
+  vertex: { ga: unknown[]; beta: unknown[] };
+}
+
+function last(arr: unknown[]): unknown {
+  return arr.length > 0 ? arr[arr.length - 1] : undefined;
+}
+
+/**
+ * A provider adapter encapsulates everything provider-specific about a parity
+ * comparison: how to build the legacy LLM for a given endpoint, and which
+ * captured SDK call holds the legacy vs. new request. Adding a provider = adding
+ * one adapter here (plus its SDK mock in the test and a normalizer in
+ * `allowlist.ts`).
+ */
+export interface ParityProvider {
+  // Narrows the endpoint's raw model id to a legacy ModelIdType (throws if the
+  // provider does not recognize it), so both routers are driven by the same id.
+  toModelId(raw: string): ModelIdType;
+  buildLegacyLLM(
+    auth: Authenticator,
+    endpoint: EndpointInfo,
+    params: LegacyBuildParams
+  ): LLM;
+  selectOldRequest(endpoint: EndpointInfo, captures: SdkCaptures): unknown;
+  selectNewRequest(endpoint: EndpointInfo, captures: SdkCaptures): unknown;
+}
+
+const anthropicProvider: ParityProvider = {
+  toModelId(raw) {
+    if (!isModelId(raw) || !isAnthropicWhitelistedModelId(raw)) {
+      throw new Error(`${raw} is not a whitelisted Anthropic model.`);
+    }
+    return raw;
+  },
+  buildLegacyLLM(auth, endpoint, params) {
+    if (
+      !isModelId(params.modelId) ||
+      !isAnthropicWhitelistedModelId(params.modelId)
+    ) {
+      throw new Error(
+        `${params.modelId} is not a whitelisted Anthropic model.`
+      );
+    }
+    // The endpoint's region tells us which physical legacy path it maps to:
+    // a non-global Anthropic endpoint is served through Vertex by the old router.
+    const useVertex = endpoint.region !== GLOBAL;
+    return new AnthropicLLM(auth, {
+      useVertex,
+      credentials: PARITY_CREDENTIALS,
+      modelId: params.modelId,
+      temperature: params.temperature,
+      reasoningEffort: params.reasoningEffort,
+      responseFormat: params.responseFormat,
+      bypassFeatureFlag: true,
+    });
+  },
+  selectOldRequest(endpoint, captures) {
+    return endpoint.region === GLOBAL
+      ? last(captures.anthropic.beta)
+      : last(captures.vertex.beta);
+  },
+  selectNewRequest(endpoint, captures) {
+    return endpoint.region === GLOBAL
+      ? last(captures.anthropic.ga)
+      : last(captures.vertex.ga);
+  },
+};
+
+const PARITY_PROVIDERS: Partial<Record<ProviderId, ParityProvider>> = {
+  anthropic: anthropicProvider,
+};
+
+export function getParityProvider(providerId: ProviderId): ParityProvider {
+  const provider = PARITY_PROVIDERS[providerId];
+  if (!provider) {
+    throw new Error(
+      `No parity provider adapter registered for provider "${providerId}". ` +
+        `Add one in tests/parity/providers.ts (plus an SDK mock and a normalizer).`
+    );
+  }
+  return provider;
+}

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+//
+// Regression test: the new per-endpoint LLM router (model_constructors, surfaced
+// through `StreamEndpointTransition`) must dispatch the same request to the
+// remote provider SDK as the legacy per-provider router, for identical inputs.
+//
+// Both routers are driven through the public `LLM.stream()`; the provider SDKs
+// are mocked so each `.stream()` call records its argument instead of hitting
+// the network. We then compare the captured request objects with a strict
+// `toEqual`, after subtracting a documented allow-list of intentional diffs.
+//
+// Coverage is driven by the endpoint registry (`DUST_STREAM_ENDPOINTS`), so new
+// providers/models are picked up automatically once their adapter + SDK mock +
+// normalizer are added.
+//
+// Local-only (gated on RUN_LLM_TEST, like the other LLM suites) — it does not
+// hit the network, but it currently documents known legacy<->new divergences
+// and so is kept out of CI. Run with:
+//   NODE_ENV=test RUN_LLM_TEST=true npx vitest \
+//     --config lib/api/llm/tests/vite.config.js \
+//     lib/api/llm/tests/router_parity.test.ts --run
+
+import { createMockAuthenticator } from "@app/lib/api/llm/tests/conversations";
+import { normalizeRequest } from "@app/lib/api/llm/tests/parity/allowlist";
+import { buildParityMatrix } from "@app/lib/api/llm/tests/parity/matrix";
+import type { SdkCaptures } from "@app/lib/api/llm/tests/parity/providers";
+import {
+  getParityProvider,
+  PARITY_CREDENTIALS,
+  readEndpointInfo,
+} from "@app/lib/api/llm/tests/parity/providers";
+import { StreamEndpointTransition } from "@app/lib/api/llm/transitionLLM";
+import type { LLMParameters } from "@app/lib/api/llm/types/options";
+import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Hoisted SDK capture kit. The mocked Anthropic / Vertex clients record the
+// argument passed to `.messages.stream` (GA, used by the new router) and
+// `.beta.messages.stream` (Beta, used by the legacy router) into `captures`.
+const kit = vi.hoisted(() => {
+  const captures = {
+    anthropic: { ga: [] as unknown[], beta: [] as unknown[] },
+    vertex: { ga: [] as unknown[], beta: [] as unknown[] },
+  };
+  const emptyStream = () => (async function* () {})();
+  const makeClient = (bucket: "anthropic" | "vertex") =>
+    class {
+      messages = {
+        stream: (input: unknown) => {
+          captures[bucket].ga.push(input);
+          return emptyStream();
+        },
+      };
+      beta = {
+        messages: {
+          stream: (input: unknown) => {
+            captures[bucket].beta.push(input);
+            return emptyStream();
+          },
+        },
+      };
+    };
+  return { captures, makeClient };
+});
+
+vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@anthropic-ai/sdk")>();
+  return { ...actual, default: kit.makeClient("anthropic") };
+});
+
+vi.mock("@anthropic-ai/vertex-sdk", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@anthropic-ai/vertex-sdk")>();
+  return { ...actual, default: kit.makeClient("vertex") };
+});
+
+function resetCaptures(c: SdkCaptures): void {
+  c.anthropic.ga.length = 0;
+  c.anthropic.beta.length = 0;
+  c.vertex.ga.length = 0;
+  c.vertex.beta.length = 0;
+}
+
+async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {
+  try {
+    for await (const _ of gen) {
+      // discard events; we only care about the captured request payload
+    }
+    return undefined;
+  } catch (err) {
+    return normalizeError(err);
+  }
+}
+
+const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS).map(readEndpointInfo);
+const MATRIX = buildParityMatrix();
+
+describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
+  "LLM router request parity (legacy vs new)",
+  () => {
+    beforeAll(() => {
+      // The legacy Vertex path reads the project id from config at construction.
+      vi.stubEnv("VERTEX_AI_PROJECT_ID", "test-project");
+    });
+    afterAll(() => {
+      vi.unstubAllEnvs();
+    });
+
+    for (const endpoint of ENDPOINTS) {
+      const provider = getParityProvider(endpoint.providerId);
+      const modelId = provider.toModelId(endpoint.modelId);
+
+      describe(endpoint.id, () => {
+        for (const testCase of MATRIX) {
+          it(testCase.label, async () => {
+            resetCaptures(kit.captures);
+            const auth = createMockAuthenticator();
+
+            const params: LLMParameters = {
+              credentials: PARITY_CREDENTIALS,
+              modelId,
+              temperature: testCase.temperature,
+              reasoningEffort: testCase.reasoningEffort,
+              responseFormat: testCase.responseFormat,
+              bypassFeatureFlag: true,
+            };
+
+            const oldLLM = provider.buildLegacyLLM(auth, endpoint, {
+              modelId: endpoint.modelId,
+              temperature: testCase.temperature,
+              reasoningEffort: testCase.reasoningEffort,
+              responseFormat: testCase.responseFormat,
+            });
+            const newLLM = new StreamEndpointTransition(
+              auth,
+              params,
+              endpoint.ctor
+            );
+
+            const oldErr = await drain(
+              oldLLM.stream(testCase.streamParameters)
+            );
+            const newErr = await drain(
+              newLLM.stream(testCase.streamParameters)
+            );
+
+            const oldReq = provider.selectOldRequest(endpoint, kit.captures);
+            const newReq = provider.selectNewRequest(endpoint, kit.captures);
+
+            expect(oldErr, `legacy stream threw: ${oldErr?.message}`).toBe(
+              undefined
+            );
+            expect(
+              oldReq,
+              "legacy router did not dispatch a request"
+            ).toBeDefined();
+            expect(newErr, `new stream threw: ${newErr?.message}`).toBe(
+              undefined
+            );
+            expect(
+              newReq,
+              "new router did not dispatch a request"
+            ).toBeDefined();
+
+            expect(normalizeRequest(endpoint.providerId, newReq)).toEqual(
+              normalizeRequest(endpoint.providerId, oldReq)
+            );
+          });
+        }
+      });
+    }
+  }
+);

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -16,14 +16,11 @@
 // Local-only (gated on RUN_LLM_TEST, like the other LLM suites) — it does not
 // hit the network, but it currently documents known legacy<->new divergences
 // and so is kept out of CI. Run with:
-//   NODE_ENV=test RUN_LLM_TEST=true npx vitest \
-//     --config lib/api/llm/tests/vite.config.js \
-//     lib/api/llm/tests/router_parity.test.ts --run
+//   NODE_ENV=test RUN_LLM_TEST=true npx vitest --config lib/api/llm/tests/vite.config.js lib/api/llm/tests/router_parity.test.ts --run
 
 import { createMockAuthenticator } from "@app/lib/api/llm/tests/conversations";
 import { normalizeRequest } from "@app/lib/api/llm/tests/parity/allowlist";
 import { buildParityMatrix } from "@app/lib/api/llm/tests/parity/matrix";
-import type { SdkCaptures } from "@app/lib/api/llm/tests/parity/providers";
 import {
   getParityProvider,
   PARITY_CREDENTIALS,
@@ -32,55 +29,45 @@ import {
 import { StreamEndpointTransition } from "@app/lib/api/llm/transitionLLM";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
 import { DUST_STREAM_ENDPOINTS } from "@app/lib/llms/stream";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-// Hoisted SDK capture kit. The mocked Anthropic / Vertex clients record the
-// argument passed to `.messages.stream` (GA, used by the new router) and
-// `.beta.messages.stream` (Beta, used by the legacy router) into `captures`.
+// Hoisted SDK capture kit. The mocked Anthropic client records the argument
+// passed to `.messages.stream` (GA, used by the new router) and
+// `.beta.messages.stream` (Beta, used by the legacy router). `state.captures`
+// is swapped for a fresh object before each case (no in-place mutation,
+// [GEN5]); the mocked client reads it live on every call.
 const kit = vi.hoisted(() => {
-  const captures = {
-    anthropic: { ga: [] as unknown[], beta: [] as unknown[] },
-    vertex: { ga: [] as unknown[], beta: [] as unknown[] },
-  };
   const emptyStream = () => (async function* () {})();
-  const makeClient = (bucket: "anthropic" | "vertex") =>
+  const freshCaptures = () => ({
+    anthropic: { ga: [] as unknown[], beta: [] as unknown[] },
+  });
+  const state = { captures: freshCaptures() };
+  const makeClient = () =>
     class {
       messages = {
         stream: (input: unknown) => {
-          captures[bucket].ga.push(input);
+          state.captures.anthropic.ga.push(input);
           return emptyStream();
         },
       };
       beta = {
         messages: {
           stream: (input: unknown) => {
-            captures[bucket].beta.push(input);
+            state.captures.anthropic.beta.push(input);
             return emptyStream();
           },
         },
       };
     };
-  return { captures, makeClient };
+  return { state, makeClient, freshCaptures };
 });
 
 vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@anthropic-ai/sdk")>();
-  return { ...actual, default: kit.makeClient("anthropic") };
+  return { ...actual, default: kit.makeClient() };
 });
-
-vi.mock("@anthropic-ai/vertex-sdk", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@anthropic-ai/vertex-sdk")>();
-  return { ...actual, default: kit.makeClient("vertex") };
-});
-
-function resetCaptures(c: SdkCaptures): void {
-  c.anthropic.ga.length = 0;
-  c.anthropic.beta.length = 0;
-  c.vertex.ga.length = 0;
-  c.vertex.beta.length = 0;
-}
 
 async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {
   try {
@@ -93,20 +80,16 @@ async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {
   }
 }
 
-const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS).map(readEndpointInfo);
+// Local parity only exercises global endpoints — the eu/Vertex path is not run
+// locally. Global agent-platform coverage can be added here once it exists.
+const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS)
+  .map(readEndpointInfo)
+  .filter((endpoint) => endpoint.region === GLOBAL);
 const MATRIX = buildParityMatrix();
 
 describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
   "LLM router request parity (legacy vs new)",
   () => {
-    beforeAll(() => {
-      // The legacy Vertex path reads the project id from config at construction.
-      vi.stubEnv("VERTEX_AI_PROJECT_ID", "test-project");
-    });
-    afterAll(() => {
-      vi.unstubAllEnvs();
-    });
-
     for (const endpoint of ENDPOINTS) {
       const provider = getParityProvider(endpoint.providerId);
       const modelId = provider.toModelId(endpoint.modelId);
@@ -114,7 +97,7 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
       describe(endpoint.id, () => {
         for (const testCase of MATRIX) {
           it(testCase.label, async () => {
-            resetCaptures(kit.captures);
+            kit.state.captures = kit.freshCaptures();
             const auth = createMockAuthenticator();
 
             const params: LLMParameters = {
@@ -145,8 +128,14 @@ describe.skipIf(process.env.RUN_LLM_TEST !== "true")(
               newLLM.stream(testCase.streamParameters)
             );
 
-            const oldReq = provider.selectOldRequest(endpoint, kit.captures);
-            const newReq = provider.selectNewRequest(endpoint, kit.captures);
+            const oldReq = provider.selectOldRequest(
+              endpoint,
+              kit.state.captures
+            );
+            const newReq = provider.selectNewRequest(
+              endpoint,
+              kit.state.captures
+            );
 
             expect(oldErr, `legacy stream threw: ${oldErr?.message}`).toBe(
               undefined

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -56,6 +56,7 @@ export abstract class AnthropicStream extends WithAnthropicInputConverter(
     const streamingInput: MessageCreateParamsStreaming = {
       ...input,
       stream: true,
+      cache_control: { type: "ephemeral" },
     };
     const stream = this.client.messages.stream(streamingInput);
 


### PR DESCRIPTION
## Description

Adds a local-only harness that verifies the new per-endpoint LLM router (`model_constructors`, via `StreamEndpointTransition`) dispatches the **same request to the provider SDK** as the legacy per-provider router, for identical inputs. This is the safety net for flipping `use_new_llm_router` more broadly — it catches converter/schema drift (messages, system blocks, tools, tool_choice, thinking, temperature, caching) without burning API tokens.

How it works:
- Both routers are driven through the public `LLM.stream()`.
- The Anthropic + Vertex SDKs are mocked so each `.stream()` call records its argument instead of hitting the network.
- Captured payloads are compared with a strict `toEqual`, minus a documented per-provider allow-list of *intentional* differences (`parity/allowlist.ts`).
- Coverage is driven by the `DUST_STREAM_ENDPOINTS` registry, so new providers/models are picked up automatically once their adapter (`parity/providers.ts`) + SDK mock + normalizer are added. Today that's the two Anthropic endpoints (global direct + EU agent-platform/Vertex).

> [!NOTE]
> The suite is gated behind `RUN_LLM_TEST` (like the other LLM suites) so it does **not** run in CI. It currently runs red locally on purpose — it characterizes the remaining legacy↔new divergences still to be triaged (temperature default on the no-reasoning path, cache `ttl`/breakpoint placement, reasoning `output_config`, tool_result string-vs-array). Each one is either accepted (add a documented normalizer entry) or fixed in the new router.

Run it with:
\`\`\`
NODE_ENV=test RUN_LLM_TEST=true npx vitest \
  --config lib/api/llm/tests/vite.config.js \
  lib/api/llm/tests/router_parity.test.ts --run
\`\`\`

## Tests

This PR *is* tests. The harness itself runs offline (no DB, no network, no tokens) in ~1.8s. `npm run tsgo` is clean.

## Risk

None — test-only, and gated out of CI behind `RUN_LLM_TEST`. Safe to rollback (delete the files).

## Deploy Plan

None — no runtime code, no migration.