### PR TITLE
Add selected spaces read service

### DIFF
--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -1,0 +1,166 @@
+import {
+  listSelectableRestrictedSpaces,
+  type SelectedConversationSpacesError,
+  validateSelectableRestrictedSpaces,
+} from "@app/lib/api/assistant/conversation/selected_spaces";
+import { Authenticator } from "@app/lib/auth";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { Result } from "@app/types/shared/result";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+function unwrapResult<T>(
+  result: Result<T, SelectedConversationSpacesError>
+): T {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+function expectErrCode<T>(
+  result: Result<T, SelectedConversationSpacesError>,
+  code: SelectedConversationSpacesError["code"]
+) {
+  expect(result.isErr()).toBe(true);
+  if (result.isErr()) {
+    expect(result.error.code).toBe(code);
+  }
+}
+
+describe("selected conversation Spaces", () => {
+  let auth: Authenticator;
+  let globalSpace: SpaceResource;
+  let user: UserType;
+  let workspace: WorkspaceType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    auth = setup.authenticator;
+    globalSpace = setup.globalSpace;
+    user = setup.user.toJSON();
+    workspace = auth.getNonNullableWorkspace();
+  });
+
+  async function enableFeature() {
+    await FeatureFlagFactory.basic(auth, "restricted_spaces_in_input_bar");
+  }
+
+  function regularGroup(space: SpaceResource) {
+    const group = space.groups.find((g) => g.kind === "regular");
+    if (!group) {
+      throw new Error("Expected regular member group on Space");
+    }
+    return group;
+  }
+
+  async function addCurrentUser(space: SpaceResource) {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await regularGroup(space).dangerouslyAddMembers(internalAdminAuth, {
+      users: [user],
+    });
+    await auth.refresh();
+  }
+
+  async function memberRestrictedSpace() {
+    const space = await SpaceFactory.regular(workspace);
+    await addCurrentUser(space);
+    return space;
+  }
+
+  async function conversation() {
+    return ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  }
+
+  it("rejects selected Spaces when the feature flag is disabled", async () => {
+    const restrictedSpace = await memberRestrictedSpace();
+
+    expectErrCode(
+      await validateSelectableRestrictedSpaces(auth, {
+        spaceIds: [restrictedSpace.sId],
+      }),
+      "feature_flag_not_found"
+    );
+  });
+
+  it("rejects selected Spaces for project conversations", async () => {
+    await enableFeature();
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    await addCurrentUser(projectSpace);
+    const projectConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+      visibility: "unlisted",
+    });
+
+    expectErrCode(
+      await listSelectableRestrictedSpaces(auth, {
+        conversation: projectConversation,
+      }),
+      "conversation_not_mutable"
+    );
+  });
+
+  it("lists selectable restricted regular Spaces and marks selected ones", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const selectableSpace = await memberRestrictedSpace();
+    const inaccessibleSpace = await SpaceFactory.regular(workspace);
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const conv = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: conv,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+
+    const selectableSpaces = unwrapResult(
+      await listSelectableRestrictedSpaces(auth, { conversation: conv })
+    );
+    expect(selectableSpaces).toHaveLength(2);
+    expect(selectableSpaces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sId: selectedSpace.sId, selected: true }),
+        expect.objectContaining({ sId: selectableSpace.sId, selected: false }),
+      ])
+    );
+    expect(selectableSpaces.map((space) => space.sId)).not.toEqual(
+      expect.arrayContaining([
+        globalSpace.sId,
+        inaccessibleSpace.sId,
+        projectSpace.sId,
+      ])
+    );
+  });
+
+  it("rejects inaccessible and non-restricted Spaces", async () => {
+    await enableFeature();
+    const inaccessibleSpace = await SpaceFactory.regular(workspace);
+
+    expectErrCode(
+      await validateSelectableRestrictedSpaces(auth, {
+        spaceIds: [inaccessibleSpace.sId],
+      }),
+      "space_not_found"
+    );
+    expectErrCode(
+      await validateSelectableRestrictedSpaces(auth, {
+        spaceIds: [globalSpace.sId],
+      }),
+      "space_not_restricted"
+    );
+  });
+});

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -1,0 +1,130 @@
+import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type {
+  ConversationWithoutContentType,
+  SelectableConversationSpaceType,
+} from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import uniq from "lodash/uniq";
+import type { Transaction } from "sequelize";
+
+export class SelectedConversationSpacesError extends Error {
+  constructor(
+    readonly code:
+      | "conversation_not_mutable"
+      | "feature_flag_not_found"
+      | "space_not_found"
+      | "space_not_restricted",
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export async function listSelectableRestrictedSpaces(
+  auth: Authenticator,
+  {
+    conversation,
+  }: {
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<
+  Result<SelectableConversationSpaceType[], SelectedConversationSpacesError>
+> {
+  if (conversation.spaceId !== null) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "conversation_not_mutable",
+        "Restricted Spaces cannot be selected from the input bar in project conversations."
+      )
+    );
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("restricted_spaces_in_input_bar")) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "feature_flag_not_found",
+        "Restricted Spaces in the input bar is not enabled for this workspace."
+      )
+    );
+  }
+
+  const [spaces, selectedSpaces] = await Promise.all([
+    SpaceResource.listWorkspaceSpacesAsMember(auth),
+    ConversationSelectedSpaceResource.listActiveSpacesByConversation(auth, {
+      conversation,
+    }),
+  ]);
+  const selectedSpaceIds = new Set(
+    selectedSpaces.map((selectedSpace) => selectedSpace.sId)
+  );
+
+  const selectableSpaces = spaces
+    .filter((space) => space.isRegularAndRestricted())
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((space) => ({
+      ...space.toJSON(),
+      selected: selectedSpaceIds.has(space.sId),
+    }));
+
+  return new Ok(selectableSpaces);
+}
+
+export async function validateSelectableRestrictedSpaces(
+  auth: Authenticator,
+  {
+    spaceIds,
+    transaction,
+  }: {
+    spaceIds: string[];
+    transaction?: Transaction;
+  }
+): Promise<Result<SpaceResource[], SelectedConversationSpacesError>> {
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("restricted_spaces_in_input_bar")) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "feature_flag_not_found",
+        "Restricted Spaces in the input bar is not enabled for this workspace."
+      )
+    );
+  }
+
+  const dedupedSpaceIds = uniq(spaceIds);
+  const spaces = await SpaceResource.fetchByIds(auth, dedupedSpaceIds, {
+    transaction,
+  });
+  const foundSpaceIds = new Set(spaces.map((space) => space.sId));
+
+  if (dedupedSpaceIds.some((spaceId) => !foundSpaceIds.has(spaceId))) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "space_not_found",
+        "One or more Spaces were not found or access was denied."
+      )
+    );
+  }
+
+  if (spaces.some((space) => !space.canRead(auth))) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "space_not_found",
+        "One or more Spaces were not found or access was denied."
+      )
+    );
+  }
+
+  if (spaces.some((space) => !space.isRegularAndRestricted())) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "space_not_restricted",
+        "Only restricted regular Spaces can be selected from the input bar."
+      )
+    );
+  }
+
+  return new Ok(spaces);
+}


### PR DESCRIPTION
## Description

Follow up of #27540. PR 3 of the restricted spaces input bar stack.

Adds the service layer that gates, lists, and validates selected restricted Spaces before the API/UI wiring lands.

**What this PR does:**
1. Adds feature-flag-gated listing for selectable restricted regular Spaces.
2. Validates selected space ids against current auth.
3. Rejects project conversations for both list and write validation paths.

Runtime scope computation lands in the later runtime-scope PR, where it can revalidate selected rows before using them.

## Tests

- Added `selected_spaces.test.ts` for flag gating, project rejection, selectable filtering, inaccessible and non-restricted validation.
- Ran `NODE_ENV=test npm test -- lib/api/assistant/conversation/selected_spaces.test.ts` in `front`.
- Ran `nvm use && NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc --noEmit` in `front`.

## Risk

Worst case, selected-space service rejects valid selections. Safe to rollback because no API/UI can write selected Spaces yet.

## Deploy Plan

- [ ] Merge/deploy #27539.
- [ ] Merge/deploy #27540.
- [ ] Deploy this PR with front.