### PR TITLE
Fix reconcile for free seats

### DIFF
--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -1,5 +1,7 @@
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import { getUserForWorkspace } from "@app/lib/api/user";
+import logger from "@app/logger/logger";
 import {
   MEMBERSHIP_SEAT_TYPES,
   type MembershipSeatType,
@@ -110,6 +112,24 @@ app.patch(
           });
         default:
           assertNever(result.error.type);
+      }
+    }
+
+    // When the user is upgrading their own seat, sync immediately so credits
+    // are available right away instead of waiting for the debounced workflow.
+    if (uId === auth.getNonNullableUser().sId) {
+      const syncResult = await syncMetronomeSeatCountForWorkspace({
+        workspace: auth.getNonNullableWorkspace(),
+      });
+      if (syncResult.isErr()) {
+        logger.warn(
+          {
+            workspaceId: auth.getNonNullableWorkspace().sId,
+            userId: uId,
+            err: syncResult.error.message,
+          },
+          "[SeatType] Immediate seat sync after self-upgrade failed; debounced workflow will retry"
+        );
       }
     }
 

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -1,4 +1,5 @@
 import { updateMembershipSeatAndTrack } from "@app/lib/api/membership";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import {
   isMetronomeBillingEnabled,
   restoreWorkspaceAfterSubscription,
@@ -527,6 +528,23 @@ export async function handleSubscriptionActivationSuccess({
         },
         "[Business Activation] Target user seat updated"
       );
+
+      // Immediately sync seats so the user lands in the correct credit state
+      // without waiting for the debounced Temporal workflow (15 s delay).
+      const syncResult = await syncMetronomeSeatCountForWorkspace({
+        workspace: lightWorkspace,
+      });
+      if (syncResult.isErr()) {
+        logger.warn(
+          { workspaceId: workspace.sId, err: syncResult.error.message },
+          "[Business Activation] Immediate seat sync failed; debounced workflow will retry"
+        );
+      } else {
+        logger.info(
+          { workspaceId: workspace.sId, status: syncResult.value.status },
+          "[Business Activation] Immediate seat sync completed"
+        );
+      }
     }
   }
 

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -484,14 +484,13 @@ export async function reconcileWorkspaceUserCreditStates({
     const seatType = membership.seatType;
 
     const normalizedSeatType = normalizeToPoolLimitSeatType(seatType);
-    const poolCapAwuCredits =
-      membership.poolCapOverrideAwuCredits ??
-      (normalizedSeatType ? defaultPoolCapAwuCredits : 0);
-    const effectiveCapAwuCredits =
-      poolCapAwuCredits !== null
-        ? poolCapAwuCredits +
-          (normalizedSeatType ? (seatAllowances[normalizedSeatType] ?? 0) : 0)
-        : null;
+    // Cap + usage only apply to pool-limit seat types (pro/max/workspace),
+    // matching fetchLiveUserCreditInputs. Free/none seats have no pool access —
+    // their effective cap is null and near-limit uses the seat-balance path.
+    const effectiveCapAwuCredits = normalizedSeatType
+      ? (membership.poolCapOverrideAwuCredits ?? defaultPoolCapAwuCredits) +
+        (seatAllowances[normalizedSeatType] ?? 0)
+      : null;
     // Seat balance comes from `listMetronomeSeatBalances` for pro/max; free
     // seats read their per-user credit balance instead (not a seat balance).
     // Pro/max read their seat balance. `expectedUserCreditState` decides routing


### PR DESCRIPTION
## Description

Three independent fixes to credit state reconciliation on CP_BUSINESS workspaces.

### 1. Fix false \"near limit\" for new free-seat users

The batch reconcile path (`reconcileWorkspaceUserCreditStates`) was computing `effectiveCapAwuCredits = 0` for free-seat users instead of `null`, because `normalizeToPoolLimitSeatType("free")` returns `null` causing the pool cap to default to `0 + 0 = 0`.

This caused `consumedAwuCredits` to be fetched as `0` (not skipped), and `computeUserNearLimit` to evaluate `0 >= 0.8 * 0` → `true`, flagging every new free-seat user as \"near limit\" immediately.

Fix: align the batch path with `fetchLiveUserCreditInputs`, which already correctly returns `null` for free/none seats. Free seat near-limit is handled by the balance-based branch in `computeUserNearLimit` (lifetime credits, not per-period consumption).

### 2. Immediate seat sync after self-upgrade

After a user upgrades their own seat, credits were not visible until the debounced Temporal seat-sync workflow fired (~15 s later). Two paths needed fixing:

- **Checkout flow** (`handleSubscriptionActivationSuccess`): called from a Metronome `payment_gate.payment_status` webhook after payment confirmation. Now calls `syncMetronomeSeatCountForWorkspace` directly after updating the seat.
- **Direct self-upgrade** (`PATCH /api/w/:wId/members/:uId/seat-type`): when `uId === auth user's sId`, calls `syncMetronomeSeatCountForWorkspace` directly before returning. Admin changing another user's seat still uses the debounced workflow.

In both cases the debounced workflow still runs as a safety net if the immediate sync fails.

## Tests

Tested manually:
- New workspace with free seat: no longer immediately flagged as near limit
- Self-upgrade from free → pro via checkout: credits visible immediately after payment
- Self-upgrade via direct seat change: credits visible immediately

## Risk

Low. All changes are additive (direct sync on top of existing debounced workflow). The reconcile fix only affects free-seat users in the batch path.

## Deploy Plan

Standard deploy, no migration needed.