### PR TITLE
fix(front): include shared migration tooling in runtime images

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -109,6 +109,8 @@ COPY --from=base-deps /app/front/package.json ./package.json
 COPY --from=base-deps /app/front/node_modules ./node_modules
 # Copy scripts directory
 COPY --from=base-deps /app/front/scripts ./scripts
+# Shared migration tooling lives at the repo root; front/package.json runs `node ../scripts/db/run-migrate.cjs`.
+COPY --from=base-deps /app/scripts/db /app/scripts/db
 # Copy built SDK
 COPY --from=base-deps /app/sdks/js/dist /app/sdks/js/dist
 COPY --from=base-deps /app/sdks/js/package.json /app/sdks/js/package.json
@@ -241,6 +243,8 @@ COPY --from=front-api-build /app/package-lock.json ./package-lock.json
 COPY --from=front-api-build /app/front ./front
 # Ensure migrate.js is present explicitly
 COPY --from=base-deps /app/front/dist/migrate.js ./front/dist/migrate.js
+# Shared migration tooling lives at the repo root; front-api/package.json runs `node ../scripts/db/run-migrate.cjs`.
+COPY --from=base-deps /app/scripts/db /app/scripts/db
 
 # front-api workspace (server.ts, app.ts, routes/, middleware/).
 COPY --from=front-api-build /app/front-api ./front-api


### PR DESCRIPTION
## Description

The `front-migration-check-pre-deploy` Helm hook job was failing on deploy with `Cannot find module '/app/scripts/db/run-migrate.cjs'`.

#27486 moved the shared migration tooling to the repo root (`scripts/db/`) and updated the `front`/`front-api` package scripts to call `node ../scripts/db/run-migrate.cjs`. The matching `COPY /scripts/db /app/scripts/db` was added only to the `base-deps` build stage of `front.Dockerfile`. The `workers` and `front-api` runtime stages build from a fresh `node:slim` base and copy artifacts selectively, so `/app/scripts/db` never made it into the deployed images — and the migration job (which runs in the `front-workers` image) couldn't find the script.

This copies `/app/scripts/db` from `base-deps` into both runtime stages. `connectors.Dockerfile` is single-stage, so it was unaffected.

## Tests

Confirm the next front image build runs `front-migration-check-pre-deploy` to completion instead of failing with the missing-module error.
