### PR TITLE
[LLM] Route credit-priced plans to EU Claude Sonnet 4.6 endpoint

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -340,7 +340,7 @@ function selectPreferredEndpoint<T extends { region: Region }>(
     {
       featureFlags,
       isEnterprise: isEnterpriseOrDust(plan),
-      creditPricing: isCreditPricedPlanPrefix(plan.code),
+      isCreditPriced: isCreditPricedPlanPrefix(plan.code),
     },
     {
       ...workspaceFilter,

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -34,10 +34,10 @@ import { getBatchEndpoints } from "@app/lib/llms/batch";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { getStreamEndpoints } from "@app/lib/llms/stream";
 import type {
-  EndpointFilter,
+  EndpointConfig,
   ValueFilter,
   Where,
-  WorkspaceFilter,
+  WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import { sortEndpointsByPreferredRegion } from "@app/lib/llms/utils/sort_endpoints";
 import { isModelId } from "@app/lib/model_constructors/types/model_ids";
@@ -302,9 +302,7 @@ function getProviderIdFilter(auth: Authenticator): ValueFilter<ProviderId> {
 }
 
 // Temporary helper while we have both systems
-export function getWorkspaceFilter(
-  auth: Authenticator
-): Where<WorkspaceFilter> {
+export function getWorkspaceFilter(auth: Authenticator): Where<EndpointConfig> {
   return {
     providerId: getProviderIdFilter(auth),
     region: getRegionFilter(auth),
@@ -324,8 +322,8 @@ function selectPreferredEndpoint<T extends { region: Region }>(
   featureFlags: WhitelistableFeature[],
   llmParameters: LLMParameters,
   getEndpoints: (
-    workspaceConfiguration: EndpointFilter,
-    inputCondition: Where<WorkspaceFilter>
+    workspaceConfiguration: WorkspaceConfig,
+    inputCondition: Where<EndpointConfig>
   ) => T[]
 ): T | null {
   // llmParameters.modelId is ModelIdType — narrow before filtering.

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -339,7 +339,7 @@ function selectPreferredEndpoint<T extends { region: Region }>(
   const endpoints = getEndpoints(
     {
       featureFlags,
-      enterprise: isEnterpriseOrDust(plan),
+      isEnterprise: isEnterpriseOrDust(plan),
       creditPricing: isCreditPricedPlanPrefix(plan.code),
     },
     {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -34,6 +34,7 @@ import { getBatchEndpoints } from "@app/lib/llms/batch";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { getStreamEndpoints } from "@app/lib/llms/stream";
 import type {
+  EndpointFilter,
   ValueFilter,
   Where,
   WorkspaceFilter,
@@ -323,10 +324,7 @@ function selectPreferredEndpoint<T extends { region: Region }>(
   featureFlags: WhitelistableFeature[],
   llmParameters: LLMParameters,
   getEndpoints: (
-    workspaceConfiguration: {
-      featureFlags: WhitelistableFeature[];
-      enterprise: boolean;
-    },
+    workspaceConfiguration: EndpointFilter,
     inputCondition: Where<WorkspaceFilter>
   ) => T[]
 ): T | null {
@@ -336,11 +334,13 @@ function selectPreferredEndpoint<T extends { region: Region }>(
   }
 
   const workspaceFilter = getWorkspaceFilter(auth);
+  const plan = auth.getNonNullablePlan();
 
   const endpoints = getEndpoints(
     {
       featureFlags,
-      enterprise: isEnterpriseOrDust(auth.getNonNullablePlan()),
+      enterprise: isEnterpriseOrDust(plan),
+      creditPricing: isCreditPricedPlanPrefix(plan.code),
     },
     {
       ...workspaceFilter,

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -2,9 +2,9 @@ import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batc
 import { DustAnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/llms/batch/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
 import type {
-  EndpointFilter,
+  EndpointConfig,
   Where,
-  WorkspaceFilter,
+  WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import type { BatchEndpointId } from "@app/lib/model_constructors/batch";
 
@@ -14,8 +14,8 @@ export const DUST_BATCH_ENDPOINTS = {
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;
 
 export function getBatchEndpoints(
-  workspaceConfiguration: EndpointFilter,
-  inputCondition: Where<WorkspaceFilter>
+  workspaceConfiguration: WorkspaceConfig,
+  inputCondition: Where<EndpointConfig>
 ) {
   return Object.values(DUST_BATCH_ENDPOINTS).filter((constructor) =>
     isEndpointAvailable(constructor, workspaceConfiguration, inputCondition)

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -1,9 +1,12 @@
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/llms/batch/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
-import type { Where, WorkspaceFilter } from "@app/lib/llms/types/filter";
+import type {
+  EndpointFilter,
+  Where,
+  WorkspaceFilter,
+} from "@app/lib/llms/types/filter";
 import type { BatchEndpointId } from "@app/lib/model_constructors/batch";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export const DUST_BATCH_ENDPOINTS = {
   [DustAnthropicGlobalClaudeSonnetFourDotSixBatch.id]:
@@ -11,10 +14,7 @@ export const DUST_BATCH_ENDPOINTS = {
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;
 
 export function getBatchEndpoints(
-  workspaceConfiguration: {
-    featureFlags: WhitelistableFeature[];
-    enterprise: boolean;
-  },
+  workspaceConfiguration: EndpointFilter,
   inputCondition: Where<WorkspaceFilter>
 ) {
   return Object.values(DUST_BATCH_ENDPOINTS).filter((constructor) =>

--- a/front/lib/llms/batch/types/configuration.ts
+++ b/front/lib/llms/batch/types/configuration.ts
@@ -1,9 +1,9 @@
-import type { EndpointFilter, Where } from "@app/lib/llms/types/filter";
+import type { Where, WorkspaceConfig } from "@app/lib/llms/types/filter";
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 
 export type DustBatchEndpointConfiguration<C extends InputConfig> =
   BaseEndpointConfiguration<C> & {
     // Filter
-    endpointFilter: Where<EndpointFilter>;
+    endpointFilter: Where<WorkspaceConfig>;
   };

--- a/front/lib/llms/batch/utils/is_endpoint_available.ts
+++ b/front/lib/llms/batch/utils/is_endpoint_available.ts
@@ -1,14 +1,14 @@
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
-import type { Where, WorkspaceFilter } from "@app/lib/llms/types/filter";
+import type {
+  EndpointFilter,
+  Where,
+  WorkspaceFilter,
+} from "@app/lib/llms/types/filter";
 import { matchesWhere } from "@app/lib/llms/utils/matches_where";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export function isEndpointAvailable(
   endpointConstructor: DustBatchEndpointConstructor,
-  workspaceConfiguration: {
-    featureFlags: WhitelistableFeature[];
-    enterprise: boolean;
-  },
+  workspaceConfiguration: EndpointFilter,
   inputCondition: Where<WorkspaceFilter>
 ) {
   // Availability is decided by matching a `where` condition from both sides:

--- a/front/lib/llms/batch/utils/is_endpoint_available.ts
+++ b/front/lib/llms/batch/utils/is_endpoint_available.ts
@@ -1,15 +1,15 @@
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import type {
-  EndpointFilter,
+  EndpointConfig,
   Where,
-  WorkspaceFilter,
+  WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import { matchesWhere } from "@app/lib/llms/utils/matches_where";
 
 export function isEndpointAvailable(
   endpointConstructor: DustBatchEndpointConstructor,
-  workspaceConfiguration: EndpointFilter,
-  inputCondition: Where<WorkspaceFilter>
+  workspaceConfiguration: WorkspaceConfig,
+  inputCondition: Where<EndpointConfig>
 ) {
   // Availability is decided by matching a `where` condition from both sides:
   //

--- a/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -9,7 +9,6 @@ export function WithDustClaudeSonnetFourDotSixConfig<
       "Anthropic's Claude Sonnet 4.6 model, balancing power and efficiency with enhanced reasoning capabilities (200k context).";
     static readonly defaultReasoningEffort = "medium";
     static readonly byok = true;
-    static readonly endpointFilter = {};
   }
 
   return DustClaudeSonnetFourDotSix;

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -10,7 +10,7 @@ export class DustAgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithDus
       {
         featureFlags: { contains: "use_vertex_for_supported_models" as const },
       },
-      { creditPricing: { eq: true } },
+      { isCreditPriced: { eq: true } },
     ],
   };
 }

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -4,6 +4,15 @@ import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_
 
 export class DustAgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithDustClaudeSonnetFourDotSixConfig(
   AgentPlatformEuropeClaudeSonnetFourDotSixStream
-) {}
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { creditPricing: { eq: true } },
+    ],
+  };
+}
 
 defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeSonnetFourDotSixStream);

--- a/front/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -4,6 +4,8 @@ import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_cons
 
 export class DustAnthropicGlobalClaudeSonnetFourDotSixStream extends WithDustClaudeSonnetFourDotSixConfig(
   AnthropicGlobalClaudeSonnetFourDotSixStream
-) {}
+) {
+  static readonly endpointFilter = {};
+}
 
 defineDustStreamEndpoint(DustAnthropicGlobalClaudeSonnetFourDotSixStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -16,7 +16,7 @@ export const DUST_STREAM_ENDPOINTS = {
 export function getStreamEndpoints(
   workspaceConfiguration: {
     featureFlags: WhitelistableFeature[];
-    enterprise: boolean;
+    isEnterprise: boolean;
     creditPricing: boolean;
   },
   inputCondition: Where<WorkspaceFilter>

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -17,6 +17,7 @@ export function getStreamEndpoints(
   workspaceConfiguration: {
     featureFlags: WhitelistableFeature[];
     enterprise: boolean;
+    creditPricing: boolean;
   },
   inputCondition: Where<WorkspaceFilter>
 ) {

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -17,7 +17,7 @@ export function getStreamEndpoints(
   workspaceConfiguration: {
     featureFlags: WhitelistableFeature[];
     isEnterprise: boolean;
-    creditPricing: boolean;
+    isCreditPriced: boolean;
   },
   inputCondition: Where<WorkspaceFilter>
 ) {

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -2,7 +2,7 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
-import type { Where, WorkspaceFilter } from "@app/lib/llms/types/filter";
+import type { EndpointConfig, Where } from "@app/lib/llms/types/filter";
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
@@ -19,7 +19,7 @@ export function getStreamEndpoints(
     isEnterprise: boolean;
     isCreditPriced: boolean;
   },
-  inputCondition: Where<WorkspaceFilter>
+  inputCondition: Where<EndpointConfig>
 ) {
   return Object.values(DUST_STREAM_ENDPOINTS).filter((constructor) =>
     isEndpointAvailable(constructor, workspaceConfiguration, inputCondition)

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -2,9 +2,12 @@ import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_st
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
-import type { EndpointConfig, Where } from "@app/lib/llms/types/filter";
+import type {
+  EndpointConfig,
+  Where,
+  WorkspaceConfig,
+} from "@app/lib/llms/types/filter";
 import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export const DUST_STREAM_ENDPOINTS = {
   [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
@@ -14,11 +17,7 @@ export const DUST_STREAM_ENDPOINTS = {
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(
-  workspaceConfiguration: {
-    featureFlags: WhitelistableFeature[];
-    isEnterprise: boolean;
-    isCreditPriced: boolean;
-  },
+  workspaceConfiguration: WorkspaceConfig,
   inputCondition: Where<EndpointConfig>
 ) {
   return Object.values(DUST_STREAM_ENDPOINTS).filter((constructor) =>

--- a/front/lib/llms/stream/types/configuration.ts
+++ b/front/lib/llms/stream/types/configuration.ts
@@ -1,4 +1,4 @@
-import type { EndpointFilter, Where } from "@app/lib/llms/types/filter";
+import type { Where, WorkspaceConfig } from "@app/lib/llms/types/filter";
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 
@@ -16,5 +16,5 @@ export type DustStreamEndpointConfiguration<C extends InputConfig> =
     defaultReasoningEffort: ReasoningEffortOf<C>;
 
     // Filter
-    endpointFilter: Where<EndpointFilter>;
+    endpointFilter: Where<WorkspaceConfig>;
   };

--- a/front/lib/llms/stream/utils/is_endpoint_available.ts
+++ b/front/lib/llms/stream/utils/is_endpoint_available.ts
@@ -1,14 +1,14 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
-import type { Where, WorkspaceFilter } from "@app/lib/llms/types/filter";
+import type {
+  EndpointFilter,
+  Where,
+  WorkspaceFilter,
+} from "@app/lib/llms/types/filter";
 import { matchesWhere } from "@app/lib/llms/utils/matches_where";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export function isEndpointAvailable(
   endpointConstructor: DustStreamEndpointConstructor,
-  workspaceConfiguration: {
-    featureFlags: WhitelistableFeature[];
-    enterprise: boolean;
-  },
+  workspaceConfiguration: EndpointFilter,
   inputCondition: Where<WorkspaceFilter>
 ) {
   // Availability is decided by matching a `where` condition from both sides:

--- a/front/lib/llms/stream/utils/is_endpoint_available.ts
+++ b/front/lib/llms/stream/utils/is_endpoint_available.ts
@@ -1,15 +1,15 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import type {
-  EndpointFilter,
+  EndpointConfig,
   Where,
-  WorkspaceFilter,
+  WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import { matchesWhere } from "@app/lib/llms/utils/matches_where";
 
 export function isEndpointAvailable(
   endpointConstructor: DustStreamEndpointConstructor,
-  workspaceConfiguration: EndpointFilter,
-  inputCondition: Where<WorkspaceFilter>
+  workspaceConfiguration: WorkspaceConfig,
+  inputCondition: Where<EndpointConfig>
 ) {
   // Availability is decided by matching a `where` condition from both sides:
   //

--- a/front/lib/llms/types/filter.ts
+++ b/front/lib/llms/types/filter.ts
@@ -7,6 +7,7 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 export type EndpointFilter = {
   featureFlags: WhitelistableFeature[];
   enterprise: boolean;
+  creditPricing: boolean;
 };
 
 export type WorkspaceFilter = {

--- a/front/lib/llms/types/filter.ts
+++ b/front/lib/llms/types/filter.ts
@@ -6,7 +6,7 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
 export type EndpointFilter = {
   featureFlags: WhitelistableFeature[];
-  enterprise: boolean;
+  isEnterprise: boolean;
   creditPricing: boolean;
 };
 

--- a/front/lib/llms/types/filter.ts
+++ b/front/lib/llms/types/filter.ts
@@ -7,7 +7,7 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 export type EndpointFilter = {
   featureFlags: WhitelistableFeature[];
   isEnterprise: boolean;
-  creditPricing: boolean;
+  isCreditPriced: boolean;
 };
 
 export type WorkspaceFilter = {

--- a/front/lib/llms/types/filter.ts
+++ b/front/lib/llms/types/filter.ts
@@ -4,13 +4,13 @@ import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids"
 import type { Region } from "@app/lib/model_constructors/types/regions";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
-export type EndpointFilter = {
+export type WorkspaceConfig = {
   featureFlags: WhitelistableFeature[];
   isEnterprise: boolean;
   isCreditPriced: boolean;
 };
 
-export type WorkspaceFilter = {
+export type EndpointConfig = {
   region: Region;
   providerId: ProviderId;
   modelId: ModelId;

--- a/front/lib/llms/utils/matches_where.test.ts
+++ b/front/lib/llms/utils/matches_where.test.ts
@@ -12,14 +12,14 @@ const enterpriseWorkspace: EndpointFilter = {
     "anthropic_vertex_fallback",
   ],
   isEnterprise: true,
-  creditPricing: false,
+  isCreditPriced: false,
 };
 
 // A representative non-enterprise workspace with no flags.
 const freeWorkspace: EndpointFilter = {
   featureFlags: [],
   isEnterprise: false,
-  creditPricing: false,
+  isCreditPriced: false,
 };
 
 describe("matchesWhere", () => {
@@ -365,7 +365,7 @@ describe("matchesWhere", () => {
       const enterpriseFlagOnly: EndpointFilter = {
         featureFlags: ["use_vertex_for_supported_models"],
         isEnterprise: false,
-        creditPricing: false,
+        isCreditPriced: false,
       };
       expect(matchesWhere(enterpriseFlagOnly, gatedEndpointFilter)).toBe(false);
     });
@@ -374,7 +374,7 @@ describe("matchesWhere", () => {
       const enterpriseNoFlag: EndpointFilter = {
         featureFlags: ["anthropic_vertex_fallback"],
         isEnterprise: true,
-        creditPricing: false,
+        isCreditPriced: false,
       };
       expect(matchesWhere(enterpriseNoFlag, gatedEndpointFilter)).toBe(false);
     });

--- a/front/lib/llms/utils/matches_where.test.ts
+++ b/front/lib/llms/utils/matches_where.test.ts
@@ -12,12 +12,14 @@ const enterpriseWorkspace: EndpointFilter = {
     "anthropic_vertex_fallback",
   ],
   enterprise: true,
+  creditPricing: false,
 };
 
 // A representative non-enterprise workspace with no flags.
 const freeWorkspace: EndpointFilter = {
   featureFlags: [],
   enterprise: false,
+  creditPricing: false,
 };
 
 describe("matchesWhere", () => {
@@ -363,6 +365,7 @@ describe("matchesWhere", () => {
       const enterpriseFlagOnly: EndpointFilter = {
         featureFlags: ["use_vertex_for_supported_models"],
         enterprise: false,
+        creditPricing: false,
       };
       expect(matchesWhere(enterpriseFlagOnly, gatedEndpointFilter)).toBe(false);
     });
@@ -371,6 +374,7 @@ describe("matchesWhere", () => {
       const enterpriseNoFlag: EndpointFilter = {
         featureFlags: ["anthropic_vertex_fallback"],
         enterprise: true,
+        creditPricing: false,
       };
       expect(matchesWhere(enterpriseNoFlag, gatedEndpointFilter)).toBe(false);
     });

--- a/front/lib/llms/utils/matches_where.test.ts
+++ b/front/lib/llms/utils/matches_where.test.ts
@@ -11,14 +11,14 @@ const enterpriseWorkspace: EndpointFilter = {
     "use_vertex_for_supported_models",
     "anthropic_vertex_fallback",
   ],
-  enterprise: true,
+  isEnterprise: true,
   creditPricing: false,
 };
 
 // A representative non-enterprise workspace with no flags.
 const freeWorkspace: EndpointFilter = {
   featureFlags: [],
-  enterprise: false,
+  isEnterprise: false,
   creditPricing: false,
 };
 
@@ -30,8 +30,8 @@ describe("matchesWhere", () => {
     });
 
     it("ignores a field whose filter is not an object (undefined)", () => {
-      // `enterprise: undefined` is a no-op, not a falsy match.
-      const where: Where<EndpointFilter> = { enterprise: undefined };
+      // `isEnterprise: undefined` is a no-op, not a falsy match.
+      const where: Where<EndpointFilter> = { isEnterprise: undefined };
       expect(matchesWhere(enterpriseWorkspace, where)).toBe(true);
       expect(matchesWhere(freeWorkspace, where)).toBe(true);
     });
@@ -40,26 +40,26 @@ describe("matchesWhere", () => {
   describe("scalar filters (enterprise)", () => {
     it("eq matches the enterprise boolean", () => {
       expect(
-        matchesWhere(enterpriseWorkspace, { enterprise: { eq: true } })
+        matchesWhere(enterpriseWorkspace, { isEnterprise: { eq: true } })
       ).toBe(true);
       expect(
-        matchesWhere(enterpriseWorkspace, { enterprise: { eq: false } })
+        matchesWhere(enterpriseWorkspace, { isEnterprise: { eq: false } })
       ).toBe(false);
-      expect(matchesWhere(freeWorkspace, { enterprise: { eq: false } })).toBe(
+      expect(matchesWhere(freeWorkspace, { isEnterprise: { eq: false } })).toBe(
         true
       );
     });
 
     it("in matches when the value is included", () => {
       expect(
-        matchesWhere(enterpriseWorkspace, { enterprise: { in: [true] } })
+        matchesWhere(enterpriseWorkspace, { isEnterprise: { in: [true] } })
       ).toBe(true);
-      expect(matchesWhere(freeWorkspace, { enterprise: { in: [true] } })).toBe(
-        false
-      );
-      // `enterprise: true` is not in `[false]`, so this excludes it.
       expect(
-        matchesWhere(enterpriseWorkspace, { enterprise: { in: [false] } })
+        matchesWhere(freeWorkspace, { isEnterprise: { in: [true] } })
+      ).toBe(false);
+      // `isEnterprise: true` is not in `[false]`, so this excludes it.
+      expect(
+        matchesWhere(enterpriseWorkspace, { isEnterprise: { in: [false] } })
       ).toBe(false);
     });
 
@@ -258,7 +258,7 @@ describe("matchesWhere", () => {
       expect(
         matchesWhere(enterpriseWorkspace, {
           and: [
-            { enterprise: { eq: true } },
+            { isEnterprise: { eq: true } },
             { featureFlags: { contains: "anthropic_vertex_fallback" } },
           ],
         })
@@ -266,7 +266,7 @@ describe("matchesWhere", () => {
       expect(
         matchesWhere(enterpriseWorkspace, {
           and: [
-            { enterprise: { eq: true } },
+            { isEnterprise: { eq: true } },
             { featureFlags: { contains: "audit_logs" } },
           ],
         })
@@ -280,13 +280,13 @@ describe("matchesWhere", () => {
     it("or requires at least one child to match", () => {
       expect(
         matchesWhere(freeWorkspace, {
-          or: [{ enterprise: { eq: true } }, { enterprise: { eq: false } }],
+          or: [{ isEnterprise: { eq: true } }, { isEnterprise: { eq: false } }],
         })
       ).toBe(true);
       expect(
         matchesWhere(freeWorkspace, {
           or: [
-            { enterprise: { eq: true } },
+            { isEnterprise: { eq: true } },
             { featureFlags: { contains: "audit_logs" } },
           ],
         })
@@ -301,12 +301,12 @@ describe("matchesWhere", () => {
     it("not inverts its child", () => {
       expect(
         matchesWhere(enterpriseWorkspace, {
-          not: { enterprise: { eq: false } },
+          not: { isEnterprise: { eq: false } },
         })
       ).toBe(true);
       expect(
         matchesWhere(enterpriseWorkspace, {
-          not: { enterprise: { eq: true } },
+          not: { isEnterprise: { eq: true } },
         })
       ).toBe(false);
     });
@@ -315,7 +315,7 @@ describe("matchesWhere", () => {
       // (enterprise AND (vertex flag OR audit flag)) AND NOT(deepseek flag)
       const where: Where<EndpointFilter> = {
         and: [
-          { enterprise: { eq: true } },
+          { isEnterprise: { eq: true } },
           {
             or: [
               { featureFlags: { contains: "use_vertex_for_supported_models" } },
@@ -333,7 +333,7 @@ describe("matchesWhere", () => {
       // Field filters and logical operators in the same `where` must all pass.
       expect(
         matchesWhere(enterpriseWorkspace, {
-          enterprise: { eq: true },
+          isEnterprise: { eq: true },
           or: [
             { featureFlags: { contains: "anthropic_vertex_fallback" } },
             { featureFlags: { contains: "audit_logs" } },
@@ -342,7 +342,7 @@ describe("matchesWhere", () => {
       ).toBe(true);
       expect(
         matchesWhere(enterpriseWorkspace, {
-          enterprise: { eq: false },
+          isEnterprise: { eq: false },
           or: [{ featureFlags: { contains: "anthropic_vertex_fallback" } }],
         })
       ).toBe(false);
@@ -353,7 +353,7 @@ describe("matchesWhere", () => {
     // A gated endpoint: only available to enterprise workspaces that have the
     // vertex routing flag enabled.
     const gatedEndpointFilter: Where<EndpointFilter> = {
-      enterprise: { eq: true },
+      isEnterprise: { eq: true },
       featureFlags: { contains: "use_vertex_for_supported_models" },
     };
 
@@ -364,7 +364,7 @@ describe("matchesWhere", () => {
     it("rejects a non-enterprise workspace", () => {
       const enterpriseFlagOnly: EndpointFilter = {
         featureFlags: ["use_vertex_for_supported_models"],
-        enterprise: false,
+        isEnterprise: false,
         creditPricing: false,
       };
       expect(matchesWhere(enterpriseFlagOnly, gatedEndpointFilter)).toBe(false);
@@ -373,7 +373,7 @@ describe("matchesWhere", () => {
     it("rejects an enterprise workspace missing the flag", () => {
       const enterpriseNoFlag: EndpointFilter = {
         featureFlags: ["anthropic_vertex_fallback"],
-        enterprise: true,
+        isEnterprise: true,
         creditPricing: false,
       };
       expect(matchesWhere(enterpriseNoFlag, gatedEndpointFilter)).toBe(false);

--- a/front/lib/llms/utils/matches_where.test.ts
+++ b/front/lib/llms/utils/matches_where.test.ts
@@ -1,12 +1,12 @@
 import type {
-  EndpointFilter,
+  EndpointConfig,
   Where,
-  WorkspaceFilter,
+  WorkspaceConfig,
 } from "@app/lib/llms/types/filter";
 import { matchesWhere } from "@app/lib/llms/utils/matches_where";
 import { describe, expect, it } from "vitest";
 
-const enterpriseWorkspace: EndpointFilter = {
+const enterpriseWorkspace: WorkspaceConfig = {
   featureFlags: [
     "use_vertex_for_supported_models",
     "anthropic_vertex_fallback",
@@ -16,7 +16,7 @@ const enterpriseWorkspace: EndpointFilter = {
 };
 
 // A representative non-enterprise workspace with no flags.
-const freeWorkspace: EndpointFilter = {
+const freeWorkspace: WorkspaceConfig = {
   featureFlags: [],
   isEnterprise: false,
   isCreditPriced: false,
@@ -31,7 +31,7 @@ describe("matchesWhere", () => {
 
     it("ignores a field whose filter is not an object (undefined)", () => {
       // `isEnterprise: undefined` is a no-op, not a falsy match.
-      const where: Where<EndpointFilter> = { isEnterprise: undefined };
+      const where: Where<WorkspaceConfig> = { isEnterprise: undefined };
       expect(matchesWhere(enterpriseWorkspace, where)).toBe(true);
       expect(matchesWhere(freeWorkspace, where)).toBe(true);
     });
@@ -209,15 +209,15 @@ describe("matchesWhere", () => {
     });
   });
 
-  describe("array filters on WorkspaceFilter lists", () => {
+  describe("array filters on EndpointConfig lists", () => {
     // Mimics an endpoint description that covers several values per
-    // WorkspaceFilter field: the set of providers / regions / models / apis it
-    // exposes. `WorkspaceFilter` itself is scalar (one value per field on a real
+    // EndpointConfig field: the set of providers / regions / models / apis it
+    // exposes. `EndpointConfig` itself is scalar (one value per field on a real
     // endpoint), so the coverage shape arrays each field.
-    type WorkspaceFilterCoverage = {
-      [K in keyof WorkspaceFilter]: WorkspaceFilter[K][];
+    type EndpointConfigCoverage = {
+      [K in keyof EndpointConfig]: EndpointConfig[K][];
     };
-    const description: WorkspaceFilterCoverage = {
+    const description: EndpointConfigCoverage = {
       region: ["eu", "global"],
       providerId: ["anthropic"],
       modelId: ["claude-sonnet-4-6"],
@@ -313,7 +313,7 @@ describe("matchesWhere", () => {
 
     it("supports nested logical operators", () => {
       // (enterprise AND (vertex flag OR audit flag)) AND NOT(deepseek flag)
-      const where: Where<EndpointFilter> = {
+      const where: Where<WorkspaceConfig> = {
         and: [
           { isEnterprise: { eq: true } },
           {
@@ -352,7 +352,7 @@ describe("matchesWhere", () => {
   describe("realistic endpoint availability scenarios", () => {
     // A gated endpoint: only available to enterprise workspaces that have the
     // vertex routing flag enabled.
-    const gatedEndpointFilter: Where<EndpointFilter> = {
+    const gatedEndpointFilter: Where<WorkspaceConfig> = {
       isEnterprise: { eq: true },
       featureFlags: { contains: "use_vertex_for_supported_models" },
     };
@@ -362,7 +362,7 @@ describe("matchesWhere", () => {
     });
 
     it("rejects a non-enterprise workspace", () => {
-      const enterpriseFlagOnly: EndpointFilter = {
+      const enterpriseFlagOnly: WorkspaceConfig = {
         featureFlags: ["use_vertex_for_supported_models"],
         isEnterprise: false,
         isCreditPriced: false,
@@ -371,7 +371,7 @@ describe("matchesWhere", () => {
     });
 
     it("rejects an enterprise workspace missing the flag", () => {
-      const enterpriseNoFlag: EndpointFilter = {
+      const enterpriseNoFlag: WorkspaceConfig = {
         featureFlags: ["anthropic_vertex_fallback"],
         isEnterprise: true,
         isCreditPriced: false,


### PR DESCRIPTION
## Description

Route credit-priced plans to the EU Claude Sonnet 4.6 agent-platform endpoint via the LLM endpoint-filter system, and clarify the filter type names (`WorkspaceConfig` for workspace traits, `EndpointConfig` for endpoint identity).

## Tests

Added unit tests for the `matchesWhere` filter matcher; type-checked locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`