### PR TITLE
Set default pool limit to 0

### DIFF
--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -89,7 +89,7 @@ export function UsageSettingsCard({
         <LockedSection locked={!hasPool}>
           <SettingsList.Row
             title="Default Workspace Credit Pool limit"
-            description="Define the Workspace Credit Pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance. Can be overridden per user in the members table."
+            description="Define the Workspace Credit Pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance. Set to 0 to prevent pool usage. Can be overridden per user in the members table."
             action={
               <div className="w-52">
                 <InputWithSave

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -17,7 +17,6 @@ import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_
 import type { WorkspaceCreditEvent } from "@app/lib/metronome/workspace_credit_state_machine";
 import { transitionWorkspaceCreditState } from "@app/lib/metronome/workspace_credit_state_machine";
 import { notifyAdminsProgrammaticCapReached } from "@app/lib/notifications/workflows/programmatic-cap-reached";
-import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -26,18 +25,17 @@ import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
-import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
 /**
  * Resolve the effective pool credit limit for a user.
  *
- * Priority: per-user Metronome override > per-seat-type workspace default > plan-tier fallback.
+ * Priority: per-user override > workspace default. When nothing is configured,
+ * defaults to 0 (no pool access). Unlimited pool is not supported.
  *
- * Returns `number | null`:
- *   - a number (including 0) when a limit is configured or implied by the plan
- *   - `null` when the user has unlimited pool access (enterprise with no limit)
+ * Returns `number`: the pool credit limit (0 = no pool access).
  */
 async function resolvePoolLimitForUser({
   workspace,
@@ -46,53 +44,32 @@ async function resolvePoolLimitForUser({
 }: {
   workspace: WorkspaceResource;
   membership: MembershipResource;
-  defaultPoolCapAwuCredits: number | null;
-}): Promise<number | null> {
-  const { metronomeCustomerId } = workspace;
-  if (!metronomeCustomerId) {
-    return null;
-  }
-
-  // Free seats have no pool access — their pool limit is always 0, regardless
-  // of any per-user cap override (a cap bounds personal spend; it is not a pool
-  // budget). This is the single source of "free has no pool": downstream
-  // routing (capped vs on_pool) then falls out of `poolLimit === 0` with no
-  // seat-type special-casing.
-  if (membership.seatType === "free") {
+  defaultPoolCapAwuCredits: number;
+}): Promise<number> {
+  if (!workspace.metronomeCustomerId) {
     return 0;
   }
-
-  // 1. Per-user override (pool-only, persisted on the membership).
+  // Seats with no pool access: free (personal lifetime credits only) and none
+  // (no seat at all). Exit early — no point inspecting overrides or defaults.
+  if (membership.seatType === "free" || membership.seatType === "none") {
+    return 0;
+  }
+  // Per-user override takes precedence over the workspace default.
   if (membership.poolCapOverrideAwuCredits !== null) {
     return membership.poolCapOverrideAwuCredits;
   }
-
-  // 2. Workspace default (pool-only, persisted on the credit-usage
-  // configuration), for pool-limit seat types.
-  const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
-  if (normalizedSeatType && defaultPoolCapAwuCredits !== null) {
-    return defaultPoolCapAwuCredits;
-  }
-
-  // 3. Plan-tier fallback: enterprise → unlimited, everything else → 0.
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
-  );
-  const planCode = subscription?.getPlan().code;
-  if (!planCode) {
-    return 0;
-  }
-  return getPlanDefaultPoolLimitAwuCredits(planCode);
+  // All remaining seat types (pro/max/workspace) have pool access governed by
+  // the workspace default (0 = no pool if not configured).
+  return defaultPoolCapAwuCredits;
 }
 
 /**
- * Transition a single user from `user_seat` / `user_seat_low_balance` when
- * Metronome fires `alerts.low_remaining_seat_balance_reached` for that user.
+ * Transition a single user from `user_seat` when Metronome fires
+ * `alerts.low_remaining_seat_balance_reached` at threshold 0 for that user.
  *
- * Resolves the user's effective pool credit limit from Metronome alerts, then
- * falls back by plan tier (enterprise → unlimited, business → 0). The state
- * machine uses this limit to decide whether the user goes to `on_pool` or
- * `capped`.
+ * Resolves the user's effective pool credit limit (0 when none is configured).
+ * The state machine uses this limit to decide whether the user goes to
+ * `on_pool` or `capped`.
  */
 export async function dispatchSeatBalanceExhausted({
   workspace,
@@ -129,7 +106,7 @@ export async function dispatchSeatBalanceExhausted({
       workspace.id
     );
   const defaultPoolCapAwuCredits =
-    creditUsageConfig?.defaultPoolCapAwuCredits ?? null;
+    creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
 
   const poolLimitAwuCredits = await resolvePoolLimitForUser({
     workspace,
@@ -383,8 +360,7 @@ async function resolveLiveUserBalance({
     userId,
     seatType,
     poolCapOverrideAwuCredits,
-    defaultPoolCapAwuCredits:
-      creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
+    defaultPoolCapAwuCredits: creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
     metronomeCustomerId,
     metronomeContractId,
   });

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1098,8 +1098,8 @@ export async function processMetronomeWebhook({
     // carries no `credit_id` for a custom-field-filtered alert, so the user is
     // resolved from the alert's enforced `custom_field_filters` via its
     // `alert_id` (see `resolvePerUserCreditAlertUserId`); events for any other
-    // alert return null and are ignored. Two thresholds mirror the seat bands:
-    // `threshold === 0` → exhausted (→ capped), else → low balance.
+    // alert return null and are ignored. Two thresholds:
+    // `threshold === 0` → exhausted (→ capped), else → near-limit flag set.
     case "alerts.low_remaining_contract_credit_balance_reached": {
       const { alert_id: alertId, threshold } = event.properties;
       const userId = await resolvePerUserCreditAlertUserId({

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -309,8 +309,7 @@ async function reconcileUser({
     // Pool-only values persisted in the DB; the live-inputs helper adds the
     // seat allowance back to get the total threshold.
     poolCapOverrideAwuCredits: membership.poolCapOverrideAwuCredits,
-    defaultPoolCapAwuCredits:
-      creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
+    defaultPoolCapAwuCredits: creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
     metronomeCustomerId,
     metronomeContractId,
   });
@@ -433,7 +432,7 @@ export async function reconcileWorkspaceUserCreditStates({
   // credit-usage configuration (both pool-only values); the seat allowances
   // are needed to derive the total thresholds.
   let seatAllowances: Partial<Record<NormalizedPoolLimitSeatType, number>>;
-  let defaultPoolCapAwuCredits: number | null;
+  let defaultPoolCapAwuCredits: number;
   let memberships: MembershipResource[];
   try {
     seatAllowances = await getSeatAllowancesByNormalizedSeatType(workspaceId);
@@ -441,8 +440,7 @@ export async function reconcileWorkspaceUserCreditStates({
       await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
         workspace.id
       );
-    defaultPoolCapAwuCredits =
-      creditUsageConfig?.defaultPoolCapAwuCredits ?? null;
+    defaultPoolCapAwuCredits = creditUsageConfig?.defaultPoolCapAwuCredits ?? 0;
     ({ memberships } = await MembershipResource.getActiveMemberships({
       workspace,
     }));
@@ -488,7 +486,7 @@ export async function reconcileWorkspaceUserCreditStates({
     const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
     const poolCapAwuCredits =
       membership.poolCapOverrideAwuCredits ??
-      (normalizedSeatType ? defaultPoolCapAwuCredits : null);
+      (normalizedSeatType ? defaultPoolCapAwuCredits : 0);
     const effectiveCapAwuCredits =
       poolCapAwuCredits !== null
         ? poolCapAwuCredits +

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -1,10 +1,12 @@
 import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
+import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/default_user_spend_limit";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -90,6 +92,16 @@ export async function syncMetronomeSeatCountForWorkspace({
     metronomeCustomerId: workspace.metronomeCustomerId,
     metronomeContractId: subscription.metronomeContractId,
   });
+
+  // Ensure per-seat-type cap alerts exist with the current default pool limit.
+  // Best-effort: a failure here must not fail the seat sync.
+  const alertSyncResult = await syncDefaultPoolCapAlertsForWorkspace(workspace);
+  if (alertSyncResult.isErr()) {
+    logger.warn(
+      { workspaceId: workspace.sId, err: alertSyncResult.error.message },
+      "[SeatSync] Failed to sync default pool cap alerts; continuing"
+    );
+  }
 
   return new Ok({ status: "synced" });
 }

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -38,6 +38,7 @@ export * from "./run_reinforcement_workflow";
 export * from "./send_onboarding_conversation";
 export * from "./set_web_providers";
 export * from "./soft_delete_conversation";
+export * from "./sync_default_pool_cap_alerts";
 export * from "./sync_metronome_seats";
 export * from "./sync_missing_transcripts_date_range";
 export * from "./toggle_auto_create_space";

--- a/front/lib/api/poke/plugins/workspaces/sync_default_pool_cap_alerts.ts
+++ b/front/lib/api/poke/plugins/workspaces/sync_default_pool_cap_alerts.ts
@@ -1,0 +1,35 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/default_user_spend_limit";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const syncDefaultPoolCapAlertsPlugin = createPlugin({
+  manifest: {
+    id: "sync-default-pool-cap-alerts",
+    name: "Sync Default Pool Cap Alerts",
+    description:
+      "Create or update Metronome per-seat-type cap and warning alerts from " +
+      "the workspace's current default pool credit limit (0 when not configured). " +
+      "Use after contract changes or to repair missing alerts.",
+    resourceTypes: ["workspaces"],
+    args: {},
+    requiredRoles: ["billing"],
+  },
+
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && isCreditPricedPlan(plan);
+  },
+
+  execute: async (auth, _resource, _args) => {
+    const workspace = auth.getNonNullableWorkspace();
+    const result = await syncDefaultPoolCapAlertsForWorkspace(workspace);
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+    return new Ok({
+      display: "text",
+      value: "Default pool cap alerts synced.",
+    });
+  },
+});

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -14,7 +14,6 @@ import {
   getProductSeatTypes,
   getSeatSubscriptionsFromContract,
 } from "@app/lib/metronome/seat_types";
-import { getPlanDefaultPoolLimitAwuCredits } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import {
@@ -27,6 +26,7 @@ import {
 } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
 
 export type DefaultUserSpendLimit = {
   awuCredits: number;
@@ -59,7 +59,7 @@ export class DefaultUserSpendLimitError extends Error {
  * (`credit_usage_configurations.defaultPoolCapAwuCredits`) is the source of
  * truth — the per-seat-type Metronome alerts (threshold = seatAllowance +
  * poolLimit) are derived from it. When no workspace default is configured,
- * falls back to the plan-tier default (`null` for enterprise = unlimited).
+ * returns 0 (no pool access). Unlimited pool is not supported.
  */
 export async function getDefaultUserSpendLimit(
   auth: Authenticator
@@ -83,30 +83,119 @@ export async function getDefaultUserSpendLimit(
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
   if (!config || config.defaultPoolCapAwuCredits === null) {
-    // No workspace-specific default configured: fall back to the plan-tier
-    // default (same resolution the per-user cap path applies).
-    const planCode = auth.getNonNullableSubscriptionResource().getPlan().code;
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        planCode,
-      },
-      "[DefaultUserSpendLimit] get: no workspace default configured, falling back to plan-tier default"
-    );
-    return new Ok({ awuCredits: getPlanDefaultPoolLimitAwuCredits(planCode) });
+    return new Ok({ awuCredits: 0 });
   }
 
   return new Ok({ awuCredits: config.defaultPoolCapAwuCredits });
 }
 
 /**
+ * Create or update Metronome per-seat-type cap + warning alerts so that every
+ * active seat type has an alert at (seatAllowance + poolAwuCredits). Uses the
+ * workspace's configured `defaultPoolCapAwuCredits` (or 0 when none is set).
+ * Call after contract provisioning or when the default changes.
+ */
+export async function syncDefaultPoolCapAlertsForWorkspace(
+  workspace: LightWorkspaceType
+): Promise<Result<void, DefaultUserSpendLimitError>> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId) {
+    return new Ok(undefined);
+  }
+
+  const config = await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+    workspace.id
+  );
+  const poolAwuCredits = config?.defaultPoolCapAwuCredits ?? 0;
+
+  const contract = await getActiveContract(workspace.sId);
+  if (!contract) {
+    logger.error(
+      { workspaceId: workspace.sId },
+      "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: no active contract found"
+    );
+    return new Err(
+      new DefaultUserSpendLimitError(
+        "contract_not_found",
+        "No active contract found for this workspace."
+      )
+    );
+  }
+  const productSeatTypes = await getProductSeatTypes();
+  const seatSubscriptions = getSeatSubscriptionsFromContract(
+    contract,
+    productSeatTypes
+  );
+
+  const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
+  for (const seatType of seatSubscriptions.keys()) {
+    const normalized = normalizeToPoolLimitSeatType(seatType);
+    if (normalized) {
+      normalizedSeatTypes.add(normalized);
+    }
+  }
+
+  for (const seatType of normalizedSeatTypes) {
+    const seatAllowance = getAwuAllocationForNormalizedSeatType(
+      contract,
+      seatType,
+      productSeatTypes
+    );
+    const totalThreshold = seatAllowance + poolAwuCredits;
+
+    const upsertResult = await upsertMetronomeDefaultUserCapAlertForSeatType({
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      seatType,
+      awuCredits: totalThreshold,
+    });
+    if (upsertResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          seatType,
+          totalThreshold,
+          err: upsertResult.error,
+        },
+        "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: failed to upsert cap alert"
+      );
+      return new Err(
+        new DefaultUserSpendLimitError(
+          "metronome_error",
+          upsertResult.error.message
+        )
+      );
+    }
+
+    const warningResult =
+      await upsertMetronomeDefaultUserWarningAlertForSeatType({
+        metronomeCustomerId,
+        workspaceId: workspace.sId,
+        seatType,
+        capAwuCredits: totalThreshold,
+      });
+    if (warningResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          seatType,
+          totalThreshold,
+          err: warningResult.error,
+        },
+        "[DefaultUserSpendLimit] syncDefaultPoolCapAlerts: failed to upsert warning alert; continuing"
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+/**
  * Update the workspace-wide default pool credit limit.
  *
- * Creates one Metronome alert per seat type on the contract. Each alert's
- * threshold = seatAllowance + poolAwuCredits so that the limit only
- * concerns pool credits, not the seat allowance.
- *
+ * Persists the new limit then syncs Metronome per-seat-type cap + warning
+ * alerts (threshold = seatAllowance + poolAwuCredits) via
+ * `syncDefaultPoolCapAlertsForWorkspace`.
  */
 export async function setDefaultUserSpendLimit(
   auth: Authenticator,
@@ -164,60 +253,6 @@ export async function setDefaultUserSpendLimit(
     "[DefaultUserSpendLimit] set: starting default per-user spend limit update"
   );
 
-  const contract = await getActiveContract(workspace.sId);
-  if (!contract) {
-    logger.error(
-      { workspaceId: workspace.sId, metronomeCustomerId },
-      "[DefaultUserSpendLimit] set: no active contract found for workspace"
-    );
-    return new Err(
-      new DefaultUserSpendLimitError(
-        "contract_not_found",
-        "No active contract found for this workspace."
-      )
-    );
-  }
-  const productSeatTypes = await getProductSeatTypes();
-
-  // Determine which seat types the contract actually sells.
-  const seatSubscriptions = getSeatSubscriptionsFromContract(
-    contract,
-    productSeatTypes
-  );
-
-  // Normalize to pool-limit seat types (dedup monthly/yearly).
-  const normalizedSeatTypes = new Set<NormalizedPoolLimitSeatType>();
-  for (const seatType of seatSubscriptions.keys()) {
-    const normalized = normalizeToPoolLimitSeatType(seatType);
-    if (normalized) {
-      normalizedSeatTypes.add(normalized);
-    }
-  }
-
-  logger.info(
-    {
-      workspaceId: workspace.sId,
-      metronomeCustomerId,
-      productSeatTypeCount: productSeatTypes.size,
-      contractSeatTypes: [...seatSubscriptions.keys()],
-      normalizedSeatTypes: [...normalizedSeatTypes],
-    },
-    "[DefaultUserSpendLimit] set: resolved seat types from contract"
-  );
-
-  if (normalizedSeatTypes.size === 0) {
-    // No seat alert will be created, so the limit would silently not apply.
-    // Surface this loudly rather than returning a success that does nothing.
-    logger.error(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId,
-        contractSeatTypes: [...seatSubscriptions.keys()],
-      },
-      "[DefaultUserSpendLimit] set: contract has no pool-limit seat types; no cap alert will be created"
-    );
-  }
-
   // Persist the admin's intent first: the credit-usage configuration column is
   // the source of truth, the per-seat-type Metronome alerts below are derived
   // enforcement (a failed sync can be retried and re-derives from this value).
@@ -238,74 +273,10 @@ export async function setDefaultUserSpendLimit(
     });
   }
 
-  // Create per-seat-type alerts.
-  for (const seatType of normalizedSeatTypes) {
-    const seatAllowance = getAwuAllocationForNormalizedSeatType(
-      contract,
-      seatType,
-      productSeatTypes
-    );
-    const totalThreshold = seatAllowance + poolAwuCredits;
-
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        metronomeCustomerId,
-        seatType,
-        seatAllowance,
-        poolAwuCredits,
-        totalThreshold,
-      },
-      "[DefaultUserSpendLimit] set: computed cap threshold for seat type (seatAllowance + poolAwuCredits)"
-    );
-
-    const upsertResult = await upsertMetronomeDefaultUserCapAlertForSeatType({
-      metronomeCustomerId,
-      workspaceId: workspace.sId,
-      seatType,
-      awuCredits: totalThreshold,
-    });
-    if (upsertResult.isErr()) {
-      logger.error(
-        {
-          workspaceId: workspace.sId,
-          metronomeCustomerId,
-          seatType,
-          seatAllowance,
-          poolAwuCredits,
-          totalThreshold,
-          err: upsertResult.error,
-        },
-        "[DefaultUserSpendLimit] set: failed to upsert default per-user cap alert"
-      );
-      return new Err(
-        new DefaultUserSpendLimitError(
-          "metronome_error",
-          upsertResult.error.message
-        )
-      );
-    }
-
-    // 80% warning alert. Errors are logged but don't fail the operation.
-    const warningResult =
-      await upsertMetronomeDefaultUserWarningAlertForSeatType({
-        metronomeCustomerId,
-        workspaceId: workspace.sId,
-        seatType,
-        capAwuCredits: totalThreshold,
-      });
-    if (warningResult.isErr()) {
-      logger.warn(
-        {
-          workspaceId: workspace.sId,
-          seatType,
-          metronomeCustomerId,
-          poolAwuCredits,
-          err: warningResult.error,
-        },
-        "[DefaultUserSpendLimit] Failed to upsert warning alert for seat type; continuing"
-      );
-    }
+  // Sync per-seat-type Metronome alerts from the newly persisted value.
+  const syncResult = await syncDefaultPoolCapAlertsForWorkspace(workspace);
+  if (syncResult.isErr()) {
+    return new Err(syncResult.error);
   }
 
   logger.info(
@@ -314,7 +285,6 @@ export async function setDefaultUserSpendLimit(
       metronomeCustomerId,
       previousAwuCredits,
       poolAwuCredits,
-      seatTypesUpdated: [...normalizedSeatTypes],
     },
     "[DefaultUserSpendLimit] set: default per-user spend limit update succeeded"
   );

--- a/front/lib/metronome/live_user_credit_inputs.test.ts
+++ b/front/lib/metronome/live_user_credit_inputs.test.ts
@@ -52,7 +52,7 @@ beforeEach(() => {
 });
 
 describe("fetchLiveUserCreditInputs", () => {
-  it("reads the live seat balance for a seat-based user", async () => {
+  it("reads the live seat balance for a seat-based user with default 0 pool cap", async () => {
     mockListMetronomeSeatBalances.mockResolvedValue(
       new Ok(seatBalance(40000, 40000))
     );
@@ -62,7 +62,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
-      defaultPoolCapAwuCredits: null,
+      defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });
@@ -71,10 +71,11 @@ describe("fetchLiveUserCreditInputs", () => {
     if (result.isOk()) {
       expect(result.value.seatBalanceAwu).toBe(40000);
       expect(result.value.seatStartingBalanceAwu).toBe(40000);
-      // No cap configured → cap fields null, usage not fetched.
-      expect(result.value.effectiveCapAwuCredits).toBeNull();
-      expect(result.value.capSource).toBe("none");
-      expect(result.value.consumedAwuCredits).toBeNull();
+      // Default 0 pool cap → effectiveCapAwuCredits = seatAllowance + 0.
+      // No contract resolves for "ws_test" so seatAllowance = 0 → cap = 0.
+      expect(result.value.effectiveCapAwuCredits).toBe(0);
+      expect(result.value.capSource).toBe("default");
+      expect(result.value.consumedAwuCredits).toBe(0);
     }
   });
 
@@ -93,7 +94,7 @@ describe("fetchLiveUserCreditInputs", () => {
       // Pool-only override from the membership; no contract resolves for
       // "ws_test" so the seat allowance is 0 and the total cap equals it.
       poolCapOverrideAwuCredits: 50000,
-      defaultPoolCapAwuCredits: null,
+      defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });
@@ -117,7 +118,7 @@ describe("fetchLiveUserCreditInputs", () => {
       userId: USER_ID,
       seatType: "max",
       poolCapOverrideAwuCredits: null,
-      defaultPoolCapAwuCredits: null,
+      defaultPoolCapAwuCredits: 0,
       metronomeCustomerId: CUSTOMER_ID,
       metronomeContractId: CONTRACT_ID,
     });

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -44,13 +44,12 @@ export function awuSeatBalanceForUser(
 }
 
 export type LiveUserCreditInputs = {
-  // Live Metronome per-seat AWU balance for this user: `seatBalanceAwu` is the
-  // amount remaining, `seatStartingBalanceAwu` the full allocation granted for
-  // the period (e.g. 8000 for a pro seat). Both null for pool-based seats with
-  // no individual allocation. The remaining/starting ratio drives the
-  // user_seat ↔ user_seat_low_balance band.
+  // Live Metronome per-seat AWU balance: remaining and full allocation.
+  // Both null for pool-based seats with no individual allocation.
   seatBalanceAwu: number | null;
   seatStartingBalanceAwu: number | null;
+  // Effective per-user cap = poolCap + seatAllowance. Null for seat types with
+  // no pool access (free, none).
   effectiveCapAwuCredits: number | null;
   capSource: "override" | "default" | "none";
   consumedAwuCredits: number | null;
@@ -86,7 +85,7 @@ export async function fetchLiveUserCreditInputs({
   userId: string;
   seatType: MembershipSeatType | null;
   poolCapOverrideAwuCredits: number | null;
-  defaultPoolCapAwuCredits: number | null;
+  defaultPoolCapAwuCredits: number;
   metronomeCustomerId: string;
   metronomeContractId: string | null;
 }): Promise<Result<LiveUserCreditInputs, Error>> {
@@ -134,57 +133,47 @@ export async function fetchLiveUserCreditInputs({
     }
   }
 
-  // Resolve the effective per-user cap threshold (in AWU credits, seat
-  // allowance included): the user-specific override if present, otherwise the
-  // workspace default for pool-limit seat types. `null` means no cap is
-  // configured for this user. Both are pool-only values persisted in the DB;
-  // the seat allowance is added back to get the total threshold.
+  // Cap + usage only apply to pool-limit seat types (pro/max/workspace).
+  // Free and none seats have no pool access — their effective cap is null.
+  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
   let effectiveCapAwuCredits: number | null = null;
   let capSource: LiveUserCreditInputs["capSource"] = "none";
+  let consumedAwuCredits: number | null = null;
 
-  const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
-  let poolCapAwuCredits: number | null = null;
-  if (poolCapOverrideAwuCredits !== null) {
-    poolCapAwuCredits = poolCapOverrideAwuCredits;
-    capSource = "override";
-  } else if (normalizedSeatType && defaultPoolCapAwuCredits !== null) {
-    poolCapAwuCredits = defaultPoolCapAwuCredits;
-    capSource = "default";
-  }
+  if (normalizedSeatType) {
+    const poolCapAwuCredits =
+      poolCapOverrideAwuCredits ?? defaultPoolCapAwuCredits;
+    capSource = poolCapOverrideAwuCredits !== null ? "override" : "default";
 
-  if (poolCapAwuCredits !== null) {
     let seatAllowance = 0;
-    if (normalizedSeatType) {
-      try {
-        const allowances =
-          await getSeatAllowancesByNormalizedSeatType(workspaceId);
-        seatAllowance = allowances[normalizedSeatType] ?? 0;
-      } catch (err) {
+    try {
+      const allowances =
+        await getSeatAllowancesByNormalizedSeatType(workspaceId);
+      seatAllowance = allowances[normalizedSeatType] ?? 0;
+    } catch (err) {
+      return new Err(
+        new Error(
+          `Failed to resolve seat allowance: ${normalizeError(err).message}`
+        )
+      );
+    }
+    effectiveCapAwuCredits = poolCapAwuCredits + seatAllowance;
+
+    if (metronomeContractId) {
+      const usageResult = await fetchPerUserAwuUsage({
+        metronomeCustomerId,
+        metronomeContractId,
+        userIds: [userId],
+      });
+      if (usageResult.isErr()) {
         return new Err(
           new Error(
-            `Failed to resolve seat allowance: ${normalizeError(err).message}`
+            `Failed to read per-user usage: ${usageResult.error.message}`
           )
         );
       }
+      consumedAwuCredits = usageResult.value.get(userId) ?? 0;
     }
-    effectiveCapAwuCredits = poolCapAwuCredits + seatAllowance;
-  }
-
-  // Consumption is only needed for the cap bands (capped / on_pool_low_balance),
-  // which require a configured cap; skip the fetch otherwise.
-  let consumedAwuCredits: number | null = null;
-  if (effectiveCapAwuCredits !== null && metronomeContractId) {
-    const usageResult = await fetchPerUserAwuUsage({
-      metronomeCustomerId,
-      metronomeContractId,
-      userIds: [userId],
-    });
-    if (usageResult.isErr()) {
-      return new Err(
-        new Error(`Failed to read per-user usage: ${usageResult.error.message}`)
-      );
-    }
-    consumedAwuCredits = usageResult.value.get(userId) ?? 0;
   }
 
   return new Ok({

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -120,22 +120,6 @@ export function isProOrBusinessPlanCode(plan?: PlanType) {
 }
 
 /**
- * Returns the implicit default pool credit limit for a plan when no explicit
- * limit has been configured in Metronome.
- *
- *   - Enterprise plans → `null` (unlimited pool access)
- *   - Everything else (business, pro, free) → `0` (no pool access)
- */
-export function getPlanDefaultPoolLimitAwuCredits(
-  planCode: string
-): number | null {
-  if (isEnterprisePlanPrefix(planCode)) {
-    return null;
-  }
-  return 0;
-}
-
-/**
  * `isUpgraded` returns true if the plan has access to all features of Dust, including large
  * language models (meaning it's either a paid plan or free plan with (eg friends and family, or
  * free trial plan)).

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -319,8 +319,14 @@ export function expectedUserCreditState({
 }): UserCreditState {
   const capKnown = perUserCapAwuCredits !== null && consumedAwuCredits !== null;
 
-  // Hard block first: consumption reached the per-user cap.
-  if (capKnown && consumedAwuCredits >= perUserCapAwuCredits) {
+  // Hard block: consumption reached the per-user cap. Only meaningful when
+  // cap > 0 — cap = 0 means "no pool access" (enforced by the state machine's
+  // seat_balance_exhausted routing), not a cap that users can "hit" by spending.
+  if (
+    capKnown &&
+    perUserCapAwuCredits > 0 &&
+    consumedAwuCredits >= perUserCapAwuCredits
+  ) {
     return "capped";
   }
 


### PR DESCRIPTION
## Context

Stacked on #27525.

Previously, the default pool credit limit for a user was resolved as follows:
- Enterprise plans → `null` (unlimited pool access)
- Everything else → `0` (no pool access)
- But only when no `credit_usage_configurations` row existed

This made unlimited pool access the default for enterprise workspaces with no explicit configuration, which was unintentional. The new semantics: **`null` / missing config always means 0** — unlimited pool access is no longer implicit for any plan. Admins must explicitly configure a pool limit via the workspace settings.

## What this PR does

**Default pool limit = 0:**
- `resolvePoolLimitForUser` (`credit_state_dispatcher.ts`): removed plan-tier fallback; `defaultPoolCapAwuCredits ?? 0` applies for all pool-limit seat types. Return type narrowed from `number | null` to `number`.
- `fetchLiveUserCreditInputs` (`live_user_credit_inputs.ts`): pool cap now always resolves for pool-limit seat types, treating `null` as 0 (was previously skipped when null).
- `getDefaultUserSpendLimit` (`default_user_spend_limit.ts`): returns `{ awuCredits: 0 }` when no config exists (was: plan-tier fallback).

**Auto-sync alerts on seat sync:**
- Extracted alert creation loop from `setDefaultUserSpendLimit` into `syncDefaultPoolCapAlertsForWorkspace(workspace: LightWorkspaceType)`.
- `syncMetronomeSeatCountForWorkspace` (`seat_sync.ts`) now calls `syncDefaultPoolCapAlertsForWorkspace` after every reconcile (best-effort). This ensures per-seat-type Metronome alerts are created whenever a new contract is provisioned or seat types change.
- `setDefaultUserSpendLimit` delegates to `syncDefaultPoolCapAlertsForWorkspace` internally.

**Poke plugin:**
- New `sync-default-pool-cap-alerts` plugin (`workspaces/sync_default_pool_cap_alerts.ts`) to manually trigger alert sync for a workspace.

**Copy update:**
- `UsageSettingsCard.tsx`: added "Set to 0 to prevent pool usage." to the default pool limit row description.

## Webhook routing audit

| Event | Dispatch | |
|---|---|---|
| `spend_threshold_reached` cap alert (per-user) | `dispatchPerUserCapReached` / `Resolved` | ✓ |
| `spend_threshold_reached` warning alert (per-user) | `setUserNearLimit(true/false)` | ✓ |
| `low_remaining_seat_balance_reached` threshold=0 | `dispatchSeatBalanceExhausted` | ✓ |
| `low_remaining_seat_balance_reached` threshold>0 | silent no-op (pro/max low-balance alerts — stale, see deploy plan) | ✓ |
| `low_remaining_seat_balance_resolved` | `dispatchSeatBalanceResolved` | ✓ |
| `low_remaining_contract_credit_balance_reached` threshold=0 | `dispatchSeatBalanceExhausted` (free seat exhausted) | ✓ |
| `low_remaining_contract_credit_balance_reached` threshold>0 | `setUserNearLimit(true)` (free seat near-limit) | ✓ |
| `low_remaining_contract_credit_balance_resolved` | `setUserNearLimit(false)` + `dispatchSeatBalanceResolved` | ✓ |

## Tests

Type-checks clean. No behavioral change for workspaces that already have an explicit `defaultPoolCapAwuCredits` configured.

## Risk

Medium. Enterprise workspaces without an explicit `defaultPoolCapAwuCredits` in `credit_usage_configurations` will have their pool limit change from unlimited to 0 after deploy. Users whose seat is exhausted will be `capped` instead of falling through to the pool.

**Mitigation:** run `syncDefaultPoolCapAlertsForWorkspace` via the poke plugin or via seat sync for affected workspaces after confirming their intended pool limit.

## Deploy Plan

1. Ensure #27523 and #27525 are deployed.
2. Deploy this PR.
3. **For any enterprise workspace that should have pool access:** set an explicit default pool limit via workspace settings or the `sync-default-pool-cap-alerts` poke plugin before or immediately after deploy.
4. **Archive the two stale Metronome default seat low-balance alerts** (`seatLowMax` at 8 000 AWU and `seatLowPro` at 1 600 AWU) — these were removed from the `ALERTS` array in `metronome_setup.ts` but still exist in Metronome and will keep firing as harmless no-ops until archived. Archive them by running:
   ```
   npx tsx front/scripts/metronome_setup.ts syncAlerts
   ```
5. Run the post-deploy migration from #27526.