### PR TITLE
Materialize selected spaces into conversation ACL

### DIFF
--- a/front/admin/audit_log_schemas/conversation.restricted_space_selected.json
+++ b/front/admin/audit_log_schemas/conversation.restricted_space_selected.json
@@ -1,0 +1,19 @@
+{
+  "action": "conversation.restricted_space_selected",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "conversation"
+    },
+    {
+      "type": "space"
+    }
+  ],
+  "metadata": {
+    "conversation_id": "string",
+    "space_id": "string",
+    "origin": "string"
+  }
+}

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -1,4 +1,18 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return { ...actual, emitAuditLogEvent: mockEmitAuditLogEvent };
+});
+
 import {
+  addSelectedConversationSpaces,
   listSelectableRestrictedSpaces,
   type SelectedConversationSpacesError,
   validateSelectableRestrictedSpaces,
@@ -12,7 +26,6 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { Result } from "@app/types/shared/result";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
 
 function unwrapResult<T>(
   result: Result<T, SelectedConversationSpacesError>
@@ -45,6 +58,7 @@ describe("selected conversation Spaces", () => {
     globalSpace = setup.globalSpace;
     user = setup.user.toJSON();
     workspace = auth.getNonNullableWorkspace();
+    mockEmitAuditLogEvent.mockClear();
   });
 
   async function enableFeature() {
@@ -94,8 +108,9 @@ describe("selected conversation Spaces", () => {
     );
   });
 
-  it("rejects selected Spaces for project conversations", async () => {
+  it("rejects selected Spaces for pod conversations", async () => {
     await enableFeature();
+    const restrictedSpace = await memberRestrictedSpace();
     const projectSpace = await SpaceFactory.project(workspace, user.id);
     await addCurrentUser(projectSpace);
     const projectConversation = await ConversationFactory.create(auth, {
@@ -105,6 +120,14 @@ describe("selected conversation Spaces", () => {
       visibility: "unlisted",
     });
 
+    expectErrCode(
+      await addSelectedConversationSpaces(auth, {
+        conversation: projectConversation,
+        origin: "input_bar",
+        spaceIds: [restrictedSpace.sId],
+      }),
+      "conversation_not_mutable"
+    );
     expectErrCode(
       await listSelectableRestrictedSpaces(auth, {
         conversation: projectConversation,
@@ -162,5 +185,58 @@ describe("selected conversation Spaces", () => {
       }),
       "space_not_restricted"
     );
+  });
+
+  it("materializes selected Spaces, dedupes input, and emits audit events", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const conv = await conversation();
+
+    const result = unwrapResult(
+      await addSelectedConversationSpaces(auth, {
+        conversation: conv,
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId, selectedSpace.sId],
+      })
+    );
+
+    expect(result.selectedSpaces).toEqual([
+      expect.objectContaining({ sId: selectedSpace.sId, selected: true }),
+    ]);
+    expect(result.effectiveAcl.spaceIds).toContain(selectedSpace.sId);
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledTimes(1);
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "conversation.restricted_space_selected",
+        metadata: {
+          conversation_id: conv.sId,
+          origin: "input_bar",
+          space_id: selectedSpace.sId,
+        },
+      })
+    );
+  });
+
+  it("does not persist selected Spaces when ACL materialization fails", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const conv = await conversation();
+    const missingConversationId = `${conv.sId}_missing`;
+
+    expectErrCode(
+      await addSelectedConversationSpaces(auth, {
+        conversation: { ...conv, sId: missingConversationId },
+        origin: "input_bar",
+        spaceIds: [selectedSpace.sId],
+      }),
+      "space_not_selectable"
+    );
+    expect(
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        { conversation: conv }
+      )
+    ).toEqual([]);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -1,12 +1,24 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import { type Authenticator, getFeatureFlags } from "@app/lib/auth";
+import type { ConversationSelectedSpaceOrigin } from "@app/lib/models/agent/conversation_selected_space";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type {
-  ConversationWithoutContentType,
-  SelectableConversationSpaceType,
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import {
+  type ConversationSelectedSpacesResponse,
+  type ConversationWithoutContentType,
+  isPodConversation,
+  type SelectableConversationSpaceType,
 } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import uniq from "lodash/uniq";
 import type { Transaction } from "sequelize";
 
@@ -16,7 +28,8 @@ export class SelectedConversationSpacesError extends Error {
       | "conversation_not_mutable"
       | "feature_flag_not_found"
       | "space_not_found"
-      | "space_not_restricted",
+      | "space_not_restricted"
+      | "space_not_selectable",
     message: string
   ) {
     super(message);
@@ -33,11 +46,11 @@ export async function listSelectableRestrictedSpaces(
 ): Promise<
   Result<SelectableConversationSpaceType[], SelectedConversationSpacesError>
 > {
-  if (conversation.spaceId !== null) {
+  if (isPodConversation(conversation)) {
     return new Err(
       new SelectedConversationSpacesError(
         "conversation_not_mutable",
-        "Restricted Spaces cannot be selected from the input bar in project conversations."
+        "Restricted Spaces cannot be selected from the input bar in pod conversations."
       )
     );
   }
@@ -127,4 +140,153 @@ export async function validateSelectableRestrictedSpaces(
   }
 
   return new Ok(spaces);
+}
+
+export async function addSelectedConversationSpaces(
+  auth: Authenticator,
+  {
+    conversation,
+    spaceIds,
+    origin,
+    auditContext,
+    transaction,
+  }: {
+    conversation: ConversationWithoutContentType;
+    spaceIds: string[];
+    origin: ConversationSelectedSpaceOrigin;
+    auditContext?: AuditLogContext;
+    transaction?: Transaction;
+  }
+): Promise<
+  Result<ConversationSelectedSpacesResponse, SelectedConversationSpacesError>
+> {
+  const dedupedSpaceIds = uniq(spaceIds);
+
+  if (dedupedSpaceIds.length === 0) {
+    const selectedSpaces =
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        {
+          conversation,
+          transaction,
+        }
+      );
+
+    return new Ok({
+      selectedSpaces: selectedSpaces.map((space) => ({
+        ...space.toJSON(),
+        selected: true,
+      })),
+      effectiveAcl: {
+        spaceIds: conversation.requestedSpaceIds,
+        viewerMustHaveAll: true as const,
+      },
+    });
+  }
+
+  let newlyActiveSpaces: SpaceResource[] = [];
+  const result = await withTransaction(async (t) => {
+    if (isPodConversation(conversation)) {
+      return new Err(
+        new SelectedConversationSpacesError(
+          "conversation_not_mutable",
+          "Restricted Spaces cannot be selected from the input bar in pod conversations."
+        )
+      );
+    }
+
+    const selectableSpacesResult = await validateSelectableRestrictedSpaces(
+      auth,
+      {
+        spaceIds: dedupedSpaceIds,
+        transaction: t,
+      }
+    );
+    if (selectableSpacesResult.isErr()) {
+      return selectableSpacesResult;
+    }
+
+    const spaces = selectableSpacesResult.value;
+    const requestedSpaceModelIds = removeNulls(
+      conversation.requestedSpaceIds.map(getResourceIdFromSId)
+    );
+    const selectedSpaceModelIds = spaces.map((space) => space.id);
+    const effectiveAclSpaceModelIds = uniq([
+      ...requestedSpaceModelIds,
+      ...selectedSpaceModelIds,
+    ]);
+
+    const updateResult = await ConversationResource.updateRequirements(
+      auth,
+      conversation.sId,
+      effectiveAclSpaceModelIds,
+      t
+    );
+    if (updateResult.isErr()) {
+      return new Err(
+        new SelectedConversationSpacesError(
+          "space_not_selectable",
+          updateResult.error.message
+        )
+      );
+    }
+
+    const { createdSpaces, reactivatedSpaces } =
+      await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        spaces,
+        origin,
+        transaction: t,
+      });
+    newlyActiveSpaces = [...createdSpaces, ...reactivatedSpaces];
+
+    const allSelectedSpaces =
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        {
+          conversation,
+          transaction: t,
+        }
+      );
+    const effectiveAclSpaceIds = uniq([
+      ...conversation.requestedSpaceIds,
+      ...spaces.map((space) => space.sId),
+    ]);
+
+    return new Ok({
+      selectedSpaces: allSelectedSpaces.map((space) => ({
+        ...space.toJSON(),
+        selected: true,
+      })),
+      effectiveAcl: {
+        spaceIds: effectiveAclSpaceIds,
+        viewerMustHaveAll: true as const,
+      },
+    });
+  }, transaction);
+
+  if (result.isOk()) {
+    for (const space of newlyActiveSpaces) {
+      void emitAuditLogEvent({
+        auth,
+        action: "conversation.restricted_space_selected",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+          buildAuditLogTarget("conversation", {
+            sId: conversation.sId,
+            name: conversation.title ?? "",
+          }),
+          buildAuditLogTarget("space", space),
+        ],
+        context: auditContext,
+        metadata: {
+          conversation_id: conversation.sId,
+          space_id: space.sId,
+          origin,
+        },
+      });
+    }
+  }
+
+  return result;
 }

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -11,6 +11,7 @@
   "audit_log.export_configured": 2,
   "audit_log.viewed": 2,
   "conversation.accessed": 3,
+  "conversation.restricted_space_selected": 1,
   "coupon.redeemed": 1,
   "coupon.revoked": 1,
   "credentials.created": 4,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -125,6 +125,7 @@ export const AUDIT_ACTIONS = [
   "space.permissions_updated",
   // Conversations.
   "conversation.accessed",
+  "conversation.restricted_space_selected",
   // Data Sources.
   "datasource.created",
   "datasource.updated",


### PR DESCRIPTION
## Why

Follow up of #27543 in the selected restricted Spaces stack. This PR adds the write path that persists selected Spaces and materializes them into the conversation ACL before downstream API, UI, and runtime PRs call it.

## Stack

- #27539: schema, model, feature flag, and cleanup hooks.
- #27540: selected Spaces resource helpers.
- #27543: gated selected Spaces read service.
- #27544: write path, audit event, and ACL materialization.

## What changed

- Adds the write path that validates selected restricted Spaces, persists them, and materializes them into the conversation ACL.
- Emits `conversation.restricted_space_selected` audit events for newly active selected Spaces.
- Keeps selected Spaces when project conversation requirements are refreshed.
- Registers the WorkOS audit schema for the new event.

## Risk

Worst case, selected Space writes fail or ACL materialization rejects the request. Safe to rollback this PR while downstream PRs are not merged.

## Deploy plan

- [x] Register `conversation.restricted_space_selected` audit schema.
- [ ] Merge after #27543.
- [ ] Deploy front.

## Verification

- `source "$HOME/.dust-hive/envs/restricted-spaces-stack/env.sh" && npx tsx admin/register_audit_log_schemas.ts --execute --changed`
- `source "$HOME/.dust-hive/envs/restricted-spaces-stack/env.sh" && NODE_ENV=test npm test -- lib/api/assistant/conversation/selected_spaces.test.ts`
- `source "$HOME/.dust-hive/envs/restricted-spaces-stack/env.sh" && NODE_ENV=test npm test -- lib/api/audit/audit_log_schemas.test.ts`
- `source "$HOME/.dust-hive/envs/restricted-spaces-stack/env.sh" && npm run lint:audit-log-schemas`
- `source ~/.nvm/nvm.sh && nvm use && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit`
- `git diff --check`
