### PR TITLE
fix: cache-bust thumbnails on file update, centralize frame CTA entitlement

### DIFF
--- a/front-api/routes/share/frame/[token].ts
+++ b/front-api/routes/share/frame/[token].ts
@@ -116,10 +116,11 @@ app.get(
     const { faviconUrl, logoUrl, ogImageUrl } =
       await getWorkspaceBrandingPublicUrls(workspace);
 
-    const description =
-      ogImageUrl === null
-        ? `Discover what ${workspace.name} built with AI. Explore now.`
-        : null;
+    // For workspaces without custom branding, add viral copy to drive sign-ups.
+    const isBrandedWorkspace = ogImageUrl !== null;
+    const description = isBrandedWorkspace
+      ? null
+      : `Discover what ${workspace.name} built with AI. Explore now.`;
 
     return ctx.json({
       description,
@@ -128,6 +129,7 @@ app.get(
       ogImageUrl,
       requiresEmailVerification,
       shareUrl,
+      showSignUpCta: !isBrandedWorkspace,
       title: file.fileName,
       vizUrl: config.getVizPublicUrl(),
       workspaceId: workspace.sId,

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -15,6 +15,7 @@ interface PublicFrameRendererProps {
   fileName?: string;
   hideHeader?: boolean;
   logoUrl?: string | null;
+  showSignUpCta?: boolean;
   shareToken: string;
   workspaceId: string;
   vizUrl: string;
@@ -25,6 +26,7 @@ export function PublicFrameRenderer({
   fileName,
   hideHeader = false,
   logoUrl,
+  showSignUpCta = false,
   shareToken,
   workspaceId,
   vizUrl,
@@ -69,6 +71,7 @@ export function PublicFrameRenderer({
           conversationUrl={conversationUrl}
           projectUrl={projectUrl}
           logoUrl={logoUrl}
+          showSignUpCta={showSignUpCta}
         />
       )}
 

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer.tsx
@@ -11,6 +11,7 @@ interface PublicInteractiveContentContainerProps {
   workspaceId: string;
   vizUrl: string;
   logoUrl?: string | null;
+  showSignUpCta?: boolean;
   hideHeader?: boolean;
 }
 
@@ -23,6 +24,7 @@ export function PublicInteractiveContentContainer({
   workspaceId,
   vizUrl,
   logoUrl,
+  showSignUpCta = false,
   hideHeader = false,
 }: PublicInteractiveContentContainerProps) {
   const { frameMetadata, isFrameLoading, error } = usePublicFrame({
@@ -54,6 +56,7 @@ export function PublicInteractiveContentContainer({
             workspaceId={workspaceId}
             vizUrl={vizUrl}
             logoUrl={logoUrl}
+            showSignUpCta={showSignUpCta}
             hideHeader={hideHeader}
           />
         );

--- a/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicInteractiveContentHeader.tsx
@@ -18,6 +18,7 @@ interface PublicInteractiveContentHeaderProps {
   conversationUrl: string | null;
   projectUrl: string | null;
   logoUrl?: string | null;
+  showSignUpCta?: boolean;
 }
 
 const UTM_PARAM = `utm_source=public-frames`;
@@ -32,6 +33,7 @@ export function PublicInteractiveContentHeader({
   conversationUrl,
   projectUrl,
   logoUrl,
+  showSignUpCta = false,
 }: PublicInteractiveContentHeaderProps) {
   const staticWebsiteUrl = config.getStaticWebsiteUrl();
   return (
@@ -65,7 +67,7 @@ export function PublicInteractiveContentHeader({
         </div>
 
         <div className="grow-1 flex basis-12 justify-end md:basis-60">
-          {!user && (
+          {!user && showSignUpCta && (
             <Button
               label="Try it yourself"
               href={`${staticWebsiteUrl}/?${UTM_PARAM}`}

--- a/front/components/pages/share/SharedFramePage.tsx
+++ b/front/components/pages/share/SharedFramePage.tsx
@@ -169,6 +169,7 @@ export function SharedFramePage() {
         workspaceId={shareMetadata.workspaceId}
         vizUrl={shareMetadata.vizUrl}
         logoUrl={shareMetadata.logoUrl}
+        showSignUpCta={shareMetadata.showSignUpCta}
         hideHeader={hideHeader}
       />
     </div>

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -862,6 +862,7 @@ describe("DustFileSystem.list thumbnail URLs", () => {
 
     const workspaceId = auth.getNonNullableWorkspace().sId;
     const prefix = `w/${workspaceId}/conversations/${conversation.sId}/files/`;
+    const updatedAt = new Date("2025-01-01T00:00:00.000Z");
     getAllFilesByPrefixMock.mockResolvedValue({
       files: [
         {
@@ -869,7 +870,7 @@ describe("DustFileSystem.list thumbnail URLs", () => {
           metadata: {
             contentType: "image/png",
             size: "1024",
-            updated: new Date().toISOString(),
+            updated: updatedAt.toISOString(),
           },
         },
       ],
@@ -885,7 +886,7 @@ describe("DustFileSystem.list thumbnail URLs", () => {
     assert(file !== undefined && !file.isDirectory);
     expect(file.thumbnailUrl).toBe(
       `https://dust.tt/api/w/${workspaceId}` +
-        `/files/path/conversation-${conversation.sId}/photo.png?thumbnail=1`
+        `/files/path/conversation-${conversation.sId}/photo.png?thumbnail=1&v=${updatedAt.getTime()}`
     );
   });
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -601,7 +601,7 @@ export class DustFileSystem {
 
     return (
       `${config.getApiBaseUrl()}/api/w/${workspaceId}` +
-      `/files/path/${encodedPath}?thumbnail=1`
+      `/files/path/${encodedPath}?thumbnail=1&v=${entry.lastModifiedMs}`
     );
   }
 

--- a/front/lib/api/files/share.ts
+++ b/front/lib/api/files/share.ts
@@ -5,6 +5,7 @@ export interface GetShareFrameMetadataResponseBody {
   ogImageUrl: string | null;
   requiresEmailVerification: boolean;
   shareUrl: string;
+  showSignUpCta: boolean;
   title: string;
   vizUrl: string;
   workspaceId: string;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Thumbnail URLs in the file explorer now include the file's last-modified timestamp so stale thumbnails are replaced when a file is overwritten.

The sign-up CTA visibility on shared frames is now decided in the API endpoint alongside the other branding entitlement logic.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
