### PR TITLE
feat(llm): route gpt-5.5 through the new LLM router

### DIFF
--- a/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_five.ts
@@ -1,0 +1,15 @@
+export function WithDustGptFiveDotFiveConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGptFiveDotFive extends Base {
+    static readonly displayName = "GPT-5.5";
+    static readonly description =
+      "OpenAI's GPT-5.5 reasoning model, with strong reasoning and tool-use capabilities (1M context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+  }
+
+  return DustGptFiveDotFive;
+}

--- a/front/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotFiveConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+
+export class DustOpenAIResponsesGlobalGptFiveDotFiveStream extends WithDustGptFiveDotFiveConfig(
+  OpenAIResponsesGlobalGptFiveDotFiveStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesGlobalGptFiveDotFiveStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,6 +1,7 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -14,6 +15,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicGlobalClaudeSonnetFourDotSixStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFiveStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,12 +1,15 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const STREAM_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
     AnthropicGlobalClaudeSonnetFourDotSixStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFiveStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;


### PR DESCRIPTION
## Description

Wires GPT-5.5 into the runtime LLM router so requests can be served by the new `model_constructors` path (behind the `use_new_llm_router` feature flag):

- Registers the endpoint in the framework registry (`STREAM_ENDPOINTS`) and the Dust registry (`DUST_STREAM_ENDPOINTS`).
- Adds the Dust-layer model config mixin (display name, description, default reasoning effort) and the global Dust stream endpoint (`endpointFilter = {}`, available to all workspaces with `openai` whitelisted).

Both registrations land together because adding the endpoint to `STREAM_ENDPOINTS` widens `StreamEndpointId`, which the Dust registry must satisfy (`Record<StreamEndpointId, …>`).

Stacked on #27574 (provider + endpoint) and #27573 (transition fix) — without the transition fix, routing a non-Anthropic model through the new router throws `Model config not found`.

## Tests

With `use_new_llm_router` enabled on a workspace, GPT-5.5 conversations are served by the new router (confirmed via the `Sending request to gpt-5.5 with new router` log in the agent-loop worker, with the legacy client's request/trace logs no longer emitted). Without the flag, requests fall through to the legacy path unchanged.

## Risk

Low. Gated behind the `use_new_llm_router` feature flag; with the flag off, behavior is unchanged. The new endpoint is opt-in per workspace.

## Deploy Plan

Standard deploy, no migration needed. Roll out by enabling `use_new_llm_router` per workspace.