### PR TITLE
feat(model_constructors): add GPT-5.5 stream endpoint

### DIFF
--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_five.ts
@@ -1,0 +1,49 @@
+import {
+  type InputConfig,
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { GPT_5_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// https://developers.openai.com/api/docs/models/gpt-5.5
+const CONTEXT_SIZE = 1_050_000;
+const MAX_OUTPUT_TOKENS = 128_000;
+const DEFAULT_REASONING_EFFORT = "medium";
+
+// gpt-5.5 accepts none/low/medium/high/xhigh. "minimal" and the universal
+// "maximal" are unsupported and surface as an input configuration error.
+const GPT_5_5_REASONING_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
+
+const configSchema = z.union([
+  inputConfigSchema.extend({
+    reasoning: z
+      .object({ effort: z.enum(GPT_5_5_REASONING_EFFORTS) })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    temperature: temperatureSchema.optional().transform(() => undefined),
+  }),
+  inputConfigSchema.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+    temperature: temperatureSchema.optional(),
+  }),
+]);
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithOpenAIGptFiveDotFiveConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class OpenAIGptFiveDotFive extends Base {
+    static readonly modelId = GPT_5_5_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<InputConfig> = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return OpenAIGptFiveDotFive;
+}

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five.ts
@@ -1,0 +1,21 @@
+import { WithOpenAIGptFiveDotFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_five";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesGlobalGptFiveDotFiveStream extends WithOpenAIGptFiveDotFiveConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.5
+  static readonly tokenPricing = {
+    cacheHit: 0.5,
+    standardInput: 5.0,
+    standardOutput: 30.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+OpenAIResponsesGlobalGptFiveDotFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesGlobalGptFiveDotFiveStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_five.test.ts
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFiveStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -1,4 +1,4 @@
-export const GPT_5_4_MODEL_ID = "gpt-5.4" as const;
+export const GPT_5_5_MODEL_ID = "gpt-5.5" as const;
 export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
@@ -7,7 +7,7 @@ export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 
 // Include a few examples for now
 export const MODEL_IDS = [
-  GPT_5_4_MODEL_ID,
+  GPT_5_5_MODEL_ID,
   GPT_5_2_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
@@ -21,6 +21,6 @@ export function isModelId(value: string): value is ModelId {
 
 export const ORDERED_LARGE_MODEL_IDS = [
   CLAUDE_SONNET_4_6_MODEL_ID,
-  GPT_5_4_MODEL_ID,
+  GPT_5_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
 ];


### PR DESCRIPTION
## Description

Adds the global GPT-5.5 stream endpoint on top of the OpenAI Responses provider: the GPT-5.5 model config (context size, max output, reasoning-effort schema, temperature handling), the endpoint class (pricing, region, id), the `gpt-5.5` model id, and the integration test.

Top of the OpenAI-provider slice: stacked on #27581 (input converter + client) → #27580 (output converter) → #27573 (transition fix).

## Tests

Integration harness (`lib/model_constructors/test/`), gated on `NODE_ENV=test` + `RUN_LLM_TEST=true` so CI never burns tokens. The GPT-5.5 contract was characterized against the live Responses API (widest schema → narrow): `minimal` effort is rejected by the API, `temperature` is stripped (reasoning model), `maximal` maps to `xhigh`, and a forced tool does not require reasoning "none".

## Risk

Low. Self-contained endpoint definition; not yet registered in the router (that follows in #27575).

## Deploy Plan

Standard deploy, no migration needed.