### PR TITLE
Clean state for programmatic usage

### DIFF
--- a/front-api/routes/w/[wId]/usage-status.ts
+++ b/front-api/routes/w/[wId]/usage-status.ts
@@ -9,6 +9,7 @@ import {
   isUserAwuWarned,
   isUserBlocked,
   isWorkspaceBalanceThresholdReached,
+  isWorkspaceProgrammaticWarningReached,
 } from "@app/lib/metronome/user_block";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -33,6 +34,7 @@ app.get(
         userNearCreditLimit: false,
         poolCreditState: "active",
         programmaticCreditStatus: "active",
+        programmaticWarningReached: false,
         balanceThresholdReached: false,
         userBlockedReason: null,
         canRequestUpgrade: false,
@@ -44,26 +46,21 @@ app.get(
       poolCreditState,
       userBlockedReason,
       programmaticState,
+      programmaticWarningReached,
       balanceThresholdReached,
     ] = await Promise.all([
       getWorkspaceCreditPoolStatus(workspace.sId),
       isUserBlocked(workspace, user),
       getWorkspaceProgrammaticCreditStatus(workspace.sId),
+      isWorkspaceProgrammaticWarningReached(workspace.sId),
       isWorkspaceBalanceThresholdReached(workspace.sId),
     ]);
 
     const userNearCreditLimit =
       !userBlockedReason && (await isUserAwuWarned(workspace.sId, user.sId));
 
-    let programmaticCreditStatus: ProgrammaticCreditStatus = "active";
-    if (programmaticState === "depleted") {
-      programmaticCreditStatus = "depleted";
-    } else if (
-      programmaticState === "active_low_balance" ||
-      programmaticState === "active_critical_balance"
-    ) {
-      programmaticCreditStatus = "warned";
-    }
+    const programmaticCreditStatus: ProgrammaticCreditStatus =
+      programmaticState === "depleted" ? "depleted" : "active";
 
     const { canRequestUpgrade, hasPendingUpgradeRequest } =
       await getUpgradeRequestAvailabilityForUser(auth, {
@@ -74,6 +71,7 @@ app.get(
       userNearCreditLimit,
       poolCreditState,
       programmaticCreditStatus,
+      programmaticWarningReached,
       balanceThresholdReached,
       userBlockedReason,
       canRequestUpgrade,

--- a/front/components/navigation/AppStatusBanner.tsx
+++ b/front/components/navigation/AppStatusBanner.tsx
@@ -209,8 +209,12 @@ interface WorkspaceUsageStatusBannerProps {
 function WorkspaceUsageStatusBanner({
   owner,
 }: WorkspaceUsageStatusBannerProps) {
-  const { poolCreditState, programmaticCreditStatus, balanceThresholdReached } =
-    useWorkspaceUsageStatus({ owner });
+  const {
+    poolCreditState,
+    programmaticCreditStatus,
+    programmaticWarningReached,
+    balanceThresholdReached,
+  } = useWorkspaceUsageStatus({ owner });
 
   // The low/critical pool states are internal throttling signals and are not
   // surfaced. Admins are alerted when the pool is fully depleted (agents
@@ -238,7 +242,8 @@ function WorkspaceUsageStatusBanner({
   // exhausted budget, so its "cap reached" banner is suppressed. The cap is
   // only fetched when the banner would otherwise show.
   const programmaticStateWouldBanner =
-    isAdmin(owner) && programmaticCreditStatus !== "active";
+    isAdmin(owner) &&
+    (programmaticCreditStatus === "depleted" || programmaticWarningReached);
   const { programmaticUsageLimit, isProgrammaticUsageLimitLoading } =
     useProgrammaticUsageLimit({
       workspaceId: owner.sId,

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -27,6 +27,7 @@ interface PokeUsageTabProps {
   stripeSubscription: PokeStripeSubscriptionWire | null;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
+  programmaticWarningReached: boolean;
   creditUsageConfig: PokeCreditUsageConfig | null;
   poolAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
@@ -63,6 +64,7 @@ interface PokeCreditStatesCardProps {
   owner: WorkspaceType;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
+  programmaticWarningReached: boolean;
   poolAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
 }
@@ -71,6 +73,7 @@ function PokeCreditStatesCard({
   owner,
   poolCreditState,
   programmaticCreditState,
+  programmaticWarningReached,
   poolAlert,
   programmaticAlerts,
 }: PokeCreditStatesCardProps) {
@@ -102,6 +105,9 @@ function PokeCreditStatesCard({
             color={creditStateChipColor(programmaticCreditState)}
             label={programmaticCreditState}
           />
+          {programmaticWarningReached && (
+            <Chip size="xs" color="warning" label="near limit" />
+          )}
           <AlertChip alert={programmaticAlerts.cap} label="cap alert" />
           <AlertChip alert={programmaticAlerts.warning} label="warning (80%)" />
           <AlertChip alert={programmaticAlerts.low} label="low (-100)" />
@@ -286,6 +292,7 @@ export function PokeUsageTab({
   stripeSubscription,
   poolCreditState,
   programmaticCreditState,
+  programmaticWarningReached,
   creditUsageConfig,
   poolAlert,
   programmaticAlerts,
@@ -311,6 +318,7 @@ export function PokeUsageTab({
         owner={owner}
         poolCreditState={poolCreditState}
         programmaticCreditState={programmaticCreditState}
+        programmaticWarningReached={programmaticWarningReached}
         poolAlert={poolAlert}
         programmaticAlerts={programmaticAlerts}
       />

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -140,6 +140,7 @@ export function WorkspacePage() {
     usageCapAlert,
     defaultAlerts,
     programmaticCreditState,
+    programmaticWarningReached,
     stripeSubscription,
     stripeCustomerId,
     subscriptions,
@@ -357,6 +358,7 @@ export function WorkspacePage() {
                   stripeSubscription={stripeSubscription}
                   poolCreditState={poolCreditState}
                   programmaticCreditState={programmaticCreditState}
+                  programmaticWarningReached={programmaticWarningReached}
                   creditUsageConfig={creditUsageConfig}
                   poolAlert={poolAlert}
                   programmaticAlerts={programmaticAlerts}

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -2,13 +2,13 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { reconcileProgrammatic } from "@app/lib/api/metronome/reconcile_credit_state";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
   clearMetronomeProgrammaticCapAlerts,
   upsertMetronomeProgrammaticCapAlerts,
 } from "@app/lib/metronome/alerts/programmatic_cap";
-import { setProgrammaticCreditStateReconciled } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isCreditPricedPlan } from "@app/types/plan";
@@ -130,15 +130,15 @@ export async function syncProgrammaticUsageLimit({
   }
 
   // Reconcile programmaticCreditState immediately so /usage-status reflects the
-  // change without waiting for a Metronome webhook. Cap > 0 → active (fresh
-  // cap, usage hasn't hit it yet); 0 or null → depleted (no access).
+  // change without waiting for a Metronome webhook.
   const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
   if (workspaceResource) {
-    const targetState =
-      normalizedCapCredits !== null && normalizedCapCredits > 0
-        ? "active"
-        : "depleted";
-    await setProgrammaticCreditStateReconciled(workspaceResource, targetState);
+    await reconcileProgrammatic({
+      workspace: workspaceResource,
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
+      execute: true,
+    });
   }
 
   void emitAuditLogEvent({

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -9,8 +9,9 @@ import { invalidateWorkspacePoolCredits } from "@app/lib/metronome/credit_balanc
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
 import {
+  clearWorkspaceProgrammaticWarningReached,
   setUserCreditState,
-  setWorkspaceProgrammaticCreditStatus,
+  setWorkspaceProgrammaticWarningReached,
 } from "@app/lib/metronome/user_block";
 import type { LiveUserSeatBalance } from "@app/lib/metronome/user_credit_state_machine";
 import { transitionUserCreditState } from "@app/lib/metronome/user_credit_state_machine";
@@ -489,6 +490,7 @@ export async function dispatchProgrammaticCapReset({
 }: {
   workspace: WorkspaceResource;
 }): Promise<void> {
+  void clearWorkspaceProgrammaticWarningReached(workspace.sId);
   await transitionProgrammaticCreditState(workspace, {
     type: "programmatic_cap_reset",
   });
@@ -508,10 +510,7 @@ export async function dispatchProgrammaticWarning({
   workspace: WorkspaceResource;
   eventId: string;
 }): Promise<void> {
-  void setWorkspaceProgrammaticCreditStatus(
-    workspace.sId,
-    "active_low_balance"
-  );
+  void setWorkspaceProgrammaticWarningReached(workspace.sId);
   void notifyAdminsProgrammaticCapAboutStatus({
     workspace,
     isBlocked: false,

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -1,7 +1,7 @@
 import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
 import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
-import { getMetronomeProgrammaticCapAlertStates } from "@app/lib/metronome/alerts/programmatic_cap";
+import { WARNING_BALANCE_RATIO } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
   listContractPerUserCreditBalances,
   listMetronomeSeatBalances,
@@ -12,12 +12,17 @@ import {
   fetchLiveUserCreditInputs,
 } from "@app/lib/metronome/live_user_credit_inputs";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import {
-  expectedProgrammaticCreditStateFromAlerts,
+  expectedProgrammaticCreditStateFromUsage,
   setProgrammaticCreditStateReconciled,
 } from "@app/lib/metronome/programmatic_credit_state_machine";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
-import { setUserNearLimit } from "@app/lib/metronome/user_block";
+import {
+  clearWorkspaceProgrammaticWarningReached,
+  setUserNearLimit,
+  setWorkspaceProgrammaticWarningReached,
+} from "@app/lib/metronome/user_block";
 import { setUserCreditStateReconciled } from "@app/lib/metronome/user_credit_state_machine";
 import {
   expectedPoolCreditStateFromBalance,
@@ -78,7 +83,8 @@ type ProgrammaticReconcileReport = {
   wasInvalid: boolean;
   corrected: boolean;
   executed: boolean;
-  alarms: { cap: boolean; low: boolean; critical: boolean };
+  monthlyCapCredits: number;
+  spentAwuCredits: number | null;
 };
 
 type UserReconcileReport = {
@@ -143,7 +149,12 @@ export async function reconcileCreditState({
     case "pool":
       return reconcilePool({ auth, workspace, metronomeCustomerId, execute });
     case "programmatic":
-      return reconcileProgrammatic({ workspace, metronomeCustomerId, execute });
+      return reconcileProgrammatic({
+        workspace,
+        metronomeCustomerId,
+        metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
+        execute,
+      });
     case "user":
       if (!userId) {
         return new Err(
@@ -162,7 +173,7 @@ export async function reconcileCreditState({
   }
 }
 
-async function reconcilePool({
+export async function reconcilePool({
   auth,
   workspace,
   metronomeCustomerId,
@@ -213,77 +224,72 @@ async function reconcilePool({
   });
 }
 
-async function reconcileProgrammatic({
+export async function reconcileProgrammatic({
   workspace,
   metronomeCustomerId,
+  metronomeContractId,
   execute,
 }: {
   workspace: WorkspaceResource;
   metronomeCustomerId: string;
+  metronomeContractId: string | null;
   execute: boolean;
 }): Promise<Result<ProgrammaticReconcileReport, Error>> {
-  // Read the cap from the DB first — it is the source of truth. A cap of 0 or
-  // null means no programmatic access; no alerts exist in that case so reading
-  // Metronome would incorrectly return "active" (no alarms → active).
   const config = await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
     workspace.id
   );
   const monthlyCapCredits = config?.programmaticMonthlyCapAwuCredits ?? 0;
 
-  const noAlarms = { cap: false, low: false, critical: false };
+  const previousState = workspace.programmaticCreditState;
 
-  if (monthlyCapCredits === 0) {
-    const expectedState: WorkspaceProgrammaticCreditState = "depleted";
-    const previousState = workspace.programmaticCreditState;
-    let newState = previousState;
+  // Cap of 0/null → always depleted; no spend to read.
+  if (monthlyCapCredits === 0 || !metronomeContractId) {
     if (execute) {
-      await setProgrammaticCreditStateReconciled(workspace, expectedState);
-      newState = workspace.programmaticCreditState;
+      await setProgrammaticCreditStateReconciled(workspace, "depleted");
+      void clearWorkspaceProgrammaticWarningReached(workspace.sId);
     }
+    const newState = workspace.programmaticCreditState;
     return new Ok({
       target: "programmatic",
       previousState,
-      expectedState,
+      expectedState: "depleted",
       newState,
-      wasInvalid: previousState !== expectedState,
+      wasInvalid: previousState !== "depleted",
       corrected: previousState !== newState,
       executed: execute,
-      alarms: noAlarms,
+      monthlyCapCredits,
+      spentAwuCredits: null,
     });
   }
 
-  // For a positive cap, read Metronome alert states to derive the expected
-  // state (cap/low/critical alarms may be in alarm if spend is high).
-  const statesResult = await getMetronomeProgrammaticCapAlertStates({
+  const spendResult = await fetchProgrammaticAwuSpend({
     metronomeCustomerId,
-    workspaceId: workspace.sId,
+    metronomeContractId,
   });
-  if (statesResult.isErr()) {
+  if (spendResult.isErr()) {
     return new Err(
       new Error(
-        `Failed to read programmatic cap alerts: ${statesResult.error.message}`
+        `Failed to read programmatic spend: ${spendResult.error.message}`
       )
     );
   }
-  const { cap, low, critical } = statesResult.value;
-  const alarms = {
-    cap: cap?.status === "in_alarm",
-    low: low?.status === "in_alarm",
-    critical: critical?.status === "in_alarm",
-  };
-  const expectedState = expectedProgrammaticCreditStateFromAlerts({
-    capInAlarm: alarms.cap,
-    criticalInAlarm: alarms.critical,
-    lowInAlarm: alarms.low,
+  const spentAwuCredits = spendResult.value ?? 0;
+  const expectedState = expectedProgrammaticCreditStateFromUsage({
+    spentAwuCredits,
+    monthlyCapCredits,
   });
-
-  const previousState = workspace.programmaticCreditState;
-  const wasInvalid = previousState !== expectedState;
 
   let newState = previousState;
   if (execute) {
     await setProgrammaticCreditStateReconciled(workspace, expectedState);
     newState = workspace.programmaticCreditState;
+    const warningReached =
+      spentAwuCredits >= monthlyCapCredits * WARNING_BALANCE_RATIO;
+    if (warningReached) {
+      void setWorkspaceProgrammaticWarningReached(workspace.sId);
+    } else {
+      void clearWorkspaceProgrammaticWarningReached(workspace.sId);
+    }
   }
 
   return new Ok({
@@ -291,14 +297,15 @@ async function reconcileProgrammatic({
     previousState,
     expectedState,
     newState,
-    wasInvalid,
+    wasInvalid: previousState !== expectedState,
     corrected: previousState !== newState,
     executed: execute,
-    alarms,
+    monthlyCapCredits,
+    spentAwuCredits,
   });
 }
 
-async function reconcileUser({
+export async function reconcileUser({
   auth,
   workspace,
   metronomeCustomerId,

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -6,6 +6,7 @@ import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_a
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getCachedWorkspaceMetronomeAlerts } from "@app/lib/metronome/alerts/workspace_alerts";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { isWorkspaceProgrammaticWarningReached } from "@app/lib/metronome/user_block";
 import { getCustomerId, getStripeSubscription } from "@app/lib/plans/stripe";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
@@ -75,6 +76,7 @@ export type PokeWorkspaceInfo = {
   // created by the Metronome setup script and shared across all customers.
   defaultAlerts: DefaultMetronomeAlerts;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
+  programmaticWarningReached: boolean;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeCustomerId: string | null;
   stripeSubscription: PokeStripeSubscriptionWire | null;
@@ -220,6 +222,9 @@ export async function getPokeWorkspaceInfo(
     usageCapAlert,
     defaultAlerts,
     programmaticCreditState: workspaceResource.programmaticCreditState,
+    programmaticWarningReached: await isWorkspaceProgrammaticWarningReached(
+      owner.sId
+    ),
     stripeCustomerId,
     stripeSubscription: stripeSubscription
       ? {

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -2,10 +2,7 @@ import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
-import {
-  dispatchPerUserCapReached,
-  dispatchPerUserCapResolved,
-} from "@app/lib/api/metronome/credit_state_dispatcher";
+import { reconcileUser } from "@app/lib/api/metronome/reconcile_credit_state";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,10 +12,7 @@ import {
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
-import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
-import { setUserNearLimit } from "@app/lib/metronome/user_block";
-import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
@@ -42,11 +36,6 @@ export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
 
 export type SetUserSpendLimitResponse = {
   limit: UserSpendLimit;
-  // The credit-state we transitioned the user to, computed locally from
-  // current pool consumption. `null` when usage couldn't be determined and
-  // we therefore did not dispatch a transition (the Metronome webhook
-  // will reconcile on the next state change).
-  transitionedTo: "reached" | "resolved" | null;
 };
 
 export type UserSpendLimitErrorType =
@@ -139,77 +128,6 @@ export async function getUserSpendLimit(
   });
 }
 
-/**
- * Resolve the credit state for a user given a freshly applied cap, by
- * comparing the user's current pool consumption to the cap. The Metronome
- * alert we just created/cleared remains the source of truth for *future*
- * crossings (the webhook keeps the state in sync); this local comparison
- * just sets the immediate state without depending on Metronome's eventual-
- * consistent alert evaluation (which can sit in `evaluating` for minutes).
- *
- * Returns `null` if usage couldn't be fetched — caller should not dispatch
- * and let the webhook reconcile.
- */
-async function resolveLocalCapState({
-  metronomeCustomerId,
-  metronomeContractId,
-  userId,
-  awuCapCredits,
-}: {
-  metronomeCustomerId: string;
-  metronomeContractId: string | null;
-  userId: string;
-  awuCapCredits: number;
-}): Promise<"reached" | "resolved" | null> {
-  if (!metronomeContractId) {
-    return null;
-  }
-  const usageResult = await fetchPerUserAwuUsage({
-    metronomeCustomerId,
-    metronomeContractId,
-    userIds: [userId],
-  });
-  if (usageResult.isErr()) {
-    logger.warn(
-      {
-        metronomeCustomerId,
-        userId: userId,
-        err: usageResult.error,
-      },
-      "[Metronome PerUserCap] Could not fetch current usage; skipping immediate state dispatch"
-    );
-    return null;
-  }
-  const consumed = usageResult.value.get(userId) ?? 0;
-  return consumed >= awuCapCredits ? "reached" : "resolved";
-}
-
-async function dispatchTransition({
-  workspace,
-  userId,
-  transitionedTo,
-}: {
-  workspace: WorkspaceResource;
-  userId: string;
-  transitionedTo: "reached" | "resolved";
-}): Promise<void> {
-  const dispatchResult =
-    transitionedTo === "reached"
-      ? await dispatchPerUserCapReached({ workspace, userId })
-      : await dispatchPerUserCapResolved({ workspace, userId });
-  if (dispatchResult.isErr()) {
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        userId,
-        transitionedTo,
-        err: dispatchResult.error,
-      },
-      "[Metronome PerUserCap] dispatch after spend-limit update failed; continuing"
-    );
-  }
-}
-
 export async function setUserSpendLimit(
   auth: Authenticator,
   {
@@ -292,8 +210,6 @@ export async function setUserSpendLimit(
     limit.kind === "limited" ? limit.awuCredits : null
   );
 
-  let transitionedTo: "reached" | "resolved" | null = null;
-
   switch (limit.kind) {
     case "unlimited": {
       const clearResult = await clearMetronomePerUserCapAlert({
@@ -315,8 +231,6 @@ export async function setUserSpendLimit(
           new UserSpendLimitError("metronome_error", clearResult.error.message)
         );
       }
-
-      // Best-effort: also clear the companion 80% warning alert.
       const clearWarningResult = await clearMetronomePerUserWarningAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
@@ -332,57 +246,14 @@ export async function setUserSpendLimit(
           "[Metronome PerUserCap] Failed to clear warning alert; continuing"
         );
       }
-      void dispatchPerUserCapResolved({
-        workspace: workspaceResource,
-        userId,
-      });
-      void setUserNearLimit(workspaceResource.sId, userId, false);
-
-      // With the override cleared, the workspace default (pool-only value
-      // persisted on the credit-usage configuration) applies for the user's
-      // seat type.
-      const normalizedSeatType = normalizeToPoolLimitSeatType(
-        membership.seatType
-      );
-      const creditUsageConfig =
-        await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
-      const defaultPoolCapAwuCredits =
-        creditUsageConfig?.defaultPoolCapAwuCredits ?? null;
-
-      if (normalizedSeatType && defaultPoolCapAwuCredits !== null) {
-        const seatAllowanceAwuCredits = await resolveUserSeatAllowance(
-          auth,
-          membership
-        );
-        transitionedTo = await resolveLocalCapState({
-          metronomeCustomerId: workspace.metronomeCustomerId,
-          metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
-          userId: user.sId,
-          awuCapCredits: defaultPoolCapAwuCredits + seatAllowanceAwuCredits,
-        });
-      } else {
-        transitionedTo = "resolved";
-      }
-
-      if (transitionedTo !== null) {
-        await dispatchTransition({
-          workspace: workspaceResource,
-          userId: user.sId,
-          transitionedTo,
-        });
-      }
-      // transitionedTo === null: usage unavailable — let webhook reconcile.
       break;
     }
     case "limited": {
-      // The admin enters pool credits. Add the seat allowance to get the
-      // total Metronome threshold.
       const seatAllowanceAwuCredits = await resolveUserSeatAllowance(
         auth,
         membership
       );
       const totalAwuCredits = limit.awuCredits + seatAllowanceAwuCredits;
-
       const upsertResult = await upsertMetronomePerUserCapAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
@@ -404,8 +275,6 @@ export async function setUserSpendLimit(
           new UserSpendLimitError("metronome_error", upsertResult.error.message)
         );
       }
-
-      // Best-effort: also upsert the companion 80% warning alert.
       const upsertWarningResult = await upsertMetronomePerUserWarningAlert({
         metronomeCustomerId: workspace.metronomeCustomerId,
         workspaceId: workspace.sId,
@@ -423,25 +292,28 @@ export async function setUserSpendLimit(
           "[Metronome PerUserCap] Failed to upsert warning alert; continuing"
         );
       }
-
-      transitionedTo = await resolveLocalCapState({
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        metronomeContractId: auth.subscription()?.metronomeContractId ?? null,
-        userId: user.sId,
-        awuCapCredits: totalAwuCredits,
-      });
-      if (transitionedTo !== null) {
-        await dispatchTransition({
-          workspace: workspaceResource,
-          userId: user.sId,
-          transitionedTo,
-        });
-      }
-      // transitionedTo === null: usage unavailable — let webhook reconcile.
       break;
     }
     default:
       assertNever(limit);
+  }
+
+  // Reconcile the user's credit state from live usage — same path as the
+  // poke reconcile button and the seat-sync reconcile.
+  const metronomeContractId = auth.subscription()?.metronomeContractId ?? null;
+  if (metronomeContractId) {
+    void reconcileUser({
+      auth,
+      workspace: workspaceResource,
+      metronomeCustomerId: workspace.metronomeCustomerId,
+      userId: user.sId,
+      execute: true,
+    }).catch((err) => {
+      logger.warn(
+        { workspaceId: workspace.sId, userId: user.sId, err },
+        "[Metronome PerUserCap] reconcileUser after spend-limit update failed; webhook will reconcile"
+      );
+    });
   }
 
   void emitAuditLogEvent({
@@ -462,5 +334,5 @@ export async function setUserSpendLimit(
     },
   });
 
-  return new Ok({ limit, transitionedTo });
+  return new Ok({ limit });
 }

--- a/front/lib/metronome/programmatic_credit_state_machine.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.ts
@@ -1,4 +1,7 @@
-import { CRITICAL_BALANCE_OFFSET } from "@app/lib/metronome/alerts/programmatic_cap";
+import {
+  CRITICAL_BALANCE_OFFSET,
+  LOW_BALANCE_OFFSET,
+} from "@app/lib/metronome/alerts/programmatic_cap";
 import { setWorkspaceProgrammaticCreditStatus } from "@app/lib/metronome/user_block";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
@@ -48,6 +51,31 @@ export function expectedProgrammaticCreditStateFromAlerts({
     return "active_critical_balance";
   }
   if (lowInAlarm) {
+    return "active_low_balance";
+  }
+  return "active";
+}
+
+/**
+ * Derives the expected programmatic credit state from live usage vs. the DB
+ * cap — the usage-first equivalent of `expectedProgrammaticCreditStateFromAlerts`.
+ * Thresholds mirror the Metronome alert offsets so the two functions agree.
+ */
+export function expectedProgrammaticCreditStateFromUsage({
+  spentAwuCredits,
+  monthlyCapCredits,
+}: {
+  spentAwuCredits: number;
+  monthlyCapCredits: number;
+}): WorkspaceProgrammaticCreditState {
+  const remaining = monthlyCapCredits - spentAwuCredits;
+  if (remaining <= 0) {
+    return "depleted";
+  }
+  if (remaining <= CRITICAL_BALANCE_OFFSET) {
+    return "active_critical_balance";
+  }
+  if (remaining <= LOW_BALANCE_OFFSET) {
     return "active_low_balance";
   }
   return "active";

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -52,7 +52,7 @@ export type UserBlockedReason =
   | "user_cap_reached"
   | "no_seat";
 
-export type ProgrammaticCreditStatus = "active" | "warned" | "depleted";
+export type ProgrammaticCreditStatus = "active" | "depleted";
 
 export type FairUseAwuCreditsStatus = {
   limit: number;
@@ -71,6 +71,9 @@ export type GetWorkspaceUsageStatusResponseBody = {
   userNearCreditLimit: boolean;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditStatus: ProgrammaticCreditStatus;
+  // True when workspace programmatic usage has crossed WARNING_BALANCE_RATIO of the monthly cap.
+  // Redis-only flag, independent of the throttling states (active_low_balance etc.).
+  programmaticWarningReached: boolean;
   balanceThresholdReached: boolean;
   // Authoritative block reason from isUserBlocked — null means the user can
   // send messages. Replaces the old client-side derivations (noSeat,
@@ -191,6 +194,36 @@ export async function isWorkspaceBalanceThresholdReached(
   const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
     client.get(buildWorkspaceBalanceThresholdReachedKey(workspaceId))
   );
+  return val === "1";
+}
+
+// Workspace programmatic 80% warning — set when the warning alert fires,
+// cleared on cap reset or reconcile. Redis-only; no DB fallback (cold miss
+// reads as false). Drives the banner independently of the throttling states.
+
+function buildWorkspaceProgrammaticWarningKey(workspaceId: string): string {
+  return `metronome:programmatic_warning:${workspaceId}`;
+}
+
+export async function setWorkspaceProgrammaticWarningReached(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(buildWorkspaceProgrammaticWarningKey(workspaceId), "1");
+}
+
+export async function clearWorkspaceProgrammaticWarningReached(
+  workspaceId: string
+): Promise<void> {
+  await setFlag(buildWorkspaceProgrammaticWarningKey(workspaceId), "0");
+}
+
+export async function isWorkspaceProgrammaticWarningReached(
+  workspaceId: string
+): Promise<boolean> {
+  const val = await runOnRedis({ origin: REDIS_ORIGIN }, async (client) =>
+    client.get(buildWorkspaceProgrammaticWarningKey(workspaceId))
+  );
+  // Redis miss (null) returns false: prefer not showing the banner over a false positive on cache wipe.
   return val === "1";
 }
 

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -285,6 +285,7 @@ export function useWorkspaceUsageStatus({
     userNearCreditLimit: data?.userNearCreditLimit ?? false,
     poolCreditState: data?.poolCreditState ?? "active",
     programmaticCreditStatus: data?.programmaticCreditStatus ?? "active",
+    programmaticWarningReached: data?.programmaticWarningReached ?? false,
     balanceThresholdReached: data?.balanceThresholdReached ?? false,
     userBlockedReason: data?.userBlockedReason ?? null,
     canRequestUpgrade: data?.canRequestUpgrade ?? false,


### PR DESCRIPTION
## Description

Large cleanup of the programmatic usage credit state management.

**Reconciliation — usage-first, no more alarm reads:**
- `reconcileProgrammatic` now reads live spend from Metronome (`fetchProgrammaticAwuSpend`) and computes state via `expectedProgrammaticCreditStateFromUsage` — same source of truth as pool (balance) and user (seat balance + usage). Alarm states are no longer read for reconciliation.
- `syncProgrammaticUsageLimit` calls `reconcileProgrammatic` directly after updating the cap, so `/usage-status` reflects the change immediately without waiting for a webhook.
- `setUserSpendLimit` now calls `reconcileUser` (replaces hand-rolled `resolveLocalCapState` + `dispatchTransition` which only computed a binary reached/resolved and missed seat balance, near-limit flag, and multi-state resolution).

**Warning flag — separated from throttling states:**
- `active_low_balance` / `active_critical_balance` are throttling-only signals (concurrency limits). They no longer drive the "Programmatic API cap at 80%" banner.
- New dedicated Redis flag `programmaticWarningReached` (mirrors `userNearLimit` / `balanceThresholdReached`) — set by `dispatchProgrammaticWarning`, cleared on cap reset or reconcile. `ProgrammaticCreditStatus` is now `"active" | "depleted"` only.
- `/usage-status` exposes `programmaticWarningReached` separately. Banner and Poke UI consume it independently.

**Other fixes:**
- `dispatchProgrammaticWarning` was incorrectly writing `active_low_balance` to Redis (wrong state, wrong threshold, no DB update). Removed.
- Cap = 0: alerts are cleared (not upserted — a cap of 0 is always fully depleted, no threshold transition can ever fire). State is set to `"depleted"` directly.
- Poke: added "near limit" badge for programmatic usage, mirroring the user near-limit badge.

## Tests

Tested manually.

## Risk

Medium — touches credit state transitions and Redis flags. All changes are additive or replace equivalent logic with more correct logic. Rollback is safe (Redis flags degrade to false on cold miss).

## Deploy Plan

Standard deploy. No migration needed.