### PR TITLE
[front] feat(usage): guide admins with no/free seat to change it

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -294,12 +294,18 @@ function getLimitPromptForCode(
     case "no_seat": {
       return {
         title: "No seat assigned",
-        validateLabel: "Ok",
+        validateLabel: isAdmin ? "Go to usage page" : "Ok",
+        onValidate: isAdmin
+          ? () => {
+              void router.push(`/w/${owner.sId}/usage?openChangeMySeat`);
+            }
+          : undefined,
         children: (
           <>
             <Page.P>
-              You don&apos;t have a seat assigned in this workspace. Please
-              contact your administrator to assign you one.
+              {isAdmin
+                ? "You don't have a seat assigned in this workspace. Go to the usage page to assign yourself one."
+                : "You don't have a seat assigned in this workspace. Please contact your administrator to assign you one."}
             </Page.P>
           </>
         ),
@@ -312,14 +318,14 @@ function getLimitPromptForCode(
         validateLabel: isAdmin ? "Go to Usage" : "Ok",
         onValidate: isAdmin
           ? () => {
-              void router.push(`/w/${owner.sId}/usage`);
+              void router.push(`/w/${owner.sId}/usage?openChangeMySeat`);
             }
           : undefined,
         children: (
           <>
             <Page.P>
               {isAdmin
-                ? "You have reached your personal usage cap. You can adjust user caps from the usage page."
+                ? "You have reached your personal usage cap. On the usage page you can change your seat or adjust user caps."
                 : "You have reached your personal usage cap. Please contact your administrator to increase it."}
             </Page.P>
           </>

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -73,24 +73,19 @@ const useGetEmailsListAndError = (
   }, [inviteEmails]);
 };
 
-// Remaining assignable seats for a tier; null means unlimited (no maxSeats cap).
-function seatAvailability(info: SeatTypeInfo): number | null {
-  return info.maxSeats === null
-    ? null
-    : Math.max(0, info.maxSeats - info.assignedCount);
+// Pre-paid slots remaining for the free seat type (minSeats floor not yet consumed).
+function freeSeatAvailability(info: SeatTypeInfo): number {
+  return Math.max(0, info.minSeats - info.assignedCount);
 }
 
-// Free seats are capped and shown as unavailable once exhausted. Paid tiers stay
-// selectable even at their cap.
 function isSeatSelectable(
   seatType: MembershipSeatType,
   info: SeatTypeInfo
 ): boolean {
   if (seatType === "free") {
-    const available = seatAvailability(info);
-    return available === null || available > 0;
+    return freeSeatAvailability(info) > 0;
   }
-  return true;
+  return info.maxSeats === null || info.assignedCount < info.maxSeats;
 }
 
 function seatBadge(
@@ -99,8 +94,8 @@ function seatBadge(
 ): ReactNode {
   let label: string;
   if (seatType === "free") {
-    const available = seatAvailability(info);
-    label = available === null ? "Available" : `${available} available`;
+    const available = freeSeatAvailability(info);
+    label = `${available} available`;
   } else {
     label = formatPriceCents(
       info.priceCents,

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -28,6 +28,7 @@ import {
   type MembershipSeatType,
 } from "@app/types/memberships";
 import type { SubscriptionPerSeatPricing } from "@app/types/plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -180,8 +181,17 @@ export function InviteEmailButtonWithModal({
   // Switch billing cadence; keep the selection valid by falling back to the
   // first selectable tier in the new cadence when the current one isn't offered.
   function handleSeatFrequencyChange(period: "monthly" | "yearly") {
-    const frequency: SeatBillingFrequency =
-      period === "yearly" ? "annual" : "monthly";
+    let frequency: SeatBillingFrequency;
+    switch (period) {
+      case "yearly":
+        frequency = "annual";
+        break;
+      case "monthly":
+        frequency = "monthly";
+        break;
+      default:
+        assertNever(period);
+    }
     setActiveFrequency(frequency);
     const inFrequency = seatTypesByFrequency[frequency];
     if (!selectedSeatType || !inFrequency.includes(selectedSeatType)) {

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -44,6 +44,7 @@ import {
   Plus,
   TextArea,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { mutate } from "swr";
 
@@ -90,6 +91,28 @@ function isSeatSelectable(
     return available === null || available > 0;
   }
   return true;
+}
+
+function seatBadge(
+  seatType: MembershipSeatType,
+  info: SeatTypeInfo
+): ReactNode {
+  let label: string;
+  if (seatType === "free") {
+    const available = seatAvailability(info);
+    label = available === null ? "Available" : `${available} available`;
+  } else {
+    label = formatPriceCents(
+      info.priceCents,
+      info.currency,
+      info.billingFrequency
+    );
+  }
+  return (
+    <span className="text-xs text-foreground dark:text-foreground-night">
+      {label}
+    </span>
+  );
 }
 
 interface InviteEmailButtonWithModalProps {
@@ -150,12 +173,15 @@ export function InviteEmailButtonWithModal({
       const info = seatPlans[s];
       return info && isSeatSelectable(s, info);
     });
-    const cheapestPaid = selectable
-      .filter((s) => s !== "free")
-      .sort(
-        (a, b) =>
-          (seatPlans[a]?.priceCents ?? 0) - (seatPlans[b]?.priceCents ?? 0)
-      )[0];
+    const paidSelectable = selectable.filter((s) => s !== "free");
+    const cheapestPaid = paidSelectable.reduce<MembershipSeatType | undefined>(
+      (min, s) =>
+        min === undefined ||
+        (seatPlans[s]?.priceCents ?? 0) < (seatPlans[min]?.priceCents ?? 0)
+          ? s
+          : min,
+      undefined
+    );
     const defaultSeat =
       selectable.find((s) => s === "free") ??
       cheapestPaid ??
@@ -204,28 +230,6 @@ export function InviteEmailButtonWithModal({
         null;
       setSelectedSeatType(nextSeat);
     }
-  }
-
-  function seatBadge(
-    seatType: MembershipSeatType,
-    info: SeatTypeInfo
-  ): React.ReactNode {
-    let label: string;
-    if (seatType === "free") {
-      const available = seatAvailability(info);
-      label = available === null ? "Available" : `${available} available`;
-    } else {
-      label = formatPriceCents(
-        info.priceCents,
-        info.currency,
-        info.billingFrequency
-      );
-    }
-    return (
-      <span className="text-xs text-foreground dark:text-foreground-night">
-        {label}
-      </span>
-    );
   }
 
   async function handleSendInvitations(

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -28,7 +28,6 @@ import {
   type MembershipSeatType,
 } from "@app/types/memberships";
 import type { SubscriptionPerSeatPricing } from "@app/types/plan";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { ActiveRoleType, WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -44,7 +43,6 @@ import {
   Plus,
   TextArea,
 } from "@dust-tt/sparkle";
-import type { ReactNode } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { mutate } from "swr";
 
@@ -73,41 +71,24 @@ const useGetEmailsListAndError = (
   }, [inviteEmails]);
 };
 
-// Pre-paid slots remaining for the free seat type (minSeats floor not yet consumed).
-function freeSeatAvailability(info: SeatTypeInfo): number {
-  return Math.max(0, info.minSeats - info.assignedCount);
+// Remaining assignable seats for a tier; null means unlimited (no maxSeats cap).
+function seatAvailability(info: SeatTypeInfo): number | null {
+  return info.maxSeats === null
+    ? null
+    : Math.max(0, info.maxSeats - info.assignedCount);
 }
 
+// Free seats are capped and shown as unavailable once exhausted. Paid tiers stay
+// selectable even at their cap.
 function isSeatSelectable(
   seatType: MembershipSeatType,
   info: SeatTypeInfo
 ): boolean {
   if (seatType === "free") {
-    return freeSeatAvailability(info) > 0;
+    const available = seatAvailability(info);
+    return available === null || available > 0;
   }
-  return info.maxSeats === null || info.assignedCount < info.maxSeats;
-}
-
-function seatBadge(
-  seatType: MembershipSeatType,
-  info: SeatTypeInfo
-): ReactNode {
-  let label: string;
-  if (seatType === "free") {
-    const available = freeSeatAvailability(info);
-    label = `${available} available`;
-  } else {
-    label = formatPriceCents(
-      info.priceCents,
-      info.currency,
-      info.billingFrequency
-    );
-  }
-  return (
-    <span className="text-xs text-foreground dark:text-foreground-night">
-      {label}
-    </span>
-  );
+  return true;
 }
 
 interface InviteEmailButtonWithModalProps {
@@ -168,15 +149,12 @@ export function InviteEmailButtonWithModal({
       const info = seatPlans[s];
       return info && isSeatSelectable(s, info);
     });
-    const paidSelectable = selectable.filter((s) => s !== "free");
-    const cheapestPaid = paidSelectable.reduce<MembershipSeatType | undefined>(
-      (min, s) =>
-        min === undefined ||
-        (seatPlans[s]?.priceCents ?? 0) < (seatPlans[min]?.priceCents ?? 0)
-          ? s
-          : min,
-      undefined
-    );
+    const cheapestPaid = selectable
+      .filter((s) => s !== "free")
+      .sort(
+        (a, b) =>
+          (seatPlans[a]?.priceCents ?? 0) - (seatPlans[b]?.priceCents ?? 0)
+      )[0];
     const defaultSeat =
       selectable.find((s) => s === "free") ??
       cheapestPaid ??
@@ -202,17 +180,8 @@ export function InviteEmailButtonWithModal({
   // Switch billing cadence; keep the selection valid by falling back to the
   // first selectable tier in the new cadence when the current one isn't offered.
   function handleSeatFrequencyChange(period: "monthly" | "yearly") {
-    let frequency: SeatBillingFrequency;
-    switch (period) {
-      case "yearly":
-        frequency = "annual";
-        break;
-      case "monthly":
-        frequency = "monthly";
-        break;
-      default:
-        assertNever(period);
-    }
+    const frequency: SeatBillingFrequency =
+      period === "yearly" ? "annual" : "monthly";
     setActiveFrequency(frequency);
     const inFrequency = seatTypesByFrequency[frequency];
     if (!selectedSeatType || !inFrequency.includes(selectedSeatType)) {
@@ -225,6 +194,28 @@ export function InviteEmailButtonWithModal({
         null;
       setSelectedSeatType(nextSeat);
     }
+  }
+
+  function seatBadge(
+    seatType: MembershipSeatType,
+    info: SeatTypeInfo
+  ): React.ReactNode {
+    let label: string;
+    if (seatType === "free") {
+      const available = seatAvailability(info);
+      label = available === null ? "Available" : `${available} available`;
+    } else {
+      label = formatPriceCents(
+        info.priceCents,
+        info.currency,
+        info.billingFrequency
+      );
+    }
+    return (
+      <span className="text-xs text-foreground dark:text-foreground-night">
+        {label}
+      </span>
+    );
   }
 
   async function handleSendInvitations(

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -23,11 +23,12 @@ import {
   isFreePlan,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
-import { useAppRouter } from "@app/lib/platform";
+import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import {
   useAwuPoolSummary,
   useAwuPurchaseInfo,
   useCreditPurchaseInfo,
+  useMyUsage,
   useSeatPlan,
 } from "@app/lib/swr/credits";
 import {
@@ -53,6 +54,7 @@ import {
   toBaseSeatType,
 } from "@app/types/memberships";
 import { isCreditPricedPlan } from "@app/types/plan";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { isAdmin } from "@app/types/user";
 import {
   AlertCircle,
@@ -105,6 +107,30 @@ function memberFromUpgradeRequest(
 
 const DEFAULT_PAGE_SIZE = 25;
 
+function noOrFreeSeatTitle(seatType: "none" | "free"): string {
+  switch (seatType) {
+    case "none":
+      return "You don't have a seat";
+    case "free":
+      return "You're on the Free seat";
+    default:
+      assertNeverAndIgnore(seatType);
+      return "";
+  }
+}
+
+function noOrFreeSeatBody(seatType: "none" | "free"): string {
+  switch (seatType) {
+    case "none":
+      return "Assign yourself a seat to send messages.";
+    case "free":
+      return "The Free seat has limited usage. Upgrade your seat to get more credits.";
+    default:
+      assertNeverAndIgnore(seatType);
+      return "";
+  }
+}
+
 export function UsagePage() {
   const owner = useWorkspace();
   const { subscription } = useAuth();
@@ -156,6 +182,8 @@ export function UsagePage() {
   const membersOrderColumn = sort?.id === "email" ? "email" : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 
+  const { myUsage } = useMyUsage({ workspaceId: owner.sId });
+  const openChangeMySeatParam = useSearchParam("openChangeMySeat");
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const [changeSeatMember, setChangeSeatMember] =
     useState<MemberUsageType | null>(null);
@@ -340,6 +368,13 @@ export function UsagePage() {
       void router.push(`/w/${owner.sId}/members`);
     }
   }, [canViewUsage, router, owner.sId]);
+
+  // Auto-open the "change my seat" modal when arriving from a blocked-state
+  useEffect(() => {
+    if (openChangeMySeatParam !== null && myUsage !== null) {
+      setChangeSeatMember(myUsage);
+    }
+  }, [openChangeMySeatParam, myUsage]);
 
   const {
     totalRemainingCredits,
@@ -562,6 +597,25 @@ export function UsagePage() {
             />
           )}
         </div>
+
+        {!isReadOnly &&
+          (myUsage?.seatType === "free" || myUsage?.seatType === "none") && (
+            <ContentMessage
+              title={noOrFreeSeatTitle(myUsage.seatType)}
+              icon={AlertCircle}
+              variant="warning"
+            >
+              <div className="flex items-center justify-between gap-4">
+                <span>{noOrFreeSeatBody(myUsage.seatType)}</span>
+                <Button
+                  label="Change my seat"
+                  variant="warning"
+                  size="xs"
+                  onClick={() => setChangeSeatMember(myUsage)}
+                />
+              </div>
+            </ContentMessage>
+          )}
 
         {showPoolSection && (
           <Page.Vertical gap="xs" align="stretch">


### PR DESCRIPTION
## Summary

- **`ReachedLimitPopup`**: the `no_seat` admin case now redirects to `/usage?openChangeMySeat` with a message explaining the action, instead of a dead-end "Ok" button. The `user_credits_exhausted` admin case also redirects there.
- **`UsagePage`**: adds a persistent warning callout when the current admin's seat is `free` or `none`, with a direct "Change my seat" button. The `?openChangeMySeat` query param auto-opens `ChangeSeatModal` on load (deep link from the popup).
- **`provider_credentials`**: makes `VERTEX_AI_PROJECT_ID` optional so local dev without Vertex AI configured doesn't throw.

## Testing

<img width="867" height="698" alt="Screenshot 2026-06-17 at 10 14 11 AM" src="https://github.com/user-attachments/assets/abffcf40-f694-48c6-b965-7a5ef4511336" />

<img width="797" height="288" alt="Screenshot 2026-06-17 at 10 14 05 AM" src="https://github.com/user-attachments/assets/62fff97d-1de9-421e-bed0-9947bc969ef6" />


## Risk

Low — additive UI changes only. No API or data model changes.

## Deployment
1. Deploy front