### PR TITLE
[LLM] Support xhigh reasoning effort for Anthropic and tighten model_constructors config typing

### DIFF
--- a/front/lib/model_constructors/batch/clients/anthropic.ts
+++ b/front/lib/model_constructors/batch/clients/anthropic.ts
@@ -9,6 +9,7 @@ import {
 import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
 import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
 import { batchResultToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { ANTHROPIC_API } from "@app/lib/model_constructors/types/provider_apis";
@@ -24,7 +25,11 @@ import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provide
  */
 export abstract class AnthropicBatch extends WithAnthropicInputConverter(
   WithAnthropicOutputConverter(
-    BatchEndpoint<MessageCreateParamsNonStreaming, MessageBatchResult>
+    BatchEndpoint<
+      MessageCreateParamsNonStreaming,
+      MessageBatchResult,
+      AnthropicInputConfig
+    >
   )
 ) {
   static readonly providerId = ANTHROPIC_PROVIDER_ID;
@@ -43,7 +48,9 @@ export abstract class AnthropicBatch extends WithAnthropicInputConverter(
     return batchResultToEvents(result, this.metadata(), this);
   }
 
-  async sendBatch(requests: Map<string, BatchRequest>): Promise<string> {
+  async sendBatch(
+    requests: Map<string, BatchRequest<AnthropicInputConfig>>
+  ): Promise<string> {
     const batchRequests = Array.from(requests.entries()).map(
       ([customId, { payload, config }]) => ({
         custom_id: customId,

--- a/front/lib/model_constructors/batch/endpoint.ts
+++ b/front/lib/model_constructors/batch/endpoint.ts
@@ -5,16 +5,23 @@ import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/ou
 
 export type BatchStatus = "ready" | "computing";
 
-export type BatchRequest = { payload: Payload; config: InputConfig };
+export type BatchRequest<C extends InputConfig = InputConfig> = {
+  payload: Payload;
+  config: C;
+};
 
 // Generic over the raw request payload `I` and per-request result `R`.
-export abstract class BatchEndpoint<I = unknown, R = unknown> extends Client {
-  abstract sendBatch(requests: Map<string, BatchRequest>): Promise<string>;
+export abstract class BatchEndpoint<
+  I = unknown,
+  R = unknown,
+  C extends InputConfig = InputConfig,
+> extends Client<C> {
+  abstract sendBatch(requests: Map<string, BatchRequest<C>>): Promise<string>;
   abstract getBatchStatus(batchId: string): Promise<BatchStatus>;
   abstract getBatchResult(
     batchId: string
   ): Promise<Map<string, NonDeltaResponseEvent[]>>;
   abstract deleteBatch(batchId: string): Promise<boolean>;
   abstract rawBatchOutputToEvents(raw: R): NonDeltaResponseEvent[];
-  abstract buildRequestPayload(payload: Payload, config: InputConfig): I;
+  abstract buildRequestPayload(payload: Payload, config: C): I;
 }

--- a/front/lib/model_constructors/client.ts
+++ b/front/lib/model_constructors/client.ts
@@ -1,14 +1,15 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 import type { ProviderApi } from "@app/lib/model_constructors/types/provider_apis";
 import type { ProviderId } from "@app/lib/model_constructors/types/provider_ids";
 import type { Region } from "@app/lib/model_constructors/types/regions";
 
-export abstract class Client {
+export abstract class Client<C extends InputConfig = InputConfig> {
   // Re-type `this.constructor` (typed as `Function` by default) so the concrete
   // subclass's static config is visible at the type level.
-  declare ["constructor"]: BaseEndpointConfiguration;
+  declare ["constructor"]: BaseEndpointConfiguration<C>;
 
   metadata(): EndpointMetadata {
     return {

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -17,7 +17,10 @@ export type BaseEndpointConfiguration<C extends InputConfig = InputConfig> = {
   // Capabilities
   contextSize: number;
   maxOutputTokens: number;
-  configSchema: z.ZodType<C>;
+  // Config schemas parse loose external input (with defaults/transforms) into
+  // the precise config `C`, so only the parsed output is constrained; the input
+  // side stays open.
+  configSchema: z.ZodType<C, z.ZodTypeDef, unknown>;
 
   // Pricing
   tokenPricing: TokenPricing;

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -20,7 +20,7 @@ import {
   userImageMessageToImageBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
-import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import type {
   Payload,
   SystemTextMessage,
@@ -32,7 +32,7 @@ type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 // API request shape. Leaf converters are bound as class fields and composites
 // route through `this`, so an endpoint can override a single leaf.
 export function WithAnthropicInputConverter<
-  TBase extends AbstractConstructor<Client>,
+  TBase extends AbstractConstructor<Client<AnthropicInputConfig>>,
 >(Base: TBase) {
   abstract class WithAnthropicInputConverter
     extends Base
@@ -61,7 +61,7 @@ export function WithAnthropicInputConverter<
 
     buildRequestPayload(
       payload: Payload,
-      config: InputConfig
+      config: AnthropicInputConfig
     ): MessageCreateParamsNonStreaming {
       const { conversation } = payload;
       const {

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
@@ -26,7 +26,6 @@ import {
 } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
 import type {
   OutputFormat,
-  Reasoning,
   ToolSpecification,
 } from "@app/lib/model_constructors/types/input/configuration";
 import type {
@@ -657,13 +656,6 @@ describe("reasoningToThinkingConfig", () => {
 
   it("disables thinking when effort is 'none'", () => {
     expect(reasoningToThinkingConfig({ effort: "none" })).toEqual({
-      thinking: { type: "disabled" },
-    });
-  });
-
-  it("disables thinking for an unsupported effort (e.g. 'minimal')", () => {
-    const reasoning = { effort: "minimal" } as Reasoning;
-    expect(reasoningToThinkingConfig(reasoning)).toEqual({
       thinking: { type: "disabled" },
     });
   });

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
@@ -668,10 +668,10 @@ describe("reasoningToThinkingConfig", () => {
     });
   });
 
-  it("disables thinking for an unsupported effort (e.g. 'xhigh')", () => {
-    const reasoning = { effort: "xhigh" } as Reasoning;
-    expect(reasoningToThinkingConfig(reasoning)).toEqual({
-      thinking: { type: "disabled" },
+  it("enables adaptive thinking for 'xhigh'", () => {
+    expect(reasoningToThinkingConfig({ effort: "xhigh" })).toEqual({
+      output_config: { effort: "xhigh" },
+      thinking: { type: "adaptive" },
     });
   });
 

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -285,6 +285,8 @@ function effortToAnthropicEffort(
       return "medium";
     case "high":
       return "high";
+    case "xhigh":
+      return "xhigh";
     case "maximal":
       return "max";
     default:

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -13,13 +13,10 @@ import type {
   ToolResultBlockParam,
   ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
-import {
-  type ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
-  isAnthropicSupportedNonNullReasoningEffort,
-} from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
+import type { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import type {
   OutputFormat,
-  Reasoning,
   ToolSpecification,
 } from "@app/lib/model_constructors/types/input/configuration";
 import type {
@@ -294,7 +291,9 @@ function effortToAnthropicEffort(
   }
 }
 
-export function reasoningToThinkingConfig(reasoning: Reasoning | undefined):
+export function reasoningToThinkingConfig(
+  reasoning: AnthropicInputConfig["reasoning"]
+):
   | {
       output_config: { effort: NonNullable<OutputConfig["effort"]> };
       thinking: ThinkingConfigAdaptive;
@@ -302,11 +301,7 @@ export function reasoningToThinkingConfig(reasoning: Reasoning | undefined):
   | {
       thinking: ThinkingConfigDisabled;
     } {
-  if (
-    !reasoning ||
-    reasoning.effort === "none" ||
-    !isAnthropicSupportedNonNullReasoningEffort(reasoning.effort)
-  ) {
+  if (!reasoning || reasoning.effort === "none") {
     return { thinking: { type: "disabled" } };
   }
 

--- a/front/lib/model_constructors/providers/anthropic/inputConfig.ts
+++ b/front/lib/model_constructors/providers/anthropic/inputConfig.ts
@@ -1,0 +1,16 @@
+import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { z } from "zod";
+
+export const anthropicConfigSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([
+        ...ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
+        "none",
+      ]),
+    })
+    .optional(),
+});
+
+export type AnthropicInputConfig = z.infer<typeof anthropicConfigSchema>;

--- a/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six.ts
@@ -1,6 +1,6 @@
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import {
-  type InputConfig,
   inputConfigSchema,
   temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
@@ -33,6 +33,8 @@ const configSchema = z.union([
   }),
 ]);
 
+export type ClaudeSonnetFourDotSix = z.infer<typeof configSchema>;
+
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithAnthropicClaudeSonnetFourDotSixConfig<
   TBase extends abstract new (
@@ -40,9 +42,17 @@ export function WithAnthropicClaudeSonnetFourDotSixConfig<
   ) => object,
 >(Base: TBase) {
   abstract class AnthropicClaudeSonnetFourDotSix extends Base {
+    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
+    // instance type carries `ClaudeSonnetFourDotSix` (not the wide `InputConfig`).
+    declare ["constructor"]: BaseEndpointConfiguration<ClaudeSonnetFourDotSix>;
+
     static readonly modelId = CLAUDE_SONNET_4_6_MODEL_ID;
 
-    static readonly configSchema: z.ZodType<InputConfig> = configSchema;
+    static readonly configSchema: z.ZodType<
+      ClaudeSonnetFourDotSix,
+      z.ZodTypeDef,
+      unknown
+    > = configSchema;
 
     static readonly contextSize = CONTEXT_SIZE;
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;

--- a/front/lib/model_constructors/providers/anthropic/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/anthropic/reasoning_efforts.ts
@@ -2,6 +2,7 @@ export const ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS = [
   "low",
   "medium",
   "high",
+  "xhigh",
   "maximal",
 ] as const;
 

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -8,6 +8,7 @@ import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/conf
 import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
 import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
 import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
+import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
@@ -34,11 +35,15 @@ const configSchema = inputConfigSchema.extend({
 
 export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
   WithAnthropicOutputConverter(
-    StreamEndpoint<MessageCreateParamsNonStreaming, RawMessageStreamEvent>
+    StreamEndpoint<
+      MessageCreateParamsNonStreaming,
+      RawMessageStreamEvent,
+      AnthropicInputConfig
+    >
   )
 ) {
   // Narrow `this.constructor` so the per-endpoint static below is visible.
-  declare ["constructor"]: BaseEndpointConfiguration & {
+  declare ["constructor"]: BaseEndpointConfiguration<AnthropicInputConfig> & {
     regionalEndpoint: AgentPlatformRegionalEndpoint;
   };
 

--- a/front/lib/model_constructors/stream/clients/anthropic.ts
+++ b/front/lib/model_constructors/stream/clients/anthropic.ts
@@ -7,38 +7,29 @@ import type {
 import { WithAnthropicInputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/input";
 import { WithAnthropicOutputConverter } from "@app/lib/model_constructors/providers/anthropic/converters/output";
 import { rawOutputToEvents } from "@app/lib/model_constructors/providers/anthropic/converters/output/utils";
-import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
+import {
+  type AnthropicInputConfig,
+  anthropicConfigSchema,
+} from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { ANTHROPIC_API } from "@app/lib/model_constructors/types/provider_apis";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 
-import { z } from "zod";
-
-const configSchema = inputConfigSchema.extend({
-  reasoning: z
-    .object({
-      effort: z.enum([
-        ...ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS,
-        "none",
-      ]),
-    })
-    .optional(),
-});
-
-type AnthropicInputConfig = z.infer<typeof configSchema>;
-
 export abstract class AnthropicStream extends WithAnthropicInputConverter(
   WithAnthropicOutputConverter(
-    StreamEndpoint<MessageCreateParamsNonStreaming, RawMessageStreamEvent>
+    StreamEndpoint<
+      MessageCreateParamsNonStreaming,
+      RawMessageStreamEvent,
+      AnthropicInputConfig
+    >
   )
 ) {
   static readonly providerId = ANTHROPIC_PROVIDER_ID;
   static readonly api = ANTHROPIC_API;
 
-  static readonly configSchema: z.ZodType<AnthropicInputConfig> = configSchema;
+  static readonly configSchema = anthropicConfigSchema;
 
   private readonly client: AnthropicClient;
 

--- a/front/lib/model_constructors/stream/configuration.ts
+++ b/front/lib/model_constructors/stream/configuration.ts
@@ -1,10 +1,16 @@
 import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import type { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 
-export type StreamModelConfiguration = BaseEndpointConfiguration;
+export type StreamModelConfiguration<C extends InputConfig = InputConfig> =
+  BaseEndpointConfiguration<C>;
 
-export type StreamEndpointConstructor = (new (
+export type StreamEndpointConstructor<
+  I = unknown,
+  O = unknown,
+  C extends InputConfig = InputConfig,
+> = (new (
   credentials: Credentials
-) => StreamEndpoint<any, any>) &
-  StreamModelConfiguration;
+) => StreamEndpoint<I, O, C>) &
+  StreamModelConfiguration<C>;

--- a/front/lib/model_constructors/stream/endpoint.ts
+++ b/front/lib/model_constructors/stream/endpoint.ts
@@ -4,8 +4,12 @@ import type { Payload } from "@app/lib/model_constructors/types/input/messages";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 
 // Generic over the raw request payload `I` and raw stream event `O`.
-export abstract class StreamEndpoint<I = unknown, O = unknown> extends Client {
-  abstract buildRequestPayload(payload: Payload, config: InputConfig): I;
+export abstract class StreamEndpoint<
+  I = unknown,
+  O = unknown,
+  C extends InputConfig = InputConfig,
+> extends Client<C> {
+  abstract buildRequestPayload(payload: Payload, config: C): I;
   abstract streamRaw(input: I): AsyncGenerator<O>;
   abstract rawStreamOutputToEvents(
     raw: AsyncGenerator<O>

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six.ts
@@ -1,4 +1,11 @@
-import { WithAnthropicClaudeSonnetFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
+import type {
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources";
+import {
+  type ClaudeSonnetFourDotSix,
+  WithAnthropicClaudeSonnetFourDotSixConfig,
+} from "@app/lib/model_constructors/providers/anthropic/models/claude_sonnet_four_dot_six";
 import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
@@ -22,4 +29,8 @@ export class AnthropicGlobalClaudeSonnetFourDotSixStream extends WithAnthropicCl
   static readonly id = this.buildId();
 }
 
-AnthropicGlobalClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor;
+AnthropicGlobalClaudeSonnetFourDotSixStream satisfies StreamEndpointConstructor<
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+  ClaudeSonnetFourDotSix
+>;


### PR DESCRIPTION
## Description

Adds `xhigh` reasoning effort support for Anthropic models and threads a precise per-endpoint `InputConfig` generic through the `model_constructors` endpoint hierarchy (extracting `AnthropicInputConfig` into `inputConfig.ts`).

## Tests

Tested locally — `npm run test` on the Anthropic input converter suite passes (57 tests), including the updated `xhigh` adaptive-thinking case.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`