### PR TITLE
Use stored value instead of resolving metronome alerts

### DIFF
--- a/front/lib/api/metronome/process_webhook.test.ts
+++ b/front/lib/api/metronome/process_webhook.test.ts
@@ -4,8 +4,6 @@ import {
   dispatchPerUserCapResolved,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
-import * as defaultUserCapAlert from "@app/lib/metronome/alerts/spend_limits";
-import * as perUserAlerts from "@app/lib/metronome/alerts/spend_limits";
 import {
   getMetronomeCommit,
   getMetronomeContractById,
@@ -18,6 +16,7 @@ import {
   getCreditTypeAwuId,
   PLAN_CODE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
+import { setUserNearLimit } from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -27,7 +26,6 @@ import {
   launchScheduleWorkspaceScrubWorkflow,
   terminateScheduleWorkspaceScrubWorkflow,
 } from "@app/temporal/scrub_workspace/client";
-import { mockCustomerAlert } from "@app/tests/utils/mocks/metronome";
 import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
@@ -68,21 +66,30 @@ vi.mock("@app/lib/api/metronome/credit_state_dispatcher", async () => {
   };
 });
 
-vi.mock("@app/lib/metronome/alerts/spend_limits", async () => {
-  const actual = await vi.importActual<typeof defaultUserCapAlert>(
-    "@app/lib/metronome/alerts/spend_limits"
-  );
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seat_types")
+  >("@app/lib/metronome/seat_types");
   return {
     ...actual,
-    getMetronomePerUserCap: vi.fn(),
-    getMetronomePerUserWarningAlert: vi.fn(),
-    getMetronomeDefaultUserCapAlertForSeatType: vi.fn(),
-    getMetronomeDefaultUserWarningAlertForSeatType: vi.fn(),
+    getSeatAllowancesByNormalizedSeatType: vi
+      .fn()
+      .mockResolvedValue({ pro: 0, max: 0, workspace: 0 }),
   };
 });
 
-// Mock UserResource.fetchById and MembershipResource for resolveUserSpendAlerts.
-// The default mock returns a user with a "pro" seat so the default alert path works.
+vi.mock("@app/lib/metronome/user_block", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/user_block")
+  >("@app/lib/metronome/user_block");
+  return {
+    ...actual,
+    setUserNearLimit: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// Mock UserResource.fetchById and MembershipResource for handlePerUserSpendThresholdEvent.
+// The default mock returns a user with a "pro" seat and a pool cap override.
 vi.mock("@app/lib/resources/user_resource", async () => {
   const actual = await vi.importActual<
     typeof import("@app/lib/resources/user_resource")
@@ -104,9 +111,10 @@ vi.mock("@app/lib/resources/membership_resource", async () => {
     ...actual,
     MembershipResource: {
       ...actual.MembershipResource,
-      getActiveMembershipOfUserInWorkspace: vi
-        .fn()
-        .mockResolvedValue({ seatType: "pro" }),
+      getActiveMembershipOfUserInWorkspace: vi.fn().mockResolvedValue({
+        seatType: "pro",
+        poolCapOverrideAwuCredits: 50_000,
+      }),
     },
   };
 });
@@ -136,16 +144,16 @@ function contractEvent(
 function spendThresholdEvent(
   type: "alerts.spend_threshold_reached" | "alerts.spend_threshold_resolved",
   groupValues?: Array<{ key: string; value?: string }>,
-  alertId?: string
+  threshold?: number
 ): MetronomeWebhookEvent {
   return {
     id: `evt_${type}_xxx`,
     type,
     properties: {
       customer_id: METRONOME_CUSTOMER_ID,
-      alert_id: alertId,
       current_spend: 1234,
       group_values: groupValues,
+      threshold,
     },
   } as MetronomeWebhookEvent;
 }
@@ -198,18 +206,7 @@ beforeEach(() => {
   vi.mocked(dispatchPerUserCapReached).mockResolvedValue(new Ok(undefined));
   vi.mocked(dispatchPerUserCapResolved).mockResolvedValue(new Ok(undefined));
   vi.mocked(dispatchPaygCapReached).mockResolvedValue(undefined);
-  vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-    new Ok(null)
-  );
-  vi.mocked(
-    defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-  ).mockResolvedValue(new Ok(null));
-  vi.mocked(perUserAlerts.getMetronomePerUserWarningAlert).mockResolvedValue(
-    new Ok(null)
-  );
-  vi.mocked(
-    defaultUserCapAlert.getMetronomeDefaultUserWarningAlertForSeatType
-  ).mockResolvedValue(new Ok(null));
+  vi.mocked(setUserNearLimit).mockResolvedValue(undefined);
 });
 
 describe("processMetronomeWebhook — contract.start", () => {
@@ -692,24 +689,19 @@ describe("processMetronomeWebhook — swap webhook ordering", () => {
   });
 });
 
-describe("processMetronomeWebhook — per-user spend threshold (no default alert)", () => {
-  it("dispatches reached when override cap alert fires (reached event)", async () => {
+// effectiveCap = poolCapOverrideAwuCredits (50_000) + seatAllowance (0, no contract in tests)
+const CAP = 50_000;
+const WARNING = Math.floor(0.8 * CAP); // 40_000
+
+describe("processMetronomeWebhook — per-user spend threshold", () => {
+  it("dispatches reached when cap threshold fires (reached event)", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_override_xxx",
-          threshold: 1000,
-          customer_status: "in_alarm",
-        })
-      )
-    );
 
     const result = await processMetronomeWebhook({
       event: spendThresholdEvent(
         "alerts.spend_threshold_reached",
         [{ key: "user_id", value: USER_ID }],
-        "alert_override_xxx"
+        CAP
       ),
       workspace,
     });
@@ -721,23 +713,14 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
 
-  it("dispatches resolved when override cap alert fires (resolved event)", async () => {
+  it("dispatches resolved when cap threshold fires (resolved event)", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_override_xxx",
-          threshold: 1000,
-          customer_status: "ok",
-        })
-      )
-    );
 
     const result = await processMetronomeWebhook({
       event: spendThresholdEvent(
         "alerts.spend_threshold_resolved",
         [{ key: "user_id", value: USER_ID }],
-        "alert_override_xxx"
+        CAP
       ),
       workspace,
     });
@@ -749,19 +732,57 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
   });
 
-  it("ignores event when neither override nor default is configured", async () => {
+  it("sets near-limit flag when warning threshold fires", async () => {
     const workspace = await setupMetronomeWorkspaceResource();
-    // getMetronomePerUserCap and getMetronomeDefaultUserCapAlertForSeatType default to Ok(null).
 
     const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_reached", [
-        { key: "user_id", value: USER_ID },
-      ]),
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_reached",
+        [{ key: "user_id", value: USER_ID }],
+        WARNING
+      ),
       workspace,
     });
 
     expect(result.isOk()).toBe(true);
-    // No matching alert → event ignored, no dispatch.
+    expect(setUserNearLimit).toHaveBeenCalledWith(workspace.sId, USER_ID, true);
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+  });
+
+  it("clears near-limit flag when warning threshold resolves", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_resolved",
+        [{ key: "user_id", value: USER_ID }],
+        WARNING
+      ),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(setUserNearLimit).toHaveBeenCalledWith(
+      workspace.sId,
+      USER_ID,
+      false
+    );
+    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
+  });
+
+  it("ignores event with unrecognized threshold", async () => {
+    const workspace = await setupMetronomeWorkspaceResource();
+
+    const result = await processMetronomeWebhook({
+      event: spendThresholdEvent(
+        "alerts.spend_threshold_reached",
+        [{ key: "user_id", value: USER_ID }],
+        99_999
+      ),
+      workspace,
+    });
+
+    expect(result.isOk()).toBe(true);
     expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
   });
@@ -779,160 +800,6 @@ describe("processMetronomeWebhook — per-user spend threshold (no default alert
     expect(result.isOk()).toBe(true);
     expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
     expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
-    // No fetch attempted — handler bails before reading override state.
-    expect(perUserAlerts.getMetronomePerUserCap).not.toHaveBeenCalled();
-  });
-});
-
-describe("processMetronomeWebhook — per-user spend threshold (default alert configured)", () => {
-  it("dispatches reached when default cap alert fires (reached event)", async () => {
-    const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_default_xxx",
-          threshold: 50_000,
-          customer_status: "in_alarm",
-        })
-      )
-    );
-
-    const result = await processMetronomeWebhook({
-      event: spendThresholdEvent(
-        "alerts.spend_threshold_reached",
-        [{ key: "user_id", value: USER_ID }],
-        "alert_default_xxx"
-      ),
-      workspace,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(dispatchPerUserCapReached).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: USER_ID })
-    );
-    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
-  });
-
-  it("override alert ID takes precedence — event matching override dispatches resolved", async () => {
-    const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_override_xxx",
-          threshold: 999_999,
-          customer_status: "ok",
-        })
-      )
-    );
-    vi.mocked(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_default_xxx",
-          threshold: 1000,
-          customer_status: "in_alarm",
-        })
-      )
-    );
-
-    // Event comes from the override alert (resolved).
-    const result = await processMetronomeWebhook({
-      event: spendThresholdEvent(
-        "alerts.spend_threshold_resolved",
-        [{ key: "user_id", value: USER_ID }],
-        "alert_override_xxx"
-      ),
-      workspace,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(dispatchPerUserCapResolved).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: USER_ID })
-    );
-    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
-    // Override existed → default lookup was skipped.
-    expect(
-      defaultUserCapAlert.getMetronomeDefaultUserCapAlertForSeatType
-    ).not.toHaveBeenCalled();
-  });
-
-  it("override alert ID takes precedence — event matching override dispatches reached", async () => {
-    const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_override_xxx",
-          threshold: 100,
-          customer_status: "in_alarm",
-        })
-      )
-    );
-
-    // Event comes from the override alert (reached).
-    const result = await processMetronomeWebhook({
-      event: spendThresholdEvent(
-        "alerts.spend_threshold_reached",
-        [{ key: "user_id", value: USER_ID }],
-        "alert_override_xxx"
-      ),
-      workspace,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(dispatchPerUserCapReached).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: USER_ID })
-    );
-    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
-  });
-
-  it("ignores event from unrelated alert when override exists", async () => {
-    const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-      new Ok(
-        mockCustomerAlert({
-          id: "alert_override_xxx",
-          threshold: 100,
-          customer_status: "in_alarm",
-        })
-      )
-    );
-
-    // Event comes from a different alert (e.g. default for another seat type).
-    const result = await processMetronomeWebhook({
-      event: spendThresholdEvent(
-        "alerts.spend_threshold_reached",
-        [{ key: "user_id", value: USER_ID }],
-        "alert_unrelated_zzz"
-      ),
-      workspace,
-    });
-
-    expect(result.isOk()).toBe(true);
-    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
-    expect(dispatchPerUserCapResolved).not.toHaveBeenCalled();
-  });
-
-  it("returns processing_failed when override lookup fails", async () => {
-    const workspace = await setupMetronomeWorkspaceResource();
-    vi.mocked(perUserAlerts.getMetronomePerUserCap).mockResolvedValue(
-      new Err(new Error("metronome down"))
-    );
-
-    const result = await processMetronomeWebhook({
-      event: spendThresholdEvent("alerts.spend_threshold_reached", [
-        { key: "user_id", value: USER_ID },
-      ]),
-      workspace,
-    });
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.type).toBe("processing_failed");
-    }
-    expect(dispatchPerUserCapReached).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -44,12 +44,7 @@ import {
   PROGRAMMATIC_LOW_BALANCE_ALERT_NAME,
   PROGRAMMATIC_WARNING_BALANCE_ALERT_NAME,
 } from "@app/lib/metronome/alerts/programmatic_cap";
-import {
-  getMetronomeDefaultUserCapAlertForSeatType,
-  getMetronomeDefaultUserWarningAlertForSeatType,
-  getMetronomePerUserCap,
-  getMetronomePerUserWarningAlert,
-} from "@app/lib/metronome/alerts/spend_limits";
+import { USER_AWU_WARNING_PERCENTAGE } from "@app/lib/metronome/alerts/spend_limits";
 import { emitSubscriptionChangedAuditEvent } from "@app/lib/metronome/audit";
 import {
   getMetronomeCommit,
@@ -75,12 +70,14 @@ import {
 import { invalidateContractCache } from "@app/lib/metronome/plan_type";
 import type { ProgrammaticCreditEvent } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { carryOverContractBalancesOnRenewal } from "@app/lib/metronome/renewal_carry_over";
+import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
 import { setUserNearLimit } from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -577,134 +574,6 @@ async function ensureWorkOSOrganizationForPaidPlan({
   }
 }
 
-/**
- * Resolve the effective per-user spend-cap state by re-deriving from
- * Metronome on every event, then dispatch to the local credit-state machine.
- *
- * Override-replaces-default: if a per-user override exists, its evaluation
- * state wins regardless of the default. Otherwise the workspace-wide
- * default's state is used. With neither configured, the user is uncapped
- * (defensive — no alert should be firing in that case).
- *
- * The dispatch is idempotent: `setUserSpendLimit` and
- * `setDefaultUserSpendLimit` (PR B) recompute and dispatch eagerly, so the
- * webhook arriving later either re-confirms the state or skips (when
- * Metronome is still in `evaluating`).
- */
-type UserSpendAlerts = {
-  capAlertId: string | null;
-  warningAlertId: string | null;
-  capThreshold: number;
-  source: "override" | "default" | "none";
-};
-
-/**
- * Resolve the Metronome alert IDs that govern this user's spend cap.
- *
- * Priority: per-user override > per-seat-type default > none.
- */
-async function resolveUserSpendAlerts({
-  metronomeCustomerId,
-  workspaceId,
-  workspace,
-  userId,
-}: {
-  metronomeCustomerId: string;
-  workspaceId: string;
-  workspace: WorkspaceResource;
-  userId: string;
-}): Promise<Result<UserSpendAlerts, ProcessMetronomeWebhookError>> {
-  // Check for a per-user override first.
-  const userCapResult = await getMetronomePerUserCap({
-    metronomeCustomerId,
-    workspaceId,
-    userId,
-  });
-  if (userCapResult.isErr()) {
-    return new Err(
-      new ProcessMetronomeWebhookError(
-        "processing_failed",
-        `Error reading per-user cap override: ${userCapResult.error.message}`
-      )
-    );
-  }
-
-  if (userCapResult.value) {
-    const userWarningResult = await getMetronomePerUserWarningAlert({
-      metronomeCustomerId,
-      workspaceId,
-      userId,
-    });
-    return new Ok({
-      capAlertId: userCapResult.value.alert.id,
-      capThreshold: userCapResult.value.alert.threshold,
-      warningAlertId: userWarningResult.isOk()
-        ? (userWarningResult.value?.alert.id ?? null)
-        : null,
-      source: "override",
-    });
-  }
-
-  // No override — resolve user's seat type and find the matching default.
-  const user = await UserResource.fetchById(userId);
-  const lightWorkspace = renderLightWorkspaceType({ workspace });
-  const membership = user
-    ? await MembershipResource.getActiveMembershipOfUserInWorkspace({
-        user,
-        workspace: lightWorkspace,
-      })
-    : null;
-  const normalizedSeatType = normalizeToPoolLimitSeatType(membership?.seatType);
-
-  if (!normalizedSeatType) {
-    return new Ok({
-      capAlertId: null,
-      warningAlertId: null,
-      capThreshold: 0,
-      source: "none",
-    });
-  }
-
-  const [defaultCapResult, defaultWarningResult] = await Promise.all([
-    getMetronomeDefaultUserCapAlertForSeatType({
-      metronomeCustomerId,
-      workspaceId,
-      seatType: normalizedSeatType,
-    }),
-    getMetronomeDefaultUserWarningAlertForSeatType({
-      metronomeCustomerId,
-      workspaceId,
-      seatType: normalizedSeatType,
-    }),
-  ]);
-  if (defaultCapResult.isErr()) {
-    return new Err(
-      new ProcessMetronomeWebhookError(
-        "processing_failed",
-        `Error reading default user cap for seat type ${normalizedSeatType}: ${defaultCapResult.error.message}`
-      )
-    );
-  }
-
-  if (!defaultCapResult.value) {
-    return new Ok({
-      capAlertId: null,
-      warningAlertId: null,
-      capThreshold: 0,
-      source: "none",
-    });
-  }
-
-  return new Ok({
-    capAlertId: defaultCapResult.value.alert.id,
-    capThreshold: defaultCapResult.value.alert.threshold,
-    warningAlertId: defaultWarningResult.isOk()
-      ? (defaultWarningResult.value?.alert.id ?? null)
-      : null,
-    source: "default",
-  });
-}
-
 type SpendThresholdEvent = Extract<
   MetronomeWebhookEvent,
   {
@@ -712,6 +581,17 @@ type SpendThresholdEvent = Extract<
   }
 >;
 
+/**
+ * Handle a per-user spend threshold event by computing the effective cap from
+ * DB data and comparing the webhook `threshold` against it — no Metronome
+ * alert lookup needed.
+ *
+ *   cap alert fires at:     effectiveCap = seatAllowance + poolCap
+ *   warning alert fires at: floor(0.8 × effectiveCap)
+ *
+ * An unmatched threshold (stale alert, previous cap value, different seat
+ * type) is logged and silently ignored.
+ */
 async function handlePerUserSpendThresholdEvent({
   workspace,
   userId,
@@ -721,8 +601,7 @@ async function handlePerUserSpendThresholdEvent({
   userId: string;
   event: SpendThresholdEvent;
 }): Promise<Result<undefined, ProcessMetronomeWebhookError>> {
-  const metronomeCustomerId = workspace.metronomeCustomerId;
-  if (!metronomeCustomerId) {
+  if (!workspace.metronomeCustomerId) {
     logger.warn(
       { eventId: event.id, eventType: event.type, workspaceId: workspace.sId },
       "[Metronome Webhook] per-user spend threshold event for workspace without metronomeCustomerId, skipping"
@@ -730,22 +609,79 @@ async function handlePerUserSpendThresholdEvent({
     return new Ok(undefined);
   }
 
-  const alertsResult = await resolveUserSpendAlerts({
-    metronomeCustomerId,
-    workspaceId: workspace.sId,
-    workspace,
-    userId,
-  });
-  if (alertsResult.isErr()) {
-    return alertsResult;
+  const threshold = event.properties.threshold;
+  if (threshold === null || threshold === undefined) {
+    return new Ok(undefined);
   }
 
-  const { capAlertId, warningAlertId, capThreshold, source } =
-    alertsResult.value;
-  const eventAlertId = event.properties.alert_id;
   const isReached = event.type === "alerts.spend_threshold_reached";
 
-  if (eventAlertId === capAlertId) {
+  // Load membership to determine seat type and per-user cap override.
+  const user = await UserResource.fetchById(userId);
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+  const membership = user
+    ? await MembershipResource.getActiveMembershipOfUserInWorkspace({
+        user,
+        workspace: lightWorkspace,
+      })
+    : null;
+
+  if (!membership) {
+    logger.warn(
+      { eventId: event.id, workspaceId: workspace.sId, userId },
+      "[Metronome Webhook] per-user spend threshold: no active membership, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const normalizedSeatType = normalizeToPoolLimitSeatType(membership.seatType);
+  if (!normalizedSeatType) {
+    // Free / none seats have no pool cap alerts.
+    logger.info(
+      {
+        eventId: event.id,
+        workspaceId: workspace.sId,
+        userId,
+        seatType: membership.seatType,
+      },
+      "[Metronome Webhook] per-user spend threshold: seat type has no pool cap, ignoring"
+    );
+    return new Ok(undefined);
+  }
+
+  // Compute effective cap from DB — mirrors the logic used when the alert was
+  // created: poolCap (override or workspace default) + seat allowance.
+  const creditUsageConfig =
+    await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+      workspace.id
+    );
+  const poolCap =
+    membership.poolCapOverrideAwuCredits ??
+    creditUsageConfig?.defaultPoolCapAwuCredits ??
+    0;
+  const capSource =
+    membership.poolCapOverrideAwuCredits !== null ? "override" : "default";
+
+  let seatAllowance = 0;
+  try {
+    const allowances = await getSeatAllowancesByNormalizedSeatType(
+      workspace.sId
+    );
+    seatAllowance = allowances[normalizedSeatType] ?? 0;
+  } catch (err) {
+    logger.warn(
+      { eventId: event.id, workspaceId: workspace.sId, userId, err },
+      "[Metronome Webhook] per-user spend threshold: failed to resolve seat allowance, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const effectiveCap = poolCap + seatAllowance;
+  const warningThreshold = Math.floor(
+    USER_AWU_WARNING_PERCENTAGE * effectiveCap
+  );
+
+  if (threshold === effectiveCap) {
     // Cap alert fired for this user.
     if (isReached) {
       const dispatchResult = await dispatchPerUserCapReached({
@@ -758,7 +694,8 @@ async function handlePerUserSpendThresholdEvent({
             eventId: event.id,
             workspaceId: workspace.sId,
             userId,
-            source,
+            capSource,
+            effectiveCap,
             err: dispatchResult.error,
           },
           "[Metronome Webhook] per-user spend threshold: dispatchPerUserCapReached failed"
@@ -771,9 +708,7 @@ async function handlePerUserSpendThresholdEvent({
         );
       }
       // Notify the user (email + in-app) that they are now hard-blocked.
-      const user = await UserResource.fetchById(userId);
       if (user) {
-        const lightWorkspace = renderLightWorkspaceType({ workspace });
         notifyUserAwuCapReached({
           userSId: user.sId,
           userEmail: user.email,
@@ -781,7 +716,7 @@ async function handlePerUserSpendThresholdEvent({
           userLastName: user.lastName,
           workspaceId: workspace.sId,
           workspaceName: lightWorkspace.name,
-          capAwuCredits: capThreshold,
+          capAwuCredits: effectiveCap,
           isBlocked: true,
         });
       }
@@ -796,7 +731,8 @@ async function handlePerUserSpendThresholdEvent({
             eventId: event.id,
             workspaceId: workspace.sId,
             userId,
-            source,
+            capSource,
+            effectiveCap,
             err: dispatchResult.error,
           },
           "[Metronome Webhook] per-user spend threshold: dispatchPerUserCapResolved failed"
@@ -809,13 +745,11 @@ async function handlePerUserSpendThresholdEvent({
         );
       }
     }
-  } else if (eventAlertId === warningAlertId) {
+  } else if (threshold === warningThreshold) {
+    // Warning alert (80%) fired — set near-limit flag and notify, don't block.
     if (isReached) {
-      // Warning alert (80%) fired — set near-limit flag and notify, don't block.
       void setUserNearLimit(workspace.sId, userId, true);
-      const user = await UserResource.fetchById(userId);
       if (user) {
-        const lightWorkspace = renderLightWorkspaceType({ workspace });
         notifyUserAwuCapReached({
           userSId: user.sId,
           userEmail: user.email,
@@ -823,26 +757,28 @@ async function handlePerUserSpendThresholdEvent({
           userLastName: user.lastName,
           workspaceId: workspace.sId,
           workspaceName: lightWorkspace.name,
-          capAwuCredits: capThreshold,
+          capAwuCredits: effectiveCap,
           isBlocked: false,
         });
       }
     } else {
-      // Warning alert resolved (cap raised/removed) — clear near-limit flag.
+      // Warning resolved (cap raised/removed) — clear near-limit flag.
       void setUserNearLimit(workspace.sId, userId, false);
     }
   } else {
-    // Event is from an unrelated alert (e.g. a different seat type) — ignore.
+    // Threshold doesn't match this user's current cap or warning — unrelated
+    // alert (stale from previous cap value, different seat type, etc.).
     logger.info(
       {
         eventId: event.id,
-        eventType: event.type,
         workspaceId: workspace.sId,
         userId,
-        eventAlertId,
-        source,
+        threshold,
+        effectiveCap,
+        warningThreshold,
+        capSource,
       },
-      "[Metronome Webhook] per-user spend threshold: event does not match user's alerts, ignoring"
+      "[Metronome Webhook] per-user spend threshold: threshold does not match computed cap, ignoring"
     );
   }
 


### PR DESCRIPTION
## Context

Stacked on #27527.

`handlePerUserSpendThresholdEvent` previously called `resolveUserSpendAlerts` to identify which alert fired (cap vs. warning) by fetching the user's alert IDs from Metronome and comparing against `event.properties.alert_id`. This required 2–4 Metronome API calls on every per-user spend threshold event.

Since we store the effective cap in the DB (`membership.poolCapOverrideAwuCredits` or `credit_usage_configurations.defaultPoolCapAwuCredits`), and we created the alerts with thresholds derived from DB values, we can simply compare the webhook `threshold` against the DB-computed cap — no Metronome lookup needed.

## What this PR does

**Removes `resolveUserSpendAlerts`** (113 lines) and the `UserSpendAlerts` type entirely.

**Rewrites `handlePerUserSpendThresholdEvent`** to:
1. Load membership from DB → seat type + pool cap override
2. Load `CreditUsageConfigurationResource` → workspace default pool cap
3. Load seat allowance from the cached active contract (`getSeatAllowancesByNormalizedSeatType`)
4. Compute `effectiveCap = poolCap + seatAllowance`
5. Compare `threshold` from the webhook:
   - `threshold === effectiveCap` → cap alert → dispatch cap reached/resolved
   - `threshold === floor(0.8 × effectiveCap)` → warning alert → set/clear `nearLimit` flag
   - anything else → stale/unrelated alert → log and ignore

**Removed imports:** `getMetronomePerUserCap`, `getMetronomePerUserWarningAlert`, `getMetronomeDefaultUserCapAlertForSeatType`, `getMetronomeDefaultUserWarningAlertForSeatType`.

**Added imports:** `CreditUsageConfigurationResource`, `getSeatAllowancesByNormalizedSeatType`, `USER_AWU_WARNING_PERCENTAGE`.

**Side benefit:** the "unrelated alert" case now logs the actual `threshold`, `effectiveCap`, and `warningThreshold` values, making it easier to debug stale alerts from previous cap values.

## Tests

Type-checks clean. Behavior unchanged for correctly-configured alerts; stale alerts (e.g. `seatLowMax`/`seatLowPro` from #27527 that haven't been archived yet) now log a clearer message instead of silently falling through the `else` branch.

## Risk

Low. The threshold comparison mirrors exactly the logic used to create the alerts (`seatAllowance + poolCap` for cap, `Math.floor(0.8 × effectiveCap)` for warning), so correctly-registered alerts will always match. Stale or unrelated alerts that previously matched by alert ID would now fall through to the "unrelated" log — correct behavior.

## Deploy Plan

Deploy after #27527. No migration needed.