### PR TITLE
Add plugin to restore missing free credits

### DIFF
--- a/front/components/poke/credits/TriggerFreeCreditSegmentGrantButton.tsx
+++ b/front/components/poke/credits/TriggerFreeCreditSegmentGrantButton.tsx
@@ -1,0 +1,61 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useRunPokePlugin } from "@app/poke/swr/plugins";
+import type { WorkspaceType } from "@app/types/user";
+import { Button } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const TRIGGER_FREE_CREDIT_PLUGIN_ID = "trigger-free-credit-segment-grant";
+
+interface TriggerFreeCreditSegmentGrantButtonProps {
+  owner: WorkspaceType;
+  metronomeCreditId: string;
+}
+
+export function TriggerFreeCreditSegmentGrantButton({
+  owner,
+  metronomeCreditId,
+}: TriggerFreeCreditSegmentGrantButtonProps) {
+  const sendNotification = useSendNotification();
+  const [isRunning, setIsRunning] = useState(false);
+
+  const { doRunPlugin } = useRunPokePlugin({
+    pluginId: TRIGGER_FREE_CREDIT_PLUGIN_ID,
+    pluginResourceTarget: {
+      resourceType: "workspaces",
+      resourceId: owner.sId,
+      workspace: owner,
+    },
+  });
+
+  const handleClick = async () => {
+    setIsRunning(true);
+    const result = await doRunPlugin({ metronomeCreditId });
+    setIsRunning(false);
+
+    if (result.isErr()) {
+      sendNotification({
+        type: "error",
+        title: "Failed to trigger free credit grant",
+        description: result.error,
+      });
+      return;
+    }
+
+    sendNotification({
+      type: "success",
+      title: "Free credit grant triggered",
+      description:
+        result.value.display === "text" ? result.value.value : undefined,
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="xs"
+      label="Grant"
+      isLoading={isRunning}
+      onClick={handleClick}
+    />
+  );
+}

--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -1,8 +1,10 @@
+import { TriggerFreeCreditSegmentGrantButton } from "@app/components/poke/credits/TriggerFreeCreditSegmentGrantButton";
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { TYPE_COLORS } from "@app/components/workspace/CreditsList";
 import type { PokeUnifiedCreditRow } from "@app/lib/api/poke/credits";
 import { getMetronomeCommitOrCreditUrl } from "@app/lib/metronome/urls";
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
+import type { WorkspaceType } from "@app/types/user";
 import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -87,12 +89,26 @@ function AmountCell({
   );
 }
 
-function StatusCell({ row }: { row: PokeUnifiedCreditRow }) {
+function StatusCell({
+  row,
+  owner,
+}: {
+  row: PokeUnifiedCreditRow;
+  owner: WorkspaceType;
+}) {
   if (!row.internal && row.metronome) {
     return (
-      <Chip color="warning" size="xs">
-        Metronome only
-      </Chip>
+      <div className="flex items-center gap-2">
+        <Chip color="warning" size="xs">
+          Metronome only
+        </Chip>
+        {row.metronome.type === "free" && (
+          <TriggerFreeCreditSegmentGrantButton
+            owner={owner}
+            metronomeCreditId={row.metronome.sId}
+          />
+        )}
+      </div>
     );
   }
   if (row.internal && !row.metronome) {
@@ -137,8 +153,10 @@ function StatusCell({ row }: { row: PokeUnifiedCreditRow }) {
 
 export function makeColumnsForUnifiedCredits({
   metronomeCustomerId,
+  owner,
 }: {
   metronomeCustomerId: string | null;
+  owner: WorkspaceType;
 }): ColumnDef<PokeUnifiedCreditRow>[] {
   return [
     {
@@ -200,7 +218,7 @@ export function makeColumnsForUnifiedCredits({
     {
       id: "status",
       header: "Status",
-      cell: ({ row }) => <StatusCell row={row.original} />,
+      cell: ({ row }) => <StatusCell row={row.original} owner={owner} />,
     },
     {
       id: "initial",

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -117,6 +117,7 @@ export function CreditsDataTable({
             <PokeDataTable
               columns={makeColumnsForUnifiedCredits({
                 metronomeCustomerId: owner.metronomeCustomerId,
+                owner,
               })}
               data={sortRowsByStartDateDescending(data.rows)}
               defaultFilterColumn="type"

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -351,7 +351,7 @@ async function reconcilePoolStateFromSegmentEvent({
 // Metronome is the source of truth: we update the segment amount there, then
 // ensure the matching DB credit (linked by metronomeCreditId) exists. Segments
 // that aren't the managed free credit are ignored.
-async function handleFreeCreditSegmentGrant({
+export async function handleFreeCreditSegmentGrant({
   workspace,
   metronomeCustomerId,
   contractId,

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -44,6 +44,7 @@ export * from "./sync_missing_transcripts_date_range";
 export * from "./toggle_auto_create_space";
 export * from "./toggle_disable_manual_invitations";
 export * from "./toggle_feature_flag";
+export * from "./trigger_free_credit_segment_grant";
 export * from "./upgrade_downgrade";
 export * from "./upgrade_to_business_plan";
 export * from "./user_identity_merge";

--- a/front/lib/api/poke/plugins/workspaces/trigger_free_credit_segment_grant.ts
+++ b/front/lib/api/poke/plugins/workspaces/trigger_free_credit_segment_grant.ts
@@ -6,7 +6,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
-import { fromZodError } from "zod-validation-error";
+import { fromError } from "zod-validation-error";
 
 const TriggerFreeGrantArgsSchema = z.object({
   metronomeCreditId: z.string().min(1, "Metronome credit ID is required"),
@@ -44,7 +44,7 @@ export const triggerFreeCreditSegmentGrantPlugin = createPlugin({
 
     const parseResult = TriggerFreeGrantArgsSchema.safeParse(args);
     if (!parseResult.success) {
-      return new Err(new Error(fromZodError(parseResult.error).message));
+      return new Err(new Error(fromError(parseResult.error).toString()));
     }
     const { metronomeCreditId } = parseResult.data;
 

--- a/front/lib/api/poke/plugins/workspaces/trigger_free_credit_segment_grant.ts
+++ b/front/lib/api/poke/plugins/workspaces/trigger_free_credit_segment_grant.ts
@@ -1,0 +1,132 @@
+import { handleFreeCreditSegmentGrant } from "@app/lib/api/metronome/process_webhook";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { getMetronomeCredit } from "@app/lib/metronome/client";
+import { isMetronomeFreeCredit } from "@app/lib/metronome/types";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { Err, Ok } from "@app/types/shared/result";
+import { z } from "zod";
+import { fromZodError } from "zod-validation-error";
+
+const TriggerFreeGrantArgsSchema = z.object({
+  metronomeCreditId: z.string().min(1, "Metronome credit ID is required"),
+});
+
+export const triggerFreeCreditSegmentGrantPlugin = createPlugin({
+  manifest: {
+    id: "trigger-free-credit-segment-grant",
+    name: "Trigger Free Monthly Credit Grant",
+    description:
+      "Manually simulate a credit.segment.start event for a specific Metronome free credit. " +
+      "Use when the webhook was not received and the DB credit is missing. " +
+      "Finds the currently active segment on the credit, recalculates the amount, " +
+      "updates Metronome, and creates the matching DB credit. Idempotent.",
+    resourceTypes: ["workspaces"],
+    args: {
+      metronomeCreditId: {
+        type: "string",
+        variant: "text",
+        label: "Metronome Credit ID",
+        description:
+          "The Metronome credit ID of the free monthly credit to grant.",
+      },
+    },
+    requiredRoles: ["billing"],
+  },
+  isApplicableTo: (auth) => {
+    const plan = auth.plan();
+    return plan !== null && !isCreditPricedPlan(plan);
+  },
+  execute: async (auth, workspace, args) => {
+    if (!workspace) {
+      return new Err(new Error("Cannot find workspace."));
+    }
+
+    const parseResult = TriggerFreeGrantArgsSchema.safeParse(args);
+    if (!parseResult.success) {
+      return new Err(new Error(fromZodError(parseResult.error).message));
+    }
+    const { metronomeCreditId } = parseResult.data;
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (!workspaceResource) {
+      return new Err(new Error(`Workspace not found: wId='${workspace.sId}'`));
+    }
+
+    const { metronomeCustomerId } = workspaceResource;
+    if (!metronomeCustomerId) {
+      return new Err(
+        new Error(
+          `Workspace "${workspace.name}" is not provisioned in Metronome.`
+        )
+      );
+    }
+
+    // Fetch the specific credit from Metronome.
+    const creditResult = await getMetronomeCredit({
+      metronomeCustomerId,
+      creditId: metronomeCreditId,
+    });
+    if (creditResult.isErr()) {
+      return new Err(creditResult.error);
+    }
+    const credit = creditResult.value;
+    if (!credit) {
+      return new Err(
+        new Error(`Credit "${metronomeCreditId}" not found in Metronome.`)
+      );
+    }
+
+    if (!isMetronomeFreeCredit(credit)) {
+      return new Err(
+        new Error(
+          `Credit "${metronomeCreditId}" is not a managed free monthly credit.`
+        )
+      );
+    }
+
+    const contractId = credit.contract?.id;
+    if (!contractId) {
+      return new Err(
+        new Error(
+          `Credit "${metronomeCreditId}" is not attached to a contract.`
+        )
+      );
+    }
+
+    // Find the segment that covers the current moment.
+    const now = new Date();
+    const activeSegment = credit.access_schedule?.schedule_items.find(
+      (s) => new Date(s.starting_at) <= now && new Date(s.ending_before) > now
+    );
+    if (!activeSegment) {
+      return new Err(
+        new Error(
+          `No active segment found on credit "${metronomeCreditId}" for the current period.`
+        )
+      );
+    }
+
+    const grantResult = await handleFreeCreditSegmentGrant({
+      workspace: workspaceResource,
+      metronomeCustomerId,
+      contractId,
+      creditId: metronomeCreditId,
+      segmentId: activeSegment.id,
+    });
+    if (grantResult.isErr()) {
+      return new Err(grantResult.error);
+    }
+
+    return new Ok({
+      display: "text",
+      value: [
+        "Free credit grant triggered successfully.",
+        `Credit: ${metronomeCreditId}`,
+        `Contract: ${contractId}`,
+        `Segment: ${activeSegment.id}`,
+        `Period: ${new Date(activeSegment.starting_at).toISOString()} → ${new Date(activeSegment.ending_before).toISOString()}`,
+      ].join("\n"),
+    });
+  },
+});


### PR DESCRIPTION
## Summary

When a `credit.segment.start` webhook is not received from Metronome, the free monthly credit is never created in DB (the row shows as "Metronome only" with $0). This adds a "Grant" button directly on those rows in the poke API Usage tab — clicking it simulates the missed webhook: fetches the credit from Metronome, finds the active segment, recalculates the amount, updates Metronome, and upserts the DB credit.

## Test plan

- [ ] Open a workspace with a legacy programmatic usage plan that has a "Metronome only" free credit row in the API Usage tab
- [ ] Click the "Grant" button on the row — verify a success notification appears and the DB credit is created
- [ ] Click again — verify idempotency (no duplicate, success notification)
- [ ] Verify the button does not appear on non-free credit rows or on matched/mismatched rows

🤖 Generated with [Claude Code](https://claude.ai/claude-code)