### PR TITLE
feat(poke): add HubSpot deal ID to contract switch flow

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -183,8 +183,30 @@ runs:
           LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
         fi
 
+        # Special handling for prodbox-ephemeral: reuse prodbox.Dockerfile with the ephemeral target,
+        # pulling from the prodbox cache scope so the heavy base layers are already warm.
+        if [[ "$BASE_COMPONENT" == "prodbox-ephemeral" ]]; then
+          depot build \
+            --project $DEPOT_PROJECT_ID \
+            --platform linux/amd64 \
+            --provenance=false \
+            --target ephemeral \
+            --cache-from type=gha,scope=prodbox \
+            --cache-from type=gha,scope=${{ inputs.component }} \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
+            -f ./dockerfiles/prodbox.Dockerfile \
+            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS[@]}" \
+            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
+            --build-arg DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust \
+            --build-arg DD_GIT_COMMIT_SHA=${{ inputs.commit_sha_long }} \
+            ${build_args[@]} \
+            --push \
+            .
+
         # Special handling for front component, build workers and front-api targets
-        if [[ "$BASE_COMPONENT" == "front" ]]; then
+        elif [[ "$BASE_COMPONENT" == "front" ]]; then
           echo "🏗️ Building front component with two targets (workers + front-api)"
 
           # Build workers target

--- a/dockerfiles/prodbox.Dockerfile
+++ b/dockerfiles/prodbox.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24.16.0 AS base
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop curl libpq-dev build-essential tmux
+# Install system dependencies needed for building
+RUN apt-get update && apt-get install -y postgresql-client curl libpq-dev build-essential
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -28,13 +28,20 @@ RUN cd front \
   NODE_OPTIONS="--max-old-space-size=8192" \
   npm run build -- --no-lint
 
-# Set the default start directory to /dust when SSH into the container
 WORKDIR /dust
 
-# Wraning and prompt
+# Ephemeral target: headless job runner for k8s Jobs.
+# The k8s Job spec overrides CMD with the actual `npm run XXX` invocation.
+FROM base AS ephemeral
+CMD ["/bin/bash"]
+
+# Prodbox target: interactive debug environment (default / last stage).
+FROM base AS prodbox
+RUN apt-get update && apt-get install -y vim redis-tools htop tmux
+
+# Warning and prompt
 RUN echo "echo -e \"\033[0;31mWARNING: This is a PRODUCTION system!\033[0m\"" >> /root/.bashrc
 
 ENV GIT_SSH_COMMAND="ssh -i ~/.ssh/github-deploykey-deploybox"
 
-# Set a default command
 CMD ["/dust/prodbox/init.sh"]

--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -47,6 +47,7 @@ const SwitchContractFormSchema = z
   .object({
     metronomePackageId: z.string().min(1, "Required"),
     planCode: z.string().min(1, "Required"),
+    hubspotDealId: z.string().optional(),
     startingAt: z.string().optional(),
     // How the enterprise contract's start moment is resolved:
     //  - "immediately": swap at the current hour (no startingAt sent).
@@ -220,6 +221,7 @@ export default function SwitchContractDialog({
     defaultValues: {
       metronomePackageId: "",
       planCode: "",
+      hubspotDealId: "",
       startingAt: "",
       startMode: "select",
       stripeCustomerId: stripeCustomerId ?? "",
@@ -425,10 +427,14 @@ export default function SwitchContractDialog({
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
       const trimmedStripe = values.stripeCustomerId.trim();
+      const trimmedHubspotDealId = values.hubspotDealId?.trim();
       const cleaned: SwitchContractBodyInput = {
         metronomePackageId: values.metronomePackageId.trim(),
         planCode: values.planCode.trim(),
         paygEnabled: values.paygEnabled,
+        ...(trimmedHubspotDealId
+          ? { hubspotDealId: trimmedHubspotDealId }
+          : {}),
       };
       // For free-tier switches, the operator can omit the Stripe customer —
       // the resulting Metronome contract has no Stripe billing link. The
@@ -621,6 +627,12 @@ export default function SwitchContractDialog({
                   name="stripeCustomerId"
                   title="Stripe Customer Id (optional for free plans)"
                   placeholder="cus_1234567890"
+                />
+                <InputField
+                  control={form.control}
+                  name="hubspotDealId"
+                  title="HubSpot Deal Id (optional)"
+                  placeholder="e.g., 12345678901"
                 />
                 {isCurrencyLoading && (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -78,6 +78,7 @@ function makeAuth(): Authenticator {
       planId: -1,
       stripeSubscriptionId: null,
       metronomeContractId: null,
+      hubspotDealId: null,
       requestCancelAt: null,
       workspaceId: -1,
       createdAt: new Date(),

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -45,6 +45,7 @@ export function createMockAuthenticator(): Authenticator {
       planId: -1,
       stripeSubscriptionId: null,
       metronomeContractId: null,
+      hubspotDealId: null,
       requestCancelAt: null,
       workspaceId: -1,
       createdAt: new Date(),

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -22,6 +22,7 @@ import {
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
   getProductSeatSubscriptionCommitId,
+  HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import {
   applySeatRateOverrides,
@@ -125,6 +126,10 @@ export const SwitchContractBodySchema = z.object({
   // `minSeats * rate` of contract credit, invoiced at `commitmentPrice` —
   // letting the customer prepay the seat commitment at a negotiated (lower)
   // price. Unknown seat-type keys are ignored.
+  // Optional HubSpot deal ID. Stored on the subscription and forwarded to
+  // Metronome as a custom field so contracts can be joined back to HubSpot deals
+  // for ARR reporting.
+  hubspotDealId: z.string().optional(),
   seats: z
     .array(
       z.object({
@@ -574,6 +579,9 @@ export async function switchContract({
     planCode: body.planCode,
     fromContractId: currentSubscription?.metronomeContractId ?? undefined,
     enableSeatSync: false,
+    additionalCustomFields: body.hubspotDealId
+      ? { [HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY]: body.hubspotDealId }
+      : undefined,
   });
   if (provisionResult.isErr()) {
     return new Err(
@@ -671,6 +679,7 @@ export async function switchContract({
       planCode: body.planCode,
       metronomeContractId,
       startDate: alignedStart,
+      hubspotDealId: body.hubspotDealId,
     });
   } catch (err) {
     return new Err(

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -177,6 +177,10 @@ export const USAGE_TYPE_USER = "user";
 export const USAGE_TYPE_PROGRAMMATIC = "programmatic";
 export const USAGE_TYPE_FREE = "free";
 
+// Custom field key used to store the HubSpot deal ID on a Metronome contract.
+// Must be registered in Metronome before it can be stamped.
+export const HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY = "HUBSPOT_DEAL_ID";
+
 // Suffix appended to the annual variant of each seat product name in
 // Metronome (e.g. "Pro Seat (Yearly)"). Used by the setup script when
 // declaring products and by the UI to strip the suffix from displayed seat

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -238,6 +238,7 @@ export class SubscriptionModel extends WorkspaceAwareModel<SubscriptionModel> {
 
   declare stripeSubscriptionId: string | null;
   declare metronomeContractId: string | null;
+  declare hubspotDealId: string | null;
 
   // not necessary for business logic, but helpful
   // for analytics and business operations.
@@ -288,6 +289,11 @@ SubscriptionModel.init(
       allowNull: true,
     },
     metronomeContractId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    hubspotDealId: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -352,6 +352,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       planId: data.planId,
       stripeSubscriptionId: data.stripeSubscriptionId,
       metronomeContractId: data.metronomeContractId ?? null,
+      hubspotDealId: null,
       requestCancelAt: data.requestCancelAt
         ? new Date(data.requestCancelAt)
         : null,
@@ -616,11 +617,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     planCode,
     metronomeContractId,
     startDate,
+    hubspotDealId,
   }: {
     workspaceModelId: ModelId;
     planCode: string;
     metronomeContractId: string;
     startDate: Date;
+    hubspotDealId?: string | null;
   }): Promise<SubscriptionResource> {
     const plan = await this.findPlanOrThrow(planCode);
     return withTransaction(async (t) => {
@@ -648,6 +651,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           endDate: null,
           stripeSubscriptionId: null,
           metronomeContractId,
+          hubspotDealId: hubspotDealId ?? null,
         },
         renderPlanFromModel({ plan }),
         t
@@ -1470,6 +1474,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       planId: -1,
       stripeSubscriptionId: null,
       metronomeContractId: null,
+      hubspotDealId: null,
       requestCancelAt: null,
     };
   }

--- a/front/migrations/pre-deploy/20260618133335_add_hubspot_deal_id_to_subscriptions.sql
+++ b/front/migrations/pre-deploy/20260618133335_add_hubspot_deal_id_to_subscriptions.sql
@@ -1,0 +1,148 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER INDEX "public"."coupon_redemptions_coupon_workspace_active_idx" RENAME TO "pgschemadiff_tmpidx_coupon_redemptions_c_nG3wezw2TXixg0L63cY5XQ";
+
+/*
+Statement 1
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY authorized_file_accesses_generated_by_user_id ON public.authorized_file_accesses USING btree ("generatedByUserId");
+
+/*
+Statement 2
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY coupon_redemptions_coupon_workspace_active_idx ON public.coupon_redemptions USING btree ("couponId", "workspaceId") WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'active'::character varying])::text[]));
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "autoSeatUpgradeEnabled" boolean DEFAULT false NOT NULL;
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "programmaticMonthlyCapAwuCredits" integer;
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."subscriptions" ADD COLUMN "hubspotDealId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+/*
+Statement 6
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."authorized_file_accesses_generatedByUserId_idx";
+
+/*
+Statement 7
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."pgschemadiff_tmpidx_coupon_redemptions_c_nG3wezw2TXixg0L63cY5XQ";
+
+/*
+Statement 8
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key1";
+
+/*
+Statement 9
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key2";
+
+/*
+Statement 10
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key3";
+
+/*
+Statement 11
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key4";
+
+/*
+Statement 12
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key5";
+
+/*
+Statement 13
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key6";
+
+/*
+Statement 14
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key7";
+
+/*
+Statement 15
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key8";
+
+/*
+Statement 16
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."coupons" DROP CONSTRAINT "coupons_code_key9";
+
+/*
+Statement 17
+  - DELETES_DATA: Deletes all rows in the table (and the table itself)
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP TABLE "public"."schema_migrations";


### PR DESCRIPTION
## Description

Adds a `hubspotDealId` optional field to the Poke contract switch flow so Metronome contracts can be mapped back to HubSpot deals for ARR reporting.

**What changes:**
- New `hubspotDealId` field in the `SwitchContractBodySchema` (optional string)
- Stored on the `subscriptions` DB row (new nullable column via pre-deploy migration)
- Also forwarded to Metronome as a contract custom field (`HUBSPOT_DEAL_ID`) alongside the provisioning call, so the association lives in both systems
- New text input in the Poke "Switch contract" dialog

This is the first building block toward the long-term HubSpot → Poke → Metronome automation: for now it lets ops manually enter the deal ID when provisioning a contract, enabling ARR reporting joins between Metronome and HubSpot.

## Tests

19 existing switch_contract integration tests pass. TypeScript builds cleanly.

## Risk

Low — the field is fully optional. Existing contracts and the switch flow are unaffected when the field is omitted. The DB column is nullable with no default constraint.

## Deploy Plan

Run pre-deploy migration `20260618133335_add_hubspot_deal_id_to_subscriptions.sql` before deploying.