### PR TITLE
Restore group membership when a user rejoins

### DIFF
--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -21,6 +21,7 @@ import {
   classifySeatChange,
   hasContractSeatSubscription,
 } from "@app/lib/metronome/seats";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -182,6 +183,18 @@ export async function createAndTrackMembership({
       ? renderLightWorkspaceType({ workspace })
       : workspace;
 
+  // Capture the previous (potentially revoked) membership before creating
+  // the new one, so we can restore group memberships that were ended at the
+  // same time as the workspace revocation.
+  const previousMembership =
+    await MembershipResource.getLatestMembershipOfUserInWorkspace({
+      user,
+      workspace: w,
+    });
+  const prevRevokedAt = previousMembership?.isRevoked()
+    ? previousMembership.endAt
+    : null;
+
   const seatType = await resolveSeatTypeForNewMembership(
     user,
     w,
@@ -195,6 +208,21 @@ export async function createAndTrackMembership({
     origin,
     seatType,
   });
+
+  if (prevRevokedAt) {
+    const restoredCount =
+      await GroupResource.restoreGroupMembershipsRevokedWith({
+        user,
+        workspace: w,
+        revokedAt: prevRevokedAt,
+      });
+    if (restoredCount > 0) {
+      logger.info(
+        { userId: user.sId, workspaceId: w.sId, restoredCount },
+        "[Membership] Restored group memberships for rejoining user"
+      );
+    }
+  }
 
   void ServerSideTracking.trackCreateMembership({
     user: user.toJSON(),

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1874,6 +1874,117 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   /**
+   * Restores group memberships for a user that were ended at approximately the
+   * same time as a workspace membership revocation. Called when a user rejoins
+   * a workspace to preserve their previously-held group memberships (e.g. agent
+   * editor access).
+   *
+   * Only restores memberships that were active (not suspended) and whose `endAt`
+   * falls within `toleranceMs` of `revokedAt`. Skips global and system groups
+   * (membership is implicit). Skips groups that no longer exist or where the
+   * user already has an active membership.
+   *
+   * Returns the number of group memberships restored.
+   */
+  static async restoreGroupMembershipsRevokedWith({
+    user,
+    workspace,
+    revokedAt,
+    toleranceMs = 60_000,
+    transaction,
+  }: {
+    user: UserResource;
+    workspace: LightWorkspaceType;
+    revokedAt: Date;
+    toleranceMs?: number;
+    transaction?: Transaction;
+  }): Promise<number> {
+    const rangeStart = new Date(revokedAt.getTime() - toleranceMs);
+    const rangeEnd = new Date(revokedAt.getTime() + toleranceMs);
+
+    const revokedMemberships = await GroupMembershipModel.findAll({
+      where: {
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "active",
+        endAt: {
+          [Op.gte]: rangeStart,
+          [Op.lte]: rangeEnd,
+        },
+      },
+      transaction,
+    });
+
+    if (revokedMemberships.length === 0) {
+      return 0;
+    }
+
+    const groupIds = [...new Set(revokedMemberships.map((m) => m.groupId))];
+
+    // Verify groups still exist and are not global/system (implicit membership).
+    const groups = await GroupModel.findAll({
+      where: {
+        id: { [Op.in]: groupIds },
+        workspaceId: workspace.id,
+        kind: { [Op.notIn]: ["global", "system"] },
+      },
+      transaction,
+    });
+
+    if (groups.length === 0) {
+      return 0;
+    }
+
+    const validGroupIds = new Set(groups.map((g) => g.id));
+
+    // Exclude groups where the user already has an active membership.
+    const now = new Date();
+    const existingActive = await GroupMembershipModel.findAll({
+      where: {
+        userId: user.id,
+        workspaceId: workspace.id,
+        groupId: { [Op.in]: [...validGroupIds] },
+        startAt: { [Op.lte]: now },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      },
+      attributes: ["groupId"],
+      transaction,
+    });
+    const alreadyActiveGroupIds = new Set(existingActive.map((m) => m.groupId));
+
+    const groupIdsToRestore = [...validGroupIds].filter(
+      (id) => !alreadyActiveGroupIds.has(id)
+    );
+
+    if (groupIdsToRestore.length === 0) {
+      return 0;
+    }
+
+    await GroupMembershipModel.bulkCreate(
+      groupIdsToRestore.map((groupId) => ({
+        groupId,
+        userId: user.id,
+        workspaceId: workspace.id,
+        startAt: now,
+        endAt: null,
+        status: "active" as const,
+      })),
+      { transaction }
+    );
+
+    const workspaceModelId = workspace.id;
+    const userModelId = user.id;
+    invalidateCacheAfterCommit(transaction, async () => {
+      await GroupResource.invalidateGroupIdsCacheForUser({
+        user: { id: userModelId },
+        workspace: { id: workspaceModelId },
+      });
+    });
+
+    return groupIdsToRestore.length;
+  }
+
+  /**
    * Restores all suspended members of this group.
    * Returns array of affected user ModelIds.
    */


### PR DESCRIPTION
## Description

When a user is removed from a workspace (via SCIM or manually), their group memberships are ended at the same time. On rejoin, only the workspace membership was restored — group memberships were not, causing users to lose editor access on agents they created.

Fix: when creating a workspace membership for a user who previously had one revoked,  now looks for group memberships ended within ±60 seconds of the workspace revocation and restores them. The 60s window matches the co-termination window in `handleDeleteWorkOSUser` (groups removed just before workspace membership). Applied to all rejoin paths, not just SCIM.

Fixes dust-tt/tasks#8984, dust-tt/tasks#8420.

## Tests

Manually verified the logic — no automated test added in this PR (flow is exercised through the SCIM Temporal activity path).

## Risk

Low. The restore path only runs when a previously revoked membership exists. It creates new group membership rows without touching existing ones, and skips groups that no longer exist or where the user is already active.

## Deploy Plan

Standard deploy, no migration needed.