### PR TITLE
Make Pods skill always auto equiped for all agents.

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -472,7 +472,6 @@ function _getDustLikeGlobalAgent(
       "skill-authoring",
       "go-deep",
       "mention_users",
-      "projects",
       "plan_mode",
       "support",
     ],

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -7,6 +7,8 @@ import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversa
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { projectsSkill } from "@app/lib/resources/skill/code_defined/projects";
+import { sandboxSkill } from "@app/lib/resources/skill/code_defined/sandbox";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -19,7 +21,12 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function disableAutoEquippedSkills() {
+  vi.spyOn(projectsSkill, "isAutoEquippedForAgentLoop").mockReturnValue(false);
+  vi.spyOn(sandboxSkill, "isAutoEquippedForAgentLoop").mockReturnValue(false);
+}
 
 describe("getJITServers", () => {
   let auth: Authenticator;
@@ -142,39 +149,49 @@ describe("getJITServers", () => {
       );
     });
 
-    it("should not include skill_management server when agent has no skills", async () => {
-      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-
-      const { servers: jitServers } = await getJITServers(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-        attachments: [],
+    describe("when no auto-equipped skills", () => {
+      beforeEach(() => {
+        disableAutoEquippedSkills();
       });
 
-      const skillManagementServer = jitServers.find(
-        (server) => server.name === "skill_management"
-      );
-
-      expect(skillManagementServer).toBeUndefined();
-    });
-
-    it("should not include skill_management server when agent only has system skills", async () => {
-      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-      await SkillFactory.linkGlobalSkillToAgent(auth, {
-        globalSkillId: "discover_tools",
-        agentConfigurationId: agentConfig.id,
-      });
-      const { servers: jitServers } = await getJITServers(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-        attachments: [],
+      afterEach(() => {
+        vi.restoreAllMocks();
       });
 
-      const skillManagementServer = jitServers.find(
-        (server) => server.name === "skill_management"
-      );
+      it("should not include skill_management server when agent has no skills", async () => {
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      expect(skillManagementServer).toBeUndefined();
+        const { servers: jitServers } = await getJITServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments: [],
+        });
+
+        const skillManagementServer = jitServers.find(
+          (server) => server.name === "skill_management"
+        );
+
+        expect(skillManagementServer).toBeUndefined();
+      });
+
+      it("should not include skill_management server when agent only has system skills", async () => {
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+        await SkillFactory.linkGlobalSkillToAgent(auth, {
+          globalSkillId: "discover_tools",
+          agentConfigurationId: agentConfig.id,
+        });
+        const { servers: jitServers } = await getJITServers(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+          attachments: [],
+        });
+
+        const skillManagementServer = jitServers.find(
+          (server) => server.name === "skill_management"
+        );
+
+        expect(skillManagementServer).toBeUndefined();
+      });
     });
 
     it("should return system skills separately from equipped skills", async () => {
@@ -260,6 +277,32 @@ describe("getJITServers", () => {
       });
 
       expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
+    });
+
+    it("auto-equips the projects skill for any agent", async () => {
+      const { enabledSkills, systemSkills, equippedSkills } =
+        await SkillResource.listForAgentLoop(auth, {
+          agentConfiguration: agentConfig,
+          conversation,
+        });
+
+      expect(systemSkills.some((s) => s.sId === "projects")).toBe(false);
+      expect(enabledSkills.some((s) => s.sId === "projects")).toBe(false);
+      expect(equippedSkills.some((s) => s.sId === "projects")).toBe(true);
+    });
+
+    it("includes skill_management so agents can enable the projects skill", async () => {
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+      const { servers: jitServers } = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments: [],
+      });
+
+      expect(
+        jitServers.some((server) => server.name === "skill_management")
+      ).toBe(true);
     });
   });
 

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -63,6 +63,8 @@ When you need to find information, use this order (skip steps if the relevant to
   // Auto-enabled whenever the conversation belongs to a Pod.
   isAutoEnabledForAgentLoop: ({ conversation }) =>
     isPodConversation(conversation),
+  // Auto-equipped for all agent loops.
+  isAutoEquippedForAgentLoop: (): boolean => true,
 } as const satisfies GlobalSkillDefinition;
 
 export async function constructProjectContext(

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -384,7 +384,7 @@ export const sandboxSkill = {
   icon: "CommandLineIcon",
   // Auto-equipped for every agent when the `sandbox_tools` flag is on (the flag gate lives in
   // isRestricted), but not enabled until the agent decides to use it.
-  isAutoEquippedForAgentLoop: () => true,
+  isAutoEquippedForAgentLoop: (): boolean => true,
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 


### PR DESCRIPTION
## Description

Added `isAutoEquippedForAgentLoop: () => true` to the `projects` skill definition, making the Pods skill universally auto-equipped for all agent loops regardless of conversation context. Previously, the skill was only `isAutoEnabledForAgentLoop` for Pod conversations, and had to be explicitly listed in `_getDustLikeGlobalAgent`'s skill array. The explicit `"projects"` entry is now removed from the Dust global agent configuration since it's handled universally by the skill itself.

## Tests

Tested manually.

## Risk

Low. The skill was already available to all agents that explicitly listed it; this change makes the equip behavior automatic and consistent. The `isAutoEnabledForAgentLoop` condition for Pod conversations remains unchanged — only equipability broadens.

## Deploy Plan

Deploy `front`.
