### PR TITLE
[connectors] Microsoft sensitivity-label reconciliation via Search API

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -707,18 +707,27 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
           );
         }
         await config.update({ allowedSensitivityLabels: labels });
+        const fullSyncRes = await launchMicrosoftFullSyncWorkflow(
+          this.connectorId
+        );
+        if (fullSyncRes.isErr()) {
+          return fullSyncRes;
+        }
+        // Reconciliation workflow handles ongoing drift (label changes on files
+        // in Microsoft with no content change, which delta misses). Start it
+        // when filtering is active, stop it when filtering is disabled.
         if (!labels || labels.length === 0) {
           await terminateWorkflow(
             microsoftSensitivityLabelsReconciliationWorkflowId(this.connectorId)
           );
-          return new Ok(undefined);
-        }
-        const workflowRes =
-          await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
-            this.connectorId
-          );
-        if (workflowRes.isErr()) {
-          return workflowRes;
+        } else {
+          const reconcileRes =
+            await launchMicrosoftSensitivityLabelsReconciliationWorkflow(
+              this.connectorId
+            );
+          if (reconcileRes.isErr()) {
+            return reconcileRes;
+          }
         }
         return new Ok(undefined);
       }

--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -18,7 +18,7 @@ import {
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { normalizeError } from "@connectors/types";
 import type { LoggerInterface, Result } from "@dust-tt/client";
-import { assertNever, Err, Ok } from "@dust-tt/client";
+import { assertNever, Err, Ok, removeNulls } from "@dust-tt/client";
 import type { Client } from "@microsoft/microsoft-graph-client";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import type {
@@ -593,6 +593,65 @@ export function getDriveInternalIdFromItem(item: DriveItem) {
 
 export function getSiteAPIPath(site: Site) {
   return `/sites/${site.id}`;
+}
+
+const SEARCH_DRIVE_ITEMS_PAGE_SIZE = 200;
+
+export async function searchDriveItems(
+  logger: LoggerInterface,
+  client: Client,
+  { queryString, from }: { queryString: string; from: number }
+): Promise<{ internalIds: string[]; nextFrom: number | null }> {
+  const response = await clientApiPost(logger, client, "/search/query", {
+    requests: [
+      {
+        entityTypes: ["driveItem"],
+        query: { queryString },
+        from,
+        size: SEARCH_DRIVE_ITEMS_PAGE_SIZE,
+        fields: ["id", "name", "parentReference", "webUrl", "file", "folder"],
+      },
+    ],
+  });
+
+  const container = response.value?.[0]?.hitsContainers?.[0];
+  const hits: Array<{ resource?: DriveItem }> = container?.hits ?? [];
+  const moreResultsAvailable = container?.moreResultsAvailable ?? false;
+
+  const internalIds: string[] = [];
+  for (const { resource } of hits) {
+    if (!resource?.file) {
+      continue;
+    }
+
+    try {
+      internalIds.push(getDriveItemInternalId(resource));
+    } catch (error) {
+      logger.warn(
+        { error: normalizeError(error) },
+        "[searchDriveItems] Could not build internalId, skipping"
+      );
+    }
+  }
+
+  return {
+    internalIds,
+    nextFrom: moreResultsAvailable ? from + SEARCH_DRIVE_ITEMS_PAGE_SIZE : null,
+  };
+}
+
+export async function getSensitivityLabels(
+  logger: LoggerInterface,
+  client: Client
+): Promise<string[]> {
+  const res = await clientApiGet(
+    logger,
+    client,
+    "/security/dataSecurityAndGovernance/sensitivityLabels"
+  );
+
+  const labels: Array<{ id?: string }> = res?.value ?? [];
+  return removeNulls(labels.map((label) => label.id ?? null));
 }
 
 export async function wrapMicrosoftGraphAPIWithResult<T>(

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -12,11 +12,14 @@ import {
   getFullDeltaResults,
   getItem,
   getParentReferenceInternalId,
+  getSensitivityLabels,
   getSiteAPIPath,
   getSites,
   itemToMicrosoftNode,
+  searchDriveItems,
 } from "@connectors/connectors/microsoft/lib/graph_api";
 import {
+  DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS,
   type DriveItem,
   MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
   type MicrosoftNode,
@@ -38,12 +41,12 @@ import {
 // biome-ignore lint/suspicious/noImportCycles: ignored using `--suppress`
 import { launchMicrosoftFullSyncWorkflow } from "@connectors/connectors/microsoft/temporal/client";
 import {
+  computeDisallowedLabels,
   deleteFile,
   deleteFolder,
   getParents,
   isAlreadySeenItem,
   recursiveNodeDeletion,
-  removeFileBasedOnSensitivityLabel,
   shouldSyncFileBasedOnSensitivityLabels,
   syncOneFile,
   updateDescendantsParentsInCore,
@@ -57,6 +60,7 @@ import {
   getAdaptiveConcurrency,
 } from "@connectors/lib/async_utils";
 import {
+  deleteDataSourceDocument,
   MAX_FILE_SIZE_TO_DOWNLOAD,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";
@@ -194,6 +198,9 @@ async function readDeltaFromGCSStream(
 
 const FILES_SYNC_CONCURRENCY = 10;
 const DELETE_CONCURRENCY = 5;
+
+// Page size for scanning sensitivity-label-skipped nodes during reconciliation.
+const HIDDEN_FILES_PAGE_SIZE = 50;
 
 export async function getRootNodesToSync(
   connectorId: ModelId
@@ -882,20 +889,15 @@ export async function syncFiles({
   }
 }
 
-export async function reconcileSensitivityLabelsForParent({
-  connectorId,
-  parentInternalId,
-  startSyncTs,
-  nextPageLink,
-}: {
-  connectorId: ModelId;
-  parentInternalId: string;
-  startSyncTs: number;
-  nextPageLink?: string;
-}): Promise<{
-  childNodes: string[];
-  nextLink?: string;
-}> {
+/**
+ * Returns the tenant sensitivity labels that are NOT in the connector's allowed
+ * set. This drives the Search queries that find already-synced files which
+ * should now be excluded. When no labels are configured (filtering disabled) the
+ * set is empty — we never exclude anything in that case.
+ */
+export async function getDisallowedSensitivityLabelGuids(
+  connectorId: ModelId
+): Promise<string[]> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector ${connectorId} not found`);
@@ -910,121 +912,203 @@ export async function reconcileSensitivityLabelsForParent({
   }
 
   const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  if (allowedLabels.length === 0) {
+    return [];
+  }
+
   const client = await getMicrosoftClient(connector.connectionId);
+  const tenantLabels = await getSensitivityLabels(logger, client);
 
-  let childrenResult: {
-    results: DriveItem[];
-    nextLink?: string;
-  };
-  try {
-    childrenResult = await getFilesAndFolders(
-      logger,
-      client,
-      parentInternalId,
-      nextPageLink,
-      allowedLabels.length > 0
-    );
-  } catch (error) {
-    if (isItemNotFoundError(error) || isMalformedDriveError(error)) {
-      logger.info(
-        {
-          connectorId,
-          parentInternalId,
-          error: normalizeError(error).message,
-        },
-        "[ReconcileSensitivityLabels] Parent not found or malformed, skipping subtree"
-      );
-      return {
-        childNodes: [],
-        nextLink: undefined,
-      };
-    }
-    throw error;
-  }
-
-  const mimeTypesToSync = await getMimeTypesToSync({
-    pdfEnabled: providerConfig.pdfEnabled || false,
-    csvEnabled: providerConfig.csvEnabled || false,
+  const disallowedLabels = computeDisallowedLabels({
+    tenantLabels,
+    allowedLabels,
   });
-
-  let removedCount = 0;
-  let addedCount = 0;
-
-  for (const child of childrenResult.results) {
-    await heartbeat();
-
-    if (!child.file) {
-      continue;
-    }
-
-    if (!child.parentReference) {
-      throw new Error(`Unexpected: parent reference missing: ${child}`);
-    }
-
-    const mimeType = child.file.mimeType;
-    if (!mimeType || !mimeTypesToSync.includes(mimeType)) {
-      continue;
-    }
-
-    const internalId = getDriveItemInternalId(child);
-    const fileResource = await MicrosoftNodeResource.fetchByInternalId(
-      connectorId,
-      internalId
-    );
-
-    const shouldSync = shouldSyncFileBasedOnSensitivityLabels({
-      fields: child.listItem?.fields,
-      allowedLabels,
-    });
-
-    const isHiddenBySensitivityLabel =
-      fileResource?.skipReason ===
-      MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED;
-
-    if (!shouldSync) {
-      await removeFileBasedOnSensitivityLabel({
-        connectorId,
-        dataSourceConfig,
-        file: child,
-        fileResource,
-        parentInternalId,
-        logger,
-      });
-      removedCount++;
-    } else if (!fileResource || isHiddenBySensitivityLabel) {
-      const didSync = await syncOneFile({
-        connectorId,
-        dataSourceConfig,
-        providerConfig,
-        file: child,
-        parentInternalId: getParentReferenceInternalId(child.parentReference),
-        startSyncTs,
-        heartbeat,
-      });
-      if (didSync) {
-        addedCount++;
-      }
-    }
-  }
 
   logger.info(
     {
       connectorId,
-      parentInternalId,
-      removedCount,
-      addedCount,
+      allowedCount: allowedLabels.length,
+      tenantCount: tenantLabels.length,
+      disallowedCount: disallowedLabels.length,
     },
-    "[ReconcileSensitivityLabels] Parent page reconciled"
+    "[SensitivityLabels] Computed disallowed label guids"
   );
 
-  const childNodes = childrenResult.results
-    .filter((item) => item.folder)
-    .map((item) => getDriveInternalIdFromItem(item));
+  return disallowedLabels;
+}
+
+export async function searchFilesByLabel({
+  connectorId,
+  labelGuid,
+  from,
+}: {
+  connectorId: ModelId;
+  labelGuid: string;
+  from: number;
+}): Promise<{ internalIds: string[]; nextFrom: number | null }> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const logger = getActivityLogger(connector);
+  const client = await getMicrosoftClient(connector.connectionId);
+
+  await heartbeat();
+
+  return searchDriveItems(logger, client, {
+    queryString: `InformationProtectionLabelId:${labelGuid}`,
+    from,
+  });
+}
+
+export async function removeSensitivityLabelFilesActivity({
+  connectorId,
+  internalIds,
+}: {
+  connectorId: ModelId;
+  internalIds: string[];
+}): Promise<void> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const logger = getActivityLogger(connector);
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const nodeResources = await MicrosoftNodeResource.fetchByInternalIds(
+    connectorId,
+    internalIds
+  );
+
+  const nodeByInternalId = new Map(nodeResources.map((n) => [n.internalId, n]));
+
+  // Only act on files we have synced that are not already hidden.
+  const toRemove = internalIds.filter((id) => {
+    const node = nodeByInternalId.get(id);
+    return (
+      node !== undefined &&
+      node.skipReason !== MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED
+    );
+  });
+
+  if (toRemove.length === 0) {
+    return;
+  }
+
+  logger.info(
+    { connectorId, count: toRemove.length },
+    "[RemoveSensitivityLabelFiles] Marking files as label-skipped"
+  );
+
+  await MicrosoftNodeResource.bulkMarkAsSensitivityLabelSkipped(
+    connectorId,
+    toRemove
+  );
+
+  for (const internalId of toRemove) {
+    await heartbeat();
+    await deleteDataSourceDocument(dataSourceConfig, internalId);
+  }
+}
+
+export async function reconcileHiddenFilesActivity({
+  connectorId,
+  idCursor,
+}: {
+  connectorId: ModelId;
+  idCursor: number;
+}): Promise<{ nextCursor: number | null }> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const logger = getActivityLogger(connector);
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const providerConfig =
+    await MicrosoftConfigurationResource.fetchByConnectorId(connectorId);
+  if (!providerConfig) {
+    throw new Error(`Configuration for connector ${connectorId} not found`);
+  }
+
+  const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
+  const client = await getMicrosoftClient(connector.connectionId);
+  const startSyncTs = new Date().getTime();
+
+  const hiddenFiles =
+    await MicrosoftNodeResource.fetchSensitivityLabelSkippedByPaginatedIds({
+      connectorId,
+      pageSize: HIDDEN_FILES_PAGE_SIZE,
+      idCursor,
+    });
+
+  if (hiddenFiles.length === 0) {
+    return { nextCursor: null };
+  }
+
+  const lastNode = hiddenFiles[hiddenFiles.length - 1];
+  const nextCursor = lastNode ? lastNode.id + 1 : null;
+
+  for (const node of hiddenFiles) {
+    await heartbeat();
+
+    const { itemAPIPath } = typeAndPathFromInternalId(node.internalId);
+
+    let file: DriveItem;
+    try {
+      file = await getItem<DriveItem>(
+        logger,
+        client,
+        `${itemAPIPath}?${DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS}`
+      );
+    } catch (error) {
+      if (isItemNotFoundError(error)) {
+        logger.info(
+          { connectorId, internalId: node.internalId },
+          "[ReconcileHiddenFiles] File not found in Graph API, leaving hidden"
+        );
+        continue;
+      }
+      throw error;
+    }
+
+    if (!file.parentReference) {
+      continue;
+    }
+
+    const shouldSync = shouldSyncFileBasedOnSensitivityLabels({
+      fields: file.listItem?.fields,
+      allowedLabels,
+    });
+
+    if (!shouldSync) {
+      continue;
+    }
+
+    logger.info(
+      { connectorId, internalId: node.internalId },
+      "[ReconcileHiddenFiles] File now allowed, re-syncing"
+    );
+
+    const parentInternalId = getParentReferenceInternalId(file.parentReference);
+
+    await syncOneFile({
+      connectorId,
+      dataSourceConfig,
+      providerConfig,
+      file,
+      parentInternalId,
+      startSyncTs,
+      heartbeat,
+    });
+  }
 
   return {
-    childNodes,
-    nextLink: childrenResult.nextLink,
+    nextCursor: hiddenFiles.length < HIDDEN_FILES_PAGE_SIZE ? null : nextCursor,
   };
 }
 

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -105,6 +105,24 @@ export function shouldSyncFileBasedOnSensitivityLabels({
   return !labelGuid || allowedLabels.includes(labelGuid);
 }
 
+/**
+ * The tenant labels that are not in the allowed set. Empty when filtering is
+ * disabled (no allowed labels) — we never exclude anything in that case.
+ */
+export function computeDisallowedLabels({
+  tenantLabels,
+  allowedLabels,
+}: {
+  tenantLabels: string[];
+  allowedLabels: string[];
+}): string[] {
+  if (allowedLabels.length === 0) {
+    return [];
+  }
+  const allowedSet = new Set(allowedLabels);
+  return tenantLabels.filter((label) => !allowedSet.has(label));
+}
+
 export async function removeFileBasedOnSensitivityLabel({
   connectorId,
   dataSourceConfig,

--- a/connectors/src/connectors/microsoft/temporal/sensitivity_labels.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/sensitivity_labels.test.ts
@@ -1,0 +1,86 @@
+import {
+  computeDisallowedLabels,
+  shouldSyncFileBasedOnSensitivityLabels,
+} from "@connectors/connectors/microsoft/temporal/file";
+import { describe, expect, it } from "vitest";
+
+describe("shouldSyncFileBasedOnSensitivityLabels", () => {
+  it("allows all files when no labels are configured", () => {
+    expect(
+      shouldSyncFileBasedOnSensitivityLabels({
+        fields: { _IpLabelId: "blocked-guid" },
+        allowedLabels: [],
+      })
+    ).toBe(true);
+  });
+
+  it("allows a file whose label is in the allowed list", () => {
+    expect(
+      shouldSyncFileBasedOnSensitivityLabels({
+        fields: { _IpLabelId: "allowed-guid" },
+        allowedLabels: ["allowed-guid", "other-guid"],
+      })
+    ).toBe(true);
+  });
+
+  it("blocks a file whose label is not in the allowed list", () => {
+    expect(
+      shouldSyncFileBasedOnSensitivityLabels({
+        fields: { _IpLabelId: "blocked-guid" },
+        allowedLabels: ["allowed-guid"],
+      })
+    ).toBe(false);
+  });
+
+  it("allows an unlabeled file even when the allowed list is non-empty", () => {
+    expect(
+      shouldSyncFileBasedOnSensitivityLabels({
+        fields: {},
+        allowedLabels: ["some-guid"],
+      })
+    ).toBe(true);
+  });
+
+  it("allows a file whose label was removed (null/undefined/empty fields)", () => {
+    // The label-removed → unlabeled → re-include case driving the now-allowed pass.
+    for (const fields of [null, undefined, { _IpLabelId: "" }]) {
+      expect(
+        shouldSyncFileBasedOnSensitivityLabels({
+          fields,
+          allowedLabels: ["some-guid"],
+        })
+      ).toBe(true);
+    }
+  });
+});
+
+// The set driving the now-excluded Search pass: tenant labels minus allowed.
+describe("computeDisallowedLabels", () => {
+  it("returns tenant labels not in the allowed set", () => {
+    expect(
+      computeDisallowedLabels({
+        tenantLabels: ["guid-a", "guid-b", "guid-c"],
+        allowedLabels: ["guid-a"],
+      })
+    ).toEqual(["guid-b", "guid-c"]);
+  });
+
+  it("returns empty when every tenant label is allowed", () => {
+    expect(
+      computeDisallowedLabels({
+        tenantLabels: ["guid-a", "guid-b"],
+        allowedLabels: ["guid-a", "guid-b"],
+      })
+    ).toEqual([]);
+  });
+
+  it("returns empty when filtering is disabled (no allowed labels)", () => {
+    // With filtering off we must not exclude anything, even if the tenant has labels.
+    expect(
+      computeDisallowedLabels({
+        tenantLabels: ["guid-a", "guid-b"],
+        allowedLabels: [],
+      })
+    ).toEqual([]);
+  });
+});

--- a/connectors/src/connectors/microsoft/temporal/workflows.ts
+++ b/connectors/src/connectors/microsoft/temporal/workflows.ts
@@ -19,7 +19,6 @@ const {
   populateDeltas,
   groupRootItemsByDriveId,
   isMicrosoftFullSyncRunning,
-  reconcileSensitivityLabelsForParent,
   launchMicrosoftFullSyncForDrive,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
@@ -35,6 +34,10 @@ const {
   fetchDeltaForRootNodesInDrive,
   processDeltaChangesFromGCS,
   cleanupDeltaGCSFile,
+  getDisallowedSensitivityLabelGuids,
+  searchFilesByLabel,
+  removeSensitivityLabelFilesActivity,
+  reconcileHiddenFilesActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "120 minutes",
   heartbeatTimeout: "5 minutes",
@@ -316,64 +319,68 @@ export async function microsoftGarbageCollectionWorkflow({
   }
 }
 
+/**
+ * Reconciles synced files against the connector's allowed sensitivity labels,
+ * catching pure label changes (no content change) that delta sync misses.
+ *
+ * Pass 1 (now excluded): for each disallowed label, ask Microsoft Search which
+ * files carry it and exclude the ones we have synced.
+ * Pass 2 (now allowed): scan our previously-excluded files and re-include any
+ * whose label was removed or changed to an allowed one.
+ *
+ * Recurs every 12 hours. Started/stopped from setConfigurationKey, so it only
+ * runs while label filtering is active.
+ */
 export async function microsoftSensitivityLabelsReconciliationWorkflow({
   connectorId,
-  startSyncTs,
-  nodeIdsToReconcile = [],
 }: {
   connectorId: ModelId;
-  startSyncTs?: number;
-  nodeIdsToReconcile?: string[];
 }) {
   await syncStarted(connectorId);
 
-  if (startSyncTs === undefined) {
-    startSyncTs = new Date().getTime();
+  const disallowedLabelGuids =
+    await getDisallowedSensitivityLabelGuids(connectorId);
+
+  for (const labelGuid of disallowedLabelGuids) {
+    let from: number | null = 0;
+    while (from !== null) {
+      const res: Awaited<ReturnType<typeof activities.searchFilesByLabel>> =
+        await searchFilesByLabel({ connectorId, labelGuid, from });
+
+      if (res.internalIds.length > 0) {
+        await removeSensitivityLabelFilesActivity({
+          connectorId,
+          internalIds: res.internalIds,
+        });
+      }
+
+      from = res.nextFrom;
+
+      if (workflowInfo().historyLength > 4000) {
+        await continueAsNew<
+          typeof microsoftSensitivityLabelsReconciliationWorkflow
+        >({ connectorId });
+      }
+    }
   }
 
-  let pendingNodeIds =
-    nodeIdsToReconcile.length === 0
-      ? await getRootNodesToSync(connectorId)
-      : nodeIdsToReconcile;
-  pendingNodeIds = uniq(pendingNodeIds);
-
-  while (pendingNodeIds.length > 0) {
-    const nodeId = pendingNodeIds.pop();
-
-    if (!nodeId) {
-      break;
-    }
-
-    let nextPageLink: string | undefined = undefined;
-
-    do {
-      const res: Awaited<
-        ReturnType<typeof activities.reconcileSensitivityLabelsForParent>
-      > = await reconcileSensitivityLabelsForParent({
-        connectorId,
-        parentInternalId: nodeId,
-        startSyncTs,
-        nextPageLink,
-      });
-
-      pendingNodeIds = uniq(pendingNodeIds.concat(res.childNodes));
-      nextPageLink = res.nextLink;
-    } while (nextPageLink);
+  let idCursor: number | null = 0;
+  while (idCursor !== null) {
+    const res: Awaited<
+      ReturnType<typeof activities.reconcileHiddenFilesActivity>
+    > = await reconcileHiddenFilesActivity({ connectorId, idCursor });
+    idCursor = res.nextCursor;
 
     if (workflowInfo().historyLength > 4000) {
       await continueAsNew<
         typeof microsoftSensitivityLabelsReconciliationWorkflow
-      >({
-        connectorId,
-        startSyncTs,
-        nodeIdsToReconcile: pendingNodeIds,
-      });
+      >({ connectorId });
     }
   }
 
   await syncSucceeded(connectorId);
 
-  await sleep("1 hour");
+  await sleep("12 hours");
   await continueAsNew<typeof microsoftSensitivityLabelsReconciliationWorkflow>({
     connectorId,
   });

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -1,6 +1,7 @@
-import type {
-  MicrosoftNode,
-  MicrosoftNodeType,
+import {
+  MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
+  type MicrosoftNode,
+  type MicrosoftNodeType,
 } from "@connectors/connectors/microsoft/lib/types";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import type { SelectedSiteMetadata } from "@connectors/lib/models/microsoft";
@@ -468,6 +469,51 @@ export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {
     });
 
     return blobs.map((blob) => new this(this.model, blob.get()));
+  }
+
+  static async fetchSensitivityLabelSkippedByPaginatedIds({
+    connectorId,
+    pageSize,
+    idCursor,
+  }: {
+    connectorId: ModelId;
+    pageSize: number;
+    idCursor: ModelId;
+  }): Promise<MicrosoftNodeResource[]> {
+    const blobs = await this.model.findAll({
+      where: {
+        connectorId,
+        skipReason: MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
+        id: {
+          [Op.gte]: idCursor,
+        },
+      },
+      limit: pageSize,
+      order: [["id", "ASC"]],
+    });
+
+    return blobs.map((blob) => new this(this.model, blob.get()));
+  }
+
+  static async bulkMarkAsSensitivityLabelSkipped(
+    connectorId: ModelId,
+    internalIds: string[]
+  ): Promise<void> {
+    if (internalIds.length === 0) {
+      return;
+    }
+    await this.model.update(
+      { skipReason: MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED },
+      {
+        where: {
+          connectorId,
+          internalId: { [Op.in]: internalIds },
+          skipReason: {
+            [Op.not]: MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED,
+          },
+        },
+      }
+    );
   }
 
   /** String representation of this node and its descendants in treeLike fashion */


### PR DESCRIPTION
## Summary

Replaces the Microsoft sensitivity-label reconciliation workflow. The old design did a full BFS tree-walk of every drive, which:

- **Infinite-looped** on a child-mapping bug — folder children were mapped with `getDriveInternalIdFromItem` (returns the *drive's* id) instead of `getDriveItemInternalId` (the folder's own id), so reconciling a drive re-queued the drive forever and the workflow never terminated.
- Ran in the default 30-min `proxyActivities` bucket with **no `heartbeatTimeout`**, so its `heartbeat()` calls were inert.
- Did per-file content work (`syncOneFile` / delete) inline during the crawl.

### New design

Delta sync already corrects labels for any file that *also* has a content change (`syncOneFile` re-fetches the label). The remaining gap is **pure label changes with no content change**, which never appear in delta. The new workflow closes that gap with two cheap, complementary passes:

1. **Now-excluded** — for each *disallowed* label (tenant labels minus the allowed set, via `GET /security/dataSecurityAndGovernance/sensitivityLabels`), query Microsoft Graph Search (`POST /search/query`, `InformationProtectionLabelId:{guid}`) for the files carrying it and exclude the ones we have synced. The data lives in Microsoft, so we ask Microsoft.
2. **Now-allowed** — scan our own DB for previously-excluded files (`skipReason === sensitivity_label_not_allowed`), re-fetch each label, and re-sync any now allowed/unlabeled. Bounded by what we already excluded, so a DB scan is cheap.

Recurs every 12h; started/stopped from `setConfigurationKey` so it only runs while filtering is active. A label config change also triggers a full sync (labels are a config key, like `pdfEnabled`), which applies the new policy immediately. Reconciliation activities moved into the 120-min / 5-min-heartbeat group alongside the delta activities. Both passes are idempotent.

## Risk

* Low (fixes existing issue)

## Testing

- Validated manually that adding of restricted label resolves in Dust
