### PR TITLE
Count seatType=none users for legacy plans

### DIFF
--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -75,6 +75,7 @@ export async function syncMetronomeSeatCountForWorkspace({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,
     workspace,
+    planCode: subscription.toJSON().plan.code,
     contract,
   });
   if (result.isErr()) {

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -75,7 +75,7 @@ export async function syncMetronomeSeatCountForWorkspace({
     metronomeCustomerId: workspace.metronomeCustomerId,
     contractId: subscription.metronomeContractId,
     workspace,
-    planCode: subscription.toJSON().plan.code,
+    planCode: subscription.getPlan().code,
     contract,
   });
   if (result.isErr()) {

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -901,7 +901,8 @@ export async function switchContract({
     metronomeCustomerId,
     metronomeContractId,
     ownerLight,
-    alignedStart.toISOString()
+    alignedStart.toISOString(),
+    body.planCode
   );
   if (resyncResult.isErr()) {
     return new Err(

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -714,6 +714,7 @@ describe("provisionMetronomeContract", () => {
       metronomeCustomerId: "m-customer",
       contractId: "m-contract",
       workspace: WORKSPACE,
+      planCode: "PRO_PLAN_SEAT_29",
       startingAt: START_DATE,
       contract: CONTRACT,
     });

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -39,6 +39,7 @@ import {
   resolveCurrencyFromStripe,
   resolvePackageAliasForCurrency,
 } from "@app/lib/plans/billing_currency";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   getStripeClient,
   getStripeCustomer,
@@ -344,7 +345,8 @@ export async function provisionMetronomeContract({
       metronomeCustomerId,
       metronomeContractId,
       workspace,
-      alignedStart.toISOString()
+      alignedStart.toISOString(),
+      planCode
     );
     logger.error(
       {
@@ -403,7 +405,8 @@ export async function syncContractQuantities(
   metronomeCustomerId: string,
   metronomeContractId: string,
   workspace: LightWorkspaceType,
-  startingAt: string
+  startingAt: string,
+  planCode: string
 ): Promise<Result<void, Error>> {
   const contractResult = await getMetronomeContractById({
     metronomeCustomerId,
@@ -426,6 +429,7 @@ export async function syncContractQuantities(
               metronomeCustomerId,
               contractId: metronomeContractId,
               workspace,
+              planCode,
               startingAt,
               contract,
             }),

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -39,7 +39,6 @@ import {
   resolveCurrencyFromStripe,
   resolvePackageAliasForCurrency,
 } from "@app/lib/plans/billing_currency";
-import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import {
   getStripeClient,
   getStripeCustomer,

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -40,7 +40,7 @@ import {
   USAGE_TAG,
 } from "@app/lib/metronome/setup_common";
 import type { BillingFrequency } from "@app/lib/metronome/types";
-
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
@@ -53,7 +53,6 @@ import {
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { isMembershipSeatType, SEAT_TYPE_ORDER } from "@app/types/memberships";
-import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -53,6 +53,7 @@ import {
 import logger from "@app/logger/logger";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { isMembershipSeatType, SEAT_TYPE_ORDER } from "@app/types/memberships";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -1175,12 +1176,14 @@ export async function syncSeatCount({
   metronomeCustomerId,
   contractId,
   workspace,
+  planCode,
   startingAt,
   contract,
 }: {
   metronomeCustomerId: string;
   contractId: string;
   workspace: LightWorkspaceType;
+  planCode: string;
   // Forced `starting_at` for the "now" reconciliation. Most callers leave it
   // undefined (uses Metronome's default, i.e. immediately). Scheduled future
   // segments always use their own `startAt` regardless of this value.
@@ -1236,6 +1239,8 @@ export async function syncSeatCount({
         // clamp the count sent to Metronome up to the configured floor.
         WorkspaceSeatLimitResource.fetchByWorkspace({ workspace }),
       ]);
+
+    const legacy = !isCreditPricedPlanPrefix(planCode);
 
     // userSId → current seat type (the seat they are on right now).
     const currentSeatByUserSId = new Map<string, MembershipSeatType>();
@@ -1335,7 +1340,13 @@ export async function syncSeatCount({
     ): string[] => {
       const sIds: string[] = [];
       for (const userSId of allUserSIds) {
-        if (seatTypeAt(userSId, tMs) === subSeatType) {
+        const userSeatType = seatTypeAt(userSId, tMs);
+        // On legacy contracts, "none" members are Platform Seat members that
+        // predate the seat system — count them alongside explicit "workspace" seats.
+        const match =
+          userSeatType === subSeatType ||
+          (legacy && subSeatType === "workspace" && userSeatType === "none");
+        if (match) {
           sIds.push(userSId);
         }
       }

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -142,6 +142,7 @@ describe("syncSeatCount min clamping", () => {
       metronomeCustomerId: "cus_1",
       contractId: "con_1",
       workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
       contract: makeContract([
         { id: "sub_ws", productId: "ws-product", mode: "QUANTITY_ONLY" },
       ]),
@@ -174,6 +175,7 @@ describe("syncSeatCount min clamping", () => {
       metronomeCustomerId: "cus_1",
       contractId: "con_1",
       workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
       contract: makeContract([
         { id: "sub_ws", productId: "ws-product", mode: "QUANTITY_ONLY" },
       ]),
@@ -202,6 +204,7 @@ describe("syncSeatCount min clamping", () => {
       metronomeCustomerId: "cus_1",
       contractId: "con_1",
       workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
       contract: makeContract([
         { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
       ]),
@@ -241,6 +244,7 @@ describe("syncSeatCount min clamping", () => {
       metronomeCustomerId: "cus_1",
       contractId: "con_1",
       workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
       contract: makeContract([
         { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
       ]),
@@ -282,6 +286,7 @@ describe("syncSeatCount min clamping", () => {
       metronomeCustomerId: "cus_1",
       contractId: "con_1",
       workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
       contract: makeContract([
         { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
       ]),
@@ -319,6 +324,7 @@ describe("syncSeatCount min clamping", () => {
       metronomeCustomerId: "cus_1",
       contractId: "con_1",
       workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
       contract: makeContract([
         { id: "sub_pro", productId: "pro-product", mode: "SEAT_BASED" },
       ]),

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -947,7 +947,8 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
         metronome.metronomeCustomerId,
         metronome.metronomeContractId,
         renderLightWorkspaceType({ workspace: workspaceResource }),
-        metronome.startingAt
+        metronome.startingAt,
+        plan.code
       );
 
       if (syncResult.isErr()) {


### PR DESCRIPTION
## Description

On legacy Metronome contracts (non-`CP_`-prefixed plans, i.e. plans predating the credit-pricing rollout), members with `seatType="none"`were previously not counted in the Metronome seat sync, causing an under-count of billable workspace seats for those legacy workspaces.

This PR threads `planCode` through the `syncSeatCount` / `syncContractQuantities` call chain and uses it to detect legacy contracts (`!isCreditPricedPlanPrefix(planCode)`). On legacy contracts, users with `seatType="none"` are counted alongside explicit `"workspace"` seat users when reconciling quantities with Metronome.

## Tests

Existing `seats_sync.test.ts` tests updated to pass `planCode: "CP_BUSINESS_PLAN"` (a credit-priced plan → `legacy=false`, preserving existing behavior). No new test case for the legacy path; the fix can be verified by inspecting Metronome seat counts for a legacy-plan workspace with `none`-seat members.

## Risk

Low. The behavioral change only affects legacy-plan workspaces (non-`CP_` plan codes). For all credit-priced plans the logic is unchanged. Slightly increases billed seat count for affected legacy workspaces, which is the correct billing behavior.

## Deploy Plan

Deploy `front`.