### PR TITLE
Fix test reports

### DIFF
--- a/.github/workflows/build-and-test-front-api.yml
+++ b/.github/workflows/build-and-test-front-api.yml
@@ -19,6 +19,7 @@ jobs:
   tests:
     name: Test Shard ${{ matrix.shardIndex }} of ${{ matrix.shardTotal }}
     strategy:
+      fail-fast: false
       matrix:
         shardIndex: [ 1, 2, 3 ]
         shardTotal: [ 3 ]
@@ -58,7 +59,7 @@ jobs:
           REDIS_CACHE_URI: "redis://localhost:5434"
           REDIS_URI: "redis://localhost:5434"
           NODE_ENV: test
-        run: npx tsx ../front/admin/db.ts && npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile=junit-shard-${{ matrix.shardIndex }}.xml
+        run: npx tsx ../front/admin/db.ts && npm run test:ci -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --outputFile.junit=junit-shard-${{ matrix.shardIndex }}.xml
       - name: Build Tests Report
         if: always()
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
@@ -68,6 +69,7 @@ jobs:
           flaky_summary: true
           group_suite: true
           check_name: Tests Report (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+          test_files_prefix: front-api
   tsgo:
     runs-on: ubuntu-latest
     steps:

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -6,7 +6,7 @@
     "dev": "tsx esbuild.dev.ts",
     "build": "tsx esbuild.production.ts",
     "test": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI vitest --run",
-    "test:ci": "vitest --reporter=junit --watch=false --test-timeout=30000",
+    "test:ci": "vitest --watch=false --test-timeout=30000",
     "lint:swagger-annotations": "BAD_FILES=$(grep -rlE 'app\\.(get|post|patch|put|delete)\\(' routes --include='*.ts' | grep -v '\\.test\\.ts$' | xargs grep -rL '@swagger\\|@ignoreswagger'); if [ -n \"$BAD_FILES\" ]; then echo \"Error: The following API route files register a handler but are missing the @swagger or @ignoreswagger annotation:\"; echo \"$BAD_FILES\"; exit 1; else echo \"Swagger annotation check: OK.\"; exit 0; fi",
     "docs": "tsx scripts/generate-swagger.ts 2>&1 | tee /dev/stderr | grep -E \"YAML.*Error\" && { echo \"Could not generate swagger because of errors\" && exit 1; } || npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
     "docs:check": "npx @redocly/cli@1.25.5 lint --extends recommended-strict --skip-rule operation-operationId --lint-config error public/swagger.json",
@@ -38,6 +38,7 @@
     "@types/jsonwebtoken": "^9.0.2",
     "@types/swagger-jsdoc": "^6.0.4",
     "esbuild": "^0.27.3",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "vitest": "^4.0.16"
   }
 }

--- a/front-api/vite.config.mjs
+++ b/front-api/vite.config.mjs
@@ -8,6 +8,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    root: new URL(".", import.meta.url).pathname,
+    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
     // jsdom mirrors front's vitest config; some test factories rely on
     // jsdom-provided globals (e.g. globalThis.name).
     environment: "jsdom",
@@ -20,6 +22,13 @@ export default defineConfig({
     maxWorkers: 5,
     minWorkers: 1,
     testTimeout: 5_000,
+    // In CI: emit a JUnit report with file= on every <testcase> so the
+    // annotation action resolves the right source file. Without file=, the
+    // action guesses from the classname, which ends in ".ts" and matches
+    // node_modules/thread-stream/test/ts.test.ts instead of the actual file.
+    reporters: process.env.CI
+      ? [["junit", { addFileAttribute: true }]]
+      : undefined,
   },
   resolve: {
     alias: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -756,7 +756,8 @@
         "@types/jsonwebtoken": "^9.0.2",
         "@types/swagger-jsdoc": "^6.0.4",
         "esbuild": "^0.27.3",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "vitest": "^4.0.16"
       }
     },
     "front-api/node_modules/@hono/mcp": {


### PR DESCRIPTION
## Description

Fix CI test infrastructure for `front-api`:

1. **`fail-fast: false` on test matrix** — previously, when any shard failed GitHub immediately cancelled the remaining shards, so those shards never generated JUnit reports. All three shards now always run to completion and produce independent reports.

2. **Pin `vitest` in `front-api/package.json`** — `front-api` was relying on the `vitest` binary hoisted from `front`'s dependency. Without an explicit declaration, vitest resolved its workspace root from the monorepo root instead of `front-api/`, causing it to discover and run `node_modules/thread-stream/test/ts.test.ts` (a test file shipped by the `thread-stream` package that uses vitest assertions). Added `vitest: "^4.0.16"` to `devDependencies` to match `front`'s version.

3. **Explicit `root` and `include` in `front-api/vite.config.mjs`** — pinned `root` to the `front-api/` directory via `import.meta.url` (immune to CWD drift) and added an explicit `include` pattern evaluated relative to that root. This ensures test discovery can never escape the `front-api/` directory tree regardless of how vitest resolves its workspace root.

## Tests

CI — the three changes together prevent the false failures from `node_modules/thread-stream/test/ts.test.ts` and ensure all shards produce reports.

## Risk

Low — CI-only changes. No production code modified.

## Deploy Plan

N/A