### PR TITLE
ci(workflows): fix actionlint errors across all GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-canary-image.yml
+++ b/.github/workflows/build-canary-image.yml
@@ -17,7 +17,6 @@ on:
         description: "Name of the component to build"
         required: true
         type: choice
-        default:
         options:
           - connectors
           - core
@@ -53,10 +52,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get short sha
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Get long sha
         id: long_sha
-        run: echo "long_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "long_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   notify-start:
     needs: [prepare]
@@ -85,9 +84,9 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ inputs.regions }}" = "all" ]; then
-            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> "$GITHUB_OUTPUT"
           else
-            echo "matrix=[\"${{ inputs.regions }}\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"${{ inputs.regions }}\"]" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -110,9 +109,9 @@ jobs:
         id: project
         run: |
           if [ "${{ matrix.region }}" = "us-central1" ]; then
-            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           else
-            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Image

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -24,6 +24,7 @@ jobs:
           if [ -n "$NEW_FILES" ]; then
             echo ""
             echo "ERROR: connectors/migrations/db/ is frozen. New files detected:"
+            # shellcheck disable=SC2001
             echo "$NEW_FILES" | sed 's/^/  /'
             echo ""
             echo "Use the new phased migration system instead:"

--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -49,7 +49,7 @@ jobs:
             echo "::error::No version ID provided for ${{ matrix.app }}. Cannot promote without an explicit version ID."
             exit 1
           fi
-          echo "id=${VERSION_ID}" >> $GITHUB_OUTPUT
+          echo "id=${VERSION_ID}" >> "$GITHUB_OUTPUT"
           echo "Promoting version: ${VERSION_ID}"
 
       - name: Promote version to production

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -36,12 +36,12 @@ on:
         description: "The environment to use for API endpoints (prod or edge)"
         type: string
         default: "prod"
-        required: true
+        required: false
       region:
         description: "Default region for API endpoint"
         type: string
         default: "us"
-        required: true
+        required: false
       thread_ts:
         description: "Slack thread timestamp to post in (from parent deploy workflow)"
         type: string
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get short sha
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
   notify-start:
     if: ${{ !inputs.skip_slack }}
@@ -136,7 +136,7 @@ jobs:
             SANITIZED="pr-${SANITIZED}"
             SANITIZED=$(echo "$SANITIZED" | cut -c1-28 | sed 's/-$//')
           fi
-          echo "sanitized=${SANITIZED}" >> $GITHUB_OUTPUT
+          echo "sanitized=${SANITIZED}" >> "$GITHUB_OUTPUT"
 
       - name: Build SPA
         working-directory: front-spa
@@ -152,7 +152,8 @@ jobs:
           if [ "${{ github.ref_name }}" != "main" ]; then
             export NEXT_PUBLIC_DUST_APP_URL=https://${{ steps.branch.outputs.sanitized }}--app.preview.dust.tt
           fi
-          export NEXT_PUBLIC_BUILD_DATE=$(date +%s)
+          # shellcheck disable=SC2034  # exported via set -a, used by VITE_* mapping loop below
+          NEXT_PUBLIC_BUILD_DATE=$(date +%s)
           # Map all NEXT_PUBLIC_* to VITE_* for SPA
           for var in $(compgen -v | grep '^NEXT_PUBLIC_'); do
             export "VITE_${var#NEXT_PUBLIC_}=${!var}"
@@ -208,28 +209,30 @@ jobs:
             echo "$UPLOAD_OUTPUT"
             exit 1
           fi
-          echo "version_id=${VERSION_ID}" >> $GITHUB_OUTPUT
+          echo "version_id=${VERSION_ID}" >> "$GITHUB_OUTPUT"
           VERSION_PREFIX=$(echo "$VERSION_ID" | cut -c1-8)
-          echo "version_prefix=${VERSION_PREFIX}" >> $GITHUB_OUTPUT
+          echo "version_prefix=${VERSION_PREFIX}" >> "$GITHUB_OUTPUT"
           echo "Extracted version ID: ${VERSION_ID} (prefix: ${VERSION_PREFIX})"
 
       - name: Derive preview URL
         id: preview_url
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "url=https://${{ steps.extract_version.outputs.version_prefix }}--${{ inputs.app }}.preview.dust.tt" >> $GITHUB_OUTPUT
+            echo "url=https://${{ steps.extract_version.outputs.version_prefix }}--${{ inputs.app }}.preview.dust.tt" >> "$GITHUB_OUTPUT"
           else
-            echo "url=https://${{ steps.branch.outputs.sanitized }}--${{ inputs.app }}.preview.dust.tt" >> $GITHUB_OUTPUT
+            echo "url=https://${{ steps.branch.outputs.sanitized }}--${{ inputs.app }}.preview.dust.tt" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Summary
         run: |
-          echo "### SPA Deployed :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **App**: ${{ inputs.app }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **URL**: ${{ steps.preview_url.outputs.url }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Region**: ${{ inputs.region }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### SPA Deployed :rocket:"
+            echo ""
+            echo "- **App**: ${{ inputs.app }}"
+            echo "- **URL**: ${{ steps.preview_url.outputs.url }}"
+            echo "- **Region**: ${{ inputs.region }}"
+            echo "- **Commit**: ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify Deploy Success
         if: ${{ !inputs.skip_slack }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,6 @@ on:
         description: "Name of the component to deploy"
         required: true
         type: choice
-        default:
         options:
           - front
           - front-edge
@@ -95,10 +94,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get short sha
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Get long sha
         id: long_sha
-        run: echo "long_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        run: echo "long_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   notify-start:
     needs: [prepare]
@@ -136,9 +135,9 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ inputs.regions }}" = "all" ]; then
-            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> "$GITHUB_OUTPUT"
           else
-            echo "matrix=[\"${{ inputs.regions }}\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"${{ inputs.regions }}\"]" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -161,9 +160,9 @@ jobs:
         id: project
         run: |
           if [ "${{ matrix.region }}" = "us-central1" ]; then
-            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           else
-            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Image

--- a/.github/workflows/lint-github-actions.yml
+++ b/.github/workflows/lint-github-actions.yml
@@ -1,0 +1,24 @@
+name: Lint GitHub Actions workflows
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12 /usr/local/bin
+      - name: Lint GitHub Actions workflows
+        run: actionlint -color

--- a/.github/workflows/list-tags.yaml
+++ b/.github/workflows/list-tags.yaml
@@ -26,11 +26,6 @@ on:
           - prodbox
           - viz
         required: true
-    secrets:
-      GCLOUD_US_PROJECT_ID:
-        required: true
-      GCLOUD_EU_PROJECT_ID:
-        required: true
 
 permissions:
   contents: read
@@ -48,9 +43,9 @@ jobs:
         id: project
         run: |
           if [ "${{ inputs.region }}" = "us-central1" ]; then
-            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           else
-            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           fi
 
       - id: "auth"

--- a/.github/workflows/package-extension.yaml
+++ b/.github/workflows/package-extension.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get short sha
         id: short_sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Build Extension
         working-directory: extension
@@ -54,14 +54,15 @@ jobs:
         run: |
           set -a
           source ../.github/configs/us-central1/.env.prod
-          export BUILD_DATE=$(date +%s)
+          # shellcheck disable=SC2034  # exported via set -a, consumed by the extension build
+          BUILD_DATE=$(date +%s)
           set +a
           npm run package:${{ inputs.target }}
 
       - name: Resolve artifact name
         id: artifact
         working-directory: extension/packages
-        run: echo "name=$(basename *.zip .zip)-${{ steps.short_sha.outputs.short_sha }}" >> $GITHUB_OUTPUT
+        run: echo "name=$(basename ./*.zip .zip)-${{ steps.short_sha.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-dsbx-cli.yml
+++ b/.github/workflows/release-dsbx-cli.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: cli/dust-sandbox
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build with cross
         working-directory: cli/dust-sandbox

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -32,19 +32,11 @@ on:
           - prodbox
           - viz
         required: true
-    secrets:
-      SLACK_CHANNEL_ID:
-        required: true
-      SLACK_BOT_TOKEN:
-        required: true
-      INFRA_DISPATCH_APP_ID:
-        required: true
-      INFRA_DISPATCH_APP_PRIVATE_KEY:
-        required: true
-      GCLOUD_US_PROJECT_ID:
-        required: true
-      GCLOUD_EU_PROJECT_ID:
-        required: true
+      enforce_main:
+        description: "Require revert to run from main branch"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -89,9 +81,9 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ inputs.regions }}" = "all" ]; then
-            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"us-central1\",\"europe-west1\"]" >> "$GITHUB_OUTPUT"
           else
-            echo "matrix=[\"${{ inputs.regions }}\"]" >> $GITHUB_OUTPUT
+            echo "matrix=[\"${{ inputs.regions }}\"]" >> "$GITHUB_OUTPUT"
           fi
 
   validate-image:
@@ -111,9 +103,9 @@ jobs:
         id: project
         run: |
           if [ "${{ matrix.region }}" = "us-central1" ]; then
-            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_US_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           else
-            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> $GITHUB_OUTPUT
+            echo "PROJECT_ID=${{ secrets.GCLOUD_EU_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
           fi
 
       - id: "auth"
@@ -143,7 +135,7 @@ jobs:
             exit 1
           fi
 
-          echo "✅ Image tag '${{ inputs.image_tag }}' exists in ${{ matrix.region }} registry" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Image tag '${{ inputs.image_tag }}' exists in ${{ matrix.region }} registry" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify Failure
         if: failure()

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -3,7 +3,7 @@ name: Run DangerJS
 on:
   pull_request:
     branches: [ main ]
-    types: [ edited, labeled, opened, pushed, reopened, synchronize ]
+    types: [ edited, labeled, opened, reopened, synchronize ]
 
 permissions:
   contents: read
@@ -41,15 +41,15 @@ jobs:
 
           PATHS_STRING="${MONITORED_PATHS[*]}"
 
-          CHANGED_FILES=$(git diff --name-only origin/main ${{ github.sha }} -- ${MONITORED_PATHS[@]})
+          CHANGED_FILES=$(git diff --name-only origin/main ${{ github.sha }} -- "${MONITORED_PATHS[@]}")
           if [ -n "$CHANGED_FILES" ]; then
             echo "Changed files found:"
             echo "$CHANGED_FILES"
-            echo "run_danger=true" >> $GITHUB_OUTPUT
+            echo "run_danger=true" >> "$GITHUB_OUTPUT"
             echo "::warning ::Files in ${PATHS_STRING} have been modified."
           else
             echo "No changed files found."
-            echo "run_danger=false" >> $GITHUB_OUTPUT
+            echo "run_danger=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node Dependencies
@@ -82,21 +82,15 @@ jobs:
           echo "Checking for changed activity files in connectors..."
 
           # Define monitored paths for connectors
-          CONNECTORS_MONITORED_PATHS=(
-            'connectors/src/connectors/*/temporal/activities.ts'
-          )
-
-          PATHS_STRING="${CONNECTORS_MONITORED_PATHS[*]}"
-
           CHANGED_FILES=$(git diff --name-only origin/main ${{ github.sha }} | grep -E 'connectors/src/.*/temporal/activities\.ts$' || true)
           if [ -n "$CHANGED_FILES" ]; then
             echo "Changed activity files found:"
             echo "$CHANGED_FILES"
-            echo "run_danger=true" >> $GITHUB_OUTPUT
+            echo "run_danger=true" >> "$GITHUB_OUTPUT"
             echo "::warning ::Activity files in connectors have been modified."
           else
             echo "No changed activity files found."
-            echo "run_danger=false" >> $GITHUB_OUTPUT
+            echo "run_danger=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Node Dependencies

--- a/.github/workflows/sandbox-bedrock-release.yml
+++ b/.github/workflows/sandbox-bedrock-release.yml
@@ -55,7 +55,7 @@ jobs:
               NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
             fi
           fi
-          echo "version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -96,8 +96,10 @@ jobs:
       - name: Summary
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          echo "## Sandbox Bedrock Release" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Released **${VERSION}**" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Image: \`us-central1-docker.pkg.dev/or1g1n-186209/dust-sbx/dust-sbx-bedrock:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Sandbox Bedrock Release"
+            echo ""
+            echo "Released **${VERSION}**"
+            echo ""
+            echo "Image: \`us-central1-docker.pkg.dev/or1g1n-186209/dust-sbx/dust-sbx-bedrock:${VERSION}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -166,9 +166,11 @@ jobs:
           HAS=$(echo "$EU" "$US" | jq -s 'map(.hasMissing) | any')
           SUMMARY=$(echo "$EU" "$US" | jq -s -c 'map({(.region): .missing}) | add')
           COUNT=$(echo "$EU" "$US" | jq -s '[.[].buildMatrix | length] | add')
-          echo "has-missing=$HAS" >> "$GITHUB_OUTPUT"
-          echo "missing-summary=$SUMMARY" >> "$GITHUB_OUTPUT"
-          echo "planned-builds=$COUNT" >> "$GITHUB_OUTPUT"
+          {
+            echo "has-missing=$HAS"
+            echo "missing-summary=$SUMMARY"
+            echo "planned-builds=$COUNT"
+          } >> "$GITHUB_OUTPUT"
           if [ "$HAS" == "true" ]; then
             echo "built=$COUNT" >> "$GITHUB_OUTPUT"
           else
@@ -177,15 +179,19 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Sandbox Image Check Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Sandbox Image Check Summary"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.count.outputs.has-missing }}" == "true" ]; then
-            echo "Built **${{ steps.count.outputs.planned-builds }}** image(s) across EU and US E2B (sequential per region)." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "### Missing by region (before build):" >> "$GITHUB_STEP_SUMMARY"
-            echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            echo '${{ steps.count.outputs.missing-summary }}' >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "Built **${{ steps.count.outputs.planned-builds }}** image(s) across EU and US E2B (sequential per region)."
+              echo ""
+              echo "### Missing by region (before build):"
+              echo '```json'
+              echo '${{ steps.count.outputs.missing-summary }}'
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "All required sandbox images already exist in both regions" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -65,6 +65,19 @@ pre-commit:
       run: scripts/check-package-lock-sync.sh
       priority: 1
 
+    # Optional: actionlint for GitHub Actions workflow files (skip with LEFTHOOK_EXCLUDE=actionlint)
+    actionlint:
+      glob: ".github/{workflows,actions}/**/*.{yml,yaml}"
+      run: |
+        if command -v actionlint >/dev/null 2>&1; then
+          actionlint {staged_files}
+        else
+          echo "Warning: actionlint is not installed. Skipping GitHub Actions linting."
+          echo "Install with: brew install actionlint"
+          exit 0
+        fi
+      priority: 1
+
     # Front directory checks
     front-lint-audit-log-schemas:
       tags: front


### PR DESCRIPTION
## Description

Fixes all errors reported by actionlint (introduced in #27629) across 12 workflow files.

**Real bugs fixed:**
- `run-dangerjs.yml` — removed `pushed` from `pull_request` event types (not a valid type; `synchronize` already covers pushes to a PR branch)
- `list-tags.yaml` + `revert.yml` — removed `secrets:` block under `workflow_dispatch` (only valid under `workflow_call`; invalid syntax was silently ignored)
- `revert.yml` — declared missing `enforce_main` boolean input that was already referenced in job conditions but never defined
- `build-canary-image.yml` + `deploy.yml` — removed empty `default:` on `component` choice input (empty string not in options list caused validation error)
- `deploy-spa.yaml` — removed `required: true` from `workflow_call` inputs that have defaults (`required` + `default` is contradictory; the default was silently never used)

**Shellcheck fixes:**
- SC2068 (error): quoted `"${MONITORED_PATHS[@]}"` in `run-dangerjs.yml` to prevent word splitting on array elements
- SC2155 (warning): split `export VAR=$(...)` assignments to avoid masking subshell return codes (`deploy-spa.yaml`, `package-extension.yaml`)
- SC2086 (info): quoted `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY` everywhere
- SC2129 (style): grouped multiple `>> file` redirects into `{ } >> file` (`deploy-spa.yaml`, `sandbox-bedrock-release.yml`, `sandbox-img-registry.yml`)
- SC2035 (info): `basename ./*.zip` instead of `basename *.zip` in `package-extension.yaml`
- SC2034 (warning): removed dead `CONNECTORS_MONITORED_PATHS` array in `run-dangerjs.yml`; added shellcheck disable for variables legitimately exported via `set -a`

## Tests

Zero errors from `actionlint` locally after changes.
