### PR TITLE
Add numbers delimiters

### DIFF
--- a/front/components/workspace/EditSpendLimitModal.tsx
+++ b/front/components/workspace/EditSpendLimitModal.tsx
@@ -259,8 +259,12 @@ export function EditSpendLimitModal({
                       type="text"
                       inputMode="numeric"
                       pattern="[0-9]*"
-                      placeholder="1000"
-                      value={creditsInput}
+                      placeholder="1,000"
+                      value={
+                        creditsInput !== ""
+                          ? Number(creditsInput).toLocaleString()
+                          : ""
+                      }
                       onChange={(e) => handleCreditsChange(e.target.value)}
                       isError={validationMessage !== null}
                       message={validationMessage ?? undefined}

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -84,9 +84,12 @@ export function UsageNotificationsCard({
               <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"
-                value={String(currentThreshold)}
+                value={currentThreshold.toLocaleString()}
                 unit="credits"
                 normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                formatValue={(value) =>
+                  value ? Number(value).toLocaleString() : value
+                }
                 onSave={handleSaveBalanceThreshold}
                 disabled={readOnly || isUsageNotificationsLoading}
               />

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -63,9 +63,14 @@ export function UsageProgrammaticLimitCard({
                 inputMode="numeric"
                 pattern="[0-9]*"
                 placeholder="No limit"
-                value={currentLimit !== null ? String(currentLimit) : ""}
+                value={
+                  currentLimit !== null ? currentLimit.toLocaleString() : ""
+                }
                 unit="credits"
                 normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                formatValue={(value) =>
+                  value ? Number(value).toLocaleString() : value
+                }
                 onSave={handleSaveLimit}
                 disabled={readOnly || isProgrammaticUsageLimitLoading}
               />

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -104,11 +104,14 @@ export function UsageSettingsCard({
                   pattern="[0-9]*"
                   value={
                     currentDefaultLimit !== null
-                      ? String(currentDefaultLimit)
+                      ? currentDefaultLimit.toLocaleString()
                       : ""
                   }
                   unit="credits"
                   normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+                  formatValue={(value) =>
+                    value ? Number(value).toLocaleString() : value
+                  }
                   onSave={handleSaveDefaultLimit}
                   disabled={readOnly || isDefaultUserSpendLimitLoading}
                 />

--- a/sparkle/src/components/InputWithSave.tsx
+++ b/sparkle/src/components/InputWithSave.tsx
@@ -16,8 +16,12 @@ export interface InputWithSaveProps
   unit?: string;
   onSave: (value: string) => Promise<void> | void;
   // Applied to the draft value on each keystroke (e.g. to strip non-digit
-  // characters for numeric inputs).
+  // characters for numeric inputs). The cleaned result is what gets passed to
+  // onSave.
   normalizeValue?: (value: string) => string;
+  // Applied to the normalized draft value for display during editing (e.g. to
+  // insert thousand-separator commas). Does not affect what onSave receives.
+  formatValue?: (value: string) => string;
   className?: string;
 }
 
@@ -28,6 +32,7 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
       unit,
       onSave,
       normalizeValue,
+      formatValue,
       className,
       disabled,
       onFocus,
@@ -64,7 +69,8 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
 
     const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
       if (!isSaving && !isEditing) {
-        setDraftValue(value ?? "");
+        const raw = value ?? "";
+        setDraftValue(normalizeValue ? normalizeValue(raw) : raw);
         setIsEditing(true);
       }
       onFocus?.(e);
@@ -122,7 +128,13 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
               "s-cursor-not-allowed s-text-muted-foreground dark:s-text-muted-foreground-night"
           )}
           data-1p-ignore
-          value={showSaveButton ? draftValue : (value ?? "")}
+          value={
+            showSaveButton
+              ? formatValue
+                ? formatValue(draftValue)
+                : draftValue
+              : (value ?? "")
+          }
           onChange={(e) =>
             setDraftValue(
               normalizeValue ? normalizeValue(e.target.value) : e.target.value


### PR DESCRIPTION
## Description

Format credit input fields with thousand-separator commas for readability (e.g. `1000000` → `1,000,000`). Applies to the three `InputWithSave` fields on the Usage page (default pool limit, programmatic limit, balance threshold) and the per-member spend limit modal.

- Added a `formatValue` prop to `InputWithSave` (sparkle) — formats the displayed value during editing without affecting what `onSave` receives (which stays digits-only via `normalizeValue`)
- Updated all four credit inputs to pass `formatValue` and a formatted `value` prop for the at-rest display

## Tests

Tested manually.

## Risk

Low — display-only change, no effect on saved values.

## Deploy Plan

Standard deploy, no migration needed.