### PR TITLE
test(llm): add OpenAI request parity coverage

### DIFF
--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -1,5 +1,7 @@
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import { isAnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
+import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
+import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -16,6 +18,7 @@ import type { LLMCredentialsType } from "@app/types/provider_credential";
 // (the legacy Anthropic client asserts a non-empty ANTHROPIC_API_KEY).
 export const PARITY_CREDENTIALS: LLMCredentialsType = {
   ANTHROPIC_API_KEY: "test-anthropic-key",
+  OPENAI_API_KEY: "test-openai-key",
 };
 
 /** Per-call parameters shared by both routers for one parity case. */
@@ -55,6 +58,13 @@ export function readEndpointInfo(
  */
 export interface SdkCaptures {
   anthropic: { ga: unknown[]; beta: unknown[] };
+  // OpenAI's legacy and new routers both call `client.responses.create`, so a
+  // single bucket holds both requests, split by call order (see the adapter).
+  openai: unknown[];
+}
+
+function first(arr: unknown[]): unknown {
+  return arr.length > 0 ? arr[0] : undefined;
 }
 
 function last(arr: unknown[]): unknown {
@@ -116,8 +126,44 @@ const anthropicProvider: ParityProvider = {
   },
 };
 
+const openaiProvider: ParityProvider = {
+  toModelId(raw) {
+    if (!isModelId(raw) || !isOpenAIResponsesWhitelistedModelId(raw)) {
+      throw new Error(`${raw} is not a whitelisted OpenAI model.`);
+    }
+    return raw;
+  },
+  buildLegacyLLM(auth, _endpoint, params) {
+    if (
+      !isModelId(params.modelId) ||
+      !isOpenAIResponsesWhitelistedModelId(params.modelId)
+    ) {
+      throw new Error(`${params.modelId} is not a whitelisted OpenAI model.`);
+    }
+    // Only global endpoints are exercised locally; the legacy counterpart is
+    // always the direct OpenAI Responses API.
+    return new OpenAIResponsesLLM(auth, {
+      credentials: PARITY_CREDENTIALS,
+      modelId: params.modelId,
+      temperature: params.temperature,
+      reasoningEffort: params.reasoningEffort,
+      responseFormat: params.responseFormat,
+      bypassFeatureFlag: true,
+    });
+  },
+  // Both routers hit the same `responses.create`; the test drains the legacy
+  // stream before the new one, so the first capture is legacy, the last is new.
+  selectOldRequest(_endpoint, captures) {
+    return first(captures.openai);
+  },
+  selectNewRequest(_endpoint, captures) {
+    return last(captures.openai);
+  },
+};
+
 const PARITY_PROVIDERS: Partial<Record<ProviderId, ParityProvider>> = {
   anthropic: anthropicProvider,
+  openai: openaiProvider,
 };
 
 export function getParityProvider(providerId: ProviderId): ParityProvider {

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -42,6 +42,7 @@ const kit = vi.hoisted(() => {
   const emptyStream = () => (async function* () {})();
   const freshCaptures = () => ({
     anthropic: { ga: [] as unknown[], beta: [] as unknown[] },
+    openai: [] as unknown[],
   });
   const state = { captures: freshCaptures() };
   const makeClient = () =>
@@ -61,12 +62,28 @@ const kit = vi.hoisted(() => {
         },
       };
     };
-  return { state, makeClient, freshCaptures };
+  // Both the legacy and new OpenAI routers call `client.responses.create`, so
+  // one bucket records both; the adapter splits them by call order.
+  const makeOpenAIClient = () =>
+    class {
+      responses = {
+        create: (input: unknown) => {
+          state.captures.openai.push(input);
+          return emptyStream();
+        },
+      };
+    };
+  return { state, makeClient, makeOpenAIClient, freshCaptures };
 });
 
 vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@anthropic-ai/sdk")>();
   return { ...actual, default: kit.makeClient() };
+});
+
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openai")>();
+  return { ...actual, default: kit.makeOpenAIClient() };
 });
 
 async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {


### PR DESCRIPTION
## Description

Extends the legacy-vs-new router request-parity harness (`router_parity.test.ts`) to cover the OpenAI Responses provider, so GPT-5.5 (and future OpenAI endpoints) are checked for request-shape parity automatically once registered in `DUST_STREAM_ENDPOINTS`:

- Adds an OpenAI parity adapter (`buildLegacyLLM` via `OpenAIResponsesLLM`, model-id narrowing, request selection).
- Adds an `openai` SDK mock + capture bucket. Both routers call the same `client.responses.create`, so a single bucket records both requests, split by call order (legacy drained first, new second).

Stacked on #27575 (router wiring) — the test iterates `DUST_STREAM_ENDPOINTS` and constructs `StreamEndpointTransition` for the OpenAI endpoint, so it needs both the registration and the transition fix beneath it.

## Tests

The test is local-only (gated on `RUN_LLM_TEST`, kept out of CI, no network — the SDKs are mocked). All 14 OpenAI parity cases pass with no allowlist normalizer needed: the new router and the legacy router dispatch identical `responses.create` payloads. Run with:

```
NODE_ENV=test RUN_LLM_TEST=true npx vitest --config lib/api/llm/tests/vite.config.js lib/api/llm/tests/router_parity.test.ts --run -t openai
```

## Risk

None. Test-only change, excluded from CI.

## Deploy Plan

No deploy impact.