### PR TITLE
Upg: allow list_pods to find open pods.

### DIFF
--- a/front-api/routes/w/[wId]/spaces/search_projects.ts
+++ b/front-api/routes/w/[wId]/spaces/search_projects.ts
@@ -1,10 +1,8 @@
 import { getPaginationParams } from "@app/lib/api/pagination";
 import {
-  enrichProjectsWithMetadata,
   type SearchProjectsResponseBody,
+  searchReadablePods,
 } from "@app/lib/api/projects/list";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -37,11 +35,7 @@ app.get("/", async (ctx): HandlerResult<SearchProjectsResponseBody> => {
   const queryString = ctx.req.query("query");
   const pagination = paginationRes.value;
 
-  const {
-    spaces: projectSpaces,
-    hasMore,
-    lastValue,
-  } = await SpaceResource.searchProjectsByNamePaginated(auth, {
+  const result = await searchReadablePods(auth, {
     query: queryString,
     pagination: {
       limit: pagination.limit,
@@ -50,28 +44,7 @@ app.get("/", async (ctx): HandlerResult<SearchProjectsResponseBody> => {
     },
   });
 
-  const projectsWithMetadata = await enrichProjectsWithMetadata(
-    auth,
-    projectSpaces
-  );
-
-  const metadataMap = new Map(projectsWithMetadata.map((p) => [p.sId, p]));
-
-  const results = [];
-  for (const space of projectSpaces) {
-    const metadata = metadataMap.get(space.sId);
-    if (!metadata) {
-      logger.warn({ spaceId: space.sId }, "Missing metadata for project");
-      continue;
-    }
-    results.push({ ...metadata, isMember: space.isMember(auth) });
-  }
-
-  return ctx.json({
-    spaces: results,
-    hasMore,
-    lastValue,
-  });
+  return ctx.json(result);
 });
 
 export default app;

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -185,8 +185,37 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   list_pods: {
     description:
-      "List non-archived Pods where you are a space member (same scope as the workspace Pod sidebar source). Each entry includes spaceId, name, and dustPod (uri + mimeType) to pass as the dustPod argument to other pod_manager tools.",
-    schema: {},
+      "List non-archived Pods. Defaults to Pods where you are a member (access='member'). " +
+      "Use access='open' to list all open Pods in the workspace. " +
+      "Each entry includes id, name, and dustPod (uri + mimeType) to pass as the dustPod argument to other pod_manager tools.",
+    schema: {
+      access: z
+        .enum(["member", "open"])
+        .default("member")
+        .optional()
+        .describe(
+          "Pod access filter: member = Pods you belong to (default); open = all open Pods in the workspace."
+        ),
+      q: z
+        .string()
+        .optional()
+        .describe("Optional case-insensitive substring filter on Pod name."),
+      limit: z
+        .number()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(20)
+        .describe(
+          "Maximum number of Pods to return per call (default: 20, max: 100)."
+        ),
+      pageCursor: z
+        .string()
+        .optional()
+        .describe(
+          "Opaque cursor from nextPageCursor of a prior list_pods call. Only for pagination."
+        ),
+    },
     stake: "never_ask",
     displayLabels: {
       running: "Listing Pods",
@@ -407,7 +436,7 @@ const POD_MANAGER_INSTRUCTIONS =
   "`remove_content_node` to remove such a reference. " +
   "Use `edit_information` to update the Pod title, description, or pinned frame. " +
   "Use `update_members` to add or remove Pod members. " +
-  "Use `list_pods` to discover Pods you can access and obtain the dustPod uri for other tools. " +
+  "Use `list_pods` to discover Pods you can access (your Pods by default, or all open Pods) and obtain the dustPod uri for other tools. " +
   "Use `retrieve_recent_documents` to load recent content from the Pod data source and from " +
   "knowledge nodes in the Pod context. " +
   `Use \`${getPrefixedToolName(POD_MANAGER_SERVER_NAME, SEMANTIC_SEARCH_TOOL_NAME)}\` to find relevant chunks in Pod files and/or conversations ` +

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -44,7 +44,7 @@ import {
   listProjectContextAttachments,
   removeContentNodesFromProject,
 } from "@app/lib/api/projects/context";
-import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
+import { listPodsForScope } from "@app/lib/api/projects/list";
 import { validatePinnedFramePath } from "@app/lib/api/projects/pinned_frame";
 import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import type { Authenticator } from "@app/lib/auth";
@@ -66,6 +66,7 @@ import {
 } from "@app/types/assistant/conversation";
 import { extractDataSourceIdFromNodeId } from "@app/types/core/content_node";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { formatConversationsForDisplay } from "./conversation_formatting";
 
@@ -602,19 +603,74 @@ export function createProjectManagerTools(
         );
       }, "Failed to list Pod members");
     },
-    list_pods: async () => {
+    list_pods: async (params) => {
       return withErrorHandling(async () => {
         const owner = auth.getNonNullableWorkspace();
         const workspaceSId = owner.sId;
-        const { nonArchivedSpaces } =
-          await listNonArchivedMemberSpacesWithMetadata(auth);
-        const memberPods = nonArchivedSpaces
-          .filter((space) => space.isProject())
-          .sort((a, b) =>
-            a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
-          );
+        const { access = "member", q, limit = 20, pageCursor } = params;
 
-        const pods = memberPods.map((pod) => ({
+        const decodedPageOffset = pageCursor
+          ? Number.parseInt(pageCursor, 10)
+          : 0;
+        const pageOffset =
+          Number.isInteger(decodedPageOffset) && decodedPageOffset >= 0
+            ? decodedPageOffset
+            : null;
+
+        if (pageOffset === null) {
+          return new Err(
+            new MCPError(
+              "Invalid pageCursor. Expected an offset cursor from a previous list_pods response.",
+              { tracked: false }
+            )
+          );
+        }
+
+        const {
+          pods: pagePods,
+          total,
+          hasMore,
+        } = await listPodsForScope(auth, {
+          access,
+          q,
+          pagination: { limit, pageOffset },
+        });
+
+        if (total === 0) {
+          let emptyMessage: string;
+          switch (access) {
+            case "open":
+              emptyMessage = q?.trim()
+                ? `No open Pods found matching "${q.trim()}".`
+                : "No non-archived open Pods found in this workspace.";
+              break;
+            case "member":
+              emptyMessage = q?.trim()
+                ? `No Pods found matching "${q.trim()}" where you are a member.`
+                : "No non-archived Pods found where you are a space member.";
+              break;
+            default:
+              assertNever(access);
+          }
+
+          return new Ok(
+            makeSuccessResponse({
+              success: true,
+              count: 0,
+              total: 0,
+              hasMore: false,
+              nextPageCursor: null,
+              pods: [],
+              message: emptyMessage,
+            })
+          );
+        }
+
+        const nextPageCursor = hasMore
+          ? String(pageOffset + pagePods.length)
+          : null;
+
+        const pods = pagePods.map((pod) => ({
           id: pod.sId,
           name: pod.name,
           dustPod: {
@@ -623,15 +679,32 @@ export function createProjectManagerTools(
           },
         }));
 
+        let accessLabel: string;
+        switch (access) {
+          case "open":
+            accessLabel = "open Pod(s)";
+            break;
+          case "member":
+            accessLabel = "Pod(s) you are a member of";
+            break;
+          default:
+            assertNever(access);
+        }
+        const filterLabel = q?.trim() ? ` matching "${q.trim()}"` : "";
+
         return new Ok(
           makeSuccessResponse({
             success: true,
             count: pods.length,
+            total,
+            hasMore,
+            nextPageCursor,
             pods,
             message:
-              pods.length === 0
-                ? "No non-archived Pods found where you are a space member."
-                : `Found ${pods.length} Pod(s). Use each entry's dustPod as the dustPod argument for other pod_manager tools.`,
+              `Found ${pods.length} of ${total} ${accessLabel}${filterLabel}.` +
+              (hasMore
+                ? " Pass nextPageCursor to fetch more Pods."
+                : " Use each entry's dustPod as the dustPod argument for other pod_manager tools."),
           })
         );
       }, "Failed to list Pods");

--- a/front/lib/api/mcp_server/tools/pods/list.ts
+++ b/front/lib/api/mcp_server/tools/pods/list.ts
@@ -1,9 +1,41 @@
 import config from "@app/lib/api/config";
 import { registerDustMcpTool } from "@app/lib/api/mcp_server/tools/register";
-import { listNonArchivedMemberSpacesWithMetadata } from "@app/lib/api/projects/list";
+import { listPodsForScope } from "@app/lib/api/projects/list";
 import { getPodRoute } from "@app/lib/utils/router";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { mcpJsonResponse } from "../response";
+import { z } from "zod";
+import { mcpError, mcpJsonResponse } from "../response";
+
+const inputSchema = {
+  access: z
+    .enum(["member", "open"])
+    .default("member")
+    .optional()
+    .describe(
+      "Pod access filter: member = Pods you belong to (default); open = all open Pods in the workspace."
+    ),
+  q: z
+    .string()
+    .optional()
+    .describe(
+      "Optional case-insensitive substring filter on Pod name (diacritics ignored)."
+    ),
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(20)
+    .describe(
+      "Maximum number of Pods to return per call (default: 20, max: 100)."
+    ),
+  lastValue: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor from a previous response's lastValue field for the next page."
+    ),
+};
 
 export function registerPodsListTool(server: McpServer) {
   registerDustMcpTool(
@@ -11,26 +43,53 @@ export function registerPodsListTool(server: McpServer) {
     "list_pods",
     {
       description:
-        "List non-archived Pods that you are a member of in the current workspace.",
+        "List non-archived Pods (20 per page by default). Defaults to Pods where you are a member (access='member'). " +
+        "Use access='open' to list all open Pods in the workspace. Supports cursor pagination via lastValue.",
+      inputSchema,
     },
-    async (auth) => {
-      const owner = auth.workspace();
-      const { nonArchivedSpaces } =
-        await listNonArchivedMemberSpacesWithMetadata(auth);
-      const memberPods = nonArchivedSpaces
-        .filter((space) => space.isProject())
-        .sort((a, b) =>
-          a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
-        );
+    async (auth, { access = "member", q, limit = 20, lastValue }) => {
+      const owner = auth.getNonNullableWorkspace();
+      const workspaceSId = owner.sId;
 
-      const pods = memberPods.map((pod) => ({
+      const decodedPageOffset = lastValue ? Number.parseInt(lastValue, 10) : 0;
+      const pageOffset =
+        Number.isInteger(decodedPageOffset) && decodedPageOffset >= 0
+          ? decodedPageOffset
+          : null;
+
+      if (pageOffset === null) {
+        return mcpError(
+          "Invalid lastValue. Expected a pagination cursor from a previous list_pods response."
+        );
+      }
+
+      const {
+        pods: pagePods,
+        total,
+        hasMore,
+      } = await listPodsForScope(auth, {
+        access,
+        q,
+        pagination: { limit, pageOffset },
+      });
+
+      const nextLastValue = hasMore
+        ? String(pageOffset + pagePods.length)
+        : null;
+
+      const pods = pagePods.map((pod) => ({
         id: pod.sId,
         name: pod.name,
-        url: `${config.getAppUrl()}${getPodRoute(owner.sId, pod.sId)}`,
+        url: `${config.getAppUrl()}${getPodRoute(workspaceSId, pod.sId)}`,
       }));
 
       return mcpJsonResponse({
         count: pods.length,
+        total,
+        hasMore,
+        lastValue: nextLastValue,
+        access,
+        q: q ?? null,
         pods,
       });
     }

--- a/front/lib/api/projects/list.test.ts
+++ b/front/lib/api/projects/list.test.ts
@@ -1,0 +1,158 @@
+import { listPodsForScope } from "@app/lib/api/projects/list";
+import { createSpaceAndGroup } from "@app/lib/api/spaces";
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("listPodsForScope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns only member Pods for the member access", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const memberPod = await SpaceFactory.project(workspace);
+    const otherPod = await SpaceFactory.project(workspace);
+
+    await ProjectMetadataResource.makeNew(adminAuth, memberPod, {
+      description: null,
+    });
+    await ProjectMetadataResource.makeNew(adminAuth, otherPod, {
+      description: null,
+    });
+
+    await memberPod.addMembers(adminAuth, { userIds: [user.sId] });
+    await auth.refresh();
+
+    const { pods, total } = await listPodsForScope(auth, {
+      access: "member",
+      pagination: { limit: 100, pageOffset: 0 },
+    });
+
+    expect(total).toBe(pods.length);
+    expect(pods.some((pod) => pod.sId === memberPod.sId)).toBe(true);
+    expect(pods.some((pod) => pod.sId === otherPod.sId)).toBe(false);
+  });
+
+  it("returns readable open Pods for the open access", async () => {
+    vi.spyOn(
+      await import("@app/lib/api/projects/connector"),
+      "createDataSourceAndConnectorForProject"
+    ).mockResolvedValue(new Ok(undefined));
+
+    const {
+      workspace,
+      user,
+      auth: adminAuth,
+    } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const openPodRes = await createSpaceAndGroup(adminAuth, {
+      name: "Open Alpha Pod",
+      isRestricted: false,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    });
+    expect(openPodRes.isOk()).toBe(true);
+
+    const privatePod = await SpaceFactory.project(workspace);
+    await ProjectMetadataResource.makeNew(adminAuth, privatePod, {
+      description: null,
+    });
+
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    const { pods, total } = await listPodsForScope(userAuth, {
+      access: "open",
+      pagination: { limit: 100, pageOffset: 0 },
+    });
+
+    expect(total).toBe(pods.length);
+    expect(pods.some((pod) => pod.name === "Open Alpha Pod")).toBe(true);
+    expect(pods.some((pod) => pod.sId === privatePod.sId)).toBe(false);
+  });
+
+  it("filters Pods by name case-insensitively", async () => {
+    vi.spyOn(
+      await import("@app/lib/api/projects/connector"),
+      "createDataSourceAndConnectorForProject"
+    ).mockResolvedValue(new Ok(undefined));
+
+    const { auth: adminAuth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const alphaPodRes = await createSpaceAndGroup(adminAuth, {
+      name: "Alpha Launch",
+      isRestricted: false,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    });
+    expect(alphaPodRes.isOk()).toBe(true);
+
+    const betaPodRes = await createSpaceAndGroup(adminAuth, {
+      name: "Beta Rollout",
+      isRestricted: false,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    });
+    expect(betaPodRes.isOk()).toBe(true);
+
+    const { pods, total } = await listPodsForScope(adminAuth, {
+      access: "open",
+      q: "alpha",
+      pagination: { limit: 100, pageOffset: 0 },
+    });
+
+    expect(total).toBe(1);
+    expect(pods).toHaveLength(1);
+    expect(pods[0]?.name).toBe("Alpha Launch");
+  });
+
+  it("ignores diacritics when filtering by name", async () => {
+    vi.spyOn(
+      await import("@app/lib/api/projects/connector"),
+      "createDataSourceAndConnectorForProject"
+    ).mockResolvedValue(new Ok(undefined));
+
+    const { auth: adminAuth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const cafePodRes = await createSpaceAndGroup(adminAuth, {
+      name: "Café Launch",
+      isRestricted: false,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    });
+    expect(cafePodRes.isOk()).toBe(true);
+
+    const { pods, total } = await listPodsForScope(adminAuth, {
+      access: "open",
+      q: "cafe",
+      pagination: { limit: 100, pageOffset: 0 },
+    });
+
+    expect(total).toBe(1);
+    expect(pods).toHaveLength(1);
+    expect(pods[0]?.name).toBe("Café Launch");
+  });
+});

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -1,6 +1,8 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { removeDiacritics } from "@app/lib/utils";
+import logger from "@app/logger/logger";
 import type { PodType, SpaceType } from "@app/types/space";
 
 export type SpacesLookupResponseBody = {
@@ -12,6 +14,166 @@ export type SearchProjectsResponseBody = {
   hasMore: boolean;
   lastValue: string | null;
 };
+
+export type ListPodsAccess = "member" | "open";
+
+export type ListPodsPagination = {
+  limit: number;
+  pageOffset: number;
+};
+
+export type ListPodsForScopeResult = {
+  pods: SpaceResource[];
+  total: number;
+  hasMore: boolean;
+};
+
+function podNameMatches(q: string | undefined, podName: string): boolean {
+  const normalizedQuery = removeDiacritics(q?.trim() ?? "").toLowerCase();
+  if (!normalizedQuery) {
+    return true;
+  }
+  return removeDiacritics(podName).toLowerCase().includes(normalizedQuery);
+}
+
+function sortPodsByName(pods: SpaceResource[]): SpaceResource[] {
+  return [...pods].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+  );
+}
+
+/**
+ * Paginated search over readable Pods. Used by the sidebar Pod browse popover
+ * (`useSearchPods` → `GET /spaces/search_projects`).
+ */
+export async function searchReadablePods(
+  auth: Authenticator,
+  {
+    query,
+    pagination,
+  }: {
+    query?: string;
+    pagination: {
+      limit: number;
+      lastValue?: string;
+      orderDirection: "asc" | "desc";
+    };
+  }
+): Promise<SearchProjectsResponseBody> {
+  const {
+    spaces: projectSpaces,
+    hasMore,
+    lastValue,
+  } = await SpaceResource.searchProjectsByNamePaginated(auth, {
+    query,
+    pagination,
+  });
+
+  const projectsWithMetadata = await enrichProjectsWithMetadata(
+    auth,
+    projectSpaces
+  );
+  const metadataMap = new Map(projectsWithMetadata.map((p) => [p.sId, p]));
+
+  const results = [];
+  for (const space of projectSpaces) {
+    const metadata = metadataMap.get(space.sId);
+    if (!metadata) {
+      logger.warn({ spaceId: space.sId }, "Missing metadata for project");
+      continue;
+    }
+    results.push({ ...metadata, isMember: space.isMember(auth) });
+  }
+
+  return {
+    spaces: results,
+    hasMore,
+    lastValue,
+  };
+}
+
+/**
+ * List non-archived Pods for the given scope, with optional diacritics-insensitive
+ * name filtering and offset-based pagination.
+ *
+ * - member: Pods where the user is a space member (sidebar default).
+ * - open: all non-archived open Pods in the workspace (via searchProjectsByNamePaginated).
+ */
+export async function listPodsForScope(
+  auth: Authenticator,
+  {
+    access,
+    q,
+    pagination,
+  }: {
+    access: ListPodsAccess;
+    q?: string;
+    pagination: ListPodsPagination;
+  }
+): Promise<ListPodsForScopeResult> {
+  const { limit, pageOffset } = pagination;
+
+  if (access === "member") {
+    const { nonArchivedSpaces } =
+      await listNonArchivedMemberSpacesWithMetadata(auth);
+    const memberPods = nonArchivedSpaces.filter((space) => space.isProject());
+    const matchingPods = memberPods.filter((pod) =>
+      podNameMatches(q, pod.name)
+    );
+    const sortedPods = sortPodsByName(matchingPods);
+    const total = sortedPods.length;
+    const pods = sortedPods.slice(pageOffset, pageOffset + limit);
+
+    return {
+      pods,
+      total,
+      hasMore: pageOffset + pods.length < total,
+    };
+  }
+
+  const pagePods: SpaceResource[] = [];
+  let total = 0;
+  let lastValue: string | undefined;
+  let hasMoreSearch = true;
+
+  while (hasMoreSearch) {
+    const page = await SpaceResource.searchProjectsByNamePaginated(auth, {
+      pagination: {
+        limit,
+        lastValue,
+        orderDirection: "asc",
+      },
+    });
+
+    const metadatas = await ProjectMetadataResource.fetchBySpaceIds(
+      auth,
+      page.spaces.map((space) => space.id)
+    );
+    const metadataMap = new Map(metadatas.map((m) => [m.spaceId, m]));
+
+    for (const space of page.spaces) {
+      if (
+        space.isOpen() &&
+        metadataMap.get(space.id)?.archivedAt === null &&
+        podNameMatches(q, space.name)
+      ) {
+        if (total >= pageOffset && pagePods.length < limit) {
+          pagePods.push(space);
+        }
+        total++;
+      }
+    }
+
+    hasMoreSearch = page.hasMore;
+    lastValue = page.lastValue ?? undefined;
+  }
+
+  return {
+    pods: pagePods,
+    total,
+    hasMore: pageOffset + pagePods.length < total,
+  };
+}
 
 /**
  * Spaces the user is a member of, with project metadata loaded, excluding


### PR DESCRIPTION
## Description

`list_pods` in both the `pod_manager` MCP tool and the external MCP server's `list.ts` previously only returned Pods the caller was a member of, with no pagination or filtering. This adds a `scopeFilter` param (`'mine'` | `'open'`) so agents can discover all non-archived open Pods in the workspace, plus `nameQuery` (case-insensitive, diacritics-normalized substring filter), `limit`, and cursor-based pagination (`pageCursor` / `nextPageCursor`). The response now includes `total` and `hasMore`.

The logic is extracted into `listPodsForScope` in `front/lib/api/projects/list.ts`, shared by both MCP surfaces. `searchReadablePods` is similarly extracted there to simplify the `search_projects` route handler.

## Tests

Added `front/lib/api/projects/list.test.ts` with 4 unit tests covering: `mine` scope membership filter, `open` scope readable-only filter, case-insensitive name filtering, and diacritics-normalized name filtering. Tested locally via the pod_manager MCP tool.

## Risk

Low. `scopeFilter` defaults to `'mine'`, preserving existing behavior for all callers. The `open` scope respects `SpaceResource` readable checks — no privilege escalation. Pagination offset cursor is validated; invalid cursors return a clean error.

## Deploy Plan

Deploy `front`.
