### PR TITLE
[LLM] Exclude google_ai_studio from non-BYOK provider filter

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -302,7 +302,10 @@ function getProviderIdFilter(auth: Authenticator): ValueFilter<ProviderId> {
   const byok = auth.getNonNullablePlan().isByok;
   const providerIds = byok
     ? intersection(whitelistedProviderIds, BYOK_MODEL_PROVIDER_IDS)
-    : whitelistedProviderIds;
+    : whitelistedProviderIds.filter(
+        // We route all non-byok gemini requests to agent platform
+        (providerId) => providerId !== "google_ai_studio"
+      );
 
   return { in: providerIds };
 }


### PR DESCRIPTION
## Description

Filter `google_ai_studio` out of the whitelisted providers for non-BYOK workspaces so non-BYOK Gemini requests get routed to the agent platform instead.

## Tests

Tested locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`