### PR TITLE
fix(front): unblock sessions when personal tool-auth fails or is aborted

### DIFF
--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
@@ -1,0 +1,223 @@
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import type { LightWorkspaceType } from "@app/types/user";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MCPServerPersonalAuthenticationRequired } from "./MCPServerPersonalAuthenticationRequired";
+
+const createPersonalConnectionMock = vi.fn();
+const resolveAuthenticationMock = vi.fn();
+const removeCompletedActionMock = vi.fn();
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({ user: { sId: "user_1" } }),
+}));
+
+vi.mock(
+  "@app/components/assistant/conversation/BlockedActionsProvider",
+  () => ({
+    useBlockedActionsContext: () => ({
+      removeCompletedAction: removeCompletedActionMock,
+    }),
+  })
+);
+
+vi.mock("@app/lib/swr/mcp_servers", () => ({
+  useCreatePersonalConnection: () => ({
+    createPersonalConnection: createPersonalConnectionMock,
+  }),
+  useMCPServer: () => ({
+    server: {
+      sId: "mcp_1",
+      name: "GitHub",
+      icon: undefined,
+      authorization: {
+        provider: "github",
+        supported_use_cases: ["personal_actions"],
+      },
+    },
+  }),
+}));
+
+vi.mock("@app/hooks/useResolveAuthentication", () => ({
+  useResolveAuthentication: () => ({
+    resolveAuthentication: resolveAuthenticationMock,
+    isResolving: false,
+  }),
+}));
+
+vi.mock("@app/lib/actions/mcp_helper", () => ({
+  getMcpServerDisplayName: (server: { name: string }) => server.name,
+}));
+
+vi.mock("@app/lib/api/assistant/conversation/can_current_user_respond", () => ({
+  canCurrentUserRespondToParentUserMessage: () => true,
+}));
+
+vi.mock("@app/components/resources/resources_icons", () => ({
+  getAvatarFromIcon: () => null,
+}));
+
+vi.mock("@app/components/oauth/PersonalAuthCredentialOverrides", () => ({
+  areCredentialOverridesValid: () => true,
+  PersonalAuthCredentialOverrides: () => null,
+}));
+
+vi.mock("@app/types/oauth/lib", () => ({
+  getOverridablePersonalAuthInputs: () => null,
+}));
+
+vi.mock("@dust-tt/sparkle", () => ({
+  ActionCardBlock: ({
+    title,
+    description,
+    actions,
+  }: {
+    title: string;
+    description?: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+      <div>{actions}</div>
+    </div>
+  ),
+  Button: ({
+    label,
+    onClick,
+    disabled,
+  }: {
+    label: string;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {label}
+    </button>
+  ),
+  Check: () => null,
+  XClose: () => null,
+}));
+
+const owner: LightWorkspaceType = {
+  id: 1,
+  sId: "w_1",
+  name: "Workspace",
+  role: "user",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  regionalModelsOnly: false,
+  sharingPolicy: "workspace_only",
+  metronomeCustomerId: null,
+};
+
+function makeBlockedAction(): BlockedToolExecution & {
+  status: "blocked_authentication_required";
+} {
+  return {
+    conversationId: "conv_1",
+    messageId: "msg_1",
+    actionId: "action_1",
+    userId: "user_1",
+    configurationId: "config_1",
+    created: 1,
+    inputs: {},
+    metadata: {
+      toolName: "tool",
+      mcpServerName: "server",
+      agentName: "agent",
+      mcpServerId: "mcp_1",
+      mcpServerDisplayName: "GitHub",
+    },
+    status: "blocked_authentication_required",
+    authorizationInfo: {
+      provider: "github",
+      supported_use_cases: ["personal_actions"],
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function renderCard() {
+  return render(
+    <MCPServerPersonalAuthenticationRequired
+      blockedAction={makeBlockedAction()}
+      triggeringUser={null}
+      owner={owner}
+      mcpServerId="mcp_1"
+      provider="github"
+    />
+  );
+}
+
+function outcomesPassedToResolve(): Array<string> {
+  return resolveAuthenticationMock.mock.calls.map((call) => call[0].outcome);
+}
+
+describe("MCPServerPersonalAuthenticationRequired", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPersonalConnectionMock.mockResolvedValue({ success: true });
+    resolveAuthenticationMock.mockResolvedValue({ success: true });
+  });
+
+  it("resolves the action as completed on a successful connection", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: /Connect/i }));
+
+    expect(outcomesPassedToResolve()).toContain("completed");
+    expect(removeCompletedActionMock).toHaveBeenCalledWith("action_1");
+  });
+
+  it("keeps Skip enabled while a connection attempt is in flight", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<{ success: boolean }>();
+    createPersonalConnectionMock.mockReturnValue(pending.promise);
+
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: /Connect/i }));
+
+    // The connection promise is still pending, but Skip must remain clickable.
+    expect(screen.getByRole("button", { name: /Skip/i })).not.toBeDisabled();
+
+    await act(async () => {
+      pending.resolve({ success: true });
+      await pending.promise;
+    });
+  });
+
+  it("does not resolve completed when the user skips mid-connection", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<{ success: boolean }>();
+    createPersonalConnectionMock.mockReturnValue(pending.promise);
+
+    renderCard();
+
+    await user.click(screen.getByRole("button", { name: /Connect/i }));
+    await user.click(screen.getByRole("button", { name: /Skip/i }));
+
+    // Connection finishes *after* the user already skipped.
+    await act(async () => {
+      pending.resolve({ success: true });
+      await pending.promise;
+    });
+
+    const outcomes = outcomesPassedToResolve();
+    expect(outcomes).toContain("denied");
+    expect(outcomes).not.toContain("completed");
+  });
+});

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -18,7 +18,7 @@ import type { OAuthProvider } from "@app/types/oauth/lib";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ActionCardBlock, Button, Check, XClose } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 interface MCPServerPersonalAuthenticationRequiredProps {
   blockedAction: BlockedToolExecution;
@@ -58,6 +58,11 @@ export function MCPServerPersonalAuthenticationRequired({
     owner,
   });
 
+  // Tracks whether the user abandoned (skipped) this action while a connection
+  // attempt is still in flight, so the post-await "completed" branch does not
+  // resolve an action that has already been denied.
+  const cancelledRef = useRef<boolean>(false);
+
   const overridableInputs = getOverridablePersonalAuthInputs({ provider });
 
   const visual = mcpServer?.icon
@@ -79,6 +84,7 @@ export function MCPServerPersonalAuthenticationRequired({
   );
 
   const onConnectClick = async (mcpServer: MCPServerType) => {
+    cancelledRef.current = false;
     setIsConnecting(true);
     setConnectionError(null);
 
@@ -104,6 +110,12 @@ export function MCPServerPersonalAuthenticationRequired({
         return;
       }
 
+      // The user skipped while the connection attempt was still in flight: the
+      // action was already denied, so do not resolve it as completed.
+      if (cancelledRef.current) {
+        return;
+      }
+
       const completionRes = await resolveAuthentication({
         outcome: "completed",
         actionId: blockedAction.actionId,
@@ -124,6 +136,8 @@ export function MCPServerPersonalAuthenticationRequired({
   };
 
   const onSkipClick = async () => {
+    // Signal any in-flight connection attempt to abandon its completed branch.
+    cancelledRef.current = true;
     setConnectionError(null);
 
     const denyRes = await resolveAuthentication({
@@ -202,7 +216,9 @@ export function MCPServerPersonalAuthenticationRequired({
           size="xs"
           label="Skip"
           icon={XClose}
-          disabled={isConnecting || isResolving}
+          // Not gated on `isConnecting`: the user must always be able to abandon
+          // a connection attempt, even if it is (or appears) stuck.
+          disabled={isResolving}
           onClick={() => void onSkipClick()}
         />
         <Button


### PR DESCRIPTION
Fix https://github.com/dust-tt/tasks/issues/8980

## Description
A failed or aborted personal tool-authentication could leave a Session stuck: setupOAuthConnection only settled on a connection_finalized message, so a blocked popup, a popup the user closed, or a flow that never posted back left the promise pending forever. isConnecting stayed true, the card became fully disabled (Connect and Skip both gated on it), the action was never resolved, and later user messages queued behind it indefinitely. This also leaked a window message listener per hung flow.

Defense in depth in the auth card so a stuck attempt can always be abandoned:
- Skip is no longer gated on isConnecting (only isResolving).
- A cancelledRef guards the post-await branch so skipping mid-connection does not resolve an already-denied action as completed.

The card is shared by Sessions and conversations via BlockedActionsProvider, so both surfaces are covered. Adds tests for every settle path, the skip-mid-connection race, and the retry-after-failure path.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually 
Now, cancel remains enabled after you attempt to authorize
If you cancel, the tool auth will re-appear and user can either retry or skip entirely
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
