### PR TITLE
[connector] remove lone surrogate

### DIFF
--- a/front/temporal/upsert_queue/activities.test.ts
+++ b/front/temporal/upsert_queue/activities.test.ts
@@ -14,38 +14,48 @@ describe("cleanUtf8Content", () => {
     expect(cleanUtf8Content('{"key": "val\0ue"}')).toBe('{"key": "value"}');
   });
 
-  it("returns early when no actual surrogate code points are present", () => {
-    // \\uD800 here is the 6-char ASCII sequence \uD800, not an actual surrogate code point.
-    // The early-exit regex sees no surrogates → returns unchanged.
-    expect(cleanUtf8Content("\\uD800")).toBe("\\uD800");
-    expect(cleanUtf8Content("\\uDC00")).toBe("\\uDC00");
+  it("returns early when no escaped surrogate sequences are present", () => {
+    // \\uABCD is the 6-char ASCII escape for a non-surrogate code point — left untouched.
+    expect(cleanUtf8Content("\\uABCD")).toBe("\\uABCD");
+    expect(cleanUtf8Content("\\u003F")).toBe("\\u003F");
   });
 
-  it("replaces lone high surrogates in escaped form when actual surrogates trigger processing", () => {
-    // \uD800 (actual code point U+D800) triggers the early-exit guard.
-    // The following \\uD800 is the 6-char escaped form — lone, so it gets replaced.
-    expect(cleanUtf8Content("\uD800\\uD800")).toBe("\uD800\\u003F");
-    expect(cleanUtf8Content("\uD800\\uDBFF")).toBe("\uD800\\u003F");
+  it("cleans escaped lone surrogates even with no actual surrogate code point present", () => {
+    // This is the real-world case: cleanUtf8Content runs on JSON-serialized text, where a
+    // lone surrogate appears as the escaped form \\uXXXX (ASCII), not an actual code point.
+    // The early-exit guard must trigger on the escaped form, otherwise cleaning is skipped.
+    expect(cleanUtf8Content("\\uD800")).toBe("\\u003F");
+    expect(cleanUtf8Content("\\uDC00")).toBe("\\u003F");
+
+    // Valid surrogate pair in escaped form — preserved.
+    expect(cleanUtf8Content("\\uD83D\\uDE00")).toBe("\\uD83D\\uDE00");
+  });
+
+  it("cleans a split emoji where the low surrogate was left lone", () => {
+    // A spoon emoji 🥄 (U+1F944 = 🥄) whose high surrogate got HTML-entity-encoded
+    // (&#xD83E;) while the low surrogate \uDD44 was left as a lone surrogate. Once serialized,
+    // \\uDD44 must be replaced so core's serde_json does not reject the body.
+    expect(cleanUtf8Content('"&#xD83E;\\uDD44"')).toBe('"&#xD83E;\\u003F"');
+  });
+
+  it("replaces lone high surrogates in escaped form", () => {
+    expect(cleanUtf8Content("\\uD800")).toBe("\\u003F");
+    expect(cleanUtf8Content("\\uDBFF")).toBe("\\u003F");
 
     // \\uD800\\uDC00 is a valid surrogate pair in escaped form — preserved.
-    expect(cleanUtf8Content("\uD800\\uD800\\uDC00")).toBe(
-      "\uD800\\uD800\\uDC00"
-    );
+    expect(cleanUtf8Content("\\uD800\\uDC00")).toBe("\\uD800\\uDC00");
   });
 
-  it("replaces lone low surrogates in escaped form when actual surrogates trigger processing", () => {
+  it("replaces lone low surrogates in escaped form", () => {
     // \\uDC00 alone (no preceding high surrogate) is invalid — replaced.
-    expect(cleanUtf8Content("\uD800\\uDC00")).toBe("\uD800\\u003F");
-    expect(cleanUtf8Content("\uD800\\uDFFF")).toBe("\uD800\\u003F");
+    expect(cleanUtf8Content("\\uDC00")).toBe("\\u003F");
+    expect(cleanUtf8Content("\\uDFFF")).toBe("\\u003F");
 
-    // \\uD800\\uDC00 valid pair — preserved.
-    expect(cleanUtf8Content("\uD800\\uD83D\\uDE00")).toBe(
-      "\uD800\\uD83D\\uDE00"
-    );
+    // \\uD83D\\uDE00 valid pair — preserved.
+    expect(cleanUtf8Content("\\uD83D\\uDE00")).toBe("\\uD83D\\uDE00");
   });
 
-  it("strips null bytes independently of the surrogate path", () => {
-    // Null bytes are stripped first; the remaining string has no actual surrogates → early exit.
-    expect(cleanUtf8Content("\0\\uD800\0")).toBe("\\uD800");
+  it("strips null bytes before the surrogate path runs", () => {
+    expect(cleanUtf8Content("\0\\uD800\0")).toBe("\\u003F");
   });
 });

--- a/front/temporal/upsert_queue/activities.ts
+++ b/front/temporal/upsert_queue/activities.ts
@@ -17,15 +17,17 @@ const { DUST_UPSERT_QUEUE_BUCKET, SERVICE_ACCOUNT } = process.env;
 
 export function cleanUtf8Content(content: string): string {
   // Strip null bytes (invalid in PostgreSQL text columns and JSON strings per RFC4627)
-  content = content.replace(/\0/g, "");
+  const withoutNullBytes = content.replace(/\0/g, "");
 
-  // Early exit if no \uD sequences found.
-  if (!/[\uD800-\uDFFF]/.test(content)) {
-    return content;
+  // This runs on JSON-serialized text, where surrogates appear as escaped `\uXXXX`
+  // sequences (not as actual surrogate code units). Early exit only when there is no
+  // escaped surrogate (\uD800-\uDFFF) to clean.
+  if (!/\\uD[89A-F][0-9A-F]{2}/i.test(withoutNullBytes)) {
+    return withoutNullBytes;
   }
   // Replace invalid high surrogates not followed by a low surrogate with a valid JSON string
   // Replace invalid low surrogates not preceded by a high surrogate with a valid JSON string
-  return content
+  return withoutNullBytes
     .replace(/\\uD[89AB][0-9A-F]{2}(?!\\uD[CDEF][0-9A-F]{2})/gi, "\\u003F")
     .replace(/(?<!\\uD[89AB][0-9A-F]{2})\\uD[CDEF][0-9A-F]{2}/gi, "\\u003F");
 }


### PR DESCRIPTION
## Description
This PR is to fix the stuck front connector trying to upload a document containing a lone surrogate. 

IIUC:
Somewhere upstream (where??), emoji got split apart:
  - The high half got turned into a different format
  - The low half was left on its own 
  
 [\uD800-\uDFFF] are reserved for use as paired code units in UTF-16, and it should never be alone. 

`cleanUtf8Content` runs when it's escaped text, and the previous regex didn't match with the escaped form? 



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
