### PR TITLE
feat(llm): add Claude Opus 4.8 to the new LLM router

### DIFF
--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -1,0 +1,15 @@
+export function WithDustClaudeOpusFourDotEightConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustClaudeOpusFourDotEight extends Base {
+    static readonly displayName = "Claude Opus 4.8";
+    static readonly description =
+      "Anthropic's Claude Opus 4.8 model, the latest and most capable model with stronger agentic coding, reasoning, and judgement (200k context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+  }
+
+  return DustClaudeOpusFourDotEight;
+}

--- a/front/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight.ts
@@ -1,0 +1,11 @@
+import { WithDustClaudeOpusFourDotEightConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_four_dot_eight";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
+
+export class DustAnthropicGlobalClaudeOpusFourDotEightStream extends WithDustClaudeOpusFourDotEightConfig(
+  AnthropicGlobalClaudeOpusFourDotEightStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAnthropicGlobalClaudeOpusFourDotEightStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,6 +1,7 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
@@ -15,6 +16,8 @@ import type { StreamEndpointId } from "@app/lib/model_constructors/stream";
 export const DUST_STREAM_ENDPOINTS = {
   [DustAnthropicGlobalClaudeSonnetFourDotSixStream.id]:
     DustAnthropicGlobalClaudeSonnetFourDotSixStream,
+  [DustAnthropicGlobalClaudeOpusFourDotEightStream.id]:
+    DustAnthropicGlobalClaudeOpusFourDotEightStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [DustGoogleAiStudioGlobalGemini31ProStream.id]:

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -4,7 +4,7 @@ import {
   inputConfigSchema,
   temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
-import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import { CLAUDE_OPUS_4_8_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
 
@@ -14,6 +14,8 @@ const MAX_OUTPUT_TOKENS = 64_000;
 
 const baseConfig = inputConfigSchema.extend({
   cacheKey: z.undefined(),
+  // Opus 4.8 rejects any explicit temperature !== 1.
+  temperature: temperatureSchema.optional().transform(() => 1 as const),
 });
 
 const configSchema = z.union([
@@ -24,32 +26,28 @@ const configSchema = z.union([
       })
       .default({ effort: DEFAULT_REASONING_EFFORT }),
     forceTool: z.undefined(),
-    // Reasoning requires temperature=1.
-    temperature: temperatureSchema.optional().transform(() => 1 as const),
   }),
   baseConfig.extend({
     reasoning: z.object({ effort: z.literal("none") }),
-    temperature: temperatureSchema.optional().default(1),
   }),
 ]);
 
-export type ClaudeSonnetFourDotSix = z.infer<typeof configSchema>;
+export type ClaudeOpusFourDotEight = z.infer<typeof configSchema>;
 
-// Mixin carrying shared config; runtime base differs per surface.
-export function WithAnthropicClaudeSonnetFourDotSixConfig<
+export function WithAnthropicClaudeOpusFourDotEightConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class AnthropicClaudeSonnetFourDotSix extends Base {
+  abstract class AnthropicClaudeOpusFourDotEight extends Base {
     // Narrow `Client`'s `["constructor"]` to this model's precise config so the
-    // instance type carries `ClaudeSonnetFourDotSix` (not the wide `InputConfig`).
-    declare ["constructor"]: BaseEndpointConfiguration<ClaudeSonnetFourDotSix>;
+    // instance type carries `ClaudeOpusFourDotEight` (not the wide `InputConfig`).
+    declare ["constructor"]: BaseEndpointConfiguration<ClaudeOpusFourDotEight>;
 
-    static readonly modelId = CLAUDE_SONNET_4_6_MODEL_ID;
+    static readonly modelId = CLAUDE_OPUS_4_8_MODEL_ID;
 
     static readonly configSchema: z.ZodType<
-      ClaudeSonnetFourDotSix,
+      ClaudeOpusFourDotEight,
       z.ZodTypeDef,
       unknown
     > = configSchema;
@@ -58,5 +56,5 @@ export function WithAnthropicClaudeSonnetFourDotSixConfig<
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
   }
 
-  return AnthropicClaudeSonnetFourDotSix;
+  return AnthropicClaudeOpusFourDotEight;
 }

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight.ts
@@ -1,0 +1,36 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources";
+import {
+  type ClaudeOpusFourDotEight,
+  WithAnthropicClaudeOpusFourDotEightConfig,
+} from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight";
+import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AnthropicGlobalClaudeOpusFourDotEightStream extends WithAnthropicClaudeOpusFourDotEightConfig(
+  AnthropicStream
+) {
+  // https://platform.claude.com/docs/en/about-claude/pricing
+  static readonly tokenPricing = {
+    cacheCreated: 6.25,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.25,
+    longCacheCreated: 10.0,
+    cacheHit: 0.5,
+    standardInput: 5.0,
+    standardOutput: 25.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicGlobalClaudeOpusFourDotEightStream satisfies StreamEndpointConstructor<
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+  ClaudeOpusFourDotEight
+>;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,6 +1,7 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
@@ -8,6 +9,8 @@ import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constr
 export const STREAM_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
     AnthropicGlobalClaudeSonnetFourDotSixStream,
+  [AnthropicGlobalClaudeOpusFourDotEightStream.id]:
+    AnthropicGlobalClaudeOpusFourDotEightStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [GoogleAiStudioGlobalGemini31ProStream.id]:

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+
+import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AnthropicGlobalClaudeOpusFourDotEightStream({
+      ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
+runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotEightStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -2,6 +2,7 @@ export const GPT_5_5_MODEL_ID = "gpt-5.5" as const;
 export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
+export const CLAUDE_OPUS_4_8_MODEL_ID = "claude-opus-4-8" as const;
 export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5-20251001" as const;
 
 export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
@@ -11,6 +12,7 @@ export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
   GPT_5_2_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_HAIKU_4_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
 ] as const;
@@ -22,6 +24,7 @@ export function isModelId(value: string): value is ModelId {
 }
 
 export const ORDERED_LARGE_MODEL_IDS = [
+  CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   GPT_5_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,


### PR DESCRIPTION
## Description

Adds **Claude Opus 4.8** (`anthropic/anthropic/global/claude-opus-4-8`) to the new endpoint-based LLM router, mirroring the existing Claude Sonnet 4.6 endpoint:

- `model_constructors`: model-config mixin + `anthropic/global` endpoint class (pricing, region, id), registered in the stream endpoints index. `claude-opus-4-8` registered in `model_ids`.
- `llms`: Dust-wrapped endpoint with display metadata (`displayName`, `description`, `defaultReasoningEffort: "medium"`, `byok`), registered in the Dust stream endpoints index.

Values double-checked against the legacy router (`lib/api/assistant/token_pricing/global.ts`, `types/assistant/models/anthropic.ts`) and the Anthropic docs:

| | value | source |
|---|---|---|
| standardInput / standardOutput | `5.0` / `25.0` | legacy global pricing |
| cacheCreated / shortCacheCreated / longCacheCreated | `6.25` / `6.25` / `10.0` | 1.25× / 2× base input |
| cacheHit | `0.5` | legacy global pricing |
| contextSize | `250_000` | legacy router |
| maxOutputTokens | `64_000` | legacy `generationTokensCount` |

Unlike Sonnet 4.6, Opus 4.8 rejects any explicit `temperature !== 1` (`400: temperature is deprecated for this model`). The `reasoning: none` branch therefore coerces `temperature → 1` (the reasoning-effort branches already did).

Also lowers the Claude Sonnet 4.6 endpoint context size from `400_000` to `250_000` to match the legacy router.

Scope note: the legacy router marks Opus 4.8 `europe-west1: false`, so only the `anthropic/global` endpoint is added (no Vertex/agent-platform endpoint).

## Tests

Added a live integration test suite (`anthropic_claude_opus_four_dot_eight.test.ts`) mirroring the Sonnet 4.6 coverage. All 40 cases pass against the live Anthropic API:

\`\`\`
NODE_ENV=test RUN_LLM_TEST=true npm run test -- \
  --config lib/model_constructors/test/vite.config.js \
  lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_eight.test.ts
# Tests 40 passed (40)
\`\`\`

Typecheck (`tsgo --noEmit`) and biome are clean.

## Risk

Low. Additive — introduces a new endpoint without altering existing routing behavior. The one existing-behavior change is the Sonnet 4.6 context size dropping from 400k to 250k, which aligns it with the legacy router (a tightening, not a loosening). Safe to roll back by reverting.

## Deploy Plan

Standard deploy. No migration or config change required.