### PR TITLE
Workspace default agent feature

### DIFF
--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -1,4 +1,6 @@
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
@@ -68,6 +70,76 @@ describe("POST /api/w/:wId (reinforcement caps)", () => {
           message: ENSURE_IS_ADMIN_ERROR_MESSAGE,
         },
       });
+    }
+  });
+});
+
+describe("POST /api/w/:wId (workspace default agent)", () => {
+  it("sets workspaceDefaultAgentId for a valid agent when the flag is enabled", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "workspace_default_agent");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await post(workspace, {
+      workspaceDefaultAgentId: agent.sId,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.workspaceDefaultAgentId).toBe(agent.sId);
+  });
+
+  it("clears the default and preserves other metadata when passed null", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "workspace_default_agent");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    // Seed an unrelated metadata key plus the default agent.
+    await post(workspace, { reinforcementCapAwuCredits: 5_000 });
+    await post(workspace, { workspaceDefaultAgentId: agent.sId });
+
+    const response = await post(workspace, { workspaceDefaultAgentId: null });
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.workspaceDefaultAgentId).toBeUndefined();
+    expect(updated?.metadata?.reinforcementCapAwuCredits).toBe(5_000);
+  });
+
+  it("returns 400 for an unknown agent", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "workspace_default_agent");
+
+    const response = await post(workspace, {
+      workspaceDefaultAgentId: "non-existent-agent",
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 403 when the feature flag is disabled", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      workspaceDefaultAgentId: "some-agent",
+    });
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("feature_flag_not_found");
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    for (const role of ["builder", "user"] as const) {
+      const { workspace } = await setup(role);
+
+      const response = await post(workspace, {
+        workspaceDefaultAgentId: "some-agent",
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
     }
   });
 });

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -1,3 +1,4 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { listActiveAgentsUsingNonRegionalModels } from "@app/lib/api/assistant/workspace_capabilities";
 import {
   buildAuditLogTarget,
@@ -6,7 +7,10 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { validateDustMcpServerAllowedRedirectUris } from "@app/lib/api/mcp_server/dust_mcp_server_settings";
 import type { GetWorkspaceResponseBody } from "@app/lib/api/workspace";
-import { renameWorkspace } from "@app/lib/api/workspace";
+import {
+  renameWorkspace,
+  updateWorkspaceMetadata,
+} from "@app/lib/api/workspace";
 import { hasFeatureFlag } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -193,6 +197,11 @@ const WorkspaceAuditLogsUpdateBodySchema = z.object({
   disableAuditLogs: z.boolean(),
 });
 
+// A null value clears the workspace-wide default agent (falls back to @dust).
+const WorkspaceDefaultAgentUpdateBodySchema = z.object({
+  workspaceDefaultAgentId: z.string().nullable(),
+});
+
 const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceAllowedDomainUpdateBodySchema,
   WorkspaceBatchDomainUpdateBodySchema,
@@ -218,6 +227,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceReinforcementCapAwuCreditsUpdateBodySchema,
   WorkspaceSelfImprovementCapPerSkillAwuCreditsUpdateBodySchema,
   WorkspaceAuditLogsUpdateBodySchema,
+  WorkspaceDefaultAgentUpdateBodySchema,
 ]);
 
 const app = workspaceApp();
@@ -641,6 +651,53 @@ app.post(
           enabled: String(!body.disableAuditLogs),
         },
       });
+    } else if ("workspaceDefaultAgentId" in body) {
+      if (!(await hasFeatureFlag(auth, "workspace_default_agent"))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "feature_flag_not_found",
+            message:
+              "The workspace default agent feature is not enabled for this workspace.",
+          },
+        });
+      }
+
+      // Validate the default agent exists and is usable (handles both global
+      // agents and workspace agents). A null value clears the default (@dust).
+      if (body.workspaceDefaultAgentId) {
+        const agent = await getAgentConfiguration(auth, {
+          agentId: body.workspaceDefaultAgentId,
+          variant: "extra_light",
+        });
+        if (!agent || agent.status !== "active") {
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Agent "${body.workspaceDefaultAgentId}" was not found or is not usable by the authenticated user.`,
+            },
+          });
+        }
+      }
+
+      const workspaceDefaultAgentId = body.workspaceDefaultAgentId ?? undefined;
+      const updateRes = await updateWorkspaceMetadata(owner, {
+        workspaceDefaultAgentId,
+      });
+      if (updateRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: updateRes.error.message,
+          },
+        });
+      }
+      owner.metadata = {
+        ...(owner.metadata ?? {}),
+        workspaceDefaultAgentId,
+      };
     } else if ("domainUpdates" in body) {
       for (const update of body.domainUpdates) {
         const updateResult = await workspace.updateDomainAutoJoinEnabled({

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -13,6 +13,7 @@ import { useConversations } from "@app/hooks/conversations";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
@@ -34,7 +35,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { UserType, WorkspaceType } from "@app/types/user";
-import { isAdmin } from "@app/types/user";
+import { getWorkspaceDefaultAgentId, isAdmin } from "@app/types/user";
 import {
   Button,
   Card,
@@ -81,6 +82,11 @@ export function ConversationContainerVirtuoso({
   const router = useAppRouter();
 
   const sendNotification = useSendNotification();
+
+  const { hasFeature } = useFeatureFlags();
+  const workspaceDefaultAgentId = hasFeature("workspace_default_agent")
+    ? getWorkspaceDefaultAgentId(owner)
+    : null;
 
   const { mutateConversations } = useConversations({
     workspaceId: owner.sId,
@@ -274,6 +280,7 @@ export function ConversationContainerVirtuoso({
               onSubmit={handleConversationCreation}
               draftKey="home-new-conversation"
               disableAutoFocus={false}
+              defaultAgentId={workspaceDefaultAgentId}
             />
           </div>
 

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -18,6 +18,7 @@ import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
 import { getSupportedFileExtensions } from "@app/types/files";
 import type { SpaceType } from "@app/types/space";
+import { isProjectType } from "@app/types/space";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
   Avatar,
@@ -99,6 +100,11 @@ export const InputBarButtons = React.memo(function InputBarButtons({
   // Current space is taken from the conversation (if already set) or from the space prop (if provided).
   const spaceId = conversation?.spaceId ?? space?.sId ?? undefined;
 
+  const isPod = space ? isProjectType(space) : false;
+  const defaultAgentUnavailableLabel = isPod
+    ? "This Pod's default agent isn't available to you, so @dust is used instead. Discuss with your Pod editors if you think this is an error."
+    : "This conversation's default agent isn't available to you, so @dust is used instead. Discuss with your Workspace admin if you think this is an error.";
+
   const handleAgentDetailsClick = (agentId: string) => {
     setQueryParam(router, "agentDetails", agentId);
   };
@@ -156,7 +162,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
                     <Icon visual={InfoCircle} size="xs" />
                   </span>
                 }
-                label="This conversation's default agent isn't available to you, so @dust is used instead. Discuss with your Workspace admin if you think this is an error."
+                label={defaultAgentUnavailableLabel}
               />
             )}
             <button

--- a/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarButtons.tsx
@@ -156,7 +156,7 @@ export const InputBarButtons = React.memo(function InputBarButtons({
                     <Icon visual={InfoCircle} size="xs" />
                   </span>
                 }
-                label="This Pod's default agent isn't available to you, so @dust is used instead. Discuss with your Pod editors if you think this is an error."
+                label="This conversation's default agent isn't available to you, so @dust is used instead. Discuss with your Workspace admin if you think this is an error."
               />
             )}
             <button

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -42,6 +42,7 @@ import {
   type PodTaskStatus,
   type PodTaskType,
 } from "@app/types/project_task";
+import { getWorkspaceDefaultAgentId } from "@app/types/user";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 export function usePodTasksPanelState({
@@ -105,6 +106,21 @@ export function usePodTasksPanelState({
     agents.sort(compareAgentsForSort);
     return agents;
   }, [agentConfigurations]);
+
+  const { hasFeature } = useFeatureFlags();
+  const { podMetadata } = usePodMetadata({
+    workspaceId: owner.sId,
+    podId,
+  });
+  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
+    ? getWorkspaceDefaultAgentId(owner)
+    : null;
+  const podDefaultAgentId =
+    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent
+      ? (podMetadata?.defaultAgentId ?? null)
+      : null;
+  const defaultAgentId = podDefaultAgentId ?? workspaceDefaultAgentId;
 
   const { hasFeature } = useFeatureFlags();
   const { podMetadata } = usePodMetadata({ workspaceId: owner.sId, podId });

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -42,7 +42,7 @@ import {
   type PodTaskStatus,
   type PodTaskType,
 } from "@app/types/project_task";
-import { getWorkspaceDefaultAgentId } from "@app/types/user";
+import { resolveDefaultAgentId } from "@app/types/user";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 export function usePodTasksPanelState({
@@ -112,21 +112,12 @@ export function usePodTasksPanelState({
     workspaceId: owner.sId,
     podId,
   });
-  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
-  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
-    ? getWorkspaceDefaultAgentId(owner)
-    : null;
-  const podDefaultAgentId =
-    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent
-      ? (podMetadata?.defaultAgentId ?? null)
-      : null;
-  const defaultAgentId = podDefaultAgentId ?? workspaceDefaultAgentId;
-
-  const { hasFeature } = useFeatureFlags();
-  const { podMetadata } = usePodMetadata({ workspaceId: owner.sId, podId });
-  const defaultAgentId = hasFeature("pod_default_agent")
-    ? (podMetadata?.defaultAgentId ?? null)
-    : null;
+  const defaultAgentId = resolveDefaultAgentId({
+    owner,
+    podDefaultAgentId: podMetadata?.defaultAgentId,
+    hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
+    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
+  });
 
   const podMembers = useMemo(() => {
     const members = spaceInfo?.members ?? [];

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -17,8 +17,8 @@ import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { PodTaskStatus, PodTaskType } from "@app/types/project_task";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
-  getWorkspaceDefaultAgentId,
   type LightWorkspaceType,
+  resolveDefaultAgentId,
 } from "@app/types/user";
 import {
   AttachmentChip,
@@ -99,21 +99,12 @@ function TaskMarkdownPopoverStartChrome({
 
   const { hasFeature } = useFeatureFlags();
   const { podMetadata } = usePodMetadata({ workspaceId: owner.sId, podId });
-<<<<<<< HEAD
-  const defaultAgentId = hasFeature("pod_default_agent")
-    ? (podMetadata?.defaultAgentId ?? null)
-    : null;
-=======
-  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
-  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
-    ? getWorkspaceDefaultAgentId(owner)
-    : null;
-  const podDefaultAgentId =
-    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent
-      ? (podMetadata?.defaultAgentId ?? null)
-      : null;
-  const defaultAgentId = podDefaultAgentId ?? workspaceDefaultAgentId;
->>>>>>> 1f938a662f (Default agent applies to tasks in pods)
+  const defaultAgentId = resolveDefaultAgentId({
+    owner,
+    podDefaultAgentId: podMetadata?.defaultAgentId,
+    hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
+    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
+  });
 
   const hasConversationLink =
     (task.status === "in_progress" || task.status === "done") &&

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -16,7 +16,10 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { PodTaskStatus, PodTaskType } from "@app/types/project_task";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import type { LightWorkspaceType } from "@app/types/user";
+import {
+  getWorkspaceDefaultAgentId,
+  type LightWorkspaceType,
+} from "@app/types/user";
 import {
   AttachmentChip,
   Avatar,
@@ -96,9 +99,21 @@ function TaskMarkdownPopoverStartChrome({
 
   const { hasFeature } = useFeatureFlags();
   const { podMetadata } = usePodMetadata({ workspaceId: owner.sId, podId });
+<<<<<<< HEAD
   const defaultAgentId = hasFeature("pod_default_agent")
     ? (podMetadata?.defaultAgentId ?? null)
     : null;
+=======
+  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
+    ? getWorkspaceDefaultAgentId(owner)
+    : null;
+  const podDefaultAgentId =
+    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent
+      ? (podMetadata?.defaultAgentId ?? null)
+      : null;
+  const defaultAgentId = podDefaultAgentId ?? workspaceDefaultAgentId;
+>>>>>>> 1f938a662f (Default agent applies to tasks in pods)
 
   const hasConversationLink =
     (task.status === "in_progress" || task.status === "done") &&

--- a/front/components/pages/workspace/WorkspaceSettingsPage.tsx
+++ b/front/components/pages/workspace/WorkspaceSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { CapabilitiesSection } from "@app/components/workspace/settings/CapabilitiesSection";
 import { IntegrationsSection } from "@app/components/workspace/settings/IntegrationsSection";
+import { PreferencesSection } from "@app/components/workspace/settings/PreferencesSection";
 import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
 import { getPublishingRestrictionMessage } from "@app/lib/api/assistant/publishing_restrictions";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -38,6 +39,7 @@ export function WorkspaceSettingsPage() {
       <Page.Vertical align="stretch" gap="md">
         <WorkspaceNameEditor owner={owner} />
       </Page.Vertical>
+      <PreferencesSection owner={owner} />
       <CapabilitiesSection
         owner={owner}
         publishingRestrictionMessage={getPublishingRestrictionMessage(

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -25,7 +25,11 @@ import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
-import type { UserType, WorkspaceType } from "@app/types/user";
+import {
+  getWorkspaceDefaultAgentId,
+  type UserType,
+  type WorkspaceType,
+} from "@app/types/user";
 import {
   Button,
   ButtonsSwitch,
@@ -106,6 +110,18 @@ export function PodConversationsTab({
     workspaceId: owner.sId,
     podId: podInfo.sId,
   });
+
+  // Unless a pod default is explicitly set, fall back to the workspace-wide default
+  // agent. The final fallback to @dust happens in `useHandleMentions`.
+  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
+    ? getWorkspaceDefaultAgentId(owner)
+    : null;
+  const podDefaultAgentId =
+    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent
+      ? (podMetadata?.defaultAgentId ?? null)
+      : null;
+  const defaultAgentId = podDefaultAgentId ?? workspaceDefaultAgentId;
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
 
@@ -207,11 +223,7 @@ export function PodConversationsTab({
                 space={podInfo}
                 disableAutoFocus={false}
                 placeholder={`Get work done in ${podInfo.name}`}
-                defaultAgentId={
-                  hasFeature("pod_default_agent")
-                    ? (podMetadata?.defaultAgentId ?? null)
-                    : null
-                }
+                defaultAgentId={defaultAgentId}
                 isDefaultAgentLoading={isPodMetadataLoading}
               />
             ) : (

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -26,7 +26,7 @@ import type { RichMention } from "@app/types/assistant/mentions";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import {
-  getWorkspaceDefaultAgentId,
+  resolveDefaultAgentId,
   type UserType,
   type WorkspaceType,
 } from "@app/types/user";
@@ -113,15 +113,12 @@ export function PodConversationsTab({
 
   // Unless a pod default is explicitly set, fall back to the workspace-wide default
   // agent. The final fallback to @dust happens in `useHandleMentions`.
-  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
-  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
-    ? getWorkspaceDefaultAgentId(owner)
-    : null;
-  const podDefaultAgentId =
-    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent
-      ? (podMetadata?.defaultAgentId ?? null)
-      : null;
-  const defaultAgentId = podDefaultAgentId ?? workspaceDefaultAgentId;
+  const defaultAgentId = resolveDefaultAgentId({
+    owner,
+    podDefaultAgentId: podMetadata?.defaultAgentId,
+    hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
+    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
+  });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);
 

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -20,7 +20,10 @@ import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
 import type { PatchPodMetadataBodyType } from "@app/types/api/internal/spaces";
 import { PatchPodMetadataBodySchema } from "@app/types/api/internal/spaces";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { LightWorkspaceType } from "@app/types/user";
+import {
+  getWorkspaceDefaultAgentId,
+  type LightWorkspaceType,
+} from "@app/types/user";
 import {
   Archive,
   Avatar,
@@ -39,6 +42,7 @@ import {
   Tooltip,
   Upload01,
   Users01,
+  XCircle,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useContext, useEffect, useState } from "react";
@@ -69,7 +73,9 @@ export function PodSettingsTab({
 
   const confirm = useContext(ConfirmContext);
   const { hasFeature } = useFeatureFlags();
-  const isDefaultAgentEnabled = hasFeature("pod_default_agent");
+  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
+  const isDefaultAgentEnabled =
+    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent;
 
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({
     workspaceId: owner.sId,
@@ -89,12 +95,21 @@ export function PodSettingsTab({
     });
   const dustAgent =
     agentConfigurations.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ?? null;
-  // Fall back to @dust when the pod's configured default agent isn't available
-  // to the current user (e.g. unpublished/deleted). This is the agent shown in
-  // the input bar and pod settings.
+  // When the pod has no default set, new conversations inherit the workspace
+  // default agent (then @dust).
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
+    ? getWorkspaceDefaultAgentId(owner)
+    : null;
+  const isInheritingWorkspaceDefault =
+    hasWorkspaceDefaultAgent && !podMetadata?.defaultAgentId;
+  const resolvedDefaultAgentId =
+    podMetadata?.defaultAgentId ?? workspaceDefaultAgentId;
+  // Fall back to @dust when the default agent isn't available to the
+  // current user (e.g. unpublished/deleted). This is the agent shown in the
+  // input bar and pod settings.
   const displayedDefaultAgent =
-    (podMetadata?.defaultAgentId &&
-      agentConfigurations.find((a) => a.sId === podMetadata.defaultAgentId)) ||
+    (resolvedDefaultAgentId &&
+      agentConfigurations.find((a) => a.sId === resolvedDefaultAgentId)) ||
     dustAgent;
   // The configured default may be an agent the current user can't access (e.g.
   // an unpublished agent). `agentConfigurations` only contains viewable agents,
@@ -133,7 +148,11 @@ export function PodSettingsTab({
     <div
       role="button"
       tabIndex={interactive ? 0 : -1}
-      aria-label={`Default agent: ${displayedDefaultAgent?.name ?? "Dust"}`}
+      aria-label={
+        isInheritingWorkspaceDefault
+          ? `Default agent: ${displayedDefaultAgent?.name ?? "Dust"} (workspace default)`
+          : `Default agent: ${displayedDefaultAgent?.name ?? "Dust"}`
+      }
       aria-disabled={!interactive}
       className={cn(
         "inline-flex box-border w-fit items-center rounded-xl h-9 px-3 gap-2 border border-border dark:border-border-night bg-background dark:bg-background-night text-sm text-primary dark:text-primary-night transition-colors duration-200",
@@ -145,6 +164,11 @@ export function PodSettingsTab({
       <Avatar size="xs" visual={displayedDefaultAgent?.pictureUrl} />
       <span className="grow truncate notranslate">
         {displayedDefaultAgent?.name ?? "Dust"}
+        {isInheritingWorkspaceDefault && (
+          <span className="ml-1 text-muted-foreground dark:text-muted-foreground-night">
+            · Workspace default
+          </span>
+        )}
       </span>
       {isDefaultAgentUnavailable && (
         <Tooltip
@@ -404,17 +428,34 @@ export function PodSettingsTab({
             <div className="heading-lg">Default agent</div>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               The agent pre-selected when anyone starts a new conversation in
-              this Pod.
+              this Pod.{" "}
+              {hasWorkspaceDefaultAgent
+                ? "When unset, it inherits the workspace default agent."
+                : "Defaults to @dust."}
             </p>
             <div className="flex items-center gap-2">
               {isPodEditor ? (
-                <AgentPicker
-                  owner={owner}
-                  agents={agentConfigurations}
-                  showFooterButtons={false}
-                  onItemClick={(agent) => saveDefaultAgent(agent.sId)}
-                  pickerButton={renderDefaultAgentPill(true)}
-                />
+                <>
+                  <AgentPicker
+                    owner={owner}
+                    agents={agentConfigurations}
+                    showFooterButtons={false}
+                    onItemClick={(agent) => saveDefaultAgent(agent.sId)}
+                    pickerButton={renderDefaultAgentPill(true)}
+                  />
+                  {/* Clearing the pod default reverts to inheriting the
+                      workspace default. Only shown when the workspace-default
+                      feature is on and an explicit pod default is set. */}
+                  {hasWorkspaceDefaultAgent && podMetadata?.defaultAgentId && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={XCircle}
+                      tooltip="Reset to workspace default"
+                      onClick={() => void saveDefaultAgent(null)}
+                    />
+                  )}
+                </>
               ) : (
                 renderDefaultAgentPill(false)
               )}

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -21,8 +21,8 @@ import type { PatchPodMetadataBodyType } from "@app/types/api/internal/spaces";
 import { PatchPodMetadataBodySchema } from "@app/types/api/internal/spaces";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
-  getWorkspaceDefaultAgentId,
   type LightWorkspaceType,
+  resolveDefaultAgentId,
 } from "@app/types/user";
 import {
   Archive,
@@ -96,14 +96,15 @@ export function PodSettingsTab({
   const dustAgent =
     agentConfigurations.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ?? null;
   // When the pod has no default set, new conversations inherit the workspace
-  // default agent (then @dust).
-  const workspaceDefaultAgentId = hasWorkspaceDefaultAgentFeature
-    ? getWorkspaceDefaultAgentId(owner)
-    : null;
+  // default agent, else then @dust.
   const isInheritingWorkspaceDefault =
     hasWorkspaceDefaultAgentFeature && !podMetadata?.defaultAgentId;
-  const resolvedDefaultAgentId =
-    podMetadata?.defaultAgentId ?? workspaceDefaultAgentId;
+  const resolvedDefaultAgentId = resolveDefaultAgentId({
+    owner,
+    podDefaultAgentId: podMetadata?.defaultAgentId,
+    hasWorkspaceDefaultAgentFeature,
+    hasPodDefaultAgentFeature: hasFeature("pod_default_agent"),
+  });
   // Fall back to @dust when the default agent isn't available to the
   // current user (e.g. unpublished/deleted). This is the agent shown in the
   // input bar and pod settings.
@@ -429,9 +430,8 @@ export function PodSettingsTab({
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               The agent pre-selected when anyone starts a new conversation in
               this Pod.{" "}
-              {hasWorkspaceDefaultAgentFeature
-                ? "When unset, it inherits the workspace default agent."
-                : "Defaults to @dust."}
+              {hasWorkspaceDefaultAgentFeature &&
+                "When unset, it inherits the Workspace default agent."}
             </p>
             <div className="flex items-center gap-2">
               {isPodEditor ? (

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -73,9 +73,9 @@ export function PodSettingsTab({
 
   const confirm = useContext(ConfirmContext);
   const { hasFeature } = useFeatureFlags();
-  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
+  const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
   const isDefaultAgentEnabled =
-    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgent;
+    hasFeature("pod_default_agent") || hasWorkspaceDefaultAgentFeature;
 
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({
     workspaceId: owner.sId,
@@ -97,11 +97,11 @@ export function PodSettingsTab({
     agentConfigurations.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ?? null;
   // When the pod has no default set, new conversations inherit the workspace
   // default agent (then @dust).
-  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgentFeature
     ? getWorkspaceDefaultAgentId(owner)
     : null;
   const isInheritingWorkspaceDefault =
-    hasWorkspaceDefaultAgent && !podMetadata?.defaultAgentId;
+    hasWorkspaceDefaultAgentFeature && !podMetadata?.defaultAgentId;
   const resolvedDefaultAgentId =
     podMetadata?.defaultAgentId ?? workspaceDefaultAgentId;
   // Fall back to @dust when the default agent isn't available to the
@@ -429,7 +429,7 @@ export function PodSettingsTab({
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               The agent pre-selected when anyone starts a new conversation in
               this Pod.{" "}
-              {hasWorkspaceDefaultAgent
+              {hasWorkspaceDefaultAgentFeature
                 ? "When unset, it inherits the workspace default agent."
                 : "Defaults to @dust."}
             </p>
@@ -446,15 +446,16 @@ export function PodSettingsTab({
                   {/* Clearing the pod default reverts to inheriting the
                       workspace default. Only shown when the workspace-default
                       feature is on and an explicit pod default is set. */}
-                  {hasWorkspaceDefaultAgent && podMetadata?.defaultAgentId && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      icon={XCircle}
-                      tooltip="Reset to workspace default"
-                      onClick={() => void saveDefaultAgent(null)}
-                    />
-                  )}
+                  {hasWorkspaceDefaultAgentFeature &&
+                    podMetadata?.defaultAgentId && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        icon={XCircle}
+                        tooltip="Reset to workspace default"
+                        onClick={() => void saveDefaultAgent(null)}
+                      />
+                    )}
                 </>
               ) : (
                 renderDefaultAgentPill(false)

--- a/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
+++ b/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
@@ -249,8 +249,8 @@ export function PodTaskStartWorkingDropdown({
                 size="xs"
                 onItemClick={(agent) => setSelectedStartAgent(agent)}
                 pickerButton={
-                  <button
-                    type="button"
+                  <div
+                    role="button"
                     aria-label={`Selected agent: ${selectedStartAgent?.name ?? "Agent"}`}
                     className={cn(
                       "inline-flex box-border max-w-full min-w-0 items-center rounded-lg h-7 heading-xs px-2 gap-1.5 text-primary-900 dark:text-primary-900-night transition-colors duration-200",
@@ -296,7 +296,7 @@ export function PodTaskStartWorkingDropdown({
                       size="xs"
                       className="-mr-1 text-faint dark:text-faint-night"
                     />
-                  </button>
+                  </div>
                 }
               />
             </div>

--- a/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
+++ b/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
@@ -249,8 +249,8 @@ export function PodTaskStartWorkingDropdown({
                 size="xs"
                 onItemClick={(agent) => setSelectedStartAgent(agent)}
                 pickerButton={
-                  <div
-                    role="button"
+                  <button
+                    type="button"
                     aria-label={`Selected agent: ${selectedStartAgent?.name ?? "Agent"}`}
                     className={cn(
                       "inline-flex box-border max-w-full min-w-0 items-center rounded-lg h-7 heading-xs px-2 gap-1.5 text-primary-900 dark:text-primary-900-night transition-colors duration-200",
@@ -296,7 +296,7 @@ export function PodTaskStartWorkingDropdown({
                       size="xs"
                       className="-mr-1 text-faint dark:text-faint-night"
                     />
-                  </div>
+                  </button>
                 }
               />
             </div>

--- a/front/components/workspace/settings/PreferencesSection.tsx
+++ b/front/components/workspace/settings/PreferencesSection.tsx
@@ -1,0 +1,30 @@
+import { WorkspaceDefaultAgentPicker } from "@app/components/workspace/settings/WorkspaceDefaultAgentPicker";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import type { WorkspaceType } from "@app/types/user";
+import { ContextItem, Page } from "@dust-tt/sparkle";
+
+interface PreferencesSectionProps {
+  owner: WorkspaceType;
+}
+
+export function PreferencesSection({ owner }: PreferencesSectionProps) {
+  const { hasFeature } = useFeatureFlags();
+  const hasWorkspaceDefaultAgent = hasFeature("workspace_default_agent");
+
+  // Nothing to render yet when the only preference is gated off.
+  if (!hasWorkspaceDefaultAgent) {
+    return null;
+  }
+
+  return (
+    <Page.Vertical align="stretch" gap="md">
+      <Page.H variant="h4">Preferences</Page.H>
+      <ContextItem.List>
+        <div className="h-full border-b border-border dark:border-border-night" />
+        {hasWorkspaceDefaultAgent && (
+          <WorkspaceDefaultAgentPicker owner={owner} />
+        )}
+      </ContextItem.List>
+    </Page.Vertical>
+  );
+}

--- a/front/components/workspace/settings/WorkspaceDefaultAgentPicker.tsx
+++ b/front/components/workspace/settings/WorkspaceDefaultAgentPicker.tsx
@@ -1,0 +1,91 @@
+import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import { ConfirmContext } from "@app/components/Confirm";
+import { useWorkspaceDefaultAgent } from "@app/hooks/useWorkspaceDefaultAgent";
+import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import type { WorkspaceType } from "@app/types/user";
+import { Avatar, Button, ContextItem, Robot } from "@dust-tt/sparkle";
+import { useContext } from "react";
+
+interface WorkspaceDefaultAgentPickerProps {
+  owner: WorkspaceType;
+}
+
+export function WorkspaceDefaultAgentPicker({
+  owner,
+}: WorkspaceDefaultAgentPickerProps) {
+  const confirm = useContext(ConfirmContext);
+  const { workspaceDefaultAgentId, isChanging, doUpdateWorkspaceDefaultAgent } =
+    useWorkspaceDefaultAgent({ owner });
+
+  const { agentConfigurations, isLoading } = useUnifiedAgentConfigurations({
+    workspaceId: owner.sId,
+  });
+
+  const dustAgent =
+    agentConfigurations.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ?? null;
+
+  // Fall back to @dust when the configured default agent isn't available (e.g.
+  // unpublished/deleted). `agentConfigurations` only contains viewable agents.
+  const displayedDefaultAgent =
+    (workspaceDefaultAgentId &&
+      agentConfigurations.find((a) => a.sId === workspaceDefaultAgentId)) ||
+    dustAgent;
+
+  const saveDefaultAgent = async (agentId: string | null) => {
+    // Warn about the implications of using another default agent before
+    // switching. Resetting back to @dust needs no confirmation.
+    if (agentId && agentId !== GLOBAL_AGENTS_SID.DUST) {
+      const confirmed = await confirm({
+        title: "Warning",
+        message:
+          "@dust is designed to give your users the best experience by default. A custom default agent may not handle every request as reliably. Do you want to set it as the workspace default anyway?",
+        validateVariant: "warning",
+        validateLabel: "Yes",
+        cancelLabel: "No",
+      });
+      if (!confirmed) {
+        return;
+      }
+    }
+    await doUpdateWorkspaceDefaultAgent(agentId);
+  };
+
+  return (
+    <ContextItem
+      title="Default agent"
+      subElement="The agent pre-selected when anyone starts a new conversation in this workspace."
+      visual={<Robot className="h-6 w-6" />}
+      hasSeparatorIfLast={true}
+      action={
+        <AgentPicker
+          owner={owner}
+          agents={agentConfigurations}
+          isLoading={isLoading}
+          disabled={isChanging}
+          showFooterButtons={false}
+          onItemClick={(agent) => void saveDefaultAgent(agent.sId)}
+          pickerButton={
+            <Button
+              variant="outline"
+              size="sm"
+              isSelect
+              disabled={isChanging || isLoading}
+              icon={
+                displayedDefaultAgent
+                  ? () => (
+                      <Avatar
+                        size="xxs"
+                        visual={displayedDefaultAgent.pictureUrl}
+                      />
+                    )
+                  : Robot
+              }
+              label={displayedDefaultAgent?.name ?? "@dust"}
+            />
+          }
+        />
+      }
+    />
+  );
+}

--- a/front/components/workspace/settings/WorkspaceDefaultAgentPicker.tsx
+++ b/front/components/workspace/settings/WorkspaceDefaultAgentPicker.tsx
@@ -7,6 +7,8 @@ import type { WorkspaceType } from "@app/types/user";
 import { Avatar, Button, ContextItem, Robot } from "@dust-tt/sparkle";
 import { useContext } from "react";
 
+const ROBOT_VISUAL = <Robot className="h-6 w-6" />;
+
 interface WorkspaceDefaultAgentPickerProps {
   owner: WorkspaceType;
 }
@@ -55,7 +57,7 @@ export function WorkspaceDefaultAgentPicker({
     <ContextItem
       title="Default agent"
       subElement="The agent pre-selected when anyone starts a new conversation in this workspace."
-      visual={<Robot className="h-6 w-6" />}
+      visual={ROBOT_VISUAL}
       hasSeparatorIfLast={true}
       action={
         <AgentPicker

--- a/front/components/workspace/settings/WorkspaceDefaultAgentPicker.tsx
+++ b/front/components/workspace/settings/WorkspaceDefaultAgentPicker.tsx
@@ -35,9 +35,12 @@ export function WorkspaceDefaultAgentPicker({
     dustAgent;
 
   const saveDefaultAgent = async (agentId: string | null) => {
+    // Selecting dust clears the stored workspaceDefaultAgentId in the DB.
+    const nextAgentId = agentId === GLOBAL_AGENTS_SID.DUST ? null : agentId;
+
     // Warn about the implications of using another default agent before
     // switching. Resetting back to @dust needs no confirmation.
-    if (agentId && agentId !== GLOBAL_AGENTS_SID.DUST) {
+    if (nextAgentId) {
       const confirmed = await confirm({
         title: "Warning",
         message:
@@ -50,7 +53,7 @@ export function WorkspaceDefaultAgentPicker({
         return;
       }
     }
-    await doUpdateWorkspaceDefaultAgent(agentId);
+    await doUpdateWorkspaceDefaultAgent(nextAgentId);
   };
 
   return (

--- a/front/hooks/useWorkspaceDefaultAgent.ts
+++ b/front/hooks/useWorkspaceDefaultAgent.ts
@@ -1,0 +1,80 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { useAuthContext } from "@app/lib/swr/workspaces";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  getWorkspaceDefaultAgentId,
+  type LightWorkspaceType,
+} from "@app/types/user";
+import { useState } from "react";
+
+interface UseWorkspaceDefaultAgentProps {
+  owner: LightWorkspaceType;
+}
+
+export function useWorkspaceDefaultAgent({
+  owner,
+}: UseWorkspaceDefaultAgentProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const { mutateAuthContext } = useAuthContext({ workspaceId: owner.sId });
+
+  const workspaceDefaultAgentId = getWorkspaceDefaultAgentId(owner);
+
+  const doUpdateWorkspaceDefaultAgent = async (
+    agentId: string | null
+  ): Promise<boolean> => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workspaceDefaultAgentId: agentId,
+        }),
+      });
+
+      if (!res.ok) {
+        let description = "Failed to update the workspace default agent.";
+        try {
+          const body = await res.json();
+          if (body?.error?.message) {
+            description = body.error.message;
+          }
+        } catch {
+          // JSON parse failure — keep fallback.
+        }
+        sendNotification({
+          type: "error",
+          title: "Failed to update the workspace default agent",
+          description,
+        });
+        return false;
+      }
+
+      // Revalidation is best-effort; failure does not mean the update failed.
+      await mutateAuthContext().catch(() => {
+        // Non-critical — the update succeeded. Context will sync on next navigation.
+      });
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update the workspace default agent",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsChanging(false);
+    }
+
+    return true;
+  };
+
+  return {
+    workspaceDefaultAgentId,
+    isChanging,
+    doUpdateWorkspaceDefaultAgent,
+  };
+}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -574,6 +574,7 @@ export interface WorkspaceMetadata {
   selfImprovementCapPerSkillAwuCredits?: number;
   webSearchProvider?: WebSearchProvider;
   webBrowseProvider?: WebBrowseProvider;
+  workspaceDefaultAgentId?: string;
 }
 
 export async function updateWorkspaceMetadata(

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -3,6 +3,7 @@ import {
   POD_TASKS_SERVER_NAME,
   UPDATE_TASKS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_tasks/metadata";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
   postNewContentFragment,
@@ -11,13 +12,16 @@ import {
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { resolvePodDefaultAgentId } from "@app/lib/api/projects/default_agent";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { serializeProjectTaskDirective } from "@app/lib/project_task/format";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { APIErrorType } from "@app/types/error";
 import type { PodTaskSourceInfo, PodTaskType } from "@app/types/project_task";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { getWorkspaceDefaultAgentId } from "@app/types/user";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { toFileContentFragment } from "../api/assistant/conversation/content_fragment";
 
@@ -116,6 +120,43 @@ function buildTaskKickoffPrompt({
       ? ["", "## Task-specific guidance", "", trimmedAgentInstructions]
       : []),
   ].join("\n");
+}
+
+// Resolves the agent a task conversation should kick off with when the caller
+// didn't pick one explicitly. Mirrors the conversation input bar resolution
+async function resolveDefaultAgentIdForTask(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<string> {
+  const featureFlags = await getFeatureFlags(auth);
+  const hasWorkspaceDefaultAgent = featureFlags.includes(
+    "workspace_default_agent"
+  );
+  const hasPodDefaultAgent = featureFlags.includes("pod_default_agent");
+
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
+    ? getWorkspaceDefaultAgentId(auth.getNonNullableWorkspace())
+    : null;
+
+  let podDefaultAgentId: string | null = null;
+  if (hasPodDefaultAgent || hasWorkspaceDefaultAgent) {
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+    podDefaultAgentId = metadata?.defaultAgentId ?? null;
+  }
+
+  const candidateId = podDefaultAgentId ?? workspaceDefaultAgentId;
+  if (!candidateId || candidateId === GLOBAL_AGENTS_SID.DUST) {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+
+  const agent = await getAgentConfiguration(auth, {
+    agentId: candidateId,
+    variant: "extra_light",
+  });
+  if (!agent || agent.status !== "active") {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+  return candidateId;
 }
 
 export async function startAgentForProjectTask(
@@ -273,12 +314,6 @@ export async function startAgentForProjectTask(
     (customMessage ?? "") +
     "\n\n" +
     "Read the attached file in full for more instructions.";
-
-  // When the caller didn't pick an agent, kick off with the pod's default
-  // agent instead of hardcoded @dust, so the configured default applies to
-  // task conversations the same way it does to new conversations.
-  const resolvedAgentConfigurationId =
-    agentConfigurationId ?? (await resolvePodDefaultAgentId(auth, space));
 
   const messageRes = await postUserMessage(auth, {
     conversation,

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -10,18 +10,18 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import { resolvePodDefaultAgentId } from "@app/lib/api/projects/default_agent";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { serializeProjectTaskDirective } from "@app/lib/project_task/format";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { APIErrorType } from "@app/types/error";
 import type { PodTaskSourceInfo, PodTaskType } from "@app/types/project_task";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { getWorkspaceDefaultAgentId } from "@app/types/user";
+import { resolveDefaultAgentId } from "@app/types/user";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { toFileContentFragment } from "../api/assistant/conversation/content_fragment";
 
@@ -122,8 +122,7 @@ function buildTaskKickoffPrompt({
   ].join("\n");
 }
 
-// Resolves the agent a task conversation should kick off with when the caller
-// didn't pick one explicitly. Mirrors the conversation input bar resolution
+// A task conversation should start with the pod's default agent if available.
 async function resolveDefaultAgentIdForTask(
   auth: Authenticator,
   space: SpaceResource
@@ -133,18 +132,18 @@ async function resolveDefaultAgentIdForTask(
     "workspace_default_agent"
   );
   const hasPodDefaultAgent = featureFlags.includes("pod_default_agent");
-
-  const workspaceDefaultAgentId = hasWorkspaceDefaultAgent
-    ? getWorkspaceDefaultAgentId(auth.getNonNullableWorkspace())
-    : null;
-
   let podDefaultAgentId: string | null = null;
   if (hasPodDefaultAgent || hasWorkspaceDefaultAgent) {
     const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
     podDefaultAgentId = metadata?.defaultAgentId ?? null;
   }
 
-  const candidateId = podDefaultAgentId ?? workspaceDefaultAgentId;
+  const candidateId = resolveDefaultAgentId({
+    owner: auth.getNonNullableWorkspace(),
+    podDefaultAgentId,
+    hasWorkspaceDefaultAgentFeature: hasWorkspaceDefaultAgent,
+    hasPodDefaultAgentFeature: hasPodDefaultAgent,
+  });
   if (!candidateId || candidateId === GLOBAL_AGENTS_SID.DUST) {
     return GLOBAL_AGENTS_SID.DUST;
   }
@@ -314,6 +313,11 @@ export async function startAgentForProjectTask(
     (customMessage ?? "") +
     "\n\n" +
     "Read the attached file in full for more instructions.";
+
+  // Use the explicitly requested agent if provided, otherwise fall back to the
+  // pod/workspace default agent for tasks (resolves to @dust when none applies).
+  const resolvedAgentConfigurationId =
+    agentConfigurationId ?? (await resolveDefaultAgentIdForTask(auth, space));
 
   const messageRes = await postUserMessage(auth, {
     conversation,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -350,6 +350,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Resize uploaded raster images via imgproxy instead of ConvertAPI",
     stage: "dust_only",
   },
+  workspace_default_agent: {
+    description:
+      "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -78,6 +78,13 @@ export type LightWorkspaceType = {
   groups?: string[];
 };
 
+export function getWorkspaceDefaultAgentId(
+  owner: LightWorkspaceType
+): string | null {
+  const value = owner.metadata?.workspaceDefaultAgentId;
+  return typeof value === "string" ? value : null;
+}
+
 export type WorkspaceType = LightWorkspaceType & {
   ssoEnforced?: boolean;
 };

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -85,6 +85,34 @@ export function getWorkspaceDefaultAgentId(
   return typeof value === "string" ? value : null;
 }
 
+/**
+ * The default agent that should be pre-selected for new conversations.
+ * A pod-level default agent takes precedence over the workspace-level default agent.
+ *
+ * Returns the resolved agent sId, or `null` when no default applies (callers then
+ * fall back to @dust). ).
+ */
+export function resolveDefaultAgentId({
+  owner,
+  podDefaultAgentId,
+  hasWorkspaceDefaultAgentFeature,
+  hasPodDefaultAgentFeature,
+}: {
+  owner: LightWorkspaceType;
+  podDefaultAgentId: string | null | undefined;
+  hasWorkspaceDefaultAgentFeature: boolean;
+  hasPodDefaultAgentFeature: boolean;
+}): string | null {
+  const workspaceDefaultAgentId = hasWorkspaceDefaultAgentFeature
+    ? getWorkspaceDefaultAgentId(owner)
+    : null;
+  const resolvedPodDefaultAgentId =
+    hasPodDefaultAgentFeature || hasWorkspaceDefaultAgentFeature
+      ? (podDefaultAgentId ?? null)
+      : null;
+  return resolvedPodDefaultAgentId ?? workspaceDefaultAgentId;
+}
+
 export type WorkspaceType = LightWorkspaceType & {
   ssoEnforced?: boolean;
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -782,6 +782,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_new_llm_router"
   | "live_speech_to_text"
   | "force_us_api_url"
+  | "workspace_default_agent"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description
Context: https://github.com/dust-tt/tasks/issues/8405#issuecomment-4732532934
Context: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1781631880585089

Workspace admin can select a default agent for all new conversations in the workspace.

Settings UI Update (confirmed with @pinotalexandre): 
<img width="1315" height="805" alt="Screenshot 2026-06-18 at 15 18 08" src="https://github.com/user-attachments/assets/edbe9696-1f25-44f3-bea4-ad171d0c3374" />

If no default agent is selected in a Pod, the Pod will automatically adopt the workspace default agent. The Pod default agent overrides the workspace default agent in that specific pod.
<img width="1582" height="500" alt="Screenshot 2026-06-18 at 15 19 45" src="https://github.com/user-attachments/assets/fe963e9a-8d26-4205-8c3c-f9ec0b1db9b6" />

## Tests
Manual - tested warning messages when selecting an unpublished/inaccessible agent and pod + workspace level precedence.

## Risk
Only released to specific companies who want this feature. General public may not know what they want in an agent, leading to a degraded experience on Dust.

## Deploy Plan
Deploy under a feature flag only to companies who have requested this feature.