### PR TITLE
fix(llm): disable OpenAI strict function calling in the new router

### DIFF
--- a/front/lib/model_constructors/providers/openai/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/openai/converters/input/utils.ts
@@ -202,6 +202,9 @@ export function toFunctionTool(tool: ToolSpecification): FunctionTool {
     type: "function",
     name: tool.name,
     description: tool.description,
+    // Tool input schemas are not authored for OpenAI strict mode (which requires
+    // every property to be listed in `required`), so keep strict off — matching
+    // the core provider, which sends `strict: false` for function tools.
     strict: false,
     parameters: { type: "object", ...tool.inputSchema },
   };

--- a/front/lib/model_constructors/providers/openai/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/openai/converters/input/utils.ts
@@ -202,7 +202,7 @@ export function toFunctionTool(tool: ToolSpecification): FunctionTool {
     type: "function",
     name: tool.name,
     description: tool.description,
-    strict: true,
+    strict: false,
     parameters: { type: "object", ...tool.inputSchema },
   };
 }


### PR DESCRIPTION
## Description

When using gpt-5.5 through the new LLM router (`use_new_llm_router` flag), the first request that includes tools fails with:

> Invalid schema for function 'web_search_browse__webbrowser': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'screenshotMode'.

The new OpenAI Responses input converter (`front/lib/model_constructors/providers/openai/converters/input/utils.ts`) hardcoded `strict: true` on every function tool. OpenAI strict function calling requires every property in `properties` to also appear in `required`. Our tool input schemas are MCP/Zod-generated and routinely carry optional properties (e.g. the webbrowser tool's `screenshotMode`, `links`), so OpenAI rejects the request with `invalid_function_parameters`.

## Tests

Verified the failing schema is the one with an optional property not listed in `required` (the existing LLM test matrix only exercises tool schemas where all properties are required, which is why this was not caught). Typecheck passes via pre-commit hooks.

## Risk

Low. `strict: false` is the behavior already running in production via the core provider; this only aligns the new router with it. Trivial to roll back (one-line change).

## Deploy Plan

Standard deploy. No migration or coordination required.