### PR TITLE
Add Spaces picker shell

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -51,6 +51,7 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { useClientType } from "@app/lib/context/clientType";
+import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
@@ -93,7 +94,6 @@ import {
   DropdownMenuTrigger,
   FilePlus03,
   Globe01,
-  Lock01,
   Plus,
   Toolbar,
   TooltipContent,
@@ -423,8 +423,11 @@ const InputBarContainer = ({
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
     useState<MCPServerViewType | null>(null);
   selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
-  selectedSpaceIdsRef.current = selectedSpaceIds;
   shouldEnableSlashSuggestionRef.current = shouldEnableSlashSuggestion;
+
+  useEffect(() => {
+    selectedSpaceIdsRef.current = selectedSpaceIds;
+  }, [selectedSpaceIds]);
 
   const selectableSpacesById = useMemo(
     () => new Map(selectableSpaces.map((space) => [space.sId, space])),
@@ -1724,7 +1727,7 @@ const InputBarContainer = ({
                   key={selectedSpace.sId}
                   size="xs"
                   label={selectedSpace.name}
-                  icon={Lock01}
+                  icon={getSpaceIcon(selectedSpace)}
                   className="m-0.5 bg-background text-foreground dark:bg-background-night dark:text-foreground-night"
                   onRemove={
                     conversation?.sId

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -2,6 +2,7 @@ import { ContextUsageIndicator } from "@app/components/assistant/conversation/in
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarButtons } from "@app/components/assistant/conversation/input_bar/InputBarButtons";
 import type { PendingInputText } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { InputBarSpacesPicker } from "@app/components/assistant/conversation/input_bar/InputBarSpacesPicker";
 import {
   INPUT_BAR_COMPACT_CONTENT_ENTER_ANIMATION_CLASSES,
   INPUT_BAR_COMPACT_PILL_INNER_CLASSES,
@@ -55,7 +56,10 @@ import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationWithoutContentType,
+  SelectableConversationSpaceType,
+} from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
@@ -89,6 +93,7 @@ import {
   DropdownMenuTrigger,
   FilePlus03,
   Globe01,
+  Lock01,
   Plus,
   Toolbar,
   TooltipContent,
@@ -132,6 +137,9 @@ function narrowToKnownSlashCommand(
 }
 
 const COLLAPSE_TRANSITION = "200ms cubic-bezier(0.34, 1.15, 0.64, 1)";
+const EMPTY_SPACE_IDS: string[] = [];
+const EMPTY_SELECTABLE_SPACES: SelectableConversationSpaceType[] = [];
+const acceptSelectedSpaceIds = async (spaceIds: string[]) => spaceIds;
 
 export const INPUT_BAR_ACTIONS = [
   "capabilities",
@@ -140,6 +148,7 @@ export const INPUT_BAR_ACTIONS = [
   "agents-list-with-actions",
   "model-picker",
   "turn-into-agent",
+  "spaces",
   "voice",
   "fullscreen",
 ] as const;
@@ -203,6 +212,7 @@ export interface InputBarContainerProps {
   getDraft: () => {
     text: string;
     agentMention?: RichAgentMention | null;
+    selectedSpaceIds?: string[];
   } | null;
   defaultAgentId?: string | null;
   isDefaultAgentLoading?: boolean;
@@ -227,10 +237,19 @@ export interface InputBarContainerProps {
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
   onResetMCPServerViews: () => void;
   owner: WorkspaceType;
-  saveDraft: (markdown: string, agentMention?: RichAgentMention | null) => void;
+  saveDraft: (
+    markdown: string,
+    agentMention?: RichAgentMention | null,
+    selectedSpaceIds?: string[]
+  ) => void;
   pendingInputText: PendingInputText | null;
   selectedAgent: RichAgentMention | null;
   selectedMCPServerViews: MCPServerViewType[];
+  selectedSpaceIds?: string[];
+  selectableSpaces?: SelectableConversationSpaceType[];
+  shouldShowSpacesAction?: boolean;
+  isSelectableSpacesLoading?: boolean;
+  onSelectedSpaceIdsChange?: (spaceIds: string[]) => Promise<string[] | null>;
   stickyMentions?: RichMention[];
   user: UserType | null;
 }
@@ -276,7 +295,12 @@ const InputBarContainer = ({
   onModelSelectionChange,
   onMCPServerViewDeselect,
   selectedMCPServerViews,
+  selectedSpaceIds = EMPTY_SPACE_IDS,
   onResetMCPServerViews,
+  onSelectedSpaceIdsChange = acceptSelectedSpaceIds,
+  selectableSpaces = EMPTY_SELECTABLE_SPACES,
+  shouldShowSpacesAction = false,
+  isSelectableSpacesLoading = false,
   saveDraft,
   user,
   disableAgentSelector,
@@ -371,6 +395,7 @@ const InputBarContainer = ({
     [selectedMCPServerViews]
   );
   const selectedMCPServerViewIdsRef = useRef(selectedMCPServerViewIds);
+  const selectedSpaceIdsRef = useRef(selectedSpaceIds);
   const shouldEnableSlashSuggestionRef = useRef(shouldEnableSlashSuggestion);
   // The slash suggestion extension captures its options at editor initialization, while the
   // conversation may only be created after the first message; the ref keeps it current.
@@ -398,7 +423,20 @@ const InputBarContainer = ({
   const [selectedServerViewForDetails, setSelectedServerViewForDetails] =
     useState<MCPServerViewType | null>(null);
   selectedMCPServerViewIdsRef.current = selectedMCPServerViewIds;
+  selectedSpaceIdsRef.current = selectedSpaceIds;
   shouldEnableSlashSuggestionRef.current = shouldEnableSlashSuggestion;
+
+  const selectableSpacesById = useMemo(
+    () => new Map(selectableSpaces.map((space) => [space.sId, space])),
+    [selectableSpaces]
+  );
+  const selectedSpaces = useMemo(
+    () =>
+      selectedSpaceIds
+        .map((spaceId) => selectableSpacesById.get(spaceId))
+        .filter((space): space is SelectableConversationSpaceType => !!space),
+    [selectableSpacesById, selectedSpaceIds]
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const removePastedAttachmentChip = useCallback(
@@ -771,8 +809,52 @@ const InputBarContainer = ({
   editorServiceRef.current = editorService;
   const saveDraftRef = useRef(saveDraft);
   saveDraftRef.current = saveDraft;
+  const selectedSingleAgentRef = useRef(selectedSingleAgent);
+  selectedSingleAgentRef.current = selectedSingleAgent;
   // Skip auto-save (especially clearDraft on empty) until initial content is restored.
   const hasCompletedInitialContentRestoreRef = useRef(false);
+
+  const saveCurrentDraftWithSelectedSpaces = useCallback(
+    (spaceIds: string[]) => {
+      if (!hasCompletedInitialContentRestoreRef.current) {
+        return;
+      }
+
+      const currentEditorService = editorServiceRef.current;
+      const { markdown } = currentEditorService.getMarkdownAndMentions();
+      saveDraftRef.current(
+        currentEditorService.isEmpty() ? "" : markdown,
+        selectedSingleAgentRef.current,
+        spaceIds
+      );
+    },
+    []
+  );
+
+  const handleSelectedSpaceIdsChange = useCallback(
+    async (spaceIds: string[]) => {
+      const acceptedSpaceIds = await onSelectedSpaceIdsChange(spaceIds);
+      if (!acceptedSpaceIds) {
+        return;
+      }
+
+      saveCurrentDraftWithSelectedSpaces(acceptedSpaceIds);
+    },
+    [onSelectedSpaceIdsChange, saveCurrentDraftWithSelectedSpaces]
+  );
+
+  const handleSelectedSpaceIdsChangeSafely = useCallback(
+    (spaceIds: string[]) => {
+      void handleSelectedSpaceIdsChange(spaceIds).catch((error) => {
+        sendNotification({
+          type: "error",
+          title: "Failed to update Spaces",
+          description: normalizeError(error).message,
+        });
+      });
+    },
+    [handleSelectedSpaceIdsChange, sendNotification]
+  );
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) {
@@ -936,11 +1018,6 @@ const InputBarContainer = ({
     editor.setEditable(!disableInput);
   }, [editor, disableInput]);
 
-  // Ref to expose the current selectedSingleAgent to the editor update listener
-  // without re-registering it on every selection change.
-  const selectedSingleAgentRef = useRef(selectedSingleAgent);
-  selectedSingleAgentRef.current = selectedSingleAgent;
-
   // When a user mention is *newly added* in single-agent mode, deselect the agent
   // and clear side-channel capabilities. Only triggers on the transition from no-user-mention to
   // user-mention so that re-selecting an agent (via card click or URL param) isn't
@@ -978,7 +1055,8 @@ const InputBarContainer = ({
     if (hasCompletedInitialContentRestoreRef.current) {
       saveDraftRef.current(
         editorIsEmpty ? "" : markdown,
-        selectedSingleAgentRef.current
+        selectedSingleAgentRef.current,
+        selectedSpaceIdsRef.current
       );
     }
     const userMentioned = editorMentions.some((m) => m.type === "user");
@@ -1641,6 +1719,26 @@ const InputBarContainer = ({
                   />
                 </React.Fragment>
               ))}
+              {selectedSpaces.map((selectedSpace) => (
+                <Chip
+                  key={selectedSpace.sId}
+                  size="xs"
+                  label={selectedSpace.name}
+                  icon={Lock01}
+                  className="m-0.5 bg-background text-foreground dark:bg-background-night dark:text-foreground-night"
+                  onRemove={
+                    conversation?.sId
+                      ? undefined
+                      : () => {
+                          handleSelectedSpaceIdsChangeSafely(
+                            selectedSpaceIds.filter(
+                              (spaceId) => spaceId !== selectedSpace.sId
+                            )
+                          );
+                        }
+                  }
+                />
+              ))}
             </div>
             <div className="flex min-h-7 w-full items-center">
               <div className={cn("flex w-full items-center px-2")}>
@@ -1688,6 +1786,22 @@ const InputBarContainer = ({
                         setOverlayOpen("attachments-picker", open)
                       }
                     />
+                    {shouldShowSpacesAction && (
+                      <InputBarSpacesPicker
+                        buttonSize={buttonSize}
+                        canDeselectSelectedSpaces={!conversation?.sId}
+                        disabled={disableInput}
+                        isLoading={isSelectableSpacesLoading}
+                        onOpenChange={(open) =>
+                          setOverlayOpen("spaces-picker", open)
+                        }
+                        onSelectedSpaceIdsChange={
+                          handleSelectedSpaceIdsChangeSafely
+                        }
+                        selectedSpaceIds={selectedSpaceIds}
+                        spaces={selectableSpaces}
+                      />
+                    )}
                   </div>
                 )}
                 <div className="grow" />

--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -1,0 +1,111 @@
+import type { SelectableConversationSpaceType } from "@app/types/assistant/conversation";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Planet,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+interface InputBarSpacesPickerProps {
+  buttonSize: "xs" | "sm";
+  canDeselectSelectedSpaces: boolean;
+  disabled: boolean;
+  isLoading: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onSelectedSpaceIdsChange: (spaceIds: string[]) => void;
+  selectedSpaceIds: string[];
+  spaces: SelectableConversationSpaceType[];
+}
+
+export function InputBarSpacesPicker({
+  buttonSize,
+  canDeselectSelectedSpaces,
+  disabled,
+  isLoading,
+  onOpenChange,
+  onSelectedSpaceIdsChange,
+  selectedSpaceIds,
+  spaces,
+}: InputBarSpacesPickerProps) {
+  const selectedSpaceIdsSet = useMemo(
+    () => new Set(selectedSpaceIds),
+    [selectedSpaceIds]
+  );
+
+  const label =
+    selectedSpaceIds.length > 0
+      ? `${selectedSpaceIds.length} Space${selectedSpaceIds.length > 1 ? "s" : ""}`
+      : "Spaces";
+
+  const handleSpaceCheckedChange = (spaceId: string, checked: boolean) => {
+    if (!checked && !canDeselectSelectedSpaces) {
+      return;
+    }
+
+    if (checked) {
+      onSelectedSpaceIdsChange(
+        selectedSpaceIdsSet.has(spaceId)
+          ? selectedSpaceIds
+          : [...selectedSpaceIds, spaceId]
+      );
+      return;
+    }
+
+    onSelectedSpaceIdsChange(selectedSpaceIds.filter((id) => id !== spaceId));
+  };
+
+  return (
+    <DropdownMenu modal={false} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost-secondary"
+          size={buttonSize}
+          icon={Planet}
+          label={label}
+          disabled={disabled}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-60">
+        <DropdownMenuLabel>Spaces</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {isLoading ? (
+          <DropdownMenuItem
+            label="Loading"
+            disabled
+            endComponent={<Spinner size="xs" />}
+          />
+        ) : spaces.length === 0 ? (
+          <DropdownMenuItem label="No Spaces available" disabled />
+        ) : (
+          <div className="max-h-64 overflow-auto">
+            {spaces.map((space) => {
+              const checked = selectedSpaceIdsSet.has(space.sId);
+
+              return (
+                <DropdownMenuCheckboxItem
+                  key={space.sId}
+                  label={space.name}
+                  checked={checked}
+                  disabled={checked && !canDeselectSelectedSpaces}
+                  onCheckedChange={(nextChecked) =>
+                    handleSpaceCheckedChange(space.sId, nextChecked === true)
+                  }
+                  onSelect={(event) => {
+                    event.preventDefault();
+                  }}
+                />
+              );
+            })}
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -1,3 +1,4 @@
+import { getSpaceIcon } from "@app/lib/spaces";
 import type { SelectableConversationSpaceType } from "@app/types/assistant/conversation";
 import {
   Button,
@@ -92,6 +93,7 @@ export function InputBarSpacesPicker({
                 <DropdownMenuCheckboxItem
                   key={space.sId}
                   label={space.name}
+                  icon={getSpaceIcon(space)}
                   checked={checked}
                   disabled={checked && !canDeselectSelectedSpaces}
                   onCheckedChange={(nextChecked) =>

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -7,6 +7,7 @@ interface ConversationDraft {
   text: string;
   timestamp: number;
   agentMention?: RichAgentMention | null;
+  selectedSpaceIds?: string[];
 }
 
 type KeyId = string;
@@ -95,6 +96,7 @@ export function useConversationDrafts({
             text: string;
             timestamp: number;
             agentMention?: RichAgentMention | null;
+            selectedSpaceIds?: string[];
           }) => void
         >
       >
@@ -111,6 +113,7 @@ export function useConversationDrafts({
         text,
         timestamp,
         agentMention,
+        selectedSpaceIds,
       }: {
         workspaceId: string;
         userId: string;
@@ -118,6 +121,7 @@ export function useConversationDrafts({
         text: string;
         timestamp: number;
         agentMention?: RichAgentMention | null;
+        selectedSpaceIds?: string[];
       }) => {
         if (!userId) {
           return;
@@ -128,6 +132,7 @@ export function useConversationDrafts({
           text,
           timestamp,
           agentMention,
+          selectedSpaceIds,
         };
         saveDraftsToStorage(drafts);
       },
@@ -156,12 +161,20 @@ export function useConversationDrafts({
   ]);
 
   const saveDraft = useCallback(
-    (text: string, agentMention?: RichAgentMention | null) => {
+    (
+      text: string,
+      agentMention?: RichAgentMention | null,
+      selectedSpaceIds: string[] = []
+    ) => {
       if (!shouldUseDraft || !userId) {
         return;
       }
 
-      if (text.trim().length === 0) {
+      if (
+        text.trim().length === 0 &&
+        !agentMention &&
+        selectedSpaceIds.length === 0
+      ) {
         clearDraft();
         return;
       }
@@ -173,6 +186,7 @@ export function useConversationDrafts({
         text,
         timestamp: Date.now(),
         agentMention,
+        selectedSpaceIds,
       });
     },
     [workspaceId, userId, shouldUseDraft, draftKey, clearDraft]

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -61,6 +61,7 @@ export function useCreateConversationWithMessage({
         contentFragments: ContentFragmentsType;
         clientSideMCPServerIds?: string[];
         selectedMCPServerViewIds?: string[];
+        selectedSpaceIds?: string[];
         origin?: ClientMessageOrigin;
         // Rich mentions used to render optimistic placeholder messages when the
         // first message is deferred and posted from `ConversationViewer`.
@@ -97,11 +98,16 @@ export function useCreateConversationWithMessage({
         contentFragments,
         clientSideMCPServerIds,
         selectedMCPServerViewIds,
+        selectedSpaceIds: requestedSpaceIds,
         origin: messageOrigin,
         richMentions,
         modelSelection,
       } = messageData;
       const origin = messageOrigin ?? contextOrigin;
+      const selectedSpaceIds =
+        requestedSpaceIds && requestedSpaceIds.length > 0
+          ? requestedSpaceIds
+          : undefined;
 
       if (deferMessage) {
         const createBody: z.infer<
@@ -114,6 +120,7 @@ export function useCreateConversationWithMessage({
           skipToolsValidation,
           message: null,
           contentFragments: [],
+          selectedSpaceIds,
         };
 
         try {
@@ -147,6 +154,7 @@ export function useCreateConversationWithMessage({
             contentFragments,
             clientSideMCPServerIds,
             selectedMCPServerViewIds,
+            selectedSpaceIds,
             origin,
             skipToolsValidation,
             profilePictureUrl: user.image,
@@ -176,6 +184,7 @@ export function useCreateConversationWithMessage({
         spaceId: spaceId ?? null,
         metadata,
         skipToolsValidation,
+        selectedSpaceIds,
         message: {
           content: input,
           context: {
@@ -183,6 +192,7 @@ export function useCreateConversationWithMessage({
             profilePictureUrl: user.image,
             clientSideMCPServerIds,
             selectedMCPServerViewIds,
+            selectedSpaceIds,
             origin,
           },
           mentions,
@@ -261,6 +271,7 @@ async function postFirstMessageInBackground({
   contentFragments,
   clientSideMCPServerIds,
   selectedMCPServerViewIds,
+  selectedSpaceIds,
   origin,
   skipToolsValidation,
   profilePictureUrl,
@@ -274,6 +285,7 @@ async function postFirstMessageInBackground({
   contentFragments: ContentFragmentsType;
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];
+  selectedSpaceIds?: string[];
   origin: ClientMessageOrigin;
   skipToolsValidation: boolean;
   profilePictureUrl: string | null;
@@ -348,6 +360,7 @@ async function postFirstMessageInBackground({
             profilePictureUrl,
             clientSideMCPServerIds,
             selectedMCPServerViewIds,
+            selectedSpaceIds,
             origin,
           },
           mentions,

--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -36,6 +36,7 @@ export function useSubmitMessage({
       mentions: MentionType[];
       contentFragments: ContentFragmentsType;
       clientSideMCPServerIds?: string[];
+      selectedSpaceIds?: string[];
       origin?: ClientMessageOrigin;
       skipToolsValidation?: boolean;
       modelSelection?: ModelSelectionType;
@@ -53,6 +54,7 @@ export function useSubmitMessage({
         mentions,
         contentFragments,
         clientSideMCPServerIds,
+        selectedSpaceIds,
         origin: messageOrigin,
         skipToolsValidation,
         modelSelection,
@@ -128,6 +130,7 @@ export function useSubmitMessage({
                 Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC",
               profilePictureUrl: user.image,
               clientSideMCPServerIds,
+              selectedSpaceIds,
               origin,
             },
             mentions,


### PR DESCRIPTION
## Stack

Runtime and API prerequisites through #27548 are merged.

1. **#27549 - Add Spaces picker shell**
2. #27550 - Wire Spaces into input bar

This PR is **280 changed lines** against `main`.

## Why

The API contract is ready, so this PR adds the reusable picker and transports selected Space IDs through drafts and message submission. The picker remains dormant until #27550 wires selection state into `InputBar`.

## What changed

- Adds `InputBarSpacesPicker` with search, selection, disabled, loading, and empty states.
- Uses the same open and restricted Space icons as the Spaces UI in picker rows and selected chips.
- Carries `selectedSpaceIds` through conversation drafts and message transport.
- Keeps the new picker path dormant until the follow-up wiring PR.

## Risk

Low. The picker is not rendered by this PR, and transport fields remain optional.

## Deploy plan

- [x] Merge the runtime and API prerequisites through #27548.
- [ ] Merge this PR.
- [ ] Deploy `front` normally.

## Verification

- `npm run tsgo -- --noEmit` in `front`
- `npx biome check` on changed TypeScript files
- `git diff --check`

