### PR TITLE
feat(model_constructors): add OpenAI Responses input converter and stream client

### DIFF
--- a/front/lib/model_constructors/providers/openai/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/openai/converters/input/index.ts
@@ -1,0 +1,100 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  assistantReasoningMessageToInputItems,
+  assistantTextMessageToInputItem,
+  assistantToolCallRequestToInputItem,
+  conversationToInput,
+  forceToolToToolChoice,
+  type MessageItemConverters,
+  outputFormatToResponseFormat,
+  reasoningToOpenAIReasoning,
+  systemMessagesToInputItems,
+  systemMessageToInputItem,
+  toFunctionTool,
+  toolCallResultMessageToInputItem,
+  userImageMessageToInputItem,
+  userTextMessageToInputItem,
+} from "@app/lib/model_constructors/providers/openai/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  Payload,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseInputItem,
+} from "openai/resources/responses/responses";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the OpenAI Responses API
+// request shape. Leaf converters are bound as class fields and composites route
+// through `this`, so an endpoint can override a single leaf.
+export function WithOpenAIResponsesInputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithOpenAIResponsesInputConverter
+    extends Base
+    implements MessageItemConverters
+  {
+    systemMessageToInputItem = systemMessageToInputItem;
+    userTextMessageToInputItem = userTextMessageToInputItem;
+    userImageMessageToInputItem = userImageMessageToInputItem;
+    toolCallResultMessageToInputItem = toolCallResultMessageToInputItem;
+    assistantTextMessageToInputItem = assistantTextMessageToInputItem;
+    assistantReasoningMessageToInputItems =
+      assistantReasoningMessageToInputItems;
+    assistantToolCallRequestToInputItem = assistantToolCallRequestToInputItem;
+
+    conversationToInput(
+      conversation: Payload["conversation"]
+    ): ResponseInputItem[] {
+      return conversationToInput(conversation, this);
+    }
+
+    systemMessagesToInputItems(
+      system: SystemTextMessage[]
+    ): ResponseInputItem[] {
+      return systemMessagesToInputItems(system, this);
+    }
+
+    buildRequestPayload(
+      payload: Payload,
+      config: InputConfig
+    ): ResponseCreateParamsNonStreaming {
+      const { conversation } = payload;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        forceTool,
+        outputFormat,
+      } = config;
+
+      const reasoningConfig = reasoningToOpenAIReasoning(reasoning);
+
+      return {
+        model: this.constructor.modelId,
+        max_output_tokens: this.constructor.maxOutputTokens,
+        input: [
+          ...this.systemMessagesToInputItems(conversation.system),
+          ...this.conversationToInput(conversation),
+        ],
+        ...(reasoningConfig
+          ? {
+              reasoning: reasoningConfig,
+              include: ["reasoning.encrypted_content"],
+            }
+          : {}),
+        tools: tools.map((tool) => toFunctionTool(tool)),
+        tool_choice: forceToolToToolChoice(tools, forceTool),
+        ...(outputFormat
+          ? { text: { format: outputFormatToResponseFormat(outputFormat) } }
+          : {}),
+        temperature,
+      };
+    }
+  }
+
+  return WithOpenAIResponsesInputConverter;
+}

--- a/front/lib/model_constructors/providers/openai/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/openai/converters/input/utils.ts
@@ -1,0 +1,242 @@
+import { isOpenAISupportedReasoningEffort } from "@app/lib/model_constructors/providers/openai/reasoning_efforts";
+import type {
+  OutputFormat,
+  Reasoning,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  FunctionTool,
+  ResponseFormatTextJSONSchemaConfig,
+  ResponseInputItem,
+  ToolChoiceFunction,
+} from "openai/resources/responses/responses";
+import type { Reasoning as OpenAIReasoning } from "openai/resources/shared";
+
+// The per-message leaf converters. Composites below take an object satisfying
+// this interface (`this`), so overriding one leaf on an endpoint changes how
+// every composite uses it.
+export interface MessageItemConverters {
+  systemMessageToInputItem(message: SystemTextMessage): ResponseInputItem;
+  userTextMessageToInputItem(message: BaseUserTextMessage): ResponseInputItem;
+  userImageMessageToInputItem(message: BaseUserImageMessage): ResponseInputItem;
+  toolCallResultMessageToInputItem(
+    message: BaseToolCallResultMessage
+  ): ResponseInputItem;
+  assistantTextMessageToInputItem(
+    message: BaseAssistantTextMessage
+  ): ResponseInputItem;
+  assistantReasoningMessageToInputItems(
+    message: BaseAssistantReasoningMessage
+  ): ResponseInputItem[];
+  assistantToolCallRequestToInputItem(
+    message: BaseAssistantToolCallRequestMessage
+  ): ResponseInputItem;
+}
+
+// -- Leaf converters: one Responses input item per message --
+
+// OpenAI uses the "developer" role for the system prompt on reasoning models.
+export function systemMessageToInputItem(
+  message: SystemTextMessage
+): ResponseInputItem {
+  return {
+    role: "developer",
+    content: [{ type: "input_text", text: message.content.value }],
+  };
+}
+
+export function userTextMessageToInputItem(
+  message: BaseUserTextMessage
+): ResponseInputItem {
+  return {
+    role: "user",
+    content: [{ type: "input_text", text: message.content.value }],
+  };
+}
+
+export function userImageMessageToInputItem(
+  message: BaseUserImageMessage
+): ResponseInputItem {
+  return {
+    role: "user",
+    content: [
+      { type: "input_image", image_url: message.content.url, detail: "auto" },
+    ],
+  };
+}
+
+export function toolCallResultMessageToInputItem(
+  message: BaseToolCallResultMessage
+): ResponseInputItem {
+  // The Responses function_call_output takes a single string; flatten parts.
+  const output = message.content.parts
+    .map((part) => {
+      switch (part.type) {
+        case "text":
+          return part.text;
+        case "image_url":
+          return `[image: ${part.url}]`;
+        default:
+          return assertNever(part);
+      }
+    })
+    .join("\n");
+  return {
+    type: "function_call_output",
+    call_id: message.content.callId,
+    output,
+  };
+}
+
+export function assistantTextMessageToInputItem(
+  message: BaseAssistantTextMessage
+): ResponseInputItem {
+  return { role: "assistant", content: message.content.value };
+}
+
+export function assistantReasoningMessageToInputItems(
+  message: BaseAssistantReasoningMessage
+): ResponseInputItem[] {
+  // The Responses API keys a replayed reasoning item by its original id, which
+  // we carry in `signature`; drop unsigned items (mirrors dropping unsigned
+  // Anthropic thinking blocks).
+  if (!message.signature) {
+    return [];
+  }
+  return [
+    {
+      id: message.signature,
+      type: "reasoning",
+      summary: message.content.value
+        ? [{ type: "summary_text", text: message.content.value }]
+        : [],
+    },
+  ];
+}
+
+export function assistantToolCallRequestToInputItem(
+  message: BaseAssistantToolCallRequestMessage
+): ResponseInputItem {
+  return {
+    type: "function_call",
+    call_id: message.content.callId,
+    name: message.content.toolName,
+    arguments: message.content.arguments,
+  };
+}
+
+// -- Composite message converters (depend on the leaf converters) --
+
+export function userMessageToInputItems(
+  message: BaseUserMessage,
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  switch (message.type) {
+    case "text":
+      return [converters.userTextMessageToInputItem(message)];
+    case "image_url":
+      return [converters.userImageMessageToInputItem(message)];
+    case "tool_call_result":
+      return [converters.toolCallResultMessageToInputItem(message)];
+    default:
+      assertNever(message);
+  }
+}
+
+export function assistantMessageToInputItems(
+  message: BaseAssistantMessage,
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  switch (message.type) {
+    case "text":
+      return [converters.assistantTextMessageToInputItem(message)];
+    case "reasoning":
+      return converters.assistantReasoningMessageToInputItems(message);
+    case "tool_call_request":
+      return [converters.assistantToolCallRequestToInputItem(message)];
+    default:
+      assertNever(message);
+  }
+}
+
+export function conversationToInput(
+  conversation: BaseConversation,
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  return conversation.messages.flatMap((message) => {
+    switch (message.role) {
+      case "user":
+        return userMessageToInputItems(message, converters);
+      case "assistant":
+        return assistantMessageToInputItems(message, converters);
+      default:
+        assertNever(message);
+    }
+  });
+}
+
+export function systemMessagesToInputItems(
+  system: SystemTextMessage[],
+  converters: MessageItemConverters
+): ResponseInputItem[] {
+  return system.map((message) => converters.systemMessageToInputItem(message));
+}
+
+// -- Config converters (pure) --
+
+export function toFunctionTool(tool: ToolSpecification): FunctionTool {
+  return {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    strict: true,
+    parameters: { type: "object", ...tool.inputSchema },
+  };
+}
+
+export function forceToolToToolChoice(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ToolChoiceFunction | "auto" {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? { type: "function", name: forceTool }
+    : "auto";
+}
+
+export function outputFormatToResponseFormat(
+  outputFormat: OutputFormat
+): ResponseFormatTextJSONSchemaConfig {
+  return {
+    type: "json_schema",
+    name: outputFormat.json_schema.name,
+    schema: outputFormat.json_schema.schema,
+    description: outputFormat.json_schema.description,
+    strict: outputFormat.json_schema.strict ?? undefined,
+  };
+}
+
+export function reasoningToOpenAIReasoning(
+  reasoning: Reasoning | undefined
+): OpenAIReasoning | undefined {
+  if (!reasoning) {
+    return undefined;
+  }
+  if (!isOpenAISupportedReasoningEffort(reasoning.effort)) {
+    // "maximal" has no OpenAI equivalent; fall back to the strongest supported.
+    return { effort: "xhigh", summary: "auto" };
+  }
+  return { effort: reasoning.effort, summary: "auto" };
+}

--- a/front/lib/model_constructors/providers/openai/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_efforts.ts
@@ -1,0 +1,24 @@
+import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
+
+// Reasoning efforts the OpenAI Responses API accepts verbatim (its
+// `ReasoningEffort` enum minus the non-OpenAI "maximal"). The strings match
+// OpenAI's, so mapping a supported effort is the identity.
+export const OPENAI_SUPPORTED_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const satisfies readonly ReasoningEffort[];
+
+export type OpenAISupportedReasoningEffort =
+  (typeof OPENAI_SUPPORTED_REASONING_EFFORTS)[number];
+
+export function isOpenAISupportedReasoningEffort(
+  effort: string
+): effort is OpenAISupportedReasoningEffort {
+  return OPENAI_SUPPORTED_REASONING_EFFORTS.some(
+    (supported) => supported === effort
+  );
+}

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -1,0 +1,69 @@
+import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/providers/openai/converters/input";
+import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/providers/openai/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/openai/converters/output/utils";
+import { OPENAI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/openai/reasoning_efforts";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { OPENAI_RESPONSES_API } from "@app/lib/model_constructors/types/provider_apis";
+import { OPENAI_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import OpenAI from "openai";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseCreateParamsStreaming,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+import { z } from "zod";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum(OPENAI_SUPPORTED_REASONING_EFFORTS),
+    })
+    .optional(),
+});
+
+type OpenAIInputConfig = z.infer<typeof configSchema>;
+
+export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConverter(
+  WithOpenAIResponsesOutputConverter(
+    StreamEndpoint<ResponseCreateParamsNonStreaming, ResponseStreamEvent>
+  )
+) {
+  static readonly providerId = OPENAI_PROVIDER_ID;
+  static readonly api = OPENAI_RESPONSES_API;
+
+  static readonly configSchema: z.ZodType<OpenAIInputConfig> = configSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ OPENAI_API_KEY, OPENAI_BASE_URL }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      apiKey: OPENAI_API_KEY,
+      baseURL: OPENAI_BASE_URL,
+    });
+  }
+
+  async *streamRaw(
+    input: ResponseCreateParamsNonStreaming
+  ): AsyncGenerator<ResponseStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ResponseCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = await this.client.responses.create(streamingInput);
+
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ResponseStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}


### PR DESCRIPTION
## Description

Second slice of the OpenAI Responses provider: the **input** converter (builds the Responses API request payload from the framework's `BaseMessage`/`InputConfig`), the reasoning-effort mapping, and the abstract `OpenAIResponsesStream` client that composes both converters and calls `client.responses.create`.

Stacked on the output-converter PR (the client composes both converter mixins). Model-agnostic — the GPT-5.5 endpoint follows on top.

## Tests

Exercised end-to-end by the GPT-5.5 integration test at the top of the stack (gated on `RUN_LLM_TEST`). Carries the same known pre-existing `output/utils.ts` type error as the slice below it; CI is expected red until the framework dependency lands.

## Risk

Low. New provider plumbing; the client is abstract and not yet registered or routed.

## Deploy Plan

Standard deploy, no migration needed.