### PR TITLE
Add fake credits consumption in noop

### DIFF
--- a/front/lib/api/llm/clients/noop/index.ts
+++ b/front/lib/api/llm/clients/noop/index.ts
@@ -6,10 +6,15 @@ import type {
 } from "@app/lib/api/llm/types/events";
 import type {
   LLMParameters,
+  LLMStreamMetadata,
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import logger from "@app/logger/logger";
 import { isTextContent } from "@app/types/assistant/generation";
+import { NOOP_MODEL_ID } from "@app/types/assistant/models/noop";
 
 const metadata = {
   clientId: "noop" as const,
@@ -20,13 +25,14 @@ const metadata = {
 
 interface NoopRequest {
   type: "noop_request";
-  lastUserMessage: string;
+  lastUserMessageContent: string;
   staticResponse?: string;
 }
 
 // NoopLLM is a dummy LLM that can respond to special commands.
 export class NoopLLM extends LLM<NoopRequest> {
   private readonly metaData?: Record<string, unknown>;
+  private simulatedRunUsages: RunUsageType[] | null = null;
 
   constructor(
     auth: Authenticator,
@@ -43,39 +49,99 @@ export class NoopLLM extends LLM<NoopRequest> {
     if (typeof staticResponse === "string") {
       return {
         type: "noop_request",
-        lastUserMessage: "",
+        lastUserMessageContent: "",
         staticResponse,
       };
     }
 
-    const lastUserMessage =
-      conversation.messages
-        .slice()
-        .reverse()
-        .find((msg) => msg.role === "user")
-        ?.content.filter(isTextContent)
+    const lastUserMsg = conversation.messages
+      .slice()
+      .reverse()
+      .find((msg) => msg.role === "user");
+
+    const lastUserMessageContent =
+      lastUserMsg?.content
+        .filter(isTextContent)
         .map((item) => item.text)
         .join("\n")
-        .split("@noop")[1]
-        ?.trim() ?? "";
+        .trim() ?? "";
 
-    return { type: "noop_request", lastUserMessage };
+    logger.info(
+      { lastUserMessageContent, rawContent: lastUserMsg?.content },
+      "[Noop] buildStreamRequestPayload"
+    );
+    return { type: "noop_request", lastUserMessageContent };
+  }
+
+  protected override getSimulatedRunUsages(): RunUsageType[] | null {
+    // Consume to prevent double-recording if the base-class hook is active.
+    const usages = this.simulatedRunUsages;
+    this.simulatedRunUsages = null;
+    logger.info({ usages }, "[Noop] getSimulatedRunUsages");
+    return usages;
+  }
+
+  async *stream(
+    streamParameters: LLMStreamParameters,
+    metadata?: LLMStreamMetadata
+  ): AsyncGenerator<LLMEvent> {
+    try {
+      yield* super.stream(streamParameters, metadata);
+    } finally {
+      if (this.simulatedRunUsages) {
+        const run = await RunResource.fetchByDustRunId(this.authenticator, {
+          dustRunId: this.traceId,
+        });
+        if (run) {
+          await run.recordRunUsage(this.authenticator, this.simulatedRunUsages);
+          logger.info(
+            { costMicroUsd: this.simulatedRunUsages[0]?.costMicroUsd },
+            "[Noop] run usage recorded"
+          );
+        } else {
+          logger.warn({ dustRunId: this.traceId }, "[Noop] run not found");
+        }
+      }
+    }
   }
 
   protected async *sendRequest(payload: NoopRequest): AsyncGenerator<LLMEvent> {
+    const command = payload.lastUserMessageContent
+      .replace(/<dust_system>[\s\S]*?<\/dust_system>/g, "")
+      .trim();
+    logger.info({ command }, "[Noop] sendRequest");
+
+    const consumeMatch = command.match(/consume \$(\d+(?:\.\d+)?)/i);
+    if (consumeMatch) {
+      const costMicroUsd = Math.round(parseFloat(consumeMatch[1]) * 1_000_000);
+      this.simulatedRunUsages = [
+        {
+          providerId: "noop",
+          modelId: NOOP_MODEL_ID,
+          promptTokens: 0,
+          completionTokens: 0,
+          cachedTokens: null,
+          costMicroUsd,
+          isBatch: false,
+        },
+      ];
+      logger.info({ costMicroUsd }, "[Noop] simulating run usage");
+    }
+
     let responseText: string;
 
     // Determine response based on the message content.
     if (payload.staticResponse) {
       responseText = payload.staticResponse;
-    } else if (payload.lastUserMessage === "long message") {
+    } else if (command === "long message") {
       // Generate a very long message.
       responseText = "This is a very long message. ".repeat(100);
-    } else if (payload.lastUserMessage === "help") {
+    } else if (command === "help") {
       // Display usage instructions.
       responseText =
         "Noop agent usage:\n" +
         "- Send 'long message' to receive a very long response\n" +
+        "- Send 'consume $X' to simulate X dollars of credit cost\n" +
         "- Send 'help' to see this help message\n" +
         "- Send anything else to see 'Soupinou!' as a response\n";
     } else {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -142,6 +142,7 @@ export async function getLegacyLLM(
   }
   if (isNoopWhitelistedModelId(modelId)) {
     return new NoopLLM(auth, {
+      context,
       credentials,
       getTraceInput,
       getTraceOutput,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -23,6 +23,7 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -339,6 +340,11 @@ export abstract class LLM<TPayload = unknown> {
             this.modelId,
             { inferenceRegion: this.metadata.inferenceRegion }
           );
+        }
+
+        const simulatedRunUsages = this.getSimulatedRunUsages();
+        if (simulatedRunUsages) {
+          await run.recordRunUsage(this.authenticator, simulatedRunUsages);
         }
 
         yield currentEvent;
@@ -662,6 +668,14 @@ export abstract class LLM<TPayload = unknown> {
    * provider-specific API calls and response streaming.
    */
   protected abstract sendRequest(payload: TPayload): AsyncGenerator<LLMEvent>;
+
+  /**
+   * Override to inject run usages that bypass token-based pricing (e.g. noop simulation).
+   * Called after the stream completes; returned entries are recorded via recordRunUsage.
+   */
+  protected getSimulatedRunUsages(): RunUsageType[] | null {
+    return null;
+  }
 
   /**
    * Orchestrates the request lifecycle: build -> capture for tracing -> send.


### PR DESCRIPTION
## Description

Adds a `consume $X` command to the `@noop` agent for simulating credit costs in dev/testing without real LLM calls.

When the user message contains `consume $X` (e.g. `consume $0.5`), a `RunUsage` entry with the corresponding `costMicroUsd` is created and picked up by the existing credit computation path — no changes to `computeAndStoreAgentMessageCredits`.

Also fixes `@noop` not having a tracing context, which caused it to skip run creation entirely.

## Tests

Tested manually with the `@noop` agent in dev.

## Risk

Dev-only feature (behind `noop_model_feature` flag). No impact on production flows.

## Deploy Plan

Standard deploy.