### PR TITLE
Chrisjow/handle gcal event html description

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -117,7 +117,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Description of the event. Supports basic HTML formatting (e.g. <b>, <i>, <br>, <a href='...'>). Always use HTML tags when the description contains any formatting; use plain text only when no formatting is needed."
+          "Description of the event. Supports basic HTML tags (<b>, <i>, <br>, <ul>, <li>, <a href='...'>). Use raw HTML tags — never escape them as entities. Use plain text only when no formatting is needed."
         ),
       start: z
         .object({ dateTime: z.string().describe("RFC3339 start time") })
@@ -164,7 +164,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "Description of the event. Supports basic HTML formatting (e.g. <b>, <i>, <br>, <a href='...'>). Always use HTML tags when the description contains any formatting; use plain text only when no formatting is needed."
+          "Description of the event. Only include this field when intentionally changing the description. Supports basic HTML tags (<b>, <i>, <br>, <ul>, <li>, <a href='...'>). Use raw HTML tags — never escape them as entities. Use plain text only when no formatting is needed."
         ),
       start: z
         .object({ dateTime: z.string().describe("RFC3339 start time") })

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -113,7 +113,12 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .default("primary")
         .describe("The calendar ID (default: 'primary')."),
       summary: z.string().describe("Title of the event."),
-      description: z.string().optional().describe("Description of the event."),
+      description: z
+        .string()
+        .optional()
+        .describe(
+          "Description of the event. Supports basic HTML formatting (e.g. <b>, <i>, <br>, <a href='...'>). Always use HTML tags when the description contains any formatting; use plain text only when no formatting is needed."
+        ),
       start: z
         .object({ dateTime: z.string().describe("RFC3339 start time") })
         .describe("Start time object."),
@@ -155,7 +160,12 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe("The calendar ID (default: 'primary')."),
       eventId: z.string().describe("The ID of the event to update."),
       summary: z.string().optional().describe("Title of the event."),
-      description: z.string().optional().describe("Description of the event."),
+      description: z
+        .string()
+        .optional()
+        .describe(
+          "Description of the event. Supports basic HTML formatting (e.g. <b>, <i>, <br>, <a href='...'>). Always use HTML tags when the description contains any formatting; use plain text only when no formatting is needed."
+        ),
       start: z
         .object({ dateTime: z.string().describe("RFC3339 start time") })
         .optional()

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -156,7 +156,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         conferenceDataVersion: 1,
         requestBody: {
           summary,
-          description,
+          ...(description !== undefined && { description }),
           start,
           end,
           ...(attendees && {


### PR DESCRIPTION
## Description

Improves the Google Calendar event tools (`create_event` and `update_event`) in two ways:
1. Updates the `description` field schema description to explicitly document HTML formatting support (bold, italic, lists, links, etc.) and instructs the model to use raw HTML tags instead of escaped entities.
2. For `update_event`, the description field is now conditionally spread into the request body (`...(description !== undefined && { description })`) to avoid accidentally overwriting an existing event description when the field is not explicitly provided.

## Tests

Manually tested via the GCal MCP server — creating and updating events with HTML-formatted descriptions.

## Risk

Low. The change only affects the tool schema description text and a minor conditional inclusion fix for the update payload. No risk of regression for calendar event creation; the update path is strictly safer than before.

## Deploy Plan

Deploy front.