### PR TITLE
Wire Spaces into input bar

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -134,6 +134,7 @@ export function ConversationContainerVirtuoso({
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
       selectedMCPServerViewIds?: string[],
+      selectedSpaceIds?: string[],
       modelSelection?: ModelSelectionType
     ): Promise<Result<undefined, DustError>> => {
       if (isSubmitting) {
@@ -183,6 +184,7 @@ export function ConversationContainerVirtuoso({
           contentFragments,
           clientSideMCPServerIds,
           selectedMCPServerViewIds,
+          selectedSpaceIds,
           richMentions: mentions,
           modelSelection,
         },

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1126,6 +1126,7 @@ export const ConversationViewer = ({
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
       _selectedMCPServerViewIds?: string[],
+      selectedSpaceIds?: string[],
       modelSelection?: ModelSelectionType
     ): Promise<Result<undefined, DustError>> => {
       if (!virtuosoMessageListRef?.current) {
@@ -1154,6 +1155,7 @@ export const ConversationViewer = ({
           clientSideMCPServerIds:
             clientSideMCPServerIds ??
             agentBuilderContext?.clientSideMCPServerIds,
+          selectedSpaceIds,
           skipToolsValidation: agentBuilderContext?.skipToolsValidation,
           modelSelection,
         };

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -21,15 +21,24 @@ import {
 } from "@app/hooks/conversations";
 import { RUNNING_AGENT_SWITCH_BLOCK_MESSAGE } from "@app/lib/api/assistant/errors";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import {
+  useAddConversationSelectedSpaces,
+  useSelectableConversationSpaces,
+} from "@app/lib/swr/conversation_selected_spaces";
+import { useSpaces } from "@app/lib/swr/spaces";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import {
   compareAgentsForSort,
   isGlobalAgentId,
 } from "@app/types/assistant/assistant";
-import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type {
+  ConversationWithoutContentType,
+  SelectableConversationSpaceType,
+} from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ModelSelectionType } from "@app/types/assistant/models/types";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
@@ -50,6 +59,20 @@ import React, {
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
+type SelectedSpacesState = {
+  key: string;
+  spaceIds: string[];
+};
+
+function sameStringSet(a: string[], b: string[]) {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  const bSet = new Set(b);
+  return a.every((value) => bSet.has(value));
+}
+
 interface InputBarProps {
   owner: WorkspaceType;
   user: UserType | null;
@@ -58,6 +81,7 @@ interface InputBarProps {
     mentions: RichMention[],
     contentFragments: ContentFragmentsType,
     selectedMCPServerViewIds?: string[],
+    selectedSpaceIds?: string[],
     modelSelection?: ModelSelectionType
   ) => Promise<Result<undefined, DustError>>;
   draftKey: string;
@@ -116,6 +140,7 @@ export const InputBar = React.memo(function InputBar({
 }: InputBarProps) {
   const [isLocalSubmitting, setIsLocalSubmitting] = useState(isSubmitting);
   const [isShaking, setIsShaking] = useState(false);
+  const { featureFlags } = useFeatureFlags();
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
@@ -235,6 +260,8 @@ export const InputBar = React.memo(function InputBar({
   const [selectedMCPServerViews, setSelectedMCPServerViews] = useState<
     MCPServerViewType[]
   >([]);
+  const [selectedSpacesState, setSelectedSpacesState] =
+    useState<SelectedSpacesState | null>(null);
 
   const { conversationTools } = useConversationTools({
     conversationId: conversation?.sId,
@@ -254,6 +281,129 @@ export const InputBar = React.memo(function InputBar({
     () => new Set(selectedMCPServerViews.map((serverView) => serverView.sId)),
     [selectedMCPServerViews]
   );
+  const spacesSelectionKey = conversation?.sId ?? `draft:${draftKey}`;
+  const draftSelectedSpaceIds = useMemo(
+    () => getDraft()?.selectedSpaceIds ?? [],
+    [getDraft]
+  );
+  const localSelectedSpaceIds =
+    selectedSpacesState?.key === spacesSelectionKey
+      ? selectedSpacesState.spaceIds
+      : null;
+  const inputBarSpaceId = conversation?.spaceId ?? space?.sId ?? undefined;
+  const shouldShowSpacesAction =
+    actions.includes("spaces") &&
+    featureFlags.includes("restricted_spaces_in_input_bar") &&
+    !isAgentBuilder &&
+    !inputBarSpaceId;
+
+  const {
+    spaces: conversationSelectableSpaces,
+    isSelectableSpacesLoading: isConversationSelectableSpacesLoading,
+    mutateSelectableSpaces,
+  } = useSelectableConversationSpaces({
+    owner,
+    conversationId: conversation?.sId ?? null,
+    disabled: !shouldShowSpacesAction || !conversation?.sId,
+  });
+  const addConversationSelectedSpaces = useAddConversationSelectedSpaces({
+    owner,
+    conversationId: conversation?.sId ?? null,
+  });
+
+  const {
+    spaces: workspaceRegularSpaces,
+    isSpacesLoading: isWorkspaceSpacesLoading,
+  } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["regular"],
+    disabled: !shouldShowSpacesAction || !!conversation?.sId,
+  });
+
+  const conversationSelectedSpaceIds = useMemo(() => {
+    const selectedSpaceIds: string[] = [];
+    for (const selectableSpace of conversationSelectableSpaces) {
+      if (selectableSpace.selected) {
+        selectedSpaceIds.push(selectableSpace.sId);
+      }
+    }
+
+    return selectedSpaceIds;
+  }, [conversationSelectableSpaces]);
+
+  const rawSelectedSpaceIds = useMemo(
+    () =>
+      conversation?.sId
+        ? Array.from(
+            new Set([
+              ...conversationSelectedSpaceIds,
+              ...(localSelectedSpaceIds ?? []),
+            ])
+          )
+        : (localSelectedSpaceIds ?? draftSelectedSpaceIds),
+    [
+      conversation?.sId,
+      conversationSelectedSpaceIds,
+      draftSelectedSpaceIds,
+      localSelectedSpaceIds,
+    ]
+  );
+  const rawSelectedSpaceIdSet = useMemo(
+    () => new Set(rawSelectedSpaceIds),
+    [rawSelectedSpaceIds]
+  );
+
+  const selectableSpaces: SelectableConversationSpaceType[] = useMemo(
+    () =>
+      conversation?.sId
+        ? conversationSelectableSpaces
+        : workspaceRegularSpaces
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((regularSpace) => ({
+              ...regularSpace,
+              selected: rawSelectedSpaceIdSet.has(regularSpace.sId),
+            })),
+    [
+      conversation?.sId,
+      conversationSelectableSpaces,
+      rawSelectedSpaceIdSet,
+      workspaceRegularSpaces,
+    ]
+  );
+  const selectableSpaceIds = useMemo(
+    () => new Set(selectableSpaces.map((space) => space.sId)),
+    [selectableSpaces]
+  );
+  const selectedSpaceIds = useMemo(() => {
+    if (!shouldShowSpacesAction) {
+      return [];
+    }
+
+    if (
+      (conversation?.sId && isConversationSelectableSpacesLoading) ||
+      (!conversation?.sId && isWorkspaceSpacesLoading)
+    ) {
+      return rawSelectedSpaceIds;
+    }
+
+    return rawSelectedSpaceIds.filter((spaceId) =>
+      selectableSpaceIds.has(spaceId)
+    );
+  }, [
+    conversation?.sId,
+    isConversationSelectableSpacesLoading,
+    isWorkspaceSpacesLoading,
+    rawSelectedSpaceIds,
+    selectableSpaceIds,
+    shouldShowSpacesAction,
+  ]);
+  const selectedSpaceIdSet = useMemo(
+    () => new Set(selectedSpaceIds),
+    [selectedSpaceIds]
+  );
+  const isSelectableSpacesLoading = conversation?.sId
+    ? isConversationSelectableSpacesLoading
+    : isWorkspaceSpacesLoading;
 
   const handleMCPServerViewSelect = useCallback(
     (serverView: MCPServerViewType) => {
@@ -283,6 +433,80 @@ export const InputBar = React.memo(function InputBar({
       void deleteTool(serverView.sId);
     },
     [deleteTool, selectedMCPServerViewIds]
+  );
+
+  const clearSideChannelSelections = useCallback(async () => {
+    const serverViewIds = selectedMCPServerViews.map(
+      (serverView) => serverView.sId
+    );
+    setSelectedMCPServerViews([]);
+    setAttachedNodes([]);
+
+    await Promise.all(
+      serverViewIds.map((serverViewId) => deleteTool(serverViewId))
+    );
+  }, [deleteTool, selectedMCPServerViews]);
+
+  const handleSelectedSpaceIdsChange = useCallback(
+    async (spaceIds: string[]): Promise<string[] | null> => {
+      if (!shouldShowSpacesAction) {
+        setSelectedSpacesState({
+          key: spacesSelectionKey,
+          spaceIds: [],
+        });
+        return [];
+      }
+
+      const nextSpaceIds = Array.from(new Set(spaceIds)).filter((spaceId) =>
+        selectableSpaceIds.has(spaceId)
+      );
+      if (sameStringSet(selectedSpaceIds, nextSpaceIds)) {
+        return selectedSpaceIds;
+      }
+
+      if (conversation?.sId) {
+        const addedSpaceIds = nextSpaceIds.filter(
+          (spaceId) => !selectedSpaceIdSet.has(spaceId)
+        );
+        if (addedSpaceIds.length === 0) {
+          return selectedSpaceIds;
+        }
+
+        const response = await addConversationSelectedSpaces(addedSpaceIds);
+        if (!response) {
+          return null;
+        }
+
+        const persistedSpaceIds = response.selectedSpaces.map(
+          (selectedSpace) => selectedSpace.sId
+        );
+        await clearSideChannelSelections();
+        setSelectedSpacesState({
+          key: spacesSelectionKey,
+          spaceIds: persistedSpaceIds,
+        });
+        await mutateSelectableSpaces();
+        return persistedSpaceIds;
+      }
+
+      await clearSideChannelSelections();
+      setSelectedSpacesState({
+        key: spacesSelectionKey,
+        spaceIds: nextSpaceIds,
+      });
+      return nextSpaceIds;
+    },
+    [
+      addConversationSelectedSpaces,
+      clearSideChannelSelections,
+      conversation?.sId,
+      mutateSelectableSpaces,
+      spacesSelectionKey,
+      selectableSpaceIds,
+      selectedSpaceIds,
+      selectedSpaceIdSet,
+      shouldShowSpacesAction,
+    ]
   );
 
   const activeAgents = useMemo(() => {
@@ -367,6 +591,7 @@ export const InputBar = React.memo(function InputBar({
           // Only send the selectedMCPServerViewIds if we are creating a new conversation.
           // Once the conversation is created, the selectedMCPServerViewIds will be updated in the conversationTools hook.
           selectedMCPServerViews.map((sv) => sv.sId),
+          selectedSpaceIds,
           modelSelectionRef.current
         );
 
@@ -374,6 +599,10 @@ export const InputBar = React.memo(function InputBar({
           clearDraft();
           resetEditorText();
           fileUploaderService.resetUpload();
+          setSelectedSpacesState({
+            key: spacesSelectionKey,
+            spaceIds: [],
+          });
         }
       } finally {
         setLoading(false);
@@ -398,8 +627,9 @@ export const InputBar = React.memo(function InputBar({
             contentNodes: attachedNodes,
           },
           // Existing conversation: MCP server views are synced via the
-          // conversationTools hook, so only the model selection is passed here.
+          // conversationTools hook.
           undefined,
+          selectedSpaceIds,
           modelSelectionRef.current
         );
 
@@ -540,6 +770,11 @@ export const InputBar = React.memo(function InputBar({
             onNodeSelect={handleNodesAttachmentSelect}
             onNodeUnselect={handleNodesAttachmentRemove}
             selectedMCPServerViews={selectedMCPServerViews}
+            selectedSpaceIds={selectedSpaceIds}
+            selectableSpaces={selectableSpaces}
+            shouldShowSpacesAction={shouldShowSpacesAction}
+            isSelectableSpacesLoading={isSelectableSpacesLoading}
+            onSelectedSpaceIdsChange={handleSelectedSpaceIdsChange}
             onMCPServerViewSelect={handleMCPServerViewSelect}
             onModelSelectionChange={handleModelSelectionChange}
             onMCPServerViewDeselect={handleMCPServerViewDeselect}

--- a/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarSpacesPicker.tsx
@@ -6,13 +6,13 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
+  DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Planet,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 interface InputBarSpacesPickerProps {
   buttonSize: "xs" | "sm";
@@ -39,11 +39,22 @@ export function InputBarSpacesPicker({
     () => new Set(selectedSpaceIds),
     [selectedSpaceIds]
   );
+  const [searchText, setSearchText] = useState("");
+  const filteredSpaces = useMemo(() => {
+    const normalizedSearchText = searchText.trim().toLowerCase();
+    if (!normalizedSearchText) {
+      return spaces;
+    }
 
-  const label =
+    return spaces.filter((space) =>
+      space.name.toLowerCase().includes(normalizedSearchText)
+    );
+  }, [searchText, spaces]);
+
+  const tooltip =
     selectedSpaceIds.length > 0
-      ? `${selectedSpaceIds.length} Space${selectedSpaceIds.length > 1 ? "s" : ""}`
-      : "Spaces";
+      ? `${selectedSpaceIds.length} Space${selectedSpaceIds.length > 1 ? "s" : ""} selected`
+      : "Select Spaces";
 
   const handleSpaceCheckedChange = (spaceId: string, checked: boolean) => {
     if (!checked && !canDeselectSelectedSpaces) {
@@ -63,19 +74,41 @@ export function InputBarSpacesPicker({
   };
 
   return (
-    <DropdownMenu modal={false} onOpenChange={onOpenChange}>
+    <DropdownMenu
+      onOpenChange={(open) => {
+        if (open) {
+          setSearchText("");
+        }
+        onOpenChange?.(open);
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost-secondary"
           size={buttonSize}
           icon={Planet}
-          label={label}
+          tooltip={tooltip}
+          aria-label={tooltip}
           disabled={disabled}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-60">
-        <DropdownMenuLabel>Spaces</DropdownMenuLabel>
-        <DropdownMenuSeparator />
+      <DropdownMenuContent
+        align="start"
+        className="w-80"
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              autoFocus
+              name="search-spaces"
+              placeholder="Search Spaces"
+              value={searchText}
+              onChange={setSearchText}
+              disabled={isLoading}
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
+      >
         {isLoading ? (
           <DropdownMenuItem
             label="Loading"
@@ -84,9 +117,11 @@ export function InputBarSpacesPicker({
           />
         ) : spaces.length === 0 ? (
           <DropdownMenuItem label="No Spaces available" disabled />
+        ) : filteredSpaces.length === 0 ? (
+          <DropdownMenuItem label="No matching Spaces" disabled />
         ) : (
-          <div className="max-h-64 overflow-auto">
-            {spaces.map((space) => {
+          <div>
+            {filteredSpaces.map((space) => {
               const checked = selectedSpaceIdsSet.has(space.sId);
 
               return (

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -100,6 +100,7 @@ export function PodPageContent({
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
       selectedMCPServerViewIds?: string[],
+      _selectedSpaceIds?: string[],
       modelSelection?: ModelSelectionType
     ): Promise<Result<undefined, DustError>> => {
       if (isSubmitting) {

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -71,6 +71,7 @@ interface PodConversationsTabProps {
     mentions: RichMention[],
     contentFragments: ContentFragmentsType,
     selectedMCPServerViewIds?: string[],
+    selectedSpaceIds?: string[],
     modelSelection?: ModelSelectionType
   ) => Promise<Result<undefined, any>>;
   onNavigateToTasks: () => void;


### PR DESCRIPTION
## Stack

1. #29142 - Allow selecting open Spaces in conversations
2. #27545 - Add selected Space runtime validation helpers
3. #27546 - Add selected Spaces append API
4. #27547 - Add selectable Spaces API and hooks
5. #27548 - Accept selected Spaces in conversation APIs
6. #27549 - Add Spaces picker shell
7. **#27550 - Wire Spaces into input bar**

This PR is **304 changed lines** against `main`.

## Why

This final UI PR exposes selected Spaces in the input bar so users can widen a conversation's runtime scope with any readable regular Space.

## What changed

- Wires the Spaces picker into `InputBar` behind `restricted_spaces_in_input_bar`.
- Shows all readable regular Spaces for new conversations, with the same open and restricted icons as the Spaces UI.
- Uses the selectable-Spaces endpoint for existing conversations and persists additions before sending follow-up messages.
- Uses an icon-only trigger and the same fixed-search-header dropdown shell as skills, tools, and knowledge.
- Filters Spaces client-side by name while keeping the menu open for multi-selection.
- Keeps the action hidden in Pod conversations, scoped Space pages, and agent builder flows.
- Retains the existing feature flag key for rollout continuity while using generic user-facing terminology.

## Risk

The entry point remains behind the existing Dust-only feature flag. Selected open Spaces widen runtime scope but do not restrict conversation visibility. Pod and scoped-Space input bars remain excluded.

## Deploy plan

- [x] Merge through #27549 first.
- [ ] Merge this PR.
- [ ] Deploy `front` and `front-api`.
- [ ] Enable and validate the existing feature flag in the intended workspace before broader rollout.

## Verification

- Selected-Space service, resource, and audit schema suites: 25 tests
- `npm run tsgo -- --noEmit` in `front`
- `npm run tsgo -- --noEmit` in `front-api`
- `npx biome check` on changed TypeScript files
- Browser-tested with 123 Spaces: open/restricted icons, filtering, no-match state, query reset, multi-select persistence, and fixed search header while scrolling
- `git diff --check`

