### PR TITLE
[connector] strip null bytes from gdrive title

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/upsert_gdrive_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/upsert_gdrive_document.ts
@@ -14,6 +14,7 @@ import type {
   GoogleDriveObjectType,
   ModelId,
 } from "@connectors/types";
+import { stripNullBytes } from "@connectors/types";
 import type { OAuth2Client } from "googleapis-common";
 
 export async function upsertGdriveDocument(
@@ -28,9 +29,11 @@ export async function upsertGdriveDocument(
   startSyncTs: number,
   isBatchSync: boolean
 ): Promise<number | undefined> {
+  const title = stripNullBytes(file.name);
+
   const content = await renderDocumentTitleAndContent({
     dataSourceConfig,
-    title: file.name,
+    title,
     updatedAt: file.updatedAtMs ? new Date(file.updatedAtMs) : undefined,
     createdAt: file.createdAtMs ? new Date(file.createdAtMs) : undefined,
     lastEditor: file.lastEditor ? file.lastEditor.displayName : undefined,
@@ -45,7 +48,7 @@ export async function upsertGdriveDocument(
     throw new Error("documentContent is undefined");
   }
 
-  const tags = [`title:${file.name}`];
+  const tags = [`title:${title}`];
   if (file.updatedAtMs) {
     tags.push(`updatedAt:${file.updatedAtMs}`);
   }
@@ -84,7 +87,7 @@ export async function upsertGdriveDocument(
       upsertContext: {
         sync_type: isBatchSync ? "batch" : "incremental",
       },
-      title: file.name,
+      title,
       mimeType: file.mimeType,
       async: true,
     });


### PR DESCRIPTION
## Description
This PR is to strip away null bytes from title of google drive to fix, similar to [the fix for intercom](https://github.com/dust-tt/dust/pull/27461) but for google drive:
```
Object: Upsert error: Failed to upsert document (error: db error: ERROR: invalid byte sequence for encoding "UTF8": 0x00

Caused by:
    ERROR: invalid byte sequence for encoding "UTF8": 0x00)
``` 

I will manually remove the null bytes from these stuck documents 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
