### PR TITLE
feat(poke): add hubspot_deal_id to contract switch flow

### DIFF
--- a/front/components/poke/subscriptions/SwitchContractDialog.tsx
+++ b/front/components/poke/subscriptions/SwitchContractDialog.tsx
@@ -47,6 +47,7 @@ const SwitchContractFormSchema = z
   .object({
     metronomePackageId: z.string().min(1, "Required"),
     planCode: z.string().min(1, "Required"),
+    hubspotDealId: z.string().optional(),
     startingAt: z.string().optional(),
     // How the enterprise contract's start moment is resolved:
     //  - "immediately": swap at the current hour (no startingAt sent).
@@ -220,6 +221,7 @@ export default function SwitchContractDialog({
     defaultValues: {
       metronomePackageId: "",
       planCode: "",
+      hubspotDealId: "",
       startingAt: "",
       startMode: "select",
       stripeCustomerId: stripeCustomerId ?? "",
@@ -425,10 +427,14 @@ export default function SwitchContractDialog({
   const onSubmit = useCallback(
     (values: SwitchContractFormValues) => {
       const trimmedStripe = values.stripeCustomerId.trim();
+      const trimmedHubspotDealId = values.hubspotDealId?.trim();
       const cleaned: SwitchContractBodyInput = {
         metronomePackageId: values.metronomePackageId.trim(),
         planCode: values.planCode.trim(),
         paygEnabled: values.paygEnabled,
+        ...(trimmedHubspotDealId
+          ? { hubspotDealId: trimmedHubspotDealId }
+          : {}),
       };
       // For free-tier switches, the operator can omit the Stripe customer —
       // the resulting Metronome contract has no Stripe billing link. The
@@ -621,6 +627,12 @@ export default function SwitchContractDialog({
                   name="stripeCustomerId"
                   title="Stripe Customer Id (optional for free plans)"
                   placeholder="cus_1234567890"
+                />
+                <InputField
+                  control={form.control}
+                  name="hubspotDealId"
+                  title="HubSpot Deal Id (optional)"
+                  placeholder="e.g., 12345678901"
                 />
                 {isCurrencyLoading && (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/lib/api/llm/getImageGenerationLLM.test.ts
+++ b/front/lib/api/llm/getImageGenerationLLM.test.ts
@@ -78,6 +78,7 @@ function makeAuth(): Authenticator {
       planId: -1,
       stripeSubscriptionId: null,
       metronomeContractId: null,
+      hubspotDealId: null,
       requestCancelAt: null,
       workspaceId: -1,
       createdAt: new Date(),

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -45,6 +45,7 @@ export function createMockAuthenticator(): Authenticator {
       planId: -1,
       stripeSubscriptionId: null,
       metronomeContractId: null,
+      hubspotDealId: null,
       requestCancelAt: null,
       workspaceId: -1,
       createdAt: new Date(),

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -22,6 +22,7 @@ import {
   getCreditTypeAwuId,
   getProductPrepaidCommitId,
   getProductSeatSubscriptionCommitId,
+  HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import {
   applySeatRateOverrides,
@@ -125,6 +126,10 @@ export const SwitchContractBodySchema = z.object({
   // `minSeats * rate` of contract credit, invoiced at `commitmentPrice` —
   // letting the customer prepay the seat commitment at a negotiated (lower)
   // price. Unknown seat-type keys are ignored.
+  // Optional HubSpot deal ID. Stored on the subscription and forwarded to
+  // Metronome as a custom field so contracts can be joined back to HubSpot deals
+  // for ARR reporting.
+  hubspotDealId: z.string().optional(),
   seats: z
     .array(
       z.object({
@@ -574,6 +579,9 @@ export async function switchContract({
     planCode: body.planCode,
     fromContractId: currentSubscription?.metronomeContractId ?? undefined,
     enableSeatSync: false,
+    additionalCustomFields: body.hubspotDealId
+      ? { [HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY]: body.hubspotDealId }
+      : undefined,
   });
   if (provisionResult.isErr()) {
     return new Err(
@@ -671,6 +679,7 @@ export async function switchContract({
       planCode: body.planCode,
       metronomeContractId,
       startDate: alignedStart,
+      hubspotDealId: body.hubspotDealId,
     });
   } catch (err) {
     return new Err(

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -177,6 +177,10 @@ export const USAGE_TYPE_USER = "user";
 export const USAGE_TYPE_PROGRAMMATIC = "programmatic";
 export const USAGE_TYPE_FREE = "free";
 
+// Custom field key used to store the HubSpot deal ID on a Metronome contract.
+// Must be registered in Metronome before it can be stamped.
+export const HUBSPOT_DEAL_ID_CUSTOM_FIELD_KEY = "HUBSPOT_DEAL_ID";
+
 // Suffix appended to the annual variant of each seat product name in
 // Metronome (e.g. "Pro Seat (Yearly)"). Used by the setup script when
 // declaring products and by the UI to strip the suffix from displayed seat

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -238,6 +238,7 @@ export class SubscriptionModel extends WorkspaceAwareModel<SubscriptionModel> {
 
   declare stripeSubscriptionId: string | null;
   declare metronomeContractId: string | null;
+  declare hubspotDealId: string | null;
 
   // not necessary for business logic, but helpful
   // for analytics and business operations.
@@ -288,6 +289,11 @@ SubscriptionModel.init(
       allowNull: true,
     },
     metronomeContractId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    hubspotDealId: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: null,

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -352,6 +352,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       planId: data.planId,
       stripeSubscriptionId: data.stripeSubscriptionId,
       metronomeContractId: data.metronomeContractId ?? null,
+      hubspotDealId: null,
       requestCancelAt: data.requestCancelAt
         ? new Date(data.requestCancelAt)
         : null,
@@ -616,11 +617,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     planCode,
     metronomeContractId,
     startDate,
+    hubspotDealId,
   }: {
     workspaceModelId: ModelId;
     planCode: string;
     metronomeContractId: string;
     startDate: Date;
+    hubspotDealId?: string | null;
   }): Promise<SubscriptionResource> {
     const plan = await this.findPlanOrThrow(planCode);
     return withTransaction(async (t) => {
@@ -648,6 +651,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
           endDate: null,
           stripeSubscriptionId: null,
           metronomeContractId,
+          hubspotDealId: hubspotDealId ?? null,
         },
         renderPlanFromModel({ plan }),
         t
@@ -1470,6 +1474,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       planId: -1,
       stripeSubscriptionId: null,
       metronomeContractId: null,
+      hubspotDealId: null,
       requestCancelAt: null,
     };
   }

--- a/front/migrations/pre-deploy/20260618160837_add_hubspot_deal.sql
+++ b/front/migrations/pre-deploy/20260618160837_add_hubspot_deal.sql
@@ -1,0 +1,4 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."subscriptions"
+    ADD COLUMN "hubspotDealId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;


### PR DESCRIPTION
## Description

Adds a `hubspotDealId` optional field to the Poke contract switch flow so Metronome contracts can be mapped back to HubSpot deals for ARR reporting.

**What changes:**
- New `hubspotDealId` field in the `SwitchContractBodySchema` (optional string)
- Stored on the `subscriptions` DB row (new nullable column via pre-deploy migration)
- Also forwarded to Metronome as a contract custom field (`HUBSPOT_DEAL_ID`) alongside the provisioning call, so the association lives in both systems
- New text input in the Poke "Switch contract" dialog

This is the first building block toward the long-term HubSpot → Poke → Metronome automation: for now it lets ops manually enter the deal ID when provisioning a contract, enabling ARR reporting joins between Metronome and HubSpot.

## Tests

## Risk


## Deploy Plan

