### PR TITLE
chore(analytics): backfill credit-cost fields on agent_message_analytics_2

### DIFF
--- a/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
@@ -45,11 +45,6 @@ POST /front.agent_message_analytics_2/_update_by_query?wait_for_completion=false
             }
           }
         },
-        {
-          "term": {
-            "workspace_id": "0ec9852c2f"
-          }
-        }
       ],
       "must_not": [
         {

--- a/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
@@ -44,6 +44,11 @@ POST /front.agent_message_analytics_2/_update_by_query?wait_for_completion=false
               "gte": "now-3M"
             }
           }
+        },
+        {
+          "term": {
+            "workspace_id": "0ec9852c2f"
+          }
         }
       ],
       "must_not": [

--- a/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
@@ -1,0 +1,58 @@
+POST /front.agent_message_analytics_2/_update_by_query?wait_for_completion=false&slices=auto&scroll_size=5000&requests_per_second=10000
+{
+  "conflicts": "proceed",
+  "script": {
+    "lang": "painless",
+    "source": "boolean isFreeUsage = ctx._source.context_origin != null && params.free_origins.contains(ctx._source.context_origin); long costMicroUsd = (ctx._source.tokens != null && ctx._source.tokens.cost_micro_usd != null) ? ctx._source.tokens.cost_micro_usd : 0; int llmAwu = isFreeUsage ? 0 : (int) Math.ceil(costMicroUsd / 8500.0); int toolAwu = 0; if (ctx._source.tools_used != null) { for (def tool : ctx._source.tools_used) { int cost = 0; def server = tool.server_name; if (!isFreeUsage && params.final_statuses.contains(tool.status) && (server == null || !params.free_tool_servers.contains(server))) { cost = (server != null && params.basic_tool_servers.contains(server)) ? 1 : 3; } tool.cost_awu = cost; toolAwu += cost; } } ctx._source.cost = ['full_awu': llmAwu + toolAwu, 'llm_awu': llmAwu, 'tool_awu': toolAwu];",
+    "params": {
+      "free_origins": ["agent_sidekick"],
+      "free_tool_servers": [
+        "agent_router",
+        "common_utilities",
+        "toolsets",
+        "agent_memory"
+      ],
+      "basic_tool_servers": [
+        "web_search_&_browse",
+        "run_agent",
+        "agent_sidekick_agent_state",
+        "agent_sidekick_context",
+        "run_dust_app",
+        "user_mentions",
+        "missing_action_catcher",
+        "primitive_types_debugger",
+        "jit_testing",
+        "skill_authoring",
+        "skill_management",
+        "schedules_management",
+        "pod_manager",
+        "pod_tasks",
+        "poke",
+        "ask_user_question",
+        "wakeups",
+        "plan_mode"
+      ],
+      "final_statuses": ["succeeded", "errored", "denied"]
+    }
+  },
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "now-3M"
+            }
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "exists": {
+            "field": "cost"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2_with_workspace_filter.http
+++ b/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2_with_workspace_filter.http
@@ -1,0 +1,63 @@
+POST /front.agent_message_analytics_2/_update_by_query?wait_for_completion=false&slices=auto&scroll_size=5000&requests_per_second=10000
+{
+  "conflicts": "proceed",
+  "script": {
+    "lang": "painless",
+    "source": "boolean isFreeUsage = ctx._source.context_origin != null && params.free_origins.contains(ctx._source.context_origin); long costMicroUsd = (ctx._source.tokens != null && ctx._source.tokens.cost_micro_usd != null) ? ctx._source.tokens.cost_micro_usd : 0; int llmAwu = isFreeUsage ? 0 : (int) Math.ceil(costMicroUsd / 8500.0); int toolAwu = 0; if (ctx._source.tools_used != null) { for (def tool : ctx._source.tools_used) { int cost = 0; def server = tool.server_name; if (!isFreeUsage && params.final_statuses.contains(tool.status) && (server == null || !params.free_tool_servers.contains(server))) { cost = (server != null && params.basic_tool_servers.contains(server)) ? 1 : 3; } tool.cost_awu = cost; toolAwu += cost; } } ctx._source.cost = ['full_awu': llmAwu + toolAwu, 'llm_awu': llmAwu, 'tool_awu': toolAwu];",
+    "params": {
+      "free_origins": ["agent_sidekick"],
+      "free_tool_servers": [
+        "agent_router",
+        "common_utilities",
+        "toolsets",
+        "agent_memory"
+      ],
+      "basic_tool_servers": [
+        "web_search_&_browse",
+        "run_agent",
+        "agent_sidekick_agent_state",
+        "agent_sidekick_context",
+        "run_dust_app",
+        "user_mentions",
+        "missing_action_catcher",
+        "primitive_types_debugger",
+        "jit_testing",
+        "skill_authoring",
+        "skill_management",
+        "schedules_management",
+        "pod_manager",
+        "pod_tasks",
+        "poke",
+        "ask_user_question",
+        "wakeups",
+        "plan_mode"
+      ],
+      "final_statuses": ["succeeded", "errored", "denied"]
+    }
+  },
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "now-3M"
+            }
+          }
+        },
+        {
+          "term": {
+            "workspace_id": "0ec9852c2f"
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "exists": {
+            "field": "cost"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a one-off Elasticsearch backfill migration for the credit-cost fields introduced in #27497.

The credit-cost PR adds `cost.{full_awu,llm_awu,tool_awu}` and `tools_used[].cost_awu` to the `agent_message_analytics_2` index, but only forward-indexed documents get them. This migration backfills existing documents, recomputing the fields purely from data each document already carries (`context_origin`, `tokens.cost_micro_usd`, `tools_used[].server_name/status`) using the same rate-card logic as the live indexer and `lib/metronome/events.ts`.

Run it with the existing runner:

```
npx tsx front/scripts/execute_elasticsearch_http.ts \
  --file front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http --execute
```

It is an `_update_by_query` painless script, scoped to the last 3 months (`timestamp >= now-3M`) and to documents without a `cost` yet (`must_not exists cost`), so it is idempotent and safe to re-run.

Known discrepancies vs a freshly-indexed document (the backfill only sees aggregated ES fields, not the underlying runs/actions):

- `llm_awu`: the indexer ceils per `(provider, model)` before summing; ES only keeps the summed `cost_micro_usd`, so we ceil the total. Result is `<=` the true value by up to `(#distinct models - 1)` credits — exact for single-model messages (the common case).
- Pre-`context_origin` documents (indexed before ~2025-11-15) have no origin, so a genuinely free `agent_sidekick` message is computed as billable. Out of scope here given the 3-month window.
- Remote-server name collisions: cost is keyed off `server_name` instead of `internalMCPServerName`; only diverges in the rare case a remote server is named exactly like an internal basic/free server.

`ancestor_message_ids` (also added in #27497) is intentionally not backfilled — it denormalizes the conversation tree and cannot be reconstructed from the document alone.

## Tests

Validate before executing:

- Dry run (no `--execute`) prints the parsed method/path/body.
- Size the working set first: `GET /front.agent_message_analytics_2/_count` with the same query.

## Risk

Low. Read-mostly migration over a single index, idempotent (`must_not exists cost`), and `conflicts=proceed` tolerates concurrent indexing.

The main operational concern is load: the index holds ~350M documents. The request is throttled (`requests_per_second=10000`, `slices=auto`, `scroll_size=5000`) and runs in the background (`wait_for_completion=false`). The 3-month `timestamp` filter bounds the working set well below the full index. Monitor the write thread pool for rejections and rethrottle live if needed:

```
POST /_update_by_query/<task_id>/_rethrottle?requests_per_second=<n>
```

## Deploy Plan

Manual, post-merge. Stacked on #27497 — merge that first so the mappings/fields exist. Then run the script against the target region's Elasticsearch, off-peak, and poll `GET /_tasks/<task_id>` until complete.
