### PR TITLE
fix(llm): use endpoint provider in transitions and log new-router selection

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,5 +1,6 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import {
   isAnthropicVertexWhitelistedModelId,
@@ -243,6 +244,10 @@ export async function getStreamLLM(
   );
 
   if (featureFlags.includes("use_new_llm_router") && streamEndpointLLM) {
+    logger.info(
+      { modelId: llmParameters.modelId },
+      `Sending request to ${llmParameters.modelId} with new router`
+    );
     return streamEndpointLLM;
   }
 

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,6 +1,5 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
-import logger from "@app/logger/logger";
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import {
   isAnthropicVertexWhitelistedModelId,
@@ -52,6 +51,7 @@ import {
   type Region,
 } from "@app/lib/model_constructors/types/regions";
 import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
+import logger from "@app/logger/logger";
 import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import type { LLMCredentialsType } from "@app/types/provider_credential";

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -540,7 +540,7 @@ export class StreamEndpointTransition extends BaseTransition {
     llmParameters: LLMParameters,
     modelConstructor: StreamEndpointConstructor
   ) {
-    super(auth, ANTHROPIC_PROVIDER_ID, llmParameters);
+    super(auth, modelConstructor.providerId, llmParameters);
     this.model = new modelConstructor(llmParameters.credentials);
 
     const { api, region } = this.model.metadata();
@@ -581,7 +581,7 @@ export class BatchEndpointTransition extends BaseTransition {
     llmParameters: LLMParameters,
     modelConstructor: BatchEndpointConstructor
   ) {
-    super(auth, ANTHROPIC_PROVIDER_ID, llmParameters);
+    super(auth, modelConstructor.providerId, llmParameters);
     this.model = new modelConstructor(llmParameters.credentials);
   }
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -1,4 +1,3 @@
-import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
 import { LLM } from "@app/lib/api/llm/llm";
 import type { BatchResult } from "@app/lib/api/llm/types/batch";
 import {
@@ -522,7 +521,7 @@ abstract class BaseTransition extends LLM {
       forceTool: forceToolCall,
       outputFormat: parseResponseFormatSchema(
         this.responseFormat,
-        ANTHROPIC_PROVIDER_ID
+        this.metadata.clientId
       ),
     });
   }


### PR DESCRIPTION
## Description

Two foundational fixes to the new per-endpoint LLM router (`model_constructors`, surfaced through `StreamEndpointTransition`/`BatchEndpointTransition`), independent of any specific model:

- **Provider routing fix.** Both transition classes hardcoded `ANTHROPIC_PROVIDER_ID` when calling the legacy `LLM` base constructor, which resolves a model config by `(modelId, providerId)`. This worked only because every registered endpoint was Anthropic — any non-Anthropic endpoint threw `Model config not found for <modelId>/anthropic`. They now pass the endpoint's own `providerId`. This is type-safe: the new `ProviderId` is declared `satisfies readonly ModelProviderIdType[]`, so it is a guaranteed subset of the legacy provider union.
- **Observability.** `getStreamLLM` now logs `Sending request to <modelId> with new router` when the new router is selected, so we can tell from the logs which router served a request (the new router otherwise emits nothing).

Foundation for routing non-Anthropic models (e.g. OpenAI GPT-5.5) through the new router in follow-up PRs.

## Tests

Type-checks clean. Anthropic endpoints are unaffected (they already passed `anthropic` to the base; behavior is identical). Verified locally that the previous crash path (`Model config not found for gpt-5.5/anthropic`) no longer occurs once a non-Anthropic endpoint is routed.

## Risk

Low. The provider value passed to the legacy base is now the endpoint's actual provider instead of a constant that only happened to be correct for Anthropic. No behavior change for existing Anthropic endpoints. The log line is info-level and gated on the new-router branch.

## Deploy Plan

Standard deploy, no migration needed.