### PR TITLE
Fix: create_pod was not supporting editors, enforce that pods cannot become editor less.

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -105,8 +105,8 @@ const MCP_TOOL_OVERRIDES: Partial<
         if (!isPodManagerUpdateMembersInput(inputs)) {
           return `Allow ${asDisplayName(agentName)} to update Pod members?`;
         }
-        const addCount = inputs.addMemberIds?.length ?? 0;
-        const removeCount = inputs.removeMemberIds?.length ?? 0;
+        const addCount = Object.keys(inputs.membersToAdd ?? {}).length;
+        const removeCount = inputs.membersToRemove?.length ?? 0;
         const parts: string[] = [];
         if (addCount > 0) {
           parts.push(`add ${addCount}`);
@@ -114,7 +114,7 @@ const MCP_TOOL_OVERRIDES: Partial<
         if (removeCount > 0) {
           parts.push(`remove ${removeCount}`);
         }
-        return `Allow ${asDisplayName(agentName)} to ${parts.join(" and ")} Pod member${addCount + removeCount === 1 ? "" : "s"}?`;
+        return `Allow ${asDisplayName(agentName)} to ${parts.join(" and ")} Pod user${addCount + removeCount === 1 ? "" : "s"}?`;
       },
       alwaysAllowLabel: (agentName) =>
         `Always allow ${asDisplayName(agentName)} to update Pod members`,

--- a/front/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/PodMembersUpdateValidationDetails.tsx
@@ -42,6 +42,7 @@ function formatMemberName({
 interface MemberChangeRowProps {
   memberSId: string;
   action: "add" | "remove";
+  role?: "member" | "editor";
   currentUserSId: string;
   memberDisplayBySId: Record<string, MemberDisplayInfo>;
   isMembersLoading: boolean;
@@ -50,6 +51,7 @@ interface MemberChangeRowProps {
 function MemberChangeRow({
   memberSId,
   action,
+  role,
   currentUserSId,
   memberDisplayBySId,
   isMembersLoading,
@@ -80,11 +82,20 @@ function MemberChangeRow({
           </div>
         )}
       </div>
-      <Chip
-        size="xs"
-        color={action === "add" ? "green" : "rose"}
-        label={action === "add" ? "Will add" : "Will remove"}
-      />
+      <div className="flex items-center gap-1.5">
+        {action === "add" && role && (
+          <Chip
+            size="xs"
+            color={role === "editor" ? "blue" : "primary"}
+            label={role === "editor" ? "Editor" : "Member"}
+          />
+        )}
+        <Chip
+          size="xs"
+          color={action === "add" ? "green" : "rose"}
+          label={action === "add" ? "Will add" : "Will remove"}
+        />
+      </div>
     </div>
   );
 }
@@ -95,8 +106,9 @@ export function PodMembersUpdateValidationDetails({
   user,
   conversationId,
 }: PodMembersUpdateValidationDetailsProps) {
-  const addMemberIds = input.addMemberIds ?? [];
-  const removeMemberIds = input.removeMemberIds ?? [];
+  const membersToAdd = input.membersToAdd ?? {};
+  const membersToRemove = input.membersToRemove ?? [];
+  const addEntries = Object.entries(membersToAdd);
   const { podLabel, isPodLabelLoading } = usePodLabel({
     owner,
     dustPodUri: input.dustPod?.uri,
@@ -104,8 +116,10 @@ export function PodMembersUpdateValidationDetails({
   });
 
   const memberSIds = useMemo(
-    () => [...new Set([...addMemberIds, ...removeMemberIds])],
-    [addMemberIds, removeMemberIds]
+    () => [
+      ...new Set([...addEntries.map(([userId]) => userId), ...membersToRemove]),
+    ],
+    [addEntries, membersToRemove]
   );
   const { membersBySId, isMembersLoading } = useMemberDetails({
     workspaceId: owner.sId,
@@ -113,14 +127,14 @@ export function PodMembersUpdateValidationDetails({
   });
 
   const summaryParts: string[] = [];
-  if (addMemberIds.length > 0) {
+  if (addEntries.length > 0) {
     summaryParts.push(
-      `add ${addMemberIds.length} member${addMemberIds.length === 1 ? "" : "s"}`
+      `add ${addEntries.length} user${addEntries.length === 1 ? "" : "s"}`
     );
   }
-  if (removeMemberIds.length > 0) {
+  if (membersToRemove.length > 0) {
     summaryParts.push(
-      `remove ${removeMemberIds.length} member${removeMemberIds.length === 1 ? "" : "s"}`
+      `remove ${membersToRemove.length} user${membersToRemove.length === 1 ? "" : "s"}`
     );
   }
 
@@ -134,21 +148,22 @@ export function PodMembersUpdateValidationDetails({
         .
       </p>
 
-      {addMemberIds.length > 0 && (
+      {addEntries.length > 0 && (
         <div className="flex flex-col gap-1.5">
           <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
-            Members to add
+            Users to add
           </div>
           <div
             className={cn(
               "divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background dark:divide-separator-night dark:border-separator-night dark:bg-background-night"
             )}
           >
-            {addMemberIds.map((memberSId) => (
+            {addEntries.map(([memberSId, role]) => (
               <MemberChangeRow
                 key={`add-${memberSId}`}
                 memberSId={memberSId}
                 action="add"
+                role={role}
                 currentUserSId={user.sId}
                 memberDisplayBySId={membersBySId}
                 isMembersLoading={isMembersLoading}
@@ -158,17 +173,17 @@ export function PodMembersUpdateValidationDetails({
         </div>
       )}
 
-      {removeMemberIds.length > 0 && (
+      {membersToRemove.length > 0 && (
         <div className="flex flex-col gap-1.5">
           <div className="text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
-            Members to remove
+            Users to remove
           </div>
           <div
             className={cn(
               "divide-y divide-separator overflow-hidden rounded-xl border border-separator bg-background dark:divide-separator-night dark:border-separator-night dark:bg-background-night"
             )}
           >
-            {removeMemberIds.map((memberSId) => (
+            {membersToRemove.map((memberSId) => (
               <MemberChangeRow
                 key={`remove-${memberSId}`}
                 memberSId={memberSId}

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -16,6 +16,7 @@ import { fetchProjectDataSourceView } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -251,6 +252,67 @@ export function makeSuccessResponse(data: Record<string, unknown>): {
  * Wraps an async operation with standardized error handling.
  * Catches exceptions and converts them to MCPError results.
  */
+export async function resolvePodUserRolesBySId(
+  auth: Authenticator,
+  pod: SpaceResource
+): Promise<Map<string, "editor" | "member">> {
+  const { groupsToProcess, allGroupMemberships } =
+    await pod.fetchManualGroupsMemberships(auth, {
+      shouldIncludeAllMembers: false,
+    });
+
+  const groupById = new Map(
+    groupsToProcess.map((group) => [group.id, group] as const)
+  );
+  const membershipByUserId = new Map<number, { isEditor: boolean }>();
+
+  for (const membership of allGroupMemberships) {
+    const group = groupById.get(membership.groupId);
+    if (!group) {
+      continue;
+    }
+
+    const previous = membershipByUserId.get(membership.userId);
+    membershipByUserId.set(membership.userId, {
+      isEditor: Boolean(previous?.isEditor) || group.kind === "space_editors",
+    });
+  }
+
+  const users = await UserResource.fetchByModelIds([
+    ...membershipByUserId.keys(),
+  ]);
+  const roleByUserSId = new Map<string, "editor" | "member">();
+
+  for (const user of users) {
+    const membership = membershipByUserId.get(user.id);
+    if (!membership) {
+      continue;
+    }
+    roleByUserSId.set(user.sId, membership.isEditor ? "editor" : "member");
+  }
+
+  return roleByUserSId;
+}
+
+export function partitionMembersToRemove(
+  membersToRemove: string[],
+  roleByUserSId: Map<string, "editor" | "member">
+): { editorIds: string[]; memberIds: string[] } {
+  const editorIds: string[] = [];
+  const memberIds: string[] = [];
+
+  for (const userId of membersToRemove) {
+    const role = roleByUserSId.get(userId);
+    if (role === "editor") {
+      editorIds.push(userId);
+    } else if (role === "member") {
+      memberIds.push(userId);
+    }
+  }
+
+  return { editorIds, memberIds };
+}
+
 export async function withErrorHandling<T>(
   operation: () => Promise<Result<T, MCPError>>,
   errorMessage: string

--- a/front/lib/api/actions/servers/pod_manager/metadata.ts
+++ b/front/lib/api/actions/servers/pod_manager/metadata.ts
@@ -7,6 +7,10 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/types";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
+import {
+  PodMembersToAddSchema,
+  PodMembersToRemoveSchema,
+} from "@app/lib/api/actions/servers/pod_manager/types";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
@@ -106,16 +110,16 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   [UPDATE_MEMBERS_TOOL_NAME]: {
     description:
-      "Add or remove Pod members by user sId. Requires Pod editor permissions.",
+      "Add or remove Pod members and editors by user id. Requires Pod editor permissions. " +
+      "Editors and members are mutually exclusive: adding an editor removes them from members, " +
+      "and adding a member is a no-op if the user is already an editor.",
     schema: {
-      addMemberIds: z
-        .array(z.string())
-        .optional()
-        .describe("User sIds to add as Pod members"),
-      removeMemberIds: z
-        .array(z.string())
-        .optional()
-        .describe("User sIds to remove from the Pod"),
+      membersToAdd: PodMembersToAddSchema.optional().describe(
+        "User ids to add mapped to their Pod role (member or editor)."
+      ),
+      membersToRemove: PodMembersToRemoveSchema.optional().describe(
+        "User ids to remove from the Pod (membership or editorship)."
+      ),
       dustPod: ConfigurableToolInputSchemas[
         INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_POD
       ]
@@ -224,7 +228,8 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   create_pod: {
     description:
-      "Create a new Pod. By default the Pod is private. You can optionally set visibility to open and add members by user sId.",
+      "Create a new Pod. By default the Pod is private. The creator is always added as a Pod editor. " +
+      "You can optionally set visibility to open and add initial members or editors via membersToAdd.",
     schema: {
       title: z.string().describe("Pod title"),
       description: z
@@ -238,12 +243,9 @@ export const POD_MANAGER_TOOLS_METADATA = createToolsRecord({
         .describe(
           "Pod visibility. Defaults to private. Open Pods are subject to workspace policy."
         ),
-      memberIds: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "Optional list of user ids to add as Pod members after Pod creation."
-        ),
+      membersToAdd: PodMembersToAddSchema.optional().describe(
+        "Optional user ids to add after creation mapped to their Pod role (member or editor). The creator is always an editor."
+      ),
       seedInitialTasks: z
         .boolean()
         .optional()

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -18,6 +18,8 @@ import {
   getPod,
   getWritablePodContext,
   makeSuccessResponse,
+  partitionMembersToRemove,
+  resolvePodUserRolesBySId,
   withErrorHandling,
 } from "@app/lib/api/actions/servers/pod_manager/helpers";
 import {
@@ -26,6 +28,7 @@ import {
   SEMANTIC_SEARCH_TOOL_NAME,
   UPDATE_MEMBERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import { partitionMembersToAdd } from "@app/lib/api/actions/servers/pod_manager/types";
 import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
 import { resolveAgentConfigurationIdByName } from "@app/lib/api/assistant/configuration/agent";
 import {
@@ -337,20 +340,66 @@ export function createProjectManagerTools(
           );
         }
 
-        const addMemberIds = params.addMemberIds ?? [];
-        const removeMemberIds = params.removeMemberIds ?? [];
+        const membersToAdd = params.membersToAdd ?? {};
+        const membersToRemove = params.membersToRemove ?? [];
+        const { editorIds: addEditorIds, memberIds: addMemberIds } =
+          partitionMembersToAdd(membersToAdd);
 
-        if (addMemberIds.length === 0 && removeMemberIds.length === 0) {
+        if (
+          addMemberIds.length === 0 &&
+          membersToRemove.length === 0 &&
+          addEditorIds.length === 0
+        ) {
           return new Err(
             new MCPError(
-              "At least one of addMemberIds or removeMemberIds must be provided",
+              "At least one of membersToAdd or membersToRemove must be provided",
               { tracked: false }
             )
           );
         }
 
-        const added: string[] = [];
-        const removed: string[] = [];
+        const roleByUserSId = await resolvePodUserRolesBySId(auth, pod);
+        const { editorIds: removeEditorIds, memberIds: removeMemberIds } =
+          partitionMembersToRemove(membersToRemove, roleByUserSId);
+
+        const addedMembers: string[] = [];
+        const removedMembers: string[] = [];
+        const addedEditors: string[] = [];
+        const removedEditors: string[] = [];
+
+        if (addEditorIds.length > 0) {
+          const uniqueAddEditorIds = [...new Set(addEditorIds)];
+          const addEditorsRes = await pod.addEditors(auth, {
+            userIds: uniqueAddEditorIds,
+          });
+          if (addEditorsRes.isErr()) {
+            return new Err(
+              new MCPError(
+                `Failed to add editors: ${addEditorsRes.error.message}`,
+                { tracked: false }
+              )
+            );
+          }
+          addedEditors.push(...addEditorsRes.value.map((user) => user.sId));
+        }
+
+        if (removeEditorIds.length > 0) {
+          const uniqueRemoveEditorIds = [...new Set(removeEditorIds)];
+          const removeEditorsRes = await pod.removeEditors(auth, {
+            userIds: uniqueRemoveEditorIds,
+          });
+          if (removeEditorsRes.isErr()) {
+            return new Err(
+              new MCPError(
+                `Failed to remove editors: ${removeEditorsRes.error.message}`,
+                { tracked: false }
+              )
+            );
+          }
+          removedEditors.push(
+            ...removeEditorsRes.value.map((user) => user.sId)
+          );
+        }
 
         if (addMemberIds.length > 0) {
           const uniqueAddIds = [...new Set(addMemberIds)];
@@ -365,10 +414,10 @@ export function createProjectManagerTools(
               )
             );
           }
-          added.push(...addMembersRes.value.map((user) => user.sId));
+          addedMembers.push(...addMembersRes.value.map((user) => user.sId));
           notifyPodMembersAdded(auth, {
             pod: pod.toJSON(),
-            addedUserIds: uniqueAddIds,
+            addedUserIds: addedMembers,
           });
         }
 
@@ -385,15 +434,33 @@ export function createProjectManagerTools(
               )
             );
           }
-          removed.push(...removeMembersRes.value.map((user) => user.sId));
+          removedMembers.push(
+            ...removeMembersRes.value.map((user) => user.sId)
+          );
         }
 
         return new Ok(
           makeSuccessResponse({
             success: true,
-            added,
-            removed,
-            message: `Pod members updated successfully.${added.length > 0 ? ` Added: ${added.join(", ")}.` : ""}${removed.length > 0 ? ` Removed: ${removed.join(", ")}.` : ""}`,
+            addedMembers,
+            removedMembers,
+            addedEditors,
+            removedEditors,
+            message: [
+              "Pod members updated successfully.",
+              addedEditors.length > 0
+                ? ` Added editors: ${addedEditors.join(", ")}.`
+                : "",
+              removedEditors.length > 0
+                ? ` Removed editors: ${removedEditors.join(", ")}.`
+                : "",
+              addedMembers.length > 0
+                ? ` Added members: ${addedMembers.join(", ")}.`
+                : "",
+              removedMembers.length > 0
+                ? ` Removed members: ${removedMembers.join(", ")}.`
+                : "",
+            ].join(""),
           })
         );
       }, "Failed to update Pod members");
@@ -767,7 +834,22 @@ export function createProjectManagerTools(
           }
         }
 
-        const pod = createSpaceRes.value;
+        // createSpaceAndGroup grants the creator editor access via a new group
+        // membership. Refresh auth so this tool can administrate the Pod immediately
+        // (e.g. addMembers, seedInitialTasks) and later tools see the membership.
+        await auth.refresh();
+
+        const pod = await SpaceResource.fetchById(
+          auth,
+          createSpaceRes.value.sId
+        );
+        if (!pod) {
+          return new Err(
+            new MCPError("Pod created but could not be retrieved.", {
+              tracked: false,
+            })
+          );
+        }
 
         if (params.description) {
           const metadata = await ProjectMetadataResource.fetchBySpace(
@@ -783,10 +865,32 @@ export function createProjectManagerTools(
           }
         }
 
-        if (params.memberIds && params.memberIds.length > 0) {
-          const uniqueMemberIds = [...new Set(params.memberIds)];
+        const creatorId = auth.getNonNullableUser().sId;
+        const membersToAdd = Object.fromEntries(
+          Object.entries(params.membersToAdd ?? {}).filter(
+            ([userId]) => userId !== creatorId
+          )
+        );
+        const { editorIds: additionalEditorIds, memberIds } =
+          partitionMembersToAdd(membersToAdd);
+
+        if (additionalEditorIds.length > 0) {
+          const addEditorsRes = await pod.addEditors(auth, {
+            userIds: additionalEditorIds,
+          });
+          if (addEditorsRes.isErr()) {
+            return new Err(
+              new MCPError(
+                `Pod created but failed to add some editors: ${addEditorsRes.error.message}`,
+                { tracked: false }
+              )
+            );
+          }
+        }
+
+        if (memberIds.length > 0) {
           const addMembersRes = await pod.addMembers(auth, {
-            userIds: uniqueMemberIds,
+            userIds: memberIds,
           });
           if (addMembersRes.isErr()) {
             return new Err(

--- a/front/lib/api/actions/servers/pod_manager/types.ts
+++ b/front/lib/api/actions/servers/pod_manager/types.ts
@@ -1,12 +1,20 @@
 import { DustPodConfigurationSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { z } from "zod";
 
+export const PodMemberRoleSchema = z.enum(["member", "editor"]);
+
+export const PodMembersToAddSchema = z.record(z.string(), PodMemberRoleSchema);
+
+export const PodMembersToRemoveSchema = z.array(z.string());
+
 export const PodManagerUpdateMembersInputSchema = z.object({
-  addMemberIds: z.array(z.string()).optional(),
-  removeMemberIds: z.array(z.string()).optional(),
+  membersToAdd: PodMembersToAddSchema.optional(),
+  membersToRemove: PodMembersToRemoveSchema.optional(),
   dustPod: DustPodConfigurationSchema.optional(),
 });
 
+export type PodMemberRole = z.infer<typeof PodMemberRoleSchema>;
+export type PodMembersToAdd = z.infer<typeof PodMembersToAddSchema>;
 export type PodManagerUpdateMembersInput = z.infer<
   typeof PodManagerUpdateMembersInputSchema
 >;
@@ -15,4 +23,22 @@ export function isPodManagerUpdateMembersInput(
   input: Record<string, unknown>
 ): input is PodManagerUpdateMembersInput {
   return PodManagerUpdateMembersInputSchema.safeParse(input).success;
+}
+
+export function partitionMembersToAdd(membersToAdd: PodMembersToAdd): {
+  editorIds: string[];
+  memberIds: string[];
+} {
+  const editorIds: string[] = [];
+  const memberIds: string[] = [];
+
+  for (const [userId, role] of Object.entries(membersToAdd)) {
+    if (role === "editor") {
+      editorIds.push(userId);
+    } else {
+      memberIds.push(userId);
+    }
+  }
+
+  return { editorIds, memberIds };
 }

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -207,6 +207,61 @@ describe("createSpaceAndGroup", () => {
       createConnectorSpy.mockRestore();
     });
 
+    it("should add the creator to the project editor group", async () => {
+      const createConnectorSpy = vi
+        .spyOn(
+          await import("@app/lib/api/projects/connector"),
+          "createDataSourceAndConnectorForProject"
+        )
+        .mockResolvedValue(new Ok(undefined));
+
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user1.sId,
+        workspace.sId
+      );
+      const staleAuthJson = userAuth.toJSON();
+
+      const result = await createSpaceAndGroup(userAuth, {
+        name: "Test Project Creator Editor",
+        isRestricted: true,
+        spaceKind: "project",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const pod = result.value;
+        const creator = userAuth.getNonNullableUser();
+        const { groupsToProcess, allGroupMemberships } =
+          await pod.fetchManualGroupsMemberships(userAuth);
+        const editorGroup = groupsToProcess.find(
+          (group) => group.kind === "space_editors"
+        );
+
+        expect(editorGroup).toBeDefined();
+        expect(
+          allGroupMemberships.some(
+            (membership) =>
+              membership.groupId === editorGroup!.id &&
+              membership.userId === creator.id
+          )
+        ).toBe(true);
+
+        const staleAuth = await Authenticator.fromJSON(staleAuthJson);
+        expect(pod.canAdministrate(staleAuth)).toBe(false);
+        expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(false);
+
+        await staleAuth.refresh();
+        expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
+
+        const refreshedPod = await SpaceResource.fetchById(staleAuth, pod.sId);
+        expect(refreshedPod?.canAdministrate(staleAuth)).toBe(true);
+      }
+
+      createConnectorSpy.mockRestore();
+    });
+
     it("should handle connector creation failure gracefully", async () => {
       // Mock createDataSourceAndConnectorForProject to fail
       const createConnectorError = new Error("Failed to create connector");

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -793,6 +793,107 @@ describe("SpaceResource", () => {
           const editorIds = editors.map((m) => m.sId);
           expect(editorIds).toContain(editorUser.sId);
         });
+
+        it("should no-op when adding an existing editor as a member", async () => {
+          await projectEditorGroup.dangerouslyAddMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          const addMembersRes = await reloadedSpace!.addMembers(editorAuth, {
+            userIds: [editorUser.sId],
+          });
+
+          expect(addMembersRes.isOk()).toBe(true);
+          if (addMembersRes.isOk()) {
+            expect(addMembersRes.value).toHaveLength(0);
+          }
+
+          const memberGroupMembers =
+            await projectMemberGroup.getActiveMembers(adminAuth);
+          expect(
+            memberGroupMembers.some((member) => member.sId === editorUser.sId)
+          ).toBe(false);
+
+          const editorGroupMembers =
+            await projectEditorGroup.getActiveMembers(adminAuth);
+          expect(
+            editorGroupMembers.some((member) => member.sId === editorUser.sId)
+          ).toBe(true);
+        });
+
+        it("should promote a member to editor and remove them from members", async () => {
+          await projectMemberGroup.dangerouslyAddMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+          await projectEditorGroup.dangerouslyAddMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          const addEditorsRes = await reloadedSpace!.addEditors(editorAuth, {
+            userIds: [memberUser.sId],
+          });
+
+          expect(addEditorsRes.isOk()).toBe(true);
+
+          const memberGroupMembers =
+            await projectMemberGroup.getActiveMembers(adminAuth);
+          expect(
+            memberGroupMembers.some((member) => member.sId === memberUser.sId)
+          ).toBe(false);
+
+          const editorGroupMembers =
+            await projectEditorGroup.getActiveMembers(adminAuth);
+          expect(
+            editorGroupMembers.some((member) => member.sId === memberUser.sId)
+          ).toBe(true);
+        });
+
+        it("should reject removing the last editor", async () => {
+          await projectEditorGroup.dangerouslyAddMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          const removeEditorsRes = await reloadedSpace!.removeEditors(
+            editorAuth,
+            {
+              userIds: [editorUser.sId],
+            }
+          );
+
+          expect(removeEditorsRes.isErr()).toBe(true);
+          if (removeEditorsRes.isErr()) {
+            expect(removeEditorsRes.error.code).toBe(
+              "group_requirements_not_met"
+            );
+          }
+        });
       });
 
       describe("with provisioned groups", () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -929,6 +929,45 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
+  private async fetchManualMemberGroupSpace(): Promise<GroupSpaceMemberResource> {
+    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+      space: this,
+      filterOnManagementMode: true,
+    });
+
+    assert(
+      memberGroupSpaces.length === 1,
+      "In manual management mode, there should be exactly one member group space."
+    );
+
+    return memberGroupSpaces[0];
+  }
+
+  private async fetchManualEditorGroupSpace(): Promise<GroupSpaceEditorResource> {
+    assert(this.isProject(), "Only projects can have editor groups.");
+
+    const editorGroupSpaces = await GroupSpaceEditorResource.fetchBySpace({
+      space: this,
+      filterOnManagementMode: true,
+    });
+
+    assert(
+      editorGroupSpaces.length === 1,
+      "In manual management mode, there should be exactly one editor group space."
+    );
+
+    return editorGroupSpaces[0];
+  }
+
+  async fetchActiveEditorUsers(auth: Authenticator): Promise<UserResource[]> {
+    if (!this.isProject()) {
+      return [];
+    }
+
+    const editorGroupSpace = await this.fetchManualEditorGroupSpace();
+    return editorGroupSpace.group.getActiveMembers(auth);
+  }
+
   async addMembers(
     auth: Authenticator,
     {
@@ -980,25 +1019,181 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
-      space: this,
-      filterOnManagementMode: true,
-    });
+    let usersToAdd = users;
+    if (this.isProject()) {
+      const activeEditors = await this.fetchActiveEditorUsers(auth);
+      const activeEditorIds = new Set(activeEditors.map((user) => user.sId));
+      usersToAdd = users.filter((user) => !activeEditorIds.has(user.sId));
+      if (usersToAdd.length === 0) {
+        return new Ok([]);
+      }
+    }
 
-    assert(
-      memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space."
-    );
+    const memberGroupSpace = await this.fetchManualMemberGroupSpace();
 
-    const addMemberRes = await memberGroupSpaces[0].addMembers(auth, {
-      users: users.map((user) => user.toJSON()),
+    const addMemberRes = await memberGroupSpace.addMembers(auth, {
+      users: usersToAdd.map((user) => user.toJSON()),
     });
 
     if (addMemberRes.isErr()) {
       return addMemberRes;
     }
 
-    return new Ok(users);
+    return new Ok(usersToAdd);
+  }
+
+  async addEditors(
+    auth: Authenticator,
+    {
+      userIds,
+    }: {
+      userIds: string[];
+    }
+  ): Promise<
+    Result<
+      UserResource[],
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_already_member"
+        | "user_not_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+        | "group_not_found"
+      >
+    >
+  > {
+    if (!this.canAdministrate(auth)) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "You do not have permission to add editors to this space."
+        )
+      );
+    }
+
+    assert(this.isProject(), "Only projects can have editors.");
+    assert(
+      this.managementMode === "manual",
+      "Can only add editors in manual management mode."
+    );
+
+    const users = await UserResource.fetchByIds(userIds);
+    const foundIds = new Set(users.map((user) => user.sId));
+    const missingIds = userIds.filter((id) => !foundIds.has(id));
+
+    if (missingIds.length > 0) {
+      return new Err(
+        new DustError(
+          "user_not_found",
+          `User(s) not found: ${missingIds.join(", ")}`
+        )
+      );
+    }
+
+    const editorGroupSpace = await this.fetchManualEditorGroupSpace();
+    const activeEditors = await editorGroupSpace.group.getActiveMembers(auth);
+    const activeEditorIds = new Set(activeEditors.map((user) => user.sId));
+    const usersToAdd = users.filter((user) => !activeEditorIds.has(user.sId));
+
+    if (usersToAdd.length === 0) {
+      return new Ok([]);
+    }
+
+    const memberGroupSpace = await this.fetchManualMemberGroupSpace();
+    const activeMembers = await memberGroupSpace.group.getActiveMembers(auth);
+    const activeMemberIds = new Set(activeMembers.map((user) => user.sId));
+    const usersToRemoveFromMembers = usersToAdd.filter((user) =>
+      activeMemberIds.has(user.sId)
+    );
+
+    if (usersToRemoveFromMembers.length > 0) {
+      const removeMemberRes = await memberGroupSpace.removeMembers(auth, {
+        users: usersToRemoveFromMembers.map((user) => user.toJSON()),
+      });
+      if (removeMemberRes.isErr()) {
+        return removeMemberRes;
+      }
+    }
+
+    const addEditorRes = await editorGroupSpace.addMembers(auth, {
+      users: usersToAdd.map((user) => user.toJSON()),
+    });
+
+    if (addEditorRes.isErr()) {
+      return addEditorRes;
+    }
+
+    return new Ok(usersToAdd);
+  }
+
+  async removeEditors(
+    auth: Authenticator,
+    {
+      userIds,
+    }: {
+      userIds: string[];
+    }
+  ): Promise<
+    Result<
+      UserResource[],
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+        | "group_not_found"
+      >
+    >
+  > {
+    if (!this.canAdministrate(auth)) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "You do not have permission to remove editors from this space."
+        )
+      );
+    }
+
+    assert(this.isProject(), "Only projects can have editors.");
+    assert(
+      this.managementMode === "manual",
+      "Can only remove editors in manual management mode."
+    );
+
+    const users = await UserResource.fetchByIds(userIds);
+    if (users.length === 0) {
+      return new Err(new DustError("user_not_found", "User not found"));
+    }
+
+    const editorGroupSpace = await this.fetchManualEditorGroupSpace();
+    const activeEditors = await editorGroupSpace.group.getActiveMembers(auth);
+    const activeEditorIds = new Set(activeEditors.map((user) => user.sId));
+    const usersToRemove = users.filter((user) => activeEditorIds.has(user.sId));
+
+    if (usersToRemove.length === 0) {
+      return new Ok([]);
+    }
+
+    if (activeEditors.length - usersToRemove.length < 1) {
+      return new Err(
+        new DustError(
+          "group_requirements_not_met",
+          "Projects must have at least one editor."
+        )
+      );
+    }
+
+    const removeEditorRes = await editorGroupSpace.removeMembers(auth, {
+      users: usersToRemove.map((user) => user.toJSON()),
+    });
+
+    if (removeEditorRes.isErr()) {
+      return removeEditorRes;
+    }
+
+    return new Ok(usersToRemove);
   }
 
   async removeMembers(
@@ -1035,18 +1230,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(new DustError("user_not_found", "User not found"));
     }
 
-    // Get the GroupSpaceMemberResource for the member group
-    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
-      space: this,
-      filterOnManagementMode: true,
-    });
+    const memberGroupSpace = await this.fetchManualMemberGroupSpace();
 
-    assert(
-      memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space."
-    );
-
-    const removeMemberRes = await memberGroupSpaces[0].removeMembers(auth, {
+    const removeMemberRes = await memberGroupSpace.removeMembers(auth, {
       users: users.map((user) => user.toJSON()),
     });
 


### PR DESCRIPTION
## Description

Two fixes to Pod editor management in the `pod_manager` MCP server:

- **`create_pod` missing editor support**: `create_pod` now accepts an optional `editorIds` parameter. The creator is always added as an editor; `auth` is refreshed post-`createSpaceAndGroup` so subsequent `addMembers`/`seedInitialTasks` calls within the same tool invocation see the correct permissions.
- **Editor invariant enforcement**: `SpaceResource` gains `addEditors` and `removeEditors` methods. `addEditors` promotes members to editor (removing them from the member group). `removeEditors` rejects the operation with `group_requirements_not_met` if it would leave the Pod editor-less. `addMembers` now no-ops for users who are already editors.
- **`update_members` tool extended**: exposes `addEditorIds`/`removeEditorIds` parameters, surfacing the above capabilities via the MCP tool interface.

## Tests

Added unit tests in `spaces.test.ts` (creator is added to the editor group, stale auth refreshes correctly) and `space_resource.test.ts` (add-editor-as-member no-op, member→editor promotion, last-editor removal rejection).

## Risk

Low. Changes are additive to existing MCP tool schemas and `SpaceResource` methods. The `addMembers` no-op path is a safe guard. The only behavioral change on existing paths is the `auth.refresh()` call after `createSpaceAndGroup`, which is required for correctness and has no side effects.

## Deploy Plan

Deploy `front` only. No SQL migrations.
