### PR TITLE
chore(mprocs): require start-mprocs.sh instead of direct mprocs invocation

### DIFF
--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -8,6 +8,18 @@
 # ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
 
 procs:
+  _check-start-script:
+    shell: |
+      if [ -z "$DUST_USE_START_MPROCS" ]; then
+        echo ""
+        echo "ERROR: Run tools/start-mprocs.sh instead of invoking mprocs directly."
+        echo "       It sets up nvm, clears stale build artifacts, and installs dependencies."
+        echo ""
+        exit 1
+      fi
+      echo "OK"
+    autostart: true
+
   core:
     cwd: "<CONFIG_DIR>/../core"
     shell: "bacon core-api"
@@ -28,51 +40,42 @@ procs:
   sparkle:
     cwd: "<CONFIG_DIR>/../sparkle"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       npm run watch
 
   sdks-js:
     cwd: "<CONFIG_DIR>/../sdks/js"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       ./admin/dev.sh
+
+  migrations:
+    cwd: "<CONFIG_DIR>/.."
+    env:
+      READY_FILE: "sdks/js/dist/client.esm.js.map"
+    shell: |
+      echo "Waiting for sdks-js to compile..."
+      echo "Expecting file: $READY_FILE"
+      while [ ! -f "$READY_FILE" ]; do sleep 1; done
+      echo "sdks-js ready. Starting migrations."
+      npm -w front run migration:apply
+      npm -w connectors run migration:apply
 
   front-api-hono:
     cwd: "<CONFIG_DIR>/../front-api"
+    env:
+      NODE_ENV: "development"
+      # Guard: throw if anything tries to load `next` at runtime.
+      NODE_OPTIONS: "--require=./forbid-next.cjs"
+      READY_FILE: "../sdks/js/dist/client.esm.js.map"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
-      READY_FILE="../sdks/js/dist/client.esm.js.map"
       echo "Waiting for sdks-js to compile..."
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
       echo "sdks-js ready. Starting front-api (Hono only, no Next)."
-      # exec replaces this shell with tsx so mprocs's signals reach node
-      # directly (npm doesn't reliably forward signals to its child).
-      export NODE_ENV=development
-      # Guard: throw if anything tries to load `next` at runtime.
-      export NODE_OPTIONS="--require=./forbid-next.cjs"
       npm run dev
 
   front-workers:
     cwd: "<CONFIG_DIR>/../front"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       echo "Waiting for front to be ready..."
       until curl -sf http://localhost:3000/api/healthz; do sleep 1; done
       echo "front ready. Starting front-workers."
@@ -80,13 +83,9 @@ procs:
 
   connectors:
     cwd: "<CONFIG_DIR>/../connectors"
+    env:
+      READY_FILE: "../sdks/js/dist/client.esm.js.map"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
-      READY_FILE="../sdks/js/dist/client.esm.js.map"
       echo "Waiting for sdks-js to compile..."
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
       echo "sdks-js ready. Starting connectors."
@@ -94,13 +93,9 @@ procs:
 
   front-spa:
     cwd: "<CONFIG_DIR>/../front-spa"
+    env:
+      READY_FILE: "../sparkle/dist/cjs/index.js"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
-      READY_FILE="../sparkle/dist/cjs/index.js"
       echo "Waiting for sparkle to compile..."
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
@@ -108,13 +103,9 @@ procs:
 
   front-poke:
     cwd: "<CONFIG_DIR>/../front-spa"
+    env:
+      READY_FILE: "../sparkle/dist/cjs/index.js"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
-      READY_FILE="../sparkle/dist/cjs/index.js"
       echo "Waiting for sparkle to compile..."
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
@@ -122,13 +113,9 @@ procs:
 
   marketing-site:
     cwd: "<CONFIG_DIR>/../marketing"
+    env:
+      READY_FILE: "../sparkle/dist/cjs/index.js"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
-      READY_FILE="../sparkle/dist/cjs/index.js"
       echo "Waiting for sparkle to compile..."
       echo "Expecting file: $READY_FILE"
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
@@ -139,44 +126,24 @@ procs:
   sparkle-storybook:
     cwd: "<CONFIG_DIR>/../sparkle"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       npm run storybook
     autostart: false
 
   sparkle-playground:
     cwd: "<CONFIG_DIR>/../sparkle/playground"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       npm install && npm run dev
     autostart: false
 
   viz:
     cwd: "<CONFIG_DIR>/../viz"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       npm run dev
     autostart: false
 
   extension:
     cwd: "<CONFIG_DIR>/../extension"
     shell: |
-      set -euo pipefail
-      export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-      nvm use
-      echo "Node $(node --version)"
       npm run dev:chrome
     autostart: false
 

--- a/tools/start-mprocs.sh
+++ b/tools/start-mprocs.sh
@@ -26,4 +26,5 @@ cd "$SCRIPT_DIR"/../ && npm install
 cd $SCRIPT_DIR
 
 # Start the dev environment using mprocs
+export DUST_USE_START_MPROCS=1
 mprocs


### PR DESCRIPTION
## Description

Adds a guard to `mprocs.yaml` that fails immediately with a clear error message when `mprocs` is invoked directly instead of through `tools/start-mprocs.sh`. The script sets `DUST_USE_START_MPROCS=1` before calling `mprocs`; a new `_check-start-script` proc checks for that variable and exits with instructions if it's missing.

Also cleans up `mprocs.yaml`: removes the repeated nvm setup boilerplate from individual procs (nvm is already handled by `start-mprocs.sh`), moves `READY_FILE` shell vars to the `env` section, and adds a `migrations` proc.

## Tests

Manual: verified `mprocs` directly shows the error, `tools/start-mprocs.sh` passes the guard.
