### PR TITLE
[LLM] Split Anthropic cache-creation tokens by TTL for accurate pricing

### DIFF
--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -357,9 +357,13 @@ function convertToOldEvent(
         standardOutput,
         cacheHit,
         cacheCreated,
+        longCacheCreated,
+        shortCacheCreated,
         reasoning,
       } = event.content;
-      const inputTokens = standardInput + cacheHit + cacheCreated;
+      const totalCacheCreated =
+        cacheCreated > 0 ? cacheCreated : longCacheCreated + shortCacheCreated;
+      const inputTokens = standardInput + cacheHit + totalCacheCreated;
       return {
         type: "token_usage",
         content: {

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@anthropic-ai/sdk";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
 import type {
+  CacheCreation,
   Message,
   MessageDeltaUsage,
   RawContentBlockDeltaEvent,
@@ -121,6 +122,8 @@ function makeStubConverters(): OutputEventConverters {
       type: "token_usage" as const,
       content: {
         cacheCreated: 0,
+        longCacheCreated: 0,
+        shortCacheCreated: 0,
         cacheHit: 0,
         standardInput: 0,
         standardOutput: 0,
@@ -376,7 +379,7 @@ describe("invalidJsonToolCallToToolCallEvent", () => {
 });
 
 describe("messageDeltaUsageToTokenUsageEvent", () => {
-  it("splits reasoning out of output tokens when a breakdown is present", () => {
+  it("splits cache creation by TTL when the breakdown is present", () => {
     const usage: MessageDeltaUsage = {
       cache_creation_input_tokens: 10,
       cache_read_input_tokens: 20,
@@ -385,10 +388,42 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
       output_tokens_details: { thinking_tokens: 15 },
       server_tool_use: null,
     };
-    expect(messageDeltaUsageToTokenUsageEvent(metadata, usage)).toEqual({
+    const cacheCreation: CacheCreation = {
+      ephemeral_1h_input_tokens: 6,
+      ephemeral_5m_input_tokens: 4,
+    };
+    expect(
+      messageDeltaUsageToTokenUsageEvent(metadata, usage, cacheCreation)
+    ).toEqual({
+      type: "token_usage",
+      content: {
+        cacheCreated: 0,
+        longCacheCreated: 6,
+        shortCacheCreated: 4,
+        cacheHit: 20,
+        standardInput: 100,
+        standardOutput: 35,
+        reasoning: 15,
+      },
+      metadata,
+    });
+  });
+
+  it("reports the flat cache-creation total as cacheCreated when no breakdown is present", () => {
+    const usage: MessageDeltaUsage = {
+      cache_creation_input_tokens: 10,
+      cache_read_input_tokens: 20,
+      input_tokens: 100,
+      output_tokens: 50,
+      output_tokens_details: { thinking_tokens: 15 },
+      server_tool_use: null,
+    };
+    expect(messageDeltaUsageToTokenUsageEvent(metadata, usage, null)).toEqual({
       type: "token_usage",
       content: {
         cacheCreated: 10,
+        longCacheCreated: 0,
+        shortCacheCreated: 0,
         cacheHit: 20,
         standardInput: 100,
         standardOutput: 35,
@@ -407,10 +442,12 @@ describe("messageDeltaUsageToTokenUsageEvent", () => {
       output_tokens_details: null,
       server_tool_use: null,
     };
-    expect(messageDeltaUsageToTokenUsageEvent(metadata, usage)).toEqual({
+    expect(messageDeltaUsageToTokenUsageEvent(metadata, usage, null)).toEqual({
       type: "token_usage",
       content: {
         cacheCreated: 0,
+        longCacheCreated: 0,
+        shortCacheCreated: 0,
         cacheHit: 0,
         standardInput: 0,
         standardOutput: 40,
@@ -971,6 +1008,62 @@ describe("rawOutputToEvents", () => {
     const success = events.find((e) => e.type === "success");
     expect(success).toMatchObject({
       content: { aggregated: [{ type: "text", content: { value: "Hi" } }] },
+    });
+  });
+
+  it("splits cache creation by TTL using the cache_creation breakdown from message_start", async () => {
+    // Anthropic only emits the per-TTL split on message_start; the trailing
+    // message_delta usage carries the flat cache_creation_input_tokens. The
+    // breakdown captured from message_start must drive the token_usage event.
+    const events = await collect(
+      rawOutputToEvents(
+        streamOf([
+          {
+            type: "message_start",
+            message: {
+              id: "msg_1",
+              usage: {
+                input_tokens: 3,
+                cache_creation_input_tokens: 4809,
+                cache_read_input_tokens: 0,
+                cache_creation: {
+                  ephemeral_5m_input_tokens: 7,
+                  ephemeral_1h_input_tokens: 4802,
+                },
+                output_tokens: 1,
+              },
+            },
+          } as RawMessageStartEvent,
+          {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn", stop_sequence: null },
+            usage: {
+              cache_creation_input_tokens: 4809,
+              cache_read_input_tokens: 0,
+              input_tokens: 3,
+              output_tokens: 5,
+              output_tokens_details: { thinking_tokens: 0 },
+              server_tool_use: null,
+            },
+          } as RawMessageStreamEvent,
+          { type: "message_stop" } as RawMessageStreamEvent,
+        ]),
+        metadata,
+        realConverters
+      )
+    );
+
+    const tokenUsage = events.find((e) => e.type === "token_usage");
+    expect(tokenUsage).toMatchObject({
+      content: {
+        cacheCreated: 0,
+        longCacheCreated: 4802,
+        shortCacheCreated: 7,
+        cacheHit: 0,
+        standardInput: 3,
+        standardOutput: 5,
+        reasoning: 0,
+      },
     });
   });
 

--- a/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/output/utils.ts
@@ -5,6 +5,7 @@ import {
 } from "@anthropic-ai/sdk";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches";
 import type {
+  CacheCreation,
   Message,
   MessageDeltaUsage,
   RawContentBlockDeltaEvent,
@@ -158,7 +159,8 @@ export interface OutputEventConverters {
   ): ToolCallEvent;
   messageDeltaUsageToTokenUsageEvent(
     metadata: EndpointMetadata,
-    usage: MessageDeltaUsage
+    usage: MessageDeltaUsage,
+    cacheCreation: CacheCreation | null
   ): TokenUsageEvent;
   stopReasonToErrorEvent(
     metadata: EndpointMetadata,
@@ -269,9 +271,9 @@ export function invalidJsonToolCallToToolCallEvent(
 
 export function messageDeltaUsageToTokenUsageEvent(
   metadata: EndpointMetadata,
-  usage: MessageDeltaUsage
+  usage: MessageDeltaUsage,
+  cacheCreation: CacheCreation | null
 ): TokenUsageEvent {
-  const cacheCreated = usage.cache_creation_input_tokens ?? 0;
   const cacheHit = usage.cache_read_input_tokens ?? 0;
   const uncachedInput = usage.input_tokens ?? 0;
   // thinking_tokens is the reasoning portion of output_tokens; subtracting
@@ -279,10 +281,28 @@ export function messageDeltaUsageToTokenUsageEvent(
   // standardOutput.
   const thinkingTokens = usage.output_tokens_details?.thinking_tokens ?? 0;
 
+  // The per-TTL breakdown lives on the full `Usage` object (`cache_creation`),
+  // not on `MessageDeltaUsage`. When it's present, split cache creation into the
+  // 1h (long) and 5m (short) buckets and leave `cacheCreated` at 0. Otherwise we
+  // only know the flat total, so report it as `cacheCreated` and leave both
+  // per-TTL buckets at 0 — consumers fall back to `long + short` only when
+  // `cacheCreated` is 0.
+  let cacheCreated = 0;
+  let longCacheCreated = 0;
+  let shortCacheCreated = 0;
+  if (cacheCreation) {
+    longCacheCreated = cacheCreation.ephemeral_1h_input_tokens;
+    shortCacheCreated = cacheCreation.ephemeral_5m_input_tokens;
+  } else {
+    cacheCreated = usage.cache_creation_input_tokens ?? 0;
+  }
+
   return {
     type: "token_usage",
     content: {
       cacheCreated,
+      longCacheCreated,
+      shortCacheCreated,
       cacheHit,
       standardInput: uncachedInput,
       standardOutput: usage.output_tokens - thinkingTokens,
@@ -655,6 +675,9 @@ export async function* rawOutputToEvents(
   const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
   let blockState: BlockState | null = null;
   let tokenUsage: MessageDeltaUsage | null = null;
+  // The per-TTL cache-creation breakdown is only emitted on `message_start`;
+  // capture it so the trailing `message_delta` usage can be split by TTL.
+  let cacheCreation: CacheCreation | null = null;
 
   while (true) {
     let result: IteratorResult<RawMessageStreamEvent>;
@@ -699,6 +722,7 @@ export async function* rawOutputToEvents(
     let outputEvents: ModelResponseEvent[];
     switch (event.type) {
       case "message_start":
+        cacheCreation = event.message.usage?.cache_creation ?? null;
         outputEvents = [
           converters.messageStartToResponseIdEvent(metadata, event),
         ];
@@ -769,7 +793,11 @@ export async function* rawOutputToEvents(
   }
 
   if (tokenUsage !== null) {
-    yield converters.messageDeltaUsageToTokenUsageEvent(metadata, tokenUsage);
+    yield converters.messageDeltaUsageToTokenUsageEvent(
+      metadata,
+      tokenUsage,
+      cacheCreation
+    );
   }
 
   yield {
@@ -871,7 +899,11 @@ export function messageToEvents(
   }
 
   events.push(
-    converters.messageDeltaUsageToTokenUsageEvent(metadata, message.usage)
+    converters.messageDeltaUsageToTokenUsageEvent(
+      metadata,
+      message.usage,
+      message.usage.cache_creation
+    )
   );
 
   events.push({ type: "success", content: { aggregated }, metadata });

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.ts
@@ -8,6 +8,9 @@ export class AgentPlatformEuropeClaudeSonnetFourDotSixStream extends WithAnthrop
   // https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#europe-west1
   static readonly tokenPricing = {
     cacheCreated: 4.13,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 4.13,
+    longCacheCreated: 6.6,
     cacheHit: 0.33,
     standardInput: 3.3,
     standardOutput: 16.5,

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -6,8 +6,12 @@ import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 export class AnthropicGlobalClaudeSonnetFourDotSixStream extends WithAnthropicClaudeSonnetFourDotSixConfig(
   AnthropicStream
 ) {
+  // https://platform.claude.com/docs/en/about-claude/pricing
   static readonly tokenPricing = {
     cacheCreated: 3.75,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 3.75,
+    longCacheCreated: 6.0,
     cacheHit: 0.3,
     standardInput: 3.0,
     standardOutput: 15.0,

--- a/front/lib/model_constructors/test/cases.ts
+++ b/front/lib/model_constructors/test/cases.ts
@@ -81,6 +81,35 @@ const SAME_ROLE_FOLLOWING_BLOCKS_CONVERSATION: BaseConversation = {
   ],
 };
 
+// Anthropic only writes a cache entry when the cumulative prefix up to a
+// breakpoint clears its minimum cacheable size (1024 tokens for Sonnet). This
+// filler pushes the system prompt well past that threshold so both breakpoints
+// in `CACHE_CONVERSATION` actually create cache entries.
+const LONG_CACHEABLE_SYSTEM_PROMPT = Array.from(
+  { length: 200 },
+  (_, i) =>
+    `Guideline ${i + 1}: Always be helpful, harmless, and honest, and follow the user's instructions exactly.`
+).join(" ");
+
+const CACHE_CONVERSATION: BaseConversation = {
+  system: [
+    {
+      role: "system",
+      type: "text",
+      content: { value: LONG_CACHEABLE_SYSTEM_PROMPT },
+      cache: "long",
+    },
+  ],
+  messages: [
+    {
+      role: "user",
+      type: "text",
+      content: { value: 'Say "Hi"' },
+      cache: "short",
+    },
+  ],
+};
+
 const REASONING_CONVERSATION: BaseConversation = {
   system: [
     {
@@ -262,6 +291,8 @@ export const TEST_KEYS = [
   "output-format/json-schema/t-default/r-high",
 
   "following/no-tools/t-default/r-default",
+
+  "cache/no-tools/t-default/r-default",
 ] as const;
 
 export type TestKey = (typeof TEST_KEYS)[number];
@@ -526,5 +557,12 @@ export const TEST_CASES: Record<TestKey, TestCase> = {
         value: "hello",
       },
     ],
+  },
+
+  // CACHE — "long" breakpoint on the system prompt, "short" on the user message.
+  "cache/no-tools/t-default/r-default": {
+    config: {},
+    conversation: CACHE_CONVERSATION,
+    defaultCheckers: [TEXT_CONTAINS_HI],
   },
 };

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_sonnet_four_dot_six.test.ts
@@ -22,6 +22,7 @@ const setup: StreamSetup = {
     "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
 
     "simple/no-tools/t-default/r-default": null,
+
     "simple/no-tools/t-default/r-none": null,
     "simple/no-tools/t-default/r-low": null,
     "simple/no-tools/t-default/r-medium": null,
@@ -60,6 +61,8 @@ const setup: StreamSetup = {
     "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
   },
 };
 

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_sonnet_four_dot_six.test.ts
@@ -60,6 +60,8 @@ const setup: StreamSetup = {
     "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
   },
 };
 

--- a/front/lib/model_constructors/types/output/events.ts
+++ b/front/lib/model_constructors/types/output/events.ts
@@ -64,6 +64,8 @@ export interface ReasoningEvent {
 }
 
 export type TokenUsageContent = {
+  longCacheCreated: number;
+  shortCacheCreated: number;
   cacheCreated: number;
   cacheHit: number;
   standardInput: number;

--- a/front/lib/model_constructors/types/token_pricing.ts
+++ b/front/lib/model_constructors/types/token_pricing.ts
@@ -1,6 +1,8 @@
 // Per M tokens
 export type TokenPricing = {
   cacheCreated?: number;
+  longCacheCreated?: number;
+  shortCacheCreated?: number;
   cacheHit?: number;
   standardInput: number;
   standardOutput: number;


### PR DESCRIPTION
## Description

Captures Anthropic's per-TTL cache-creation split (`ephemeral_1h`/`ephemeral_5m`, emitted only on `message_start`) and routes it through the token-usage pipeline so 1h ("long") and 5m ("short") cache writes are priced at their distinct rates, falling back to the flat `cacheCreated` total when no breakdown is present.

## Tests

Added unit tests for the TTL split in the converter (including a case built from a real captured stream) and new `cache/no-tools` integration test cases for the affected Sonnet 4.6 endpoints. Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`