### PR TITLE
[LLM] Sort stream endpoints to prefer the current region first

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -34,6 +34,7 @@ import type {
   Where,
   WorkspaceFilter,
 } from "@app/lib/llms/stream/types/filter";
+import { sortEndpointsByPreferredRegion } from "@app/lib/llms/utils/sort_endpoints";
 import { isModelId } from "@app/lib/model_constructors/types/model_ids";
 import {
   isProviderId,
@@ -51,7 +52,6 @@ import type { LLMCredentialsType } from "@app/types/provider_credential";
 import type { RegionType } from "@app/types/region";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import intersection from "lodash/intersection";
-import sortBy from "lodash/sortBy";
 
 // EAP (Early Access Program) models are served through a dedicated Anthropic
 // workspace key (ANTHROPIC_EAP_API_KEY) rather than the workspace's
@@ -248,6 +248,7 @@ export async function getLLM(
 
 function getRegionFilter(auth: Authenticator): ValueFilter<Region> | undefined {
   const dustRegion = multiRegionsConfig.getCurrentRegion();
+
   const regionalModelsOnly = auth.getNonNullableWorkspace().regionalModelsOnly;
   if (dustRegion === "us-central1" || !regionalModelsOnly) {
     return undefined;
@@ -310,9 +311,9 @@ function getStreamEndpointLLM(
 
   const preferredRegion = REGION_MAPPING[multiRegionsConfig.getCurrentRegion()];
 
-  const sortedEndpoints = sortBy(
+  const sortedEndpoints = sortEndpointsByPreferredRegion(
     endpoints,
-    (endpoint) => endpoint.region === preferredRegion
+    preferredRegion
   );
 
   const endpoint = sortedEndpoints[0];

--- a/front/lib/llms/utils/sort_endpoints.test.ts
+++ b/front/lib/llms/utils/sort_endpoints.test.ts
@@ -1,0 +1,96 @@
+import { sortEndpointsByPreferredRegion } from "@app/lib/llms/utils/sort_endpoints";
+import { EUROPE, GLOBAL, US } from "@app/lib/model_constructors/types/regions";
+import { describe, expect, it } from "vitest";
+
+type TestEndpoint = {
+  id: string;
+  region: typeof EUROPE | typeof US | typeof GLOBAL;
+};
+
+describe("sortEndpointsByPreferredRegion", () => {
+  it("puts the endpoint matching the preferred region first", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "us", region: US },
+      { id: "global", region: GLOBAL },
+      { id: "eu", region: EUROPE },
+    ];
+
+    const sorted = sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(sorted[0]).toEqual({ id: "eu", region: EUROPE });
+  });
+
+  it("moves all preferred-region endpoints ahead of the others", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "us", region: US },
+      { id: "eu-1", region: EUROPE },
+      { id: "global", region: GLOBAL },
+      { id: "eu-2", region: EUROPE },
+    ];
+
+    const sorted = sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(sorted.map((e) => e.region)).toEqual([EUROPE, EUROPE, US, GLOBAL]);
+  });
+
+  it("preserves the relative order of matching endpoints (stable sort)", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "eu-1", region: EUROPE },
+      { id: "eu-2", region: EUROPE },
+      { id: "us", region: US },
+    ];
+
+    const sorted = sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(sorted.map((e) => e.id)).toEqual(["eu-1", "eu-2", "us"]);
+  });
+
+  it("preserves the relative order of non-matching endpoints (stable sort)", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "us", region: US },
+      { id: "global", region: GLOBAL },
+      { id: "eu", region: EUROPE },
+    ];
+
+    const sorted = sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(sorted.map((e) => e.id)).toEqual(["eu", "us", "global"]);
+  });
+
+  it("keeps the original order when no endpoint matches", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "us", region: US },
+      { id: "global", region: GLOBAL },
+    ];
+
+    const sorted = sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(sorted.map((e) => e.id)).toEqual(["us", "global"]);
+  });
+
+  it("keeps the original order when every endpoint matches", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "eu-1", region: EUROPE },
+      { id: "eu-2", region: EUROPE },
+    ];
+
+    const sorted = sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(sorted.map((e) => e.id)).toEqual(["eu-1", "eu-2"]);
+  });
+
+  it("returns an empty array for no endpoints", () => {
+    expect(sortEndpointsByPreferredRegion([], GLOBAL)).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const endpoints: TestEndpoint[] = [
+      { id: "us", region: US },
+      { id: "eu", region: EUROPE },
+    ];
+
+    sortEndpointsByPreferredRegion(endpoints, EUROPE);
+
+    expect(endpoints.map((e) => e.id)).toEqual(["us", "eu"]);
+  });
+});

--- a/front/lib/llms/utils/sort_endpoints.ts
+++ b/front/lib/llms/utils/sort_endpoints.ts
@@ -1,0 +1,12 @@
+import type { Region } from "@app/lib/model_constructors/types/regions";
+import sortBy from "lodash/sortBy";
+
+// Orders endpoints so that those matching the preferred region come first,
+// preserving the relative order of the remaining endpoints (lodash `sortBy` is
+// stable). Callers typically pick the first element as the best match.
+export function sortEndpointsByPreferredRegion<T extends { region: Region }>(
+  endpoints: T[],
+  preferredRegion: Region
+): T[] {
+  return sortBy(endpoints, (endpoint) => endpoint.region !== preferredRegion);
+}


### PR DESCRIPTION
## Description

Fixes stream endpoint selection so the endpoint matching the current region is sorted first (the previous inline `sortBy` predicate sorted it last), and extracts the logic into a reusable `sortEndpointsByPreferredRegion` util.

## Tests

Added unit tests for `sortEndpointsByPreferredRegion` (ordering, stability, no mutation, edge cases) — 8/8 passing.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`