### PR TITLE
add Gemini endpoint to the model_constructors router

### DIFF
--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -176,3 +176,10 @@ export function getParityProvider(providerId: ProviderId): ParityProvider {
   }
   return provider;
 }
+
+// Whether a provider has a parity adapter yet. Endpoints whose provider has no
+// adapter are skipped by the parity suite (rather than throwing) until their
+// adapter + SDK mock + normalizer are added.
+export function hasParityProvider(providerId: ProviderId): boolean {
+  return PARITY_PROVIDERS[providerId] !== undefined;
+}

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -23,6 +23,7 @@ import { normalizeRequest } from "@app/lib/api/llm/tests/parity/allowlist";
 import { buildParityMatrix } from "@app/lib/api/llm/tests/parity/matrix";
 import {
   getParityProvider,
+  hasParityProvider,
   PARITY_CREDENTIALS,
   readEndpointInfo,
 } from "@app/lib/api/llm/tests/parity/providers";
@@ -101,7 +102,11 @@ async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {
 // locally. Global agent-platform coverage can be added here once it exists.
 const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS)
   .map(readEndpointInfo)
-  .filter((endpoint) => endpoint.region === GLOBAL);
+  // Skip providers without a parity adapter yet (e.g. google_ai_studio).
+  .filter(
+    (endpoint) =>
+      endpoint.region === GLOBAL && hasParityProvider(endpoint.providerId)
+  );
 const MATRIX = buildParityMatrix();
 
 describe.skipIf(process.env.RUN_LLM_TEST !== "true")(

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -4,7 +4,7 @@ export function WithDustGoogleAiStudioGemini31ProConfig<
   ) => object,
 >(Base: TBase) {
   abstract class DustGoogleAiStudioGemini31Pro extends Base {
-    static readonly displayName = "Gemini 3.1 Pro";
+    static readonly displayName = "Gemini 3.1 Pro (Preview)";
     static readonly description =
       "Google's Gemini 3.1 Pro model, a state-of-the-art reasoning model with a 1M-token context window.";
     static readonly defaultReasoningEffort = "low";

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -7,7 +7,7 @@ export function WithDustGoogleAiStudioGemini31ProConfig<
     static readonly displayName = "Gemini 3.1 Pro";
     static readonly description =
       "Google's Gemini 3.1 Pro model, a state-of-the-art reasoning model with a 1M-token context window.";
-    static readonly defaultReasoningEffort = "high";
+    static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
   }
 

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,0 +1,15 @@
+export function WithDustGoogleAiStudioGemini31ProConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGoogleAiStudioGemini31Pro extends Base {
+    static readonly displayName = "Gemini 3.1 Pro";
+    static readonly description =
+      "Google's Gemini 3.1 Pro model, a state-of-the-art reasoning model with a 1M-token context window.";
+    static readonly defaultReasoningEffort = "high";
+    static readonly byok = true;
+  }
+
+  return DustGoogleAiStudioGemini31Pro;
+}

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGemini31ProConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+
+export class DustGoogleAiStudioGlobalGemini31ProStream extends WithDustGoogleAiStudioGemini31ProConfig(
+  GoogleAiStudioGlobalGemini31ProStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustGoogleAiStudioGlobalGemini31ProStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,6 +1,7 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
@@ -15,6 +16,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicGlobalClaudeSonnetFourDotSixStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [DustGoogleAiStudioGlobalGemini31ProStream.id]:
+    DustGoogleAiStudioGlobalGemini31ProStream,
   [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/index.ts
@@ -1,0 +1,98 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  assistantReasoningMessageToPart,
+  assistantTextMessageToPart,
+  assistantToolCallRequestToPart,
+  type ContentBlockConverters,
+  conversationToContents,
+  forceToolNameToToolConfig,
+  outputFormatToResponseSchema,
+  reasoningToThinkingConfig,
+  systemMessagesToSystemInstruction,
+  systemMessageToPart,
+  toFunctionDeclaration,
+  toolCallResultMessageToContent,
+  userImageMessageToPart,
+  userTextMessageToPart,
+} from "@app/lib/model_constructors/providers/google_ai_studio/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  Payload,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import type { Content, GenerateContentParameters } from "@google/genai";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the Gemini
+// `generateContentStream` request shape. Leaf converters are bound as class
+// fields and composites route through `this`, so an endpoint can override a
+// single leaf.
+export function WithGoogleAiStudioInputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithGoogleAiStudioInputConverter
+    extends Base
+    implements ContentBlockConverters
+  {
+    systemMessageToPart = systemMessageToPart;
+    userTextMessageToPart = userTextMessageToPart;
+    userImageMessageToPart = userImageMessageToPart;
+    toolCallResultMessageToContent = toolCallResultMessageToContent;
+    assistantTextMessageToPart = assistantTextMessageToPart;
+    assistantReasoningMessageToPart = assistantReasoningMessageToPart;
+    assistantToolCallRequestToPart = assistantToolCallRequestToPart;
+
+    conversationToContents(conversation: Payload["conversation"]): Content[] {
+      return conversationToContents(conversation, this);
+    }
+
+    systemMessagesToSystemInstruction(
+      system: SystemTextMessage[]
+    ): Content | undefined {
+      return systemMessagesToSystemInstruction(system, this);
+    }
+
+    buildRequestPayload(
+      payload: Payload,
+      config: InputConfig
+    ): GenerateContentParameters {
+      const { conversation } = payload;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        forceTool,
+        outputFormat,
+      } = config;
+
+      return {
+        model: this.constructor.modelId,
+        contents: this.conversationToContents(conversation),
+        config: {
+          systemInstruction: this.systemMessagesToSystemInstruction(
+            conversation.system
+          ),
+          // We only ever need a single candidate.
+          candidateCount: 1,
+          temperature,
+          tools:
+            tools.length > 0
+              ? [{ functionDeclarations: tools.map(toFunctionDeclaration) }]
+              : undefined,
+          toolConfig: forceToolNameToToolConfig(tools, forceTool),
+          thinkingConfig: reasoningToThinkingConfig(reasoning),
+          maxOutputTokens: this.constructor.maxOutputTokens,
+          ...(outputFormat
+            ? {
+                responseMimeType: "application/json",
+                responseSchema: outputFormatToResponseSchema(outputFormat),
+              }
+            : {}),
+        },
+      };
+    }
+  }
+
+  return WithGoogleAiStudioInputConverter;
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/index.ts
@@ -15,7 +15,7 @@ import {
   userImageMessageToPart,
   userTextMessageToPart,
 } from "@app/lib/model_constructors/providers/google_ai_studio/converters/input/utils";
-import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { GoogleAiStudioInputConfig } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
 import type {
   Payload,
   SystemTextMessage,
@@ -29,7 +29,7 @@ type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 // fields and composites route through `this`, so an endpoint can override a
 // single leaf.
 export function WithGoogleAiStudioInputConverter<
-  TBase extends AbstractConstructor<Client>,
+  TBase extends AbstractConstructor<Client<GoogleAiStudioInputConfig>>,
 >(Base: TBase) {
   abstract class WithGoogleAiStudioInputConverter
     extends Base
@@ -55,7 +55,7 @@ export function WithGoogleAiStudioInputConverter<
 
     buildRequestPayload(
       payload: Payload,
-      config: InputConfig
+      config: GoogleAiStudioInputConfig
     ): GenerateContentParameters {
       const { conversation } = payload;
       const {

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
@@ -1,10 +1,7 @@
-import {
-  type GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS,
-  isGeminiSupportedNonNullReasoningEffort,
-} from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import type { GoogleAiStudioInputConfig } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
+import type { GeminiSupportedReasoningEffort } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import type {
   OutputFormat,
-  Reasoning,
   ToolSpecification,
 } from "@app/lib/model_constructors/types/input/configuration";
 import type {
@@ -31,10 +28,6 @@ import type {
   ToolConfig,
 } from "@google/genai";
 import { FunctionCallingConfigMode, ThinkingLevel } from "@google/genai";
-
-// Gemini 3 cannot fully disable thinking, so `none` uses the smallest budget
-// with thoughts hidden. Other efforts map to a native thinking level.
-const NONE_THINKING_BUDGET = 128;
 
 // The per-message leaf converters. Composites below take an object satisfying
 // this interface (`this`), so overriding one leaf on an endpoint changes how
@@ -284,16 +277,16 @@ export function forceToolNameToToolConfig(
 }
 
 function effortToThinkingLevel(
-  effort: (typeof GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number]
+  effort: GeminiSupportedReasoningEffort
 ): ThinkingLevel {
   switch (effort) {
+    case "minimal":
+      return ThinkingLevel.MINIMAL;
     case "low":
       return ThinkingLevel.LOW;
     case "medium":
       return ThinkingLevel.MEDIUM;
     case "high":
-    // Gemini's highest native level; `maximal` maps here.
-    case "maximal":
       return ThinkingLevel.HIGH;
     default:
       assertNever(effort);
@@ -301,16 +294,10 @@ function effortToThinkingLevel(
 }
 
 export function reasoningToThinkingConfig(
-  reasoning: Reasoning | undefined
+  reasoning: GoogleAiStudioInputConfig["reasoning"]
 ): ThinkingConfig | undefined {
   if (!reasoning) {
     return undefined;
-  }
-  if (
-    reasoning.effort === "none" ||
-    !isGeminiSupportedNonNullReasoningEffort(reasoning.effort)
-  ) {
-    return { thinkingBudget: NONE_THINKING_BUDGET, includeThoughts: false };
   }
   return {
     thinkingLevel: effortToThinkingLevel(reasoning.effort),

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
@@ -1,0 +1,319 @@
+import {
+  type GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+  isGeminiSupportedNonNullReasoningEffort,
+} from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import type {
+  OutputFormat,
+  Reasoning,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isRecord } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import type {
+  Content,
+  FunctionDeclaration,
+  Part,
+  SchemaUnion,
+  ThinkingConfig,
+  ToolConfig,
+} from "@google/genai";
+import { FunctionCallingConfigMode, ThinkingLevel } from "@google/genai";
+
+// Gemini 3 cannot fully disable thinking, so `none` uses the smallest budget
+// with thoughts hidden. Other efforts map to a native thinking level.
+const NONE_THINKING_BUDGET = 128;
+
+// The per-message leaf converters. Composites below take an object satisfying
+// this interface (`this`), so overriding one leaf on an endpoint changes how
+// every composite uses it.
+export interface ContentBlockConverters {
+  systemMessageToPart(message: SystemTextMessage): Part;
+  userTextMessageToPart(message: BaseUserTextMessage): Part;
+  userImageMessageToPart(message: BaseUserImageMessage): Part;
+  toolCallResultMessageToContent(message: BaseToolCallResultMessage): Content;
+  assistantTextMessageToPart(message: BaseAssistantTextMessage): Part;
+  assistantReasoningMessageToPart(message: BaseAssistantReasoningMessage): Part;
+  assistantToolCallRequestToPart(
+    message: BaseAssistantToolCallRequestMessage
+  ): Part;
+}
+
+// -- Small, reusable building blocks --
+
+// Parses tool-call arguments into an object, falling back to `{}` for malformed
+// or non-object JSON.
+export function parseToolArguments(
+  argumentsJson: string
+): Record<string, unknown> {
+  const parsed = safeParseJSON(argumentsJson);
+  if (parsed.isErr() || parsed.value === null || !isRecord(parsed.value)) {
+    return {};
+  }
+  return parsed.value;
+}
+
+// -- Leaf converters: one Gemini part (or content) per message --
+
+export function systemMessageToPart(message: SystemTextMessage): Part {
+  return { text: message.content.value };
+}
+
+export function userTextMessageToPart(message: BaseUserTextMessage): Part {
+  return { text: message.content.value };
+}
+
+// Gemini only accepts inline base64 image data, which requires an async fetch
+// that the synchronous `buildRequestPayload` contract cannot perform. Until the
+// framework supports async payload building, surface the image as a text note
+// rather than dropping it silently.
+export function userImageMessageToPart(_message: BaseUserImageMessage): Part {
+  return { text: "Attachment: image could not be loaded." };
+}
+
+export function toolCallResultMessageToContent(
+  message: BaseToolCallResultMessage
+): Content {
+  const output = message.content.parts
+    .map((part) => {
+      switch (part.type) {
+        case "text":
+          return part.text;
+        case "image_url":
+          return "Attachment: image could not be loaded.";
+        default:
+          return assertNever(part);
+      }
+    })
+    .join("\n");
+
+  return {
+    role: "user",
+    parts: [
+      {
+        functionResponse: {
+          id: message.content.callId,
+          response: message.content.isError ? { error: output } : { output },
+        },
+      },
+    ],
+  };
+}
+
+export function assistantTextMessageToPart(
+  message: BaseAssistantTextMessage
+): Part {
+  return { text: message.content.value };
+}
+
+export function assistantReasoningMessageToPart(
+  message: BaseAssistantReasoningMessage
+): Part {
+  return {
+    text: message.content.value,
+    thought: true,
+    // Gemini 3 requires the thought signature to be echoed back in subsequent
+    // requests; omit it when absent rather than sending an empty string.
+    ...(message.signature ? { thoughtSignature: message.signature } : {}),
+  };
+}
+
+export function assistantToolCallRequestToPart(
+  message: BaseAssistantToolCallRequestMessage
+): Part {
+  return {
+    functionCall: {
+      id: message.content.callId,
+      name: message.content.toolName,
+      args: parseToolArguments(message.content.arguments),
+    },
+    ...(message.signature ? { thoughtSignature: message.signature } : {}),
+  };
+}
+
+// -- Composite message converters (depend on the leaf converters) --
+
+function userMessageToContent(
+  message: BaseUserMessage,
+  converters: ContentBlockConverters
+): Content {
+  switch (message.type) {
+    case "text":
+      return {
+        role: "user",
+        parts: [converters.userTextMessageToPart(message)],
+      };
+    case "image_url":
+      return {
+        role: "user",
+        parts: [converters.userImageMessageToPart(message)],
+      };
+    case "tool_call_result":
+      return converters.toolCallResultMessageToContent(message);
+    default:
+      assertNever(message);
+  }
+}
+
+function assistantMessageToContent(
+  message: BaseAssistantMessage,
+  converters: ContentBlockConverters
+): Content {
+  switch (message.type) {
+    case "text":
+      return {
+        role: "model",
+        parts: [converters.assistantTextMessageToPart(message)],
+      };
+    case "reasoning":
+      return {
+        role: "model",
+        parts: [converters.assistantReasoningMessageToPart(message)],
+      };
+    case "tool_call_request":
+      return {
+        role: "model",
+        parts: [converters.assistantToolCallRequestToPart(message)],
+      };
+    default:
+      assertNever(message);
+  }
+}
+
+function isFunctionResponseContent(content: Content): boolean {
+  const parts = content.parts ?? [];
+  return (
+    content.role === "user" &&
+    parts.length > 0 &&
+    parts.every((part) => part.functionResponse !== undefined)
+  );
+}
+
+export function conversationToContents(
+  conversation: BaseConversation,
+  converters: ContentBlockConverters
+): Content[] {
+  const contents = conversation.messages.map((message) => {
+    switch (message.role) {
+      case "user":
+        return userMessageToContent(message, converters);
+      case "assistant":
+        return assistantMessageToContent(message, converters);
+      default:
+        assertNever(message);
+    }
+  });
+
+  // Merge consecutive function-response turns into one user turn: Gemini
+  // requires the functionResponse part count to match the functionCall count of
+  // the preceding model turn.
+  return contents.reduce<Content[]>((merged, content) => {
+    const previous = merged[merged.length - 1];
+    if (
+      previous &&
+      isFunctionResponseContent(previous) &&
+      isFunctionResponseContent(content)
+    ) {
+      return [
+        ...merged.slice(0, -1),
+        {
+          ...previous,
+          parts: [...(previous.parts ?? []), ...(content.parts ?? [])],
+        },
+      ];
+    }
+    return [...merged, content];
+  }, []);
+}
+
+export function systemMessagesToSystemInstruction(
+  system: SystemTextMessage[],
+  converters: ContentBlockConverters
+): Content | undefined {
+  if (system.length === 0) {
+    return undefined;
+  }
+  return {
+    role: "user",
+    parts: system.map((message) => converters.systemMessageToPart(message)),
+  };
+}
+
+// -- Config converters (pure) --
+
+export function toFunctionDeclaration(
+  tool: ToolSpecification
+): FunctionDeclaration {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parametersJsonSchema: tool.inputSchema,
+  };
+}
+
+export function outputFormatToResponseSchema(
+  outputFormat: OutputFormat
+): SchemaUnion {
+  return outputFormat.json_schema.schema;
+}
+
+export function forceToolNameToToolConfig(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ToolConfig | undefined {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? {
+        functionCallingConfig: {
+          allowedFunctionNames: [forceTool],
+          mode: FunctionCallingConfigMode.ANY,
+        },
+      }
+    : undefined;
+}
+
+function effortToThinkingLevel(
+  effort: (typeof GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number]
+): ThinkingLevel {
+  switch (effort) {
+    case "low":
+      return ThinkingLevel.LOW;
+    case "medium":
+      return ThinkingLevel.MEDIUM;
+    case "high":
+    // Gemini's highest native level; `maximal` maps here.
+    case "maximal":
+      return ThinkingLevel.HIGH;
+    default:
+      assertNever(effort);
+  }
+}
+
+export function reasoningToThinkingConfig(
+  reasoning: Reasoning | undefined
+): ThinkingConfig | undefined {
+  if (!reasoning) {
+    return undefined;
+  }
+  if (
+    reasoning.effort === "none" ||
+    !isGeminiSupportedNonNullReasoningEffort(reasoning.effort)
+  ) {
+    return { thinkingBudget: NONE_THINKING_BUDGET, includeThoughts: false };
+  }
+  return {
+    thinkingLevel: effortToThinkingLevel(reasoning.effort),
+    includeThoughts: true,
+  };
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/output/index.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/output/index.ts
@@ -1,0 +1,41 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  accumulatedReasoningToReasoningEvent,
+  accumulatedTextToTextEvent,
+  finishReasonToErrorEvent,
+  functionCallToToolCallEvent,
+  functionCallToToolCallStartedEvent,
+  type OutputEventConverters,
+  reasoningDeltaToReasoningDeltaEvent,
+  responseIdToResponseIdEvent,
+  streamErrorToErrorEvent,
+  textDeltaToTextDeltaEvent,
+  usageToTokenUsageEvent,
+} from "@app/lib/model_constructors/providers/google_ai_studio/converters/output/utils";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Binds the Gemini leaf output converters onto a client as class fields (an
+// endpoint can override a single leaf by re-declaring its field). The composite
+// is per-surface, so each supplies its own `rawOutputToEvents`.
+export function WithGoogleAiStudioOutputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithGoogleAiStudioOutputConverter
+    extends Base
+    implements OutputEventConverters
+  {
+    responseIdToResponseIdEvent = responseIdToResponseIdEvent;
+    textDeltaToTextDeltaEvent = textDeltaToTextDeltaEvent;
+    reasoningDeltaToReasoningDeltaEvent = reasoningDeltaToReasoningDeltaEvent;
+    accumulatedTextToTextEvent = accumulatedTextToTextEvent;
+    accumulatedReasoningToReasoningEvent = accumulatedReasoningToReasoningEvent;
+    functionCallToToolCallStartedEvent = functionCallToToolCallStartedEvent;
+    functionCallToToolCallEvent = functionCallToToolCallEvent;
+    usageToTokenUsageEvent = usageToTokenUsageEvent;
+    finishReasonToErrorEvent = finishReasonToErrorEvent;
+    streamErrorToErrorEvent = streamErrorToErrorEvent;
+  }
+
+  return WithGoogleAiStudioOutputConverter;
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
@@ -198,14 +198,8 @@ export function finishReasonToErrorEvent(
         type: "model_output_error",
         message: `Model generated an invalid tool call for ${metadata.modelId}.`,
       });
-    case FinishReason.NO_IMAGE:
-    case FinishReason.OTHER:
-    case FinishReason.FINISH_REASON_UNSPECIFIED:
-      return buildErrorEvent({
-        metadata,
-        type: "unknown_error",
-        message: `Unexpected finish reason from Google: ${finishReason}.`,
-      });
+    // Any other finish reason (OTHER, NO_IMAGE, unspecified, future values, ...)
+    // is surfaced as an unknown error.
     default:
       return buildErrorEvent({
         metadata,

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
@@ -1,0 +1,486 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ModelResponseEvent,
+  ReasoningDeltaEvent,
+  ReasoningEvent,
+  ResponseIdEvent,
+  TextDeltaEvent,
+  TextEvent,
+  TokenUsageEvent,
+  ToolCallEvent,
+  ToolCallStartedEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type {
+  GenerateContentResponse,
+  GenerateContentResponseUsageMetadata,
+  Part,
+} from "@google/genai";
+import { ApiError, FinishReason } from "@google/genai";
+
+// The per-signal leaf converters. The composite below takes an object
+// satisfying this interface (`this`), so overriding one leaf on an endpoint
+// changes how the composite uses it.
+export interface OutputEventConverters {
+  responseIdToResponseIdEvent(
+    metadata: EndpointMetadata,
+    responseId: string
+  ): ResponseIdEvent;
+  textDeltaToTextDeltaEvent(
+    metadata: EndpointMetadata,
+    delta: string
+  ): TextDeltaEvent;
+  reasoningDeltaToReasoningDeltaEvent(
+    metadata: EndpointMetadata,
+    delta: string
+  ): ReasoningDeltaEvent;
+  accumulatedTextToTextEvent(
+    metadata: EndpointMetadata,
+    text: string
+  ): TextEvent;
+  accumulatedReasoningToReasoningEvent(
+    metadata: EndpointMetadata,
+    text: string,
+    signature?: string
+  ): ReasoningEvent;
+  functionCallToToolCallStartedEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    index: number,
+    name: string
+  ): ToolCallStartedEvent;
+  functionCallToToolCallEvent(
+    metadata: EndpointMetadata,
+    id: string,
+    name: string,
+    args: Record<string, unknown>
+  ): ToolCallEvent;
+  usageToTokenUsageEvent(
+    metadata: EndpointMetadata,
+    usage: GenerateContentResponseUsageMetadata | undefined
+  ): TokenUsageEvent;
+  finishReasonToErrorEvent(
+    metadata: EndpointMetadata,
+    finishReason: FinishReason
+  ): ErrorEvent | null;
+  streamErrorToErrorEvent(
+    metadata: EndpointMetadata,
+    error: unknown
+  ): ErrorEvent;
+}
+
+// -- Leaf converters: one unified event per Gemini stream signal --
+
+export function responseIdToResponseIdEvent(
+  metadata: EndpointMetadata,
+  responseId: string
+): ResponseIdEvent {
+  return { type: "response_id", content: { responseId }, metadata };
+}
+
+export function textDeltaToTextDeltaEvent(
+  metadata: EndpointMetadata,
+  delta: string
+): TextDeltaEvent {
+  return { type: "text_delta", content: { value: delta }, metadata };
+}
+
+export function reasoningDeltaToReasoningDeltaEvent(
+  metadata: EndpointMetadata,
+  delta: string
+): ReasoningDeltaEvent {
+  return { type: "reasoning_delta", content: { value: delta }, metadata };
+}
+
+export function accumulatedTextToTextEvent(
+  metadata: EndpointMetadata,
+  text: string
+): TextEvent {
+  return { type: "text", content: { value: text }, metadata };
+}
+
+export function accumulatedReasoningToReasoningEvent(
+  metadata: EndpointMetadata,
+  text: string,
+  signature?: string
+): ReasoningEvent {
+  return {
+    type: "reasoning",
+    content: { value: text },
+    metadata: {
+      ...metadata,
+      ...(signature ? { content: { signature } } : {}),
+    },
+  };
+}
+
+export function functionCallToToolCallStartedEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  index: number,
+  name: string
+): ToolCallStartedEvent {
+  return { type: "tool_call_started", content: { id, index, name }, metadata };
+}
+
+export function functionCallToToolCallEvent(
+  metadata: EndpointMetadata,
+  id: string,
+  name: string,
+  args: Record<string, unknown>
+): ToolCallEvent {
+  return {
+    type: "tool_call",
+    content: { id, name, arguments: args },
+    metadata,
+  };
+}
+
+export function usageToTokenUsageEvent(
+  metadata: EndpointMetadata,
+  usage: GenerateContentResponseUsageMetadata | undefined
+): TokenUsageEvent {
+  const cacheHit = usage?.cachedContentTokenCount ?? 0;
+  // Gemini's promptTokenCount includes cached and tool-use input tokens;
+  // subtract the cached portion so it is not counted twice against pricing.
+  const totalInput =
+    (usage?.promptTokenCount ?? 0) + (usage?.toolUsePromptTokenCount ?? 0);
+  return {
+    type: "token_usage",
+    content: {
+      // Gemini uses implicit caching with no explicit cache-creation tokens and
+      // no per-TTL (short/long) breakdown.
+      cacheCreated: 0,
+      longCacheCreated: 0,
+      shortCacheCreated: 0,
+      cacheHit,
+      standardInput: Math.max(0, totalInput - cacheHit),
+      standardOutput: usage?.candidatesTokenCount ?? 0,
+      reasoning: usage?.thoughtsTokenCount ?? 0,
+    },
+    metadata,
+  };
+}
+
+export function finishReasonToErrorEvent(
+  metadata: EndpointMetadata,
+  finishReason: FinishReason
+): ErrorEvent | null {
+  switch (finishReason) {
+    case FinishReason.STOP:
+      return null;
+    case FinishReason.MAX_TOKENS:
+      return buildErrorEvent({
+        metadata,
+        type: "stop_error",
+        message: "The maximum response length was reached.",
+      });
+    case FinishReason.SAFETY:
+    case FinishReason.RECITATION:
+    case FinishReason.PROHIBITED_CONTENT:
+    case FinishReason.SPII:
+    case FinishReason.IMAGE_PROHIBITED_CONTENT:
+    case FinishReason.BLOCKLIST:
+    case FinishReason.IMAGE_SAFETY:
+    case FinishReason.LANGUAGE:
+      return buildErrorEvent({
+        metadata,
+        type: "refusal_error",
+        message:
+          "Google safety filters prevented this response. Try starting a new conversation or rephrasing your request.",
+      });
+    case FinishReason.MALFORMED_FUNCTION_CALL:
+    case FinishReason.UNEXPECTED_TOOL_CALL:
+      return buildErrorEvent({
+        metadata,
+        type: "model_output_error",
+        message: `Model generated an invalid tool call for ${metadata.modelId}.`,
+      });
+    case FinishReason.NO_IMAGE:
+    case FinishReason.OTHER:
+    case FinishReason.FINISH_REASON_UNSPECIFIED:
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Unexpected finish reason from Google: ${finishReason}.`,
+      });
+    default:
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Unexpected finish reason from Google: ${finishReason}.`,
+      });
+  }
+}
+
+// Maps an HTTP status from a Google `ApiError` to a unified error event.
+function apiErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: ApiError
+): ErrorEvent {
+  const status = error.status;
+  const isAuthMessage = error.message
+    .toLowerCase()
+    .includes("api key not valid");
+
+  if (status === 401 || (status === 400 && isAuthMessage)) {
+    return buildErrorEvent({
+      metadata,
+      type: "authentication_error",
+      message: `Authentication failed for Google: ${error.message}`,
+      originalError: error,
+    });
+  }
+  switch (status) {
+    case 400:
+      return buildErrorEvent({
+        metadata,
+        type: "invalid_request_error",
+        message: `Invalid request to Google: ${error.message}`,
+        originalError: error,
+      });
+    case 403:
+      return buildErrorEvent({
+        metadata,
+        type: "permission_error",
+        message: `Permission denied for Google: ${error.message}`,
+        originalError: error,
+      });
+    case 404:
+      return buildErrorEvent({
+        metadata,
+        type: "not_found_error",
+        message: `Resource not found for Google: ${error.message}`,
+        originalError: error,
+      });
+    case 429:
+      return buildErrorEvent({
+        metadata,
+        type: "rate_limit_error",
+        message: `Rate limit exceeded for Google/${metadata.modelId}: ${error.message}`,
+        originalError: error,
+      });
+    case 503:
+      return buildErrorEvent({
+        metadata,
+        type: "overloaded_error",
+        message: `Google is overloaded: ${error.message}`,
+        originalError: error,
+      });
+    default:
+      if (status >= 500 && status < 600) {
+        return buildErrorEvent({
+          metadata,
+          type: "server_error",
+          message: `Server error from Google (${status}): ${error.message}`,
+          originalError: error,
+        });
+      }
+      return buildErrorEvent({
+        metadata,
+        type: "unknown_error",
+        message: `Error from Google (${status}): ${error.message}`,
+        originalError: error,
+      });
+  }
+}
+
+// Maps any error thrown by the Google SDK while streaming into a unified
+// `ErrorEvent`, so everything leaving the endpoint is an event, not an exception.
+export function streamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  if (error instanceof ApiError) {
+    return apiErrorToErrorEvent(metadata, error);
+  }
+  return buildErrorEvent({
+    metadata,
+    type: "unknown_error",
+    message: `Unknown error from Google: ${normalizeError(error).message}`,
+    originalError: error,
+  });
+}
+
+// -- Accumulator across the stream: text/reasoning are concatenated until a
+// tool call or the final finish reason flushes them as a single event. --
+
+type Accumulator = {
+  textParts: string;
+  reasoningParts: string;
+  thoughtSignature?: string;
+  toolCallIndex: number;
+};
+
+// Flushes any pending reasoning then text as accumulated events, appending them
+// to `aggregated`. Reasoning is flushed before text so the final text block
+// stays last (checkers assert on the last aggregated event).
+function flushAccumulated(
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  const events: ModelResponseEvent[] = [];
+  if (acc.reasoningParts) {
+    const event = converters.accumulatedReasoningToReasoningEvent(
+      metadata,
+      acc.reasoningParts,
+      acc.thoughtSignature
+    );
+    aggregated.push(event);
+    events.push(event);
+    acc.reasoningParts = "";
+  }
+  if (acc.textParts) {
+    const event = converters.accumulatedTextToTextEvent(
+      metadata,
+      acc.textParts.trim()
+    );
+    aggregated.push(event);
+    events.push(event);
+    acc.textParts = "";
+  }
+  return events;
+}
+
+// Converts a single content part into the events to emit, mutating the
+// accumulator for text/reasoning deltas. Function calls flush pending
+// text/reasoning first, then emit the tool-call events.
+function partToEvents(
+  part: Part,
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  if (part.functionCall) {
+    const events = flushAccumulated(acc, metadata, converters, aggregated);
+    const { id, name, args } = part.functionCall;
+    // Google may omit the id; the consumer requires one to correlate the result.
+    const callId = id ?? `fc_${acc.toolCallIndex}`;
+    if (!name) {
+      return events;
+    }
+    events.push(
+      converters.functionCallToToolCallStartedEvent(
+        metadata,
+        callId,
+        acc.toolCallIndex,
+        name
+      )
+    );
+    const toolCallEvent = converters.functionCallToToolCallEvent(
+      metadata,
+      callId,
+      name,
+      args ?? {}
+    );
+    aggregated.push(toolCallEvent);
+    events.push(toolCallEvent);
+    acc.toolCallIndex += 1;
+    return events;
+  }
+
+  if (!part.text) {
+    return [];
+  }
+
+  if (part.thoughtSignature) {
+    acc.thoughtSignature = part.thoughtSignature;
+  }
+
+  if (part.thought) {
+    acc.reasoningParts += part.text;
+    return [
+      converters.reasoningDeltaToReasoningDeltaEvent(metadata, part.text),
+    ];
+  }
+
+  acc.textParts += part.text;
+  return [converters.textDeltaToTextDeltaEvent(metadata, part.text)];
+}
+
+// -- Entry point: drive the raw stream into unified events --
+
+export async function* rawOutputToEvents(
+  stream: AsyncGenerator<GenerateContentResponse>,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): AsyncGenerator<ModelResponseEvent> {
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const acc: Accumulator = {
+    textParts: "",
+    reasoningParts: "",
+    toolCallIndex: 0,
+  };
+  let hasYieldedResponseId = false;
+  let usage: GenerateContentResponseUsageMetadata | undefined;
+
+  while (true) {
+    let result: IteratorResult<GenerateContentResponse>;
+    try {
+      result = await stream.next();
+    } catch (err) {
+      yield converters.streamErrorToErrorEvent(metadata, err);
+      return;
+    }
+    if (result.done) {
+      break;
+    }
+
+    const response = result.value;
+    usage = response.usageMetadata ?? usage;
+
+    if (!hasYieldedResponseId && response.responseId) {
+      yield converters.responseIdToResponseIdEvent(
+        metadata,
+        response.responseId
+      );
+      hasYieldedResponseId = true;
+    }
+
+    const candidate = response.candidates?.[0];
+    if (!candidate) {
+      continue;
+    }
+
+    for (const part of candidate.content?.parts ?? []) {
+      for (const event of partToEvents(
+        part,
+        acc,
+        metadata,
+        converters,
+        aggregated
+      )) {
+        yield event;
+      }
+    }
+
+    if (candidate.finishReason) {
+      const errorEvent = converters.finishReasonToErrorEvent(
+        metadata,
+        candidate.finishReason
+      );
+      if (errorEvent) {
+        // Terminal failure: surface the error and stop without a success event.
+        yield errorEvent;
+        return;
+      }
+      // Successful finish: flush any pending text/reasoning before the success.
+      for (const event of flushAccumulated(
+        acc,
+        metadata,
+        converters,
+        aggregated
+      )) {
+        yield event;
+      }
+    }
+  }
+
+  yield converters.usageToTokenUsageEvent(metadata, usage);
+  yield { type: "success", content: { aggregated }, metadata };
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 export const googleAiStudioConfigSchema = inputConfigSchema.extend({
   reasoning: z
     .object({
-      effort: z.enum([...GEMINI_SUPPORTED_REASONING_EFFORTS]),
+      effort: z.enum(GEMINI_SUPPORTED_REASONING_EFFORTS),
     })
     .optional(),
 });

--- a/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
@@ -1,0 +1,18 @@
+import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { z } from "zod";
+
+// Provider-wide input config: the widest reasoning contract any Gemini model
+// accepts (all four native thinking levels). Per-model schemas narrow this
+// further (e.g. Pro drops `minimal`).
+export const googleAiStudioConfigSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([...GEMINI_SUPPORTED_REASONING_EFFORTS]),
+    })
+    .optional(),
+});
+
+export type GoogleAiStudioInputConfig = z.infer<
+  typeof googleAiStudioConfigSchema
+>;

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,0 +1,48 @@
+import { GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { GEMINI_3_1_PRO_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// Verified against https://ai.google.dev/gemini-api/docs/models (2026-06-18):
+// Gemini 3 Pro has a 1M-token context window and up to 64k output tokens.
+const CONTEXT_SIZE = 1_000_000;
+const MAX_OUTPUT_TOKENS = 65_536;
+const DEFAULT_REASONING_EFFORT = "high";
+
+const baseConfig = inputConfigSchema.extend({
+  // Gemini uses implicit caching; we do not pass an explicit cache key.
+  cacheKey: z.undefined(),
+});
+
+// Gemini 3 only exposes `none` plus the native thinking levels (low/medium/high)
+// and strongly recommends `temperature: 1`, so we coerce temperature to 1.
+const configSchema = baseConfig.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([...GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS, "none"]),
+    })
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+  temperature: temperatureSchema.optional().transform(() => 1 as const),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithGoogleAiStudioGemini31ProConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class GoogleAiStudioGemini31Pro extends Base {
+    static readonly modelId = GEMINI_3_1_PRO_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return GoogleAiStudioGemini31Pro;
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,4 +1,4 @@
-import { GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import { GEMINI_PRO_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import {
   inputConfigSchema,
   temperatureSchema,
@@ -18,12 +18,12 @@ const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
 });
 
-// Gemini 3 only exposes `none` plus the native thinking levels (low/medium/high)
-// and strongly recommends `temperature: 1`, so we coerce temperature to 1.
+// Pro supports the low/medium/high thinking levels (no `minimal`) and strongly
+// recommends `temperature: 1`, so we coerce temperature to 1.
 const configSchema = baseConfig.extend({
   reasoning: z
     .object({
-      effort: z.enum([...GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS, "none"]),
+      effort: z.enum([...GEMINI_PRO_SUPPORTED_REASONING_EFFORTS]),
     })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
   temperature: temperatureSchema.optional().transform(() => 1 as const),

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -23,7 +23,7 @@ const baseConfig = inputConfigSchema.extend({
 const configSchema = baseConfig.extend({
   reasoning: z
     .object({
-      effort: z.enum([...GEMINI_PRO_SUPPORTED_REASONING_EFFORTS]),
+      effort: z.enum(GEMINI_PRO_SUPPORTED_REASONING_EFFORTS),
     })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
   temperature: temperatureSchema.optional().transform(() => 1 as const),

--- a/front/lib/model_constructors/providers/google_ai_studio/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/reasoning_efforts.ts
@@ -1,0 +1,22 @@
+// Reasoning efforts Gemini 3.x models accept as a non-null thinking level. The
+// `none` effort is handled separately (a minimal thinking budget with thoughts
+// hidden), since Gemini 3 cannot fully disable thinking. `maximal` maps to the
+// highest native level (HIGH), mirroring the Anthropic sibling; `minimal` and
+// `xhigh` are intentionally unsupported.
+export const GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "maximal",
+] as const;
+
+export type GeminiSupportedNonNullReasoningEffort =
+  (typeof GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number];
+
+export function isGeminiSupportedNonNullReasoningEffort(
+  effort: string
+): effort is GeminiSupportedNonNullReasoningEffort {
+  return GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS.some(
+    (supported) => supported === effort
+  );
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/reasoning_efforts.ts
@@ -1,22 +1,16 @@
-// Reasoning efforts Gemini 3.x models accept as a non-null thinking level. The
-// `none` effort is handled separately (a minimal thinking budget with thoughts
-// hidden), since Gemini 3 cannot fully disable thinking. `maximal` maps to the
-// highest native level (HIGH), mirroring the Anthropic sibling; `minimal` and
-// `xhigh` are intentionally unsupported.
-export const GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS = [
+// Native Gemini 3.x thinking levels exposed as reasoning efforts. Every Gemini
+// model supports low/medium/high; Flash and Flash-Lite additionally support
+// `minimal`. Gemini always thinks, so there is no `none` effort.
+export const GEMINI_PRO_SUPPORTED_REASONING_EFFORTS = [
   "low",
   "medium",
   "high",
-  "maximal",
 ] as const;
 
-export type GeminiSupportedNonNullReasoningEffort =
-  (typeof GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS)[number];
+export const GEMINI_SUPPORTED_REASONING_EFFORTS = [
+  "minimal",
+  ...GEMINI_PRO_SUPPORTED_REASONING_EFFORTS,
+] as const;
 
-export function isGeminiSupportedNonNullReasoningEffort(
-  effort: string
-): effort is GeminiSupportedNonNullReasoningEffort {
-  return GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS.some(
-    (supported) => supported === effort
-  );
-}
+export type GeminiSupportedReasoningEffort =
+  (typeof GEMINI_SUPPORTED_REASONING_EFFORTS)[number];

--- a/front/lib/model_constructors/stream/clients/google_ai_studio.ts
+++ b/front/lib/model_constructors/stream/clients/google_ai_studio.ts
@@ -1,0 +1,61 @@
+import { WithGoogleAiStudioInputConverter } from "@app/lib/model_constructors/providers/google_ai_studio/converters/input";
+import { WithGoogleAiStudioOutputConverter } from "@app/lib/model_constructors/providers/google_ai_studio/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/google_ai_studio/converters/output/utils";
+import { GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { GOOGLE_AI_STUDIO_API } from "@app/lib/model_constructors/types/provider_apis";
+import { GOOGLE_AI_STUDIO_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from "@google/genai";
+import { GoogleGenAI } from "@google/genai";
+
+import { z } from "zod";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([...GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS, "none"]),
+    })
+    .optional(),
+});
+
+type GoogleAiStudioInputConfig = z.infer<typeof configSchema>;
+
+export abstract class GoogleAiStudioStream extends WithGoogleAiStudioInputConverter(
+  WithGoogleAiStudioOutputConverter(
+    StreamEndpoint<GenerateContentParameters, GenerateContentResponse>
+  )
+) {
+  static readonly providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
+  static readonly api = GOOGLE_AI_STUDIO_API;
+
+  static readonly configSchema: z.ZodType<GoogleAiStudioInputConfig> =
+    configSchema;
+
+  private readonly client: GoogleGenAI;
+
+  constructor({ GOOGLE_AI_STUDIO_API_KEY }: Credentials) {
+    super();
+    this.client = new GoogleGenAI({ apiKey: GOOGLE_AI_STUDIO_API_KEY });
+  }
+
+  async *streamRaw(
+    input: GenerateContentParameters
+  ): AsyncGenerator<GenerateContentResponse> {
+    const stream = await this.client.models.generateContentStream(input);
+    for await (const chunk of stream) {
+      yield chunk;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<GenerateContentResponse>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/clients/google_ai_studio.ts
+++ b/front/lib/model_constructors/stream/clients/google_ai_studio.ts
@@ -1,10 +1,12 @@
 import { WithGoogleAiStudioInputConverter } from "@app/lib/model_constructors/providers/google_ai_studio/converters/input";
 import { WithGoogleAiStudioOutputConverter } from "@app/lib/model_constructors/providers/google_ai_studio/converters/output";
 import { rawOutputToEvents } from "@app/lib/model_constructors/providers/google_ai_studio/converters/output/utils";
-import { GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import {
+  type GoogleAiStudioInputConfig,
+  googleAiStudioConfigSchema,
+} from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { GOOGLE_AI_STUDIO_API } from "@app/lib/model_constructors/types/provider_apis";
 import { GOOGLE_AI_STUDIO_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
@@ -14,28 +16,19 @@ import type {
 } from "@google/genai";
 import { GoogleGenAI } from "@google/genai";
 
-import { z } from "zod";
-
-const configSchema = inputConfigSchema.extend({
-  reasoning: z
-    .object({
-      effort: z.enum([...GEMINI_SUPPORTED_NON_NULL_REASONING_EFFORTS, "none"]),
-    })
-    .optional(),
-});
-
-type GoogleAiStudioInputConfig = z.infer<typeof configSchema>;
-
 export abstract class GoogleAiStudioStream extends WithGoogleAiStudioInputConverter(
   WithGoogleAiStudioOutputConverter(
-    StreamEndpoint<GenerateContentParameters, GenerateContentResponse>
+    StreamEndpoint<
+      GenerateContentParameters,
+      GenerateContentResponse,
+      GoogleAiStudioInputConfig
+    >
   )
 ) {
   static readonly providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
   static readonly api = GOOGLE_AI_STUDIO_API;
 
-  static readonly configSchema: z.ZodType<GoogleAiStudioInputConfig> =
-    configSchema;
+  static readonly configSchema = googleAiStudioConfigSchema;
 
   private readonly client: GoogleGenAI;
 

--- a/front/lib/model_constructors/stream/clients/google_ai_studio.ts
+++ b/front/lib/model_constructors/stream/clients/google_ai_studio.ts
@@ -40,10 +40,7 @@ export abstract class GoogleAiStudioStream extends WithGoogleAiStudioInputConver
   async *streamRaw(
     input: GenerateContentParameters
   ): AsyncGenerator<GenerateContentResponse> {
-    const stream = await this.client.models.generateContentStream(input);
-    for await (const chunk of stream) {
-      yield chunk;
-    }
+    yield* await this.client.models.generateContentStream(input);
   }
 
   async *rawStreamOutputToEvents(

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -7,6 +7,7 @@ export class GoogleAiStudioGlobalGemini31ProStream extends WithGoogleAiStudioGem
   GoogleAiStudioStream
 ) {
   // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
+  //TODO(new-llm): implement progressive token billing
   static readonly tokenPricing = {
     cacheCreated: 4.5,
     cacheHit: 0.4,

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -1,0 +1,22 @@
+import { WithGoogleAiStudioGemini31ProConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro";
+import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGemini31ProStream extends WithGoogleAiStudioGemini31ProConfig(
+  GoogleAiStudioStream
+) {
+  // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 0,
+    cacheHit: 0.2,
+    standardInput: 2.0,
+    standardOutput: 12.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGemini31ProStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -8,10 +8,10 @@ export class GoogleAiStudioGlobalGemini31ProStream extends WithGoogleAiStudioGem
 ) {
   // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
   static readonly tokenPricing = {
-    cacheCreated: 0,
-    cacheHit: 0.2,
-    standardInput: 2.0,
-    standardOutput: 12.0,
+    cacheCreated: 4.5,
+    cacheHit: 0.4,
+    standardInput: 4.0,
+    standardOutput: 18.0,
   };
 
   static readonly region = GLOBAL;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,6 +1,7 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const STREAM_ENDPOINTS = {
@@ -8,6 +9,8 @@ export const STREAM_ENDPOINTS = {
     AnthropicGlobalClaudeSonnetFourDotSixStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [GoogleAiStudioGlobalGemini31ProStream.id]:
+    GoogleAiStudioGlobalGemini31ProStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
@@ -14,37 +14,40 @@ const setup: StreamSetup = {
   // `null` runs the case with its default checkers; a checker array overrides
   // them. Every case always runs.
   tests: {
-    // Gemini 3 supports none/low/medium/high (+ maximal → high). The `minimal`
-    // effort is unsupported and rejected by the config schema.
+    // Pro supports low/medium/high only. `minimal`, `none`, and `maximal` are
+    // unsupported and rejected by the config schema.
     "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
 
     "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-none": null,
     "simple/no-tools/t-default/r-low": null,
     "simple/no-tools/t-default/r-medium": null,
     "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-default/r-maximal": null,
     "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-none": null,
     "simple/no-tools/t-0/r-low": null,
     "simple/no-tools/t-0/r-medium": null,
     "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0/r-maximal": null,
     "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-none": null,
     "simple/no-tools/t-0.1/r-low": null,
     "simple/no-tools/t-0.1/r-medium": null,
     "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-0.1/r-maximal": null,
     "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-none": null,
     "simple/no-tools/t-1/r-low": null,
     "simple/no-tools/t-1/r-medium": null,
     "simple/no-tools/t-1/r-high": null,
-    "simple/no-tools/t-1/r-maximal": null,
 
     // Gemini ignores the Anthropic-style cache markers (it uses implicit
     // caching), so this behaves like a plain "say Hi" prompt.
@@ -56,12 +59,9 @@ const setup: StreamSetup = {
 
     "calc/calc/t-default/r-default/force-tool-default": null,
     "calc/calc/t-default/r-default/force-tool": null,
-    "calc/calc/t-default/r-none/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-none": null,
     "reasoning/no-tools/t-default/r-low": null,
 
-    "output-format/json-schema/t-default/r-none": null,
     "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new GoogleAiStudioGlobalGemini31ProStream({
+      GOOGLE_AI_STUDIO_API_KEY:
+        process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Gemini 3 supports none/low/medium/high (+ maximal → high). The `minimal`
+    // effort is unsupported and rejected by the config schema.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+runStreamEndpointTests(GoogleAiStudioGlobalGemini31ProStream, setup);


### PR DESCRIPTION
  ## What & why

  Adds the **Gemini** provider to the new per-endpoint LLM router (`lib/model_constructors`) and wires it up for runtime use, starting with the `gemini-3.1-pro-preview` streaming endpoint (`google_ai_studio/google-ai-studio/global/gemini-3.1-pro-preview`).

  Until now the new router only had Anthropic endpoints; this is the first non-Anthropic provider on it, which also surfaced two latent bugs in the shared transition layer (see *Bug fixes* below).

  ## What's included

  **Provider layer (`lib/model_constructors/providers/google_ai_studio/`)**
  - `reasoning_efforts.ts` — supported efforts (`low`/`medium`/`high`, `maximal`→`HIGH`)
  - `converters/input/{utils,index}.ts` — conversation + config → `@google/genai` `GenerateContentParameters`
  - `converters/output/{utils,index}.ts` — Gemini stream → unified `ModelResponseEvent`s (ported from the legacy `lib/api/llm/clients/google` client)
  - `models/gemini_3_1_pro.ts` — model-config mixin (schema, context, max output)

  **Endpoint + client**
  - `stream/clients/google_ai_studio.ts` — `GoogleGenAI` client
  - `stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts` — the endpoint, registered in `stream/index.ts`

  **Runtime wiring (`lib/llms/`)**
  - Dust model-config + endpoint wrapper, registered in `DUST_STREAM_ENDPOINTS` — selectable at runtime behind the `use_new_llm_router` flag.

  ## Bug fixes (shared layer, exposed by the first non-Anthropic endpoint)

  - **`NaN` token usage** → `column "nan" does not exist` on the `run_usages`
    insert. The Gemini token-usage event was missing the now-required
    `longCacheCreated`/`shortCacheCreated` fields, so the transition computed
    `undefined + undefined = NaN`. Set both to `0` (Gemini uses implicit caching).

  ## Behavior decisions
  - Reasoning efforts mirror the Anthropic sibling: `none/low/medium/high` accepted,
    `maximal`→`HIGH`, `minimal`/`xhigh` rejected as `input_configuration_error`.
  - Temperature is coerced to `1` (Google's recommendation for Gemini 3).
  - Forced tool calls are allowed with or without reasoning.

  ## Testing
  - New live-API endpoint test (`test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts`),
    gated on `RUN_LLM_TEST` — **40/40 cases pass** against the real Gemini API.
  - `tsgo` clean; biome formatted.
  - The local-only router parity suite now skips providers without an adapter
    (instead of throwing at collection) so it stays green.

  ## Known follow-ups / limitations
  - **Pricing not verified** — `tokenPricing` is best-effort with a link to Google's
    pricing page; confirm before enabling for real workspaces.
  - **Images**: Gemini needs base64-inlined images, which the synchronous
    `buildRequestPayload` contract can't fetch; image messages currently degrade to
    a text placeholder. Text / tools / reasoning / output-format are fully supported.
  - **Batch surface** and a **router-parity adapter** for Google are not included.