### PR TITLE
Grant Support access to delete data source Poke plugin

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
@@ -24,7 +24,7 @@ export const deleteDataSourcePlugin = createPlugin({
           "WARNING: This will immediately and permanently delete ALL files and bypass safety checks. The data will be unrecoverable. Only use if you are absolutely certain.",
       },
     },
-    requiredRoles: ["engineering"],
+    requiredRoles: ["engineering", "support"],
   },
   execute: async (auth, dataSource, args) => {
     if (!dataSource) {


### PR DESCRIPTION
## Description

Grant the Support Poke role access to the `Delete Data Source` plugin.

This keeps the existing Engineering access and adds Support to the plugin's `requiredRoles`, matching the support policy discussed in the related Slack thread: Support may use this destructive action when the request, target, authorization, and papertrail are clear.

## Tests

Ran `git diff --check` locally in the Computer.

No unit tests were run because this is a one-line Poke role mapping change. Final validation is expected through PR CI.

## Risk

This expands access to a destructive Poke plugin for users with the Support role. The plugin already has a destructive-action warning, defaults to soft delete via `softDeleteDataSourceAndLaunchScrubWorkflow`, and keeps the existing force-delete safety check path. Operationally, Support should follow the candidate Support Knowledge policy requiring clear authorization, target verification, and papertrail before use.

## Deploy Plan

Standard deploy. No migration or manual rollout step required.
