### PR TITLE
Clarify empty/0 values

### DIFF
--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -234,7 +234,7 @@ function WorkspaceUsageStatusBanner({
     poolStateWouldBanner &&
     !isMetronomeContractLoading &&
     !contract?.hasPersonalCreditSeats;
-  // A cap of 0 is a deliberate hard block on programmatic API, not an
+  // A cap of 0 or null is a deliberate hard block on programmatic API, not an
   // exhausted budget, so its "cap reached" banner is suppressed. The cap is
   // only fetched when the banner would otherwise show.
   const programmaticStateWouldBanner =
@@ -244,10 +244,11 @@ function WorkspaceUsageStatusBanner({
       workspaceId: owner.sId,
       disabled: !programmaticStateWouldBanner,
     });
+  const monthlyCapCredits = programmaticUsageLimit?.monthlyCapCredits ?? 0;
   const showProgrammaticBanner =
     programmaticStateWouldBanner &&
     !isProgrammaticUsageLimitLoading &&
-    programmaticUsageLimit?.monthlyCapCredits !== 0;
+    monthlyCapCredits !== 0;
   // The admin-configured balance-threshold warning is only relevant before the
   // pool is depleted/overage — those states have their own (stronger) banner.
   const showBalanceThresholdBanner =

--- a/front/components/workspace/usage/UsageNotificationsCard.tsx
+++ b/front/components/workspace/usage/UsageNotificationsCard.tsx
@@ -27,6 +27,7 @@ export function UsageNotificationsCard({
 
   const [isSavingUpgradeRequestEmail, setIsSavingUpgradeRequestEmail] =
     useState(false);
+  const [isEditingThreshold, setIsEditingThreshold] = useState(false);
 
   const handleToggleUpgradeRequestEmail = async () => {
     setIsSavingUpgradeRequestEmail(true);
@@ -84,13 +85,24 @@ export function UsageNotificationsCard({
               <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"
-                value={currentThreshold.toLocaleString()}
-                unit="credits"
+                placeholder="Disabled"
+                value={
+                  currentThreshold === 0
+                    ? ""
+                    : currentThreshold.toLocaleString()
+                }
+                unit={
+                  currentThreshold === 0 && !isEditingThreshold
+                    ? undefined
+                    : "credits"
+                }
                 normalizeValue={(value) => value.replace(/[^\d]/g, "")}
                 formatValue={(value) =>
                   value ? Number(value).toLocaleString() : value
                 }
                 onSave={handleSaveBalanceThreshold}
+                onFocus={() => setIsEditingThreshold(true)}
+                onBlur={() => setIsEditingThreshold(false)}
                 disabled={readOnly || isUsageNotificationsLoading}
               />
             </div>

--- a/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
+++ b/front/components/workspace/usage/UsageProgrammaticLimitCard.tsx
@@ -3,6 +3,7 @@ import {
   useUpdateProgrammaticUsageLimit,
 } from "@app/lib/swr/usage_settings";
 import { InputWithSave, Page, SettingsList } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface UsageProgrammaticLimitCardProps {
   workspaceId: string;
@@ -21,15 +22,18 @@ export function UsageProgrammaticLimitCard({
 
   const currentLimit = programmaticUsageLimit?.monthlyCapCredits ?? null;
 
+  const [isEditing, setIsEditing] = useState(false);
+
   const handleSaveLimit = async (newValue: string) => {
     const trimmed = newValue.trim();
 
-    // An empty value means no limit.
+    // An empty value means no programmatic access. Save 0 (not null) so
+    // Metronome alerts are upserted with cap=0 and actually block access.
     if (trimmed === "") {
-      if (currentLimit === null) {
+      if (currentLimit === null || currentLimit === 0) {
         return;
       }
-      await doUpdateProgrammaticUsageLimit(null);
+      await doUpdateProgrammaticUsageLimit(0);
       return;
     }
 
@@ -62,16 +66,24 @@ export function UsageProgrammaticLimitCard({
               <InputWithSave
                 inputMode="numeric"
                 pattern="[0-9]*"
-                placeholder="No limit"
+                placeholder="No access"
                 value={
-                  currentLimit !== null ? currentLimit.toLocaleString() : ""
+                  currentLimit === null || currentLimit === 0
+                    ? ""
+                    : currentLimit.toLocaleString()
                 }
-                unit="credits"
+                unit={
+                  (currentLimit === null || currentLimit === 0) && !isEditing
+                    ? undefined
+                    : "credits"
+                }
                 normalizeValue={(value) => value.replace(/[^\d]/g, "")}
                 formatValue={(value) =>
                   value ? Number(value).toLocaleString() : value
                 }
                 onSave={handleSaveLimit}
+                onFocus={() => setIsEditing(true)}
+                onBlur={() => setIsEditing(false)}
                 disabled={readOnly || isProgrammaticUsageLimitLoading}
               />
             </div>

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -41,6 +41,7 @@ export function UsageSettingsCard({
   const [isSavingAllowUpgradeRequest, setIsSavingAllowUpgradeRequest] =
     useState(false);
   const [isSavingAutoSeatUpgrade, setIsSavingAutoSeatUpgrade] = useState(false);
+  const [isEditingDefaultLimit, setIsEditingDefaultLimit] = useState(false);
 
   const handleToggleAllowUpgradeRequest = async () => {
     setIsSavingAllowUpgradeRequest(true);
@@ -102,17 +103,26 @@ export function UsageSettingsCard({
                 <InputWithSave
                   inputMode="numeric"
                   pattern="[0-9]*"
+                  placeholder="No access"
                   value={
-                    currentDefaultLimit !== null
-                      ? currentDefaultLimit.toLocaleString()
-                      : ""
+                    currentDefaultLimit === null || currentDefaultLimit === 0
+                      ? ""
+                      : currentDefaultLimit.toLocaleString()
                   }
-                  unit="credits"
+                  unit={
+                    (currentDefaultLimit === null ||
+                      currentDefaultLimit === 0) &&
+                    !isEditingDefaultLimit
+                      ? undefined
+                      : "credits"
+                  }
                   normalizeValue={(value) => value.replace(/[^\d]/g, "")}
                   formatValue={(value) =>
                     value ? Number(value).toLocaleString() : value
                   }
                   onSave={handleSaveDefaultLimit}
+                  onFocus={() => setIsEditingDefaultLimit(true)}
+                  onBlur={() => setIsEditingDefaultLimit(false)}
                   disabled={readOnly || isDefaultUserSpendLimitLoading}
                 />
               </div>

--- a/front/lib/api/credits/programmatic_usage_limit.test.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.test.ts
@@ -59,7 +59,7 @@ describe("syncProgrammaticUsageLimit persistence", () => {
     ).toHaveBeenCalled();
   });
 
-  it("persists 0 as a hard cap rather than clearing it", async () => {
+  it("persists 0 as a hard cap and clears alerts (cap of 0 is always depleted — no alert transition can fire)", async () => {
     const workspace = await WorkspaceFactory.creditPriced({
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
     });
@@ -71,10 +71,10 @@ describe("syncProgrammaticUsageLimit persistence", () => {
     expect(read.isOk() && read.value).toBe(0);
     expect(
       programmaticCap.upsertMetronomeProgrammaticCapAlerts
-    ).toHaveBeenCalled();
+    ).not.toHaveBeenCalled();
     expect(
       programmaticCap.clearMetronomeProgrammaticCapAlerts
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalled();
   });
 
   it("clears the cap and the alerts when set to null", async () => {

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -8,7 +8,9 @@ import {
   clearMetronomeProgrammaticCapAlerts,
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
+import { setProgrammaticCreditStateReconciled } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -47,10 +49,10 @@ export async function getProgrammaticUsageLimit(
  * Set or clear the workspace's programmatic usage monthly cap.
  *
  * Persists the cap on `credit_usage_configurations` (the source of truth),
- * then derives the four Metronome programmatic alerts (cap, warning, low,
- * critical) from it. A non-negative `monthlyCapCredits` upserts the alerts
- * (0 included, as a hard cap); `null` or a negative value clears both the
- * stored cap and the alerts.
+ * then derives the Metronome programmatic alerts from it (only for positive
+ * caps; 0 and null both clear the alerts since a cap of 0 is always depleted),
+ * and finally reconciles `programmaticCreditState` so usage-status reflects
+ * the change immediately without waiting for a webhook.
  */
 export async function syncProgrammaticUsageLimit({
   auth,
@@ -106,8 +108,10 @@ export async function syncProgrammaticUsageLimit({
     });
   }
 
+  // Alerts only make sense for a positive cap: a cap of 0 means usage is
+  // always fully depleted, so no threshold transition can ever fire.
   const alertResult =
-    normalizedCapCredits !== null
+    normalizedCapCredits !== null && normalizedCapCredits > 0
       ? await upsertMetronomeProgrammaticCapAlerts({
           metronomeCustomerId: workspace.metronomeCustomerId,
           workspaceId: workspace.sId,
@@ -123,6 +127,18 @@ export async function syncProgrammaticUsageLimit({
         `Failed to sync Metronome programmatic cap alerts: ${alertResult.error.message}`
       )
     );
+  }
+
+  // Reconcile programmaticCreditState immediately so /usage-status reflects the
+  // change without waiting for a Metronome webhook. Cap > 0 → active (fresh
+  // cap, usage hasn't hit it yet); 0 or null → depleted (no access).
+  const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+  if (workspaceResource) {
+    const targetState =
+      normalizedCapCredits !== null && normalizedCapCredits > 0
+        ? "active"
+        : "depleted";
+    await setProgrammaticCreditStateReconciled(workspaceResource, targetState);
   }
 
   void emitAuditLogEvent({

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -222,6 +222,38 @@ async function reconcileProgrammatic({
   metronomeCustomerId: string;
   execute: boolean;
 }): Promise<Result<ProgrammaticReconcileReport, Error>> {
+  // Read the cap from the DB first — it is the source of truth. A cap of 0 or
+  // null means no programmatic access; no alerts exist in that case so reading
+  // Metronome would incorrectly return "active" (no alarms → active).
+  const config = await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+    workspace.id
+  );
+  const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? 0;
+
+  const noAlarms = { cap: false, low: false, critical: false };
+
+  if (monthlyCapCredits === 0) {
+    const expectedState: WorkspaceProgrammaticCreditState = "depleted";
+    const previousState = workspace.programmaticCreditState;
+    let newState = previousState;
+    if (execute) {
+      await setProgrammaticCreditStateReconciled(workspace, expectedState);
+      newState = workspace.programmaticCreditState;
+    }
+    return new Ok({
+      target: "programmatic",
+      previousState,
+      expectedState,
+      newState,
+      wasInvalid: previousState !== expectedState,
+      corrected: previousState !== newState,
+      executed: execute,
+      alarms: noAlarms,
+    });
+  }
+
+  // For a positive cap, read Metronome alert states to derive the expected
+  // state (cap/low/critical alarms may be in alarm if spend is high).
   const statesResult = await getMetronomeProgrammaticCapAlertStates({
     metronomeCustomerId,
     workspaceId: workspace.sId,

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -391,20 +391,21 @@ export function useUpdateProgrammaticUsageLimit({
         await res.json()
       );
 
-      if (monthlyCapCredits === null) {
+      if (monthlyCapCredits === null || monthlyCapCredits === 0) {
         sendNotification({
           type: "success",
-          title: "Programmatic usage limit has been removed",
+          title: "Programmatic access disabled",
         });
       } else {
         sendNotification({
           type: "success",
           title: "Programmatic usage limit updated",
-          description: `The monthly programmatic usage limit has been set to ${monthlyCapCredits.toLocaleString("en-US")} credits.`,
+          description: `Monthly limit set to ${monthlyCapCredits.toLocaleString()} credits.`,
         });
       }
 
       await mutate(programmaticUsageLimitUrl(workspaceId));
+      await mutate(`/api/w/${workspaceId}/usage-status`);
       return body;
     },
     [workspaceId, sendNotification]


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/8819

## Description

Clarifies the meaning of empty/zero values across programmatic and pool credit settings, and fixes related logic bugs.

### UI / UX

- **Programmatic monthly limit**: `null` or `0` → empty field with "No access" placeholder; "credits" unit label hidden until focused
- **Workspace credit pool threshold**: `0` → empty field with "Disabled" placeholder; "credits" unit label hidden until focused
- **Default workspace credit pool limit**: `null` or `0` → empty field with "No access" placeholder; "credits" unit label hidden until focused
- **Notification copy**: saving a limit of 0 now says "Programmatic access disabled" instead of "Programmatic usage limit has been removed"

### Logic / bug fixes

- **Empty field saves 0, not null**: clearing the programmatic limit field now persists `0` (hard block) rather than `null` (no limit), matching the intent of the placeholder text
- **Alerts skipped for cap = 0**: a cap of 0 is always fully depleted, so no threshold transition can ever fire; Metronome alerts are now cleared (not upserted) in that case
- **Immediate state reconciliation**: after saving a cap change, `programmaticCreditState` is reconciled right away so `/usage-status` reflects the new state without waiting for a Metronome webhook
- **Reconcile reads DB first for cap = 0**: the reconciliation logic now reads the stored cap before querying Metronome alert states; Metronome returns "active" when no alerts exist, which would incorrectly override the "depleted" state for a cap of 0
- **Banner null-safety**: `AppStatusBanner` now coalesces `monthlyCapCredits ?? 0` before comparing to `0`, so a `null` cap is treated as a hard block
- **SWR cache invalidation**: `useUpdateProgrammaticUsageLimit` now also mutates `/usage-status` after a successful save so the banner updates immediately

## Tests

Unit tests updated for the cap = 0 alert behavior. Tested manually.

## Risk

Low — UI is display-only; logic changes only affect the 0-cap edge case which had no real contracts yet.

## Deploy Plan

Standard deploy, no migration needed.