### PR TITLE
fix(front): keep caret in place when pasted URL becomes a preview node

### DIFF
--- a/front/components/editor/input_bar/useUrlHandler.test.ts
+++ b/front/components/editor/input_bar/useUrlHandler.test.ts
@@ -1,0 +1,90 @@
+import { DataSourceLinkExtension } from "@app/components/editor/extensions/input_bar/DataSourceLinkExtension";
+import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+import { remapCaretAfterUrlReplacement } from "@app/components/editor/input_bar/useUrlHandler";
+import type { Editor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const PASTED_URL = "https://example.com/x";
+
+// Performs the same insertion `useUrlHandler.replaceUrl` does (swap the pasted
+// URL range for a `dataSourceLink` node + trailing space) and then delegates
+// the caret restoration to the *real* production helper, so these tests guard
+// `remapCaretAfterUrlReplacement` rather than a copy of it.
+function replaceUrlRange(
+  editor: Editor,
+  range: { from: number; to: number },
+  title: string,
+  url: string
+): void {
+  const content = [
+    {
+      type: "dataSourceLink",
+      attrs: { nodeId: null, title, provider: null, spaceId: null, url },
+      text: `:content_node_mention[${title}]{url=${url}}`,
+    },
+    { type: "text", text: " " },
+  ];
+
+  const { from: savedCursor } = editor.state.selection;
+  const oldDocSize = editor.state.doc.content.size;
+
+  const success = editor.commands.insertContentAt(range, content);
+
+  if (success) {
+    remapCaretAfterUrlReplacement(editor, {
+      savedCursor,
+      oldDocSize,
+      replacedTo: range.to,
+    });
+  }
+}
+
+describe("remapCaretAfterUrlReplacement", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([DataSourceLinkExtension]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("should keep the caret after text typed past the pasted URL", () => {
+    // User pasted a URL then kept typing: "look <URL> here".
+    const prefix = "look ";
+    editor.commands.insertContent(`${prefix}${PASTED_URL} here`);
+
+    // Caret sits at the very end (after the text typed past the URL).
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    const urlFrom = 1 + prefix.length;
+    const urlTo = urlFrom + PASTED_URL.length;
+
+    replaceUrlRange(editor, { from: urlFrom, to: urlTo }, "Doc", PASTED_URL);
+
+    // The caret must land at the very end, right after the typed suffix — not
+    // back at the inserted node (which would scramble further typing).
+    const { from } = editor.state.selection;
+    expect(from).toBe(editor.state.doc.content.size - 1);
+    expect(editor.state.doc.textBetween(0, from)).toMatch(/here$/);
+  });
+
+  it("should not pull the caret back when it sits before the replaced URL", () => {
+    const prefix = "look ";
+    editor.commands.insertContent(`${prefix}${PASTED_URL}`);
+
+    // Caret moved back into the prefix, before the URL.
+    editor.commands.setTextSelection(2);
+
+    const urlFrom = 1 + prefix.length;
+    const urlTo = urlFrom + PASTED_URL.length;
+
+    replaceUrlRange(editor, { from: urlFrom, to: urlTo }, "Doc", PASTED_URL);
+
+    // The guard skips the remap for carets before the URL. Without it, the
+    // (large, negative) size delta would yank the caret to the document start;
+    // instead it follows TipTap's default and stays past the URL position.
+    expect(editor.state.selection.from).toBeGreaterThan(urlFrom);
+  });
+});

--- a/front/components/editor/input_bar/useUrlHandler.tsx
+++ b/front/components/editor/input_bar/useUrlHandler.tsx
@@ -6,6 +6,34 @@ import { useCallback, useEffect } from "react";
 
 import type { URLState } from "../extensions/input_bar/URLStorageExtension";
 
+// `insertContentAt` defaults to `updateSelection: true`, which drops the caret
+// right after the inserted node. When the user had already typed past the
+// pasted URL (caret at or after the replaced range), that places the caret
+// before their typed text and scrambles subsequent input. Re-map the caret by
+// the document size delta so it stays at the user's logical typing position.
+// When the caret was inside/before the URL we leave the default untouched.
+export function remapCaretAfterUrlReplacement(
+  editor: Editor,
+  {
+    savedCursor,
+    oldDocSize,
+    replacedTo,
+  }: { savedCursor: number; oldDocSize: number; replacedTo: number }
+): void {
+  if (savedCursor < replacedTo) {
+    return;
+  }
+
+  const delta = editor.state.doc.content.size - oldDocSize;
+  // Clamp to the last selectable position: `content.size - 1` excludes the
+  // paragraph's closing token, which is not a valid caret position.
+  const newPos = Math.min(
+    savedCursor + delta,
+    editor.state.doc.content.size - 1
+  );
+  editor.commands.setTextSelection(newPos);
+}
+
 const useUrlHandler = (
   editor: Editor | null,
   selectedNode: DataSourceViewContentNode | null,
@@ -59,11 +87,25 @@ const useUrlHandler = (
             { type: "text", text: " " },
           ];
 
+          // Capture the caret and document size before the insertion so we
+          // can restore the user's logical typing position afterwards.
+          const { from: savedCursor } = editor.state.selection;
+          const oldDocSize = doc.content.size;
+
           try {
             const success = editor.commands.insertContentAt(
               { from: pendingUrl.from, to: pendingUrl.to },
               content
             );
+
+            if (success) {
+              remapCaretAfterUrlReplacement(editor, {
+                savedCursor,
+                oldDocSize,
+                replacedTo: pendingUrl.to,
+              });
+            }
+
             resolve(success);
           } catch (error) {
             console.error("Failed to replace URL:", error);


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/9031
## Description
When a user pasted a link and kept typing, the async replacement of the URL with a `dataSourceLink` preview node moved the caret to just after the inserted node — i.e. before the text already typed past the URL — so subsequent keystrokes landed in the wrong place and scrambled the input.

`insertContentAt` defaults to `updateSelection: true`. Extract a pure `remapCaretAfterUrlReplacement` helper that, when the caret was at or after the replaced range, re-maps it by the document size delta so it stays at the user's logical typing position. Carets inside/before the URL keep TipTap's default behavior.

Also switch the error path from `console.error` to the app logger with `normalizeError`.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually, cursor stays where expected now after link reformatting
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
