### PR TITLE
refacto: split getDasaSourceViewUsage in multiple queries

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -1,7 +1,7 @@
 import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
 import {
   getDataSourcesUsageByCategory,
-  getDataSourceViewsUsageByCategory,
+  getDataSourceViewsUsageByIds,
 } from "@app/lib/api/agent_data_sources";
 import type {
   GetSpaceDataSourceViewsResponseBody,
@@ -179,7 +179,10 @@ app.get(
         usages[dsView.id] = usagesByDataSources[dsView.dataSource.id];
       });
     } else {
-      usages = await getDataSourceViewsUsageByCategory({ auth, category });
+      usages = await getDataSourceViewsUsageByIds({
+        auth,
+        dataSourceViewIds: dataSourceViews.map((dsv) => dsv.id),
+      });
     }
 
     const enhancedDataSourceViews: DataSourceViewsWithDetails[] =

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -1,7 +1,7 @@
 import type { DataSourcesUsageByAgent } from "@app/lib/api/agent_data_sources";
 import {
   getDataSourcesUsageByCategory,
-  getDataSourceViewsUsageByIds,
+  getDataSourceViewsUsageByModelIds,
 } from "@app/lib/api/agent_data_sources";
 import type {
   GetSpaceDataSourceViewsResponseBody,
@@ -179,9 +179,9 @@ app.get(
         usages[dsView.id] = usagesByDataSources[dsView.dataSource.id];
       });
     } else {
-      usages = await getDataSourceViewsUsageByIds({
+      usages = await getDataSourceViewsUsageByModelIds({
         auth,
-        dataSourceViewIds: dataSourceViews.map((dsv) => dsv.id),
+        dataSourceViewModelIds: dataSourceViews.map((dsv) => dsv.id),
       });
     }
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -258,30 +258,21 @@ app.get(
 
     const categories: { [key: string]: SpaceCategoryInfo } = {};
     for (const category of DATA_SOURCE_VIEW_CATEGORIES) {
-      categories[category] = {
-        count: 0,
-        usage: { count: 0, agents: [] },
-      };
-
       const dataSourceViewsInCategory = dataSourceViewsList.filter(
         (view) => view.toJSON().category === category
       );
 
-      for (const dsView of dataSourceViewsInCategory) {
-        categories[category].count += 1;
-        const usage = usages[dsView.id];
-        if (usage) {
-          categories[category].usage.agents = categories[
-            category
-          ].usage.agents.concat(usage.agents);
-          categories[category].usage.agents = uniqBy(
-            categories[category].usage.agents,
-            "sId"
-          );
-        }
-      }
-      categories[category].usage.count =
-        categories[category].usage.agents.length;
+      const agents = uniqBy(
+        dataSourceViewsInCategory.flatMap(
+          (view) => usages[view.id]?.agents ?? []
+        ),
+        "sId"
+      );
+
+      categories[category] = {
+        count: dataSourceViewsInCategory.length,
+        usage: { count: agents.length, agents },
+      };
     }
 
     categories["apps"].count = appsList.length;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,4 +1,4 @@
-import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sources";
+import { getDataSourceViewsUsageByIds } from "@app/lib/api/agent_data_sources";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -251,6 +251,11 @@ app.get(
       (a) => a.toJSON().server.availability === "manual"
     ).length;
 
+    const usages = await getDataSourceViewsUsageByIds({
+      auth,
+      dataSourceViewIds: dataSourceViewsList.map((dsv) => dsv.id),
+    });
+
     const categories: { [key: string]: SpaceCategoryInfo } = {};
     for (const category of DATA_SOURCE_VIEW_CATEGORIES) {
       categories[category] = {
@@ -262,29 +267,21 @@ app.get(
         (view) => view.toJSON().category === category
       );
 
-      // The usage call is expensive, so only run it when there are views.
-      if (dataSourceViewsInCategory.length > 0) {
-        const usages = await getDataSourceViewsUsageByCategory({
-          auth,
-          category,
-        });
-
-        for (const dsView of dataSourceViewsInCategory) {
-          categories[category].count += 1;
-          const usage = usages[dsView.id];
-          if (usage) {
-            categories[category].usage.agents = categories[
-              category
-            ].usage.agents.concat(usage.agents);
-            categories[category].usage.agents = uniqBy(
-              categories[category].usage.agents,
-              "sId"
-            );
-          }
+      for (const dsView of dataSourceViewsInCategory) {
+        categories[category].count += 1;
+        const usage = usages[dsView.id];
+        if (usage) {
+          categories[category].usage.agents = categories[
+            category
+          ].usage.agents.concat(usage.agents);
+          categories[category].usage.agents = uniqBy(
+            categories[category].usage.agents,
+            "sId"
+          );
         }
-        categories[category].usage.count =
-          categories[category].usage.agents.length;
       }
+      categories[category].usage.count =
+        categories[category].usage.agents.length;
     }
 
     categories["apps"].count = appsList.length;

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,4 +1,4 @@
-import { getDataSourceViewsUsageByIds } from "@app/lib/api/agent_data_sources";
+import { getDataSourceViewsUsageByModelIds } from "@app/lib/api/agent_data_sources";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -251,9 +251,9 @@ app.get(
       (a) => a.toJSON().server.availability === "manual"
     ).length;
 
-    const usages = await getDataSourceViewsUsageByIds({
+    const usages = await getDataSourceViewsUsageByModelIds({
       auth,
-      dataSourceViewIds: dataSourceViewsList.map((dsv) => dsv.id),
+      dataSourceViewModelIds: dataSourceViewsList.map((dsv) => dsv.id),
     });
 
     const categories: { [key: string]: SpaceCategoryInfo } = {};

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -8,7 +8,6 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
-import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type {
   AgentsUsageType,
@@ -18,8 +17,8 @@ import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import sortBy from "lodash/sortBy";
+import uniq from "lodash/uniq";
 import uniqBy from "lodash/uniqBy";
 import type { ProjectionAlias, WhereAttributeHashValue } from "sequelize";
 import { Op, Sequelize } from "sequelize";
@@ -53,12 +52,12 @@ const agentAggregates: ProjectionAlias[] = (
   alias,
 ]);
 
-export async function getDataSourceViewsUsageByCategory({
+export async function getDataSourceViewsUsageByIds({
   auth,
-  category,
+  dataSourceViewIds,
 }: {
   auth: Authenticator;
-  category: DataSourceViewCategory;
+  dataSourceViewIds: ModelId[];
 }): Promise<DataSourcesUsageByAgent> {
   const owner = auth.workspace();
 
@@ -73,33 +72,56 @@ export async function getDataSourceViewsUsageByCategory({
     return {};
   }
 
-  let connectorProvider: WhereAttributeHashValue<ConnectorProvider | null> =
-    null;
-
-  switch (category) {
-    case "folder":
-      connectorProvider = null;
-      break;
-    case "website":
-      connectorProvider = "webcrawler";
-      break;
-    case "managed":
-      connectorProvider = {
-        [Op.in]: CONNECTOR_PROVIDERS.filter(isManagedConnectorProvider),
-      };
-      break;
-    case "apps":
-      return {};
-    case "actions":
-      connectorProvider = null;
-      break;
-    case "triggers":
-      connectorProvider = null;
-      break;
-    default:
-      assertNever(category);
+  const uniqueDataSourceViewIds = uniq(dataSourceViewIds);
+  if (uniqueDataSourceViewIds.length === 0) {
+    return {};
   }
 
+  // Step 1 & 2: fetch the config links from both sources.
+  const [dataSourceConfigLinks, tableConfigLinks] = await Promise.all([
+    AgentDataSourceConfigurationModel.findAll({
+      raw: true,
+      attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
+      where: {
+        workspaceId: owner.id,
+        dataSourceViewId: { [Op.in]: uniqueDataSourceViewIds },
+      },
+    }),
+    AgentTablesQueryConfigurationTableModel.findAll({
+      raw: true,
+      attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
+      where: {
+        workspaceId: owner.id,
+        dataSourceViewId: { [Op.in]: uniqueDataSourceViewIds },
+      },
+    }),
+  ]);
+
+  // Step 3: fetch the MCP server configuration -> agent configuration mappings
+  // once for both sources.
+  const mcpServerConfigurationIds = uniq(
+    [...dataSourceConfigLinks, ...tableConfigLinks]
+      .map((link) => link.mcpServerConfigurationId)
+      .filter((id): id is ModelId => id !== null && id !== undefined)
+  );
+
+  const mcpConfigs =
+    mcpServerConfigurationIds.length > 0
+      ? await AgentMCPServerConfigurationModel.findAll({
+          raw: true,
+          attributes: ["id", "agentConfigurationId"],
+          where: {
+            workspaceId: owner.id,
+            id: { [Op.in]: mcpServerConfigurationIds },
+          },
+        })
+      : [];
+
+  const mcpConfigById = new Map(
+    mcpConfigs.map((config) => [config.id, config])
+  );
+
+  // Step 4: fetch the agent configurations
   const getAgentsForUser = async () =>
     (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
       (g) => g.agentConfigurationId
@@ -126,139 +148,128 @@ export async function getDataSourceViewsUsageByCategory({
     ],
   });
 
-  const agentConfigurationInclude = {
-    model: AgentConfigurationModel,
-    as: "agent_configuration",
-    attributes: [],
-    required: true,
-    where: auth.isAdmin()
-      ? getAgentWhereClauseAdmin()
-      : await getAgentWhereClauseNonAdmin(),
+  // 4A. Agents for AgentDataSourceConfigurationModel links.
+  const dataSourceAgentConfigurationIds = uniq(
+    dataSourceConfigLinks
+      .map((link) =>
+        link.mcpServerConfigurationId === null
+          ? undefined
+          : mcpConfigById.get(link.mcpServerConfigurationId)
+              ?.agentConfigurationId
+      )
+      .filter((id): id is ModelId => id !== null && id !== undefined)
+  );
+
+  const dataSourceAgents =
+    dataSourceAgentConfigurationIds.length > 0
+      ? await AgentConfigurationModel.findAll({
+          raw: true,
+          attributes: ["id", "sId", "name", "pictureUrl"],
+          where: {
+            ...(auth.isAdmin()
+              ? getAgentWhereClauseAdmin()
+              : await getAgentWhereClauseNonAdmin()),
+            id: { [Op.in]: dataSourceAgentConfigurationIds },
+          },
+        })
+      : [];
+
+  // 4B. Agents for AgentTablesQueryConfigurationTableModel links.
+  const tableAgentConfigurationIds = uniq(
+    tableConfigLinks
+      .map(
+        (link) =>
+          mcpConfigById.get(link.mcpServerConfigurationId)?.agentConfigurationId
+      )
+      .filter((id): id is ModelId => id !== null && id !== undefined)
+  );
+
+  const tableAgents =
+    tableAgentConfigurationIds.length > 0
+      ? await AgentConfigurationModel.findAll({
+          raw: true,
+          attributes: ["id", "sId", "name", "pictureUrl"],
+          where: {
+            status: "active",
+            workspaceId: owner.id,
+            id: { [Op.in]: tableAgentConfigurationIds },
+          },
+        })
+      : [];
+
+  // Step 5: join in memory and build the result.
+  const dataSourceAgentById = new Map(
+    dataSourceAgents.map((agent) => [agent.id, agent])
+  );
+  const tableAgentById = new Map(tableAgents.map((agent) => [agent.id, agent]));
+
+  const result: DataSourcesUsageByAgent = {};
+
+  const pushAgentForDataSourceView = ({
+    dataSourceViewId,
+    agent,
+  }: {
+    dataSourceViewId: ModelId;
+    agent: {
+      sId: string;
+      name: string;
+      pictureUrl: string;
+    };
+  }) => {
+    if (
+      !agent.sId ||
+      agent.sId.length === 0 ||
+      !agent.name ||
+      agent.name.length === 0
+    ) {
+      return;
+    }
+
+    let usage = result[dataSourceViewId];
+    if (!usage) {
+      usage = { count: 0, agents: [] };
+      result[dataSourceViewId] = usage;
+    }
+
+    usage.agents.push({
+      sId: agent.sId,
+      name: agent.name,
+      pictureUrl: agent.pictureUrl,
+    });
   };
 
-  const res = (await Promise.all([
-    AgentDataSourceConfigurationModel.findAll({
-      raw: true,
-      group: ["dataSourceView.id"],
-      where: {
-        workspaceId: owner.id,
-      },
-      attributes: [
-        [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        ...agentAggregates,
-      ],
-      include: [
-        {
-          model: DataSourceViewModel,
-          as: "dataSourceView",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: DataSourceModel,
-              as: "dataSourceForView",
-              attributes: [],
-              required: true,
-              where: {
-                connectorProvider: connectorProvider,
-              },
-            },
-          ],
-        },
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [agentConfigurationInclude],
-        },
-      ],
-    }),
-    AgentTablesQueryConfigurationTableModel.findAll({
-      raw: true,
-      group: ["dataSourceView.id"],
-      where: {
-        workspaceId: owner.id,
-      },
-      attributes: [
-        [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        ...agentAggregates,
-      ],
-      include: [
-        {
-          model: DataSourceViewModel,
-          as: "dataSourceView",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: DataSourceModel,
-              as: "dataSourceForView",
-              attributes: [],
-              required: true,
-              where: {
-                connectorProvider: connectorProvider,
-              },
-            },
-          ],
-        },
-        {
-          model: AgentMCPServerConfigurationModel,
-          as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfigurationModel,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
-        },
-      ],
-    }),
-  ])) as unknown as {
-    dataSourceViewId: ModelId;
-    names: string[];
-    sIds: string[];
-    pictureUrls: string[];
-  }[][];
+  for (const link of dataSourceConfigLinks) {
+    if (link.mcpServerConfigurationId === null) {
+      continue;
+    }
+    const mcpConfig = mcpConfigById.get(link.mcpServerConfigurationId);
+    if (!mcpConfig) {
+      continue;
+    }
+    const agent = dataSourceAgentById.get(mcpConfig.agentConfigurationId);
+    if (!agent) {
+      continue;
+    }
+    pushAgentForDataSourceView({
+      dataSourceViewId: link.dataSourceViewId,
+      agent,
+    });
+  }
 
-  const result = res
-    .flat()
-    .reduce<DataSourcesUsageByAgent>((acc, dsViewConfig) => {
-      let usage = acc[dsViewConfig.dataSourceViewId];
-
-      if (!usage) {
-        usage = {
-          count: 0,
-          agents: [],
-        };
-        acc[dsViewConfig.dataSourceViewId] = usage;
-      }
-
-      const newAgents = dsViewConfig.sIds
-        .map((sId, index) => ({
-          sId,
-          name: dsViewConfig.names[index],
-          pictureUrl: dsViewConfig.pictureUrls[index],
-        }))
-        .filter(
-          (agent) =>
-            agent.sId &&
-            agent.sId.length > 0 &&
-            agent.name &&
-            agent.name.length > 0
-        );
-
-      usage.agents.push(...newAgents);
-      return acc;
-    }, {});
+  for (const link of tableConfigLinks) {
+    const mcpConfig = mcpConfigById.get(link.mcpServerConfigurationId);
+    if (!mcpConfig) {
+      continue;
+    }
+    const agent = tableAgentById.get(mcpConfig.agentConfigurationId);
+    if (!agent) {
+      continue;
+    }
+    pushAgentForDataSourceView({
+      dataSourceViewId: link.dataSourceViewId,
+      agent,
+    });
+  }
 
   Object.values(result).forEach((usage) => {
     if (usage) {

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -52,12 +52,12 @@ const agentAggregates: ProjectionAlias[] = (
   alias,
 ]);
 
-export async function getDataSourceViewsUsageByIds({
+export async function getDataSourceViewsUsageByModelIds({
   auth,
-  dataSourceViewIds,
+  dataSourceViewModelIds,
 }: {
   auth: Authenticator;
-  dataSourceViewIds: ModelId[];
+  dataSourceViewModelIds: ModelId[];
 }): Promise<DataSourcesUsageByAgent> {
   const owner = auth.workspace();
 
@@ -72,8 +72,8 @@ export async function getDataSourceViewsUsageByIds({
     return {};
   }
 
-  const uniqueDataSourceViewIds = uniq(dataSourceViewIds);
-  if (uniqueDataSourceViewIds.length === 0) {
+  const uniqueDataSourceViewModelIds = uniq(dataSourceViewModelIds);
+  if (uniqueDataSourceViewModelIds.length === 0) {
     return {};
   }
 
@@ -84,7 +84,7 @@ export async function getDataSourceViewsUsageByIds({
       attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
       where: {
         workspaceId: owner.id,
-        dataSourceViewId: { [Op.in]: uniqueDataSourceViewIds },
+        dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
       },
     }),
     AgentTablesQueryConfigurationTableModel.findAll({
@@ -92,32 +92,32 @@ export async function getDataSourceViewsUsageByIds({
       attributes: ["dataSourceViewId", "mcpServerConfigurationId"],
       where: {
         workspaceId: owner.id,
-        dataSourceViewId: { [Op.in]: uniqueDataSourceViewIds },
+        dataSourceViewId: { [Op.in]: uniqueDataSourceViewModelIds },
       },
     }),
   ]);
 
   // Step 3: fetch the MCP server configuration -> agent configuration mappings
   // once for both sources.
-  const mcpServerConfigurationIds = uniq(
+  const mcpServerConfigurationModelIds = uniq(
     [...dataSourceConfigLinks, ...tableConfigLinks]
       .map((link) => link.mcpServerConfigurationId)
       .filter((id): id is ModelId => id !== null && id !== undefined)
   );
 
   const mcpConfigs =
-    mcpServerConfigurationIds.length > 0
+    mcpServerConfigurationModelIds.length > 0
       ? await AgentMCPServerConfigurationModel.findAll({
           raw: true,
           attributes: ["id", "agentConfigurationId"],
           where: {
             workspaceId: owner.id,
-            id: { [Op.in]: mcpServerConfigurationIds },
+            id: { [Op.in]: mcpServerConfigurationModelIds },
           },
         })
       : [];
 
-  const mcpConfigById = new Map(
+  const mcpConfigByModelId = new Map(
     mcpConfigs.map((config) => [config.id, config])
   );
 
@@ -149,19 +149,19 @@ export async function getDataSourceViewsUsageByIds({
   });
 
   // 4A. Agents for AgentDataSourceConfigurationModel links.
-  const dataSourceAgentConfigurationIds = uniq(
+  const dataSourceAgentConfigurationModelIds = uniq(
     dataSourceConfigLinks
       .map((link) =>
         link.mcpServerConfigurationId === null
           ? undefined
-          : mcpConfigById.get(link.mcpServerConfigurationId)
+          : mcpConfigByModelId.get(link.mcpServerConfigurationId)
               ?.agentConfigurationId
       )
       .filter((id): id is ModelId => id !== null && id !== undefined)
   );
 
   const dataSourceAgents =
-    dataSourceAgentConfigurationIds.length > 0
+    dataSourceAgentConfigurationModelIds.length > 0
       ? await AgentConfigurationModel.findAll({
           raw: true,
           attributes: ["id", "sId", "name", "pictureUrl"],
@@ -169,39 +169,42 @@ export async function getDataSourceViewsUsageByIds({
             ...(auth.isAdmin()
               ? getAgentWhereClauseAdmin()
               : await getAgentWhereClauseNonAdmin()),
-            id: { [Op.in]: dataSourceAgentConfigurationIds },
+            id: { [Op.in]: dataSourceAgentConfigurationModelIds },
           },
         })
       : [];
 
   // 4B. Agents for AgentTablesQueryConfigurationTableModel links.
-  const tableAgentConfigurationIds = uniq(
+  const tableAgentConfigurationModelIds = uniq(
     tableConfigLinks
       .map(
         (link) =>
-          mcpConfigById.get(link.mcpServerConfigurationId)?.agentConfigurationId
+          mcpConfigByModelId.get(link.mcpServerConfigurationId)
+            ?.agentConfigurationId
       )
       .filter((id): id is ModelId => id !== null && id !== undefined)
   );
 
   const tableAgents =
-    tableAgentConfigurationIds.length > 0
+    tableAgentConfigurationModelIds.length > 0
       ? await AgentConfigurationModel.findAll({
           raw: true,
           attributes: ["id", "sId", "name", "pictureUrl"],
           where: {
             status: "active",
             workspaceId: owner.id,
-            id: { [Op.in]: tableAgentConfigurationIds },
+            id: { [Op.in]: tableAgentConfigurationModelIds },
           },
         })
       : [];
 
   // Step 5: join in memory and build the result.
-  const dataSourceAgentById = new Map(
+  const dataSourceAgentByModelId = new Map(
     dataSourceAgents.map((agent) => [agent.id, agent])
   );
-  const tableAgentById = new Map(tableAgents.map((agent) => [agent.id, agent]));
+  const tableAgentByModelId = new Map(
+    tableAgents.map((agent) => [agent.id, agent])
+  );
 
   const result: DataSourcesUsageByAgent = {};
 
@@ -242,11 +245,11 @@ export async function getDataSourceViewsUsageByIds({
     if (link.mcpServerConfigurationId === null) {
       continue;
     }
-    const mcpConfig = mcpConfigById.get(link.mcpServerConfigurationId);
+    const mcpConfig = mcpConfigByModelId.get(link.mcpServerConfigurationId);
     if (!mcpConfig) {
       continue;
     }
-    const agent = dataSourceAgentById.get(mcpConfig.agentConfigurationId);
+    const agent = dataSourceAgentByModelId.get(mcpConfig.agentConfigurationId);
     if (!agent) {
       continue;
     }
@@ -257,11 +260,11 @@ export async function getDataSourceViewsUsageByIds({
   }
 
   for (const link of tableConfigLinks) {
-    const mcpConfig = mcpConfigById.get(link.mcpServerConfigurationId);
+    const mcpConfig = mcpConfigByModelId.get(link.mcpServerConfigurationId);
     if (!mcpConfig) {
       continue;
     }
-    const agent = tableAgentById.get(mcpConfig.agentConfigurationId);
+    const agent = tableAgentByModelId.get(mcpConfig.agentConfigurationId);
     if (!agent) {
       continue;
     }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -17,6 +17,7 @@ import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
 import sortBy from "lodash/sortBy";
 import uniq from "lodash/uniq";
 import uniqBy from "lodash/uniqBy";
@@ -100,9 +101,11 @@ export async function getDataSourceViewsUsageByModelIds({
   // Step 3: fetch the MCP server configuration -> agent configuration mappings
   // once for both sources.
   const mcpServerConfigurationModelIds = uniq(
-    [...dataSourceConfigLinks, ...tableConfigLinks]
-      .map((link) => link.mcpServerConfigurationId)
-      .filter((id): id is ModelId => id !== null && id !== undefined)
+    removeNulls(
+      [...dataSourceConfigLinks, ...tableConfigLinks].map(
+        (link) => link.mcpServerConfigurationId
+      )
+    )
   );
 
   const mcpConfigs =
@@ -150,14 +153,14 @@ export async function getDataSourceViewsUsageByModelIds({
 
   // 4A. Agents for AgentDataSourceConfigurationModel links.
   const dataSourceAgentConfigurationModelIds = uniq(
-    dataSourceConfigLinks
-      .map((link) =>
+    removeNulls(
+      dataSourceConfigLinks.map((link) =>
         link.mcpServerConfigurationId === null
           ? undefined
           : mcpConfigByModelId.get(link.mcpServerConfigurationId)
               ?.agentConfigurationId
       )
-      .filter((id): id is ModelId => id !== null && id !== undefined)
+    )
   );
 
   const dataSourceAgents =
@@ -176,13 +179,13 @@ export async function getDataSourceViewsUsageByModelIds({
 
   // 4B. Agents for AgentTablesQueryConfigurationTableModel links.
   const tableAgentConfigurationModelIds = uniq(
-    tableConfigLinks
-      .map(
+    removeNulls(
+      tableConfigLinks.map(
         (link) =>
           mcpConfigByModelId.get(link.mcpServerConfigurationId)
             ?.agentConfigurationId
       )
-      .filter((id): id is ModelId => id !== null && id !== undefined)
+    )
   );
 
   const tableAgents =
@@ -219,15 +222,6 @@ export async function getDataSourceViewsUsageByModelIds({
       pictureUrl: string;
     };
   }) => {
-    if (
-      !agent.sId ||
-      agent.sId.length === 0 ||
-      !agent.name ||
-      agent.name.length === 0
-    ) {
-      return;
-    }
-
     let usage = result[dataSourceViewId];
     if (!usage) {
       usage = { count: 0, agents: [] };


### PR DESCRIPTION
## Description

This PR refactors `getDataSourceViewsUsageByCategory` into `getDataSourceViewsUsageByIds`, replacing a single complex SQL query filtered by category with multiple lighter, targeted queries joined in memory.

- Takes a list of `dataSourceViewIds` directly instead of a category, eliminating the category-to-connector-provider switch logic
- Breaks the query into sequential steps: fetch config links (data source + table configs in parallel), resolve MCP server → agent mappings, then fetch agent configurations
- Joins results in memory rather than relying on heavy SQL joins

## Tests

Manually.

## Risks

Low. Easy to revert.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Standard deployment.

<!-- Outline the deployment steps. -->

