### PR TITLE
ci: add actionlint linting for GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint-github-actions.yml
+++ b/.github/workflows/lint-github-actions.yml
@@ -1,0 +1,24 @@
+name: Lint GitHub Actions workflows
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12 /usr/local/bin
+      - name: Lint GitHub Actions workflows
+        run: actionlint -color

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,6 +65,19 @@ pre-commit:
       run: scripts/check-package-lock-sync.sh
       priority: 1
 
+    # Optional: actionlint for GitHub Actions workflow files (skip with LEFTHOOK_EXCLUDE=actionlint)
+    actionlint:
+      glob: ".github/{workflows,actions}/**/*.{yml,yaml}"
+      run: |
+        if command -v actionlint >/dev/null 2>&1; then
+          actionlint {staged_files}
+        else
+          echo "Warning: actionlint is not installed. Skipping GitHub Actions linting."
+          echo "Install with: brew install actionlint"
+          exit 0
+        fi
+      priority: 1
+
     # Front directory checks
     front-lint-audit-log-schemas:
       tags: front


### PR DESCRIPTION
## Description

Adds [actionlint](https://github.com/rhysd/actionlint) to catch errors in GitHub Actions workflow files — YAML syntax, schema violations, invalid expressions, bad job dependencies, shellcheck issues in `run:` blocks.

Two integration points:
- **CI** (`.github/workflows/lint-github-actions.yml`): runs on PRs that touch `.github/workflows/**` or `.github/actions/**`, installs actionlint v1.7.12 via the official download script
- **Lefthook** (`lefthook.yml`): optional pre-commit hook scoped to workflow files; silently skips if actionlint isn't installed (`brew install actionlint`)

## Tests

None needed — pure CI/tooling config.

## Risk

Low. The lefthook hook is optional (no hard failure if tool is absent). The CI job only runs on workflow-touching PRs.
