### PR TITLE
[LLM] Make Vertex AI project ID config optional

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -664,8 +664,8 @@ const config = {
       "METRONOME_STRIPE_DELIVERY_METHOD_ID"
     );
   },
-  getVertexAiProjectId: (): string => {
-    return EnvironmentConfig.getEnvVariable("VERTEX_AI_PROJECT_ID");
+  getVertexAiProjectId: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("VERTEX_AI_PROJECT_ID");
   },
   getDustWebhooksPublicUrl: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DUST_WEBHOOKS_PUBLIC_URL");


### PR DESCRIPTION
## Description

Make `getVertexAiProjectId` return `string | undefined` via `getOptionalEnvVariable` so US pods, which do not have the `VERTEX_AI_PROJECT_ID` env variable set, no longer crash on startup.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`