### PR TITLE
Clean states and transitions

### DIFF
--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -244,56 +244,6 @@ export async function dispatchSeatBalanceResolved({
   }
 }
 
-export async function dispatchSeatLowBalance({
-  workspace,
-  userId,
-  threshold,
-}: {
-  workspace: WorkspaceResource;
-  userId: string;
-  threshold: number;
-}): Promise<void> {
-  const user = await UserResource.fetchById(userId);
-  if (!user) {
-    logger.warn(
-      { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] dispatchSeatLowBalance: user not found, skipping"
-    );
-    return;
-  }
-
-  const lightWorkspace = renderLightWorkspaceType({ workspace });
-  const membership =
-    await MembershipResource.getActiveMembershipOfUserInWorkspace({
-      user,
-      workspace: lightWorkspace,
-    });
-  if (!membership) {
-    logger.warn(
-      { workspaceId: workspace.sId, userId },
-      "[CreditStateDispatcher] dispatchSeatLowBalance: no active membership, skipping"
-    );
-    return;
-  }
-
-  const result = await transitionUserCreditState(
-    membership,
-    { type: "seat_low_balance", threshold },
-    { workspaceId: workspace.sId, userId, seatType: membership.seatType }
-  );
-  if (result.isErr()) {
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        userId,
-        seatType: membership.seatType,
-        creditState: membership.creditState,
-      },
-      "[CreditStateDispatcher] dispatchSeatLowBalance: transition skipped"
-    );
-  }
-}
-
 export async function dispatchPerUserCapReached({
   workspace,
   userId,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -19,7 +19,6 @@ import {
   dispatchProgrammaticWarning,
   dispatchSeatBalanceExhausted,
   dispatchSeatBalanceResolved,
-  dispatchSeatLowBalance,
   syncPoolCreditStateFromBalance,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
@@ -1069,24 +1068,8 @@ export async function processMetronomeWebhook({
       if (threshold === 0) {
         await dispatchSeatBalanceExhausted({ workspace, userId });
         logger.info(
-          {
-            eventId: event.id,
-            workspaceId: workspace.sId,
-            userId,
-            remaining: threshold,
-          },
+          { eventId: event.id, workspaceId: workspace.sId, userId },
           "[Metronome Webhook] low_remaining_seat_balance_reached: seat balance exhausted dispatched"
-        );
-      } else {
-        await dispatchSeatLowBalance({ workspace, userId, threshold });
-        logger.info(
-          {
-            eventId: event.id,
-            workspaceId: workspace.sId,
-            userId,
-            remaining: threshold,
-          },
-          "[Metronome Webhook] low_remaining_seat_balance_reached: seat low balance dispatched"
         );
       }
       break;
@@ -1134,14 +1117,13 @@ export async function processMetronomeWebhook({
         );
       } else {
         void setUserNearLimit(workspace.sId, userId, true);
-        await dispatchSeatLowBalance({ workspace, userId, threshold });
         logger.info(
           {
             eventId: event.id,
             workspaceId: workspace.sId,
             userId,
           },
-          "[Metronome Webhook] low_remaining_contract_credit_balance_reached: per-user credit low balance dispatched"
+          "[Metronome Webhook] low_remaining_contract_credit_balance_reached: free seat near-limit flag set"
         );
       }
       break;

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -17,6 +17,7 @@ import {
   setProgrammaticCreditStateReconciled,
 } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
+import { setUserNearLimit } from "@app/lib/metronome/user_block";
 import { setUserCreditStateReconciled } from "@app/lib/metronome/user_credit_state_machine";
 import {
   expectedPoolCreditStateFromBalance,
@@ -38,6 +39,7 @@ import type {
   UserCreditState,
 } from "@app/types/memberships";
 import {
+  computeUserNearLimit,
   expectedUserCreditState,
   normalizeToPoolLimitSeatType,
 } from "@app/types/memberships";
@@ -330,6 +332,13 @@ async function reconcileUser({
     perUserCapAwuCredits: effectiveCapAwuCredits,
     consumedAwuCredits,
   });
+  const nearLimit = computeUserNearLimit({
+    seatType,
+    seatBalanceAwu,
+    seatStartingBalanceAwu,
+    effectiveCapAwuCredits,
+    consumedAwuCredits,
+  });
   const wasInvalid = normalizeUserCreditState(previousState) !== expectedState;
 
   let newState = previousState;
@@ -339,6 +348,7 @@ async function reconcileUser({
       userId,
       seatType,
     });
+    void setUserNearLimit(workspace.sId, userId, nearLimit);
   }
 
   return new Ok({
@@ -493,13 +503,24 @@ export async function reconcileWorkspaceUserCreditStates({
       awuSeatBalanceForUser(seatBalances, userId) ??
       perUserCreditBalances.get(userId) ??
       null;
+    const seatBalanceAwu = seat?.balanceAwu ?? null;
+    const seatStartingBalanceAwu = seat?.startingBalanceAwu ?? null;
+    const consumedAwuCredits =
+      effectiveCapAwuCredits !== null ? (usageByUser.get(userId) ?? 0) : null;
+
     const expectedState = expectedUserCreditState({
       seatType,
-      seatBalanceAwu: seat?.balanceAwu ?? null,
-      seatStartingBalanceAwu: seat?.startingBalanceAwu ?? null,
+      seatBalanceAwu,
+      seatStartingBalanceAwu,
       perUserCapAwuCredits: effectiveCapAwuCredits,
-      consumedAwuCredits:
-        effectiveCapAwuCredits !== null ? (usageByUser.get(userId) ?? 0) : null,
+      consumedAwuCredits,
+    });
+    const nearLimit = computeUserNearLimit({
+      seatType,
+      seatBalanceAwu,
+      seatStartingBalanceAwu,
+      effectiveCapAwuCredits,
+      consumedAwuCredits,
     });
 
     try {
@@ -511,6 +532,7 @@ export async function reconcileWorkspaceUserCreditStates({
         userId,
         seatType,
       });
+      void setUserNearLimit(workspaceId, userId, nearLimit);
     } catch (err) {
       logger.error(
         { workspaceId, userId, err: normalizeError(err) },

--- a/front/lib/metronome/alerts/per_user_credit_balance.ts
+++ b/front/lib/metronome/alerts/per_user_credit_balance.ts
@@ -10,10 +10,10 @@ import {
 } from "@app/lib/metronome/client";
 import {
   getCreditTypeAwuId,
+  NEAR_LIMIT_FRACTION,
   PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import logger from "@app/logger/logger";
-import { SEAT_LOW_BALANCE_FRACTION } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -219,7 +219,7 @@ export async function upsertPerUserCreditBalanceAlerts({
   const lowBalanceResult = await upsertMetronomeAlert({
     alert_type: "low_remaining_contract_credit_balance_reached",
     name: perUserCreditAlertName("low balance", workspaceId, userId),
-    threshold: Math.floor(SEAT_LOW_BALANCE_FRACTION * allowanceAwu),
+    threshold: Math.floor((1 - NEAR_LIMIT_FRACTION) * allowanceAwu),
     credit_type_id: creditTypeId,
     customer_id: metronomeCustomerId,
     uniqueness_key: lowBalanceAlertUniquenessKey(workspaceId, userId),

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -299,6 +299,11 @@ export const MAX_SEAT_MONTHLY_AWU_CREDITS = 40000;
 export const SEAT_PRIORITY_SUBSCRIPTION_COMMIT = 300;
 export const SEAT_PRIORITY_COUPON_CREDIT = 300;
 
+// 80% threshold for near-limit warnings: applies to both cap consumption
+// (consumed ≥ 80% of effectiveCapAwuCredits) and seat depletion (≤ 20%
+// remaining = 80% used).
+export const NEAR_LIMIT_FRACTION = 0.8;
+
 // tier product accessors — ordered array for indexed access.
 export const MAX_MAU_TIERS = 6;
 

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -1,6 +1,5 @@
 import {
   FREE_SEAT_LIFETIME_AWU_CREDITS,
-  MAX_SEAT_MONTHLY_AWU_CREDITS,
   PRO_SEAT_MONTHLY_AWU_CREDITS,
 } from "@app/lib/metronome/constants";
 import type { UserCreditContext } from "@app/lib/metronome/user_credit_state_machine";
@@ -213,7 +212,7 @@ describe("UserCreditStateMachine — transitions", () => {
     );
   });
 
-  it("capped + per_user_cap_resolved with a low personal balance → user_seat_low_balance", async () => {
+  it("capped + per_user_cap_resolved with personal balance (even low) → user_seat", async () => {
     const membership = makeMembership("capped", "max");
     const result = await transitionUserCreditState(
       membership,
@@ -231,10 +230,10 @@ describe("UserCreditStateMachine — transitions", () => {
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("user_seat_low_balance");
+      expect(result.value).toBe("user_seat");
     }
     expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "user_seat_low_balance",
+      "user_seat",
       undefined
     );
   });
@@ -310,7 +309,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("user_seat_low_balance + free seat → capped", async () => {
+  it("legacy user_seat_low_balance (alias → user_seat) + free seat → capped", async () => {
     const membership = makeMembership("user_seat_low_balance", "free");
     const result = await transitionUserCreditState(
       membership,
@@ -398,7 +397,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("user_seat_low_balance + max seat + pool limit null → on_pool", async () => {
+  it("legacy user_seat_low_balance (alias → user_seat) + max seat + pool limit null → on_pool", async () => {
     const membership = makeMembership("user_seat_low_balance", "max");
     const result = await transitionUserCreditState(
       membership,
@@ -449,8 +448,8 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
   });
 
-  // Guard 2: same as above from user_seat_low_balance.
-  it("user_seat_low_balance + pro + 0% cap remaining + pool limit > 0 → capped", async () => {
+  // Guard 1: same as above from legacy user_seat_low_balance (alias → user_seat).
+  it("legacy user_seat_low_balance + pro + 0% cap remaining + pool limit > 0 → capped", async () => {
     const membership = makeMembership("user_seat_low_balance", "pro");
     const result = await transitionUserCreditState(
       membership,
@@ -472,8 +471,9 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
   });
 
-  // Guard 3: < 20 % cap remaining → on_pool_low_balance.
-  it("user_seat + pro + 10% cap remaining → on_pool_low_balance", async () => {
+  // Guard 2: pool budget left → on_pool. nearLimit flag is set by the spend
+  // threshold webhook separately; the state machine no longer tracks it.
+  it("user_seat + pro + 10% cap remaining → on_pool (near-limit via flag, not state)", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
@@ -487,16 +487,15 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("on_pool_low_balance");
+      expect(result.value).toBe("on_pool");
     }
     expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "on_pool_low_balance",
+      "on_pool",
       undefined
     );
   });
 
-  // Guard 3: boundary — exactly 19 % (just below 0.2) → on_pool_low_balance.
-  it("user_seat + pro + 19% cap remaining → on_pool_low_balance", async () => {
+  it("user_seat + pro + 19% cap remaining → on_pool", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
@@ -510,16 +509,15 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("on_pool_low_balance");
+      expect(result.value).toBe("on_pool");
     }
     expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "on_pool_low_balance",
+      "on_pool",
       undefined
     );
   });
 
-  // Guard 4: exactly 20 % is NOT < 0.2, so guard 3 does not fire → on_pool.
-  it("user_seat + pro + exactly 20% cap remaining → on_pool (not low balance)", async () => {
+  it("user_seat + pro + exactly 20% cap remaining → on_pool", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
@@ -541,7 +539,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
   });
 
-  // Guard 4: ample cap remaining → on_pool.
   it("user_seat + pro + 50% cap remaining → on_pool", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
@@ -564,8 +561,7 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
     );
   });
 
-  // Guard 4: null percentage (no cap configured) → on_pool (guard 3 skipped).
-  it("user_seat + pro + null cap percentage → on_pool", async () => {
+  it("user_seat + pro + null cap percentage → on_pool (no cap configured)", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
       membership,
@@ -607,110 +603,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
   });
 });
 
-describe("UserCreditStateMachine — seat_low_balance", () => {
-  it("user_seat + max threshold + max seat → user_seat_low_balance", async () => {
-    const membership = makeMembership("user_seat", "max");
-    const result = await transitionUserCreditState(
-      membership,
-      {
-        type: "seat_low_balance",
-        threshold: 0.2 * MAX_SEAT_MONTHLY_AWU_CREDITS,
-      },
-      { ...baseCtx, seatType: "max" }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("user_seat_low_balance");
-    }
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "user_seat_low_balance",
-      undefined
-    );
-    expect(mockSetUserCreditState).toHaveBeenCalledWith(
-      "ws_test",
-      "u_test",
-      "user_seat_low_balance"
-    );
-  });
-
-  it("user_seat + pro threshold + pro seat → user_seat_low_balance", async () => {
-    const membership = makeMembership("user_seat", "pro");
-    const result = await transitionUserCreditState(
-      membership,
-      {
-        type: "seat_low_balance",
-        threshold: 0.2 * PRO_SEAT_MONTHLY_AWU_CREDITS,
-      },
-      { ...baseCtx, seatType: "pro" }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("user_seat_low_balance");
-    }
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "user_seat_low_balance",
-      undefined
-    );
-    expect(mockSetUserCreditState).toHaveBeenCalledWith(
-      "ws_test",
-      "u_test",
-      "user_seat_low_balance"
-    );
-  });
-
-  it("user_seat + free seat → user_seat_low_balance (no threshold matching)", async () => {
-    const membership = makeMembership("user_seat", "free");
-    // The per-user free-credit alert is scoped to this user, so the free guard
-    // matches on seat type alone — the threshold value is not checked.
-    const result = await transitionUserCreditState(
-      membership,
-      { type: "seat_low_balance", threshold: 60 },
-      { ...baseCtx, seatType: "free" }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("user_seat_low_balance");
-    }
-  });
-
-  it("user_seat + max threshold + pro seat → no transition (guard mismatch)", async () => {
-    const membership = makeMembership("user_seat", "pro");
-    const result = await transitionUserCreditState(
-      membership,
-      {
-        type: "seat_low_balance",
-        threshold: 0.2 * MAX_SEAT_MONTHLY_AWU_CREDITS,
-      },
-      { ...baseCtx, seatType: "pro" }
-    );
-    expect(result.isErr()).toBe(true);
-    expect(membership.updateCreditState).not.toHaveBeenCalled();
-    expect(mockSetUserCreditState).not.toHaveBeenCalled();
-  });
-
-  it("user_seat_low_balance + max threshold + max seat is idempotent", async () => {
-    const membership = makeMembership("user_seat_low_balance", "max");
-    const result = await transitionUserCreditState(
-      membership,
-      {
-        type: "seat_low_balance",
-        threshold: 0.2 * MAX_SEAT_MONTHLY_AWU_CREDITS,
-      },
-      { ...baseCtx, seatType: "max" }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("user_seat_low_balance");
-    }
-    expect(membership.updateCreditState).not.toHaveBeenCalled();
-    expect(mockSetUserCreditState).toHaveBeenCalledWith(
-      "ws_test",
-      "u_test",
-      "user_seat_low_balance"
-    );
-  });
-});
-
 // ---------------------------------------------------------------------------
 // Seat balance replenished
 // ---------------------------------------------------------------------------
@@ -738,7 +630,7 @@ describe("UserCreditStateMachine — seat_balance_resolved", () => {
     }
   });
 
-  it("free capped → user_seat_low_balance when only a low balance is left", async () => {
+  it("free capped → user_seat when only a low balance is left (near-limit via flag)", async () => {
     const membership = makeMembership("capped", "free");
     const result = await transitionUserCreditState(
       membership,
@@ -756,15 +648,15 @@ describe("UserCreditStateMachine — seat_balance_resolved", () => {
     );
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
-      expect(result.value).toBe("user_seat_low_balance");
+      expect(result.value).toBe("user_seat");
     }
     expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "user_seat_low_balance",
+      "user_seat",
       undefined
     );
   });
 
-  it("pro user_seat_low_balance → user_seat on a full billing-period renewal", async () => {
+  it("legacy user_seat_low_balance (alias → user_seat) → user_seat on billing-period renewal", async () => {
     const membership = makeMembership("user_seat_low_balance", "pro");
     const result = await transitionUserCreditState(
       membership,

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -1,7 +1,3 @@
-import {
-  MAX_SEAT_MONTHLY_AWU_CREDITS,
-  PRO_SEAT_MONTHLY_AWU_CREDITS,
-} from "@app/lib/metronome/constants";
 import { setUserCreditState } from "@app/lib/metronome/user_block";
 import type { MembershipResource } from "@app/lib/resources/membership_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
@@ -10,12 +6,7 @@ import type {
   MembershipSeatType,
   UserCreditState,
 } from "@app/types/memberships";
-import {
-  CAP_WARNING_FRACTION,
-  expectedUserCreditState,
-  isSeatBased,
-  SEAT_LOW_BALANCE_FRACTION,
-} from "@app/types/memberships";
+import { expectedUserCreditState, isSeatBased } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { Transaction } from "sequelize";
@@ -83,11 +74,6 @@ export type UserCreditEvent =
    */
   | { type: "seat_balance_exhausted" }
   /**
-   * This user's personal seat balance crossed a low-balance warning threshold
-   * (balance > 0). Moves `user_seat` → `user_seat_low_balance`.
-   */
-  | { type: "seat_low_balance"; threshold: number }
-  /**
    * Billing-period renewal: Metronome replenished this user's seat balance.
    * Only applies to pro/max seats (workspace seats have no individual seat
    * balance; free seats stay `capped`). Resets any state back to `user_seat`.
@@ -125,165 +111,55 @@ function targetBandFromLiveBalance(ctx: UserCreditContext): UserCreditState {
 
 const TRANSITIONS: UserCreditTransition[] = [
   {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
+    from: ["user_seat", "on_pool", "capped"],
     event: "per_user_cap_reached",
     to: "capped",
   },
   {
-    from: ["on_pool", "on_pool_low_balance", "capped"],
+    from: ["on_pool", "capped"],
     event: "admin_raised_user_cap",
     to: "on_pool",
   },
-  // per_user_cap_resolved: the cap dimension cleared, so re-derive the seat↔pool
-  // band from the live balance snapshot and route to it via guards (same shape
-  // as the seat_balance_exhausted transitions below). A seat-based user who
-  // still has personal balance lands back in `user_seat` /
-  // `user_seat_low_balance`; otherwise they spend from the pool. The unguarded
-  // entry last is the default — also the no-snapshot case (reconcile / billing
-  // webhooks correct it later).
+  // per_user_cap_resolved: the cap dimension cleared — re-derive the seat↔pool
+  // band from the live balance snapshot. A seat-based user with personal balance
+  // lands back in `user_seat`; otherwise `on_pool`. The unguarded entry last is
+  // the default (also the no-snapshot case; reconcile / billing webhooks
+  // correct it later).
   {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
+    from: ["user_seat", "on_pool", "capped"],
     event: "per_user_cap_resolved",
     guard: (ctx) => targetBandFromLiveBalance(ctx) === "user_seat",
     to: "user_seat",
   },
   {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
-    event: "per_user_cap_resolved",
-    guard: (ctx) => targetBandFromLiveBalance(ctx) === "user_seat_low_balance",
-    to: "user_seat_low_balance",
-  },
-  {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
-    event: "per_user_cap_resolved",
-    guard: (ctx) => targetBandFromLiveBalance(ctx) === "on_pool_low_balance",
-    to: "on_pool_low_balance",
-  },
-  {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
+    from: ["user_seat", "on_pool", "capped"],
     event: "per_user_cap_resolved",
     to: "on_pool",
   },
-  // Seat balance exhausted. Routing is driven by `ctx.poolLimitAwuCredits`, not
-  // the seat type — a no-pool seat (free) simply has poolLimit 0. Order matters:
-  // most specific guard first.
-  //  1. No pool budget (poolLimit 0, incl. free) or per-user cap also exhausted
-  //     → capped.
+  // Seat balance exhausted. Routing is driven by `ctx.poolLimitAwuCredits`.
+  // Order matters: most specific guard first.
+  //  1. No pool budget (free seats, poolLimit 0) or per-user cap also exhausted → capped.
   {
-    from: ["user_seat", "user_seat_low_balance", "capped"],
+    from: ["user_seat", "capped"],
     event: "seat_balance_exhausted",
     guard: (ctx) =>
       ctx.poolLimitAwuCredits === 0 || ctx.remainingCapCreditsPercentage === 0,
     to: "capped",
   },
-  //  2. Pool budget left but < 20 % of cap remaining → on_pool_low_balance.
+  //  2. Pool budget left → on_pool.
   {
-    from: ["user_seat", "user_seat_low_balance"],
-    event: "seat_balance_exhausted",
-    guard: (ctx) =>
-      ctx.remainingCapCreditsPercentage != null &&
-      ctx.remainingCapCreditsPercentage < 1 - CAP_WARNING_FRACTION,
-    to: "on_pool_low_balance",
-  },
-  //  3. Pool budget left (poolLimit > 0 or null/unlimited) → on_pool.
-  {
-    from: ["user_seat", "user_seat_low_balance", "on_pool"],
+    from: ["user_seat", "on_pool"],
     event: "seat_balance_exhausted",
     guard: (ctx) => ctx.poolLimitAwuCredits !== 0,
     to: "on_pool",
   },
 
-  // Seat low-balance warning (balance > 0). Guards match threshold to seat
-  // type so only the intended seats transition.
+  // Seat balance replenished — billing-period renewal (pro/max) or fresh credit
+  // for a free seat. Resets any seat-based user from any state, including
+  // `capped`. Workspace seats have no seat balance and are reset by
+  // per_user_cap_resolved instead.
   {
-    from: ["user_seat", "user_seat_low_balance"],
-    event: "seat_low_balance",
-    guard: (ctx, event) =>
-      event.type === "seat_low_balance" &&
-      event.threshold ===
-        SEAT_LOW_BALANCE_FRACTION * MAX_SEAT_MONTHLY_AWU_CREDITS &&
-      (ctx.seatType === "max" || ctx.seatType === "max_yearly"),
-    to: "user_seat_low_balance",
-  },
-  {
-    from: ["user_seat", "user_seat_low_balance"],
-    event: "seat_low_balance",
-    guard: (ctx, event) =>
-      event.type === "seat_low_balance" &&
-      event.threshold === 0.2 * PRO_SEAT_MONTHLY_AWU_CREDITS &&
-      (ctx.seatType === "pro" || ctx.seatType === "pro_yearly"),
-    to: "user_seat_low_balance",
-  },
-  // Free seats: the per-user credit-balance alert is scoped to this one user
-  // (not a workspace-wide fan-out), so it's always relevant — no threshold
-  // disambiguation needed. Match on seat type alone, with no hardcoded
-  // threshold value.
-  {
-    from: ["user_seat", "user_seat_low_balance"],
-    event: "seat_low_balance",
-    guard: (ctx) => ctx.seatType === "free",
-    to: "user_seat_low_balance",
-  },
-
-  // Seat balance replenished — for pro/max a billing-period renewal, for free a
-  // fresh credit clearing its low/empty alert. Reset any seat-based user
-  // (pro/max/free) from any state, including `capped` (a free seat exhausted to
-  // 0 is `capped`, so it must be reachable here). The live balance decides the
-  // band: a partial refill that's still under the low-balance threshold lands
-  // in `user_seat_low_balance`, otherwise `user_seat`. Workspace (pool-based)
-  // seats have no seat balance and are reset by per_user_cap_resolved instead.
-  {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
-    event: "seat_balance_resolved",
-    guard: (ctx) =>
-      isSeatBased(ctx.seatType) &&
-      targetBandFromLiveBalance(ctx) === "user_seat_low_balance",
-    to: "user_seat_low_balance",
-  },
-  {
-    from: [
-      "user_seat",
-      "user_seat_low_balance",
-      "on_pool",
-      "on_pool_low_balance",
-      "capped",
-    ],
+    from: ["user_seat", "on_pool", "capped"],
     event: "seat_balance_resolved",
     guard: (ctx) => isSeatBased(ctx.seatType),
     to: "user_seat",
@@ -312,10 +188,17 @@ export async function transitionUserCreditState(
   { transaction }: { transaction?: Transaction } = {}
 ): Promise<Result<UserCreditState, Error>> {
   const rawState = membership.creditState;
-  // "normal" is the legacy alias of "on_pool" (migration window): match
-  // transitions as if the row were already "on_pool". A matching transition
-  // then persists the canonical value, opportunistically migrating the row.
-  const currentState = rawState === "normal" ? "on_pool" : rawState;
+  // Legacy aliases (migration window): normalize to canonical states so
+  // transitions match correctly, and the next write persists the canonical value.
+  //   "normal"                → "on_pool"
+  //   "on_pool_low_balance"   → "on_pool"
+  //   "user_seat_low_balance" → "user_seat"
+  const currentState =
+    rawState === "normal" || rawState === "on_pool_low_balance"
+      ? "on_pool"
+      : rawState === "user_seat_low_balance"
+        ? "user_seat"
+        : rawState;
   const match = findTransition(currentState, event, ctx);
 
   if (!match) {

--- a/front/types/memberships.test.ts
+++ b/front/types/memberships.test.ts
@@ -57,7 +57,7 @@ describe("expectedUserCreditState", () => {
     ).toBe("user_seat");
   });
 
-  it("pro seat with ≤20% personal balance remaining → user_seat_low_balance", () => {
+  it("pro seat with ≤20% personal balance remaining → user_seat (no low-balance sub-state)", () => {
     expect(
       expectedUserCreditState({
         seatType: "pro",
@@ -66,7 +66,7 @@ describe("expectedUserCreditState", () => {
         perUserCapAwuCredits: CAP,
         consumedAwuCredits: 0.8 * PRO_ALLOWANCE,
       })
-    ).toBe("user_seat_low_balance");
+    ).toBe("user_seat");
   });
 
   it("pro seat with exhausted personal balance, below the cap warning → on_pool", () => {
@@ -145,7 +145,7 @@ describe("expectedUserCreditState", () => {
     ).toBe("capped");
   });
 
-  it("on pool at ≥80% of cap → on_pool_low_balance", () => {
+  it("on pool at ≥80% of cap → on_pool (near-limit tracked separately via nearLimit flag)", () => {
     expect(
       expectedUserCreditState({
         seatType: "workspace",
@@ -154,7 +154,7 @@ describe("expectedUserCreditState", () => {
         perUserCapAwuCredits: CAP,
         consumedAwuCredits: 0.8 * CAP,
       })
-    ).toBe("on_pool_low_balance");
+    ).toBe("on_pool");
   });
 
   it("no cap configured → never capped (uncapped pool user)", () => {

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -1,3 +1,4 @@
+import { NEAR_LIMIT_FRACTION } from "@app/lib/metronome/constants";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const MEMBERSHIP_ROLE_TYPES = [
@@ -260,13 +261,6 @@ export interface MembershipUpgradeRequestType {
   };
 }
 
-// Fraction of the personal seat balance / per-user cap at which the
-// low-balance warning bands kick in. Mirrors the seat-low-balance guards in
-// `lib/metronome/user_credit_state_machine.ts` (threshold === 0.2 * allowance)
-// and `USER_AWU_WARNING_PERCENTAGE` (0.8) backing the per-user warning alerts.
-export const SEAT_LOW_BALANCE_FRACTION = 0.2;
-export const CAP_WARNING_FRACTION = 0.8;
-
 /**
  * The credit state a freshly-allocated seat should start in, derived purely
  * from the seat type (assumes a full, unspent balance):
@@ -291,12 +285,10 @@ export function initialCreditStateForSeatType(
  *     first — if consumption reached the cap, the personal seat is necessarily
  *     exhausted too.
  *   - the seat↔pool dimension: a seat-based user with personal balance left is
- *     `user_seat` (or `user_seat_low_balance` at ≤20% remaining); once the
- *     personal balance is exhausted — or for pool-based seats that never had
- *     one — they spend from the workspace pool (`on_pool`, or
- *     `on_pool_low_balance` at ≥80% of the cap). Free seats are the exception:
- *     they are seat-based but have no pool fallback, so an exhausted free seat
- *     is `capped`.
+ *     `user_seat`; once the personal balance is exhausted — or for pool-based
+ *     seats that never had one — they spend from the workspace pool (`on_pool`).
+ *     Free seats are the exception: they are seat-based but have no pool
+ *     fallback, so an exhausted free seat is `capped`.
  *
  * `seatBalanceAwu` / `seatStartingBalanceAwu` come from the live per-seat /
  * per-user credit balance; `seatBalanceAwu > 0` means the user still holds
@@ -334,12 +326,6 @@ export function expectedUserCreditState({
 
   // Seat-based user still holding personal credit.
   if (isSeatBased(seatType) && seatBalanceAwu !== null && seatBalanceAwu > 0) {
-    if (
-      seatStartingBalanceAwu !== null &&
-      seatBalanceAwu <= SEAT_LOW_BALANCE_FRACTION * seatStartingBalanceAwu
-    ) {
-      return "user_seat_low_balance";
-    }
     return "user_seat";
   }
 
@@ -354,12 +340,42 @@ export function expectedUserCreditState({
   }
 
   // Pool-backed seats (pro/max with depleted balance) and pool-based seats spend
-  // from the workspace pool. Surface the 80% cap warning when applicable.
-  if (
-    capKnown &&
-    consumedAwuCredits >= CAP_WARNING_FRACTION * perUserCapAwuCredits
-  ) {
-    return "on_pool_low_balance";
-  }
+  // from the workspace pool.
   return "on_pool";
+}
+
+/**
+ * Compute whether a user should see the "near limit" warning banner from their
+ * live Metronome inputs. Two sources:
+ *   - Cap consumption ≥ 80 % of the effective per-user cap (seat allowance +
+ *     pool limit). Applies to pro/max pool users.
+ *   - Free seat: ≥ 80 % of the lifetime credit consumed (≤ 20 % remaining).
+ */
+export function computeUserNearLimit({
+  seatType,
+  seatBalanceAwu,
+  seatStartingBalanceAwu,
+  effectiveCapAwuCredits,
+  consumedAwuCredits,
+}: {
+  seatType: MembershipSeatType | null | undefined;
+  seatBalanceAwu: number | null;
+  seatStartingBalanceAwu: number | null;
+  effectiveCapAwuCredits: number | null;
+  consumedAwuCredits: number | null;
+}): boolean {
+  // Cap-based warning (pro/max with a configured cap).
+  if (effectiveCapAwuCredits !== null && consumedAwuCredits !== null) {
+    return consumedAwuCredits >= NEAR_LIMIT_FRACTION * effectiveCapAwuCredits;
+  }
+  // Free-seat lifetime credit warning (no pool fallback, no cap).
+  if (
+    seatType === "free" &&
+    seatBalanceAwu !== null &&
+    seatStartingBalanceAwu !== null &&
+    seatStartingBalanceAwu > 0
+  ) {
+    return seatBalanceAwu <= (1 - NEAR_LIMIT_FRACTION) * seatStartingBalanceAwu;
+  }
+  return false;
 }


### PR DESCRIPTION
## Context

Stacked on #27523.

Now that the near-limit signal lives in a separate `nearLimit` Redis flag, `on_pool_low_balance` and `user_seat_low_balance` carry no additional meaning beyond their canonical equivalents (`on_pool` and `user_seat`). This PR stops writing them and treats them as legacy read-only aliases — same pattern already used for `normal → on_pool`.

## What this PR does

**State machine:**
- Adds alias normalization in `transitionUserCreditState`: `on_pool_low_balance → on_pool`, `user_seat_low_balance → user_seat` (so existing DB rows transition correctly on their next event).
- Removes all transitions that wrote `on_pool_low_balance` or `user_seat_low_balance` as their target.
- Removes `seat_low_balance` event and `dispatchSeatLowBalance` (free seat near-limit is now handled by `setUserNearLimit` directly in the webhook, without a state transition).
- Removes `SEAT_LOW_BALANCE_FRACTION` and `CAP_WARNING_FRACTION` constants.

**`expectedUserCreditState`:**
- Now returns only `user_seat`, `on_pool`, or `capped` — never the low-balance sub-states.
- Adds `computeUserNearLimit` alongside it, taking the same live inputs and returning a boolean based on 80% of the effective cap (or ≥80% of free seat lifetime credit consumed).

**Reconciliation:**
- Both the single-user and workspace-wide reconcile paths now call `setUserNearLimit` with the result of `computeUserNearLimit` after each state reconcile, ensuring the flag stays accurate from live Metronome data.

**Backward compatibility:** `user_seat_low_balance` and `on_pool_low_balance` remain in `USER_CREDIT_STATES` as accepted aliases so existing DB rows are read correctly. The alias normalization in the state machine opportunistically migrates rows on their next state write.

## Tests

State machine test suite updated: removed `seat_low_balance` describe block, updated expectations to `user_seat` / `on_pool` (no longer low-balance sub-states), and added legacy alias tests.

## Risk

Low. The state machine no longer writes new `on_pool_low_balance` / `user_seat_low_balance` rows. Existing rows are handled via alias normalization. The DB migration (PR #27526) cleans up remaining rows post-deploy.

## Deploy Plan

1. Deploy this PR.
2. Run the post-deploy migration from PR #27526 to rename remaining legacy rows.