### PR TITLE
[front] Fix tsgo: read balance threshold from credit usage config

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -1,7 +1,4 @@
-import {
-  getWorkspaceBalanceThreshold,
-  syncMetronomeBalanceThresholdAlert,
-} from "@app/lib/api/credits/balance_threshold_alert";
+import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
 import { syncCreditBasedPayg } from "@app/lib/api/credits/credit_based_payg";
 import {
   getProgrammaticUsageLimit,
@@ -139,9 +136,8 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-    const [balanceThreshold, defaultPoolLimit, programmaticLimit, usageConfig] =
+    const [defaultPoolLimit, programmaticLimit, usageConfig] =
       await Promise.all([
-        getWorkspaceBalanceThreshold(auth),
         getDefaultUserSpendLimit(auth),
         getProgrammaticUsageLimit(auth),
         getUsageConfiguration(auth),
@@ -151,7 +147,7 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       defaultDiscountPercent: config?.defaultDiscountPercent ?? 0,
       paygEnabled: config?.paygEnabled ?? false,
       usageCapCredits: config?.usageCapCredits ?? 0,
-      balanceThresholdCredits: balanceThreshold ?? 0,
+      balanceThresholdCredits: config?.balanceThresholdAwuCredits ?? 0,
       defaultPoolCapCredits: defaultPoolLimit.isOk()
         ? (defaultPoolLimit.value.awuCredits ?? 0)
         : 0,


### PR DESCRIPTION
## Description

getWorkspaceBalanceThreshold was removed when the balance-threshold source of truth moved to the credit_usage_configurations DB column. Read config.balanceThresholdAwuCredits directly instead.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
