### PR TITLE
feat(analytics): add skills metadata export table

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -258,7 +258,7 @@
             "in": "query",
             "name": "table",
             "required": true,
-            "description": "The analytics table to export:\n- \"usage_metrics\": Messages, conversations, and active users over time.\n- \"active_users\": Daily, weekly, and monthly active user counts.\n- \"source\": Message volume by context origin (web, slack, etc.).\n- \"agents\": Top agents by message count.\n- \"users\": Top users by message count.\n- \"skill_usage\": Skill executions and unique users over time.\n- \"tool_usage\": Tool executions and unique users over time.\n- \"messages\": Detailed message-level logs.\n- \"feedback\": Detailed message-level feedback (thumbs, content, conversation URL).\n",
+            "description": "The analytics table to export:\n- \"usage_metrics\": Messages, conversations, and active users over time.\n- \"active_users\": Daily, weekly, and monthly active user counts.\n- \"source\": Message volume by context origin (web, slack, etc.).\n- \"agents\": Top agents by message count.\n- \"users\": Top users by message count.\n- \"skills\": Skill metadata catalog.\n- \"skill_usage\": Skill executions and unique users over time.\n- \"tool_usage\": Tool executions and unique users over time.\n- \"messages\": Detailed message-level logs.\n- \"feedback\": Detailed message-level feedback (thumbs, content, conversation URL).\n",
             "schema": {
               "type": "string",
               "enum": [
@@ -267,6 +267,7 @@
                 "source",
                 "agents",
                 "users",
+                "skills",
                 "skill_usage",
                 "tool_usage",
                 "messages",

--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -65,6 +65,30 @@ vi.mock("@app/lib/api/analytics/users_export", async () => ({
   ),
 }));
 
+vi.mock("@app/lib/api/analytics/skills_export", async () => ({
+  SKILL_EXPORT_HEADERS: [
+    "skillId",
+    "name",
+    "description",
+    "editedByEmail",
+    "createdAt",
+    "lastEdit",
+  ],
+  fetchSkillExportRows: vi.fn(
+    async () =>
+      new Ok([
+        {
+          skillId: "skill-123",
+          name: "Research",
+          description: "Looks things up",
+          editedByEmail: "alice@example.com",
+          createdAt: "2024-05-01",
+          lastEdit: "2024-06-01",
+        },
+      ])
+  ),
+}));
+
 vi.mock("@app/lib/api/assistant/observability/skill_usage", async () => ({
   fetchAvailableSkills: vi.fn(async () => new Ok([])),
   fetchSkillUsageMetrics: vi.fn(async () => new Ok([])),
@@ -313,6 +337,18 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
     expect(csv).toContain("userName,messageCount");
   });
 
+  it("returns CSV for skills table", async () => {
+    const { response } = await setupTest({ table: "skills" });
+
+    expect(response.status).toBe(200);
+    const csv = await response.text();
+    expect(csv).toContain(
+      "skillId,name,description,editedByEmail,createdAt,lastEdit"
+    );
+    expect(csv).toContain("Research");
+    expect(csv).toContain("alice@example.com");
+  });
+
   it("returns CSV for skill_usage table", async () => {
     const { response } = await setupTest({ table: "skill_usage" });
 
@@ -436,6 +472,24 @@ describe("GET /api/v1/w/[wId]/analytics/export", () => {
       agentId: "agent-123",
       name: "TestAgent",
       messages: 5,
+    });
+  });
+
+  it("returns typed JSON for skills", async () => {
+    const { response } = await setupTest({
+      table: "skills",
+      format: "json",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data[0]).toEqual({
+      skillId: "skill-123",
+      name: "Research",
+      description: "Looks things up",
+      editedByEmail: "alice@example.com",
+      createdAt: "2024-05-01",
+      lastEdit: "2024-06-01",
     });
   });
 

--- a/front-api/routes/v1/w/[wId]/analytics/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.ts
@@ -25,13 +25,14 @@
  *           - "source": Message volume by context origin (web, slack, etc.).
  *           - "agents": Top agents by message count.
  *           - "users": Top users by message count.
+ *           - "skills": Skill metadata catalog.
  *           - "skill_usage": Skill executions and unique users over time.
  *           - "tool_usage": Tool executions and unique users over time.
  *           - "messages": Detailed message-level logs.
  *           - "feedback": Detailed message-level feedback (thumbs, content, conversation URL).
  *         schema:
  *           type: string
- *           enum: [usage_metrics, active_users, source, agents, users, skill_usage, tool_usage, messages, feedback]
+ *           enum: [usage_metrics, active_users, source, agents, users, skills, skill_usage, tool_usage, messages, feedback]
  *       - in: query
  *         name: startDate
  *         required: true

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -14,6 +14,11 @@ import {
   fetchMessageExportRows,
   MESSAGE_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/messages_export";
+import type { SkillExportRow } from "@app/lib/api/analytics/skills_export";
+import {
+  fetchSkillExportRows,
+  SKILL_EXPORT_HEADERS,
+} from "@app/lib/api/analytics/skills_export";
 import type { UserExportRow } from "@app/lib/api/analytics/users_export";
 import {
   fetchUserExportRows,
@@ -46,6 +51,7 @@ type AnalyticsExportTable =
   | "source"
   | "agents"
   | "users"
+  | "skills"
   | "skill_usage"
   | "tool_usage"
   | "messages"
@@ -146,6 +152,11 @@ export type ExportTableData =
       rows: UserExportRow[];
     }
   | {
+      table: "skills";
+      headers: typeof SKILL_EXPORT_HEADERS;
+      rows: SkillExportRow[];
+    }
+  | {
       table: "skill_usage";
       headers: typeof SKILL_USAGE_HEADERS;
       rows: SkillUsageRow[];
@@ -200,6 +211,8 @@ export async function exportTable({
       });
     case "users":
       return exportUsers({ startDate, endDate, timezone, owner });
+    case "skills":
+      return exportSkills({ auth, startDate, endDate, timezone, owner });
     case "skill_usage":
       return exportSkillUsage({ startDate, endDate, timezone, owner });
     case "tool_usage":
@@ -224,6 +237,8 @@ export function stringifyExportTableAsCsv(data: ExportTableData): string {
     case "agents":
       return stringifyRowsAsCsv(data.headers, data.rows);
     case "users":
+      return stringifyRowsAsCsv(data.headers, data.rows);
+    case "skills":
       return stringifyRowsAsCsv(data.headers, data.rows);
     case "skill_usage":
       return stringifyRowsAsCsv(data.headers, data.rows);
@@ -446,6 +461,40 @@ async function exportUsers({
   return new Ok({
     table: "users",
     headers: USER_EXPORT_HEADERS,
+    rows: result.value,
+  });
+}
+
+async function exportSkills({
+  auth,
+  startDate,
+  endDate,
+  timezone,
+  owner,
+}: {
+  auth: Authenticator;
+  startDate: string;
+  endDate: string;
+  timezone: string;
+  owner: WorkspaceType;
+}): Promise<Result<ExportTableData, Error>> {
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    startDate,
+    endDate,
+  });
+
+  const result = await fetchSkillExportRows(auth, baseQuery, timezone);
+
+  if (result.isErr()) {
+    return new Err(
+      new Error(`Failed to retrieve skills: ${result.error.message}`)
+    );
+  }
+
+  return new Ok({
+    table: "skills",
+    headers: SKILL_EXPORT_HEADERS,
     rows: result.value,
   });
 }

--- a/front/lib/api/analytics/skills_export.ts
+++ b/front/lib/api/analytics/skills_export.ts
@@ -1,0 +1,87 @@
+import { fetchUsedSkills } from "@app/lib/api/assistant/observability/skill_usage";
+import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { estypes } from "@elastic/elasticsearch";
+
+export const SKILL_EXPORT_HEADERS = [
+  "skillId",
+  "name",
+  "description",
+  "editedByEmail",
+  "createdAt",
+  "lastEdit",
+] as const;
+
+export type SkillExportRow = Record<
+  (typeof SKILL_EXPORT_HEADERS)[number],
+  string
+>;
+
+export async function fetchSkillExportRows(
+  auth: Authenticator,
+  baseQuery: estypes.QueryDslQueryContainer,
+  timezone: string
+): Promise<Result<SkillExportRow[], Error>> {
+  const customSkills = await SkillResource.listByWorkspace(auth, {
+    status: "active",
+    onlyCustom: true,
+    withInstructions: false,
+    withTools: false,
+  });
+
+  const editorModelIds = [
+    ...new Set(removeNulls(customSkills.map((skill) => skill.editedBy))),
+  ];
+  const editors =
+    editorModelIds.length > 0
+      ? await UserResource.fetchByModelIds(editorModelIds)
+      : [];
+  const emailByEditorModelId = new Map(
+    editors.map((editor) => [editor.id, editor.email])
+  );
+
+  const rows: SkillExportRow[] = customSkills.map((skill) => {
+    return {
+      skillId: skill.sId,
+      name: skill.name,
+      description: skill.agentFacingDescription,
+      editedByEmail:
+        skill.editedBy !== null
+          ? (emailByEditorModelId.get(skill.editedBy) ?? "")
+          : "",
+      createdAt: formatDateFromMillis(skill.createdAt.getTime(), timezone),
+      lastEdit: formatDateFromMillis(skill.updatedAt.getTime(), timezone),
+    };
+  });
+
+  const usedSkillsResult = await fetchUsedSkills(baseQuery);
+  if (usedSkillsResult.isErr()) {
+    return new Err(usedSkillsResult.error);
+  }
+
+  const globalSkillIds = usedSkillsResult.value.filter(
+    (skillId) => !isResourceSId("skill", skillId)
+  );
+
+  if (globalSkillIds.length > 0) {
+    const globalSkills = await SkillResource.fetchByIds(auth, globalSkillIds);
+    for (const skill of globalSkills) {
+      rows.push({
+        skillId: skill.sId,
+        name: skill.name,
+        description: skill.agentFacingDescription,
+        editedByEmail: "",
+        createdAt: "",
+        lastEdit: "",
+      });
+    }
+  }
+
+  return new Ok(rows.sort((a, b) => a.name.localeCompare(b.name)));
+}

--- a/front/lib/api/analytics/skills_export.ts
+++ b/front/lib/api/analytics/skills_export.ts
@@ -28,15 +28,33 @@ export async function fetchSkillExportRows(
   baseQuery: estypes.QueryDslQueryContainer,
   timezone: string
 ): Promise<Result<SkillExportRow[], Error>> {
-  const customSkills = await SkillResource.listByWorkspace(auth, {
+  const activeCustomSkills = await SkillResource.listByWorkspace(auth, {
     status: "active",
     onlyCustom: true,
     withInstructions: false,
     withTools: false,
   });
 
+  const usedSkillsResult = await fetchUsedSkills(baseQuery);
+  if (usedSkillsResult.isErr()) {
+    return new Err(usedSkillsResult.error);
+  }
+
+  const activeCustomSkillIds = new Set(
+    activeCustomSkills.map((skill) => skill.sId)
+  );
+  const usedButNotActiveIds = usedSkillsResult.value.filter(
+    (skillId) => !activeCustomSkillIds.has(skillId)
+  );
+  const rehydratedSkills =
+    usedButNotActiveIds.length > 0
+      ? await SkillResource.fetchByIds(auth, usedButNotActiveIds)
+      : [];
+
+  const allSkills = [...activeCustomSkills, ...rehydratedSkills];
+
   const editorModelIds = [
-    ...new Set(removeNulls(customSkills.map((skill) => skill.editedBy))),
+    ...new Set(removeNulls(allSkills.map((skill) => skill.editedBy))),
   ];
   const editors =
     editorModelIds.length > 0
@@ -46,42 +64,24 @@ export async function fetchSkillExportRows(
     editors.map((editor) => [editor.id, editor.email])
   );
 
-  const rows: SkillExportRow[] = customSkills.map((skill) => {
+  const rows = allSkills.map<SkillExportRow>((skill) => {
+    const isGlobal = !isResourceSId("skill", skill.sId);
     return {
       skillId: skill.sId,
       name: skill.name,
       description: skill.agentFacingDescription,
       editedByEmail:
-        skill.editedBy !== null
+        !isGlobal && skill.editedBy !== null
           ? (emailByEditorModelId.get(skill.editedBy) ?? "")
           : "",
-      createdAt: formatDateFromMillis(skill.createdAt.getTime(), timezone),
-      lastEdit: formatDateFromMillis(skill.updatedAt.getTime(), timezone),
+      createdAt: isGlobal
+        ? ""
+        : formatDateFromMillis(skill.createdAt.getTime(), timezone),
+      lastEdit: isGlobal
+        ? ""
+        : formatDateFromMillis(skill.updatedAt.getTime(), timezone),
     };
   });
-
-  const usedSkillsResult = await fetchUsedSkills(baseQuery);
-  if (usedSkillsResult.isErr()) {
-    return new Err(usedSkillsResult.error);
-  }
-
-  const globalSkillIds = usedSkillsResult.value.filter(
-    (skillId) => !isResourceSId("skill", skillId)
-  );
-
-  if (globalSkillIds.length > 0) {
-    const globalSkills = await SkillResource.fetchByIds(auth, globalSkillIds);
-    for (const skill of globalSkills) {
-      rows.push({
-        skillId: skill.sId,
-        name: skill.name,
-        description: skill.agentFacingDescription,
-        editedByEmail: "",
-        createdAt: "",
-        lastEdit: "",
-      });
-    }
-  }
 
   return new Ok(rows.sort((a, b) => a.name.localeCompare(b.name)));
 }

--- a/front/lib/api/assistant/observability/skill_usage.ts
+++ b/front/lib/api/assistant/observability/skill_usage.ts
@@ -70,6 +70,12 @@ type SkillListAggs = {
   };
 };
 
+type SkillIdListAggs = {
+  skills_nested: {
+    by_skill_id: estypes.AggregationsMultiBucketAggregateBase<SkillBucket>;
+  };
+};
+
 function bucketToPoint(bucket: DateBucket, timezone: string): SkillUsagePoint {
   return {
     timestamp: bucket.key,
@@ -213,4 +219,38 @@ export async function fetchAvailableSkills(
   }));
 
   return new Ok(skills);
+}
+
+export async function fetchUsedSkills(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<string[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    skills_nested: {
+      nested: { path: "skills_used" },
+      aggs: {
+        by_skill_id: {
+          terms: {
+            field: "skills_used.skill_id",
+            size: 1000,
+            order: { _count: "desc" },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, SkillIdListAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const skillIdBuckets = bucketsToArray<SkillBucket>(
+    result.value.aggregations?.skills_nested?.by_skill_id?.buckets
+  );
+
+  return new Ok(skillIdBuckets.map((bucket) => bucket.key));
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3035,6 +3035,7 @@ const AnalyticsExportTableSchema = z.enum([
   "source",
   "agents",
   "users",
+  "skills",
   "skill_usage",
   "tool_usage",
   "messages",


### PR DESCRIPTION
## Description

Adds a new "skills" analytics export table exposed via GET /api/v1/w/{wId}/analytics/export. It complements the existing "skill_usage" time-series table by providing per-skill metadata (skillId, name, description, editedByEmail, createdAt, lastEdit).

skill_usage is left unchanged. Skills only track a last editor (editedBy), not an original author, so the creator field is exposed as editedByEmail.

Mirrors the "agents" export policy for global skills: all active custom skills are listed regardless of usage, plus Dust-provided global skills that were actually used in the date range (surfaced from skill_usage), with blank creation date and editor since they are not workspace-created.

Rows are scoped to the workspace's active custom skills and the caller's readable spaces; editor emails are privacy-filtered.

skill_usage could expose a `skillId` field to have a stable field (skill can be renamed) to eventually join with skills, will add that in a follow-up PR.

## Tests

unit + local

## Risk

low, new entrypoint

## Deploy Plan

deploy front + openAPI docs
