### PR TITLE
fix(voice): replace deprecated ScriptProcessorNode with AudioWorkletNode

### DIFF
--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -57,10 +57,17 @@ export function useVoiceLiveTranscriberService({
   // Keep latest callbacks in refs so the stable SDK closures always see fresh values.
   const onTranscribeDeltaRef = useRef(onTranscribeDelta);
   onTranscribeDeltaRef.current = onTranscribeDelta;
+  const onTranscribeCompleteRef = useRef(onTranscribeComplete);
+  onTranscribeCompleteRef.current = onTranscribeComplete;
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
   const sendNotification = useSendNotification();
+
+  // Tracks whether we are in the process of shutting down after a user-initiated stop.
+  // When true, the next committed_transcript triggers disconnect + onTranscribeComplete.
+  const isShuttingDownRef = useRef(false);
+  const shutdownTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const cleanup = useCallback(() => {
     if (levelIntervalRef.current !== null) {
@@ -86,11 +93,30 @@ export function useVoiceLiveTranscriberService({
     setLevel(0);
   }, []);
 
+  // Finalizes shutdown after the committed_transcript from a user stop is received,
+  // or on the safety timeout if the server never responds.
+  const finishShutdown = useCallback(() => {
+    if (!isShuttingDownRef.current) {
+      return;
+    }
+    if (shutdownTimeoutRef.current !== null) {
+      clearTimeout(shutdownTimeoutRef.current);
+      shutdownTimeoutRef.current = null;
+    }
+    isShuttingDownRef.current = false;
+    scribeRef.current.disconnect();
+    setStatus("idle");
+    onTranscribeCompleteRef.current?.();
+  }, []);
+
   const handleCommittedTranscript = useCallback(
     ({ text }: { text: string }) => {
       onTranscribeDeltaRef.current?.(text);
+      // If we committed as part of a user-initiated stop, disconnect now that
+      // the server has delivered the final transcript.
+      finishShutdown();
     },
-    []
+    [finishShutdown]
   );
 
   const handleError = useCallback(
@@ -98,6 +124,11 @@ export function useVoiceLiveTranscriberService({
       const error =
         err instanceof Error ? err : new Error("Transcription error.");
       onErrorRef.current?.(error);
+      if (shutdownTimeoutRef.current !== null) {
+        clearTimeout(shutdownTimeoutRef.current);
+        shutdownTimeoutRef.current = null;
+      }
+      isShuttingDownRef.current = false;
       cleanup();
       setStatus("idle");
     },
@@ -213,12 +244,23 @@ export function useVoiceLiveTranscriberService({
       return;
     }
 
-    scribeRef.current.disconnect();
+    // 1. Stop audio capture so no more audio is sent to the WebSocket.
     cleanup();
-    setStatus("idle");
 
-    onTranscribeComplete?.();
-  }, [status, onTranscribeComplete, cleanup]);
+    // 2. Force-commit buffered audio so the server flushes any pending transcript.
+    //    Guard against a second invocation while a shutdown is already in progress
+    //    (isShuttingDownRef is a ref so it updates synchronously, unlike React state).
+    if (!isShuttingDownRef.current) {
+      scribeRef.current.commit();
+    }
+
+    // 3. Mark shutdown pending — handleCommittedTranscript will disconnect once the
+    //    server delivers the committed_transcript response to the commit above.
+    isShuttingDownRef.current = true;
+
+    // 4. Safety timeout: force-close if the server never delivers a committed_transcript.
+    shutdownTimeoutRef.current = setTimeout(finishShutdown, 2000);
+  }, [status, cleanup, finishShutdown]);
 
   return owner.metadata?.allowVoiceTranscription !== false
     ? { status, level, elapsedSeconds, startRecording, stopRecording }

--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -24,13 +24,30 @@ interface UseVoiceLiveTranscriberServiceParams {
 
 export type VoiceLiveTranscriberService = VoiceTranscriberService;
 
-function float32ToInt16(input: Float32Array): Int16Array {
-  const output = new Int16Array(input.length);
-  for (let i = 0; i < input.length; i++) {
-    const s = Math.max(-1, Math.min(1, input[i]));
-    output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+// AudioWorklet processor: converts float32 PCM to int16 and transfers the buffer
+// to the main thread. Runs on the dedicated audio-rendering thread (not main thread).
+const PCM_WORKLET_CODE = `
+class PCMProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      const float32 = input[0];
+      const int16 = new Int16Array(float32.length);
+      for (let i = 0; i < float32.length; i++) {
+        const s = Math.max(-1, Math.min(1, float32[i]));
+        int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      this.port.postMessage(int16.buffer, [int16.buffer]);
+    }
+    return true;
   }
-  return output;
+}
+registerProcessor('pcm-processor', PCMProcessor);
+`;
+
+function createPCMWorkletURL(): string {
+  const blob = new Blob([PCM_WORKLET_CODE], { type: "application/javascript" });
+  return URL.createObjectURL(blob);
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -50,7 +67,7 @@ export function useVoiceLiveTranscriberService({
 
   const streamRef = useRef<MediaStream | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
-  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const processorRef = useRef<AudioWorkletNode | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const levelIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -201,20 +218,19 @@ export function useVoiceLiveTranscriberService({
         setLevel
       );
 
-      // ScriptProcessorNode captures raw PCM and forwards it to Scribe.
-      // eslint-disable-next-line deprecation/deprecation
-      const processor = audioContext.createScriptProcessor(4096, 1, 1);
-      processorRef.current = processor;
-      source.connect(processor);
-      // ScriptProcessorNode must be connected to destination to fire onaudioprocess.
-      processor.connect(audioContext.destination);
+      // AudioWorkletNode captures raw PCM on the audio thread and posts int16 buffers
+      // to the main thread, which forwards them to Scribe.
+      const workletUrl = createPCMWorkletURL();
+      await audioContext.audioWorklet.addModule(workletUrl);
+      URL.revokeObjectURL(workletUrl);
 
-      processor.onaudioprocess = (e) => {
-        const inputData = e.inputBuffer.getChannelData(0);
-        const int16 = float32ToInt16(inputData);
-        const b64 = arrayBufferToBase64(int16.buffer as ArrayBuffer);
+      const workletNode = new AudioWorkletNode(audioContext, "pcm-processor");
+      workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
+        const b64 = arrayBufferToBase64(event.data);
         scribeRef.current.sendAudio(b64, { sampleRate: 16000 });
       };
+      source.connect(workletNode);
+      processorRef.current = workletNode;
 
       setStatus("recording");
     } catch (err) {


### PR DESCRIPTION
## Description

Replaces the deprecated `ScriptProcessorNode` with `AudioWorkletNode` for PCM audio capture in the voice live transcriber.

`ScriptProcessorNode` runs on the main thread and is deprecated in the Web Audio API spec. The new implementation uses an `AudioWorkletNode` with an inline processor (serialized to a Blob URL) that runs on the dedicated audio-rendering thread, then transfers int16 buffers back to the main thread via `postMessage` with transferable buffers — avoiding any copy overhead.

## Tests

Tested manually by recording voice input and verifying transcription works correctly with the new worklet.
