### PR TITLE
Clean old states

### DIFF
--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -54,10 +54,7 @@ const USER_CREDIT_STATE_CHIP_COLOR: Record<
   "success" | "warning" | "rose" | "info"
 > = {
   user_seat: "info",
-  user_seat_low_balance: "warning",
-  normal: "success",
   on_pool: "success",
-  on_pool_low_balance: "warning",
   capped: "rose",
 };
 

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -191,7 +191,7 @@ export async function dispatchSeatBalanceResolved({
 
   // The seat balance came back; the band the user lands in depends on how much
   // is left. Read the live balance so the state machine can route to
-  // `user_seat` vs `user_seat_low_balance` (or the pool for non-seat users).
+  // `user_seat` or the pool for non-seat users.
   const liveBalance = await resolveLiveUserBalance({
     workspace,
     userId,
@@ -299,9 +299,9 @@ export async function dispatchPerUserCapResolved({
   // Resolving the per-user cap only clears the cap dimension; the seat↔pool band
   // the user lands in depends on their live balance. Read it from Metronome and
   // pass it into the transition context so the state machine picks the correct
-  // band (a seat-based user with personal balance left → `user_seat` /
-  // `user_seat_low_balance`; otherwise the pool). When the live read isn't
-  // available the transition defaults to `on_pool` and the reconcile / billing
+  // band (a seat-based user with personal balance left → `user_seat`;
+  // otherwise the pool). When the live read isn't available the transition
+  // defaults to `on_pool` and the reconcile / billing
   // webhooks correct it later.
   const liveBalance = await resolveLiveUserBalance({
     workspace,

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -101,7 +101,7 @@ type UserReconcileReport = {
   // amount remaining, `seatStartingBalanceAwu` the full allocation granted for
   // the period (e.g. 8000 for a pro seat). Both null for pool-based seats with
   // no individual allocation. The remaining/starting ratio drives the
-  // user_seat ↔ user_seat_low_balance band.
+  // seat↔pool band.
   seatBalanceAwu: number | null;
   seatStartingBalanceAwu: number | null;
   effectiveCapAwuCredits: number | null;
@@ -113,12 +113,6 @@ export type ReconcileCreditStateReport =
   | PoolReconcileReport
   | ProgrammaticReconcileReport
   | UserReconcileReport;
-
-// Treat the legacy "normal" alias as its canonical "on_pool" value when
-// comparing the persisted state with the expected one (see USER_CREDIT_STATES).
-function normalizeUserCreditState(state: UserCreditState): UserCreditState {
-  return state === "normal" ? "on_pool" : state;
-}
 
 /**
  * Debug/reconcile entry point behind the poke "Check & Reconcile Credit State"
@@ -377,7 +371,7 @@ export async function reconcileUser({
     effectiveCapAwuCredits,
     consumedAwuCredits,
   });
-  const wasInvalid = normalizeUserCreditState(previousState) !== expectedState;
+  const wasInvalid = previousState !== expectedState;
 
   let newState = previousState;
   if (execute) {
@@ -397,7 +391,7 @@ export async function reconcileUser({
     expectedState,
     newState,
     wasInvalid,
-    corrected: normalizeUserCreditState(previousState) !== newState,
+    corrected: previousState !== newState,
     executed: execute,
     seatBalanceAwu,
     seatStartingBalanceAwu,

--- a/front/lib/metronome/alerts/per_user_credit_balance.ts
+++ b/front/lib/metronome/alerts/per_user_credit_balance.ts
@@ -30,11 +30,8 @@ export type PerUserCreditAlerts = {
 // so the seat-balance alert can't track it. Metronome alerts can filter on a
 // credit's custom field but not on its presentation specifier, so we scope a
 // per-user `low_remaining_contract_credit_balance_reached` alert to the credit
-// stamped with this user's sId (`DUST_PER_USER_CREDIT_USER`). Two alerts per
-// user mirror the seat-balance bands, distinguished by `threshold` in the
-// webhook payload (the same way `low_remaining_seat_balance_reached` is
-// handled): the exhaustion alert (threshold 0) drives `capped`, the low-balance
-// alert (threshold = 20% of the allowance) drives `user_seat_low_balance`.
+// stamped with this user's sId (`DUST_PER_USER_CREDIT_USER`). Two thresholds:
+// exhaustion (0) drives `capped`; low-balance (20% remaining) sets `nearLimit`.
 
 // The alert NAME embeds the workspace and user for readability in the Metronome
 // dashboard, but it is NOT the source of truth for resolution — names aren't

--- a/front/lib/metronome/user_block.test.ts
+++ b/front/lib/metronome/user_block.test.ts
@@ -132,44 +132,8 @@ describe("isUserBlocked", () => {
     expect(blocked).toBeNull();
   });
 
-  it("does not block a 'user_seat_low_balance' user when the pool is depleted", async () => {
-    redisValues.set(
-      "metronome:user_credit_state:ws_test:u_test",
-      "user_seat_low_balance"
-    );
-    redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
-
-    const blocked = await isUserBlocked(workspace, user);
-
-    expect(blocked).toBeNull();
-  });
-
   it("blocks an 'on_pool' user when the pool is depleted", async () => {
     redisValues.set("metronome:user_credit_state:ws_test:u_test", "on_pool");
-    redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
-
-    const blocked = await isUserBlocked(workspace, user);
-
-    expect(blocked).toBe("credits_exhausted");
-  });
-
-  it("does not block a warned 'on_pool_low_balance' user when pool is active", async () => {
-    redisValues.set(
-      "metronome:user_credit_state:ws_test:u_test",
-      "on_pool_low_balance"
-    );
-    redisValues.set("metronome:pool_credit_status:ws_test", "active");
-
-    const blocked = await isUserBlocked(workspace, user);
-
-    expect(blocked).toBeNull();
-  });
-
-  it("blocks an 'on_pool_low_balance' user when pool is depleted", async () => {
-    redisValues.set(
-      "metronome:user_credit_state:ws_test:u_test",
-      "on_pool_low_balance"
-    );
     redisValues.set("metronome:pool_credit_status:ws_test", "depleted");
 
     const blocked = await isUserBlocked(workspace, user);

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -127,9 +127,7 @@ async function setFlag(key: string, value: string): Promise<void> {
 //   - Admin removes/raises per-user cap (spend_limit.ts).
 //   - Reconciliation: recomputed from live Metronome balance on each reconcile.
 //
-// Cache-miss fallback: infer from the credit state so that existing
-// `on_pool_low_balance` / `user_seat_low_balance` rows continue to show the
-// banner until they are migrated or reconciled.
+// Cache-miss: returns false; reconciliation will set the correct value.
 
 function buildUserNearLimitKey(workspaceId: string, userId: string): string {
   return `metronome:user_near_limit:${workspaceId}:${userId}`;
@@ -156,10 +154,7 @@ async function getUserNearLimit(
   if (cached !== null) {
     return cached === "1";
   }
-  // Cache miss: fall back to credit state for existing rows that haven't been
-  // migrated yet (on_pool_low_balance / user_seat_low_balance).
-  const state = await getUserCreditState(workspaceId, userId);
-  return state === "on_pool_low_balance" || state === "user_seat_low_balance";
+  return false;
 }
 
 export async function isUserAwuWarned(
@@ -340,9 +335,9 @@ export async function isUserBlocked(
 
   let workspacePoolDepleted = poolStatus === "depleted";
 
-  // A user spending from their personal seat balance (`user_seat` /
-  // `user_seat_low_balance`) still has their own credits, so workspace pool
-  // depletion must not block them — only their per-user cap can.
+  // A user spending from their personal seat balance (`user_seat`) still has
+  // their own credits, so workspace pool depletion must not block them — only
+  // their per-user cap can.
   if (workspacePoolDepleted && isSpendingFromPersonalSeat(userCreditState)) {
     workspacePoolDepleted = false;
   }

--- a/front/lib/metronome/user_credit_state_machine.test.ts
+++ b/front/lib/metronome/user_credit_state_machine.test.ts
@@ -1,7 +1,4 @@
-import {
-  FREE_SEAT_LIFETIME_AWU_CREDITS,
-  PRO_SEAT_MONTHLY_AWU_CREDITS,
-} from "@app/lib/metronome/constants";
+import { FREE_SEAT_LIFETIME_AWU_CREDITS } from "@app/lib/metronome/constants";
 import type { UserCreditContext } from "@app/lib/metronome/user_credit_state_machine";
 import {
   setUserCreditStateReconciled,
@@ -309,28 +306,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
     );
   });
 
-  it("legacy user_seat_low_balance (alias → user_seat) + free seat → capped", async () => {
-    const membership = makeMembership("user_seat_low_balance", "free");
-    const result = await transitionUserCreditState(
-      membership,
-      { type: "seat_balance_exhausted" },
-      { ...baseCtx, seatType: "free", poolLimitAwuCredits: 0 }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("capped");
-    }
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "capped",
-      undefined
-    );
-    expect(mockSetUserCreditState).toHaveBeenCalledWith(
-      "ws_test",
-      "u_test",
-      "capped"
-    );
-  });
-
   it("user_seat + pro seat + pool limit > 0 → on_pool", async () => {
     const membership = makeMembership("user_seat", "pro");
     const result = await transitionUserCreditState(
@@ -396,28 +371,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted", () => {
       "capped"
     );
   });
-
-  it("legacy user_seat_low_balance (alias → user_seat) + max seat + pool limit null → on_pool", async () => {
-    const membership = makeMembership("user_seat_low_balance", "max");
-    const result = await transitionUserCreditState(
-      membership,
-      { type: "seat_balance_exhausted" },
-      { ...baseCtx, seatType: "max", poolLimitAwuCredits: null }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("on_pool");
-    }
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "on_pool",
-      undefined
-    );
-    expect(mockSetUserCreditState).toHaveBeenCalledWith(
-      "ws_test",
-      "u_test",
-      "on_pool"
-    );
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -428,29 +381,6 @@ describe("UserCreditStateMachine — seat_balance_exhausted with remainingCapCre
   // Guard 2: cap fully exhausted (0 %) beats pool room → capped.
   it("user_seat + pro + 0% cap remaining + pool limit > 0 → capped", async () => {
     const membership = makeMembership("user_seat", "pro");
-    const result = await transitionUserCreditState(
-      membership,
-      { type: "seat_balance_exhausted" },
-      {
-        ...baseCtx,
-        seatType: "pro",
-        remainingCapCreditsPercentage: 0,
-        poolLimitAwuCredits: 5000,
-      }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("capped");
-    }
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "capped",
-      undefined
-    );
-  });
-
-  // Guard 1: same as above from legacy user_seat_low_balance (alias → user_seat).
-  it("legacy user_seat_low_balance + pro + 0% cap remaining + pool limit > 0 → capped", async () => {
-    const membership = makeMembership("user_seat_low_balance", "pro");
     const result = await transitionUserCreditState(
       membership,
       { type: "seat_balance_exhausted" },
@@ -656,28 +586,6 @@ describe("UserCreditStateMachine — seat_balance_resolved", () => {
     );
   });
 
-  it("legacy user_seat_low_balance (alias → user_seat) → user_seat on billing-period renewal", async () => {
-    const membership = makeMembership("user_seat_low_balance", "pro");
-    const result = await transitionUserCreditState(
-      membership,
-      { type: "seat_balance_resolved" },
-      {
-        ...baseCtx,
-        seatType: "pro",
-        liveBalance: {
-          seatBalanceAwu: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          seatStartingBalanceAwu: PRO_SEAT_MONTHLY_AWU_CREDITS,
-          perUserCapAwuCredits: null,
-          consumedAwuCredits: null,
-        },
-      }
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      expect(result.value).toBe("user_seat");
-    }
-  });
-
   it("free capped → user_seat without a live balance (default)", async () => {
     const membership = makeMembership("capped", "free");
     const result = await transitionUserCreditState(
@@ -738,19 +646,6 @@ describe("UserCreditStateMachine — setUserCreditStateReconciled", () => {
       "ws_test",
       "u_test",
       "user_seat"
-    );
-  });
-
-  it("migrates a legacy 'normal' row to 'on_pool'", async () => {
-    const membership = makeMembership("normal", "workspace");
-    const result = await setUserCreditStateReconciled(membership, "on_pool", {
-      ...baseCtx,
-      seatType: "workspace",
-    });
-    expect(result).toBe("on_pool");
-    expect(membership.updateCreditState).toHaveBeenCalledWith(
-      "on_pool",
-      undefined
     );
   });
 

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -31,15 +31,15 @@ export type UserCreditContext = {
   seatType?: MembershipSeatType | null;
   /**
    * Live balance snapshot. When present, the `per_user_cap_resolved` transition
-   * recomputes the correct seat↔pool band from it (user_seat /
-   * user_seat_low_balance / on_pool / on_pool_low_balance) instead of defaulting
-   * to `on_pool`. Absent for events that don't carry balance data.
+   * recomputes the correct seat↔pool band from it (user_seat or on_pool)
+   * instead of defaulting to `on_pool`. Absent for events that don't carry
+   * balance data.
    */
   liveBalance?: LiveUserSeatBalance;
   /**
    * Fraction of the user's per-user cap credits still remaining (0–1).
    * Required by guards on `seat_balance_exhausted` for paid seats to decide
-   * whether to land on `on_pool`, `on_pool_low_balance`, or `capped`.
+   * whether to land on `on_pool` or `capped`.
    */
   remainingCapCreditsPercentage?: number | null;
   /**
@@ -188,25 +188,14 @@ export async function transitionUserCreditState(
   { transaction }: { transaction?: Transaction } = {}
 ): Promise<Result<UserCreditState, Error>> {
   const rawState = membership.creditState;
-  // Legacy aliases (migration window): normalize to canonical states so
-  // transitions match correctly, and the next write persists the canonical value.
-  //   "normal"                → "on_pool"
-  //   "on_pool_low_balance"   → "on_pool"
-  //   "user_seat_low_balance" → "user_seat"
-  const currentState =
-    rawState === "normal" || rawState === "on_pool_low_balance"
-      ? "on_pool"
-      : rawState === "user_seat_low_balance"
-        ? "user_seat"
-        : rawState;
-  const match = findTransition(currentState, event, ctx);
+  const match = findTransition(rawState, event, ctx);
 
   if (!match) {
     logger.warn(
       {
         workspaceId: ctx.workspaceId,
         userId: ctx.userId,
-        fromState: currentState,
+        fromState: rawState,
         event,
         eventType: event.type,
       },
@@ -214,13 +203,11 @@ export async function transitionUserCreditState(
     );
     return new Err(
       new Error(
-        `[UserCreditStateMachine] Illegal transition: ${currentState} + ${event.type}`
+        `[UserCreditStateMachine] Illegal transition: ${rawState} + ${event.type}`
       )
     );
   }
 
-  // Compare against the raw value so a legacy "normal" row is rewritten to the
-  // canonical "on_pool" even when the normalized state already matches.
   if (rawState !== match.to) {
     await membership.updateCreditState(match.to, transaction);
   }
@@ -249,8 +236,7 @@ export async function transitionUserCreditState(
  * state directly from the live source of truth (Metronome seat balance + cap +
  * usage) — the seat↔pool dimension is not reachable from the event-driven
  * transitions alone (e.g. nothing dispatches a user back to `user_seat` outside
- * a billing-cycle webhook). Persists the new state (treating the legacy
- * "normal" alias as "on_pool" so such rows migrate) and syncs the same caches
+ * a billing-cycle webhook). Persists the new state and syncs the same caches
  * the transitions do.
  */
 export async function setUserCreditStateReconciled(

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -180,31 +180,17 @@ export function isSeatBased(
 //
 // Two customer shapes:
 //   - pool-based only: users spend from a shared workspace credits pool (they
-//     may be capped). Such users sit in the `on_pool*` states.
+//     may be capped). Such users sit in the `on_pool` state.
 //   - seat-based: each user has a personal credit balance they spend first,
-//     then fall back to the workspace pool. Such users start in `user_seat*`
-//     and move to `on_pool*` once their personal balance is exhausted.
+//     then fall back to the workspace pool. Such users start in `user_seat`
+//     and move to `on_pool` once their personal balance is exhausted.
 //
-//   user_seat:             spending from personal credits.
-//   user_seat_low_balance: same, but ≥80% of personal credits already used.
-//   on_pool:               personal credits exhausted (or pool-based workspace);
-//                          spending from the workspace pool. (Formerly "normal".)
-//   on_pool_low_balance:   same, but ≥80% of the per-user cap already used.
-//   capped:                per-user spend cap hit; can no longer spend.
+//   user_seat: spending from personal credits.
+//   on_pool:   personal credits exhausted (or pool-based workspace);
+//              spending from the workspace pool.
+//   capped:    per-user spend cap hit; can no longer spend.
 //
-// MIGRATION (transitional): "normal" is the legacy name for "on_pool" and is
-// kept as an accepted alias so the deployed code reads existing rows without
-// breaking. It is treated as equivalent to "on_pool" everywhere (see the state
-// machine). Remove it once migration 665 has renamed all rows and the
-// follow-up PR lands.
-export const USER_CREDIT_STATES = [
-  "user_seat",
-  "user_seat_low_balance",
-  "normal",
-  "on_pool",
-  "on_pool_low_balance",
-  "capped",
-] as const;
+export const USER_CREDIT_STATES = ["user_seat", "on_pool", "capped"] as const;
 
 export type UserCreditState = (typeof USER_CREDIT_STATES)[number];
 
@@ -225,11 +211,8 @@ export function isUserCreditState(value: unknown): value is UserCreditState {
 export function isSpendingFromPersonalSeat(state: UserCreditState): boolean {
   switch (state) {
     case "user_seat":
-    case "user_seat_low_balance":
       return true;
-    case "normal":
     case "on_pool":
-    case "on_pool_low_balance":
     case "capped":
       return false;
     default:


### PR DESCRIPTION
Stacked on #27534.

Removes `user_seat_low_balance` and `on_pool_low_balance` from the codebase now that the DB migration (#27526) has run and no rows with these values remain.

- **`types/memberships.ts`**: removed both states from `USER_CREDIT_STATES` and their cases from `isSpendingFromPersonalSeat`
- **`user_credit_state_machine.ts`**: removed the two alias mappings (only `normal → on_pool` remains pending migration 665); updated stale comments
- **`user_block.ts`**: removed the cache-miss fallback that read old state values — cold cache now returns `false` directly
- **`PokeMembersUsageTable.tsx`**: removed chip color entries for both states
- Stale comment fixes in `credit_state_dispatcher.ts`, `reconcile_credit_state.ts`, `per_user_credit_balance.ts`
- 7 legacy alias tests removed (`user_block.test.ts` × 3, `user_credit_state_machine.test.ts` × 4)

## Deploy Plan

Run after #27526 migration has been applied.