### PR TITLE
feat(llm): add Claude Haiku 4.5 anthropic global endpoint

### DIFF
--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -48,6 +48,7 @@ export function WithAnthropicInputConverter<
       assistantReasoningMessageToThinkingBlocks;
     assistantToolCallRequestToToolUseBlock =
       assistantToolCallRequestToToolUseBlock;
+    reasoningToThinkingConfig = reasoningToThinkingConfig;
 
     conversationToMessages(
       conversation: Payload["conversation"]
@@ -72,7 +73,7 @@ export function WithAnthropicInputConverter<
         outputFormat,
       } = config;
 
-      const thinkingConfig = reasoningToThinkingConfig(reasoning);
+      const thinkingConfig = this.reasoningToThinkingConfig(reasoning);
       const outputConfig = {
         ...(outputFormat ? outputFormatToOutputConfig(outputFormat) : {}),
         ...("output_config" in thinkingConfig

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.ts
@@ -7,6 +7,7 @@ import type {
   ThinkingBlockParam,
   ThinkingConfigAdaptive,
   ThinkingConfigDisabled,
+  ThinkingConfigEnabled,
   Tool,
   ToolChoiceAuto,
   ToolChoiceTool,
@@ -291,16 +292,21 @@ function effortToAnthropicEffort(
   }
 }
 
-export function reasoningToThinkingConfig(
+export type ReasoningToThinkingConfig = (
   reasoning: AnthropicInputConfig["reasoning"]
-):
+) =>
   | {
       output_config: { effort: NonNullable<OutputConfig["effort"]> };
       thinking: ThinkingConfigAdaptive;
     }
-  | {
-      thinking: ThinkingConfigDisabled;
-    } {
+  | { thinking: ThinkingConfigEnabled }
+  | { thinking: ThinkingConfigDisabled };
+
+// Adaptive thinking; extended-thinking-only models swap in
+// `reasoningToExtendedThinkingConfig`.
+export const reasoningToThinkingConfig: ReasoningToThinkingConfig = (
+  reasoning
+) => {
   if (!reasoning || reasoning.effort === "none") {
     return { thinking: { type: "disabled" } };
   }
@@ -309,4 +315,30 @@ export function reasoningToThinkingConfig(
     output_config: { effort: effortToAnthropicEffort(reasoning.effort) },
     thinking: { type: "adaptive" },
   };
-}
+};
+
+// low/medium/high mirror the legacy budget mapping (1024 minimum); xhigh/maximal
+// extend it. budget_tokens must be >= 1024 and < max_tokens.
+const EXTENDED_THINKING_BUDGET_TOKENS = {
+  low: 1_024,
+  medium: 1_024,
+  high: 4_096,
+  xhigh: 8_192,
+  maximal: 16_384,
+} as const;
+
+// Extended thinking for models without adaptive-thinking support (e.g. Haiku 4.5).
+export const reasoningToExtendedThinkingConfig: ReasoningToThinkingConfig = (
+  reasoning
+) => {
+  if (!reasoning || reasoning.effort === "none") {
+    return { thinking: { type: "disabled" } };
+  }
+
+  return {
+    thinking: {
+      type: "enabled",
+      budget_tokens: EXTENDED_THINKING_BUDGET_TOKENS[reasoning.effort],
+    },
+  };
+};

--- a/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,0 +1,66 @@
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import { reasoningToExtendedThinkingConfig } from "@app/lib/model_constructors/providers/anthropic/converters/input/utils";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { CLAUDE_HAIKU_4_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+const CONTEXT_SIZE = 200_000;
+const DEFAULT_REASONING_EFFORT = "low";
+const MAX_OUTPUT_TOKENS = 64_000;
+
+const baseConfig = inputConfigSchema.extend({
+  cacheKey: z.undefined(),
+});
+
+const configSchema = z.union([
+  baseConfig.extend({
+    reasoning: z
+      .object({
+        effort: z.enum(["low", "medium", "high"]),
+      })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    forceTool: z.undefined(),
+    // Reasoning requires temperature=1.
+    temperature: temperatureSchema.optional().transform(() => 1 as const),
+  }),
+  baseConfig.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+    temperature: temperatureSchema.optional().default(1),
+  }),
+]);
+
+export type ClaudeHaikuFourDotFive = z.infer<typeof configSchema>;
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithAnthropicClaudeHaikuFourDotFiveConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class AnthropicClaudeHaikuFourDotFive extends Base {
+    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
+    // instance type carries `ClaudeHaikuFourDotFive` (not the wide `InputConfig`).
+    declare ["constructor"]: BaseEndpointConfiguration<ClaudeHaikuFourDotFive>;
+
+    static readonly modelId = CLAUDE_HAIKU_4_5_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<
+      ClaudeHaikuFourDotFive,
+      z.ZodTypeDef,
+      unknown
+    > = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+
+    // Haiku 4.5 has extended thinking but not adaptive thinking, so it overrides
+    // the converter's default (adaptive) thinking leaf.
+    reasoningToThinkingConfig = reasoningToExtendedThinkingConfig;
+  }
+
+  return AnthropicClaudeHaikuFourDotFive;
+}

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five.ts
@@ -1,0 +1,36 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources";
+import {
+  type ClaudeHaikuFourDotFive,
+  WithAnthropicClaudeHaikuFourDotFiveConfig,
+} from "@app/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five";
+import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AnthropicGlobalClaudeHaikuFourDotFiveStream extends WithAnthropicClaudeHaikuFourDotFiveConfig(
+  AnthropicStream
+) {
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 1.25,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 1.25,
+    longCacheCreated: 2.0,
+    cacheHit: 0.1,
+    standardInput: 1.0,
+    standardOutput: 5.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicGlobalClaudeHaikuFourDotFiveStream satisfies StreamEndpointConstructor<
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+  ClaudeHaikuFourDotFive
+>;

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+
+import { AnthropicGlobalClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_haiku_four_dot_five";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AnthropicGlobalClaudeHaikuFourDotFiveStream({
+      ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Only low/medium/high reasoning efforts are supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_haiku_four_dot_five.test.ts
+runStreamEndpointTests(AnthropicGlobalClaudeHaikuFourDotFiveStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -2,6 +2,7 @@ export const GPT_5_5_MODEL_ID = "gpt-5.5" as const;
 export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
+export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5" as const;
 
 export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 
@@ -10,6 +11,7 @@ export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
   GPT_5_2_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_HAIKU_4_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
 ] as const;
 


### PR DESCRIPTION
## Description

Adds Claude Haiku 4.5 (`claude-haiku-4-5`) to `model_constructors`: model id, model-config mixin, and the direct Anthropic API (global) endpoint.

Haiku 4.5 supports extended thinking but not adaptive thinking, so the Anthropic input converter's thinking-config leaf is made overridable; the Haiku mixin swaps in an extended-thinking variant (`budget_tokens`, values matching the legacy `ANTHROPIC_THINKING_BUDGET_TOKENS_MAPPING`). Other endpoints (Sonnet) keep the default adaptive leaf.

## Tests

`model_constructors` integration suite against the live Anthropic API — 40/40 green (all reasoning efforts, plus the expected `input_configuration_error` policy cases for `minimal` and forced-tool-without-reasoning-none).

## Risk

Low. New model + endpoint; the only shared change is making one converter leaf overridable, which defaults to existing behaviour.

## Deploy Plan

Standard. No migration.