### PR TITLE
feat(settings): show pending invitations in user settings popover

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -1,6 +1,7 @@
 import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
 import type { NotificationPreferencesRefProps } from "@app/components/me/NotificationPreferences";
 import { NotificationPreferences } from "@app/components/me/NotificationPreferences";
+import { PendingInvitationsTable } from "@app/components/me/PendingInvitationsTable";
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -17,9 +18,11 @@ import {
 } from "@app/lib/swr/credits";
 import {
   usePatchUser,
+  usePendingInvitations,
   useUser,
   useWorkspaceUsageStatus,
 } from "@app/lib/swr/user";
+import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import type { WorkspaceType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
 import {
@@ -40,6 +43,7 @@ import {
   Edit04,
   Input,
   Label,
+  Mail01,
   Moon01,
   NavigationList,
   NavigationListItem,
@@ -69,7 +73,8 @@ type SettingsSection =
   | "usage"
   | "customization"
   | "notifications"
-  | "tools";
+  | "tools"
+  | "invitations";
 
 interface UserSettingsPopoverProps {
   open: boolean;
@@ -670,6 +675,33 @@ function ToolsSection({ owner }: { owner: WorkspaceType }) {
   );
 }
 
+// ─── Invitations ──────────────────────────────────────────────────────────────
+
+interface InvitationsSectionProps {
+  invitations: PendingInvitationOption[];
+  isLoading: boolean;
+}
+
+function InvitationsSection({
+  invitations,
+  isLoading,
+}: InvitationsSectionProps) {
+  return (
+    <SectionContent
+      title="Invitations"
+      description="Workspaces you've been invited to join"
+    >
+      {isLoading ? (
+        <div className="flex justify-center py-6">
+          <Spinner />
+        </div>
+      ) : (
+        <PendingInvitationsTable invitations={invitations} />
+      )}
+    </SectionContent>
+  );
+}
+
 // ─── Root ─────────────────────────────────────────────────────────────────────
 
 const NAV_ITEMS: Array<{
@@ -691,6 +723,23 @@ export function UserSettingsPopover({
 }: UserSettingsPopoverProps) {
   const [activeSection, setActiveSection] =
     useState<SettingsSection>("personal");
+
+  // Only fetch while the popover is open: it is always mounted in the user menu.
+  const { pendingInvitations, isPendingInvitationsLoading } =
+    usePendingInvitations({ workspaceId: owner.sId, disabled: !open });
+  const hasPendingInvitations = pendingInvitations.length > 0;
+
+  // The "Invitations" item only appears when the user has pending invitations.
+  const navItems = useMemo<typeof NAV_ITEMS>(
+    () =>
+      hasPendingInvitations
+        ? [
+            ...NAV_ITEMS,
+            { section: "invitations", icon: Mail01, label: "Invitations" },
+          ]
+        : NAV_ITEMS,
+    [hasPendingInvitations]
+  );
 
   useEffect(() => {
     if (open) {
@@ -717,7 +766,7 @@ export function UserSettingsPopover({
               />
             </DialogClose>
             <div className="flex flex-1">
-              {NAV_ITEMS.map(({ section, icon: Icon, label }) => (
+              {navItems.map(({ section, icon: Icon, label }) => (
                 <button
                   key={section}
                   type="button"
@@ -746,7 +795,7 @@ export function UserSettingsPopover({
               </DialogClose>
             </div>
             <NavigationList className="flex-1 px-2 pb-3">
-              {NAV_ITEMS.map(({ section, icon, label }) => (
+              {navItems.map(({ section, icon, label }) => (
                 <NavigationListItem
                   key={section}
                   icon={icon}
@@ -770,6 +819,12 @@ export function UserSettingsPopover({
               <NotificationsSection owner={owner} />
             )}
             {activeSection === "tools" && <ToolsSection owner={owner} />}
+            {activeSection === "invitations" && (
+              <InvitationsSection
+                invitations={pendingInvitations}
+                isLoading={isPendingInvitationsLoading}
+              />
+            )}
           </div>
         </div>
       </DialogContent>

--- a/front/components/me/PendingInvitationsTable.tsx
+++ b/front/components/me/PendingInvitationsTable.tsx
@@ -1,0 +1,131 @@
+import config from "@app/lib/api/config";
+import { classNames } from "@app/lib/utils";
+import type { PendingInvitationOption } from "@app/types/membership_invitation";
+import { Button, DataTable, Label } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { MouseEvent } from "react";
+import { useMemo } from "react";
+
+interface PendingInvitationsTableRow extends PendingInvitationOption {
+  onJoin: () => void;
+  // Present only to satisfy DataTable's TBaseData constraint, which requires a row
+  // to share at least one of its optional props. Joining is button-only.
+  onClick?: () => void;
+}
+
+interface PendingInvitationsTableProps {
+  invitations: PendingInvitationOption[];
+}
+
+export function PendingInvitationsTable({
+  invitations,
+}: PendingInvitationsTableProps) {
+  const sortedInvitations = useMemo(
+    () =>
+      invitations
+        .slice()
+        .sort((a, b) => a.workspaceName.localeCompare(b.workspaceName)),
+    [invitations]
+  );
+
+  const rows = useMemo<PendingInvitationsTableRow[]>(
+    () =>
+      sortedInvitations.map((invitation) => ({
+        ...invitation,
+        onJoin: () => {
+          if (invitation.isExpired) {
+            return;
+          }
+          window.location.assign(
+            `${config.getApiBaseUrl()}/api/login?inviteToken=${encodeURIComponent(invitation.token)}`
+          );
+        },
+      })),
+    [sortedInvitations]
+  );
+
+  const columns = useMemo<ColumnDef<PendingInvitationsTableRow>[]>(
+    () => [
+      {
+        accessorKey: "workspaceName",
+        header: "Workspace",
+        sortingFn: (rowA, rowB) =>
+          rowA.original.workspaceName.localeCompare(
+            rowB.original.workspaceName
+          ),
+        cell: ({ row }) => (
+          <DataTable.CellContent grow>
+            <div
+              className={classNames(
+                "flex flex-col gap-1 py-3",
+                row.original.isExpired && "opacity-60"
+              )}
+            >
+              <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {row.original.workspaceName}
+              </span>
+              <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                Role: {row.original.initialRole}
+              </span>
+            </div>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-full",
+        },
+      },
+      {
+        id: "createdAt",
+        header: "Invited",
+        sortingFn: (rowA, rowB) =>
+          rowA.original.createdAt - rowB.original.createdAt,
+        cell: ({ row }) => (
+          <DataTable.CellContent>
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {new Date(row.original.createdAt).toLocaleString()}
+            </span>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-48",
+        },
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => (
+          <DataTable.CellContent className="w-full justify-end">
+            <Button
+              size="xs"
+              variant={row.original.isExpired ? "outline" : "primary"}
+              label={row.original.isExpired ? "Expired" : "Join"}
+              disabled={row.original.isExpired}
+              onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                event.stopPropagation();
+                row.original.onJoin();
+              }}
+            />
+          </DataTable.CellContent>
+        ),
+        meta: {
+          className: "w-24",
+        },
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.length > 0 ? (
+        <DataTable
+          data={rows}
+          columns={columns}
+          sorting={[{ id: "workspaceName", desc: false }]}
+        />
+      ) : (
+        <Label>No pending invitations found.</Label>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Restores the user's "Pending Invitations" list that was lost when the page-based `/me` personal settings (`ProfilePage` + `PendingInvitationsTable`) was replaced by `UserSettingsPopover`.

It comes back as a dedicated **Invitations** tab in the popover, shown only when the user has at least one pending workspace invitation. Each row lists the workspace, invite date, and a **Join** button (expired invites are dimmed/disabled). The heavy `PendingInvitationsTable` is restored under `components/me/` (mirroring `NotificationPreferences`/`UserToolsTable`), with a thin `InvitationsSection` wrapper in the popover. The list is fetched via the existing `usePendingInvitations` hook, gated on `disabled: !open` since the popover is always mounted in the user menu.

## Tests

<img width="1055" height="590" alt="image" src="https://github.com/user-attachments/assets/3ae92c23-91e0-47cd-b815-9e38783030cf" />