### PR TITLE
feat(connectors): install postgresql-client for migration apply support

### DIFF
--- a/dockerfiles/connectors.Dockerfile
+++ b/dockerfiles/connectors.Dockerfile
@@ -1,5 +1,9 @@
 FROM node:24.14.0 as connectors
 
+RUN apt-get update && \
+  apt-get install -y postgresql-client && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g npm@11.11.0
 
 WORKDIR /app


### PR DESCRIPTION
## Description

Installs `postgresql-client` in the connectors Docker image. The connectors migration script (`scripts/migrate.ts`) uses `psql` to apply SQL migration files directly — bypassing PgBouncer's transaction-pooling mode, which is required for `CREATE INDEX CONCURRENTLY` and `SET SESSION` statements. Without `psql` in the image, `migration:apply:pre-deploy` and `migration:apply:post-deploy` would fail at runtime.

The front image already includes `postgresql-client`; this brings connectors to parity.
