### PR TITLE
fixes trailing comma in migration script

### DIFF
--- a/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260618_backfill_cost_to_agent_message_analytics_2.http
@@ -44,7 +44,7 @@ POST /front.agent_message_analytics_2/_update_by_query?wait_for_completion=false
               "gte": "now-3M"
             }
           }
-        },
+        }
       ],
       "must_not": [
         {


### PR DESCRIPTION
## Description

This PR removes a typo.


## Tests

I extensively tested that it did not work before

## Risk

We risk that the script now passes and downs ES 
(but I'd say this won't happen)


## Deploy Plan

