### PR TITLE
feat(voice): animate partial transcripts with AnimatedText

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -771,10 +771,14 @@ const InputBarContainer = ({
 
   const voiceLiveTranscriberService = useVoiceLiveTranscriberService({
     owner,
+    onPartialTranscript: (text) => {
+      editorService.setVoicePartialText(text);
+    },
     onTranscribeDelta: (text) => {
-      editorService.appendText(text);
+      editorService.commitVoicePartialText(text);
     },
     onTranscribeComplete: () => {
+      editorService.finalizeVoicePartial();
       if (isCompactRef.current) {
         void submitCompactVoiceMessageRef.current?.();
       }

--- a/front/components/editor/extensions/VoicePartialExtension.tsx
+++ b/front/components/editor/extensions/VoicePartialExtension.tsx
@@ -1,0 +1,47 @@
+import { AnimatedText } from "@dust-tt/sparkle";
+import type { NodeViewProps } from "@tiptap/core";
+import { Node } from "@tiptap/core";
+import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+
+function VoicePartialNodeView({ node }: NodeViewProps) {
+  return (
+    <NodeViewWrapper as="span" className="inline">
+      <AnimatedText variant="muted">{node.attrs.text as string}</AnimatedText>
+    </NodeViewWrapper>
+  );
+}
+
+export const VoicePartialNode = Node.create({
+  name: "voicePartial",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      text: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-voice-partial]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["span", { ...HTMLAttributes, "data-voice-partial": "" }];
+  },
+
+  // Used by doc.textBetween and plain-text extractions.
+  renderText({ node }) {
+    return node.attrs.text as string;
+  },
+
+  // Used by @tiptap/markdown when serializing to markdown (e.g. on submit while
+  // a partial is still pending). Outputs the partial text as-is.
+  renderMarkdown: (node) => (node.attrs?.text as string) ?? "",
+
+  addNodeView() {
+    return ReactNodeViewRenderer(VoicePartialNodeView);
+  },
+});

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -12,6 +12,7 @@ import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
+import { VoicePartialNode } from "@app/components/editor/extensions/VoicePartialExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { emojiPluginKey } from "@app/components/editor/input_bar/emojiSuggestion";
@@ -54,6 +55,97 @@ const useEditorService = (editor: Editor | null) => {
       // Append text at the end of the document (always at the end, regardless of cursor position).
       appendText: (text: string) => {
         editor?.chain().focus("end").insertContent(text).run();
+      },
+      // Insert or update the animated voicePartial node at the end of the document.
+      // Called on each partial transcript while voice recording is active.
+      setVoicePartialText: (text: string) => {
+        if (!editor) {
+          return;
+        }
+        let partialPos: number | null = null;
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "voicePartial" && partialPos === null) {
+            partialPos = pos;
+            return false;
+          }
+          return true;
+        });
+        if (partialPos !== null) {
+          const p = partialPos;
+          editor
+            .chain()
+            .command(({ tr }) => {
+              tr.setNodeMarkup(p, undefined, { text });
+              return true;
+            })
+            .run();
+        } else {
+          editor
+            .chain()
+            .focus("end")
+            .insertContent({ type: "voicePartial", attrs: { text } })
+            .run();
+        }
+      },
+      // Replace the voicePartial node with the committed plain text.
+      // Called when the transcription engine finalizes a segment.
+      commitVoicePartialText: (committedText: string) => {
+        if (!editor) {
+          return;
+        }
+        let found = false;
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "voicePartial" && !found) {
+            found = true;
+            const nodeSize = node.nodeSize;
+            editor
+              .chain()
+              .command(({ tr }) => {
+                if (committedText) {
+                  tr.replaceWith(
+                    pos,
+                    pos + nodeSize,
+                    editor.schema.text(committedText)
+                  );
+                } else {
+                  tr.delete(pos, pos + nodeSize);
+                }
+                return true;
+              })
+              .run();
+            return false;
+          }
+          return true;
+        });
+        if (!found && committedText) {
+          editor.chain().focus("end").insertContent(committedText).run();
+        }
+      },
+      // Convert any pending voicePartial node to plain text in place.
+      // Called when recording stops to finalize whatever partial was last shown.
+      finalizeVoicePartial: () => {
+        if (!editor) {
+          return;
+        }
+        editor.state.doc.descendants((node, pos) => {
+          if (node.type.name === "voicePartial") {
+            const text = node.attrs.text as string;
+            const nodeSize = node.nodeSize;
+            editor
+              .chain()
+              .command(({ tr }) => {
+                if (text) {
+                  tr.replaceWith(pos, pos + nodeSize, editor.schema.text(text));
+                } else {
+                  tr.delete(pos, pos + nodeSize);
+                }
+                return true;
+              })
+              .run();
+            return false;
+          }
+          return true;
+        });
       },
       // Insert mention helper function.
       insertMention: ({
@@ -341,6 +433,7 @@ export const buildEditorExtensions = ({
     SkillNode.configure({
       onSkillDetails: slashSuggestion?.onSkillDetails,
     }),
+    VoicePartialNode,
     createEmojiExtension({ onActiveChange: notifySuggestionActiveChange }),
     Placeholder.configure({
       placeholder: ({ node }) => {

--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -17,6 +17,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseVoiceLiveTranscriberServiceParams {
   owner: LightWorkspaceType;
+  // Called on each partial transcript — insert or update the pending animated node.
+  onPartialTranscript?: (text: string) => void;
+  // Called when the engine commits a segment — replace the animated node with plain text.
   onTranscribeDelta?: (text: string) => void;
   onTranscribeComplete?: () => void;
   onError?: (error: Error) => void;
@@ -57,6 +60,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 
 export function useVoiceLiveTranscriberService({
   owner,
+  onPartialTranscript,
   onTranscribeDelta,
   onTranscribeComplete,
   onError,
@@ -72,6 +76,8 @@ export function useVoiceLiveTranscriberService({
   const levelIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // Keep latest callbacks in refs so the stable SDK closures always see fresh values.
+  const onPartialTranscriptRef = useRef(onPartialTranscript);
+  onPartialTranscriptRef.current = onPartialTranscript;
   const onTranscribeDeltaRef = useRef(onTranscribeDelta);
   onTranscribeDeltaRef.current = onTranscribeDelta;
   const onTranscribeCompleteRef = useRef(onTranscribeComplete);
@@ -126,6 +132,10 @@ export function useVoiceLiveTranscriberService({
     onTranscribeCompleteRef.current?.();
   }, []);
 
+  const handlePartialTranscript = useCallback(({ text }: { text: string }) => {
+    onPartialTranscriptRef.current?.(text);
+  }, []);
+
   const handleCommittedTranscript = useCallback(
     ({ text }: { text: string }) => {
       onTranscribeDeltaRef.current?.(text);
@@ -157,6 +167,7 @@ export function useVoiceLiveTranscriberService({
     audioFormat: AudioFormat.PCM_16000,
     sampleRate: 16000,
     commitStrategy: CommitStrategy.VAD,
+    onPartialTranscript: handlePartialTranscript,
     onCommittedTranscript: handleCommittedTranscript,
     onError: handleError,
   });
@@ -227,7 +238,9 @@ export function useVoiceLiveTranscriberService({
       const workletNode = new AudioWorkletNode(audioContext, "pcm-processor");
       workletNode.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
         const b64 = arrayBufferToBase64(event.data);
-        scribeRef.current.sendAudio(b64, { sampleRate: 16000 });
+        if (!isShuttingDownRef.current || scribeRef.current.isConnected) {
+          scribeRef.current.sendAudio(b64, { sampleRate: 16000 });
+        }
       };
       source.connect(workletNode);
       processorRef.current = workletNode;


### PR DESCRIPTION
## Description

Animates partial transcripts in the input bar editor during voice recording using `AnimatedText` from Sparkle.

Stacked on #27553.

Previously, committed transcript segments were appended as plain text directly. This PR adds real-time visual feedback for in-flight (partial) transcripts:

- A new `VoicePartialNode` TipTap extension renders a `voicePartial` inline atom node that wraps `AnimatedText` with `variant="muted"`, giving a visual cue that the text is still being recognized.
- `useCustomEditor` gains three editor service methods: `setVoicePartialText` (insert/update the partial node), `commitVoicePartialText` (replace the partial with final plain text), and `finalizeVoicePartial` (flush any remaining partial on stop).
- `useVoiceLiveTranscriberService` now accepts an `onPartialTranscript` callback wired to ElevenLabs Scribe's `onPartialTranscript` event, in addition to the existing `onTranscribeDelta` (committed segments).
- `InputBarContainer` wires these three callbacks together so the editor animates partials live and commits them on each VAD-triggered segment.

https://github.com/user-attachments/assets/e159a999-3b32-4721-ac89-dd9f15f052c5


