### PR TITLE
Fix profile modal tool dropdown closing immediately

### DIFF
--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -173,7 +173,7 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
         header: "",
         accessorKey: "actions",
         cell: ({ row }) => (
-          <DropdownMenu modal={false}>
+          <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 icon={DotsHorizontal}


### PR DESCRIPTION
### Problem
In the user profile modal, under **Tools and Triggers**, clicking the `⋯` menu on a connected tool (Gmail, HubSpot) opened the dropdown and immediately closed it, making "Clear confirmation preferences" and "Disconnect" unusable.

### Cause
The dropdown in `UserToolsTable.tsx` was the only one in this modal using `modal={false}`. Its content is portaled to `<body>`, outside the modal Dialog's DOM. With `modal={false}` the dropdown doesn't trap focus, so the Dialog's focus scope pulled focus back inside on open — the dropdown read this as a focus-outside event and closed itself.

### Fix
Removed `modal={false}`, matching the default behavior used by the other (working) dropdowns in the same modal.

### Testing
- Verified the dropdown now stays open and both actions fire correctly.