### PR TITLE
Show nearLimit in poke

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -102,6 +102,7 @@ function memberFromUpgradeRequest(
     freeCreditLowAlert: null,
     freeCreditEmptyAlert: null,
     creditState: "capped",
+    nearLimit: false,
   };
 }
 

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -218,7 +218,7 @@ function makeColumns({
       header: "Credit state",
       enableSorting: false,
       cell: ({ row }) => {
-        const { creditState, sId } = row.original;
+        const { creditState, nearLimit, sId } = row.original;
         return (
           <span className="inline-flex items-center gap-2">
             <Chip
@@ -226,6 +226,7 @@ function makeColumns({
               color={USER_CREDIT_STATE_CHIP_COLOR[creditState] ?? "info"}
               label={creditState}
             />
+            {nearLimit && <Chip size="xs" color="warning" label="near limit" />}
             <CreditStateLogsLink
               machine="user"
               workspaceId={owner.sId}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -34,6 +34,7 @@ import {
   type SeatData,
 } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
+import { isUserAwuWarned } from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -42,6 +43,7 @@ import {
   resolveEffectiveSpendLimitAwuCredits,
   resolveEffectiveSpendLimitSource,
 } from "@app/lib/spend_limits/effective";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   MembershipSeatType,
@@ -112,6 +114,9 @@ export type MemberUsageType = {
   // Per-user credit state machine state (personal-credits → pool → capped
   // progression) persisted on the membership. Surfaced for debugging.
   creditState: UserCreditState;
+  // Whether the user has consumed ≥ 80% of their effective limit. Driven by
+  // the nearLimit Redis flag (see user_block.ts). Poke-only.
+  nearLimit: boolean;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -744,6 +749,7 @@ export async function getMemberUsage({
       freeCreditLowAlert: null,
       freeCreditEmptyAlert: null,
       creditState: membership.creditState,
+      nearLimit: false,
     },
   };
 }
@@ -900,6 +906,19 @@ export async function getMembersUsage({
     });
 
   const membershipByUserId = new Map(memberships.map((m) => [m.userId, m]));
+
+  // Bulk-fetch near-limit flags from Redis (poke-only, gated on includeAlertLinks).
+  const nearLimitByUserId = includeAlertLinks
+    ? new Map(
+        await concurrentExecutor(
+          users,
+          async (u) =>
+            [u.sId, await isUserAwuWarned(workspace.sId, u.sId)] as const,
+          { concurrency: 8 }
+        )
+      )
+    : new Map<string, boolean>();
+
   const membersUsage: MemberUsageType[] = users.flatMap((u) => {
     const membership = membershipByUserId.get(u.id);
     if (!membership) {
@@ -1000,6 +1019,7 @@ export async function getMembersUsage({
         freeCreditLowAlert: freeCreditAlerts?.low ?? null,
         freeCreditEmptyAlert: freeCreditAlerts?.empty ?? null,
         creditState: membership.creditState,
+        nearLimit: nearLimitByUserId.get(userId) ?? false,
       },
     ];
   });

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -1,5 +1,21 @@
+import {
+  getWorkspaceBalanceThreshold,
+  syncMetronomeBalanceThresholdAlert,
+} from "@app/lib/api/credits/balance_threshold_alert";
 import { syncCreditBasedPayg } from "@app/lib/api/credits/credit_based_payg";
+import {
+  getProgrammaticUsageLimit,
+  syncProgrammaticUsageLimit,
+} from "@app/lib/api/credits/programmatic_usage_limit";
+import {
+  getUsageConfiguration,
+  updateUsageConfiguration,
+} from "@app/lib/api/credits/usage_configuration";
 import { createPlugin } from "@app/lib/api/poke/types";
+import {
+  getDefaultUserSpendLimit,
+  setDefaultUserSpendLimit,
+} from "@app/lib/api/workspace/default_user_spend_limit";
 import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constants";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
@@ -7,6 +23,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
 export const MAX_AWU_USAGE_CAP_CREDITS = 2_000_000;
+const POKE_AUDIT_CONTEXT = { location: "poke" };
 
 const CreditUsageConfigurationSchema = z.object({
   defaultDiscountPercent: z
@@ -27,6 +44,22 @@ const CreditUsageConfigurationSchema = z.object({
       `AWU usage cap cannot exceed ${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()} credits`
     )
     .default(0),
+  balanceThresholdCredits: z
+    .number()
+    .int("Balance threshold must be an integer number of credits")
+    .min(0, "Balance threshold must be non-negative")
+    .default(0),
+  defaultPoolCapCredits: z
+    .number()
+    .int("Default pool cap must be an integer number of credits")
+    .min(0, "Default pool cap must be non-negative")
+    .default(0),
+  programmaticMonthlyCapCredits: z
+    .number()
+    .int("Programmatic monthly cap must be an integer number of credits")
+    .min(0, "Programmatic monthly cap must be non-negative")
+    .default(0),
+  autoSeatUpgradeEnabled: z.boolean().default(false),
 });
 
 export const manageCreditUsageConfigurationPlugin = createPlugin({
@@ -34,11 +67,9 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     id: "manage-credit-usage-configuration",
     name: "Manage Credit Usage Configuration",
     description:
-      "Configure AWU credit usage settings for this workspace: the default " +
-      "discount applied to AWU credit purchases, whether PAYG is enabled, " +
-      "and the workspace usage cap (in AWU credits) used to drive the " +
-      "Metronome spend-threshold alert. PAYG and the usage cap are " +
-      "independent: either can be set without the other.",
+      "Configure AWU credit usage settings: discount, PAYG, programmatic cap, " +
+      "workspace usage cap, balance threshold alert, default per-user pool limit, " +
+      "and auto-upgrade seats.",
     resourceTypes: ["workspaces"],
     args: {
       defaultDiscountPercent: {
@@ -53,15 +84,46 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
         variant: "toggle",
         label: "PAYG Enabled",
         description:
-          "Enable Pay-as-you-go for this workspace (Metronome-billed " +
-          "workspaces only). Independent from the usage cap below.",
+          "Enable Pay-as-you-go for this workspace (Metronome-billed workspaces only).",
         async: true,
       },
       usageCapCredits: {
         type: "number",
         variant: "text",
-        label: "AWU Usage Cap (credits)",
-        description: `Workspace usage cap (in AWU credits) at which the Metronome spend-threshold alert fires. Set to 0 to disable the alert. Range: 0-${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()}.`,
+        label: "Workspace Credit Pool Monthly Usage Cap (credits)",
+        description: `Workspace-level monthly spend cap for the Metronome spend-threshold alert. Set to 0 to disable. Range: 0-${MAX_AWU_USAGE_CAP_CREDITS.toLocaleString()}.`,
+        async: true,
+      },
+      balanceThresholdCredits: {
+        type: "number",
+        variant: "text",
+        label: "Workspace Credit Pool Balance Threshold Alert (credits)",
+        description:
+          "Email admins when the workspace pool balance drops below this amount. Set to 0 to disable.",
+        async: true,
+      },
+      defaultPoolCapCredits: {
+        type: "number",
+        variant: "text",
+        label: "Default Per-User Pool Limit (credits)",
+        description:
+          "Default pool credit limit added on top of each seat's allowance. Set to 0 to prevent pool usage.",
+        async: true,
+      },
+      programmaticMonthlyCapCredits: {
+        type: "number",
+        variant: "text",
+        label: "Programmatic Monthly Cap (credits)",
+        description:
+          "Monthly cap on programmatic (API) AWU usage. Set to 0 to disable.",
+        async: true,
+      },
+      autoSeatUpgradeEnabled: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Auto-Upgrade Seats",
+        description:
+          "Automatically upgrade members to the next seat tier when they hit their credit limit.",
         async: true,
       },
     },
@@ -77,18 +139,26 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-    if (!config) {
-      return new Ok({
-        defaultDiscountPercent: 0,
-        paygEnabled: false,
-        usageCapCredits: 0,
-      });
-    }
+    const [balanceThreshold, defaultPoolLimit, programmaticLimit, usageConfig] =
+      await Promise.all([
+        getWorkspaceBalanceThreshold(auth),
+        getDefaultUserSpendLimit(auth),
+        getProgrammaticUsageLimit(auth),
+        getUsageConfiguration(auth),
+      ]);
 
     return new Ok({
-      defaultDiscountPercent: config.defaultDiscountPercent,
-      paygEnabled: config.paygEnabled,
-      usageCapCredits: config.usageCapCredits ?? 0,
+      defaultDiscountPercent: config?.defaultDiscountPercent ?? 0,
+      paygEnabled: config?.paygEnabled ?? false,
+      usageCapCredits: config?.usageCapCredits ?? 0,
+      balanceThresholdCredits: balanceThreshold ?? 0,
+      defaultPoolCapCredits: defaultPoolLimit.isOk()
+        ? (defaultPoolLimit.value.awuCredits ?? 0)
+        : 0,
+      programmaticMonthlyCapCredits: programmaticLimit.isOk()
+        ? (programmaticLimit.value ?? 0)
+        : 0,
+      autoSeatUpgradeEnabled: usageConfig.autoSeatUpgradeEnabled,
     });
   },
 
@@ -103,7 +173,6 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     }
 
     const parseResult = CreditUsageConfigurationSchema.safeParse(args);
-
     if (!parseResult.success) {
       return new Err(
         new Error(
@@ -114,15 +183,22 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       );
     }
 
-    const { defaultDiscountPercent, paygEnabled, usageCapCredits } =
-      parseResult.data;
+    const {
+      defaultDiscountPercent,
+      paygEnabled,
+      usageCapCredits,
+      balanceThresholdCredits,
+      defaultPoolCapCredits,
+      programmaticMonthlyCapCredits,
+      autoSeatUpgradeEnabled,
+    } = parseResult.data;
 
     const resolvedUsageCapCredits =
       usageCapCredits > 0 ? usageCapCredits : null;
 
+    // 1. Core config (discount, PAYG, workspace usage cap).
     const existingConfig =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-
     if (existingConfig) {
       const updateResult = await existingConfig.updateConfiguration(auth, {
         defaultDiscountPercent,
@@ -155,16 +231,58 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       return paygResult;
     }
 
-    const discountStatus = `Discount: ${defaultDiscountPercent}%`;
-    const paygStatus = `PAYG: ${paygEnabled ? "enabled" : "disabled"}`;
-    const capStatus =
-      resolvedUsageCapCredits !== null
-        ? `Usage cap: ${resolvedUsageCapCredits.toLocaleString()} credits`
-        : "Usage cap: disabled";
+    // 2. Balance threshold alert.
+    const balanceResult = await syncMetronomeBalanceThresholdAlert({
+      auth,
+      balanceThresholdCredits:
+        balanceThresholdCredits > 0 ? balanceThresholdCredits : null,
+    });
+    if (balanceResult.isErr()) {
+      return new Err(balanceResult.error);
+    }
+
+    // 3. Default per-user pool limit.
+    const poolResult = await setDefaultUserSpendLimit(auth, {
+      awuCredits: defaultPoolCapCredits,
+      auditContext: POKE_AUDIT_CONTEXT,
+    });
+    if (poolResult.isErr()) {
+      return new Err(poolResult.error);
+    }
+
+    // 4. Programmatic monthly cap.
+    const programmaticResult = await syncProgrammaticUsageLimit({
+      auth,
+      monthlyCapCredits:
+        programmaticMonthlyCapCredits > 0
+          ? programmaticMonthlyCapCredits
+          : null,
+      auditContext: POKE_AUDIT_CONTEXT,
+    });
+    if (programmaticResult.isErr()) {
+      return new Err(programmaticResult.error);
+    }
+
+    // 5. Auto-upgrade seats toggle.
+    const toggleResult = await updateUsageConfiguration(auth, {
+      autoSeatUpgradeEnabled,
+    });
+    if (toggleResult.isErr()) {
+      return new Err(toggleResult.error);
+    }
 
     return new Ok({
       display: "text",
-      value: `${existingConfig ? "Changes saved" : "Configuration created"}. ${discountStatus}. ${paygStatus}. ${capStatus}.`,
+      value: [
+        existingConfig ? "Changes saved" : "Configuration created",
+        `Discount: ${defaultDiscountPercent}%`,
+        `PAYG: ${paygEnabled ? "on" : "off"}`,
+        `Usage cap: ${resolvedUsageCapCredits?.toLocaleString() ?? "disabled"}`,
+        `Balance threshold: ${balanceThresholdCredits > 0 ? `${balanceThresholdCredits.toLocaleString()} credits` : "disabled"}`,
+        `Pool limit: ${defaultPoolCapCredits.toLocaleString()} credits`,
+        `Programmatic cap: ${programmaticMonthlyCapCredits > 0 ? `${programmaticMonthlyCapCredits.toLocaleString()} credits/month` : "disabled"}`,
+        `Auto-upgrade: ${autoSeatUpgradeEnabled ? "on" : "off"}`,
+      ].join(". "),
     });
   },
 });


### PR DESCRIPTION
## What this PR does

Two independent improvements to the poke credit management UI:

### 1. `nearLimit` flag in the members table

The per-user credit state column in `PokeMembersUsageTable` now shows a yellow **"near limit"** chip beside the credit state when the user's `nearLimit` Redis flag is set (i.e. they have consumed ≥ 80% of their effective cap, or a free seat's lifetime credit is ≥ 80% depleted).

- **`MemberUsageType`** gains a `nearLimit: boolean` field, populated by bulk-calling `isUserAwuWarned` for all users in parallel before the `flatMap` (gated on `includeAlertLinks` so customer-facing pages are unaffected).
- The `nearLimit` flag is set to `false` in the non-Metronome fallback path and in `UsagePage.tsx`'s stub member.

### 2. Expanded `Manage Credit Usage Configuration` poke plugin

The plugin now exposes all workspace credit settings in a single form instead of just discount / PAYG / usage cap:

| Field | Was editable? | API called |
|---|---|---|
| Default Discount (%) | ✓ | `updateConfiguration` |
| PAYG Enabled | ✓ | `syncCreditBasedPayg` |
| Workspace Credit Pool Monthly Usage Cap | ✓ (renamed) | `syncCreditBasedPayg` |
| **Workspace Credit Pool Balance Threshold Alert** | ✗ → ✓ | `syncMetronomeBalanceThresholdAlert` |
| **Default Per-User Pool Limit** | ✗ → ✓ | `setDefaultUserSpendLimit` |
| **Programmatic Monthly Cap** | ✗ → ✓ | `syncProgrammaticUsageLimit` |
| **Auto-Upgrade Seats** | ✗ → ✓ | `updateUsageConfiguration` |

`populateAsyncArgs` reads all current values in parallel to pre-fill the form. The label "AWU Usage Cap" is renamed to "Workspace Credit Pool Monthly Usage Cap" for clarity.

## Tests

Type-checks clean. No behavioral change to existing fields.

## Risk

Low. The new fields call the same APIs already exposed via the workspace settings UI and existing poke plugins. All operations are idempotent.

## Deploy Plan

Deploy normally. No migration needed.