### PR TITLE
Clear balance threshold alert when updating

### DIFF
--- a/front/lib/api/credits/balance_threshold_alert.ts
+++ b/front/lib/api/credits/balance_threshold_alert.ts
@@ -79,6 +79,12 @@ export async function syncMetronomeBalanceThresholdAlert({
     );
   }
 
+  // Clear the in-app warning banner optimistically. The threshold changed so the
+  // previous "reached" state no longer applies — if the new threshold is still
+  // breached Metronome will re-evaluate immediately and the webhook will re-set
+  // the flag.
+  void clearWorkspaceBalanceThresholdReached(workspace.sId);
+
   return new Ok(undefined);
 }
 


### PR DESCRIPTION
## Bug fix

When an admin changed the workspace credit pool balance threshold, the old Metronome alert was dropped and a new one created at the new threshold. The new alert starts green (not in alarm), but the Redis flag `metronome:balance_threshold_warning:<ws>` was never cleared — so the in-app warning banner kept showing even though the balance was above the new threshold.

## Fix

`syncMetronomeBalanceThresholdAlert` now calls `clearWorkspaceBalanceThresholdReached` after every successful alert sync (upsert or clear). The clear is optimistic: if the new threshold is still breached, Metronome re-evaluates the new alert immediately and the webhook re-sets the flag.

## Risk

Very low. The worst case (new threshold breached) produces a brief banner flicker — it clears then re-appears when the webhook fires. This is better than the previous behavior where the banner stayed permanently stale.

## Deploy Plan

Deploy normally. No migration needed.