### PR TITLE
feat(llm): add headroom-ai message compression flag

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -238,6 +238,14 @@ const config = {
   getVizJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("VIZ_JWT_SECRET");
   },
+  // Base URL of the local headroom-ai compression proxy. The headroom-ai client
+  // delegates compression to this proxy; defaults to the local proxy port.
+  getHeadroomProxyUrl: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("HEADROOM_PROXY_URL") ??
+      "http://localhost:8787"
+    );
+  },
   getAcademyJwtSecret: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_ACADEMY_JWT_SECRET");
   },

--- a/front/lib/api/llm/headroom.ts
+++ b/front/lib/api/llm/headroom.ts
@@ -1,0 +1,341 @@
+import config from "@app/lib/api/config";
+import type { BaseMessage } from "@app/lib/model_constructors/types/input/messages";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { CompressResult, OpenAIMessage } from "headroom-ai";
+import { compress } from "headroom-ai";
+
+// The headroom-ai SDK is a thin client over the local compression proxy; give it
+// a bounded budget so a slow/unavailable proxy can never stall a model request.
+const HEADROOM_TIMEOUT_MS = 15_000;
+
+// Attribution slug surfaced in the headroom proxy telemetry/stats.
+const HEADROOM_STACK = "dust_llm_router";
+
+// Datadog metric namespace for headroom compression telemetry.
+const HEADROOM_METRIC_PREFIX = "headroom_compression";
+
+type CompressionOutcome = "applied" | "skipped" | "error";
+
+// Emit compression telemetry to Datadog, mirroring what we log. Tagged by model
+// id (bounded cardinality) and outcome; workspace id is intentionally kept to
+// logs only to avoid exploding metric tag cardinality. Token counts and ratio
+// go out as distributions so percentiles aggregate correctly across app servers.
+function recordCompressionMetrics(
+  modelId: string,
+  outcome: CompressionOutcome,
+  result?: CompressResult
+): void {
+  const client = getStatsDClient();
+  const tags = [`model_id:${modelId}`, `outcome:${outcome}`];
+
+  client.increment(`${HEADROOM_METRIC_PREFIX}.count`, 1, tags);
+
+  if (result) {
+    client.distribution(
+      `${HEADROOM_METRIC_PREFIX}.tokens_before`,
+      result.tokensBefore,
+      tags
+    );
+    client.distribution(
+      `${HEADROOM_METRIC_PREFIX}.tokens_after`,
+      result.tokensAfter,
+      tags
+    );
+    client.distribution(
+      `${HEADROOM_METRIC_PREFIX}.tokens_saved`,
+      result.tokensSaved,
+      tags
+    );
+    client.distribution(
+      `${HEADROOM_METRIC_PREFIX}.ratio`,
+      result.compressionRatio,
+      tags
+    );
+  }
+}
+
+// Maps Dust internal model ids to the model names headroom-ai / LiteLLM expect
+// (keys in model_prices_and_context_window.json). Only ids that differ from a
+// bare LiteLLM key are listed; OpenAI, Anthropic, Google, and DeepSeek ids
+// already match a bare key and pass through unchanged via `toHeadroomModelId`.
+//
+// LiteLLM namespaces these providers with a prefix. The legacy Claude 3.5 ids
+// (`claude-3-5-sonnet-*`, `claude-3-5-haiku-20241022`), `o1-mini`, and the
+// internal `noop` model have no distinct bare LiteLLM key, so they intentionally
+// fall through to headroom's default tokenizer.
+const DUST_TO_LITELLM_MODEL_ID: Record<string, string> = {
+  // Mistral — LiteLLM `mistral/` prefix.
+  "mistral-large-latest": "mistral/mistral-large-latest",
+  "mistral-medium": "mistral/mistral-medium",
+  // No dated 3.5 key in LiteLLM; use the generic latest medium for tokenization.
+  "mistral-medium-3-5": "mistral/mistral-medium-latest",
+  "mistral-small-latest": "mistral/mistral-small-latest",
+  "codestral-latest": "mistral/codestral-latest",
+
+  // xAI Grok — LiteLLM `xai/` prefix. The v4 `*-fast-*` ids drop `-latest`.
+  "grok-3-latest": "xai/grok-3-latest",
+  "grok-3-mini-latest": "xai/grok-3-mini-latest",
+  "grok-4-latest": "xai/grok-4-latest",
+  "grok-4-fast-reasoning-latest": "xai/grok-4-fast-reasoning",
+  "grok-4-fast-non-reasoning-latest": "xai/grok-4-fast-non-reasoning",
+  "grok-4-1-fast-reasoning-latest": "xai/grok-4-1-fast-reasoning-latest",
+  "grok-4-1-fast-non-reasoning-latest":
+    "xai/grok-4-1-fast-non-reasoning-latest",
+
+  // TogetherAI — LiteLLM `together_ai/` prefix.
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo":
+    "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+  "Qwen/Qwen2.5-Coder-32B-Instruct":
+    "together_ai/Qwen/Qwen2.5-Coder-32B-Instruct",
+  "Qwen/QwQ-32B-Preview": "together_ai/Qwen/QwQ-32B-Preview",
+  "Qwen/Qwen2-72B-Instruct": "together_ai/Qwen/Qwen2-72B-Instruct",
+  "deepseek-ai/DeepSeek-V3": "together_ai/deepseek-ai/DeepSeek-V3",
+
+  // Fireworks — LiteLLM `fireworks_ai/` prefix.
+  "accounts/fireworks/models/deepseek-v3p2":
+    "fireworks_ai/accounts/fireworks/models/deepseek-v3p2",
+  "accounts/fireworks/models/deepseek-v4-pro":
+    "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro",
+  "accounts/fireworks/models/glm-5":
+    "fireworks_ai/accounts/fireworks/models/glm-5",
+  "accounts/fireworks/models/glm-5p2":
+    "fireworks_ai/accounts/fireworks/models/glm-5p2",
+  "accounts/fireworks/models/kimi-k2-instruct-0905":
+    "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct-0905",
+  "accounts/fireworks/models/kimi-k2p5":
+    "fireworks_ai/accounts/fireworks/models/kimi-k2p5",
+  "accounts/fireworks/models/minimax-m2p5":
+    "fireworks_ai/accounts/fireworks/models/minimax-m2p5",
+};
+
+// Translate a Dust model id to the name headroom-ai / LiteLLM expects. Unmapped
+// ids (which already match a bare LiteLLM key, plus custom/future models) are
+// returned unchanged so headroom can resolve them or fall back gracefully.
+export function toHeadroomModelId(modelId: string): string {
+  return DUST_TO_LITELLM_MODEL_ID[modelId] ?? modelId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readRole(value: unknown): string | null {
+  if (isRecord(value) && typeof value.role === "string") {
+    return value.role;
+  }
+  return null;
+}
+
+// We only ever rewrite plain-string message content. Structured content (image
+// parts, tool calls) comes back as arrays/objects and is left untouched.
+function readStringContent(value: unknown): string | null {
+  if (isRecord(value) && typeof value.content === "string") {
+    return value.content;
+  }
+  return null;
+}
+
+// Project a Dust `BaseMessage` onto the OpenAI message shape that the proxy
+// understands. This is a faithful 1:1 mapping: every message in, every message
+// out, preserving role family so the compressed result can be realigned by
+// index.
+function baseMessageToOpenAI(message: BaseMessage): OpenAIMessage {
+  switch (message.role) {
+    case "user":
+      switch (message.type) {
+        case "text":
+          return { role: "user", content: message.content.value };
+        case "image_url":
+          return {
+            role: "user",
+            content: [
+              { type: "image_url", image_url: { url: message.content.url } },
+            ],
+          };
+        case "tool_call_result": {
+          const texts: string[] = [];
+          for (const part of message.content.parts) {
+            if (part.type === "text") {
+              texts.push(part.text);
+            }
+          }
+          return {
+            role: "tool",
+            tool_call_id: message.content.callId,
+            content: texts.join("\n"),
+          };
+        }
+        default:
+          return assertNever(message);
+      }
+    case "assistant":
+      switch (message.type) {
+        case "text":
+        case "reasoning":
+          return { role: "assistant", content: message.content.value };
+        case "tool_call_request":
+          return {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: message.content.callId,
+                type: "function",
+                function: {
+                  name: message.content.toolName,
+                  arguments: message.content.arguments,
+                },
+              },
+            ],
+          };
+        default:
+          return assertNever(message);
+      }
+    default:
+      return assertNever(message);
+  }
+}
+
+// Write compressed text back into the original message, returning a NEW message
+// (never mutating the input). Only text-bearing, safe-to-rewrite content is
+// updated; reasoning signatures, tool-call arguments, images, and call IDs are
+// preserved exactly so tool-calling and prompt caching keep working.
+function applyCompressedText(original: BaseMessage, text: string): BaseMessage {
+  switch (original.role) {
+    case "user":
+      switch (original.type) {
+        case "text":
+          return { ...original, content: { value: text } };
+        case "image_url":
+          return original;
+        case "tool_call_result": {
+          // Only collapse when every part is text; mixed/image parts are kept
+          // as-is to avoid dropping non-text content.
+          const allText = original.content.parts.every(
+            (part) => part.type === "text"
+          );
+          if (!allText) {
+            return original;
+          }
+          return {
+            ...original,
+            content: {
+              ...original.content,
+              parts: [{ type: "text", text }],
+            },
+          };
+        }
+        default:
+          return assertNever(original);
+      }
+    case "assistant":
+      switch (original.type) {
+        case "text":
+          return { ...original, content: { value: text } };
+        case "reasoning":
+        case "tool_call_request":
+          return original;
+        default:
+          return assertNever(original);
+      }
+    default:
+      return assertNever(original);
+  }
+}
+
+interface CompressConversationOptions {
+  modelId: string;
+  workspaceId: string;
+}
+
+/**
+ * Compress conversation messages through the local headroom-ai proxy.
+ *
+ * Safety contract: this is best-effort and never throws. The compressed result
+ * is applied only when it comes back as a strict 1:1, role-aligned array; if the
+ * proxy is down, errors, or drops/merges turns (rolling window / intelligent
+ * context), the original messages are returned unchanged. The system prompt is
+ * never passed here — only the conversation turns.
+ */
+export async function compressConversationMessages(
+  messages: BaseMessage[],
+  { modelId, workspaceId }: CompressConversationOptions
+): Promise<BaseMessage[]> {
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  const openAIMessages = messages.map(baseMessageToOpenAI);
+
+  try {
+    // `compress` is an external library boundary, so catching here is expected.
+    const result = await compress(openAIMessages, {
+      model: toHeadroomModelId(modelId),
+      baseUrl: config.getHeadroomProxyUrl(),
+      timeout: HEADROOM_TIMEOUT_MS,
+      // On any proxy error the client returns the original messages untouched.
+      fallback: true,
+      stack: HEADROOM_STACK,
+    });
+
+    const compressed = result.messages;
+
+    if (
+      !result.compressed ||
+      !Array.isArray(compressed) ||
+      compressed.length !== openAIMessages.length
+    ) {
+      logger.info(
+        {
+          workspaceId,
+          modelId,
+          compressed: result.compressed,
+          inputCount: openAIMessages.length,
+          returnedCount: Array.isArray(compressed) ? compressed.length : null,
+        },
+        "[headroom] Skipping compression: result is not a 1:1 message array."
+      );
+      recordCompressionMetrics(modelId, "skipped");
+      return messages;
+    }
+
+    const rewritten = messages.map((message, i) => {
+      const compressedMessage = compressed[i];
+      // Realign by role; bail on this message if the proxy reshaped it.
+      if (readRole(compressedMessage) !== openAIMessages[i].role) {
+        return message;
+      }
+      const text = readStringContent(compressedMessage);
+      if (text === null) {
+        return message;
+      }
+      return applyCompressedText(message, text);
+    });
+
+    logger.info(
+      {
+        workspaceId,
+        modelId,
+        tokensBefore: result.tokensBefore,
+        tokensAfter: result.tokensAfter,
+        tokensSaved: result.tokensSaved,
+        compressionRatio: result.compressionRatio,
+        transformsApplied: result.transformsApplied,
+      },
+      "[headroom] Compressed conversation messages."
+    );
+    recordCompressionMetrics(modelId, "applied", result);
+
+    return rewritten;
+  } catch (err) {
+    logger.error(
+      { workspaceId, modelId, err: normalizeError(err) },
+      "[headroom] Compression failed; using uncompressed messages."
+    );
+    recordCompressionMetrics(modelId, "error");
+    return messages;
+  }
+}

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -1,3 +1,4 @@
+import { compressConversationMessages } from "@app/lib/api/llm/headroom";
 import { LLM } from "@app/lib/api/llm/llm";
 import type { BatchResult } from "@app/lib/api/llm/types/batch";
 import {
@@ -22,7 +23,7 @@ import {
   extractEncryptedContentFromMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
 import type {
   BatchEndpoint,
@@ -554,9 +555,27 @@ export class StreamEndpointTransition extends BaseTransition {
     };
   }
 
-  protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
+  protected async buildStreamRequestPayload(
+    streamParameters: LLMStreamParameters
+  ) {
+    const { conversation } = this.buildPayload(streamParameters);
+
+    // Optionally route the conversation turns through the local headroom-ai
+    // proxy to compress them before dispatch. Gated by a feature flag and scoped
+    // to the streaming surface; the system prompt is intentionally left intact to
+    // preserve agent behavior.
+    const messages = (await hasFeatureFlag(
+      this.authenticator,
+      "headroom_compression"
+    ))
+      ? await compressConversationMessages(conversation.messages, {
+          modelId: this.modelId,
+          workspaceId: this.authenticator.getNonNullableWorkspace().sId,
+        })
+      : conversation.messages;
+
     return this.model.buildRequestPayload(
-      this.buildPayload(streamParameters),
+      { conversation: { ...conversation, messages } },
       this.buildConfig(streamParameters, this.model.constructor.configSchema)
     );
   }

--- a/front/package.json
+++ b/front/package.json
@@ -154,6 +154,7 @@
     "fs-extra": "^11.1.1",
     "google-auth-library": "^9.15.1",
     "googleapis": "^118.0.0",
+    "headroom-ai": "^0.22.4",
     "hot-shots": "^12.1.0",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^9.1.0",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -335,6 +335,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Resize uploaded raster images via imgproxy instead of ConvertAPI",
     stage: "dust_only",
   },
+  headroom_compression: {
+    description:
+      "Compress conversation messages through the local headroom-ai proxy before sending them to the LLM (new router, streaming path only).",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/package-lock.json
+++ b/package-lock.json
@@ -611,6 +611,7 @@
         "fs-extra": "^11.1.1",
         "google-auth-library": "^9.15.1",
         "googleapis": "^118.0.0",
+        "headroom-ai": "^0.22.4",
         "hot-shots": "^12.1.0",
         "html-escaper": "^3.0.3",
         "htmlparser2": "^9.1.0",
@@ -32750,6 +32751,35 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/headroom-ai": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/headroom-ai/-/headroom-ai-0.22.4.tgz",
+      "integrity": "sha512-9a0rgB/jsWe8gs/ggyUwe6E8DYwKAuBvlUml2ApwlUjb5EfJ611X6X+WG0SiXw3nO6sdyV1/+Ah5uw9P7ecnjw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@ai-sdk/provider": ">=1.0.0",
+        "@anthropic-ai/sdk": ">=0.30.0",
+        "ai": ">=6.0.0",
+        "openai": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
       }
     },
     "node_modules/heap-js": {


### PR DESCRIPTION
## Description

Adds an experimental, flag-gated integration of the `headroom-ai` context-compression proxy into the new LLM router.

When the `headroom_compression` feature flag is enabled (and the new router is active via `use_new_llm_router`), conversation messages on the **streaming** path are routed through the local headroom proxy (`http://localhost:8787`, overridable via `HEADROOM_PROXY_URL`) to compress them before dispatch to the provider. The system prompt is intentionally left untouched to preserve agent behavior.

The integration is best-effort and never throws: the compressed output is applied only when it comes back as a strict 1:1, role-aligned message array. On any proxy error, timeout, or turn drop/merge it falls back to the original messages. Tool-call arguments, reasoning signatures, images, and call IDs are preserved exactly. `compress()` is called directly (it returns messages only), so no `headroom_retrieve` tool is injected into the agent tool set.

Changes:
- New `headroom_compression` feature flag (`dust_only`, default off).
- New `compressConversationMessages` helper mapping the router's `BaseMessage[]` to/from the OpenAI message shape around the proxy call.
- Wires compression into `StreamEndpointTransition.buildStreamRequestPayload` (streaming only; batch untouched).
- Adds the `headroom-ai` dependency and a `getHeadroomProxyUrl()` config accessor.

## Tests

Manual. Requires the headroom proxy running on port 8787 and both `use_new_llm_router` and `headroom_compression` enabled for the workspace. Look for `[headroom] Compressed conversation messages.` logs (with token savings) and `[headroom] Skipping…` when the safety guard or fallback engages. No behavior change when the flag is off.

## Risk

Low. Gated behind a default-off `dust_only` flag and limited to the new router's streaming path; rollback is simply disabling the flag. When enabled, conversation content transits the local proxy, and the helper degrades to uncompressed messages whenever the proxy is unavailable.

## Deploy Plan

No special steps — ships disabled. Enable per-workspace only once a headroom proxy is reachable in the target environment.
