### PR TITLE
Introduce Auto model for agents

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -1,5 +1,8 @@
 import { listActiveAgentsUsingNonRegionalModels } from "@app/lib/api/assistant/workspace_capabilities";
 import {
+  getEnabledModelFromPreference,
+} from "@app/lib/api/assistant/models";
+import {
   buildAuditLogTarget,
   emitAuditLogEvent,
   getAuditLogContext,
@@ -12,6 +15,13 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import { EmbeddingProviderSchema } from "@app/types/assistant/models/embedding";
+import { isAutoModelId } from "@app/types/assistant/models/auto";
+import { ModelIdSchema } from "@app/types/assistant/models/models";
+import {
+  WORKSPACE_BACKUP_MODEL_METADATA_KEY,
+  WORKSPACE_DEFAULT_MODEL_METADATA_KEY,
+  type WorkspaceModelPreference,
+} from "@app/types/assistant/models/preferences";
 import { ModelProviderIdSchema } from "@app/types/assistant/models/providers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
@@ -111,6 +121,16 @@ const WorkspaceProvidersUpdateBodySchema = z.object({
   defaultEmbeddingProvider: EmbeddingProviderSchema.nullable(),
 });
 
+const WorkspaceModelPreferenceSchema = z.object({
+  providerId: ModelProviderIdSchema,
+  modelId: ModelIdSchema,
+});
+
+const WorkspaceModelPreferencesUpdateBodySchema = z.object({
+  defaultModel: WorkspaceModelPreferenceSchema.nullable(),
+  backupModel: WorkspaceModelPreferenceSchema.nullable(),
+});
+
 const WorkspaceWorkOSUpdateBodySchema = z.object({
   workOSOrganizationId: z.string().nullable(),
 });
@@ -200,6 +220,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceSsoEnforceUpdateBodySchema,
   WorkspaceRegionalModelsOnlyUpdateBodySchema,
   WorkspaceProvidersUpdateBodySchema,
+  WorkspaceModelPreferencesUpdateBodySchema,
   WorkspaceWorkOSUpdateBodySchema,
   WorkspaceInteractiveContentSharingUpdateBodySchema,
   WorkspaceSharingPolicyUpdateBodySchema,
@@ -390,6 +411,110 @@ app.post(
       });
       owner.whiteListedProviders = body.whiteListedProviders;
       owner.defaultEmbeddingProvider = workspace.defaultEmbeddingProvider;
+    } else if ("defaultModel" in body && "backupModel" in body) {
+      const { defaultModel, backupModel } = body;
+
+      if (defaultModel && isAutoModelId(defaultModel.modelId)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The default model must be a concrete model.",
+          },
+        });
+      }
+
+      if (backupModel && isAutoModelId(backupModel.modelId)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The backup model must be a concrete model.",
+          },
+        });
+      }
+
+      if (
+        defaultModel &&
+        backupModel &&
+        defaultModel.providerId === backupModel.providerId &&
+        defaultModel.modelId === backupModel.modelId
+      ) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The backup model must be different from the default model.",
+          },
+        });
+      }
+
+      const validatePreference = (
+        preference: WorkspaceModelPreference | null
+      ) => {
+        if (!preference) {
+          return true;
+        }
+
+        return Boolean(getEnabledModelFromPreference(auth, preference));
+      };
+
+      if (!validatePreference(defaultModel)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The default model must be enabled for this workspace and region.",
+          },
+        });
+      }
+
+      if (!validatePreference(backupModel)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The backup model must be enabled for this workspace and region.",
+          },
+        });
+      }
+
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+      };
+
+      if (defaultModel) {
+        newMetadata[WORKSPACE_DEFAULT_MODEL_METADATA_KEY] = defaultModel;
+      } else {
+        delete newMetadata[WORKSPACE_DEFAULT_MODEL_METADATA_KEY];
+      }
+
+      if (backupModel) {
+        newMetadata[WORKSPACE_BACKUP_MODEL_METADATA_KEY] = backupModel;
+      } else {
+        delete newMetadata[WORKSPACE_BACKUP_MODEL_METADATA_KEY];
+      }
+
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.model_preferences_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          default_model: defaultModel
+            ? `${defaultModel.providerId}/${defaultModel.modelId}`
+            : "system",
+          backup_model: backupModel
+            ? `${backupModel.providerId}/${backupModel.modelId}`
+            : "none",
+        },
+      });
     } else if ("workOSOrganizationId" in body) {
       await workspace.updateWorkspaceSettings({
         workOSOrganizationId: body.workOSOrganizationId,

--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -2,6 +2,7 @@ import {
   CLAUDE_4_5_HAIKU_20251001_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/types/assistant/models/mistral";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
@@ -12,6 +13,7 @@ import type {
 } from "@app/types/assistant/models/types";
 
 export const BEST_PERFORMING_MODELS_ID: ModelIdType[] = [
+  AUTO_MODEL_ID,
   GPT_5_5_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   CLAUDE_4_5_HAIKU_20251001_MODEL_ID,

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -7,6 +7,10 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import {
+  AUTO_MODEL_CONFIG,
+  AUTO_MODEL_ID,
+} from "@app/types/assistant/models/auto";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/types/assistant/models/mistral";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
@@ -62,6 +66,7 @@ export function transformAgentConfigurationToFormData(
 }
 
 const PREFERRED_LARGE_MODEL_IDS: ModelIdType[] = [
+  AUTO_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   GPT_5_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
@@ -98,7 +103,7 @@ export function getDefaultAgentFormData({
 }): AgentBuilderFormData {
   // Static fallback — overridden by the useEffect in AgentBuilder once available
   // models are loaded.
-  const defaultModel = CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+  const defaultModel = AUTO_MODEL_CONFIG;
 
   return {
     agentSettings: {

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -31,6 +31,7 @@ export function ModelProvidersPage() {
           workspace={workspace}
           providersSelection={providersSelection}
           isWorkspaceValidating={isWorkspaceValidating}
+          mutateWorkspace={mutateWorkspace}
           onToggleProvider={toggleProvider}
           onSelectAllProviders={selectAllProviders}
         />

--- a/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPageContent.tsx
@@ -3,10 +3,12 @@ import { EmbeddingModelSelect } from "@app/components/pages/workspace/model_prov
 import { ProvidersConfigurationList } from "@app/components/pages/workspace/model_providers/ProvidersConfigurationList";
 import { ProvidersToggleList } from "@app/components/pages/workspace/model_providers/ProvidersToggleList";
 import { RegionalModelsOnlyToggle } from "@app/components/pages/workspace/model_providers/RegionalModelsOnlyToggle";
+import { WorkspaceModelPreferences } from "@app/components/pages/workspace/model_providers/WorkspaceModelPreferences";
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { isModelAvailable } from "@app/lib/assistant";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -21,6 +23,7 @@ interface ModelProvidersPageContentProps {
   workspace: WorkspaceType;
   providersSelection: ProvidersSelection;
   isWorkspaceValidating: boolean;
+  mutateWorkspace: () => Promise<unknown>;
   onToggleProvider: (provider: ModelProviderIdType) => void;
   onSelectAllProviders: () => void;
 }
@@ -29,6 +32,7 @@ export function ModelProvidersPageContent({
   workspace,
   providersSelection,
   isWorkspaceValidating,
+  mutateWorkspace,
   onToggleProvider,
   onSelectAllProviders,
 }: ModelProvidersPageContentProps) {
@@ -57,6 +61,11 @@ export function ModelProvidersPageContent({
       modelConfigurations.map(({ displayName }) => displayName).join(", ")
   );
 
+  const enabledConcreteModels = filteredModels.filter(
+    (model) =>
+      model.modelId !== AUTO_MODEL_ID && providersSelection[model.providerId]
+  );
+
   return (
     <div className="flex flex-col gap-8">
       {plan.isByok ? (
@@ -79,6 +88,11 @@ export function ModelProvidersPageContent({
           />
         </>
       )}
+      <WorkspaceModelPreferences
+        workspace={workspace}
+        models={enabledConcreteModels}
+        mutateWorkspace={mutateWorkspace}
+      />
       <EmbeddingModelSelect workspace={workspace} />
     </div>
   );

--- a/front/components/pages/workspace/model_providers/WorkspaceModelPreferences.tsx
+++ b/front/components/pages/workspace/model_providers/WorkspaceModelPreferences.tsx
@@ -1,0 +1,250 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  getWorkspaceBackupModelPreference,
+  getWorkspaceDefaultModelPreference,
+  type WorkspaceModelPreference,
+} from "@app/types/assistant/models/preferences";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContextItem,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+interface WorkspaceModelPreferencesProps {
+  workspace: WorkspaceType;
+  models: ModelConfigurationType[];
+  mutateWorkspace: () => Promise<unknown>;
+}
+
+type PreferenceKind = "default" | "backup";
+
+function toPreference(
+  model: ModelConfigurationType | null
+): WorkspaceModelPreference | null {
+  if (!model) {
+    return null;
+  }
+
+  return {
+    providerId: model.providerId,
+    modelId: model.modelId,
+  };
+}
+
+function isSamePreference(
+  a: WorkspaceModelPreference | null,
+  b: WorkspaceModelPreference | null
+) {
+  return a?.providerId === b?.providerId && a?.modelId === b?.modelId;
+}
+
+function getModelLabel(
+  models: ModelConfigurationType[],
+  preference: WorkspaceModelPreference | null,
+  fallbackLabel: string
+) {
+  if (!preference) {
+    return fallbackLabel;
+  }
+
+  return (
+    models.find(
+      (model) =>
+        model.providerId === preference.providerId &&
+        model.modelId === preference.modelId
+    )?.displayName ?? `${preference.providerId}/${preference.modelId}`
+  );
+}
+
+function ModelPreferenceRow({
+  description,
+  disabledModelPreference,
+  fallbackLabel,
+  isSaving,
+  kind,
+  models,
+  onSelect,
+  preference,
+  title,
+}: {
+  description: string;
+  disabledModelPreference: WorkspaceModelPreference | null;
+  fallbackLabel: string;
+  isSaving: boolean;
+  kind: PreferenceKind;
+  models: ModelConfigurationType[];
+  onSelect: (kind: PreferenceKind, model: ModelConfigurationType | null) => void;
+  preference: WorkspaceModelPreference | null;
+  title: string;
+}) {
+  const label = getModelLabel(models, preference, fallbackLabel);
+
+  return (
+    <ContextItem
+      title={title}
+      hasSeparator={false}
+      action={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild disabled={isSaving}>
+            <Button isSelect label={label} variant="outline" size="sm" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="max-h-96 w-80 overflow-y-auto">
+            <DropdownMenuItem
+              label={fallbackLabel}
+              onClick={() => onSelect(kind, null)}
+            />
+            <DropdownMenuLabel label="Models" />
+            {models.map((model) => {
+              const modelPreference = toPreference(model);
+              const disabled = isSamePreference(
+                modelPreference,
+                disabledModelPreference
+              );
+
+              return (
+                <DropdownMenuItem
+                  key={`${kind}-${model.providerId}-${model.modelId}`}
+                  disabled={disabled}
+                  label={model.displayName}
+                  description={model.shortDescription}
+                  onClick={() => onSelect(kind, model)}
+                />
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    >
+      <ContextItem.Description>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </span>
+      </ContextItem.Description>
+    </ContextItem>
+  );
+}
+
+export function WorkspaceModelPreferences({
+  workspace,
+  models,
+  mutateWorkspace,
+}: WorkspaceModelPreferencesProps) {
+  const sendNotification = useSendNotification();
+  const [isSaving, setIsSaving] = useState(false);
+  const [defaultModel, setDefaultModel] =
+    useState<WorkspaceModelPreference | null>(() =>
+      getWorkspaceDefaultModelPreference(workspace.metadata)
+    );
+  const [backupModel, setBackupModel] =
+    useState<WorkspaceModelPreference | null>(() =>
+      getWorkspaceBackupModelPreference(workspace.metadata)
+    );
+
+  useEffect(() => {
+    setDefaultModel(getWorkspaceDefaultModelPreference(workspace.metadata));
+    setBackupModel(getWorkspaceBackupModelPreference(workspace.metadata));
+  }, [workspace.metadata]);
+
+  const savePreferences = async ({
+    nextBackupModel,
+    nextDefaultModel,
+  }: {
+    nextBackupModel: WorkspaceModelPreference | null;
+    nextDefaultModel: WorkspaceModelPreference | null;
+  }) => {
+    const previousDefaultModel = defaultModel;
+    const previousBackupModel = backupModel;
+
+    setDefaultModel(nextDefaultModel);
+    setBackupModel(nextBackupModel);
+    setIsSaving(true);
+
+    try {
+      const response = await clientFetch(`/api/w/${workspace.sId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          defaultModel: nextDefaultModel,
+          backupModel: nextBackupModel,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to update workspace model preferences");
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Model preferences updated",
+        description: "The workspace model preferences have been updated.",
+      });
+
+      await mutateWorkspace();
+    } catch {
+      setDefaultModel(previousDefaultModel);
+      setBackupModel(previousBackupModel);
+      sendNotification({
+        type: "error",
+        title: "Update failed",
+        description:
+          "An unexpected error occurred while updating model preferences.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleSelect = (
+    kind: PreferenceKind,
+    model: ModelConfigurationType | null
+  ) => {
+    const preference = toPreference(model);
+
+    void savePreferences({
+      nextDefaultModel: kind === "default" ? preference : defaultModel,
+      nextBackupModel: kind === "backup" ? preference : backupModel,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ModelPreferenceRow
+        kind="default"
+        title="Default model for Auto"
+        description={
+          "When an agent uses Auto, Dust will prefer this model if it is still " +
+          "available for the workspace. If unset or unavailable, Dust falls " +
+          "back to its system default order."
+        }
+        fallbackLabel="Dust system default"
+        models={models}
+        preference={defaultModel}
+        disabledModelPreference={backupModel}
+        isSaving={isSaving}
+        onSelect={handleSelect}
+      />
+      <ModelPreferenceRow
+        kind="backup"
+        title="Backup model"
+        description={
+          "Optional fallback preference for Auto and future provider failover. " +
+          "The backup must be different from the default model."
+        }
+        fallbackLabel="No backup model"
+        models={models}
+        preference={backupModel}
+        disabledModelPreference={defaultModel}
+        isSaving={isSaving}
+        onSelect={handleSelect}
+      />
+    </div>
+  );
+}

--- a/front/components/providers/model_configs.ts
+++ b/front/components/providers/model_configs.ts
@@ -5,6 +5,7 @@ import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import {
   FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
   FIREWORKS_GLM_5P2_MODEL_CONFIG,
@@ -32,6 +33,7 @@ import type { ModelConfig } from "@app/types/assistant/models/types";
 import { GROK_4_MODEL_CONFIG } from "@app/types/assistant/models/xai";
 
 export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
+  AUTO_MODEL_CONFIG,
   GPT_5_5_MODEL_CONFIG,
   GPT_5_4_MINI_MODEL_CONFIG,
   GPT_5_4_NANO_MODEL_CONFIG,

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -2,6 +2,7 @@ import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
@@ -24,6 +25,11 @@ import {
   BYOK_MODEL_PROVIDER_IDS,
   MODEL_PROVIDER_IDS,
 } from "@app/types/assistant/models/providers";
+import {
+  getWorkspaceBackupModelPreference,
+  getWorkspaceDefaultModelPreference,
+  type WorkspaceModelPreference,
+} from "@app/types/assistant/models/preferences";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -139,6 +145,43 @@ export function getLargeWhitelistedModel(
   );
 }
 
+export function getEnabledModelFromPreference(
+  auth: Authenticator,
+  preference: WorkspaceModelPreference | null,
+  { forBatch = false }: { forBatch?: boolean } = {}
+): ModelConfigurationType | null {
+  if (!preference || isAutoModelId(preference.modelId)) {
+    return null;
+  }
+
+  const modelConfig = getSupportedModelConfig(preference);
+  if (!modelConfig) {
+    return null;
+  }
+
+  const context = getModelEnablementContextWithoutFeatureFlag(auth);
+  if (!isModelEnabled(modelConfig, context)) {
+    return null;
+  }
+
+  if (forBatch && !modelConfig.supportsBatchProcessing) {
+    return null;
+  }
+
+  return modelConfig;
+}
+
+export function getWorkspaceBackupModel(
+  auth: Authenticator,
+  { forBatch = false }: { forBatch?: boolean } = {}
+): ModelConfigurationType | null {
+  return getEnabledModelFromPreference(
+    auth,
+    getWorkspaceBackupModelPreference(auth.getNonNullableWorkspace().metadata),
+    { forBatch }
+  );
+}
+
 export function resolveAutoModel(
   auth: Authenticator,
   modelId: string,
@@ -146,6 +189,20 @@ export function resolveAutoModel(
 ): ModelConfigurationType | null {
   if (!isAutoModelId(modelId)) {
     return null;
+  }
+
+  const defaultModel = getEnabledModelFromPreference(
+    auth,
+    getWorkspaceDefaultModelPreference(auth.getNonNullableWorkspace().metadata),
+    { forBatch }
+  );
+  if (defaultModel) {
+    return defaultModel;
+  }
+
+  const backupModel = getWorkspaceBackupModel(auth, { forBatch });
+  if (backupModel) {
+    return backupModel;
   }
 
   return getLargeWhitelistedModel(auth, new Set(), { forBatch });

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -6,6 +6,7 @@ import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { isAutoModelId } from "@app/types/assistant/models/auto";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
@@ -136,6 +137,18 @@ export function getLargeWhitelistedModel(
     getModelEnablementContextWithoutFeatureFlag(auth, excludeProviders),
     { forBatch }
   );
+}
+
+export function resolveAutoModel(
+  auth: Authenticator,
+  modelId: string,
+  { forBatch = false }: { forBatch?: boolean } = {}
+): ModelConfigurationType | null {
+  if (!isAutoModelId(modelId)) {
+    return null;
+  }
+
+  return getLargeWhitelistedModel(auth, new Set(), { forBatch });
 }
 
 const ORDERED_SMALL_MODEL_CONFIGS: ModelConfigurationType[] = [

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -84,6 +84,7 @@ export const AUDIT_ACTIONS = [
   // Workspace settings.
   "workspace.audit_logs_updated",
   "workspace.default_user_spend_limit_updated",
+  "workspace.model_preferences_updated",
   "workspace.programmatic_usage_limit_updated",
   "workspace_branding.asset_promoted",
   "workspace_branding.asset_deleted",

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,4 +1,7 @@
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import {
+  getWhitelistedProviders,
+  resolveAutoModel,
+} from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import {
@@ -230,8 +233,13 @@ export async function getLegacyLLM(
 // router when enabled, falling back to the legacy per-provider clients.
 export async function getStreamLLM(
   auth: Authenticator,
-  llmParameters: LLMParameters
+  inputLLMParameters: LLMParameters
 ): Promise<LLM | null> {
+  const llmParameters = resolveAutoLLMParameters(auth, inputLLMParameters);
+  if (!llmParameters) {
+    return null;
+  }
+
   const modelConfig = getModelConfigByModelId(llmParameters.modelId);
   if (!modelConfig) {
     return null;
@@ -261,8 +269,15 @@ export async function getStreamLLM(
 // when enabled, falling back to the legacy per-provider clients.
 export async function getBatchLLM(
   auth: Authenticator,
-  llmParameters: LLMParameters
+  inputLLMParameters: LLMParameters
 ): Promise<LLM | null> {
+  const llmParameters = resolveAutoLLMParameters(auth, inputLLMParameters, {
+    forBatch: true,
+  });
+  if (!llmParameters) {
+    return null;
+  }
+
   const modelConfig = getModelConfigByModelId(llmParameters.modelId);
   if (!modelConfig) {
     return null;
@@ -282,6 +297,27 @@ export async function getBatchLLM(
   const legacyLLM = await getLegacyLLM(auth, llmParameters);
 
   return legacyLLM;
+}
+
+function resolveAutoLLMParameters(
+  auth: Authenticator,
+  llmParameters: LLMParameters,
+  { forBatch = false }: { forBatch?: boolean } = {}
+): LLMParameters | null {
+  const autoResolvedModel = resolveAutoModel(auth, llmParameters.modelId, {
+    forBatch,
+  });
+
+  if (!autoResolvedModel) {
+    return llmParameters;
+  }
+
+  return {
+    ...llmParameters,
+    modelId: autoResolvedModel.modelId,
+    reasoningEffort:
+      llmParameters.reasoningEffort ?? autoResolvedModel.defaultReasoningEffort,
+  };
 }
 
 function getRegionFilter(auth: Authenticator): ValueFilter<Region> | undefined {

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -1,5 +1,6 @@
 import {
   getWhitelistedProviders,
+  getWorkspaceBackupModel,
   resolveAutoModel,
 } from "@app/lib/api/assistant/models";
 import config from "@app/lib/api/config";
@@ -235,14 +236,22 @@ export async function getStreamLLM(
   auth: Authenticator,
   inputLLMParameters: LLMParameters
 ): Promise<LLM | null> {
-  const llmParameters = resolveAutoLLMParameters(auth, inputLLMParameters);
+  let llmParameters = resolveAutoLLMParameters(auth, inputLLMParameters);
   if (!llmParameters) {
     return null;
   }
 
-  const modelConfig = getModelConfigByModelId(llmParameters.modelId);
+  let modelConfig = getModelConfigByModelId(llmParameters.modelId);
   if (!modelConfig) {
-    return null;
+    llmParameters = resolveBackupLLMParameters(auth, llmParameters);
+    if (!llmParameters) {
+      return null;
+    }
+
+    modelConfig = getModelConfigByModelId(llmParameters.modelId);
+    if (!modelConfig) {
+      return null;
+    }
   }
   const featureFlags = await getFeatureFlags(auth);
 
@@ -261,6 +270,15 @@ export async function getStreamLLM(
   }
 
   const legacyLLM = await getLegacyLLM(auth, llmParameters);
+  if (!legacyLLM) {
+    const backupLLMParameters = resolveBackupLLMParameters(
+      auth,
+      llmParameters
+    );
+    if (backupLLMParameters) {
+      return getLegacyLLM(auth, backupLLMParameters);
+    }
+  }
 
   return legacyLLM;
 }
@@ -271,16 +289,26 @@ export async function getBatchLLM(
   auth: Authenticator,
   inputLLMParameters: LLMParameters
 ): Promise<LLM | null> {
-  const llmParameters = resolveAutoLLMParameters(auth, inputLLMParameters, {
+  let llmParameters = resolveAutoLLMParameters(auth, inputLLMParameters, {
     forBatch: true,
   });
   if (!llmParameters) {
     return null;
   }
 
-  const modelConfig = getModelConfigByModelId(llmParameters.modelId);
+  let modelConfig = getModelConfigByModelId(llmParameters.modelId);
   if (!modelConfig) {
-    return null;
+    llmParameters = resolveBackupLLMParameters(auth, llmParameters, {
+      forBatch: true,
+    });
+    if (!llmParameters) {
+      return null;
+    }
+
+    modelConfig = getModelConfigByModelId(llmParameters.modelId);
+    if (!modelConfig) {
+      return null;
+    }
   }
   const featureFlags = await getFeatureFlags(auth);
 
@@ -295,6 +323,16 @@ export async function getBatchLLM(
   }
 
   const legacyLLM = await getLegacyLLM(auth, llmParameters);
+  if (!legacyLLM) {
+    const backupLLMParameters = resolveBackupLLMParameters(
+      auth,
+      llmParameters,
+      { forBatch: true }
+    );
+    if (backupLLMParameters) {
+      return getLegacyLLM(auth, backupLLMParameters);
+    }
+  }
 
   return legacyLLM;
 }
@@ -317,6 +355,24 @@ function resolveAutoLLMParameters(
     modelId: autoResolvedModel.modelId,
     reasoningEffort:
       llmParameters.reasoningEffort ?? autoResolvedModel.defaultReasoningEffort,
+  };
+}
+
+function resolveBackupLLMParameters(
+  auth: Authenticator,
+  llmParameters: LLMParameters,
+  { forBatch = false }: { forBatch?: boolean } = {}
+): LLMParameters | null {
+  const backupModel = getWorkspaceBackupModel(auth, { forBatch });
+  if (!backupModel || backupModel.modelId === llmParameters.modelId) {
+    return null;
+  }
+
+  return {
+    ...llmParameters,
+    modelId: backupModel.modelId,
+    reasoningEffort:
+      llmParameters.reasoningEffort ?? backupModel.defaultReasoningEffort,
   };
 }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -38,7 +38,7 @@ export function isModelAvailable(
     return false;
   }
 
-  if (plan?.isByok && !isByokProviderId(m.providerId)) {
+  if (plan?.isByok && m.modelId !== "auto" && !isByokProviderId(m.providerId)) {
     return false;
   }
 
@@ -82,7 +82,7 @@ export function isModelEnabled(
 ) {
   return (
     isModelAvailable(m, { featureFlags, plan, regionalModelsOnly, region }) &&
-    whitelistedProviders.has(m.providerId)
+    (m.modelId === "auto" || whitelistedProviders.has(m.providerId))
   );
 }
 

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -38,7 +38,11 @@ export function isModelAvailable(
     return false;
   }
 
-  if (plan?.isByok && m.modelId !== "auto" && !isByokProviderId(m.providerId)) {
+  if (
+    plan?.isByok &&
+    m.modelId !== "auto" &&
+    !isByokProviderId(m.providerId)
+  ) {
     return false;
   }
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -30,6 +30,7 @@ import {
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
+import { resolveAutoModel } from "@app/lib/api/assistant/models";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import {
@@ -169,7 +170,10 @@ export async function runModel(
 
   localLogger.info("Starting multi-action loop iteration");
 
-  const model = getSupportedModelConfig(agentConfiguration.model);
+  const configuredModel = getSupportedModelConfig(agentConfiguration.model);
+  const model = configuredModel
+    ? resolveAutoModel(auth, configuredModel.modelId) ?? configuredModel
+    : null;
 
   async function publishAgentError(
     error: {

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -1,0 +1,24 @@
+import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+
+export const AUTO_MODEL_ID = "auto" as const;
+
+export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
+  ...CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+  providerId: "noop",
+  modelId: AUTO_MODEL_ID,
+  displayName: "Auto",
+  description:
+    "Dust automatically selects the best available model for this workspace at runtime.",
+  shortDescription: "Dust selects the model at runtime",
+  isLegacy: false,
+  isLatest: true,
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
+};
+
+export function isAutoModelId(modelId: string): modelId is typeof AUTO_MODEL_ID {
+  return modelId === AUTO_MODEL_ID;
+}

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -36,6 +36,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "./anthropic";
+import { AUTO_MODEL_CONFIG, AUTO_MODEL_ID } from "./auto";
 // Custom models (generated at build time from GCS, empty in dev).
 import {
   CUSTOM_MODEL_CONFIGS,
@@ -170,6 +171,7 @@ import {
 
 // Static model IDs (compile-time known, used for pricing maps).
 export const STATIC_MODEL_IDS = [
+  AUTO_MODEL_ID,
   GPT_3_5_TURBO_MODEL_ID,
   GPT_4_TURBO_MODEL_ID,
   GPT_4O_MODEL_ID,
@@ -272,6 +274,7 @@ export const IMAGE_MODEL_IDS = [
 
 export type ImageModelIdType = (typeof IMAGE_MODEL_IDS)[number];
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
+  AUTO_MODEL_CONFIG,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
   GPT_4O_MODEL_CONFIG,

--- a/front/types/assistant/models/preferences.ts
+++ b/front/types/assistant/models/preferences.ts
@@ -1,0 +1,64 @@
+import { isModelId } from "@app/types/assistant/models/models";
+import { isModelProviderId } from "@app/types/assistant/models/providers";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
+
+export const WORKSPACE_DEFAULT_MODEL_METADATA_KEY =
+  "defaultModelConfiguration";
+export const WORKSPACE_BACKUP_MODEL_METADATA_KEY = "backupModelConfiguration";
+
+export type WorkspaceModelPreference = {
+  providerId: ModelProviderIdType;
+  modelId: ModelIdType;
+};
+
+type WorkspaceMetadata =
+  | Record<string, string | number | boolean | object | undefined>
+  | null
+  | undefined;
+
+function isWorkspaceModelPreference(
+  value: unknown
+): value is WorkspaceModelPreference {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const { providerId, modelId } = value as Record<string, unknown>;
+
+  return (
+    typeof providerId === "string" &&
+    typeof modelId === "string" &&
+    isModelProviderId(providerId) &&
+    isModelId(modelId)
+  );
+}
+
+function getWorkspaceModelPreferenceFromMetadata(
+  metadata: WorkspaceMetadata,
+  key: string
+): WorkspaceModelPreference | null {
+  const value = metadata?.[key];
+
+  return isWorkspaceModelPreference(value) ? value : null;
+}
+
+export function getWorkspaceDefaultModelPreference(
+  metadata: WorkspaceMetadata
+): WorkspaceModelPreference | null {
+  return getWorkspaceModelPreferenceFromMetadata(
+    metadata,
+    WORKSPACE_DEFAULT_MODEL_METADATA_KEY
+  );
+}
+
+export function getWorkspaceBackupModelPreference(
+  metadata: WorkspaceMetadata
+): WorkspaceModelPreference | null {
+  return getWorkspaceModelPreferenceFromMetadata(
+    metadata,
+    WORKSPACE_BACKUP_MODEL_METADATA_KEY
+  );
+}


### PR DESCRIPTION
## Description

Introduces `Auto` as a first-class agent model and adds workspace-admin model preferences.

`Auto` is now available in the model registry and model picker, selected by default for newly-created agents, and resolved at runtime to a concrete model before the LLM router/provider layer. The runtime resolution order is:

1. workspace admin default model, when configured and still enabled;
2. workspace admin backup model, when configured and still enabled;
3. the existing Dust ordered large-model default.

What is included:
- Adds the `auto` model id and `AUTO_MODEL_CONFIG`.
- Returns `Auto` from `/api/w/:wId/models` through the existing used-models list.
- Makes `Auto` part of the best-performing model group and the default model for new agent forms.
- Adds workspace metadata helpers for default and backup model preferences.
- Adds admin API validation for default and backup model preferences, including enabled-model and region/provider constraints.
- Adds model-provider admin page controls for default model and backup model.
- Resolves `Auto` before streaming/batch LLM routing.
- Resolves `Auto` before the Temporal agent loop renders the conversation, so rendering/tokenization/logging use the concrete model selected for the run.
- Uses the configured backup model as an initialization fallback when a model cannot be resolved by the LLM router.

What is intentionally left as follow-up work:
- A migration that moves existing agents from the previous default model to `Auto` after notice.
- Provider-outage classification, circuit-breaking, and retry/fallback after an already-started provider stream fails. This PR establishes the admin preferences, validation, and runtime resolution hooks needed for that work.

## Risk

Medium. This touches the shared model registry, agent-builder defaults, workspace admin settings, and LLM routing entry points.

`Auto` is persisted with the existing `noop` provider id to avoid introducing a pseudo-provider into provider whitelisting and admin provider controls. Runtime calls resolve `Auto` to a concrete enabled model before provider routing.

Workspace preferences are stored in workspace metadata and treated as preferences, not guarantees. If an admin later disables a provider, removes BYOK credentials, or enables regional-only constraints that invalidate a saved preference, runtime resolution skips the stale preference and falls back safely.

## Deploy Plan

Ship without a data migration. New agents default to `Auto`; existing agents are unchanged. Admins can configure default and backup model preferences from the model providers settings page.

## Rollback Plan

Revert this PR. Agents already saved with `modelId: auto` would need to be edited or migrated back to a concrete model if the rollback happens after users create Auto agents.

## Tests

- `git diff --cached --check`
- Attempted a targeted TypeScript check with `tsc`, but the Computer image has `tsc` installed without `node`, so it failed before running: `/usr/bin/env: node: No such file or directory`.

Full validation is expected from PR CI.