### PR TITLE
Add selected spaces resource helpers

### DIFF
--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -65,7 +65,7 @@ describe("ConversationSelectedSpaceResource", () => {
     expect(result.reactivatedSpaces).toEqual([]);
   });
 
-  it("lists active rows and hydrates Spaces in selection order", async () => {
+  it("lists active rows and hydrates Spaces", async () => {
     const conversation = await createConversation();
     const firstSpace = await createMemberRestrictedRegularSpace();
     const secondSpace = await createMemberRestrictedRegularSpace();
@@ -93,10 +93,10 @@ describe("ConversationSelectedSpaceResource", () => {
         conversation,
       }
     );
-    expect(allRows.map((row) => row.spaceId)).toEqual([
-      secondSpace.id,
-      firstSpace.id,
-    ]);
+    expect(allRows.map((row) => row.spaceId)).toHaveLength(2);
+    expect(allRows.map((row) => row.spaceId)).toEqual(
+      expect.arrayContaining([secondSpace.id, firstSpace.id])
+    );
 
     const activeSpaces =
       await ConversationSelectedSpaceResource.listActiveSpacesByConversation(

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -1,5 +1,4 @@
 import { Authenticator } from "@app/lib/auth";
-import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -76,16 +75,10 @@ describe("ConversationSelectedSpaceResource", () => {
       origin: "input_bar",
       spaces: [secondSpace, firstSpace],
     });
-    await ConversationSelectedSpaceModel.update(
-      { removedAt: new Date() },
-      {
-        where: {
-          conversationId: conversation.id,
-          spaceId: firstSpace.id,
-          workspaceId: workspace.id,
-        },
-      }
-    );
+    await ConversationSelectedSpaceResource.removeForConversation(auth, {
+      conversation,
+      spaces: [firstSpace],
+    });
 
     const activeRows =
       await ConversationSelectedSpaceResource.listByConversation(auth, {
@@ -132,16 +125,10 @@ describe("ConversationSelectedSpaceResource", () => {
     ).toEqual([space.sId]);
     expect(created.reactivatedSpaces).toEqual([]);
 
-    await ConversationSelectedSpaceModel.update(
-      { removedAt: new Date() },
-      {
-        where: {
-          conversationId: conversation.id,
-          spaceId: space.id,
-          workspaceId: workspace.id,
-        },
-      }
-    );
+    await ConversationSelectedSpaceResource.removeForConversation(auth, {
+      conversation,
+      spaces: [space],
+    });
 
     const reactivated =
       await ConversationSelectedSpaceResource.upsertForConversation(auth, {
@@ -163,5 +150,37 @@ describe("ConversationSelectedSpaceResource", () => {
     );
     expect(row.origin).toBe("parent_conversation");
     expect(row.removedAt).toBeNull();
+  });
+
+  it("deduplicates selected Spaces before creating rows", async () => {
+    const conversation = await createConversation();
+    const space = await createMemberRestrictedRegularSpace();
+
+    const created =
+      await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        origin: "input_bar",
+        spaces: [space, space],
+      });
+
+    expect(created.selectedSpaces.map((row) => row.spaceId)).toEqual([
+      space.id,
+    ]);
+    expect(
+      created.createdSpaces.map((createdSpace) => createdSpace.sId)
+    ).toEqual([space.sId]);
+
+    const alreadySelected =
+      await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        origin: "input_bar",
+        spaces: [space, space],
+      });
+
+    expect(alreadySelected.selectedSpaces.map((row) => row.spaceId)).toEqual([
+      space.id,
+    ]);
+    expect(alreadySelected.createdSpaces).toEqual([]);
+    expect(alreadySelected.reactivatedSpaces).toEqual([]);
   });
 });

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -1,0 +1,167 @@
+import { Authenticator } from "@app/lib/auth";
+import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("ConversationSelectedSpaceResource", () => {
+  let auth: Authenticator;
+  let user: UserType;
+  let workspace: WorkspaceType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    user = setup.user.toJSON();
+    workspace = auth.getNonNullableWorkspace();
+  });
+
+  async function addCurrentUserToRegularGroup(space: SpaceResource) {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const memberGroup = space.groups.find((group) => group.kind === "regular");
+    if (!memberGroup) {
+      throw new Error("Expected regular member group on Space");
+    }
+
+    await memberGroup.dangerouslyAddMembers(internalAdminAuth, {
+      users: [user],
+    });
+    await auth.refresh();
+  }
+
+  async function createMemberRestrictedRegularSpace() {
+    const space = await SpaceFactory.regular(workspace);
+    await addCurrentUserToRegularGroup(space);
+
+    return space;
+  }
+
+  async function createConversation(): Promise<ConversationWithoutContentType> {
+    return ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  }
+
+  it("returns empty buckets for empty input", async () => {
+    const conversation = await createConversation();
+
+    const result =
+      await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        origin: "input_bar",
+        spaces: [],
+      });
+
+    expect(result.selectedSpaces).toEqual([]);
+    expect(result.createdSpaces).toEqual([]);
+    expect(result.reactivatedSpaces).toEqual([]);
+  });
+
+  it("lists active rows and hydrates Spaces in selection order", async () => {
+    const conversation = await createConversation();
+    const firstSpace = await createMemberRestrictedRegularSpace();
+    const secondSpace = await createMemberRestrictedRegularSpace();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation,
+      origin: "input_bar",
+      spaces: [secondSpace, firstSpace],
+    });
+    await ConversationSelectedSpaceModel.update(
+      { removedAt: new Date() },
+      {
+        where: {
+          conversationId: conversation.id,
+          spaceId: firstSpace.id,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const activeRows =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        conversation,
+      });
+    expect(activeRows.map((row) => row.spaceId)).toEqual([secondSpace.id]);
+
+    const allRows = await ConversationSelectedSpaceResource.listByConversation(
+      auth,
+      {
+        activeOnly: false,
+        conversation,
+      }
+    );
+    expect(allRows.map((row) => row.spaceId)).toEqual([
+      secondSpace.id,
+      firstSpace.id,
+    ]);
+
+    const activeSpaces =
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        { conversation }
+      );
+    expect(activeSpaces.map((space) => space.sId)).toEqual([secondSpace.sId]);
+  });
+
+  it("creates and reactivates selected Spaces", async () => {
+    const conversation = await createConversation();
+    const space = await createMemberRestrictedRegularSpace();
+
+    const created =
+      await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        origin: "input_bar",
+        spaces: [space],
+      });
+
+    expect(created.selectedSpaces.map((row) => row.spaceId)).toEqual([
+      space.id,
+    ]);
+    expect(
+      created.createdSpaces.map((createdSpace) => createdSpace.sId)
+    ).toEqual([space.sId]);
+    expect(created.reactivatedSpaces).toEqual([]);
+
+    await ConversationSelectedSpaceModel.update(
+      { removedAt: new Date() },
+      {
+        where: {
+          conversationId: conversation.id,
+          spaceId: space.id,
+          workspaceId: workspace.id,
+        },
+      }
+    );
+
+    const reactivated =
+      await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        origin: "parent_conversation",
+        spaces: [space],
+      });
+
+    expect(reactivated.createdSpaces).toEqual([]);
+    expect(
+      reactivated.reactivatedSpaces.map(
+        (reactivatedSpace) => reactivatedSpace.sId
+      )
+    ).toEqual([space.sId]);
+
+    const [row] = await ConversationSelectedSpaceResource.listByConversation(
+      auth,
+      { conversation }
+    );
+    expect(row.origin).toBe("parent_conversation");
+    expect(row.removedAt).toBeNull();
+  });
+});

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -1,12 +1,41 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { ConversationSelectedSpaceOrigin } from "@app/lib/models/agent/conversation_selected_space";
 import { ConversationSelectedSpaceModel } from "@app/lib/models/agent/conversation_selected_space";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+function sortSelectedSpaceRowsBySelectionOrder<T extends { id: ModelId }>(
+  rows: T[]
+): T[] {
+  return [...rows].sort((left, right) => left.id - right.id);
+}
+
+// `fetchByModelIds` uses an IN query, so it does not preserve the requested id order.
+function pickSpacesInModelIdOrder({
+  spaces,
+  orderedSpaceModelIds,
+}: {
+  spaces: SpaceResource[];
+  orderedSpaceModelIds: ModelId[];
+}): SpaceResource[] {
+  const spacesByModelId = new Map(spaces.map((space) => [space.id, space]));
+
+  return removeNulls(
+    orderedSpaceModelIds.map((spaceModelId) =>
+      spacesByModelId.get(spaceModelId)
+    )
+  );
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationSelectedSpaceResource
@@ -22,6 +51,176 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
     blob: Attributes<ConversationSelectedSpaceModel>
   ) {
     super(model, blob);
+  }
+
+  static async listByConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      activeOnly = true,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      activeOnly?: boolean;
+      transaction?: Transaction;
+    }
+  ): Promise<ConversationSelectedSpaceResource[]> {
+    const rows = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        ...(activeOnly ? { removedAt: null } : {}),
+      },
+      transaction,
+    });
+
+    return sortSelectedSpaceRowsBySelectionOrder(rows).map(
+      (row) => new this(this.model, row.get())
+    );
+  }
+
+  static async listActiveSpacesByConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      transaction?: Transaction;
+    }
+  ): Promise<SpaceResource[]> {
+    const selectedSpaces = await this.listByConversation(auth, {
+      conversation,
+      transaction,
+    });
+
+    const selectedSpaceModelIds = selectedSpaces.map(
+      (selectedSpace) => selectedSpace.spaceId
+    );
+    const spaces = await SpaceResource.fetchByModelIds(
+      auth,
+      selectedSpaceModelIds,
+      { transaction }
+    );
+
+    return pickSpacesInModelIdOrder({
+      spaces,
+      orderedSpaceModelIds: selectedSpaceModelIds,
+    });
+  }
+
+  static async upsertForConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      spaces,
+      origin,
+      transaction,
+    }: {
+      conversation: ConversationWithoutContentType;
+      spaces: SpaceResource[];
+      origin: ConversationSelectedSpaceOrigin;
+      transaction?: Transaction;
+    }
+  ): Promise<{
+    selectedSpaces: ConversationSelectedSpaceResource[];
+    createdSpaces: SpaceResource[];
+    reactivatedSpaces: SpaceResource[];
+  }> {
+    return withTransaction(async (t) => {
+      const workspace = auth.getNonNullableWorkspace();
+      const user = auth.getNonNullableUser();
+      const spaceModelIds = spaces.map((space) => space.id);
+
+      if (spaceModelIds.length === 0) {
+        return {
+          selectedSpaces: [],
+          createdSpaces: [],
+          reactivatedSpaces: [],
+        };
+      }
+
+      const existingRows = await this.model.findAll({
+        where: {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+          spaceId: {
+            [Op.in]: spaceModelIds,
+          },
+        },
+        transaction: t,
+      });
+      const orderedExistingRows =
+        sortSelectedSpaceRowsBySelectionOrder(existingRows);
+      const existingSpaceModelIds = new Set(
+        existingRows.map((row) => row.spaceId)
+      );
+      const reactivatedRows = orderedExistingRows.filter(
+        (row) => row.removedAt !== null
+      );
+      const reactivatedSpaceModelIds = reactivatedRows.map(
+        (row) => row.spaceId
+      );
+      const reactivatedRowModelIds = reactivatedRows.map((row) => row.id);
+      const createdSpaces = spaces.filter(
+        (space) => !existingSpaceModelIds.has(space.id)
+      );
+
+      if (createdSpaces.length > 0) {
+        await this.model.bulkCreate(
+          createdSpaces.map((space) => ({
+            workspaceId: workspace.id,
+            conversationId: conversation.id,
+            spaceId: space.id,
+            selectedByUserId: user.id,
+            origin,
+            removedAt: null,
+          })),
+          { ignoreDuplicates: true, transaction: t }
+        );
+      }
+
+      if (reactivatedRowModelIds.length > 0) {
+        await this.model.update(
+          {
+            selectedByUserId: user.id,
+            origin,
+            removedAt: null,
+          },
+          {
+            where: {
+              workspaceId: workspace.id,
+              id: {
+                [Op.in]: reactivatedRowModelIds,
+              },
+            },
+            transaction: t,
+          }
+        );
+      }
+
+      const selectedRows = await this.model.findAll({
+        where: {
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+          spaceId: {
+            [Op.in]: spaceModelIds,
+          },
+        },
+        transaction: t,
+      });
+
+      return {
+        selectedSpaces: sortSelectedSpaceRowsBySelectionOrder(selectedRows).map(
+          (row) => new this(this.model, row.get())
+        ),
+        createdSpaces,
+        reactivatedSpaces: pickSpacesInModelIdOrder({
+          spaces,
+          orderedSpaceModelIds: reactivatedSpaceModelIds,
+        }),
+      };
+    }, transaction);
   }
 
   static async deleteForConversation(

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -17,6 +17,7 @@ import { Op } from "sequelize";
 function sortSelectedSpaceRowsBySelectionOrder<T extends { id: ModelId }>(
   rows: T[]
 ): T[] {
+  // Selection order is insertion order. Reactivating a row keeps its original position.
   return [...rows].sort((left, right) => left.id - right.id);
 }
 
@@ -35,6 +36,22 @@ function pickSpacesInModelIdOrder({
       spacesByModelId.get(spaceModelId)
     )
   );
+}
+
+function dedupeSpacesByFirstModelId(spaces: SpaceResource[]): SpaceResource[] {
+  const seenSpaceModelIds = new Set<ModelId>();
+  const uniqueSpaces: SpaceResource[] = [];
+
+  for (const space of spaces) {
+    if (seenSpaceModelIds.has(space.id)) {
+      continue;
+    }
+
+    seenSpaceModelIds.add(space.id);
+    uniqueSpaces.push(space);
+  }
+
+  return uniqueSpaces;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -130,7 +147,8 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
     return withTransaction(async (t) => {
       const workspace = auth.getNonNullableWorkspace();
       const user = auth.getNonNullableUser();
-      const spaceModelIds = spaces.map((space) => space.id);
+      const uniqueSpaces = dedupeSpacesByFirstModelId(spaces);
+      const spaceModelIds = uniqueSpaces.map((space) => space.id);
 
       if (spaceModelIds.length === 0) {
         return {
@@ -162,13 +180,14 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
         (row) => row.spaceId
       );
       const reactivatedRowModelIds = reactivatedRows.map((row) => row.id);
-      const createdSpaces = spaces.filter(
+      const missingSpaces = uniqueSpaces.filter(
         (space) => !existingSpaceModelIds.has(space.id)
       );
+      let createdSpaceModelIds: ModelId[] = [];
 
-      if (createdSpaces.length > 0) {
-        await this.model.bulkCreate(
-          createdSpaces.map((space) => ({
+      if (missingSpaces.length > 0) {
+        const createdRows = await this.model.bulkCreate(
+          missingSpaces.map((space) => ({
             workspaceId: workspace.id,
             conversationId: conversation.id,
             spaceId: space.id,
@@ -178,6 +197,11 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
           })),
           { ignoreDuplicates: true, transaction: t }
         );
+
+        // With `ignoreDuplicates`, rows skipped by a concurrent insert come back without an id.
+        createdSpaceModelIds = createdRows
+          .filter((row) => Number.isInteger(row.id))
+          .map((row) => row.spaceId);
       }
 
       if (reactivatedRowModelIds.length > 0) {
@@ -214,13 +238,54 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
         selectedSpaces: sortSelectedSpaceRowsBySelectionOrder(selectedRows).map(
           (row) => new this(this.model, row.get())
         ),
-        createdSpaces,
+        createdSpaces: pickSpacesInModelIdOrder({
+          spaces: uniqueSpaces,
+          orderedSpaceModelIds: createdSpaceModelIds,
+        }),
         reactivatedSpaces: pickSpacesInModelIdOrder({
-          spaces,
+          spaces: uniqueSpaces,
           orderedSpaceModelIds: reactivatedSpaceModelIds,
         }),
       };
     }, transaction);
+  }
+
+  static async removeForConversation(
+    auth: Authenticator,
+    {
+      conversation,
+      spaces,
+      transaction,
+    }: {
+      conversation: { id: ModelId };
+      spaces: SpaceResource[];
+      transaction?: Transaction;
+    }
+  ): Promise<number> {
+    const spaceModelIds = dedupeSpacesByFirstModelId(spaces).map(
+      (space) => space.id
+    );
+
+    if (spaceModelIds.length === 0) {
+      return 0;
+    }
+
+    const [updatedCount] = await this.model.update(
+      { removedAt: new Date() },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          conversationId: conversation.id,
+          removedAt: null,
+          spaceId: {
+            [Op.in]: spaceModelIds,
+          },
+        },
+        transaction,
+      }
+    );
+
+    return updatedCount;
   }
 
   static async deleteForConversation(

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -10,49 +10,9 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
-import { removeNulls } from "@app/types/shared/utils/general";
+import uniqBy from "lodash/uniqBy";
 import type { Attributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
-
-function sortSelectedSpaceRowsBySelectionOrder<T extends { id: ModelId }>(
-  rows: T[]
-): T[] {
-  // Selection order is insertion order. Reactivating a row keeps its original position.
-  return [...rows].sort((left, right) => left.id - right.id);
-}
-
-// `fetchByModelIds` uses an IN query, so it does not preserve the requested id order.
-function pickSpacesInModelIdOrder({
-  spaces,
-  orderedSpaceModelIds,
-}: {
-  spaces: SpaceResource[];
-  orderedSpaceModelIds: ModelId[];
-}): SpaceResource[] {
-  const spacesByModelId = new Map(spaces.map((space) => [space.id, space]));
-
-  return removeNulls(
-    orderedSpaceModelIds.map((spaceModelId) =>
-      spacesByModelId.get(spaceModelId)
-    )
-  );
-}
-
-function dedupeSpacesByFirstModelId(spaces: SpaceResource[]): SpaceResource[] {
-  const seenSpaceModelIds = new Set<ModelId>();
-  const uniqueSpaces: SpaceResource[] = [];
-
-  for (const space of spaces) {
-    if (seenSpaceModelIds.has(space.id)) {
-      continue;
-    }
-
-    seenSpaceModelIds.add(space.id);
-    uniqueSpaces.push(space);
-  }
-
-  return uniqueSpaces;
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ConversationSelectedSpaceResource
@@ -91,9 +51,7 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
       transaction,
     });
 
-    return sortSelectedSpaceRowsBySelectionOrder(rows).map(
-      (row) => new this(this.model, row.get())
-    );
+    return rows.map((row) => new this(this.model, row.get()));
   }
 
   static async listActiveSpacesByConversation(
@@ -114,15 +72,9 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
     const selectedSpaceModelIds = selectedSpaces.map(
       (selectedSpace) => selectedSpace.spaceId
     );
-    const spaces = await SpaceResource.fetchByModelIds(
-      auth,
-      selectedSpaceModelIds,
-      { transaction }
-    );
-
-    return pickSpacesInModelIdOrder({
-      spaces,
-      orderedSpaceModelIds: selectedSpaceModelIds,
+    // Fetch through SpaceResource so the returned spaces include their groups.
+    return SpaceResource.fetchByModelIds(auth, selectedSpaceModelIds, {
+      transaction,
     });
   }
 
@@ -147,7 +99,7 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
     return withTransaction(async (t) => {
       const workspace = auth.getNonNullableWorkspace();
       const user = auth.getNonNullableUser();
-      const uniqueSpaces = dedupeSpacesByFirstModelId(spaces);
+      const uniqueSpaces = uniqBy(spaces, "id");
       const spaceModelIds = uniqueSpaces.map((space) => space.id);
 
       if (spaceModelIds.length === 0) {
@@ -168,22 +120,14 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
         },
         transaction: t,
       });
-      const orderedExistingRows =
-        sortSelectedSpaceRowsBySelectionOrder(existingRows);
       const existingSpaceModelIds = new Set(
         existingRows.map((row) => row.spaceId)
       );
-      const reactivatedRows = orderedExistingRows.filter(
-        (row) => row.removedAt !== null
-      );
-      const reactivatedSpaceModelIds = reactivatedRows.map(
-        (row) => row.spaceId
-      );
-      const reactivatedRowModelIds = reactivatedRows.map((row) => row.id);
+      const removedRows = existingRows.filter((row) => row.removedAt !== null);
       const missingSpaces = uniqueSpaces.filter(
         (space) => !existingSpaceModelIds.has(space.id)
       );
-      let createdSpaceModelIds: ModelId[] = [];
+      let createdSpaceModelIds = new Set<ModelId>();
 
       if (missingSpaces.length > 0) {
         const createdRows = await this.model.bulkCreate(
@@ -199,13 +143,16 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
         );
 
         // With `ignoreDuplicates`, rows skipped by a concurrent insert come back without an id.
-        createdSpaceModelIds = createdRows
-          .filter((row) => Number.isInteger(row.id))
-          .map((row) => row.spaceId);
+        createdSpaceModelIds = new Set(
+          createdRows
+            .filter((row) => Number.isInteger(row.id))
+            .map((row) => row.spaceId)
+        );
       }
 
-      if (reactivatedRowModelIds.length > 0) {
-        await this.model.update(
+      let reactivatedSpaceModelIds = new Set<ModelId>();
+      if (removedRows.length > 0) {
+        const [, reactivatedRows] = await this.model.update(
           {
             selectedByUserId: user.id,
             origin,
@@ -215,11 +162,15 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
             where: {
               workspaceId: workspace.id,
               id: {
-                [Op.in]: reactivatedRowModelIds,
+                [Op.in]: removedRows.map((row) => row.id),
               },
             },
             transaction: t,
+            returning: true,
           }
+        );
+        reactivatedSpaceModelIds = new Set(
+          reactivatedRows.map((row) => row.spaceId)
         );
       }
 
@@ -235,17 +186,15 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
       });
 
       return {
-        selectedSpaces: sortSelectedSpaceRowsBySelectionOrder(selectedRows).map(
+        selectedSpaces: selectedRows.map(
           (row) => new this(this.model, row.get())
         ),
-        createdSpaces: pickSpacesInModelIdOrder({
-          spaces: uniqueSpaces,
-          orderedSpaceModelIds: createdSpaceModelIds,
-        }),
-        reactivatedSpaces: pickSpacesInModelIdOrder({
-          spaces: uniqueSpaces,
-          orderedSpaceModelIds: reactivatedSpaceModelIds,
-        }),
+        createdSpaces: uniqueSpaces.filter((space) =>
+          createdSpaceModelIds.has(space.id)
+        ),
+        reactivatedSpaces: uniqueSpaces.filter((space) =>
+          reactivatedSpaceModelIds.has(space.id)
+        ),
       };
     }, transaction);
   }
@@ -262,9 +211,7 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
       transaction?: Transaction;
     }
   ): Promise<number> {
-    const spaceModelIds = dedupeSpacesByFirstModelId(spaces).map(
-      (space) => space.id
-    );
+    const spaceModelIds = uniqBy(spaces, "id").map((space) => space.id);
 
     if (spaceModelIds.length === 0) {
       return 0;


### PR DESCRIPTION
## Description

Follow up of #27539.

Adds the selected-space resource helpers needed by the restricted Spaces input bar stack. This PR only introduces the resource-layer primitives; service and API entry points come in follow-up PRs.

**What this PR does:**
1. Lists selected Spaces for a conversation.
2. Hydrates active selected Spaces as `SpaceResource`s.
3. Inserts new selected Spaces, de-duping duplicate input and reporting only rows actually inserted.
4. Reactivates tombstoned selections in one transaction.
5. Adds a resource-level soft-remove helper for selected Spaces.

## Tests

- Added `conversation_selected_space_resource.test.ts` for empty input, active/all listing, hydration, insert, duplicate input handling, and reactivation.
- Ran `npx biome check --write lib/resources/conversation_selected_space_resource.ts lib/resources/conversation_selected_space_resource.test.ts` in `front`.
- Ran `NODE_ENV=test npm test -- lib/resources/conversation_selected_space_resource.test.ts` in `front`.
- Attempted `nvm use && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` in `front`; the local Hive dependency link resolves `@dust-tt/sparkle` to the parent checkout and fails on unrelated missing Sparkle exports across UI files.

## Risk

Worst case, later PRs cannot use the helper as-is and we revert this resource-only commit. Safe to rollback before the service/API PRs are deployed.

## Deploy Plan

- [x] #27539 is merged into `main`.
- [x] #27920 fixed the #27539 migration foreign key issue and is merged into `main`.
- [ ] Deploy current `main` with #27539 and #27920.
- [ ] Deploy this PR after that main deploy.