### PR TITLE
feat(llm): add Claude Haiku 4.5 agent-platform EU endpoint

### DIFF
--- a/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five.ts
@@ -1,0 +1,15 @@
+export function WithDustClaudeHaikuFourDotFive<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustClaudeHaikuFourDotFive extends Base {
+    static readonly displayName = "Claude 4.5 Haiku";
+    static readonly description =
+      "Anthropic's Claude 4.5 Haiku model, cost effective and high throughput (200k context).";
+    static readonly defaultReasoningEffort = "low";
+    static readonly byok = true;
+  }
+
+  return DustClaudeHaikuFourDotFive;
+}

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
@@ -1,0 +1,18 @@
+import { WithDustClaudeHaikuFourDotFive } from "@app/lib/llms/providers/anthropic/models/claude_haiku_four_dot_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
+
+export class DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream extends WithDustClaudeHaikuFourDotFive(
+  AgentPlatformEuropeClaudeHaikuFourDotFiveStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,4 +1,5 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
@@ -17,6 +18,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
+  [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
+    DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -12,10 +12,6 @@ export type BaseEndpointConfiguration<C extends InputConfig = InputConfig> = {
   providerId: ProviderId;
   api: ProviderApi;
   modelId: ModelId;
-  // Wire id sent to the provider API when it differs from our canonical
-  // `modelId` (e.g. Vertex expects `claude-haiku-4-5@20251001`). Defaults to
-  // `modelId`.
-  providerModelId?: string;
   region: Region;
 
   // Capabilities

--- a/front/lib/model_constructors/configuration.ts
+++ b/front/lib/model_constructors/configuration.ts
@@ -12,6 +12,10 @@ export type BaseEndpointConfiguration<C extends InputConfig = InputConfig> = {
   providerId: ProviderId;
   api: ProviderApi;
   modelId: ModelId;
+  // Wire id sent to the provider API when it differs from our canonical
+  // `modelId` (e.g. Vertex expects `claude-haiku-4-5@20251001`). Defaults to
+  // `modelId`.
+  providerModelId?: string;
   region: Region;
 
   // Capabilities

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -1,6 +1,7 @@
 import type {
   MessageCreateParamsNonStreaming,
   MessageParam,
+  Model,
   TextBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { Client } from "@app/lib/model_constructors/client";
@@ -25,6 +26,7 @@ import type {
   Payload,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 
 type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 
@@ -49,6 +51,7 @@ export function WithAnthropicInputConverter<
     assistantToolCallRequestToToolUseBlock =
       assistantToolCallRequestToToolUseBlock;
     reasoningToThinkingConfig = reasoningToThinkingConfig;
+    modelIdToApiModelId = (modelId: ModelId): Model => modelId;
 
     conversationToMessages(
       conversation: Payload["conversation"]
@@ -82,7 +85,7 @@ export function WithAnthropicInputConverter<
       };
 
       return {
-        model: this.constructor.providerModelId ?? this.constructor.modelId,
+        model: this.modelIdToApiModelId(this.constructor.modelId),
         max_tokens: this.constructor.maxOutputTokens,
         messages: this.conversationToMessages(conversation),
         system: this.systemMessagesToSystemParam(conversation.system),

--- a/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/index.ts
@@ -82,7 +82,7 @@ export function WithAnthropicInputConverter<
       };
 
       return {
-        model: this.constructor.modelId,
+        model: this.constructor.providerModelId ?? this.constructor.modelId,
         max_tokens: this.constructor.maxOutputTokens,
         messages: this.conversationToMessages(conversation),
         system: this.systemMessagesToSystemParam(conversation.system),

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -1,6 +1,7 @@
 import type {
   MessageCreateParamsNonStreaming,
   MessageCreateParamsStreaming,
+  Model,
   RawMessageStreamEvent,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import AnthropicVertex from "@anthropic-ai/vertex-sdk";
@@ -13,6 +14,10 @@ import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_c
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
 import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import {
+  CLAUDE_HAIKU_4_5_MODEL_ID,
+  type ModelId,
+} from "@app/lib/model_constructors/types/model_ids";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { AGENT_PLATFORM_API } from "@app/lib/model_constructors/types/provider_apis";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
@@ -32,6 +37,10 @@ const configSchema = inputConfigSchema.extend({
     })
     .optional(),
 });
+
+const MODEL_MAPPING: Partial<Record<ModelId, Model>> = {
+  [CLAUDE_HAIKU_4_5_MODEL_ID]: "claude-haiku-4-5@20251001",
+};
 
 export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
   WithAnthropicOutputConverter(
@@ -64,6 +73,9 @@ export abstract class AgentPlatformStream extends WithAnthropicInputConverter(
       projectId: AGENT_PLATFORM_PROJECT_ID,
     });
   }
+
+  modelIdToApiModelId = (modelId: ModelId): Model =>
+    MODEL_MAPPING[modelId] ?? modelId;
 
   async *streamRaw(
     input: MessageCreateParamsNonStreaming

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
@@ -1,0 +1,28 @@
+import { WithAnthropicClaudeHaikuFourDotFiveConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_haiku_four_dot_five";
+import { AgentPlatformStream } from "@app/lib/model_constructors/stream/clients/agent_platform";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+
+export class AgentPlatformEuropeClaudeHaikuFourDotFiveStream extends WithAnthropicClaudeHaikuFourDotFiveConfig(
+  AgentPlatformStream
+) {
+  // Vertex expects the dated id; our canonical `modelId` is the dateless alias.
+  static readonly providerModelId = "claude-haiku-4-5@20251001";
+
+  // Vertex regional/multi-region endpoints add a 10% premium over global.
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 1.375,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 1.375,
+    longCacheCreated: 2.2,
+    cacheHit: 0.11,
+    standardInput: 1.1,
+    standardOutput: 5.5,
+  };
+  static readonly region = "eu";
+  static readonly regionalEndpoint = "eu";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeClaudeHaikuFourDotFiveStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five.ts
@@ -5,9 +5,6 @@ import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stre
 export class AgentPlatformEuropeClaudeHaikuFourDotFiveStream extends WithAnthropicClaudeHaikuFourDotFiveConfig(
   AgentPlatformStream
 ) {
-  // Vertex expects the dated id; our canonical `modelId` is the dateless alias.
-  static readonly providerModelId = "claude-haiku-4-5@20251001";
-
   // Vertex regional/multi-region endpoints add a 10% premium over global.
   // https://platform.claude.com/docs/en/about-claude/pricing
   static readonly tokenPricing = {

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,4 +1,5 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
@@ -10,6 +11,8 @@ export const STREAM_ENDPOINTS = {
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
+  [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
+    AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeClaudeHaikuFourDotFiveStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Only low/medium/high reasoning efforts are supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_claude_haiku_four_dot_five.test.ts
+runStreamEndpointTests(AgentPlatformEuropeClaudeHaikuFourDotFiveStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -2,7 +2,7 @@ export const GPT_5_5_MODEL_ID = "gpt-5.5" as const;
 export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
-export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5" as const;
+export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5-20251001" as const;
 
 export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 


### PR DESCRIPTION
## Description

Adds the Vertex (agent-platform) EU endpoint for Claude Haiku 4.5.

Its Vertex wire id (`claude-haiku-4-5@20251001`) differs from our canonical model id, so `BaseEndpointConfiguration` gains an optional `providerModelId` that the Anthropic converter uses when set (defaults to `modelId`, so existing endpoints are unaffected).

## Tests

Live Vertex run is currently blocked by a project-wide GCP quota gap (`eu_multi_region` requests for Anthropic base models 429 `RESOURCE_EXHAUSTED` — the already-merged Sonnet EU endpoint hits the identical limit). Verified instead via: the wire id resolves on Vertex (the 429 names the base model), the schema/thinking path is identical to the fully-green global endpoint (#27622), and the local `input_configuration_error` cases pass.

## Risk

Low. New endpoint; the only shared change is the optional `providerModelId`, which defaults to the existing `modelId`.

## Deploy Plan

Standard. EU traffic needs the GCP `eu_multi_region` quota granted for `anthropic-claude-haiku-4-5` before it serves live.