### PR TITLE
Add selected Space runtime validation helpers

### DIFF
--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -13,6 +13,8 @@ vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
 
 import {
   addSelectedConversationSpaces,
+  copySelectedConversationSpacesToChild,
+  getEffectiveSpaceIdsForAgentRun,
   listSelectableSpaces,
   type SelectedConversationSpacesError,
   validateSelectableSpaces,
@@ -21,6 +23,7 @@ import { Authenticator } from "@app/lib/auth";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -81,6 +84,16 @@ describe("selected conversation Spaces", () => {
       workspace.sId
     );
     await regularGroup(space).dangerouslyAddMembers(internalAdminAuth, {
+      users: [user],
+    });
+    await auth.refresh();
+  }
+
+  async function removeCurrentUser(space: SpaceResource) {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await regularGroup(space).dangerouslyRemoveMembers(internalAdminAuth, {
       users: [user],
     });
     await auth.refresh();
@@ -267,5 +280,115 @@ describe("selected conversation Spaces", () => {
       )
     ).toEqual([]);
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("uses selected Spaces as effective runtime scope when still valid", async () => {
+    await enableFeature();
+    const selectedSpace = await memberOpenSpace();
+    const requestedSpaceModelIds = [globalSpace.id];
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: requestedSpaceModelIds }
+    );
+    const conv = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: conv,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+
+    const effectiveSpaceIds = await getEffectiveSpaceIdsForAgentRun(auth, {
+      agentConfiguration,
+      conversation: conv,
+    });
+
+    expect(effectiveSpaceIds).toEqual(
+      expect.arrayContaining([globalSpace.sId, selectedSpace.sId])
+    );
+  });
+
+  it("keeps valid selected Spaces when another selection becomes invalid", async () => {
+    await enableFeature();
+    const validSelectedSpace = await memberRestrictedSpace();
+    const invalidSelectedSpace = await memberRestrictedSpace();
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: [globalSpace.id] }
+    );
+    const conv = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: conv,
+      origin: "input_bar",
+      spaces: [validSelectedSpace, invalidSelectedSpace],
+    });
+    await removeCurrentUser(invalidSelectedSpace);
+
+    await expect(
+      getEffectiveSpaceIdsForAgentRun(auth, {
+        agentConfiguration,
+        conversation: conv,
+      })
+    ).resolves.toEqual([globalSpace.sId, validSelectedSpace.sId]);
+  });
+
+  it("copies valid selected Spaces to a child conversation", async () => {
+    await enableFeature();
+    const selectedSpace = await memberRestrictedSpace();
+    const parentConversation = await conversation();
+    const childConversation = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: parentConversation,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+    const userSpy = vi.spyOn(auth, "user").mockReturnValue(null);
+
+    unwrapResult(
+      await copySelectedConversationSpacesToChild(auth, {
+        parentConversation,
+        childConversationId: childConversation.sId,
+      })
+    );
+    userSpy.mockRestore();
+
+    const childSelectedSpaces =
+      await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+        auth,
+        { conversation: childConversation }
+      );
+    expect(childSelectedSpaces.map((space) => space.sId)).toEqual([
+      selectedSpace.sId,
+    ]);
+    const [selectedSpaceRow] =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        conversation: childConversation,
+      });
+    expect(selectedSpaceRow.origin).toBe("parent_conversation");
+  });
+
+  it("ignores selected Spaces at runtime when the feature flag is disabled", async () => {
+    const selectedSpace = await memberRestrictedSpace();
+    const requestedSpaceModelIds = [globalSpace.id];
+    const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { requestedSpaceIds: requestedSpaceModelIds }
+    );
+    const conv = await conversation();
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: conv,
+      origin: "input_bar",
+      spaces: [selectedSpace],
+    });
+
+    await expect(
+      getEffectiveSpaceIdsForAgentRun(auth, {
+        agentConfiguration,
+        conversation: conv,
+      })
+    ).resolves.toEqual([globalSpace.sId]);
   });
 });

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -26,6 +26,7 @@ export class SelectedConversationSpacesError extends Error {
   constructor(
     readonly code:
       | "conversation_not_mutable"
+      | "conversation_not_found"
       | "feature_flag_not_found"
       | "space_not_found"
       | "space_not_selectable",
@@ -148,12 +149,14 @@ export async function addSelectedConversationSpaces(
     spaceIds,
     origin,
     auditContext,
+    sourceSelections,
     transaction,
   }: {
     conversation: ConversationWithoutContentType;
     spaceIds: string[];
     origin: ConversationSelectedSpaceOrigin;
     auditContext?: AuditLogContext;
+    sourceSelections?: ConversationSelectedSpaceResource[];
     transaction?: Transaction;
   }
 ): Promise<
@@ -232,6 +235,7 @@ export async function addSelectedConversationSpaces(
         conversation,
         spaces,
         origin,
+        sourceSelections,
         transaction: t,
       });
     newlyActiveSpaces = [...createdSpaces, ...reactivatedSpaces];
@@ -285,4 +289,121 @@ export async function addSelectedConversationSpaces(
   }
 
   return result;
+}
+
+export async function getEffectiveSpaceIdsForAgentRun(
+  auth: Authenticator,
+  {
+    agentConfiguration,
+    conversation,
+    transaction,
+  }: {
+    agentConfiguration: { requestedSpaceIds: string[] };
+    conversation: ConversationWithoutContentType;
+    transaction?: Transaction;
+  }
+): Promise<string[]> {
+  const selectedSpaceIds = await getValidSelectedSpaceIdsForAgentRun(auth, {
+    conversation,
+    transaction,
+  });
+
+  return uniq([...agentConfiguration.requestedSpaceIds, ...selectedSpaceIds]);
+}
+
+/**
+ * Validates durable conversation selections against the runtime authenticator.
+ * Selector provenance is audit history, not an ongoing authorization grant;
+ * system-key runs intentionally preserve selections materialized in the ACL.
+ */
+export async function getValidSelectedSpaceIdsForAgentRun(
+  auth: Authenticator,
+  {
+    conversation,
+    transaction,
+  }: {
+    conversation: ConversationWithoutContentType;
+    transaction?: Transaction;
+  }
+): Promise<string[]> {
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("restricted_spaces_in_input_bar")) {
+    return [];
+  }
+
+  const selectedSpaces =
+    await ConversationSelectedSpaceResource.listActiveSpacesByConversation(
+      auth,
+      {
+        conversation,
+        transaction,
+      }
+    );
+
+  return selectedSpaces
+    .filter((space) => space.canRead(auth) && space.isRegular())
+    .map((space) => space.sId);
+}
+
+export async function copySelectedConversationSpacesToChild(
+  auth: Authenticator,
+  {
+    parentConversation,
+    childConversationId,
+  }: {
+    parentConversation: ConversationWithoutContentType;
+    childConversationId: string;
+  }
+): Promise<Result<undefined, SelectedConversationSpacesError>> {
+  const selectedSpaceIds = await getValidSelectedSpaceIdsForAgentRun(auth, {
+    conversation: parentConversation,
+  });
+  if (selectedSpaceIds.length === 0) {
+    return new Ok(undefined);
+  }
+
+  const childConversation = await ConversationResource.fetchById(
+    auth,
+    childConversationId
+  );
+  if (!childConversation) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "conversation_not_found",
+        "Child conversation not found or access was denied."
+      )
+    );
+  }
+
+  const parentSelections =
+    await ConversationSelectedSpaceResource.listByConversation(auth, {
+      activeOnly: false,
+      conversation: parentConversation,
+    });
+  const selectedSpaceModelIds = new Set(
+    removeNulls(selectedSpaceIds.map(getResourceIdFromSId))
+  );
+  const sourceSelections = parentSelections.filter((selection) =>
+    selectedSpaceModelIds.has(selection.spaceId)
+  );
+  if (sourceSelections.length !== selectedSpaceModelIds.size) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "space_not_selectable",
+        "Selected Space provenance changed while creating the child conversation."
+      )
+    );
+  }
+
+  const result = await addSelectedConversationSpaces(auth, {
+    conversation: childConversation.toJSON(),
+    spaceIds: selectedSpaceIds,
+    origin: "parent_conversation",
+    sourceSelections,
+  });
+  if (result.isErr()) {
+    return new Err(result.error);
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -291,6 +291,12 @@ export async function addSelectedConversationSpaces(
   return result;
 }
 
+/**
+ * An agent's configured Spaces are only its default scope. A conversation can
+ * add other Spaces, so runtime skill and tool resolution must combine both
+ * sources after revalidating the conversation selections. Centralizing that
+ * merge keeps every runtime consumer on the same authorization-safe scope.
+ */
 export async function getEffectiveSpaceIdsForAgentRun(
   auth: Authenticator,
   {

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -3,10 +3,12 @@ import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversati
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("ConversationSelectedSpaceResource", () => {
   let auth: Authenticator;
@@ -150,6 +152,84 @@ describe("ConversationSelectedSpaceResource", () => {
     );
     expect(row.origin).toBe("parent_conversation");
     expect(row.removedAt).toBeNull();
+  });
+
+  it("preserves each source selector when reactivating Spaces", async () => {
+    const sourceConversation = await createConversation();
+    const childConversation = await createConversation();
+    const firstSpace = await createMemberRestrictedRegularSpace();
+    const secondSpace = await createMemberRestrictedRegularSpace();
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: sourceConversation,
+      origin: "input_bar",
+      spaces: [firstSpace],
+    });
+    await ConversationSelectedSpaceResource.upsertForConversation(otherAuth, {
+      conversation: sourceConversation,
+      origin: "input_bar",
+      spaces: [secondSpace],
+    });
+    const sourceSelections =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        conversation: sourceConversation,
+      });
+
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: childConversation,
+      origin: "parent_conversation",
+      sourceSelections,
+      spaces: [firstSpace, secondSpace],
+    });
+    await ConversationSelectedSpaceResource.removeForConversation(auth, {
+      conversation: childConversation,
+      spaces: [firstSpace, secondSpace],
+    });
+    await ConversationSelectedSpaceResource.upsertForConversation(auth, {
+      conversation: childConversation,
+      origin: "parent_conversation",
+      sourceSelections,
+      spaces: [firstSpace, secondSpace],
+    });
+
+    const childSelections =
+      await ConversationSelectedSpaceResource.listByConversation(auth, {
+        conversation: childConversation,
+      });
+    expect(
+      new Map(
+        childSelections.map((selection) => [
+          selection.spaceId,
+          selection.selectedByUserId,
+        ])
+      )
+    ).toEqual(
+      new Map([
+        [firstSpace.id, user.id],
+        [secondSpace.id, otherUser.id],
+      ])
+    );
+  });
+
+  it("requires a selector for userless selected Space creation", async () => {
+    const conversation = await createConversation();
+    const space = await createMemberRestrictedRegularSpace();
+    const userSpy = vi.spyOn(auth, "user").mockReturnValue(null);
+
+    await expect(
+      ConversationSelectedSpaceResource.upsertForConversation(auth, {
+        conversation,
+        origin: "parent_conversation",
+        spaces: [space],
+      })
+    ).rejects.toThrow("A selecting user is required for a selected Space.");
+    userSpy.mockRestore();
   });
 
   it("deduplicates selected Spaces before creating rows", async () => {

--- a/front/lib/resources/conversation_selected_space_resource.ts
+++ b/front/lib/resources/conversation_selected_space_resource.ts
@@ -84,11 +84,13 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
       conversation,
       spaces,
       origin,
+      sourceSelections,
       transaction,
     }: {
       conversation: ConversationWithoutContentType;
       spaces: SpaceResource[];
       origin: ConversationSelectedSpaceOrigin;
+      sourceSelections?: ConversationSelectedSpaceResource[];
       transaction?: Transaction;
     }
   ): Promise<{
@@ -98,9 +100,23 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
   }> {
     return withTransaction(async (t) => {
       const workspace = auth.getNonNullableWorkspace();
-      const user = auth.getNonNullableUser();
       const uniqueSpaces = uniqBy(spaces, "id");
       const spaceModelIds = uniqueSpaces.map((space) => space.id);
+      const authUserId = auth.user()?.id;
+      const selectedByUserModelIdBySpaceModelId = new Map(
+        sourceSelections?.map((selection) => [
+          selection.spaceId,
+          selection.selectedByUserId,
+        ])
+      );
+      const getSelectedByUserModelId = (spaceModelId: ModelId): ModelId => {
+        const selectedByUserModelId =
+          selectedByUserModelIdBySpaceModelId.get(spaceModelId) ?? authUserId;
+        if (!selectedByUserModelId) {
+          throw new Error("A selecting user is required for a selected Space.");
+        }
+        return selectedByUserModelId;
+      };
 
       if (spaceModelIds.length === 0) {
         return {
@@ -135,7 +151,7 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
             workspaceId: workspace.id,
             conversationId: conversation.id,
             spaceId: space.id,
-            selectedByUserId: user.id,
+            selectedByUserId: getSelectedByUserModelId(space.id),
             origin,
             removedAt: null,
           })),
@@ -152,23 +168,38 @@ export class ConversationSelectedSpaceResource extends BaseResource<Conversation
 
       let reactivatedSpaceModelIds = new Set<ModelId>();
       if (removedRows.length > 0) {
-        const [, reactivatedRows] = await this.model.update(
-          {
-            selectedByUserId: user.id,
-            origin,
-            removedAt: null,
-          },
-          {
-            where: {
-              workspaceId: workspace.id,
-              id: {
-                [Op.in]: removedRows.map((row) => row.id),
-              },
+        const rowsBySelectedByUserId = new Map<
+          ModelId,
+          ConversationSelectedSpaceModel[]
+        >();
+        for (const row of removedRows) {
+          const selectedByUserModelId = getSelectedByUserModelId(row.spaceId);
+          const rows = rowsBySelectedByUserId.get(selectedByUserModelId) ?? [];
+          rows.push(row);
+          rowsBySelectedByUserId.set(selectedByUserModelId, rows);
+        }
+
+        const reactivatedRows: ConversationSelectedSpaceModel[] = [];
+        for (const [selectedByUserModelId, rows] of rowsBySelectedByUserId) {
+          const [, updatedRows] = await this.model.update(
+            {
+              selectedByUserId: selectedByUserModelId,
+              origin,
+              removedAt: null,
             },
-            transaction: t,
-            returning: true,
-          }
-        );
+            {
+              where: {
+                workspaceId: workspace.id,
+                id: {
+                  [Op.in]: rows.map((row) => row.id),
+                },
+              },
+              transaction: t,
+              returning: true,
+            }
+          );
+          reactivatedRows.push(...updatedRows);
+        }
         reactivatedSpaceModelIds = new Set(
           reactivatedRows.map((row) => row.spaceId)
         );


### PR DESCRIPTION
## Stack

1. #29142 - Allow selecting open Spaces in conversations (merged)
2. **#27545 - Add selected Space runtime validation helpers**
3. #28905 - Use selected Spaces for runtime skill scope
4. #28906 - Inherit selected Spaces in sub-agent conversations
5. #28911 - Cover sub-agent cleanup boundaries

This PR is **399 changed lines** against `main`.

## Why

Selected-Space rows can become stale after access or Space changes, and child conversations may be created by system-key runs without a current user. Runtime consumers need one shared validation path, and child inheritance must preserve who originally selected each Space.

## What changed

- Adds `getValidSelectedSpaceIdsForAgentRun`, which returns active selected regular Spaces that remain readable while the feature is enabled.
- Adds `getEffectiveSpaceIdsForAgentRun`, which combines the agent's configured Spaces with valid conversation selections.
- Adds `copySelectedConversationSpacesToChild` for materializing valid selections into a child conversation.
- Extends selected-Space upserts to accept per-Space selector provenance, including userless and system-key execution.
- Revalidates selections independently, so one stale selection does not discard other valid selections.
- Preserves durable selected-Space ACL rows for system-key runs while treating selector identity as audit provenance.
- Adds focused coverage for feature gating, partial invalidation, open Space transitions, effective scope, child copying, and selector provenance.

## Risk

This PR only adds foundational helpers and provenance support. Runtime skill resolution and `run_agent` adoption are in the next PRs. Invalid selected rows are ignored instead of widening runtime scope. No schema or migration changes are included.

## Deploy plan

- [x] Merge and deploy #29142.
- [ ] Merge this PR and deploy `front` normally.
- [ ] Merge #28905, then #28906, then test-only #28911.

## Verification

- Focused runtime stack suite: 116 tests
- `npm run tsgo -- --noEmit` in `front`
- `npm run tsgo -- --noEmit` in `front-api`
- `npx biome check` on changed TypeScript files
- `git diff --check`
