### PR TITLE
[front] fix(usage): improve usage page descriptions and members table pagination

### DIFF
--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -72,7 +72,13 @@ export function UsageNotificationsCard({
       <SettingsList>
         <SettingsList.Row
           title="Workspace credit pool threshold"
-          description="Email all workspace admins when your remaining workspace credit pool balance drops below this amount (in credits). Set to 0 to disable."
+          description={
+            <>
+              Email all workspace admins when your remaining workspace credit
+              pool balance drops below this amount.{" "}
+              <strong>Set to 0 to disable.</strong>
+            </>
+          }
           action={
             <div className="w-52">
               <InputWithSave

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -51,7 +51,12 @@ export function UsageProgrammaticLimitCard({
       <SettingsList>
         <SettingsList.Row
           title="Programmatic monthly limit"
-          description="Maximum credits allowed for programmatic usage per month."
+          description={
+            <>
+              Maximum credits allowed for programmatic usage per month.{" "}
+              <strong> Set to 0 to block all programmatic access. </strong>
+            </>
+          }
           action={
             <div className="w-52">
               <InputWithSave

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -89,7 +89,14 @@ export function UsageSettingsCard({
         <LockedSection locked={!hasPool}>
           <SettingsList.Row
             title="Default Workspace Credit Pool limit"
-            description="Define the Workspace Credit Pool credit limit for users in your workspace. This limit is added on top of each seat's built-in allowance. Set to 0 to prevent pool usage. Can be overridden per user in the members table."
+            description={
+              <>
+                Define the Workspace Credit Pool credit limit for users in your
+                workspace. This limit is added on top of each seat&apos;s
+                built-in allowance. Can be overridden per user in the members
+                table. <strong>Set to 0 to remove pool access.</strong>
+              </>
+            }
             action={
               <div className="w-52">
                 <InputWithSave

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -174,6 +174,7 @@ export function useSearchMembers<
       `/api/w/${workspaceId}/members/search?${searchParams.toString()}`,
       searchMembersFetcher,
       {
+        keepPreviousData: true,
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
         disabled,
@@ -282,6 +283,7 @@ export function useMembersUsage({
     `${membersUsageUrl(workspaceId)}?${searchParams.toString()}`,
     membersUsageFetcher,
     {
+      keepPreviousData: true,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       disabled,


### PR DESCRIPTION
## Summary
- Clarify zero-value semantics in three usage settings descriptions: pool limit=0 removes pool access, programmatic cap=0 blocks all API access, threshold=0 disables the alert email — all three claims verified against enforcement logic in code
- Bold the zero-value hint in each description for scannability; remove redundant "(in credits)" from the threshold field (unit already shown in the input)
- Add `keepPreviousData: true` to `useSearchMembers` and `useMembersUsage` SWR hooks so table rows stay visible during page transitions instead of going blank

## Testing
- [ ] Visit the Usage page as a workspace admin
- [ ] Verify each description renders with bold text (not literal `<strong>` tags)
- [ ] Navigate between pages in the members table — rows should stay visible while loading

## Risk
Low — copy-only changes and a non-breaking SWR option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)