### PR TITLE
Live-update the wake-up banner on fire/create/cancel

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -11835,6 +11835,9 @@
           },
           {
             "$ref": "#/components/schemas/PrivateConversationTitleEvent"
+          },
+          {
+            "$ref": "#/components/schemas/PrivateWakeUpUpdatedEvent"
           }
         ]
       },
@@ -12003,6 +12006,37 @@
           },
           "title": {
             "type": "string"
+          }
+        }
+      },
+      "PrivateWakeUpUpdatedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "created",
+          "conversationId",
+          "wakeUpId",
+          "userId"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "wake_up_updated"
+            ]
+          },
+          "created": {
+            "type": "integer"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "wakeUpId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string",
+            "description": "sId of the user who owns the wake-up."
           }
         }
       },

--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
@@ -50,6 +50,19 @@ function planUpdatedEvent(): ConversationEvent {
   };
 }
 
+function wakeUpUpdatedEvent(): ConversationEvent {
+  return {
+    eventId: "wakeup",
+    data: {
+      type: "wake_up_updated",
+      created: 0,
+      conversationId: "conv",
+      wakeUpId: "wu_test",
+      userId: "u_test",
+    },
+  };
+}
+
 function getEvents(
   workspaceId: string,
   conversationId: string,
@@ -147,7 +160,11 @@ describe("GET /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events", () => {
     const { workspace, key, conversation } = await setupConversation();
 
     vi.mocked(getConversationEvents).mockImplementation(
-      asyncIteratorFrom([titleEvent("kept"), planUpdatedEvent()])
+      asyncIteratorFrom([
+        titleEvent("kept"),
+        planUpdatedEvent(),
+        wakeUpUpdatedEvent(),
+      ])
     );
 
     const response = await getEvents(
@@ -159,6 +176,8 @@ describe("GET /api/sse/v1/w/[wId]/assistant/conversations/[cId]/events", () => {
     const body = await response.text();
     expect(body).toContain("kept");
     expect(body).not.toContain("plan_updated");
+    // wake_up_updated is front-only; it must never reach the public API stream.
+    expect(body).not.toContain("wake_up_updated");
   });
 
   it("delivers events produced before an iterator error and ends the stream", async () => {

--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -17,7 +17,8 @@ const transformForV1: ConversationEventsOptions["transformEvent"] = async (
   if (
     event.data.type === "compaction_message_new" ||
     event.data.type === "compaction_message_done" ||
-    event.data.type === "plan_updated"
+    event.data.type === "plan_updated" ||
+    event.data.type === "wake_up_updated"
   ) {
     return null;
   }

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1282,6 +1282,7 @@
  *         - $ref: '#/components/schemas/PrivateCompactionMessageNewEvent'
  *         - $ref: '#/components/schemas/PrivateCompactionMessageDoneEvent'
  *         - $ref: '#/components/schemas/PrivateConversationTitleEvent'
+ *         - $ref: '#/components/schemas/PrivateWakeUpUpdatedEvent'
  *     PrivateUserMessageNewEvent:
  *       type: object
  *       required: [type, created, messageId, message]
@@ -1365,6 +1366,22 @@
  *           type: integer
  *         title:
  *           type: string
+ *     PrivateWakeUpUpdatedEvent:
+ *       type: object
+ *       required: [type, created, conversationId, wakeUpId, userId]
+ *       properties:
+ *         type:
+ *           type: string
+ *           enum: [wake_up_updated]
+ *         created:
+ *           type: integer
+ *         conversationId:
+ *           type: string
+ *         wakeUpId:
+ *           type: string
+ *         userId:
+ *           type: string
+ *           description: sId of the user who owns the wake-up.
  *     PrivateAgentMessageEvent:
  *       type: object
  *       description: Server-Sent Event for agent message streaming. Discriminated on the `type` field. Each event also includes a `step` integer.

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -49,7 +49,6 @@ import {
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
-import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useAgentMessageStream } from "@app/hooks/useAgentMessageStream";
 import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -62,23 +61,19 @@ import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
-import { useConversationWakeUps } from "@app/lib/swr/wakeups";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
-import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import datadogLogger from "@app/logger/datadogLogger";
 import {
   canShowAgentConversationActions,
   isGlobalAgentId,
   isGlobalAgentWithFeedback,
 } from "@app/types/assistant/assistant";
-import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { isLightAgentMessageType } from "@app/types/assistant/conversation";
 import type {
   RichAgentMention,
   RichMention,
 } from "@app/types/assistant/mentions";
-import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import {
   isInteractiveContentType,
@@ -298,15 +293,6 @@ export function AgentMessage({
     owner,
     options: { disabled: true },
   });
-  const { mutateWakeUps } = useConversationWakeUps({
-    owner,
-    conversationId,
-    disabled: true,
-  });
-  const { mutateConversations } = useConversations({
-    workspaceId: owner.sId,
-    options: { disabled: true },
-  });
 
   const methods = useVirtuosoMethods<
     VirtuosoMessage,
@@ -446,24 +432,6 @@ export function AgentMessage({
             ) {
               void mutateSandboxFiles();
             }
-            if (action.internalMCPServerName === "wakeups") {
-              void mutateWakeUps().then((updated) => {
-                const activeWakeUp =
-                  updated?.wakeUps.find(isActiveWakeUp) ?? null;
-                const nextWakeupAt = activeWakeUp
-                  ? getNextWakeUpFireAtFromScheduleConfig(
-                      activeWakeUp.scheduleConfig
-                    )
-                  : null;
-                void mutateConversations(
-                  (currentData: ConversationListItemType[] | undefined) =>
-                    currentData?.map((c) =>
-                      c.sId === conversationId ? { ...c, nextWakeupAt } : c
-                    ),
-                  { revalidate: false }
-                );
-              });
-            }
             break;
           }
           case "end-of-stream":
@@ -485,8 +453,6 @@ export function AgentMessage({
         mutateConversationAttachments,
         mutateSandboxStatus,
         mutateSandboxFiles,
-        mutateWakeUps,
-        mutateConversations,
       ]
     ),
     streamId,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -61,6 +61,8 @@ import {
   CompactionStartedEvent,
 } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useConversationWakeUps } from "@app/lib/swr/wakeups";
+import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
 import logger from "@app/logger/logger";
 import {
   type ConversationForkedChildType,
@@ -73,6 +75,7 @@ import {
   isRichAgentMention,
   toMentionType,
 } from "@app/types/assistant/mentions";
+import { isActiveWakeUp } from "@app/types/assistant/wakeups";
 import type { ContentFragmentsType } from "@app/types/content_fragment";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -417,6 +420,12 @@ export const ConversationViewer = ({
     conversationId,
     workspaceId: owner.sId,
     options: { disabled: true }, // We don't need the participants, only the mutator.
+  });
+
+  const { mutateWakeUps } = useConversationWakeUps({
+    owner,
+    conversationId,
+    disabled: true, // We don't fetch here, only patch the cache on wake_up_updated events.
   });
 
   const { mutateContextUsage } = useConversationContextUsage({
@@ -1058,6 +1067,24 @@ export const ConversationViewer = ({
             );
             break;
           }
+          case "wake_up_updated": {
+            // Refetch wake-ups, then sync the conversation list's nextWakeupAt. Only one wake-up
+            // can be active per conversation, so the active one fully determines that value.
+            void mutateWakeUps().then((updated) => {
+              const active = updated?.wakeUps.find(isActiveWakeUp) ?? null;
+              const nextWakeupAt = active
+                ? getNextWakeUpFireAtFromScheduleConfig(active.scheduleConfig)
+                : null;
+              void mutateConversations(
+                (currentData: ConversationListItemType[] | undefined) =>
+                  currentData?.map((c) =>
+                    c.sId === conversationId ? { ...c, nextWakeupAt } : c
+                  ),
+                { revalidate: false }
+              );
+            });
+            break;
+          }
           default:
             ((t: never) => {
               logger.error({ event: t }, "Unknown event type");
@@ -1075,6 +1102,7 @@ export const ConversationViewer = ({
       mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
+      mutateWakeUps,
       openPanel,
       owner.sId,
       user.sId,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3034,6 +3034,7 @@ export async function isConversationEventAllowedForAuth(
     case "conversation_title":
     case "user_message_promoted":
     case "plan_updated":
+    case "wake_up_updated":
       return true;
     default:
       assertNever(type);

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -132,6 +132,7 @@ function isMessageEventParams(
     case "compaction_message_done":
     case "conversation_title":
     case "plan_updated":
+    case "wake_up_updated":
       return false;
     default:
       assertNever(eventType);

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -23,6 +23,7 @@ import type {
   PlanUpdatedEvent,
   UserMessageNewEvent,
   UserMessagePromotedEvent,
+  WakeUpUpdatedEvent,
 } from "@app/types/assistant/conversation";
 import type { GenerationTokensEvent } from "@app/types/assistant/generation";
 
@@ -49,7 +50,8 @@ export type ConversationEvents =
   | AgentMessageDoneEvent
   | CompactionMessageNewEvent
   | CompactionMessageDoneEvent
-  | PlanUpdatedEvent;
+  | PlanUpdatedEvent
+  | WakeUpUpdatedEvent;
 
 export const TERMINAL_AGENT_MESSAGE_EVENT_TYPES: AgentMessageEvents["type"][] =
   [

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -1,3 +1,4 @@
+import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -14,6 +15,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getNextWakeUpFireAtFromScheduleConfig } from "@app/lib/utils/wakeup_description";
+import logger from "@app/logger/logger";
 import {
   cancelWakeUpTemporalWorkflow,
   launchOrScheduleWakeUpTemporalWorkflow,
@@ -239,6 +241,8 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     if (temporalResult.isErr()) {
       return temporalResult;
     }
+
+    await wakeUp.notifyConversationOfWakeUpChange(auth);
 
     void emitAuditLogEvent({
       auth,
@@ -511,7 +515,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       transaction
     );
 
-    await this.triggerConversationESIndexing(auth);
+    await this.notifyConversationOfWakeUpChange(auth);
 
     void emitAuditLogEvent({
       auth,
@@ -545,7 +549,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       transaction
     );
 
-    await this.triggerConversationESIndexing(auth);
+    await this.notifyConversationOfWakeUpChange(auth);
 
     void emitAuditLogEvent({
       auth,
@@ -632,7 +636,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
       transaction
     );
 
-    await this.triggerConversationESIndexing(auth);
+    await this.notifyConversationOfWakeUpChange(auth);
 
     void emitAuditLogEvent({
       auth,
@@ -724,15 +728,44 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     };
   }
 
-  private async triggerConversationESIndexing(
+  // Re-index the conversation and push a `wake_up_updated` event so viewers update their wake-up
+  // state (notably the banner) live. This is a best-effort UX signal, not part of the wake-up
+  // mutation: a Redis/indexing hiccup must never make a committed status change (or a successful
+  // makeNew whose row + workflow already exist) look like a failure. The client refetches on this
+  // event, so a missed one only means the banner updates on the next refresh.
+  private async notifyConversationOfWakeUpChange(
     auth: Authenticator
   ): Promise<void> {
     const conversation =
       (
         await ConversationResource.fetchByModelIds(auth, [this.conversationId])
       )[0] ?? null;
-    if (conversation) {
+    if (!conversation) {
+      return;
+    }
+
+    try {
       await ConversationResource.triggerEsIndexing(auth, conversation.sId);
+
+      await publishConversationEvent(
+        {
+          type: "wake_up_updated",
+          created: Date.now(),
+          conversationId: conversation.sId,
+          wakeUpId: this.sId,
+          userId: this.user.sId,
+        },
+        { conversationId: conversation.sId }
+      );
+    } catch (err) {
+      logger.error(
+        {
+          wakeUpId: this.sId,
+          conversationId: conversation.sId,
+          err: normalizeError(err),
+        },
+        "Failed to notify conversation of wake-up change."
+      );
     }
   }
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -772,6 +772,17 @@ export type PlanUpdatedEvent = {
   hasApproval: boolean;
 };
 
+// Event sent when a wake-up in the conversation is created or changes status. Thin payload: the
+// client refetches /wakeups on receipt, so the banner always reflects the committed state
+// regardless of when the event arrives.
+export type WakeUpUpdatedEvent = {
+  type: "wake_up_updated";
+  created: number;
+  conversationId: string;
+  wakeUpId: string;
+  userId: string;
+};
+
 export const ConversationMCPServerViewOrigins = [
   "agent_enabled",
   "conversation",


### PR DESCRIPTION
## What

Live-update the wake-up banner: when a wake-up fires (or is created/cancelled/expired), the banner now appears/disappears without a page refresh.

## Why

The banner is driven by the `/wakeups` SWR cache, which was only revalidated when the agent called a `wakeups` tool. A wake-up *firing* doesn't call a tool, so nothing invalidated the cache and the banner stayed until a manual refresh.

## How

- Add a thin `wake_up_updated` conversation event (`{ wakeUpId, userId }`), published from the resource layer on every status transition (`makeNew`, `markFired`, `markCancelled`, `markExpired`).
- On receipt, the client refetches `/wakeups` and re-syncs `nextWakeupAt`. The banner reflects committed state regardless of event timing.
- Remove the now-redundant `agent_action_success` wakeups special-case in `AgentMessage` (one path instead of two; also fixes cross-client create/cancel).

## Notes

- Filtered from the public `/api/v1` SSE stream (internal feature); covered by a v1 SSE test.
- The publish is best-effort (external Redis/index calls are caught + logged) so a hiccup never fails scheduling or a committed transition.
- `WakeUpType` and the private `/wakeups` response are unchanged (no API break).

## Tests

- v1 SSE filter test asserts `wake_up_updated` never reaches the public stream.
- `tsgo` clean (front + front-api), biome clean, swagger regenerated.

## Deployment

Deploy front and front-sse.
