### PR TITLE
Accept selected Spaces in conversation APIs

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7683,6 +7683,12 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "selectedSpaceIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     }
                   },
@@ -8311,6 +8317,12 @@
                             "items": {
                               "type": "string"
                             }
+                          },
+                          "selectedSpaceIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
@@ -8325,6 +8337,12 @@
                   "metadata": {
                     "type": "object",
                     "nullable": true
+                  },
+                  "selectedSpaceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "skipToolsValidation": {
                     "type": "boolean"
@@ -12110,6 +12128,12 @@
               "zendesk",
               "onboarding_conversation"
             ]
+          },
+          "selectedSpaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -13458,6 +13482,12 @@
             "type": "string",
             "description": "URL of the user's profile picture",
             "example": "https://example.com/profiles/johndoe123.jpg"
+          },
+          "selectedSpaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "agenticMessageData": {
             "type": "object",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1285,6 +1285,10 @@
  *         origin:
  *           type: string
  *           enum: [web, project_kickoff, extension, agent_sidekick, api, cli, cli_programmatic, email, excel, gsheet, make, n8n, powerpoint, raycast, slack, slack_workflow, teams, transcript, triggered_programmatic, triggered, wakeup, zapier, zendesk, onboarding_conversation]
+ *         selectedSpaceIds:
+ *           type: array
+ *           items:
+ *             type: string
  *     PrivateReaction:
  *       type: object
  *       description: A reaction on a message.

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -123,6 +123,10 @@
  *           type: string
  *           description: URL of the user's profile picture
  *           example: "https://example.com/profiles/johndoe123.jpg"
+ *         selectedSpaceIds:
+ *           type: array
+ *           items:
+ *             type: string
  *         agenticMessageData:
  *           type: object
  *           properties:

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -2,7 +2,9 @@ import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_re
 import { isSidekickConversation } from "@app/lib/api/actions/servers/helpers";
 import { postUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { addSelectedConversationSpaces } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -27,6 +29,7 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
+import { apiErrorForSelectedSpaces } from "../selected_spaces_errors";
 import message from "./[mId]";
 
 const ParamsSchema = z.object({
@@ -147,6 +150,10 @@ const app = workspaceApp();
  *                     items:
  *                       type: string
  *                   selectedMCPServerViewIds:
+ *                     type: array
+ *                     items:
+ *                       type: string
+ *                   selectedSpaceIds:
  *                     type: array
  *                     items:
  *                       type: string
@@ -303,7 +310,24 @@ app.post(
       });
     }
 
-    const conversation = conversationRes.value;
+    let conversation = conversationRes.value;
+
+    if (context.selectedSpaceIds?.length) {
+      const selectedSpacesResult = await addSelectedConversationSpaces(auth, {
+        conversation,
+        spaceIds: context.selectedSpaceIds,
+        origin: "input_bar",
+        auditContext: getAuditLogContext(auth),
+      });
+      if (selectedSpacesResult.isErr()) {
+        return apiErrorForSelectedSpaces(ctx, selectedSpacesResult.error);
+      }
+
+      conversation = {
+        ...conversation,
+        requestedSpaceIds: selectedSpacesResult.value.effectiveAcl.spaceIds,
+      };
+    }
 
     if (context.selectedMCPServerViewIds?.length) {
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
@@ -393,6 +417,7 @@ app.post(
         profilePictureUrl: context.profilePictureUrl ?? user.imageUrl,
         origin,
         clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
+        selectedSpaceIds: context.selectedSpaceIds ?? [],
       },
       skipToolsValidation: skipToolsValidation ?? false,
       modelSelection,

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -5,6 +5,11 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import {
+  addSelectedConversationSpaces,
+  validateSelectableSpaces,
+} from "@app/lib/api/assistant/conversation/selected_spaces";
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -25,9 +30,11 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import uniq from "lodash/uniq";
 import { z } from "zod";
 
 import conversation from "./[cId]";
+import { apiErrorForSelectedSpaces } from "./[cId]/selected_spaces_errors";
 import bulkActions from "./bulk-actions";
 import search from "./search";
 import semanticSearch from "./semantic_search";
@@ -150,6 +157,10 @@ const app = workspaceApp();
  *                         type: array
  *                         items:
  *                           type: string
+ *                       selectedSpaceIds:
+ *                         type: array
+ *                         items:
+ *                           type: string
  *               contentFragments:
  *                 type: array
  *                 items:
@@ -157,6 +168,10 @@ const app = workspaceApp();
  *               metadata:
  *                 type: object
  *                 nullable: true
+ *               selectedSpaceIds:
+ *                 type: array
+ *                 items:
+ *                   type: string
  *               skipToolsValidation:
  *                 type: boolean
  *     responses:
@@ -231,8 +246,24 @@ app.post(
       message,
       contentFragments,
       metadata,
+      selectedSpaceIds,
       skipToolsValidation,
     } = ctx.req.valid("json");
+
+    const allSelectedSpaceIds = uniq([
+      ...(selectedSpaceIds ?? []),
+      ...(message?.context.selectedSpaceIds ?? []),
+    ]);
+
+    if (allSelectedSpaceIds.length > 0) {
+      const validationResult = await validateSelectableSpaces(auth, {
+        podId: spaceId,
+        spaceIds: allSelectedSpaceIds,
+      });
+      if (validationResult.isErr()) {
+        return apiErrorForSelectedSpaces(ctx, validationResult.error);
+      }
+    }
 
     if (message?.context.clientSideMCPServerIds) {
       const hasServerAccess = await concurrentExecutor(
@@ -275,6 +306,23 @@ app.post(
       spaceId: spaceModelId,
       metadata,
     });
+
+    if (allSelectedSpaceIds.length > 0) {
+      const selectedSpacesResult = await addSelectedConversationSpaces(auth, {
+        conversation: newConversation,
+        spaceIds: allSelectedSpaceIds,
+        origin: "input_bar",
+        auditContext: getAuditLogContext(auth),
+      });
+      if (selectedSpacesResult.isErr()) {
+        return apiErrorForSelectedSpaces(ctx, selectedSpacesResult.error);
+      }
+
+      newConversation = {
+        ...newConversation,
+        requestedSpaceIds: selectedSpacesResult.value.effectiveAcl.spaceIds,
+      };
+    }
 
     if (newConversation.depth === 0) {
       await ConversationResource.upsertParticipation(auth, {
@@ -401,6 +449,7 @@ app.post(
           profilePictureUrl: message.context.profilePictureUrl,
           origin: message.context.origin ?? "web",
           clientSideMCPServerIds: message.context.clientSideMCPServerIds ?? [],
+          selectedSpaceIds: allSelectedSpaceIds,
         },
         skipToolsValidation: skipToolsValidation ?? false,
         modelSelection: message.modelSelection,

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -167,6 +167,13 @@ describe("selected conversation Spaces", () => {
       }),
       "conversation_not_mutable"
     );
+    expectErrCode(
+      await validateSelectableSpaces(auth, {
+        podId: projectSpace.sId,
+        spaceIds: [restrictedSpace.sId],
+      }),
+      "conversation_not_mutable"
+    );
   });
 
   it("lists selectable regular Spaces and marks selected ones", async () => {

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -89,13 +89,24 @@ export async function listSelectableSpaces(
 export async function validateSelectableSpaces(
   auth: Authenticator,
   {
+    podId,
     spaceIds,
     transaction,
   }: {
+    podId?: string | null;
     spaceIds: string[];
     transaction?: Transaction;
   }
 ): Promise<Result<SpaceResource[], SelectedConversationSpacesError>> {
+  if (podId) {
+    return new Err(
+      new SelectedConversationSpacesError(
+        "conversation_not_mutable",
+        "Spaces cannot be selected from the input bar in pod conversations."
+      )
+    );
+  }
+
   const featureFlags = await getFeatureFlags(auth);
   if (!featureFlags.includes("restricted_spaces_in_input_bar")) {
     return new Err(

--- a/front/types/api/assistant.ts
+++ b/front/types/api/assistant.ts
@@ -30,6 +30,7 @@ export const MessageBaseSchema = z.object({
     profilePictureUrl: z.string().nullable(),
     clientSideMCPServerIds: z.array(z.string()).optional(),
     selectedMCPServerViewIds: z.array(z.string()).optional(),
+    selectedSpaceIds: z.array(z.string()).optional(),
     originMessageId: z.string().optional(),
     origin: UserMessageOriginSchema.optional(),
   }),
@@ -196,6 +197,7 @@ export const InternalPostConversationsRequestBodySchema = z.object({
   message: MessageBaseSchema.nullable(),
   contentFragments: z.array(InternalPostContentFragmentRequestBodySchema),
   metadata: ConversationMetadataSchema.optional(),
+  selectedSpaceIds: z.array(z.string()).optional(),
   skipToolsValidation: z.boolean().optional(),
 });
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -150,6 +150,7 @@ export type UserMessageContext = {
   lastTriggerRunAt?: number | null;
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];
+  selectedSpaceIds?: string[];
   apiKeyId?: number | null;
   authMethod?: string | null;
 };


### PR DESCRIPTION
## Stack

Runtime prerequisites, #27546, and #27547 are merged.

1. **#27548 - Accept selected Spaces in conversation APIs**
2. #27549 - Add Spaces picker shell
3. #27550 - Wire Spaces into input bar

This PR is **135 changed lines** against `main`.

## Why

The selected-Spaces APIs exist, so create and message posting can now accept selected Spaces inline and materialize the conversation ACL before agent execution starts.

## What changed

- Adds optional `selectedSpaceIds` to internal create-conversation and post-message request schemas.
- Extends `validateSelectableSpaces` with Pod context so create-time validation enforces the same policy as existing-conversation writes.
- Validates selected Spaces before creating a conversation, then materializes ACL before posting the initial message.
- Materializes newly selected Spaces before posting follow-up messages.
- Regenerates private Swagger documentation and client types.

## Risk

The new request field is optional and not sent until downstream UI PRs merge. Invalid or inaccessible selections reject the request before generation starts. No schema or migration changes are included.

## Deploy plan

- [x] Merge the runtime prerequisites, #27546, and #27547.
- [ ] Merge this PR.
- [ ] Deploy `front-api` and `front`.

## Verification

- `NODE_ENV=test npm test lib/api/assistant/conversation/selected_spaces.test.ts`: 11 tests
- `npm run docs` in `front-api`
- `npm run tsgo -- --noEmit` in `front-api`
- `npm run tsgo -- --noEmit` in `front`
- `npx biome check` on changed TypeScript files
- `git diff --check`
