### PR TITLE
Emit file preview directives from file tools

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -60,6 +60,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
+import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import datadogLogger from "@app/logger/datadogLogger";
@@ -1302,6 +1303,9 @@ function AgentMessageContent({
   );
   const matches = (agentMessage.content ?? "").matchAll(markdownImageRegex);
   const referencedFileIds = new Set([...matches].map((m) => m[1]));
+  const referencedFilePaths = getFilePreviewDirectivePaths(
+    agentMessage.content ?? ""
+  );
 
   // Get completed images that are not already referenced in the Markdown content.
   // Combine from actions (updated during streaming) and generatedFiles (available on reload).
@@ -1354,7 +1358,8 @@ function AgentMessageContent({
   const generatedFiles = filesFromMessage.filter(
     (file) =>
       !isSupportedImageContentType(file.contentType) &&
-      !isInteractiveContentType(file.contentType)
+      !isInteractiveContentType(file.contentType) &&
+      (file.filePath === undefined || !referencedFilePaths.has(file.filePath))
   );
 
   return (

--- a/front/components/markdown/FilePreviewBlock.test.tsx
+++ b/front/components/markdown/FilePreviewBlock.test.tsx
@@ -1,0 +1,151 @@
+import { FilePreviewProvider } from "@app/components/assistant/conversation/FilePreviewContext";
+import {
+  getFilePreviewDirectivePaths,
+  getFilePreviewMarkdownDirective,
+} from "@app/lib/markdown/file_preview";
+import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { filePreviewDirective, getFilePreviewPlugin } from "./FilePreviewBlock";
+
+const mockOwner = LightWorkspaceFactory.build({
+  sId: "w_test_ws",
+});
+
+type DirectiveNode = {
+  attributes?: Record<string, string>;
+  children?: Array<{ type: string; value: string }>;
+  data?: {
+    hName?: string;
+    hProperties?: Record<string, string | undefined>;
+  };
+  name: string;
+  type: "leafDirective" | "textDirective";
+};
+
+type DirectiveTree = {
+  children: DirectiveNode[];
+  type: "root";
+};
+
+describe("filePreviewDirective", () => {
+  it("transforms :preview_file textDirective nodes with path and content type", () => {
+    const tree: DirectiveTree = {
+      type: "root",
+      children: [
+        {
+          type: "textDirective",
+          name: "preview_file",
+          attributes: {
+            path: "conversation-c1/report.pdf",
+            contentType: "application/pdf",
+          },
+          children: [{ type: "text", value: "report.pdf" }],
+        },
+      ],
+    };
+
+    filePreviewDirective()(tree);
+
+    expect(tree.children[0].data?.hName).toBe("file_preview");
+    expect(tree.children[0].data?.hProperties).toEqual({
+      path: "conversation-c1/report.pdf",
+      title: "report.pdf",
+      contentType: "application/pdf",
+    });
+  });
+
+  it("supports title and content_type attributes", () => {
+    const tree: DirectiveTree = {
+      type: "root",
+      children: [
+        {
+          type: "textDirective",
+          name: "preview_file",
+          attributes: {
+            path: "pod-p1/export.csv",
+            title: "export.csv",
+            content_type: "text/csv",
+          },
+        },
+      ],
+    };
+
+    filePreviewDirective()(tree);
+
+    expect(tree.children[0].data?.hProperties).toEqual({
+      path: "pod-p1/export.csv",
+      title: "export.csv",
+      contentType: "text/csv",
+    });
+  });
+
+  it("does not transform directives without a path", () => {
+    const tree: DirectiveTree = {
+      type: "root",
+      children: [
+        {
+          type: "textDirective",
+          name: "preview_file",
+          attributes: {},
+          children: [{ type: "text", value: "report.pdf" }],
+        },
+      ],
+    };
+
+    filePreviewDirective()(tree);
+
+    expect(tree.children[0].data).toBeUndefined();
+  });
+});
+
+describe("getFilePreviewDirectivePaths", () => {
+  it("extracts paths from generated text directives", () => {
+    const directive = getFilePreviewMarkdownDirective({
+      path: 'conversation-c1/reports/report "Q2".pdf',
+      title: 'report "Q2".pdf',
+      contentType: "application/pdf",
+    });
+
+    expect([...getFilePreviewDirectivePaths(`Preview\n${directive}`)]).toEqual([
+      'conversation-c1/reports/report "Q2".pdf',
+    ]);
+  });
+});
+
+describe("getFilePreviewPlugin", () => {
+  it("renders a previewable file with the file name", async () => {
+    const FilePreview = getFilePreviewPlugin();
+
+    const { container } = render(
+      <FilePreviewProvider owner={mockOwner}>
+        <FilePreview
+          path="conversation-c1/reports/report final.pdf"
+          title="report final.pdf"
+          contentType="application/pdf"
+        />
+      </FilePreviewProvider>
+    );
+
+    expect(screen.getByText("report final.pdf")).toBeInTheDocument();
+    expect(container.querySelector("a[href*='download=1']")).toBeNull();
+
+    fireEvent.click(screen.getByText("report final.pdf"));
+
+    expect(
+      await screen.findByRole("dialog", { name: "report final.pdf" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download" })
+    ).toBeInTheDocument();
+  });
+
+  it("infers the file name from the scoped path when metadata is absent", () => {
+    const FilePreview = getFilePreviewPlugin();
+
+    render(<FilePreview path="conversation-c1/exports/data.csv" />);
+
+    expect(screen.getByText("data.csv")).toBeInTheDocument();
+  });
+});

--- a/front/lib/api/actions/servers/files/metadata.ts
+++ b/front/lib/api/actions/servers/files/metadata.ts
@@ -6,6 +6,7 @@ import {
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   INTERACTIVE_CONTENT_SERVER_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import { FILE_PREVIEW_DIRECTIVE_EXAMPLE } from "@app/lib/markdown/file_preview";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
@@ -45,6 +46,12 @@ const SCOPED_PATH_HINT =
   "Paths use `conversation-<id>/...` or `pod-<id>/...` for any conversation or Pod you can access; " +
   "defaults target the current conversation and its Pod when applicable.";
 
+const FILE_PREVIEW_DIRECTIVE_HINT =
+  "To show a previewable file citation for a scoped file path in a final response, " +
+  `output the markdown directive \`${FILE_PREVIEW_DIRECTIVE_EXAMPLE}\`; include \`contentType\` when known. ` +
+  "The rendered citation opens the file preview, where the user can download the file. " +
+  "Use the scoped path exactly as returned by this server and never invent an app URL for it.";
+
 const LIST_SCOPE_SCHEMA = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("conversation"),
@@ -69,6 +76,7 @@ const LIST_SCOPE_SCHEMA = z.discriminatedUnion("type", [
 const LIST_TOOL = {
   description:
     `${LIST_DESCRIPTION_PREFIX} ` +
+    `${FILE_PREVIEW_DIRECTIVE_HINT} ` +
     'Defaults to the current conversation\'s files. Omit `scope` or pass `{ type: "conversation" }`. ' +
     'Pass `{ type: "pod" }` to list a Pod\'s shared files. ' +
     "Optional `conversation_id` or `pod_id` on the matching variant list another accessible scope.",
@@ -352,7 +360,7 @@ export const FILES_SERVER = {
       "Defaults to the current conversation (and its Pod when applicable). " +
       "Files include user uploads, sandbox outputs, and tool results. " +
       "Scoped paths such as `conversation-<id>/chart.png` or `pod-<id>/spec.md` identify files " +
-      "and can be used to reference, display, or link them in responses. " +
+      "and can be used to reference or display them in responses. " +
       "Processed siblings (resized images, audio transcripts) are listed alongside their source with an annotation.",
     authorization: null,
     icon: "ActionDocumentTextIcon" as const,

--- a/front/lib/api/actions/servers/files/tools/copy.test.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.test.ts
@@ -68,12 +68,23 @@ describe("copyHandler", () => {
     if (!result.isOk()) {
       return;
     }
-    expect(result.value).toEqual([
-      {
-        type: "text",
-        text: `Copied \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`.`,
+    expect(result.value[0]).toEqual({
+      type: "text",
+      text:
+        `Copied \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. ` +
+        `To show a previewable file citation in your response, output this markdown directive exactly on its own line:\n` +
+        `:preview_file{path="pod-${spaceId}/report.pdf" title="report.pdf" contentType="text/plain"}\n` +
+        "The rendered citation opens the file preview, where the user can download the file. " +
+        "Do not invent a URL for this file.",
+    });
+    expect(result.value[1]).toMatchObject({
+      type: "resource",
+      resource: {
+        path: `pod-${spaceId}/report.pdf`,
+        title: "report.pdf",
+        contentType: "text/plain",
       },
-    ]);
+    });
   });
 
   it("copies a file from pod to conversation mount", async () => {

--- a/front/lib/api/actions/servers/files/tools/copy.ts
+++ b/front/lib/api/actions/servers/files/tools/copy.ts
@@ -1,4 +1,5 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolHandlerExtra,
   ToolHandlerResult,
@@ -13,11 +14,14 @@ import {
   requireAgentLoopConversation,
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import {
+  isAllSupportedFileContentType,
   isInteractiveContentType,
   stripMimeParameters,
 } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export async function copyHandler(
   { source, dest }: { source: string; dest: string },
@@ -106,10 +110,36 @@ export async function copyHandler(
     }
   }
 
-  return new Ok([
+  const destFileName = dest.split("/").pop() ?? dest;
+  const items: Array<
+    | { type: "text"; text: string }
+    | { type: "resource"; resource: ToolGeneratedFilePathType }
+  > = [
     {
       type: "text",
-      text: `Copied \`${source}\` to \`${dest}\`.`,
+      text:
+        `Copied \`${source}\` to \`${dest}\`. ` +
+        getFilePreviewDirectiveInstruction({
+          contentType: mimeType,
+          path: dest,
+          title: destFileName,
+        }),
     },
-  ]);
+  ];
+
+  if (isAllSupportedFileContentType(mimeType)) {
+    items.push({
+      type: "resource",
+      resource: {
+        text: `Copied \`${source}\` to \`${dest}\``,
+        uri: dest,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE_PATH,
+        path: dest,
+        title: destFileName,
+        contentType: mimeType,
+      },
+    });
+  }
+
+  return new Ok(items);
 }

--- a/front/lib/api/actions/servers/files/tools/create.ts
+++ b/front/lib/api/actions/servers/files/tools/create.ts
@@ -14,6 +14,7 @@ import {
   frameFileCreateRejectedError,
   frameFileEditRejectedError,
 } from "@app/lib/api/actions/servers/files/tools/utils";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import {
   isAllSupportedFileContentType,
   isInteractiveContentType,
@@ -102,7 +103,13 @@ export async function createHandler(
   > = [
     {
       type: "text",
-      text: `${verb} \`${path}\` (${content_type}, ${sizeKb} KB). The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+      text:
+        `${verb} \`${path}\` (${content_type}, ${sizeKb} KB). ` +
+        getFilePreviewDirectiveInstruction({
+          contentType: content_type,
+          path,
+          title: fileName,
+        }),
     },
   ];
 

--- a/front/lib/api/actions/servers/files/tools/extract_text.ts
+++ b/front/lib/api/actions/servers/files/tools/extract_text.ts
@@ -10,6 +10,7 @@ import {
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import config from "@app/lib/api/config";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import {
@@ -138,7 +139,13 @@ export async function extractTextHandler(
   return new Ok([
     {
       type: "text",
-      text: `Extracted text from \`${path}\` to \`${outputPath}\` (${sizeKb} KB). The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+      text:
+        `Extracted text from \`${path}\` to \`${outputPath}\` (${sizeKb} KB). ` +
+        getFilePreviewDirectiveInstruction({
+          contentType: "text/plain",
+          path: outputPath,
+          title: fileName,
+        }),
     },
     {
       type: "resource",

--- a/front/lib/api/actions/servers/files/tools/move.test.ts
+++ b/front/lib/api/actions/servers/files/tools/move.test.ts
@@ -75,7 +75,12 @@ describe("moveHandler", () => {
     }
     expect(result.value[0]).toEqual({
       type: "text",
-      text: `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+      text:
+        `Moved \`conversation-${conversation.sId}/report.pdf\` to \`pod-${spaceId}/report.pdf\`. ` +
+        `To show a previewable file citation in your response, output this markdown directive exactly on its own line:\n` +
+        `:preview_file{path="pod-${spaceId}/report.pdf" title="report.pdf" contentType="text/plain"}\n` +
+        "The rendered citation opens the file preview, where the user can download the file. " +
+        "Do not invent a URL for this file.",
     });
   });
 

--- a/front/lib/api/actions/servers/files/tools/move.ts
+++ b/front/lib/api/actions/servers/files/tools/move.ts
@@ -10,6 +10,7 @@ import {
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { moveCanonicalFile } from "@app/lib/api/files/file_system_ops";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import {
   isAllSupportedFileContentType,
   stripMimeParameters,
@@ -101,7 +102,13 @@ export async function moveHandler(
   > = [
     {
       type: "text",
-      text: `Moved \`${source}\` to \`${dest}\`. The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+      text:
+        `Moved \`${source}\` to \`${dest}\`. ` +
+        getFilePreviewDirectiveInstruction({
+          contentType: mimeType,
+          path: dest,
+          title: dest.split("/").pop() ?? dest,
+        }),
     },
   ];
 

--- a/front/lib/api/actions/servers/files/tools/upload_from_url.ts
+++ b/front/lib/api/actions/servers/files/tools/upload_from_url.ts
@@ -10,6 +10,7 @@ import {
   scopedPathsFromArgs,
 } from "@app/lib/api/actions/servers/files/tools/agent_loop_fs";
 import { uploadFileFromUrlToFileSystem } from "@app/lib/api/file_system/upload_from_url";
+import { getFilePreviewDirectiveInstruction } from "@app/lib/markdown/file_preview";
 import { isAllSupportedFileContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -59,7 +60,13 @@ export async function uploadFromUrlHandler(
   > = [
     {
       type: "text",
-      text: `${verb} \`${path}\` from URL (${contentType}, ${sizeKb} KB). The user is presented with an attachment to download the file, do not attempt to generate a link to it.`,
+      text:
+        `${verb} \`${path}\` from URL (${contentType}, ${sizeKb} KB). ` +
+        getFilePreviewDirectiveInstruction({
+          contentType,
+          path,
+          title: fileName,
+        }),
     },
   ];
 

--- a/front/lib/markdown/file_preview.ts
+++ b/front/lib/markdown/file_preview.ts
@@ -19,6 +19,13 @@ export type ParsedFilePreviewDirective = {
   title?: string;
 };
 
+const FILE_PREVIEW_DIRECTIVE_REGEX = new RegExp(
+  String.raw`:${FILE_PREVIEW_DIRECTIVE_NAME}(?:\[[^\]\n]*\])?\{([^}\n]*)\}`,
+  "g"
+);
+const FILE_PREVIEW_PATH_ATTRIBUTE_REGEX =
+  /\bpath\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s}]+))/;
+
 function fileExtensionLabel(fileName: string): string | null {
   const lastDot = fileName.lastIndexOf(".");
   if (lastDot <= 0 || lastDot === fileName.length - 1) {
@@ -186,6 +193,22 @@ export function getFilePreviewMarkdownDirective({
   return `:${FILE_PREVIEW_DIRECTIVE_NAME}{${attributes.join(" ")}}`;
 }
 
+export function getFilePreviewDirectivePaths(content: string): Set<string> {
+  const paths = new Set<string>();
+
+  for (const match of content.matchAll(FILE_PREVIEW_DIRECTIVE_REGEX)) {
+    const attributes = match[1];
+    const pathMatch = attributes.match(FILE_PREVIEW_PATH_ATTRIBUTE_REGEX);
+    const encodedPath = pathMatch?.[1] ?? pathMatch?.[2] ?? pathMatch?.[3];
+
+    if (encodedPath) {
+      paths.add(unescape(encodedPath));
+    }
+  }
+
+  return paths;
+}
+
 export function getFilePreviewDirectiveInstruction({
   contentType,
   path,
@@ -198,6 +221,7 @@ export function getFilePreviewDirectiveInstruction({
   return (
     "To show a previewable file citation in your response, output this markdown directive exactly on its own line:\n" +
     `${getFilePreviewMarkdownDirective({ contentType, path, title })}\n` +
+    "The rendered citation opens the file preview, where the user can download the file. " +
     "Do not invent a URL for this file."
   );
 }


### PR DESCRIPTION
## Description

Follow-up to #27531. Main now includes #27809, which made scoped file preview citations render as compact inline citations. This PR is rebased directly on latest `main` and only wires file-producing tools to emit those scoped file preview directives.

Instead of telling the agent that the user will see an attachment, or leaving it room to invent a URL, file tools now give the agent an exact `:preview_file{...}` directive to include in the final answer.

## Chapters

### 1. Tool prompt contract

The files server metadata documents the `:preview_file{...}` directive for scoped file paths returned by `files__list`.

The file-producing handlers (`create`, `copy`, `move`, `upload_from_url`, and `extract_text`) now append the same concrete instruction after they create, copy, move, upload, or extract a file. The instruction says that the rendered citation opens the file preview, where the user can download the file, and explicitly tells the agent not to invent a URL.

### 2. Directive helper reuse

`front/lib/markdown/file_preview.ts` owns the shared instruction helper used by the file tools. This keeps the generated directive syntax, escaping behavior, and prompt wording in one place.

It also exposes path extraction for generated `:preview_file{...}` directives so the message renderer can tell which file paths are already linked inline.

### 3. Avoid duplicate generated-file attachments

`AgentMessage.tsx` parses the final message for `:preview_file{...}` paths and filters those paths out of the fallback generated-files grid at the bottom of the message.

That means a file cited inline by the agent appears once, as the compact preview citation from current `main`, instead of also appearing again as an automatically rendered attachment card.

### 4. Coverage

The tests cover directive path extraction, rendering the preview citation behavior, and the copy/move tool prompt snapshots. The snapshots verify the exact model-facing instruction that includes the directive and the preview/download wording.

## Tests

- `NODE_ENV=test npm run test -- lib/markdown/file_preview.test.ts components/assistant/AgentMessageMarkdown.integration.test.tsx components/markdown/FilePreviewBlock.test.tsx lib/api/actions/servers/files/tools/copy.test.ts lib/api/actions/servers/files/tools/move.test.ts`
- `npx biome check components/assistant/conversation/AgentMessage.tsx components/markdown/FilePreviewBlock.test.tsx lib/api/actions/servers/files/metadata.ts lib/api/actions/servers/files/tools/copy.test.ts lib/api/actions/servers/files/tools/copy.ts lib/api/actions/servers/files/tools/create.ts lib/api/actions/servers/files/tools/extract_text.ts lib/api/actions/servers/files/tools/move.test.ts lib/api/actions/servers/files/tools/move.ts lib/api/actions/servers/files/tools/upload_from_url.ts lib/markdown/file_preview.ts`
- `npm --prefix front run tsgo`

## Risk

Low. This changes model-facing file-tool instructions and suppresses duplicate fallback rendering for files already cited inline. The renderer behavior comes from current `main` via #27809.

## Deploy Plan

Standard deploy.
