### PR TITLE
fix(usage): ceil agent message credit cost per execution to match Metronome billing (#27497)

### DIFF
--- a/front/lib/api/assistant/credit_cost.test.ts
+++ b/front/lib/api/assistant/credit_cost.test.ts
@@ -2,12 +2,15 @@ import { computeAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import {
   awuFromMicroUsd,
   intelligenceAwuFromRunUsages,
+  intelligenceAwuFromRunUsagesGroupedByRunKey,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { describe, expect, it } from "vitest";
 
-function usage(overrides: Partial<RunUsageType>): RunUsageType {
+function usage(
+  overrides: Partial<RunUsageType & { runKey: string | null }>
+): RunUsageType & { runKey: string | null } {
   return {
     completionTokens: 0,
     promptTokens: 0,
@@ -17,6 +20,7 @@ function usage(overrides: Partial<RunUsageType>): RunUsageType {
     modelId: "gpt-4o",
     providerId: "openai",
     isBatch: false,
+    runKey: null,
     ...overrides,
   };
 }
@@ -56,6 +60,41 @@ describe("intelligenceAwuFromRunUsages", () => {
 
   it("returns 0 for no usages", () => {
     expect(intelligenceAwuFromRunUsages([])).toBe(0);
+  });
+});
+
+describe("intelligenceAwuFromRunUsagesGroupedByRunKey", () => {
+  it("ceils per runKey (execution) so it matches additive Metronome events on interrupt/resume", () => {
+    // Ceiling over the union (the old behavior) would undercount: ceil(10000/8500)=2
+    // here it happens to match, so use an uneven split to prove the difference.
+    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey([
+      usage({ costMicroUsd: 9000, runKey: "exec1" }), // ceil -> 2
+      usage({ costMicroUsd: 1000, runKey: "exec2" }), // ceil -> 1
+    ]);
+    expect(credits).toBe(3);
+  });
+
+  it("still ceils per (provider, model) within a single execution", () => {
+    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey([
+      usage({ costMicroUsd: 5000, modelId: "gpt-4o", runKey: "exec1" }),
+      usage({
+        costMicroUsd: 5000,
+        modelId: "claude-opus-4-8",
+        providerId: "anthropic",
+        runKey: "exec1",
+      }),
+    ]);
+    // Same execution, two models: ceil(5000)=1 per model -> 2.
+    expect(credits).toBe(2);
+  });
+
+  it("folds untagged (null runKey) usages into a single legacy group", () => {
+    const credits = intelligenceAwuFromRunUsagesGroupedByRunKey([
+      usage({ costMicroUsd: 9000, runKey: null }),
+      usage({ costMicroUsd: 1000, runKey: null }),
+    ]);
+    // Both summed before ceiling: ceil(10000/8500) = 2.
+    expect(credits).toBe(2);
   });
 });
 

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -3,7 +3,8 @@ import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  intelligenceAwuFromRunUsages,
+  computeRunKey,
+  intelligenceAwuFromRunUsagesGroupedByRunKey,
   isFreeOrigin,
   toolAwuFromActions,
 } from "@app/lib/metronome/events";
@@ -28,7 +29,7 @@ export function computeAgentMessageCredits({
   actions,
   isFreeUsage = false,
 }: {
-  runUsages: RunUsageType[];
+  runUsages: (RunUsageType & { runKey: string | null })[];
   actions: CreditActionMinimalInput[];
   isFreeUsage?: boolean;
 }): number | null {
@@ -44,8 +45,12 @@ export function computeAgentMessageCredits({
     return 0;
   }
 
+  // Intelligence cost is ceiled per agent-loop execution (runKey) to match the
+  // per-execution Metronome events. Tool cost has no ceiling (fixed 1/3 per
+  // action), so it is grouping-invariant and stays message-level.
   return (
-    intelligenceAwuFromRunUsages(runUsages) + toolAwuFromActions(finalActions)
+    intelligenceAwuFromRunUsagesGroupedByRunKey(runUsages) +
+    toolAwuFromActions(finalActions)
   );
 }
 
@@ -61,10 +66,18 @@ export function computeAgentMessageCredits({
  * Computes from the message's full accumulated runIds + all final-status actions (the message-level
  * total), so re-runs (interrupt/resume) overwrite the stored value with the complete cost. Only
  * persists for statuses we track for billing, matching the Metronome gate.
+ *
+ * Before recomputing, this execution's runs are tagged with their runKey (from `dustRunIds`) so the
+ * intelligence cost is ceiled per agent-loop execution — exactly matching the per-execution
+ * Metronome events. Tagging is idempotent (same runIds → same runKey), so it stays overwrite-safe
+ * across Temporal retries.
  */
 export async function computeAndStoreAgentMessageCredits(
   auth: Authenticator,
-  { agentMessageId }: { agentMessageId: string }
+  {
+    agentMessageId,
+    dustRunIds,
+  }: { agentMessageId: string; dustRunIds?: string[] }
 ): Promise<number | null> {
   const creditContext =
     await ConversationResource.fetchAgentMessageCreditContext(auth, {
@@ -84,6 +97,17 @@ export async function computeAndStoreAgentMessageCredits(
 
   if (!AGENT_MESSAGE_STATUSES_TO_TRACK.includes(status)) {
     return null;
+  }
+
+  // Tag this execution's runs with their runKey before recomputing, so the
+  // recompute (which reads the message's full accumulated runIds) ceils each
+  // execution's intelligence cost independently. Prior executions tagged their
+  // own runs in their own finalize.
+  if (dustRunIds && dustRunIds.length > 0) {
+    await RunResource.setRunKeyForDustRunIds(auth, {
+      dustRunIds,
+      runKey: computeRunKey(dustRunIds),
+    });
   }
 
   const [runUsages, actions] = await Promise.all([
@@ -140,7 +164,7 @@ export async function computeAndStoreAgentMessageCredits(
 async function fetchRunUsagesForAgentMessage(
   auth: Authenticator,
   runIds: string[] | null
-): Promise<RunUsageType[]> {
+): Promise<(RunUsageType & { runKey: string | null })[]> {
   const dustRunIds = [...new Set(runIds ?? [])];
   if (dustRunIds.length === 0) {
     return [];

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -220,6 +220,23 @@ function getToolUsageType(
 }
 
 // ---------------------------------------------------------------------------
+// Run key
+// ---------------------------------------------------------------------------
+
+// Identifies a single agent-loop execution by the set of dustRunIds it
+// produced. Same runIds → same key (so Metronome deduplicates retries and the
+// credit-cost recompute groups runs the same way); a new execution
+// (interrupt/resume) has different runIds → different key → additive billing.
+// The credit-cost flow ceils intelligence cost per key, exactly matching the
+// per-execution Metronome events.
+export function computeRunKey(dustRunIds: string[]): string {
+  return createHash("sha256")
+    .update([...dustRunIds].sort().join(","))
+    .digest("hex")
+    .slice(0, 8);
+}
+
+// ---------------------------------------------------------------------------
 // AWU credit conversion helpers
 // ---------------------------------------------------------------------------
 // These are the single source of truth for converting raw usage into AWU
@@ -234,9 +251,13 @@ export function awuFromMicroUsd(microUsd: number): number {
   return Math.ceil(microUsd / 0.85 / 10_000);
 }
 
-// Intelligence (AI compute) credits for a set of run usages. Usages are
-// grouped by (providerId, modelId) and converted per group before summing —
-// this mirrors `buildLlmUsageEvents` so the total equals the billed amount.
+// Intelligence (AI compute) credits for a *single execution's* run usages.
+// Usages are grouped by (providerId, modelId) and converted per group before
+// summing — this mirrors the per-execution `buildLlmUsageEvents` event so the
+// total equals the billed amount for that execution. To get the message-level
+// total across interrupt/resume executions, use
+// `intelligenceAwuFromRunUsagesGroupedByRunKey` (which ceils per execution),
+// not this directly over the union of all runs.
 export function intelligenceAwuFromRunUsages(
   runUsages: RunUsageType[]
 ): number {
@@ -250,6 +271,35 @@ export function intelligenceAwuFromRunUsages(
   let total = 0;
   for (const costMicroUsd of costByModel.values()) {
     total += awuFromMicroUsd(costMicroUsd);
+  }
+  return total;
+}
+
+// Synthetic group for run usages whose run has no runKey yet (legacy rows, or
+// non-agent-loop runs). They are summed together so behavior matches the old
+// single-ceil computation for them.
+const LEGACY_RUN_KEY = "__legacy__";
+
+// Intelligence credits for an agent message, ceiling per agent-loop execution
+// (runKey) to exactly match the per-execution Metronome events. Metronome emits
+// one additive event per execution (interrupt/resume → new runKey → new event),
+// each ceiling per (providerId, modelId). Ceiling over the union of executions
+// instead would undercount (`ceil(a) + ceil(b) >= ceil(a + b)`), so we group by
+// runKey first, ceil each group via `intelligenceAwuFromRunUsages`, then sum.
+export function intelligenceAwuFromRunUsagesGroupedByRunKey(
+  runUsages: (RunUsageType & { runKey: string | null })[]
+): number {
+  const byRunKey = new Map<string, RunUsageType[]>();
+  for (const usage of runUsages) {
+    const key = usage.runKey ?? LEGACY_RUN_KEY;
+    const group = byRunKey.get(key) ?? [];
+    group.push(usage);
+    byRunKey.set(key, group);
+  }
+
+  let total = 0;
+  for (const group of byRunKey.values()) {
+    total += intelligenceAwuFromRunUsages(group);
   }
   return total;
 }

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -172,6 +172,27 @@ export class RunResource extends BaseResource<RunModel> {
     return runs.map((r) => new this(this.model, r.get()));
   }
 
+  // Tag an agent-loop execution's runs with their runKey so credit cost can be
+  // ceiled per execution group (matching the Metronome billing partition).
+  // Idempotent: a finalize retry recomputes the same key for the same runIds.
+  static async setRunKeyForDustRunIds(
+    auth: Authenticator,
+    { dustRunIds, runKey }: { dustRunIds: string[]; runKey: string }
+  ): Promise<void> {
+    if (dustRunIds.length === 0) {
+      return;
+    }
+    await this.model.update(
+      { runKey },
+      {
+        where: {
+          dustRunId: { [Op.in]: dustRunIds },
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+  }
+
   static async listRunUsagesForRuns(
     auth: Authenticator,
     {
@@ -179,11 +200,20 @@ export class RunResource extends BaseResource<RunModel> {
     }: {
       runs: RunResource[];
     }
-  ): Promise<(RunUsageType & { runModelId: ModelId })[]> {
+  ): Promise<
+    (RunUsageType & { runModelId: ModelId; runKey: string | null })[]
+  > {
     const runModelIds = runs.map((run) => run.id);
     if (runModelIds.length === 0) {
       return [];
     }
+
+    // runKey identifies the agent-loop execution a run belongs to, so callers
+    // can group usages by execution (e.g. to ceil credit cost per the billed
+    // Metronome partition).
+    const runKeyByModelId = new Map<ModelId, string | null>(
+      runs.map((run) => [run.id, run.runKey])
+    );
 
     const usages = await RunUsageModel.findAll({
       where: {
@@ -194,6 +224,7 @@ export class RunResource extends BaseResource<RunModel> {
 
     return usages.map((usage) => ({
       runModelId: usage.runId,
+      runKey: runKeyByModelId.get(usage.runId) ?? null,
       completionTokens: usage.completionTokens,
       modelId: usage.modelId as ModelIdType,
       promptTokens: usage.promptTokens,

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -11,6 +11,11 @@ export class RunModel extends WorkspaceAwareModel<RunModel> {
   declare dustRunId: string;
   declare runType: string;
   declare useWorkspaceCredentials: boolean | null;
+  // Identifies the agent-loop execution this run belongs to (sha256 of the
+  // execution's sorted dustRunIds). Set at finalize so per-execution credit
+  // costs can be ceiled per group, matching the Metronome billing partition.
+  // Null for non-agent-loop runs and legacy rows.
+  declare runKey: string | null;
 
   declare appId: ForeignKey<AppModel["id"]> | null;
 
@@ -39,6 +44,10 @@ RunModel.init(
     },
     useWorkspaceCredentials: {
       type: DataTypes.BOOLEAN,
+      allowNull: true,
+    },
+    runKey: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
   },

--- a/front/migrations/pre-deploy/20260618094013_add_run_key_to_runs.sql
+++ b/front/migrations/pre-deploy/20260618094013_add_run_key_to_runs.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."runs" ADD COLUMN "runKey" character varying(255) COLLATE "pg_catalog"."default";

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -31,9 +31,7 @@ export async function finalizeSuccessfulAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
-    computeAndStoreAgentMessageCredits(auth, {
-      agentMessageId: agentLoopArgs.agentMessageId,
-    }),
+    computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
     sendEmailReplyOnCompletion(auth, agentLoopArgs),
@@ -59,9 +57,7 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
-    computeAndStoreAgentMessageCredits(auth, {
-      agentMessageId: agentLoopArgs.agentMessageId,
-    }),
+    computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
   ]);
@@ -88,9 +84,7 @@ export async function finalizeInterruptedAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
-    computeAndStoreAgentMessageCredits(auth, {
-      agentMessageId: agentLoopArgs.agentMessageId,
-    }),
+    computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
     conversationUnreadNotification(auth, agentLoopArgs),
     handleMentions(auth, agentLoopArgs),
   ]);
@@ -109,9 +103,7 @@ export async function finalizeCancelledAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
-    computeAndStoreAgentMessageCredits(auth, {
-      agentMessageId: agentLoopArgs.agentMessageId,
-    }),
+    computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
     sendEmailReplyOnError(
       auth,
       agentLoopArgs,
@@ -134,9 +126,7 @@ export async function finalizeErroredAgentLoopActivity(
     launchAgentMessageAnalytics(auth, agentLoopArgs),
     launchTrackProgrammaticUsage(auth, agentLoopArgs),
     launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
-    computeAndStoreAgentMessageCredits(auth, {
-      agentMessageId: agentLoopArgs.agentMessageId,
-    }),
+    computeAndStoreAgentMessageCredits(auth, agentLoopArgs),
     sendEmailReplyOnError(
       auth,
       agentLoopArgs,

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -10,6 +10,7 @@ import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
   buildLlmUsageEvents,
   buildToolUseEvents,
+  computeRunKey,
   getUsageType,
 } from "@app/lib/metronome/events";
 import {
@@ -40,7 +41,6 @@ import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { isHiddenHelperSubAgentId } from "@app/types/assistant/assistant";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
-import { createHash } from "crypto";
 
 export async function recordUsageActivity(workspaceId: string) {
   const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -367,10 +367,9 @@ export async function emitMetronomeUsageEventsActivity(
   // Deterministic runKey based on the specific dustRunIds being processed.
   // Same runIds → same transaction IDs → Metronome deduplicates retries.
   // Different runIds (new agent loop execution) → different transaction IDs.
-  const runKey = createHash("sha256")
-    .update(effectiveRunIds.sort().join(","))
-    .digest("hex")
-    .slice(0, 8);
+  // Shared with the credit-cost flow (computeRunKey) so the credit recompute
+  // ceils per the exact same execution partition that is billed here.
+  const runKey = computeRunKey(effectiveRunIds);
 
   // Build and ingest events.
   const llmEvents = buildLlmUsageEvents({


### PR DESCRIPTION
## Description

The per-message `costCredits` we persist did not match what Metronome bills once an agent loop is interrupted and resumed.

Metronome emits **one additive `llm_usage` event per execution** (a resume produces a new `runKey` → a new, non-deduplicated event), and ceils the AWU conversion per `(providerId, modelId)` *within each execution*. The credit-cost recompute instead fetched the message's full accumulated `runIds` and ceiled once over the union of all executions. Since `ceil(a) + ceil(b) >= ceil(a + b)`, the stored `costCredits` undercounted billing by the fractional remainders lost at each execution boundary.

This change makes the credit cost ceil **per execution (runKey)**, exactly matching the per-execution Metronome events, while staying idempotent (overwrite, not `+=`).

- New nullable `runKey` column on `runs`, tagged at finalize from the execution's `dustRunIds` via a shared `computeRunKey` helper (same hash the Metronome flow uses, so the two cannot drift).
- `intelligenceAwuFromRunUsagesGroupedByRunKey` groups usages by execution, ceils each group per `(provider, model)`, then sums. Untagged (`null` runKey) runs fold into a single legacy group, preserving prior behavior for historical rows.
- Tool credits stay message-level (fixed 1/3 per action, no ceiling → grouping-invariant).

## Tests

- Unit tests in `credit_cost.test.ts` cover the interrupt/resume case (per-execution ceiling beats union ceiling), per-`(provider, model)` ceiling within a single execution, and the legacy `null`-runKey fold. `npm run test -- credit_cost` passes (14/14).

## Deploy Plan

- Pre-deploy migration adds the nullable `runKey` column (metadata-only `ADD COLUMN`, no index, no table rewrite). Run before the new code goes live.
- Forward-only: runs created before deploy keep `runKey = null` and fall into the legacy single-ceil group (unchanged behavior). New messages get exact Metronome parity.
