### PR TITLE
Add selected spaces schema and feature flag

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -37,6 +37,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { ConversationBranchModel } from "@app/lib/models/agent/conversation_branch";
 import { ConversationForkModel } from "@app/lib/models/agent/conversation_fork";
+import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { TagAgentModel } from "@app/lib/models/agent/tag_agent";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
@@ -177,6 +178,7 @@ export function loadAllModels() {
     WebhookRequestModel,
     WebhookRequestTriggerModel,
     ConversationModel,
+    ConversationSelectedSpaceModel,
     ConversationParticipantModel,
     UserConversationReadsModel,
     WakeUpModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -20,6 +20,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import {
@@ -186,6 +187,9 @@ export async function destroyConversation(
 
   await ConversationForkResource.deleteForConversationModelId(auth, {
     conversationModelId: conversation.id,
+  });
+  await ConversationSelectedSpaceResource.deleteForConversation(auth, {
+    conversation,
   });
 
   // Clean up all branches attached to this conversation before deleting messages.

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -6,6 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AppResource } from "@app/lib/resources/app_resource";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -419,6 +420,11 @@ export async function hardDeleteSpace(
         throw res.error;
       }
     }
+
+    await ConversationSelectedSpaceResource.deleteAllBySpace(auth, {
+      spaceModelId: space.id,
+      transaction: t,
+    });
 
     const res = await space.delete(auth, { hardDelete: true, transaction: t });
     if (res.isErr()) {

--- a/front/lib/models/agent/conversation_selected_space.ts
+++ b/front/lib/models/agent/conversation_selected_space.ts
@@ -1,0 +1,136 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  CreationOptional,
+  ForeignKey,
+  ModelAttributes,
+  NonAttribute,
+} from "sequelize";
+
+export type ConversationSelectedSpaceOrigin =
+  | "input_bar"
+  | "parent_conversation"
+  | "pod_context"
+  | "sticky_preference";
+
+const CONVERSATION_SELECTED_SPACE_MODEL_ATTRIBUTES = {
+  createdAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW,
+  },
+  updatedAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    defaultValue: DataTypes.NOW,
+  },
+  conversationId: {
+    type: DataTypes.BIGINT,
+    allowNull: false,
+    references: {
+      model: ConversationModel,
+      key: "id",
+    },
+  },
+  spaceId: {
+    type: DataTypes.BIGINT,
+    allowNull: false,
+    references: {
+      model: SpaceModel,
+      key: "id",
+    },
+  },
+  selectedByUserId: {
+    type: DataTypes.BIGINT,
+    allowNull: false,
+    references: {
+      model: UserModel,
+      key: "id",
+    },
+  },
+  origin: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  removedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+} as const satisfies ModelAttributes;
+
+export class ConversationSelectedSpaceModel extends WorkspaceAwareModel<ConversationSelectedSpaceModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]>;
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare selectedByUserId: ForeignKey<UserModel["id"]>;
+  declare origin: ConversationSelectedSpaceOrigin;
+  declare removedAt: Date | null;
+
+  declare conversation: NonAttribute<ConversationModel>;
+  declare space: NonAttribute<SpaceModel>;
+  declare selectedByUser: NonAttribute<UserModel>;
+}
+
+ConversationSelectedSpaceModel.init(
+  CONVERSATION_SELECTED_SPACE_MODEL_ATTRIBUTES,
+  {
+    modelName: "conversation_selected_spaces",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "conversationId", "spaceId"],
+        name: "conversation_selected_spaces_wid_cid_sid",
+        concurrently: true,
+      },
+      {
+        fields: ["conversationId"],
+        name: "conversation_selected_spaces_conversation_id",
+        concurrently: true,
+      },
+      {
+        fields: ["spaceId"],
+        name: "conversation_selected_spaces_space_id",
+        concurrently: true,
+      },
+      {
+        fields: ["selectedByUserId"],
+        name: "conversation_selected_spaces_selected_by_user_id",
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ConversationModel.hasMany(ConversationSelectedSpaceModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationSelectedSpaceModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  as: "conversation",
+});
+
+SpaceModel.hasMany(ConversationSelectedSpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationSelectedSpaceModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  as: "space",
+});
+
+UserModel.hasMany(ConversationSelectedSpaceModel, {
+  foreignKey: { name: "selectedByUserId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+ConversationSelectedSpaceModel.belongsTo(UserModel, {
+  foreignKey: { name: "selectedByUserId", allowNull: false },
+  as: "selectedByUser",
+});

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -10,6 +10,7 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
 import { getReinforcedSkillsMetadata } from "@app/lib/reinforcement/types";
 import { ConversationBranchResource } from "@app/lib/resources/conversation_branch_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
@@ -745,6 +746,47 @@ describe("destroyConversation", () => {
         where: {
           agentMessageId,
           workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      })
+    ).resolves.toBe(0);
+  });
+
+  it("should delete selected spaces before deleting a conversation", async () => {
+    const conversationType = await ConversationFactory.create(auth, {
+      agentConfigurationId,
+      messagesCreatedAt: [new Date()],
+    });
+    const conversation = await ConversationResource.fetchById(
+      auth,
+      conversationType.sId
+    );
+    if (!conversation) {
+      throw new Error("Conversation should exist");
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const user = auth.user();
+    if (!user) {
+      throw new Error("User should exist");
+    }
+
+    const space = await SpaceFactory.regular(workspace);
+    await ConversationSelectedSpaceModel.create({
+      workspaceId: workspace.id,
+      conversationId: conversation.id,
+      spaceId: space.id,
+      selectedByUserId: user.id,
+      origin: "input_bar",
+    });
+
+    const result = await destroyConversation(auth, { conversation });
+
+    expect(result.isOk()).toBe(true);
+    await expect(
+      ConversationSelectedSpaceModel.count({
+        where: {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
         },
       })
     ).resolves.toBe(0);
@@ -6795,6 +6837,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "conversation_fork",
   "conversation_mcp_server_view",
   "conversation_participant",
+  "conversation_selected_spaces",
   "conversation_skills",
   "data_source",
   "message",

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -1,0 +1,79 @@
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { Attributes, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ConversationSelectedSpaceResource
+  extends ReadonlyAttributesType<ConversationSelectedSpaceModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ConversationSelectedSpaceResource extends BaseResource<ConversationSelectedSpaceModel> {
+  static model: ModelStaticWorkspaceAware<ConversationSelectedSpaceModel> =
+    ConversationSelectedSpaceModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<ConversationSelectedSpaceModel>,
+    blob: Attributes<ConversationSelectedSpaceModel>
+  ) {
+    super(model, blob);
+  }
+
+  static async deleteForConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      transaction,
+    }: {
+      conversation: { id: ModelId };
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+      },
+      transaction,
+    });
+  }
+
+  static async deleteAllBySpace(
+    auth: Authenticator,
+    {
+      spaceModelId,
+      transaction,
+    }: {
+      spaceModelId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: spaceModelId,
+      },
+      transaction,
+    });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<number, Error>> {
+    const deletedCount = await this.model.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(deletedCount);
+  }
+}

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1,6 +1,8 @@
 import { loadAllModels } from "@app/admin/db";
+import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceEditorResource } from "@app/lib/resources/group_space_editor_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
@@ -10,6 +12,8 @@ import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_me
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -90,6 +94,52 @@ describe("SpaceResource", () => {
       await MembershipFactory.associate(workspace, user1, { role: "user" });
       await MembershipFactory.associate(workspace, user2, { role: "user" });
       await MembershipFactory.associate(workspace, user3, { role: "user" });
+    });
+
+    it("should delete selected spaces before hard deleting a space", async () => {
+      const agent = await AgentConfigurationFactory.createTestAgent(adminAuth, {
+        name: "Test Agent",
+        description: "Test agent",
+        scope: "hidden",
+      });
+      const conversation = await ConversationFactory.create(adminAuth, {
+        agentConfigurationId: agent.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      await ConversationSelectedSpaceModel.create({
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        spaceId: regularSpace.id,
+        selectedByUserId: user1.id,
+        origin: "input_bar",
+      });
+
+      const softDeleteResult = await regularSpace.delete(adminAuth, {
+        hardDelete: false,
+      });
+      expect(softDeleteResult.isOk()).toBe(true);
+
+      const deletedSpace = await SpaceResource.fetchById(
+        adminAuth,
+        regularSpace.sId,
+        { includeDeleted: true }
+      );
+      if (!deletedSpace) {
+        throw new Error("Deleted space should exist");
+      }
+
+      const hardDeleteResult = await hardDeleteSpace(adminAuth, deletedSpace);
+
+      expect(hardDeleteResult.isOk()).toBe(true);
+      await expect(
+        ConversationSelectedSpaceModel.count({
+          where: {
+            workspaceId: workspace.id,
+            spaceId: regularSpace.id,
+          },
+        })
+      ).resolves.toBe(0);
     });
 
     describe("authorization checks", () => {
@@ -1688,6 +1738,7 @@ describe("searchProjectsByNamePaginated", () => {
 const KNOWN_SPACE_RELATED_MODELS = [
   "agent_project_configuration",
   "app",
+  "conversation_selected_spaces",
   "content_fragment",
   "conversation",
   "data_source",

--- a/front/migrations/pre-deploy/20260624143314_add_conversation_selected_spaces.sql
+++ b/front/migrations/pre-deploy/20260624143314_add_conversation_selected_spaces.sql
@@ -1,0 +1,31 @@
+-- Migration created on Jun 24, 2026
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE IF NOT EXISTS "conversation_selected_spaces" (
+    "createdAt" timestamp WITH time zone NOT NULL DEFAULT NOW(),
+    "updatedAt" timestamp WITH time zone NOT NULL DEFAULT NOW(),
+    "conversationId" bigint NOT NULL REFERENCES "conversations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "spaceId" bigint NOT NULL REFERENCES "spaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "selectedByUserId" bigint NOT NULL REFERENCES "users" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "origin" varchar(255) NOT NULL,
+    "removedAt" timestamp WITH time zone,
+    "workspaceId" bigint NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "id" bigserial,
+    PRIMARY KEY ("id")
+);
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY "conversation_selected_spaces_wid_cid_sid" ON "conversation_selected_spaces" ("workspaceId", "conversationId", "spaceId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "conversation_selected_spaces_conversation_id" ON "conversation_selected_spaces" ("conversationId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "conversation_selected_spaces_space_id" ON "conversation_selected_spaces" ("spaceId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "conversation_selected_spaces_selected_by_user_id" ON "conversation_selected_spaces" ("selectedByUserId");

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -9,6 +9,7 @@ import type { ContentFragmentType } from "../content_fragment";
 import type { AllSupportedWithDustSpecificFileContentType } from "../files";
 import type { ModelId } from "../shared/model_id";
 import { assertNeverAndIgnore } from "../shared/utils/assert_never";
+import type { SpaceType } from "../space";
 import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
@@ -564,6 +565,18 @@ export type ConversationWithoutContentType = ConversationListItemType & {
   depth: number;
   branchId: string | null;
   forkingData?: ConversationForkingDataType;
+};
+
+export type SelectableConversationSpaceType = SpaceType & {
+  selected: boolean;
+};
+
+export type ConversationSelectedSpacesResponse = {
+  selectedSpaces: SelectableConversationSpaceType[];
+  effectiveAcl: {
+    spaceIds: string[];
+    viewerMustHaveAll: true;
+  };
 };
 
 type ConversationDisplayTitleInput = Pick<

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -300,6 +300,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable ES-backed conversation listing in the sidebar (read path)",
     stage: "dust_only",
   },
+  restricted_spaces_in_input_bar: {
+    description:
+      "Allow users to explicitly select restricted Spaces from the conversation input bar.",
+    stage: "dust_only",
+  },
   new_file_explorer: {
     description:
       "Unified GCS-backed file explorer with folder hierarchy, replacing the two-tab files panel.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -750,6 +750,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "poke_mcp"
   | "restrict_agents_publishing"
   | "restrict_agents_publishing_to_admins"
+  | "restricted_spaces_in_input_bar"
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "sandbox_dsbx_tools"


### PR DESCRIPTION
## Description

Context: [Runbook: Deploy / Run migrations](https://app.notion.com/p/5669e328475d489ba16298a77f2aa45c).

PR 1 of the restricted spaces input bar stack: add the storage substrate for per-conversation selected restricted Spaces.

**What this PR does:**
1. Adds `conversation_selected_spaces` through a `pre-deploy` front migration.
2. Registers the Sequelize model and cleanup resource.
3. Deletes selected-space rows when conversations or spaces are deleted.
4. Adds the gated feature flag and shared response types for later PRs.

**Follow-up plan:**
- PR2: add selected-space resource read and upsert helpers.
- PR3: add read and validation service helpers.
- PR4+: wire materialization, runtime scope, APIs, and the input bar UI behind `restricted_spaces_in_input_bar`.

## Tests

- Ran `npm run migration:status` in `front` and confirmed `pre-deploy/20260624143314_add_conversation_selected_spaces.sql` is detected as pending.
- Ran `NODE_ENV=test npm test -- lib/resources/conversation_resource.test.ts lib/resources/space_resource.test.ts` in `front`.
- Ran `NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` in `front`.

## Risk

Worst case, an unused table and feature flag ship before the write path. Safe to rollback before later stack PRs deploy. After the migration is applied, rollback leaves an inert table in DB.

## Deploy Plan

- [ ] Before deploy, run `./scripts/run-migrations.sh status front` and confirm `pre-deploy/20260624143314_add_conversation_selected_spaces.sql` is pending.
- [ ] Run `./scripts/run-migrations.sh pre-deploy front` across regions.
- [ ] Deploy this PR.
- [ ] Run `./scripts/run-migrations.sh status front` and confirm this pre-deploy migration is no longer pending.
- [ ] Do not deploy stack PRs that write selected Spaces before this PR and migration are live.
