### PR TITLE
MCP server proxified oauth strip unsupported grants (local fix), support fallback when missing resource param.

### DIFF
--- a/front-api/routes/mcp/well-known.ts
+++ b/front-api/routes/mcp/well-known.ts
@@ -1,3 +1,4 @@
+import { sanitizeOAuthRegistrationRequestBody } from "@app/lib/api/mcp_server/oauth_registration";
 import {
   getMcpAuthorizationServers,
   getMcpAuthorizationServerUrl,
@@ -87,10 +88,12 @@ async function proxyOAuthPostRequest(
     headers.set("accept", accept);
   }
 
+  const body = sanitizeOAuthRegistrationRequestBody(await c.req.text());
+
   const response = await fetch(upstreamUrl, {
     method: "POST",
     headers,
-    body: await c.req.text(),
+    body,
   });
 
   const responseHeaders = new Headers();
@@ -99,7 +102,8 @@ async function proxyOAuthPostRequest(
     responseHeaders.set("content-type", responseContentType);
   }
 
-  return new Response(await response.text(), {
+  const responseBody = await response.text();
+  return new Response(responseBody, {
     status: response.status,
     headers: responseHeaders,
   });

--- a/front/lib/api/mcp_server/auth.ts
+++ b/front/lib/api/mcp_server/auth.ts
@@ -1,3 +1,4 @@
+import config from "@app/lib/api/config";
 import {
   areRedirectUrisAllowed,
   getDustMcpServerAllowedRedirectUris,
@@ -123,7 +124,44 @@ export const mcpServerAuthMiddleware = createMiddleware<{
     }
 
     if (!tokenAudienceMatchesResource(payload.aud, DUST_MCP_SERVER_URL)) {
-      throw new Error("Token audience does not match MCP resource URL");
+      logger.info(
+        { aud: payload.aud },
+        "Token audience does not match MCP resource URL, falling back to application:client_id claim"
+      );
+
+      const clientId = payload["application:client_id"];
+      if (typeof clientId !== "string" || !clientId.trim()) {
+        throw new Error(
+          "Access token with mismatched audience: missing application:client_id claim"
+        );
+      }
+
+      const applicationResult = await getWorkOSConnectApplication(
+        clientId.trim()
+      );
+      if (applicationResult.isErr()) {
+        throw new Error(
+          "Access token with mismatched audience: failed to fetch WorkOS Connect application"
+        );
+      }
+
+      const application = applicationResult.value;
+      if (application.application_type !== "oauth") {
+        throw new Error("Connect application is not an OAuth application");
+      }
+
+      // Check if it's a dynamically registered application and that the token audience matches workOSClientID.
+      // And check that application client id is not workOSClientID.
+      // This doesn't prove that the token is for the mcp resource but at least we know it's a connect application.
+      if (
+        !application.was_dynamically_registered ||
+        payload.aud !== config.getWorkOSClientId() ||
+        application.client_id === config.getWorkOSClientId()
+      ) {
+        throw new Error(
+          "Access token with mismatched audience: invalid application"
+        );
+      }
     }
 
     const authResult = await getAuthenticatorFromWorkOSClaims(payload);

--- a/front/lib/api/mcp_server/oauth_registration.test.ts
+++ b/front/lib/api/mcp_server/oauth_registration.test.ts
@@ -1,0 +1,34 @@
+import { sanitizeOAuthRegistrationRequestBody } from "@app/lib/api/mcp_server/oauth_registration";
+import { describe, expect, it } from "vitest";
+
+describe("sanitizeOAuthRegistrationRequestBody", () => {
+  it("removes device_code from grant_types", () => {
+    const body = JSON.stringify({
+      client_name: "Raycast MCP: Dust (dev)",
+      grant_types: [
+        "authorization_code",
+        "refresh_token",
+        "urn:ietf:params:oauth:grant-type:device_code",
+      ],
+      redirect_uris: ["raycast://oauth?package_name=mcp_server_dust_(dev)"],
+    });
+
+    expect(JSON.parse(sanitizeOAuthRegistrationRequestBody(body))).toEqual({
+      client_name: "Raycast MCP: Dust (dev)",
+      grant_types: ["authorization_code", "refresh_token"],
+      redirect_uris: ["raycast://oauth?package_name=mcp_server_dust_(dev)"],
+    });
+  });
+
+  it("leaves supported grant_types unchanged", () => {
+    const body = JSON.stringify({
+      grant_types: ["authorization_code", "refresh_token"],
+    });
+
+    expect(sanitizeOAuthRegistrationRequestBody(body)).toBe(body);
+  });
+
+  it("returns invalid JSON unchanged", () => {
+    expect(sanitizeOAuthRegistrationRequestBody("not-json")).toBe("not-json");
+  });
+});

--- a/front/lib/api/mcp_server/oauth_registration.ts
+++ b/front/lib/api/mcp_server/oauth_registration.ts
@@ -1,0 +1,38 @@
+/** Grant types accepted by WorkOS AuthKit dynamic client registration. */
+export const WORKOS_DCR_GRANT_TYPES = [
+  "authorization_code",
+  "refresh_token",
+] as const;
+
+const WORKOS_DCR_GRANT_TYPE_SET = new Set<string>(WORKOS_DCR_GRANT_TYPES);
+
+/**
+ * WorkOS AuthKit metadata advertises device_code, but `/oauth2/register` rejects
+ * it. Strip unsupported grant types before proxying DCR (e.g. Raycast MCP).
+ */
+export function sanitizeOAuthRegistrationRequestBody(body: string): string {
+  try {
+    const payload = JSON.parse(body) as { grant_types?: unknown };
+    if (!Array.isArray(payload.grant_types)) {
+      return body;
+    }
+
+    const grantTypes = payload.grant_types.filter(
+      (grantType): grantType is string =>
+        typeof grantType === "string" &&
+        WORKOS_DCR_GRANT_TYPE_SET.has(grantType)
+    );
+
+    if (grantTypes.length === payload.grant_types.length) {
+      return body;
+    }
+
+    if (grantTypes.length === 0) {
+      return body;
+    }
+
+    return JSON.stringify({ ...payload, grant_types: grantTypes });
+  } catch {
+    return body;
+  }
+}


### PR DESCRIPTION
## Description

Two fixes for the proxified MCP OAuth flow:

- **Strip unsupported grant types on DCR proxy**: WorkOS AuthKit well-known metadata advertises `device_code`, but `/oauth2/register` rejects it. `sanitizeOAuthRegistrationRequestBody` filters `grant_types` to only `authorization_code` and `refresh_token` before proxying DCR requests — fixes Raycast MCP client registration locally.
- **Fallback when `resource` param is missing**: `mcpServerAuthMiddleware` previously threw immediately when `tokenAudienceMatchesResource` failed. It now falls back to validating via the `application:client_id` claim: fetches the WorkOS Connect application and confirms it's a dynamically-registered OAuth app whose `aud` equals `workOSClientId` and whose `client_id` differs from `workOSClientId`. Handles MCP clients that omit the `resource` parameter at token exchange time.

## Tests

- Added unit tests for `sanitizeOAuthRegistrationRequestBody` (`oauth_registration.test.ts`): covers `device_code` removal, no-op for already-supported grants, and passthrough for invalid JSON.
- Tested locally with the Raycast MCP client.

## Risk

Low. The DCR sanitization is strictly defensive — it only removes unsupported values and passes the body through unchanged on parse error. The auth fallback only activates when the primary audience check already fails, and enforces strict conditions (dynamically registered app, correct `aud`, non-workOS `client_id`) before accepting the token.

## Deploy Plan

Deploy front-api and front.
