### PR TITLE
[LLM] always use eu vertex region for anthropic

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -43,7 +43,6 @@ import type {
 import { normalizePrompt } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { CLAUDE_4_5_HAIKU_20251001_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
 import assert from "assert";
@@ -160,18 +159,10 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       apiKey: ANTHROPIC_API_KEY,
     });
 
-    const vertexInferenceRegion =
-      this.modelId === CLAUDE_4_5_HAIKU_20251001_MODEL_ID
-        ? "europe-west1"
-        : "eu";
     // Vertex does not support batches.
-    this.inferenceClient = getInferenceClient(
-      this.useVertex,
-      vertexInferenceRegion,
-      {
-        anthropicClient: this.client,
-      }
-    );
+    this.inferenceClient = getInferenceClient(this.useVertex, "eu", {
+      anthropicClient: this.client,
+    });
   }
 
   private async buildBaseRequestPayload({


### PR DESCRIPTION
## Description

Always use the `eu` Vertex AI region for Anthropic models instead of special-casing `europe-west1` for Claude 4.5 Haiku.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`