### PR TITLE
chore(infra): add prodbox-ephemeral image for running k8s jobs

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -183,8 +183,30 @@ runs:
           LATEST_TAGS+=("-t" "${REGISTRY}/${COMPONENT}:latest")
         fi
 
+        # Special handling for prodbox-ephemeral: reuse prodbox.Dockerfile with the ephemeral target,
+        # pulling from the prodbox cache scope so the heavy base layers are already warm.
+        if [[ "$BASE_COMPONENT" == "prodbox-ephemeral" ]]; then
+          depot build \
+            --project $DEPOT_PROJECT_ID \
+            --platform linux/amd64 \
+            --provenance=false \
+            --target ephemeral \
+            --cache-from type=gha,scope=prodbox \
+            --cache-from type=gha,scope=${{ inputs.component }} \
+            --cache-to type=gha,mode=max,scope=${{ inputs.component }} \
+            -f ./dockerfiles/prodbox.Dockerfile \
+            -t ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project_id }}/dust-images/${COMPONENT}:${{ inputs.commit_sha }} \
+            "${LATEST_TAGS[@]}" \
+            --build-arg COMMIT_HASH=${{ inputs.commit_sha }} \
+            --build-arg COMMIT_HASH_LONG=${{ inputs.commit_sha_long }} \
+            --build-arg DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust \
+            --build-arg DD_GIT_COMMIT_SHA=${{ inputs.commit_sha_long }} \
+            ${build_args[@]} \
+            --push \
+            .
+
         # Special handling for front component, build workers and front-api targets
-        if [[ "$BASE_COMPONENT" == "front" ]]; then
+        elif [[ "$BASE_COMPONENT" == "front" ]]; then
           echo "🏗️ Building front component with two targets (workers + front-api)"
 
           # Build workers target

--- a/.github/workflows/build-prodbox-ephemeral.yml
+++ b/.github/workflows/build-prodbox-ephemeral.yml
@@ -1,0 +1,145 @@
+name: Build prodbox-ephemeral image
+run-name: Build prodbox-ephemeral image for ${{ inputs.regions }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      regions:
+        description: "Regions to build image for"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - "us-central1"
+          - "europe-west1"
+          - "all"
+      depot_region:
+        description: "Depot region to use for building"
+        required: true
+        default: "us"
+        type: choice
+        options:
+          - "us"
+          - "eu"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: "build_prodbox-ephemeral"
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      short_sha: ${{ steps.short_sha.outputs.short_sha }}
+      long_sha: ${{ steps.long_sha.outputs.long_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Get short sha
+        id: short_sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get long sha
+        id: long_sha
+        run: echo "long_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+  notify-start:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    outputs:
+      thread_ts: ${{ steps.build_message.outputs.thread_ts }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Notify Build Start
+        id: build_message
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "start"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          component: prodbox-ephemeral
+          image_tag: ${{ needs.prepare.outputs.short_sha }}
+          region: ${{ inputs.regions }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  create-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [ "${{ inputs.regions }}" = "all" ]; then
+            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=[\"${{ inputs.regions }}\"]" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    permissions:
+      contents: read
+      id-token: write
+    needs: [prepare, notify-start, create-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 50
+
+      - name: Set project ID
+        id: project
+        run: |
+          if [ "${{ matrix.region }}" = "us-central1" ]; then
+            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> $GITHUB_OUTPUT
+          else
+            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Image
+        id: build
+        uses: ./.github/actions/build-image
+        with:
+          commit_sha_long: ${{ needs.prepare.outputs.long_sha }}
+          commit_sha: ${{ needs.prepare.outputs.short_sha }}
+          component: prodbox-ephemeral
+          depot_eu_project_id: ${{ secrets.DEPOT_EU_PROJECT_ID }}
+          depot_eu_token: ${{ secrets.DEPOT_EU_PROJECT_TOKEN }}
+          depot_region: ${{ inputs.depot_region }}
+          depot_us_project_id: ${{ secrets.DEPOT_PROJECT_ID }}
+          depot_us_token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
+          project_id: ${{ steps.project.outputs.PROJECT_ID }}
+          region: ${{ matrix.region }}
+          workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
+
+      - name: Notify build success
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "build_success"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-start.outputs.thread_ts }}
+          component: prodbox-ephemeral
+          image_tag: ${{ needs.prepare.outputs.short_sha }}
+          region: ${{ matrix.region }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          current_version: ${{ steps.build.outputs.current_version }}
+          commit_diff: ${{ steps.build.outputs.commit_diff }}
+          commit_count: ${{ steps.build.outputs.commit_count }}
+
+      - name: Notify Failure
+        if: failure()
+        uses: ./.github/actions/slack-notify
+        with:
+          step: "failure"
+          channel: ${{ secrets.SLACK_CHANNEL_ID }}
+          component: prodbox-ephemeral
+          image_tag: ${{ needs.prepare.outputs.short_sha }}
+          region: ${{ inputs.regions }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          thread_ts: "${{ needs.notify-start.outputs.thread_ts }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ on:
           - core
           - front-sse
           - prodbox
+          - prodbox-ephemeral
           - oauth
           - viz
           - dante

--- a/dockerfiles/prodbox.Dockerfile
+++ b/dockerfiles/prodbox.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24.16.0 AS base
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop curl libpq-dev build-essential tmux
+# Install system dependencies needed for building
+RUN apt-get update && apt-get install -y postgresql-client curl libpq-dev build-essential
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -28,13 +28,20 @@ RUN cd front \
   NODE_OPTIONS="--max-old-space-size=8192" \
   npm run build -- --no-lint
 
-# Set the default start directory to /dust when SSH into the container
 WORKDIR /dust
 
-# Wraning and prompt
+# Ephemeral target: headless job runner for k8s Jobs.
+# The k8s Job spec overrides CMD with the actual `npm run XXX` invocation.
+FROM base AS ephemeral
+CMD ["/bin/bash"]
+
+# Prodbox target: interactive debug environment (default / last stage).
+FROM base AS prodbox
+RUN apt-get update && apt-get install -y vim redis-tools htop tmux
+
+# Warning and prompt
 RUN echo "echo -e \"\033[0;31mWARNING: This is a PRODUCTION system!\033[0m\"" >> /root/.bashrc
 
 ENV GIT_SSH_COMMAND="ssh -i ~/.ssh/github-deploykey-deploybox"
 
-# Set a default command
 CMD ["/dust/prodbox/init.sh"]

--- a/dockerfiles/prodbox.Dockerfile
+++ b/dockerfiles/prodbox.Dockerfile
@@ -31,8 +31,12 @@ RUN cd front \
 WORKDIR /dust
 
 # Ephemeral target: headless job runner for k8s Jobs.
-# The k8s Job spec overrides CMD with the actual `npm run XXX` invocation.
+# The entrypoint pulls the latest code from `main` (using the mounted GitHub
+# deploy key) then execs the command the k8s Job spec passes as `args`
+# (e.g. `npm run migration:apply:pre-deploy --workspace front`).
 FROM base AS ephemeral
+ENV GIT_SSH_COMMAND="ssh -i ~/.ssh/github-deploykey-deploybox"
+ENTRYPOINT ["/bin/bash", "/dust/prodbox/ephemeral-entrypoint.sh"]
 CMD ["/bin/bash"]
 
 # Prodbox target: interactive debug environment (default / last stage).

--- a/prodbox/ephemeral-entrypoint.sh
+++ b/prodbox/ephemeral-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Entrypoint for the prodbox-ephemeral image used by one-off k8s Jobs (e.g.
+# database migrations). It fetches the latest code from `main` so the job runs
+# against up-to-date sources, then execs the command passed by the k8s Job spec
+# (e.g. `npm run migration:apply:pre-deploy --workspace front`).
+set -euo pipefail
+
+DEPLOY_KEY="/etc/github-deploykey-deploybox/github-deploykey-deploybox"
+
+if [ -f "${DEPLOY_KEY}" ]; then
+  echo "Fetching latest code from origin/main..."
+
+  # ssh refuses keys readable by others and we cannot chmod on the mounted
+  # volume, so copy the key to a private location first (mirrors prodbox/init.sh).
+  mkdir -p ~/.ssh
+  chmod 700 ~/.ssh
+  cp "${DEPLOY_KEY}" ~/.ssh/github-deploykey-deploybox
+  ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+  chmod 600 ~/.ssh/*
+
+  # Fast-forward only: never create a merge commit on top of the baked-in tree.
+  git config pull.ff only
+  git remote set-url origin git@github.com:dust-tt/dust.git
+  git pull origin main
+else
+  echo "No deploy key mounted at ${DEPLOY_KEY}; running with code baked into the image."
+fi
+
+exec "$@"


### PR DESCRIPTION
## Description

Introduces a `prodbox-ephemeral` Docker image intended for running one-off jobs in k8s (migrations, scripts, workers). The image shares the same build chain as `prodbox` via a multi-stage Dockerfile, so the heavy base layers are cached and reused.

**Dockerfile changes** — `prodbox.Dockerfile` is refactored into three stages:
- `base`: npm ci + builds sdks/sparkle/connectors/front (shared, no interactive tools)
- `ephemeral`: `FROM base`, `CMD ["/bin/bash"]` — k8s Jobs override the command with the actual `npm run XXX`
- `prodbox` (last/default stage): `FROM base` + vim/tmux/htop/redis-tools + init.sh

**Build action** — `build-image/action.yml` gets a `prodbox-ephemeral` branch that builds `prodbox.Dockerfile --target ephemeral` and warms from the `prodbox` GHA cache scope.

**New workflow** — `build-prodbox-ephemeral.yml`: a `workflow_dispatch`-only workflow (no Helm deploy triggered) that fans out across US/EU regions via matrix and pushes to GCP Artifact Registry.

## Tests

Verified the Dockerfile structure manually (stage names, CMD overrides, tool presence per stage).

## Deploy Plan

Run the new `Build prodbox-ephemeral image` workflow once to push the initial image. k8s Job specs in dust-infra can then reference `{region}-docker.pkg.dev/{project}/dust-images/prodbox-ephemeral:latest`.