### PR TITLE
Fix dust-hive connectors DB init after initdb tooling removal

### DIFF
--- a/x/henry/dust-hive/biome.json
+++ b/x/henry/dust-hive/biome.json
@@ -1,12 +1,10 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "complexity": {
         "noExcessiveCognitiveComplexity": "error",
         "noForEach": "warn",
@@ -26,8 +24,8 @@
         "useNodejsImportProtocol": "error"
       },
       "suspicious": {
-        "noConsoleLog": "off",
-        "noExplicitAny": "error"
+        "noExplicitAny": "error",
+        "noConsole": { "level": "off", "options": { "allow": ["log"] } }
       },
       "performance": {
         "noAccumulatingSpread": "error",
@@ -49,6 +47,6 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", "*.log", "bun.lockb"]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/*.log", "!**/bun.lockb"]
   }
 }

--- a/x/henry/dust-hive/bun.lock
+++ b/x/henry/dust-hive/bun.lock
@@ -11,30 +11,30 @@
         "zod": "^4.3.5",
       },
       "devDependencies": {
-        "@biomejs/biome": "^1.9.0",
+        "@biomejs/biome": "2.5.0",
         "@types/bun": "latest",
         "typescript": "^5.0.0",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
 
     "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 

--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -1,6 +1,6 @@
 import { requireEnvironment } from "../lib/commands";
 import { removeDockerVolumes, stopDocker } from "../lib/docker";
-import { type Environment, deleteEnvironmentDir, getEnvironment } from "../lib/environment";
+import { deleteEnvironmentDir, type Environment, getEnvironment } from "../lib/environment";
 import { directoryExists } from "../lib/fs";
 import { logger } from "../lib/logger";
 import { getConfiguredMultiplexer, getSessionName } from "../lib/multiplexer";
@@ -11,7 +11,7 @@ import { readPid, stopAllServices } from "../lib/process";
 import { restoreTerminal, selectMultipleEnvironments } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import type { ServiceName } from "../lib/services";
-import { type Settings, loadSettings } from "../lib/settings";
+import { loadSettings, type Settings } from "../lib/settings";
 import { isDockerRunning } from "../lib/state";
 import { getTemporalNamespaces } from "../lib/temporal";
 import { isTemporalServerRunning } from "../lib/temporal-server";

--- a/x/henry/dust-hive/src/commands/forward.ts
+++ b/x/henry/dust-hive/src/commands/forward.ts
@@ -2,7 +2,7 @@ import { getEnvironment } from "../lib/environment";
 import { getForwarderStatus, startForwarder, stopForwarder } from "../lib/forward";
 import { FORWARDER_MAPPINGS } from "../lib/forwarderConfig";
 import { logger } from "../lib/logger";
-import { FORWARDER_LOG_PATH, detectEnvFromCwd } from "../lib/paths";
+import { detectEnvFromCwd, FORWARDER_LOG_PATH } from "../lib/paths";
 import { isServiceRunning } from "../lib/process";
 import { restoreTerminal, selectEnvironment } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";

--- a/x/henry/dust-hive/src/commands/logs.ts
+++ b/x/henry/dust-hive/src/commands/logs.ts
@@ -5,7 +5,7 @@ import { withEnvironment } from "../lib/commands";
 import { getLogPath } from "../lib/paths";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { ensureServiceLogsTui } from "../lib/scripts";
-import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
+import { ALL_SERVICES, isServiceName, type ServiceName } from "../lib/services";
 
 interface LogsOptions {
   follow?: boolean;

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -2,15 +2,15 @@ import { setLastActiveEnv } from "../lib/activity";
 import { type Environment, getEnvironment } from "../lib/environment";
 import { logger } from "../lib/logger";
 import {
+  getConfiguredMultiplexer,
+  getSessionName,
   type LayoutConfig,
   MAIN_SESSION_NAME,
   type MainLayoutConfig,
-  getConfiguredMultiplexer,
-  getSessionName,
 } from "../lib/multiplexer";
 import { getEnvFilePath, getWorktreeDir } from "../lib/paths";
 import { selectEnvironmentWithFzf } from "../lib/prompt";
-import { CommandError, Err, Ok, type Result, envNotFoundError } from "../lib/result";
+import { CommandError, Err, envNotFoundError, Ok, type Result } from "../lib/result";
 
 interface OpenOptions {
   warmCommand?: string | undefined;

--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -5,7 +5,7 @@ import { stopService } from "../lib/process";
 import { restoreTerminal } from "../lib/prompt";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
+import { ALL_SERVICES, isServiceName, type ServiceName } from "../lib/services";
 
 async function selectService(): Promise<ServiceName | null> {
   const result = await p.select({

--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -4,20 +4,20 @@ import { setCacheSource } from "../lib/cache";
 import { writeDockerComposeOverride } from "../lib/docker";
 import { writeEnvSh } from "../lib/envgen";
 import {
-  type Environment,
-  type EnvironmentMetadata,
   createEnvironment,
   deleteEnvironmentDir,
+  type Environment,
+  type EnvironmentMetadata,
   environmentExists,
   validateEnvName,
 } from "../lib/environment";
 import { logger } from "../lib/logger";
-import { HIVES_DIR, findRepoRoot, getEnvFilePath, getWorktreeDir } from "../lib/paths";
+import { findRepoRoot, getEnvFilePath, getWorktreeDir, HIVES_DIR } from "../lib/paths";
 import type { PortAllocation } from "../lib/ports";
 import { allocateNextPort, calculatePorts, savePortAllocation } from "../lib/ports";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { type Settings, getBranchName, loadSettings } from "../lib/settings";
+import { getBranchName, loadSettings, type Settings } from "../lib/settings";
 import { installAllDependencies } from "../lib/setup";
 import { createTestDatabase, isTestPostgresRunning } from "../lib/test-postgres";
 import {

--- a/x/henry/dust-hive/src/commands/status.ts
+++ b/x/henry/dust-hive/src/commands/status.ts
@@ -2,7 +2,7 @@ import { withEnvironment } from "../lib/commands";
 import { getLogPath } from "../lib/paths";
 import type { PortAllocation } from "../lib/ports";
 import { isServiceRunning } from "../lib/process";
-import { SERVICE_REGISTRY, checkServiceHealth, getHealthChecks } from "../lib/registry";
+import { checkServiceHealth, getHealthChecks, SERVICE_REGISTRY } from "../lib/registry";
 import { Ok } from "../lib/result";
 import { ALL_SERVICES } from "../lib/services";
 import { getStateInfo, isDockerRunning } from "../lib/state";

--- a/x/henry/dust-hive/src/commands/sync.ts
+++ b/x/henry/dust-hive/src/commands/sync.ts
@@ -5,13 +5,13 @@ import { join } from "node:path";
 import {
   ALL_BINARIES,
   type Binary,
-  type SyncState,
   binaryExists,
   buildBinaries,
   coreChangedBetweenCommits,
   getHeadCommit,
   getSyncState,
   hashFile,
+  type SyncState,
   saveSyncState,
   setCacheSource,
 } from "../lib/cache";

--- a/x/henry/dust-hive/src/commands/up.ts
+++ b/x/henry/dust-hive/src/commands/up.ts
@@ -1,5 +1,5 @@
 import { logger } from "../lib/logger";
-import { TEMPORAL_PORT, findRepoRoot } from "../lib/paths";
+import { findRepoRoot, TEMPORAL_PORT } from "../lib/paths";
 import { checkMainRepoPreconditions } from "../lib/repo-preconditions";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { isTemporalServerRunning, startTemporalServer } from "../lib/temporal-server";

--- a/x/henry/dust-hive/src/lib/commands.ts
+++ b/x/henry/dust-hive/src/lib/commands.ts
@@ -3,7 +3,7 @@
 import { setLastActiveEnv } from "./activity";
 import { type Environment, getEnvironment } from "./environment";
 import { restoreTerminal, selectEnvironment } from "./prompt";
-import { CommandError, Err, Ok, type Result, envNotFoundError } from "./result";
+import { CommandError, Err, envNotFoundError, Ok, type Result } from "./result";
 
 export type EnvironmentNameArg = string | string[] | undefined;
 

--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -1,6 +1,6 @@
 // Data-driven database initialization with binary caching
 
-import { type InitBinary, binaryExists, getBinaryPath, getCacheSource } from "./cache";
+import { binaryExists, getBinaryPath, getCacheSource, type InitBinary } from "./cache";
 import { getServiceContainerId } from "./docker";
 import { buildPostgresUri, loadEnvVars } from "./env-utils";
 import type { Environment } from "./environment";
@@ -8,7 +8,7 @@ import { logger } from "./logger";
 import { getEnvFilePath, getWorktreeDir } from "./paths";
 import { runSqlSeed } from "./seed";
 import { buildShell } from "./shell";
-import { SEARCH_ATTRIBUTES, TEMPORAL_NAMESPACE_CONFIG, getTemporalNamespaces } from "./temporal";
+import { getTemporalNamespaces, SEARCH_ATTRIBUTES, TEMPORAL_NAMESPACE_CONFIG } from "./temporal";
 
 export { getTemporalNamespaces } from "./temporal";
 
@@ -423,10 +423,15 @@ async function runConnectorsDbInit(env: Environment): Promise<boolean> {
   const envShPath = getEnvFilePath(env.name);
   const worktreePath = getWorktreeDir(env.name, env.metadata.repoRoot);
 
+  // connectors/admin/init_db.sh (sequelize sync) was removed as deprecated initdb
+  // tooling (#27417). Schema setup now goes through the migration tooling, same as
+  // production: the baseline migration creates the full schema (tables, indexes,
+  // the unaccent extension, and notion search-vector triggers). Idempotent: a
+  // re-run reports "No pending migrations" and exits 0.
   const command = buildShell({
     sourceEnv: envShPath,
     sourceNvm: true,
-    run: "./admin/init_db.sh --unsafe",
+    run: "npm run migration:apply",
   });
 
   const proc = Bun.spawn(["bash", "-c", command], {
@@ -439,14 +444,7 @@ async function runConnectorsDbInit(env: Environment): Promise<boolean> {
   const stderr = await new Response(proc.stderr).text();
   await proc.exited;
 
-  // Treat "already exists" or "No migrations" as success (idempotent)
-  // Note: Postgres outputs "relation X already exists" which is caught by "already exists"
-  const alreadyExists =
-    stderr.includes("already exists") ||
-    stdout.includes("already exists") ||
-    stdout.includes("No migrations");
-
-  if (proc.exitCode !== 0 && !alreadyExists) {
+  if (proc.exitCode !== 0) {
     console.log(stdout);
     console.error(stderr);
     return false;

--- a/x/henry/dust-hive/src/lib/multiplexer/index.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/index.ts
@@ -11,7 +11,7 @@ import type { MultiplexerAdapter, MultiplexerType } from "./types";
 import { ZellijAdapter } from "./zellij";
 
 // Re-export types for convenience
-export type { MultiplexerAdapter, MultiplexerType, LayoutConfig, MainLayoutConfig } from "./types";
+export type { LayoutConfig, MainLayoutConfig, MultiplexerAdapter, MultiplexerType } from "./types";
 export { getSessionName, getTabName, MAIN_SESSION_NAME, SESSION_PREFIX } from "./types";
 
 /**

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -12,7 +12,7 @@ import type {
   MultiplexerAdapter,
   MultiplexerType,
 } from "./types";
-import { SESSION_PREFIX, getTabName } from "./types";
+import { getTabName, SESSION_PREFIX } from "./types";
 
 /**
  * Base directory for tmux layout scripts

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -13,7 +13,7 @@ import type {
   MultiplexerAdapter,
   MultiplexerType,
 } from "./types";
-import { SESSION_PREFIX, getTabName } from "./types";
+import { getTabName, SESSION_PREFIX } from "./types";
 
 /**
  * Base directory for zellij layouts

--- a/x/henry/dust-hive/src/lib/seed.ts
+++ b/x/henry/dust-hive/src/lib/seed.ts
@@ -10,7 +10,7 @@
 import { buildPostgresUri, loadEnvVars } from "./env-utils";
 import type { Environment } from "./environment";
 import { logger } from "./logger";
-import { SEED_USER_PATH, getEnvFilePath, getWorktreeDir } from "./paths";
+import { getEnvFilePath, getWorktreeDir, SEED_USER_PATH } from "./paths";
 import { buildShell, shellQuote } from "./shell";
 
 // Keep in sync with front/scripts/seed/* (workspace created by dust-hive seed SQL).

--- a/x/henry/dust-hive/tests/lib/paths.test.ts
+++ b/x/henry/dust-hive/tests/lib/paths.test.ts
@@ -6,7 +6,6 @@ import {
   CONFIG_ENV_PATH,
   DUST_HIVE_ENVS,
   DUST_HIVE_HOME,
-  HIVES_DIR,
   findRepoRoot,
   getDockerOverridePath,
   getEnvDir,
@@ -17,6 +16,7 @@ import {
   getPidPath,
   getPortsPath,
   getWorktreeDir,
+  HIVES_DIR,
 } from "../../src/lib/paths";
 
 describe("paths", () => {

--- a/x/henry/dust-hive/tests/lib/ports.test.ts
+++ b/x/henry/dust-hive/tests/lib/ports.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { BASE_PORT, PORT_INCREMENT, PORT_OFFSETS, calculatePorts } from "../../src/lib/ports";
+import { BASE_PORT, calculatePorts, PORT_INCREMENT, PORT_OFFSETS } from "../../src/lib/ports";
 
 describe("ports", () => {
   describe("calculatePorts", () => {

--- a/x/henry/dust-hive/tests/lib/registry.test.ts
+++ b/x/henry/dust-hive/tests/lib/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { calculatePorts } from "../../src/lib/ports";
-import { SERVICE_REGISTRY, WARM_SERVICES, getHealthChecks } from "../../src/lib/registry";
+import { getHealthChecks, SERVICE_REGISTRY, WARM_SERVICES } from "../../src/lib/registry";
 import { ALL_SERVICES } from "../../src/lib/services";
 
 describe("registry", () => {

--- a/x/henry/dust-hive/tests/lib/result.test.ts
+++ b/x/henry/dust-hive/tests/lib/result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { CommandError, Err, Ok, envNotFoundError } from "../../src/lib/result";
+import { CommandError, Err, envNotFoundError, Ok } from "../../src/lib/result";
 
 describe("result", () => {
   describe("Ok", () => {

--- a/x/henry/dust-hive/tests/lib/state.test.ts
+++ b/x/henry/dust-hive/tests/lib/state.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import type { ServiceName } from "../../src/lib/services";
 import {
-  type EnvironmentState,
-  type StateInfo,
   detectWarnings,
   determineState,
+  type EnvironmentState,
   formatState,
+  type StateInfo,
 } from "../../src/lib/state";
 
 describe("state", () => {


### PR DESCRIPTION
## Description

Env warming broke after #27417 removed `connectors/admin/init_db.sh`, failing with `bash: ./admin/init_db.sh: No such file or directory` and `DB schema init failed for: connectors`.

`runConnectorsDbInit` now runs `npm run migration:apply`, the same path production uses. The baseline migration builds the full schema (tables, indexes, the `unaccent` extension, notion search-vector triggers), so it fully replaces the old sequelize sync. Idempotent on re-warm: a second run reports "No pending migrations" and exits 0.

Second commit finishes the biome 2.5 upgrade from #27489, which bumped `@biomejs/biome` in package.json but left the lockfile and `biome.json` on 1.x, breaking the dust-hive CI on main (frozen install + lint). Regenerates the lockfile, migrates the config to the 2.x schema, and applies the import-ordering biome 2.x expects.

## Tests

Ran `npm run migration:apply` against a fresh hive connectors DB: full schema created. Re-ran it: "No pending migrations", exit 0. `bun run test` (198 pass), `tsc`, and `biome check` all clean locally for the dust-hive tool.

## Risk

Low. Dev tooling only, no production code.

## Deploy Plan

Standard deploy.