### PR TITLE
Upg: no approval flow in restricted pod when all members have access to the restricted spaces used by the agent.

### DIFF
--- a/front/lib/api/assistant/conversation/messages.test.ts
+++ b/front/lib/api/assistant/conversation/messages.test.ts
@@ -1215,7 +1215,7 @@ describe("createAgentMessages", () => {
       expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
     });
 
-    it("should allow agent mentions when agent uses restricted spaces other than conversation's space but the user is the sole manual member of the restricted conversation space", async () => {
+    it("should reject agent mentions when agent uses restricted spaces other than conversation's space even if the user is the sole manual member of the conversation space", async () => {
       const conversationSpace = await SpaceFactory.regular(workspace);
       const user = auth.getNonNullableUser();
       const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -1325,13 +1325,15 @@ describe("createAgentMessages", () => {
         }
       );
 
-      expect(agentMessages).toHaveLength(1);
-      expect(agentMessages[0].configuration.sId).toBe(agentConfig.sId);
+      // Normally this agent would not be mentionable: getAgentConfiguration
+      // filters agents by requestedSpaceIds the user cannot read. This test
+      // bypasses that early check to assert the Pod-level guard still rejects.
+      expect(agentMessages).toHaveLength(0);
 
       expect(richMentions).toHaveLength(1);
       if (isRichAgentMention(richMentions[0])) {
         expect(richMentions[0].id).toBe(agentConfig.sId);
-        expect(richMentions[0].status).toBe("approved");
+        expect(richMentions[0].status).toBe("agent_restricted_by_space_usage");
       }
 
       const mentionInDb = await MentionModel.findOne({
@@ -1342,7 +1344,7 @@ describe("createAgentMessages", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("approved");
+      expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
     });
 
     it("should allow agent mentions when agent uses global space other than conversation's space", async () => {

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -355,7 +355,40 @@ describe("canAgentBeUsedInProjectConversation", () => {
     ).resolves.toBe(false);
   });
 
-  it("allows the agent under the sole-member exception when multiple extra spaces are restricted", async () => {
+  it("rejects the agent when the sole project member is not in a required restricted space", async () => {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const otherRestrictedSpace = await SpaceFactory.project(workspace);
+
+    await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+    await auth.refresh();
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+    const conversationJson = await fetchConversationWithoutContent(
+      conversation.sId
+    );
+
+    await expect(
+      canAgentBeUsedInProjectConversation(auth, {
+        configuration: lightConfiguration([
+          projectSpace.sId,
+          otherRestrictedSpace.sId,
+        ]),
+        conversation: conversationJson,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("allows the agent when all project members belong to every required restricted space", async () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -367,6 +400,16 @@ describe("canAgentBeUsedInProjectConversation", () => {
     const otherRestrictedSpaceB = await SpaceFactory.project(workspace);
 
     await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+    await addUserToSpaceRegularGroup(
+      internalAdminAuth,
+      otherRestrictedSpaceA,
+      userJson
+    );
+    await addUserToSpaceRegularGroup(
+      internalAdminAuth,
+      otherRestrictedSpaceB,
+      userJson
+    );
     await auth.refresh();
 
     const conversation = await ConversationFactory.create(auth, {
@@ -390,7 +433,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
     ).resolves.toBe(true);
   });
 
-  it("allows the agent under the sole-member exception when extra spaces mix open and restricted", async () => {
+  it("allows the agent when all project members belong to required restricted spaces mixed with open spaces", async () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -401,6 +444,11 @@ describe("canAgentBeUsedInProjectConversation", () => {
     const otherRestrictedSpace = await SpaceFactory.project(workspace);
 
     await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+    await addUserToSpaceRegularGroup(
+      internalAdminAuth,
+      otherRestrictedSpace,
+      userJson
+    );
     await auth.refresh();
 
     const conversation = await ConversationFactory.create(auth, {
@@ -424,7 +472,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
     ).resolves.toBe(true);
   });
 
-  it("allows the agent under the sole-member exception with a single extra restricted space", async () => {
+  it("allows the agent when all project members belong to a single required restricted space", async () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
@@ -435,6 +483,11 @@ describe("canAgentBeUsedInProjectConversation", () => {
     const otherRestrictedSpace = await SpaceFactory.project(workspace);
 
     await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+    await addUserToSpaceRegularGroup(
+      internalAdminAuth,
+      otherRestrictedSpace,
+      userJson
+    );
     await auth.refresh();
 
     const conversation = await ConversationFactory.create(auth, {
@@ -455,6 +508,115 @@ describe("canAgentBeUsedInProjectConversation", () => {
         conversation: conversationJson,
       })
     ).resolves.toBe(true);
+  });
+
+  it("allows the agent when a multi-member restricted project has all members in every required restricted space", async () => {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const otherRestrictedSpaceA = await SpaceFactory.project(workspace);
+    const otherRestrictedSpaceB = await SpaceFactory.project(workspace);
+
+    await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+    const secondUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, secondUser, { role: "user" });
+    await addUserToSpaceRegularGroup(
+      internalAdminAuth,
+      projectSpace,
+      secondUser.toJSON()
+    );
+    for (const restrictedSpace of [
+      otherRestrictedSpaceA,
+      otherRestrictedSpaceB,
+    ]) {
+      await addUserToSpaceRegularGroup(
+        internalAdminAuth,
+        restrictedSpace,
+        userJson
+      );
+      await addUserToSpaceRegularGroup(
+        internalAdminAuth,
+        restrictedSpace,
+        secondUser.toJSON()
+      );
+    }
+    await auth.refresh();
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+    const conversationJson = await fetchConversationWithoutContent(
+      conversation.sId
+    );
+
+    await expect(
+      canAgentBeUsedInProjectConversation(auth, {
+        configuration: lightConfiguration([
+          projectSpace.sId,
+          otherRestrictedSpaceA.sId,
+          otherRestrictedSpaceB.sId,
+        ]),
+        conversation: conversationJson,
+      })
+    ).resolves.toBe(true);
+  });
+
+  it("rejects the agent when a project member is missing from one of multiple required restricted spaces", async () => {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const otherRestrictedSpaceA = await SpaceFactory.project(workspace);
+    const otherRestrictedSpaceB = await SpaceFactory.project(workspace);
+
+    await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+    const secondUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, secondUser, { role: "user" });
+    await addUserToSpaceRegularGroup(
+      internalAdminAuth,
+      projectSpace,
+      secondUser.toJSON()
+    );
+    for (const restrictedSpace of [
+      otherRestrictedSpaceA,
+      otherRestrictedSpaceB,
+    ]) {
+      await addUserToSpaceRegularGroup(
+        internalAdminAuth,
+        restrictedSpace,
+        userJson
+      );
+    }
+    await auth.refresh();
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+    const conversationJson = await fetchConversationWithoutContent(
+      conversation.sId
+    );
+
+    await expect(
+      canAgentBeUsedInProjectConversation(auth, {
+        configuration: lightConfiguration([
+          projectSpace.sId,
+          otherRestrictedSpaceA.sId,
+          otherRestrictedSpaceB.sId,
+        ]),
+        conversation: conversationJson,
+      })
+    ).resolves.toBe(false);
   });
 
   it("rejects the agent when multiple extra spaces are restricted and the project has more than one manual member", async () => {
@@ -499,7 +661,7 @@ describe("canAgentBeUsedInProjectConversation", () => {
     ).resolves.toBe(false);
   });
 
-  it("rejects the agent when another required space is restricted and the project has more than one manual member", async () => {
+  it("rejects the agent when a project member is missing from a required restricted space", async () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -132,14 +132,32 @@ export async function canAgentBeUsedInProjectConversation(
         throw new Error("Unexpected: project not found");
       }
 
-      // Special case for restricted projects with only one member that is the user, we can use the agent directly.
+      // Special case for restricted projects whose members all belong to every
+      // restricted space required by the agent, we can use the agent directly.
       if (!project.isOpen()) {
-        const members =
+        const restrictedAgentSpaces = spaces.filter(
+          (space) => space.sId !== conversation.spaceId && !space.isOpen()
+        );
+        const projectMembers =
           await project.fetchDistinctActiveManualGroupMembers(auth);
-        if (
-          members.length === 1 &&
-          members[0].sId === auth.getNonNullableUser().sId
-        ) {
+
+        if (restrictedAgentSpaces.length > 0 && projectMembers.length > 0) {
+          const workspaceId = auth.getNonNullableWorkspace().sId;
+          const memberAuths = await Promise.all(
+            projectMembers.map((member) =>
+              Authenticator.fromUserIdAndWorkspaceId(member.sId, workspaceId)
+            )
+          );
+
+          // O(n×m) sync membership checks; both arrays are small (Pod members and
+          // agent restricted spaces are typically each well under 100 elements).
+          for (const restrictedSpace of restrictedAgentSpaces) {
+            for (const memberAuth of memberAuths) {
+              if (!memberAuth || !restrictedSpace.isMember(memberAuth)) {
+                return false;
+              }
+            }
+          }
           return true;
         }
       }


### PR DESCRIPTION
## Description

`canAgentBeUsedInProjectConversation` had a "sole-member exception" that skipped the approval flow only when the restricted Pod had exactly one member who was the current user. This was too narrow: it blocked valid multi-member cases and didn't correctly model the actual access risk.

Replaced the single-member check with a membership intersection: if all Pod members already belong to every restricted space used by the agent, no approval is needed — there's no data-leak risk. The check iterates over `projectMembers × restrictedAgentSpaces` via `isUserMemberOfSpace`, returning `false` early if any member lacks access to any required space.

Updated existing tests to properly enroll users in the restricted spaces (previous tests were implicitly relying on the now-removed sole-member shortcut) and added new multi-member allow/reject cases.

## Tests

Updated and expanded `permissions.test.ts` under `canAgentBeUsedInProjectConversation`:
- Fixed existing tests to add users to required restricted spaces (previously passing under the old sole-member logic)
- Added: multi-member Pod where all members have access → `true`
- Added: multi-member Pod where one member is missing from a restricted space → `false`
- Added: sole member not enrolled in a required restricted space → `false`

## Risk

Low. The change broadens when approval is skipped — only when the membership check positively passes for every member × space pair. A bug would show fewer approval dialogs than expected, not bypass security for unauthorized users.

## Deploy Plan

Deploy `front`.
