### PR TITLE
billing: migrate low_balance credit states

### DIFF
--- a/front/migrations/post-deploy/20260617000000_migrate_low_balance_credit_states.sql
+++ b/front/migrations/post-deploy/20260617000000_migrate_low_balance_credit_states.sql
@@ -1,0 +1,17 @@
+-- Migrate legacy low-balance credit states to their canonical equivalents.
+--
+-- `on_pool_low_balance` and `user_seat_low_balance` were sub-states that encoded
+-- the near-limit warning signal inside the credit state. The warning is now held
+-- in a separate `nearLimit` Redis flag (see user_block.ts), so these states carry
+-- no additional meaning beyond their canonical equivalents.
+--
+-- After this migration runs, the alias mappings and the states themselves can be
+-- removed from USER_CREDIT_STATES and transitionUserCreditState.
+
+UPDATE "memberships"
+SET "creditState" = 'on_pool'
+WHERE "creditState" = 'on_pool_low_balance';
+
+UPDATE "memberships"
+SET "creditState" = 'user_seat'
+WHERE "creditState" = 'user_seat_low_balance';


### PR DESCRIPTION
Post-deploy migration that renames the two deprecated per-user credit states to their canonical equivalents:

- `on_pool_low_balance` → `on_pool`
- `user_seat_low_balance` → `user_seat`

These sub-states previously encoded the near-limit warning signal inside the credit state. The warning is now stored in a separate `nearLimit` Redis flag (see #27523). The state machine has already stopped writing them and treats them as aliases; this migration cleans up existing rows.

Run after all PRs in the stack (#27523, #27525, #27527) are deployed:
```
npm run migration:apply:post-deploy
```