### PR TITLE
add Mistral provider and Mistral Large endpoint

### DIFF
--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -1,0 +1,15 @@
+export function WithDustMistralLargeConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustMistralLarge extends Base {
+    static readonly displayName = "Mistral Large";
+    static readonly description = "Mistral's large model (256k context).";
+    // Mistral Large is a non-reasoning model.
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = true;
+  }
+
+  return DustMistralLarge;
+}

--- a/front/lib/llms/stream/endpoints/mistral_eu_mistral_large.ts
+++ b/front/lib/llms/stream/endpoints/mistral_eu_mistral_large.ts
@@ -1,0 +1,11 @@
+import { WithDustMistralLargeConfig } from "@app/lib/llms/providers/mistral/models/mistral_large";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
+
+export class DustMistralEuropeMistralLargeStream extends WithDustMistralLargeConfig(
+  MistralEuropeMistralLargeStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustMistralEuropeMistralLargeStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -4,6 +4,7 @@ import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/s
 import { DustGoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { DustMistralEuropeMistralLargeStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_large";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
@@ -26,6 +27,7 @@ export const DUST_STREAM_ENDPOINTS = {
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
   [DustGoogleAiStudioGlobalGemini31FlashLiteStream.id]:
     DustGoogleAiStudioGlobalGemini31FlashLiteStream,
+  [DustMistralEuropeMistralLargeStream.id]: DustMistralEuropeMistralLargeStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/providers/mistral/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/input/index.ts
@@ -1,0 +1,63 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  assistantReasoningMessageToMessage,
+  assistantTextMessageToMessage,
+  assistantToolCallRequestToMessage,
+  conversationToMistralMessages,
+  forceToolNameToToolChoice,
+  type MistralMessageConverters,
+  outputFormatToResponseFormat,
+  systemMessageToMessage,
+  toolCallResultMessageToMessage,
+  toTool,
+  userImageMessageToMessage,
+  userTextMessageToMessage,
+} from "@app/lib/model_constructors/providers/mistral/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type { ChatCompletionStreamRequest } from "@mistralai/mistralai/models/components";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the Mistral
+// `chat.stream` request shape. Leaf converters are bound as class fields and the
+// composite routes through `this`, so an endpoint can override a single leaf.
+export function WithMistralInputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithMistralInputConverter
+    extends Base
+    implements MistralMessageConverters
+  {
+    systemMessageToMessage = systemMessageToMessage;
+    userTextMessageToMessage = userTextMessageToMessage;
+    userImageMessageToMessage = userImageMessageToMessage;
+    toolCallResultMessageToMessage = toolCallResultMessageToMessage;
+    assistantTextMessageToMessage = assistantTextMessageToMessage;
+    assistantReasoningMessageToMessage = assistantReasoningMessageToMessage;
+    assistantToolCallRequestToMessage = assistantToolCallRequestToMessage;
+
+    buildRequestPayload(
+      payload: Payload,
+      config: InputConfig
+    ): ChatCompletionStreamRequest {
+      const { conversation } = payload;
+      const { tools = [], temperature, forceTool, outputFormat } = config;
+
+      // Mistral is not sent an explicit max-output cap (matching the legacy
+      // client); it uses its own default.
+      return {
+        model: this.constructor.modelId,
+        messages: conversationToMistralMessages(conversation, this),
+        temperature,
+        tools: tools.map(toTool),
+        toolChoice: forceToolNameToToolChoice(tools, forceTool),
+        ...(outputFormat
+          ? { responseFormat: outputFormatToResponseFormat(outputFormat) }
+          : {}),
+      };
+    }
+  }
+
+  return WithMistralInputConverter;
+}

--- a/front/lib/model_constructors/providers/mistral/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/input/utils.ts
@@ -1,0 +1,241 @@
+import type {
+  OutputFormat,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  ChatCompletionStreamRequest,
+  ResponseFormat,
+  Tool,
+  ToolChoice,
+} from "@mistralai/mistralai/models/components";
+
+type MistralMessage = ChatCompletionStreamRequest["messages"][number];
+
+const TOOL_CALL_ID_LENGTH = 9;
+
+// Mistral requires tool-call ids to be exactly 9 alphanumeric chars, but ids can
+// originate from other providers. Normalize to that shape deterministically.
+export function sanitizeToolCallId(id: string): string {
+  let s = id.replace(/[^a-zA-Z0-9]/g, "0");
+  if (s.length > TOOL_CALL_ID_LENGTH) {
+    s = s.slice(0, TOOL_CALL_ID_LENGTH);
+  }
+  if (s.length < TOOL_CALL_ID_LENGTH) {
+    s = s.padStart(TOOL_CALL_ID_LENGTH, "0");
+  }
+  return s;
+}
+
+// The per-message leaf converters. The composite below takes an object
+// satisfying this interface (`this`), so overriding one leaf on an endpoint
+// changes how the composite uses it.
+export interface MistralMessageConverters {
+  systemMessageToMessage(message: SystemTextMessage): MistralMessage;
+  userTextMessageToMessage(message: BaseUserTextMessage): MistralMessage;
+  userImageMessageToMessage(message: BaseUserImageMessage): MistralMessage;
+  toolCallResultMessageToMessage(
+    message: BaseToolCallResultMessage
+  ): MistralMessage;
+  assistantTextMessageToMessage(
+    message: BaseAssistantTextMessage
+  ): MistralMessage;
+  assistantReasoningMessageToMessage(
+    message: BaseAssistantReasoningMessage
+  ): MistralMessage;
+  assistantToolCallRequestToMessage(
+    message: BaseAssistantToolCallRequestMessage
+  ): MistralMessage;
+}
+
+// -- Leaf converters: one Mistral message per conversation message --
+
+export function systemMessageToMessage(
+  message: SystemTextMessage
+): MistralMessage {
+  return { role: "system", content: message.content.value };
+}
+
+export function userTextMessageToMessage(
+  message: BaseUserTextMessage
+): MistralMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: message.content.value }],
+  };
+}
+
+export function userImageMessageToMessage(
+  message: BaseUserImageMessage
+): MistralMessage {
+  return {
+    role: "user",
+    content: [{ type: "image_url", imageUrl: message.content.url }],
+  };
+}
+
+export function toolCallResultMessageToMessage(
+  message: BaseToolCallResultMessage
+): MistralMessage {
+  const content = message.content.parts
+    .map((part) => {
+      switch (part.type) {
+        case "text":
+          return part.text;
+        case "image_url":
+          return part.url;
+        default:
+          return assertNever(part);
+      }
+    })
+    .join("\n");
+
+  return {
+    role: "tool",
+    content,
+    toolCallId: sanitizeToolCallId(message.content.callId),
+  };
+}
+
+export function assistantTextMessageToMessage(
+  message: BaseAssistantTextMessage
+): MistralMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: message.content.value }],
+  };
+}
+
+export function assistantReasoningMessageToMessage(
+  message: BaseAssistantReasoningMessage
+): MistralMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "thinking",
+        thinking: [{ type: "text", text: message.content.value }],
+      },
+    ],
+  };
+}
+
+export function assistantToolCallRequestToMessage(
+  message: BaseAssistantToolCallRequestMessage
+): MistralMessage {
+  return {
+    role: "assistant",
+    toolCalls: [
+      {
+        id: sanitizeToolCallId(message.content.callId),
+        function: {
+          name: message.content.toolName,
+          arguments: message.content.arguments,
+        },
+      },
+    ],
+  };
+}
+
+// -- Composite message converter --
+
+function userMessageToMessage(
+  message: BaseUserMessage,
+  converters: MistralMessageConverters
+): MistralMessage {
+  switch (message.type) {
+    case "text":
+      return converters.userTextMessageToMessage(message);
+    case "image_url":
+      return converters.userImageMessageToMessage(message);
+    case "tool_call_result":
+      return converters.toolCallResultMessageToMessage(message);
+    default:
+      assertNever(message);
+  }
+}
+
+function assistantMessageToMessage(
+  message: BaseAssistantMessage,
+  converters: MistralMessageConverters
+): MistralMessage {
+  switch (message.type) {
+    case "text":
+      return converters.assistantTextMessageToMessage(message);
+    case "reasoning":
+      return converters.assistantReasoningMessageToMessage(message);
+    case "tool_call_request":
+      return converters.assistantToolCallRequestToMessage(message);
+    default:
+      assertNever(message);
+  }
+}
+
+export function conversationToMistralMessages(
+  conversation: BaseConversation,
+  converters: MistralMessageConverters
+): MistralMessage[] {
+  const system = conversation.system.map((message) =>
+    converters.systemMessageToMessage(message)
+  );
+  const messages = conversation.messages.map((message) => {
+    switch (message.role) {
+      case "user":
+        return userMessageToMessage(message, converters);
+      case "assistant":
+        return assistantMessageToMessage(message, converters);
+      default:
+        assertNever(message);
+    }
+  });
+  return [...system, ...messages];
+}
+
+// -- Config converters (pure) --
+
+export function toTool(tool: ToolSpecification): Tool {
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+      strict: false,
+    },
+  };
+}
+
+export function forceToolNameToToolChoice(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ToolChoice | "auto" {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? { type: "function", function: { name: forceTool } }
+    : "auto";
+}
+
+export function outputFormatToResponseFormat(
+  outputFormat: OutputFormat
+): ResponseFormat {
+  return {
+    type: "json_schema",
+    jsonSchema: {
+      name: outputFormat.json_schema.name,
+      description: outputFormat.json_schema.description,
+      schemaDefinition: outputFormat.json_schema.schema,
+      strict: outputFormat.json_schema.strict ?? undefined,
+    },
+  };
+}

--- a/front/lib/model_constructors/providers/mistral/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/output/utils.ts
@@ -1,0 +1,335 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ModelResponseEvent,
+  ReasoningEvent,
+  TextEvent,
+  ToolCallEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isRecord, isString } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import type {
+  CompletionEvent,
+  ContentChunk,
+  ThinkChunk,
+  ToolCall,
+  UsageInfo,
+} from "@mistralai/mistralai/models/components";
+import { CompletionResponseStreamChoiceFinishReason } from "@mistralai/mistralai/models/components";
+import { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
+
+// Parses tool-call arguments into an object, falling back to `{}` for malformed
+// or non-object JSON.
+function parseToolArguments(argumentsJson: string): Record<string, unknown> {
+  const parsed = safeParseJSON(argumentsJson);
+  if (parsed.isErr() || parsed.value === null || !isRecord(parsed.value)) {
+    return {};
+  }
+  return parsed.value;
+}
+
+function thinkingChunkToText(thinking: ThinkChunk["thinking"]): string {
+  return thinking
+    .map((chunk) => (chunk.type === "text" ? chunk.text : ""))
+    .join("");
+}
+
+function usageToTokenUsageEvent(
+  metadata: EndpointMetadata,
+  usage: UsageInfo | undefined
+): ModelResponseEvent {
+  return {
+    type: "token_usage",
+    content: {
+      cacheCreated: 0,
+      longCacheCreated: 0,
+      shortCacheCreated: 0,
+      cacheHit: 0,
+      standardInput: usage?.promptTokens ?? 0,
+      standardOutput: usage?.completionTokens ?? 0,
+      reasoning: 0,
+    },
+    metadata,
+  };
+}
+
+// Maps any error thrown by the Mistral SDK while streaming into a unified
+// `ErrorEvent`, so everything leaving the endpoint is an event, not an exception.
+export function streamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  if (error instanceof MistralError) {
+    const status = error.statusCode;
+    switch (status) {
+      case 400:
+        return buildErrorEvent({
+          metadata,
+          type: "invalid_request_error",
+          message: `Invalid request to Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 401:
+        return buildErrorEvent({
+          metadata,
+          type: "authentication_error",
+          message: `Authentication failed for Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 403:
+        return buildErrorEvent({
+          metadata,
+          type: "permission_error",
+          message: `Permission denied for Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 404:
+        return buildErrorEvent({
+          metadata,
+          type: "not_found_error",
+          message: `Resource not found for Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 429:
+        return buildErrorEvent({
+          metadata,
+          type: "rate_limit_error",
+          message: `Rate limit exceeded for Mistral/${metadata.modelId}: ${error.message}`,
+          originalError: error,
+        });
+      default:
+        if (status >= 500 && status < 600) {
+          return buildErrorEvent({
+            metadata,
+            type: "server_error",
+            message: `Server error from Mistral (${status}): ${error.message}`,
+            originalError: error,
+          });
+        }
+        return buildErrorEvent({
+          metadata,
+          type: "unknown_error",
+          message: `Error from Mistral (${status}): ${error.message}`,
+          originalError: error,
+        });
+    }
+  }
+  return buildErrorEvent({
+    metadata,
+    type: "unknown_error",
+    message: `Unknown error from Mistral: ${normalizeError(error).message}`,
+    originalError: error,
+  });
+}
+
+type Accumulator = {
+  textParts: string;
+  reasoningParts: string;
+  toolCallIndex: number;
+};
+
+// Flushes pending reasoning then text as accumulated events, appending them to
+// `aggregated`. Reasoning is flushed before text so the final text block stays
+// last (checkers assert on the last aggregated event).
+function flushAccumulated(
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  const events: ModelResponseEvent[] = [];
+  if (acc.reasoningParts) {
+    const event: ReasoningEvent = {
+      type: "reasoning",
+      content: { value: acc.reasoningParts },
+      metadata,
+    };
+    aggregated.push(event);
+    events.push(event);
+    acc.reasoningParts = "";
+  }
+  if (acc.textParts) {
+    const event: TextEvent = {
+      type: "text",
+      content: { value: acc.textParts },
+      metadata,
+    };
+    aggregated.push(event);
+    events.push(event);
+    acc.textParts = "";
+  }
+  return events;
+}
+
+function contentToEvents(
+  content: string | ContentChunk[],
+  acc: Accumulator,
+  metadata: EndpointMetadata
+): ModelResponseEvent[] {
+  if (isString(content)) {
+    if (!content) {
+      return [];
+    }
+    acc.textParts += content;
+    return [{ type: "text_delta", content: { value: content }, metadata }];
+  }
+
+  const events: ModelResponseEvent[] = [];
+  for (const chunk of content) {
+    switch (chunk.type) {
+      case "text":
+        if (chunk.text) {
+          acc.textParts += chunk.text;
+          events.push({
+            type: "text_delta",
+            content: { value: chunk.text },
+            metadata,
+          });
+        }
+        break;
+      case "thinking": {
+        const text = thinkingChunkToText(chunk.thinking);
+        if (text) {
+          acc.reasoningParts += text;
+          events.push({
+            type: "reasoning_delta",
+            content: { value: text },
+            metadata,
+          });
+        }
+        break;
+      }
+      default:
+        // Only text and thinking chunks are surfaced.
+        break;
+    }
+  }
+  return events;
+}
+
+function toolCallToEvents(
+  toolCall: ToolCall,
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  if (!toolCall.id) {
+    return [];
+  }
+  const args = isString(toolCall.function.arguments)
+    ? parseToolArguments(toolCall.function.arguments)
+    : toolCall.function.arguments;
+
+  const events: ModelResponseEvent[] = [
+    {
+      type: "tool_call_started",
+      content: {
+        id: toolCall.id,
+        index: acc.toolCallIndex,
+        name: toolCall.function.name,
+      },
+      metadata,
+    },
+  ];
+  const toolCallEvent: ToolCallEvent = {
+    type: "tool_call",
+    content: { id: toolCall.id, name: toolCall.function.name, arguments: args },
+    metadata,
+  };
+  aggregated.push(toolCallEvent);
+  events.push(toolCallEvent);
+  acc.toolCallIndex += 1;
+  return events;
+}
+
+// -- Entry point: drive the raw Mistral stream into unified events --
+
+export async function* rawOutputToEvents(
+  stream: AsyncGenerator<CompletionEvent>,
+  metadata: EndpointMetadata
+): AsyncGenerator<ModelResponseEvent> {
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const acc: Accumulator = {
+    textParts: "",
+    reasoningParts: "",
+    toolCallIndex: 0,
+  };
+  let hasYieldedResponseId = false;
+  let usage: UsageInfo | undefined;
+
+  while (true) {
+    let result: IteratorResult<CompletionEvent>;
+    try {
+      result = await stream.next();
+    } catch (err) {
+      yield streamErrorToErrorEvent(metadata, err);
+      return;
+    }
+    if (result.done) {
+      break;
+    }
+
+    const event = result.value;
+    if (!hasYieldedResponseId && event.data.id) {
+      yield {
+        type: "response_id",
+        content: { responseId: event.data.id },
+        metadata,
+      };
+      hasYieldedResponseId = true;
+    }
+    usage = event.data.usage ?? usage;
+
+    const choice = event.data.choices?.[0];
+    if (!choice) {
+      continue;
+    }
+    const { delta, finishReason } = choice;
+
+    if (delta.toolCalls) {
+      // Flush any text/reasoning produced before the tool call.
+      for (const e of flushAccumulated(acc, metadata, aggregated)) {
+        yield e;
+      }
+      for (const toolCall of delta.toolCalls) {
+        for (const e of toolCallToEvents(toolCall, acc, metadata, aggregated)) {
+          yield e;
+        }
+      }
+    } else if (delta.content) {
+      for (const e of contentToEvents(delta.content, acc, metadata)) {
+        yield e;
+      }
+    }
+
+    if (!finishReason) {
+      continue;
+    }
+    switch (finishReason) {
+      case CompletionResponseStreamChoiceFinishReason.Length:
+        yield buildErrorEvent({
+          metadata,
+          type: "stop_error",
+          message: "The maximum response length was reached.",
+        });
+        return;
+      case CompletionResponseStreamChoiceFinishReason.Error:
+        yield buildErrorEvent({
+          metadata,
+          type: "server_error",
+          message: "Mistral reported an error during completion.",
+        });
+        return;
+      // Stop / ToolCalls: flush any pending text/reasoning before success.
+      default:
+        for (const e of flushAccumulated(acc, metadata, aggregated)) {
+          yield e;
+        }
+        break;
+    }
+  }
+
+  yield usageToTokenUsageEvent(metadata, usage);
+  yield { type: "success", content: { aggregated }, metadata };
+}

--- a/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
@@ -1,0 +1,39 @@
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { MISTRAL_LARGE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// Verified against https://docs.mistral.ai/getting-started/models/models_overview
+// (2026-06-18): Mistral Large (mistral-large-3) has a 256k-token context window.
+const CONTEXT_SIZE = 256_000;
+// Capability metadata only — the request does not send an explicit max (the
+// legacy client doesn't either), so Mistral uses its own default.
+const MAX_OUTPUT_TOKENS = 2_048;
+
+// Mistral Large is a non-reasoning model: it only accepts `none`, and the
+// request never sends a reasoning effort. Temperature passes through unchanged.
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.literal("none") })
+    .default({ effort: "none" }),
+  // Mistral has no explicit prompt-cache key.
+  cacheKey: z.undefined(),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithMistralLargeConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class MistralLarge extends Base {
+    static readonly modelId = MISTRAL_LARGE_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return MistralLarge;
+}

--- a/front/lib/model_constructors/stream/clients/mistral.ts
+++ b/front/lib/model_constructors/stream/clients/mistral.ts
@@ -1,0 +1,47 @@
+import { WithMistralInputConverter } from "@app/lib/model_constructors/providers/mistral/converters/input";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/mistral/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { MISTRAL_API } from "@app/lib/model_constructors/types/provider_apis";
+import { MISTRAL_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { Mistral } from "@mistralai/mistralai";
+import type {
+  ChatCompletionStreamRequest,
+  CompletionEvent,
+} from "@mistralai/mistralai/models/components";
+
+import type { z } from "zod";
+
+export abstract class MistralStream extends WithMistralInputConverter(
+  StreamEndpoint<ChatCompletionStreamRequest, CompletionEvent>
+) {
+  static readonly providerId = MISTRAL_PROVIDER_ID;
+  static readonly api = MISTRAL_API;
+
+  static readonly configSchema: z.ZodType<z.infer<typeof inputConfigSchema>> =
+    inputConfigSchema;
+
+  private readonly client: Mistral;
+
+  constructor({ MISTRAL_API_KEY }: Credentials) {
+    super();
+    this.client = new Mistral({ apiKey: MISTRAL_API_KEY });
+  }
+
+  async *streamRaw(
+    input: ChatCompletionStreamRequest
+  ): AsyncGenerator<CompletionEvent> {
+    const stream = await this.client.chat.stream(input);
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<CompletionEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata());
+  }
+}

--- a/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large.ts
+++ b/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large.ts
@@ -1,0 +1,21 @@
+import { WithMistralLargeConfig } from "@app/lib/model_constructors/providers/mistral/models/mistral_large";
+import { MistralStream } from "@app/lib/model_constructors/stream/clients/mistral";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class MistralEuropeMistralLargeStream extends WithMistralLargeConfig(
+  MistralStream
+) {
+  // https://mistral.ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    standardInput: 2.0,
+    standardOutput: 6.0,
+  };
+
+  // Inference runs in the EU; the endpoint remains usable from both US and EU.
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+}
+
+MistralEuropeMistralLargeStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -4,6 +4,7 @@ import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_cons
 import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const STREAM_ENDPOINTS = {
@@ -19,6 +20,7 @@ export const STREAM_ENDPOINTS = {
     OpenAIResponsesGlobalGptFiveDotFiveStream,
   [GoogleAiStudioGlobalGemini31FlashLiteStream.id]:
     GoogleAiStudioGlobalGemini31FlashLiteStream,
+  [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new MistralEuropeMistralLargeStream({
+      MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
+    }),
+  // Mistral Large is a non-reasoning model: only `none` is accepted, so every
+  // other reasoning effort is rejected by the config schema.
+  tests: {
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+
+    // Supported (`none`/default) cases run with their default checkers.
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
+runStreamEndpointTests(MistralEuropeMistralLargeStream, setup);

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -4,4 +4,5 @@ export type Credentials = {
   ANTHROPIC_API_KEY?: string;
   GOOGLE_AI_STUDIO_API_KEY?: string;
   AGENT_PLATFORM_PROJECT_ID?: string;
+  MISTRAL_API_KEY?: string;
 };

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -8,6 +8,8 @@ export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 export const GEMINI_3_5_FLASH_MODEL_ID = "gemini-3.5-flash" as const;
 export const GEMINI_3_1_FLASH_LITE_MODEL_ID = "gemini-3.1-flash-lite" as const;
 
+export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
+
 // Include a few examples for now
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
@@ -17,6 +19,7 @@ export const MODEL_IDS = [
   GEMINI_3_1_PRO_MODEL_ID,
   GEMINI_3_5_FLASH_MODEL_ID,
   GEMINI_3_1_FLASH_LITE_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -2,11 +2,13 @@ export const OPENAI_RESPONSES_API = "openai-responses" as const;
 export const ANTHROPIC_API = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_API = "google-ai-studio" as const;
 export const AGENT_PLATFORM_API = "agent-platform" as const;
+export const MISTRAL_API = "mistral" as const;
 
 const PROVIDER_APIS = [
   OPENAI_RESPONSES_API,
   ANTHROPIC_API,
   GOOGLE_AI_STUDIO_API,
   AGENT_PLATFORM_API,
+  MISTRAL_API,
 ] as const;
 export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -3,6 +3,7 @@ import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 export const OPENAI_PROVIDER_ID = "openai" as const;
 export const ANTHROPIC_PROVIDER_ID = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
+export const MISTRAL_PROVIDER_ID = "mistral" as const;
 
 // `satisfies readonly ModelProviderIdType[]` guarantees every new-system
 // provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
@@ -13,6 +14,7 @@ const PROVIDER_IDS = [
   OPENAI_PROVIDER_ID,
   ANTHROPIC_PROVIDER_ID,
   GOOGLE_AI_STUDIO_PROVIDER_ID,
+  MISTRAL_PROVIDER_ID,
 ] as const satisfies readonly ModelProviderIdType[];
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 


### PR DESCRIPTION
  ## What & why

  Adds **Mistral** as a new provider in the model_constructors router, plus the
  `mistral-large-latest` stream endpoint, wired for runtime use. Unlike the Gemini
  Flash/Flash-Lite additions, Mistral shares no provider layer with existing
  providers, so this ports a full provider from the legacy `@mistralai/mistralai`
  client.

  ## Region / availability

  The endpoint is `region: eu` (inference runs in the EU), but it is **not**
  restricted to EU workspaces — Mistral is usable from both US and EU. No change
  was made to the shared region filter (`getRegionFilter` already never blocks the
  US region), and `endpointFilter` is empty.

  ## Changes

  **Types**
  - `MISTRAL_PROVIDER_ID` (`mistral`), `MISTRAL_API` (`mistral`),
    `MISTRAL_LARGE_MODEL_ID` (`mistral-large-latest`), and the `MISTRAL_API_KEY`
    credential.

  **Provider layer (`providers/mistral/`)** — ported from the legacy client:
  - input converter: conversation → Mistral messages (text/image/tool-result/
    assistant/tool-call), tools, tool-choice, response-format; `sanitizeToolCallId`.
  - output converter: Mistral stream → unified `ModelResponseEvent`s (text, tool
    calls, usage, finish-reason and SDK error mapping). Reasoning chunks are
    handled generically even though Large doesn't emit them.
  - model-config mixin: **non-reasoning** (`none`-only schema, default `none`),
    256k context. No `maxTokens` is sent (matching the legacy client).
  - `MistralStream` SDK client.

  **Endpoint + wiring**
  - `stream/endpoints/mistral_eu_mistral_large.ts` (`mistral/mistral/eu/mistral-large-latest`),
    registered in `STREAM_ENDPOINTS`.
  - `lib/llms` Dust wrapper (`defaultReasoningEffort: "none"`) registered in
    `DUST_STREAM_ENDPOINTS`, so it's runtime-selectable behind `use_new_llm_router`.

  **Tests**
  - New live-API endpoint test. Since Mistral Large only supports `none`, every
    non-`none` reasoning effort asserts `input_configuration_error`; the supported
    cases run their default checkers.

  ## Testing
  - `tsgo` clean; biome clean.
  - Live Mistral API: **40/40** (text, multi-turn, tool calls, forced tools,
    output-format, cache-markers-ignored; unsupported reasoning efforts reject
    locally before any request).

  ## Note
  - `tokenPricing` carries a "verify before launch" comment — confirm against
    Mistral's pricing page before enabling for real workspaces.