### PR TITLE
feat(models): add Auto model tier with workspace default and backup models

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -1,3 +1,4 @@
+import { validateWorkspaceModelSettings } from "@app/lib/api/assistant/models";
 import { listActiveAgentsUsingNonRegionalModels } from "@app/lib/api/assistant/workspace_capabilities";
 import {
   buildAuditLogTarget,
@@ -111,6 +112,15 @@ const WorkspaceProvidersUpdateBodySchema = z.object({
   defaultEmbeddingProvider: EmbeddingProviderSchema.nullable(),
 });
 
+const WorkspaceModelSettingsUpdateBodySchema = z.object({
+  // modelId of the workspace default model used by the "auto" tier; null clears
+  // it (falls back to the Dust default).
+  defaultModelId: z.string().nullable(),
+  // modelId of the workspace backup model used on provider outages; null clears
+  // it.
+  backupModelId: z.string().nullable(),
+});
+
 const WorkspaceWorkOSUpdateBodySchema = z.object({
   workOSOrganizationId: z.string().nullable(),
 });
@@ -200,6 +210,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceSsoEnforceUpdateBodySchema,
   WorkspaceRegionalModelsOnlyUpdateBodySchema,
   WorkspaceProvidersUpdateBodySchema,
+  WorkspaceModelSettingsUpdateBodySchema,
   WorkspaceWorkOSUpdateBodySchema,
   WorkspaceInteractiveContentSharingUpdateBodySchema,
   WorkspaceSharingPolicyUpdateBodySchema,
@@ -390,6 +401,38 @@ app.post(
       });
       owner.whiteListedProviders = body.whiteListedProviders;
       owner.defaultEmbeddingProvider = workspace.defaultEmbeddingProvider;
+    } else if ("defaultModelId" in body && "backupModelId" in body) {
+      const validationRes = await validateWorkspaceModelSettings(auth, {
+        defaultModelId: body.defaultModelId,
+        backupModelId: body.backupModelId,
+      });
+      if (validationRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: validationRes.error.message,
+          },
+        });
+      }
+
+      await workspace.updateWorkspaceSettings({
+        defaultModelId: body.defaultModelId,
+        backupModelId: body.backupModelId,
+      });
+      owner.defaultModelId = body.defaultModelId;
+      owner.backupModelId = body.backupModelId;
+
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.model_settings_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          default_model_id: String(body.defaultModelId),
+          backup_model_id: String(body.backupModelId),
+        },
+      });
     } else if ("workOSOrganizationId" in body) {
       await workspace.updateWorkspaceSettings({
         workOSOrganizationId: body.workOSOrganizationId,

--- a/front-api/routes/w/[wId]/models.ts
+++ b/front-api/routes/w/[wId]/models.ts
@@ -5,6 +5,7 @@ import { config as regionConfig } from "@app/lib/api/regions/config";
 import { filterEnabledModels } from "@app/lib/assistant";
 import { getFeatureFlags } from "@app/lib/auth";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/dust";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -21,8 +22,13 @@ app.get("/", async (ctx): HandlerResult<GetEnabledModelsResponseType> => {
   const region = regionConfig.getCurrentRegion();
   const whitelistedProviders = getWhitelistedProviders(auth);
 
-  // Include both standard models and custom models (from GCS at build time).
-  const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
+  // Include the "auto" sentinel (gated by the auto_model_tier feature flag via
+  // filterEnabledModels), standard models, and custom models (from GCS).
+  const allUsedModels = [
+    AUTO_MODEL_CONFIG,
+    ...USED_MODEL_CONFIGS,
+    ...CUSTOM_MODEL_CONFIGS,
+  ];
   const models = filterEnabledModels(allUsedModels, {
     featureFlags,
     plan,

--- a/front/admin/audit_log_schemas/workspace.model_settings_updated.json
+++ b/front/admin/audit_log_schemas/workspace.model_settings_updated.json
@@ -1,0 +1,10 @@
+{
+  "action": "workspace.model_settings_updated",
+  "targets": [
+    { "type": "workspace" }
+  ],
+  "metadata": {
+    "default_model_id": "string",
+    "backup_model_id": "string"
+  }
+}

--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -2,6 +2,7 @@ import {
   CLAUDE_4_5_HAIKU_20251001_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { isAutoModel } from "@app/types/assistant/models/dust";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/types/assistant/models/mistral";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
@@ -60,9 +61,16 @@ export interface ModelCategories {
 export function getModelsCategorization(
   models: ModelConfigurationType[]
 ): ModelCategories {
+  // The "auto" sentinel is surfaced first, above the best-performing models,
+  // and never grouped under a provider.
+  const autoModel = models.find(isAutoModel);
+  const nonAutoModels = autoModel
+    ? models.filter((m) => !isAutoModel(m))
+    : models;
+
   // Use existing categorization to separate best performing models
   const { bestPerformingModelConfigs, otherModelConfigs } =
-    categorizeModels(models);
+    categorizeModels(nonAutoModels);
 
   // Group remaining models by provider and separate recent vs older
   const providerGroups = new Map<
@@ -87,7 +95,9 @@ export function getModelsCategorization(
   }
 
   return {
-    bestGeneralModels: bestPerformingModelConfigs,
+    bestGeneralModels: autoModel
+      ? [autoModel, ...bestPerformingModelConfigs]
+      : bestPerformingModelConfigs,
     providerGroups,
   };
 }

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -7,6 +7,7 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import { isAutoModel } from "@app/types/assistant/models/dust";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/types/assistant/models/mistral";
 import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
@@ -77,6 +78,12 @@ const PREFERRED_LARGE_MODEL_IDS: ModelIdType[] = [
 export function getDefaultModel(
   availableModels: ModelConfigurationType[]
 ): ModelConfigurationType {
+  // Prefer the "auto" tier when available to the workspace.
+  const autoModel = availableModels.find(isAutoModel);
+  if (autoModel) {
+    return autoModel;
+  }
+
   for (const modelId of PREFERRED_LARGE_MODEL_IDS) {
     const model = availableModels.find((m) => m.modelId === modelId);
     if (model) {

--- a/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
@@ -36,6 +36,8 @@ const owner: LightWorkspaceType = {
   segmentation: null,
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
+  defaultModelId: null,
+  backupModelId: null,
   regionalModelsOnly: false,
   sharingPolicy: "workspace_only",
   metronomeCustomerId: null,

--- a/front/components/assistant/conversation/UserAnswerRequired.test.tsx
+++ b/front/components/assistant/conversation/UserAnswerRequired.test.tsx
@@ -155,6 +155,8 @@ const owner: LightWorkspaceType = {
   segmentation: null,
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
+  defaultModelId: null,
+  backupModelId: null,
   regionalModelsOnly: false,
   sharingPolicy: "workspace_only",
   metronomeCustomerId: null,

--- a/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
+++ b/front/components/assistant/conversation/actions/inline/InlineActivitySteps.test.tsx
@@ -35,6 +35,8 @@ const mockOwner: WorkspaceType = {
   segmentation: null,
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
+  defaultModelId: null,
+  backupModelId: null,
   sharingPolicy: "workspace_only",
   metronomeCustomerId: null,
   regionalModelsOnly: false,

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -18,6 +18,8 @@ describe("buildEditorExtensions", () => {
     segmentation: null,
     whiteListedProviders: null,
     defaultEmbeddingProvider: null,
+    defaultModelId: null,
+    backupModelId: null,
     metadata: null,
     metronomeCustomerId: null,
     sharingPolicy: "all_scopes",

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -1,6 +1,7 @@
 import { ModelProvidersPageContent } from "@app/components/pages/workspace/model_providers/ModelProvidersPageContent";
+import { WorkspaceModelSettings } from "@app/components/pages/workspace/model_providers/WorkspaceModelSettings";
 import { useProvidersSelection } from "@app/hooks/useProvidersSelection";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useWorkspace as useWorkspaceDetails } from "@app/lib/swr/workspaces";
 import { Brain, Page, Spinner } from "@dust-tt/sparkle";
 
@@ -8,6 +9,7 @@ export function ModelProvidersPage() {
   const owner = useWorkspace();
   const { workspace, isWorkspaceValidating, mutateWorkspace } =
     useWorkspaceDetails({ owner });
+  const { hasFeature } = useFeatureFlags();
   const { providersSelection, toggleProvider, selectAllProviders } =
     useProvidersSelection(workspace, owner, mutateWorkspace);
 
@@ -34,6 +36,13 @@ export function ModelProvidersPage() {
           onToggleProvider={toggleProvider}
           onSelectAllProviders={selectAllProviders}
         />
+        {hasFeature("auto_model_tier") && (
+          <WorkspaceModelSettings
+            owner={owner}
+            workspace={workspace}
+            mutateWorkspace={mutateWorkspace}
+          />
+        )}
       </Page.Vertical>
     </Page.Vertical>
   );

--- a/front/components/pages/workspace/model_providers/WorkspaceModelSettings.tsx
+++ b/front/components/pages/workspace/model_providers/WorkspaceModelSettings.tsx
@@ -1,0 +1,152 @@
+import { useWorkspaceModelSettings } from "@app/hooks/useWorkspaceModelSettings";
+import { useModels } from "@app/lib/swr/models";
+import { CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { isAutoModel } from "@app/types/assistant/models/dust";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useEffect, useMemo, useState } from "react";
+
+interface WorkspaceModelSettingsProps {
+  owner: LightWorkspaceType;
+  workspace: WorkspaceType;
+  mutateWorkspace: () => Promise<unknown>;
+}
+
+// `null` is a valid selection: default falls back to the Dust default, backup
+// means "no backup".
+function labelForSelection(
+  modelId: string | null,
+  models: ModelConfigurationType[],
+  nullLabel: string
+): string {
+  if (!modelId) {
+    return nullLabel;
+  }
+  return models.find((m) => m.modelId === modelId)?.displayName ?? modelId;
+}
+
+export function WorkspaceModelSettings({
+  owner,
+  workspace,
+  mutateWorkspace,
+}: WorkspaceModelSettingsProps) {
+  const { models, isModelsLoading } = useModels({ owner });
+  const { saveModelSettings, isSaving } = useWorkspaceModelSettings(
+    owner,
+    mutateWorkspace
+  );
+
+  // Selectable models exclude the "auto" sentinel (can't be a default/backup).
+  const selectableModels = useMemo(
+    () => models.filter((m) => !isAutoModel(m)),
+    [models]
+  );
+
+  const [defaultModelId, setDefaultModelId] = useState<string | null>(
+    workspace.defaultModelId
+  );
+  const [backupModelId, setBackupModelId] = useState<string | null>(
+    workspace.backupModelId
+  );
+
+  useEffect(() => {
+    setDefaultModelId(workspace.defaultModelId);
+    setBackupModelId(workspace.backupModelId);
+  }, [workspace.defaultModelId, workspace.backupModelId]);
+
+  const hasChanges =
+    defaultModelId !== workspace.defaultModelId ||
+    backupModelId !== workspace.backupModelId;
+
+  const dustDefaultLabel = `Dust default (${CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG.displayName})`;
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <div className="font-semibold">Auto model tier</div>
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        The default model is used by agents on the "Auto" tier. The backup model
+        is used as an automatic fallback for all agents during provider outages.
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium">Default model</div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild disabled={isModelsLoading || isSaving}>
+            <Button
+              isSelect
+              label={labelForSelection(
+                defaultModelId,
+                selectableModels,
+                dustDefaultLabel
+              )}
+              variant="outline"
+              size="sm"
+              disabled={isModelsLoading || isSaving}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem
+              label={dustDefaultLabel}
+              onClick={() => setDefaultModelId(null)}
+            />
+            {selectableModels.map((model) => (
+              <DropdownMenuItem
+                key={model.modelId}
+                label={model.displayName}
+                onClick={() => setDefaultModelId(model.modelId)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium">Backup model</div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild disabled={isModelsLoading || isSaving}>
+            <Button
+              isSelect
+              label={labelForSelection(backupModelId, selectableModels, "None")}
+              variant="outline"
+              size="sm"
+              disabled={isModelsLoading || isSaving}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem
+              label="None"
+              onClick={() => setBackupModelId(null)}
+            />
+            {selectableModels.map((model) => (
+              <DropdownMenuItem
+                key={model.modelId}
+                label={model.displayName}
+                onClick={() => setBackupModelId(model.modelId)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          label="Save"
+          variant="primary"
+          size="sm"
+          disabled={!hasChanges || isSaving}
+          isLoading={isSaving}
+          onClick={() => {
+            void saveModelSettings({ defaultModelId, backupModelId });
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -52,6 +52,9 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
   noop: {
     light: DustLogo,
   },
+  dust: {
+    light: DustLogo,
+  },
 };
 
 export const getModelProviderLogo = (

--- a/front/hooks/useAgentMessageStream.test.ts
+++ b/front/hooks/useAgentMessageStream.test.ts
@@ -131,6 +131,8 @@ const mockOwner: LightWorkspaceType = {
   segmentation: null,
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
+  defaultModelId: null,
+  backupModelId: null,
   regionalModelsOnly: false,
   sharingPolicy: "workspace_only",
   metronomeCustomerId: null,

--- a/front/hooks/useChildAgentStream.test.ts
+++ b/front/hooks/useChildAgentStream.test.ts
@@ -17,6 +17,8 @@ const mockOwner: LightWorkspaceType = {
   segmentation: null,
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
+  defaultModelId: null,
+  backupModelId: null,
   regionalModelsOnly: false,
   sharingPolicy: "workspace_only",
   metronomeCustomerId: null,

--- a/front/hooks/useWorkspaceModelSettings.ts
+++ b/front/hooks/useWorkspaceModelSettings.ts
@@ -1,0 +1,63 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useCallback, useState } from "react";
+
+export function useWorkspaceModelSettings(
+  owner: LightWorkspaceType,
+  mutateWorkspace: () => Promise<unknown>
+) {
+  const [isSaving, setIsSaving] = useState(false);
+  const sendNotification = useSendNotification();
+
+  const saveModelSettings = useCallback(
+    async ({
+      defaultModelId,
+      backupModelId,
+    }: {
+      defaultModelId: string | null;
+      backupModelId: string | null;
+    }): Promise<boolean> => {
+      setIsSaving(true);
+      try {
+        const response = await clientFetch(`/api/w/${owner.sId}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ defaultModelId, backupModelId }),
+        });
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          throw new Error(
+            body?.error?.message ?? "Failed to update model settings."
+          );
+        }
+
+        sendNotification({
+          type: "success",
+          title: "Model settings updated",
+          description:
+            "The workspace default and backup models have been updated.",
+        });
+
+        await mutateWorkspace();
+        return true;
+      } catch (err) {
+        sendNotification({
+          type: "error",
+          title: "Update failed",
+          description:
+            err instanceof Error
+              ? err.message
+              : "An unexpected error occurred while updating model settings.",
+        });
+        return false;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [owner.sId, mutateWorkspace, sendNotification]
+  );
+
+  return { saveModelSettings, isSaving };
+}

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -27,6 +27,8 @@ const mockWorkspace: WorkspaceType = {
   segmentation: null,
   whiteListedProviders: null,
   defaultEmbeddingProvider: null,
+  defaultModelId: null,
+  backupModelId: null,
   metadata: {},
   metronomeCustomerId: null,
   sharingPolicy: "all_scopes",

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -25,8 +25,8 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { getConversationDataSourceViews } from "@app/lib/api/assistant/jit/utils";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import { resolveAgentModelConfiguration } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import {
   CONTENT_OUTDATED_MSG,
   getContentFragmentFromAttachmentFile,
@@ -140,9 +140,10 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     }
 
     const conversation = agentLoopContext.runContext.conversation;
-    const model = getSupportedModelConfig(
+    const model = resolveAgentModelConfiguration(
+      auth,
       agentLoopContext.runContext.agentConfiguration.model
-    );
+    )?.modelConfig;
     if (!model) {
       return new Err(new MCPError("Model configuration not found"));
     }

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -1,12 +1,12 @@
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
+import { resolveAgentModelConfiguration } from "@app/lib/api/assistant/models";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
 import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import { systemPromptToText } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ConversationType,
@@ -104,7 +104,10 @@ export async function getPromptForProcessDustApp({
   const userMessage: UserMessageType =
     lastUserMessageTuple[0] as UserMessageType;
 
-  const model = getSupportedModelConfig(agentConfiguration.model);
+  const model = resolveAgentModelConfiguration(
+    auth,
+    agentConfiguration.model
+  )?.modelConfig;
   if (!model) {
     throw new Error(
       `Model config not found for ${agentConfiguration.model.modelId}`

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -13,12 +13,12 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { resolveAgentModelConfiguration } from "@app/lib/api/assistant/models";
 import { getDatasetSchema } from "@app/lib/api/datasets";
 import { writeToToolOutputsFolder } from "@app/lib/api/files/action_output_fs";
 import { makeFileName } from "@app/lib/api/files/action_output_fs/naming";
 import type { Authenticator } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
 import type { BlockRunConfig, SpecificationBlockType } from "@app/types/app";
@@ -289,9 +289,10 @@ export async function prepareParamsWithHistory(
   if (
     schema?.some((s) => s.key === DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY)
   ) {
-    const model = getSupportedModelConfig(
+    const model = resolveAgentModelConfiguration(
+      auth,
       agentLoopRunContext.agentConfiguration.model
-    );
+    )?.modelConfig;
 
     if (model) {
       const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -27,7 +27,10 @@ import {
   batchRenderMessages,
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
-import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
+import {
+  isProviderWhitelisted,
+  resolveAgentModelConfiguration,
+} from "@app/lib/api/assistant/models";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -63,7 +66,6 @@ import { fetchLatestProjectContextFileContentFragment } from "@app/lib/api/proje
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import {
   getWorkspaceCreditPoolStatus,
@@ -791,7 +793,12 @@ export async function postUserMessage(
       });
     }
 
-    const supportedModelConfig = getSupportedModelConfig(agentConfig.model);
+    // Resolve "auto" to the concrete model the agent will actually run, so the
+    // availability check reflects the real model rather than the sentinel.
+    const supportedModelConfig = resolveAgentModelConfiguration(
+      auth,
+      agentConfig.model
+    )?.modelConfig;
     if (
       supportedModelConfig &&
       !isModelAvailable(supportedModelConfig, {

--- a/front/lib/api/assistant/conversation/compaction.ts
+++ b/front/lib/api/assistant/conversation/compaction.ts
@@ -3,6 +3,7 @@ import {
   getNextConversationMessageRank,
 } from "@app/lib/api/assistant/conversation/lock";
 import { createCompactionMessage } from "@app/lib/api/assistant/conversation/messages";
+import { resolveAgentModelConfiguration } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -188,12 +189,25 @@ export async function compactConversation(
     { conversationId: conversation.sId }
   );
 
+  // Compaction can't run on the "auto" sentinel — resolve it to the concrete
+  // workspace default model before launching the workflow.
+  const resolved = resolveAgentModelConfiguration(auth, {
+    ...model,
+    temperature: 0,
+  });
+  const effectiveModel: SupportedModel = resolved
+    ? {
+        providerId: resolved.modelConfig.providerId,
+        modelId: resolved.modelConfig.modelId,
+      }
+    : model;
+
   void launchCompactionWorkflow({
     auth,
     conversationId: conversation.sId,
     compactionMessageId: compactionMessage.sId,
     compactionMessageVersion: compactionMessage.version,
-    model,
+    model: effectiveModel,
     sourceConversation,
   });
 

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -1,7 +1,17 @@
-import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
+import {
+  getWhitelistedProviders,
+  resolveAgentModelConfiguration,
+  validateWorkspaceModelSettings,
+} from "@app/lib/api/assistant/models";
 import { Authenticator } from "@app/lib/auth";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import {
+  AUTO_MODEL_ID,
+  AUTO_PROVIDER_ID,
+} from "@app/types/assistant/models/dust";
+import { GPT_5_5_MODEL_ID } from "@app/types/assistant/models/openai";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { describe, expect, it, vi } from "vitest";
@@ -32,17 +42,17 @@ describe("getWhitelistedProviders", () => {
     expect(providers).toEqual(new Set(MODEL_PROVIDER_IDS));
   });
 
-  it("returns only whitelisted providers plus noop", async () => {
+  it("returns only whitelisted providers plus meta-providers", async () => {
     const workspace = await WorkspaceFactory.basic({
       whiteListedProviders: ["anthropic"],
     });
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["anthropic", "noop"]));
+    expect(providers).toEqual(new Set(["anthropic", "noop", "dust"]));
   });
 
-  it("BYOK: only includes providers with configured keys plus noop", async () => {
+  it("BYOK: only includes providers with configured keys plus meta-providers", async () => {
     const workspace = await WorkspaceFactory.byok();
     mockCredentials([
       { providerId: "openai", isHealthy: true },
@@ -51,7 +61,7 @@ describe("getWhitelistedProviders", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["openai", "anthropic", "noop"]));
+    expect(providers).toEqual(new Set(["openai", "anthropic", "noop", "dust"]));
   });
 
   it("BYOK + restricted whitelist: healthy key for non-whitelisted provider is ignored", async () => {
@@ -65,15 +75,129 @@ describe("getWhitelistedProviders", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["anthropic", "noop"]));
+    expect(providers).toEqual(new Set(["anthropic", "noop", "dust"]));
   });
 
-  it("BYOK + no keys: only noop is whitelisted", async () => {
+  it("BYOK + no keys: only meta-providers are whitelisted", async () => {
     const workspace = await WorkspaceFactory.byok();
     mockCredentials([]);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const providers = getWhitelistedProviders(auth);
-    expect(providers).toEqual(new Set(["noop"]));
+    expect(providers).toEqual(new Set(["noop", "dust"]));
+  });
+});
+
+describe("resolveAgentModelConfiguration", () => {
+  const autoAgentModel = {
+    providerId: AUTO_PROVIDER_ID,
+    modelId: AUTO_MODEL_ID,
+    temperature: 0.7,
+    reasoningEffort: "medium" as const,
+  };
+
+  it("resolves auto to Claude Sonnet 4.6 when no workspace default is set", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const resolved = resolveAgentModelConfiguration(auth, autoAgentModel);
+    expect(resolved?.modelConfig.modelId).toBe(CLAUDE_SONNET_4_6_MODEL_ID);
+    expect(resolved?.effectiveModel.providerId).toBe("anthropic");
+    expect(resolved?.effectiveModel.modelId).toBe(CLAUDE_SONNET_4_6_MODEL_ID);
+  });
+
+  it("resolves auto to the workspace default model when set", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      defaultModelId: GPT_5_5_MODEL_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const resolved = resolveAgentModelConfiguration(auth, autoAgentModel);
+    expect(resolved?.modelConfig.modelId).toBe(GPT_5_5_MODEL_ID);
+  });
+
+  it("resolves a concrete model to itself", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      defaultModelId: GPT_5_5_MODEL_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const resolved = resolveAgentModelConfiguration(auth, {
+      providerId: "anthropic",
+      modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+      temperature: 0.5,
+    });
+    expect(resolved?.modelConfig.modelId).toBe(CLAUDE_SONNET_4_6_MODEL_ID);
+  });
+
+  it("uses the workspace backup model when useBackup is set", async () => {
+    const workspace = await WorkspaceFactory.basic({
+      defaultModelId: GPT_5_5_MODEL_ID,
+      backupModelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    });
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const resolved = resolveAgentModelConfiguration(auth, autoAgentModel, {
+      useBackup: true,
+    });
+    expect(resolved?.modelConfig.modelId).toBe(CLAUDE_SONNET_4_6_MODEL_ID);
+  });
+
+  it("clamps an unsupported reasoning effort to the model default", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    // Claude Sonnet 4.6 does not support the "none" effort.
+    const resolved = resolveAgentModelConfiguration(auth, {
+      providerId: "anthropic",
+      modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+      temperature: 0.5,
+      reasoningEffort: "none",
+    });
+    expect(resolved?.effectiveModel.reasoningEffort).toBe(
+      resolved?.modelConfig.defaultReasoningEffort
+    );
+    expect(resolved?.effectiveModel.reasoningEffort).not.toBe("none");
+  });
+});
+
+describe("validateWorkspaceModelSettings", () => {
+  it("rejects the auto sentinel as a default model", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const res = await validateWorkspaceModelSettings(auth, {
+      defaultModelId: AUTO_MODEL_ID,
+    });
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.type).toBe("model_is_auto");
+      expect(res.error.field).toBe("defaultModelId");
+    }
+  });
+
+  it("rejects an unknown model", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const res = await validateWorkspaceModelSettings(auth, {
+      backupModelId: "not-a-real-model",
+    });
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.type).toBe("invalid_model");
+      expect(res.error.field).toBe("backupModelId");
+    }
+  });
+
+  it("accepts an enabled concrete model and null clears", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const res = await validateWorkspaceModelSettings(auth, {
+      defaultModelId: CLAUDE_SONNET_4_6_MODEL_ID,
+      backupModelId: null,
+    });
+    expect(res.isOk()).toBe(true);
   });
 });

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,11 +1,18 @@
 import { config as regionConfig } from "@app/lib/api/regions/config";
 import { isModelEnabled } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import {
+  getModelConfigByModelId,
+  getSupportedModelConfig,
+} from "@app/lib/llms/model_configurations";
 import { isByokTransitioningPlan } from "@app/lib/plans/plan_codes";
+import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
+import { isAutoModel } from "@app/types/assistant/models/dust";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
@@ -31,6 +38,8 @@ import {
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
   GROK_4_MODEL_CONFIG,
 } from "@app/types/assistant/models/xai";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 export type GetEnabledModelsResponseType = {
   models: ModelConfigurationType[];
@@ -47,6 +56,9 @@ export function getWhitelistedProviders(
 
   // noop never sees user data, always whitelisted.
   whiteListedProviders.add("noop");
+  // "dust" is the meta-provider for the "auto" sentinel; it resolves to a
+  // concrete model at runtime, so it is always whitelisted.
+  whiteListedProviders.add("dust");
 
   if (!plan.isByok) {
     return whiteListedProviders;
@@ -60,6 +72,7 @@ export function getWhitelistedProviders(
       BYOK_MODEL_PROVIDER_IDS
     );
     allByokProviderIds.add("noop");
+    allByokProviderIds.add("dust");
 
     return allByokProviderIds;
   }
@@ -72,6 +85,9 @@ export function getWhitelistedProviders(
 
   // noop never needs credentials.
   configuredProviders.add("noop");
+  // "dust" (the "auto" sentinel) resolves to a concrete model at runtime and
+  // needs no credentials of its own.
+  configuredProviders.add("dust");
 
   return whiteListedProviders.intersection(configuredProviders);
 }
@@ -172,4 +188,164 @@ function _getLargeWhitelistedModel(
         isModelEnabled(m, context) && (!hasBatch || m.supportsBatchProcessing)
     ) ?? null
   );
+}
+
+export type ResolvedAgentModel = {
+  // The concrete model config to run with.
+  modelConfig: ModelConfigurationType;
+  // The agent model config with concrete providerId/modelId and a
+  // reasoning effort the resolved model actually supports.
+  effectiveModel: AgentModelConfigurationType;
+};
+
+function buildResolvedAgentModel(
+  modelConfig: ModelConfigurationType,
+  agentModel: AgentModelConfigurationType
+): ResolvedAgentModel {
+  // Clamp the stored reasoning effort to what the resolved model supports.
+  const storedEffort = agentModel.reasoningEffort;
+  const reasoningEffort =
+    storedEffort && modelConfig.supportedReasoningEfforts[storedEffort]
+      ? storedEffort
+      : modelConfig.defaultReasoningEffort;
+
+  return {
+    modelConfig,
+    effectiveModel: {
+      ...agentModel,
+      providerId: modelConfig.providerId,
+      modelId: modelConfig.modelId,
+      reasoningEffort,
+    },
+  };
+}
+
+/**
+ * Resolves an agent's stored model config to the concrete model to run with.
+ *
+ * - When `useBackup` is set and the workspace has a valid backup model, the
+ *   backup model is used (cross-provider failover on provider outages). Applies
+ *   to all agents, "auto" or not.
+ * - Otherwise, the "auto" sentinel resolves to the workspace default model,
+ *   falling back to Claude Sonnet 4.6 when unset/invalid.
+ * - Otherwise, the agent's own concrete model is used (today's behavior).
+ *
+ * Returns null only when a concrete (non-auto) agent model is no longer known,
+ * preserving the existing "unknown model" handling at the call site.
+ */
+export function resolveAgentModelConfiguration(
+  auth: Authenticator,
+  agentModel: AgentModelConfigurationType,
+  { useBackup = false }: { useBackup?: boolean } = {}
+): ResolvedAgentModel | null {
+  const owner = auth.getNonNullableWorkspace();
+
+  if (useBackup && owner.backupModelId) {
+    const backup = getModelConfigByModelId(owner.backupModelId);
+    if (backup && !isAutoModel(backup)) {
+      return buildResolvedAgentModel(backup, agentModel);
+    }
+    // Misconfigured backup: fall through to the primary resolution below.
+  }
+
+  if (isAutoModel(agentModel)) {
+    const configured = owner.defaultModelId
+      ? getModelConfigByModelId(owner.defaultModelId)
+      : null;
+    const resolved =
+      configured && !isAutoModel(configured)
+        ? configured
+        : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
+    return buildResolvedAgentModel(resolved, agentModel);
+  }
+
+  const concrete = getSupportedModelConfig(agentModel);
+  if (!concrete) {
+    return null;
+  }
+  return buildResolvedAgentModel(concrete, agentModel);
+}
+
+export type WorkspaceModelSettingField = "defaultModelId" | "backupModelId";
+
+export type WorkspaceModelSettingsErrorType =
+  | "invalid_model"
+  | "model_not_enabled"
+  | "model_is_auto";
+
+export class WorkspaceModelSettingsError extends Error {
+  constructor(
+    readonly type: WorkspaceModelSettingsErrorType,
+    readonly field: WorkspaceModelSettingField,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Validates the workspace default/backup model settings. Each provided modelId
+ * (when not null) must be a concrete, workspace-enabled model — never the
+ * "auto" sentinel. Feature-flag-gated and regional models are honored.
+ */
+export async function validateWorkspaceModelSettings(
+  auth: Authenticator,
+  settings: {
+    defaultModelId?: string | null;
+    backupModelId?: string | null;
+  }
+): Promise<Result<void, WorkspaceModelSettingsError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(auth);
+  const context: ModelEnablementContext = {
+    featureFlags,
+    plan: auth.plan(),
+    regionalModelsOnly: owner.regionalModelsOnly,
+    region: regionConfig.getCurrentRegion(),
+    whitelistedProviders: getWhitelistedProviders(auth),
+  };
+
+  const fields: WorkspaceModelSettingField[] = [
+    "defaultModelId",
+    "backupModelId",
+  ];
+  for (const field of fields) {
+    const modelId = settings[field];
+    // undefined => not being updated; null => explicitly cleared.
+    if (modelId === undefined || modelId === null) {
+      continue;
+    }
+
+    const label = field === "defaultModelId" ? "default" : "backup";
+    const modelConfig = getModelConfigByModelId(modelId);
+    if (!modelConfig) {
+      return new Err(
+        new WorkspaceModelSettingsError(
+          "invalid_model",
+          field,
+          `Unknown ${label} model "${modelId}".`
+        )
+      );
+    }
+    if (isAutoModel(modelConfig)) {
+      return new Err(
+        new WorkspaceModelSettingsError(
+          "model_is_auto",
+          field,
+          `The "Auto" model cannot be selected as the ${label} model.`
+        )
+      );
+    }
+    if (!isModelEnabled(modelConfig, context)) {
+      return new Err(
+        new WorkspaceModelSettingsError(
+          "model_not_enabled",
+          field,
+          `Model "${modelConfig.displayName}" is not enabled for this workspace and cannot be used as the ${label} model.`
+        )
+      );
+    }
+  }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -85,6 +85,7 @@ export const AUDIT_ACTIONS = [
   "workspace.audit_logs_updated",
   "workspace.default_user_spend_limit_updated",
   "workspace.programmatic_usage_limit_updated",
+  "workspace.model_settings_updated",
   "workspace_branding.asset_promoted",
   "workspace_branding.asset_deleted",
   // SCIM / Directory Sync.

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -243,6 +243,8 @@ const USERFACING_CLIENT_ID: Record<ModelProviderIdType, string> = {
   xai: "xAI",
   google_ai_studio: "Google AI Studio",
   noop: "Noop",
+  // Meta-provider; resolved to a concrete model before any provider call.
+  dust: "Auto",
 };
 
 /**

--- a/front/lib/api/sandbox/image/profile.ts
+++ b/front/lib/api/sandbox/image/profile.ts
@@ -24,6 +24,9 @@ export function providerToProfile(
     case "xai":
     case "fireworks":
     case "noop":
+    // "dust" (the "auto" sentinel) resolves to a concrete model before any
+    // provider call, so this branch is never actually reached for it.
+    case "dust":
       return "anthropic";
     default:
       assertNever(providerId);

--- a/front/lib/api/workos/organization.test.ts
+++ b/front/lib/api/workos/organization.test.ts
@@ -48,6 +48,8 @@ function makeWorkspace(
     segmentation: null,
     whiteListedProviders: null,
     defaultEmbeddingProvider: null,
+    defaultModelId: null,
+    backupModelId: null,
     regionalModelsOnly: false,
     workOSOrganizationId: "org_123",
     metadata: null,

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -3,6 +3,7 @@ import {
   isEnterprisePlanPrefix,
   isUpgraded,
 } from "@app/lib/plans/plan_codes";
+import { isAutoModel } from "@app/types/assistant/models/dust";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,
@@ -38,7 +39,9 @@ export function isModelAvailable(
     return false;
   }
 
-  if (plan?.isByok && !isByokProviderId(m.providerId)) {
+  // The "auto" sentinel resolves to a concrete (BYOK-validated) model at
+  // runtime, so it is exempt from the BYOK provider check here.
+  if (plan?.isByok && !isAutoModel(m) && !isByokProviderId(m.providerId)) {
     return false;
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -983,6 +983,8 @@ export class Authenticator {
           workOSOrganizationId: this._workspace.workOSOrganizationId,
           whiteListedProviders: this._workspace.whiteListedProviders,
           defaultEmbeddingProvider: this._workspace.defaultEmbeddingProvider,
+          defaultModelId: this._workspace.defaultModelId,
+          backupModelId: this._workspace.backupModelId,
           metadata: this._workspace.metadata,
           metronomeCustomerId: this._workspace.metronomeCustomerId ?? null,
           sharingPolicy: this._workspace.sharingPolicy ?? "all_scopes",

--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -71,6 +71,8 @@ function makeWorkspace(
     segmentation: null,
     whiteListedProviders: null,
     defaultEmbeddingProvider: null,
+    defaultModelId: null,
+    backupModelId: null,
     regionalModelsOnly: false,
     metadata: null,
     metronomeCustomerId: null,

--- a/front/lib/misc.test.ts
+++ b/front/lib/misc.test.ts
@@ -13,6 +13,8 @@ function makeWorkspace(sId: string): LightWorkspaceType {
     segmentation: null,
     whiteListedProviders: null,
     defaultEmbeddingProvider: null,
+    defaultModelId: null,
+    backupModelId: null,
     regionalModelsOnly: false,
     metronomeCustomerId: null,
     sharingPolicy: "workspace_only",

--- a/front/lib/resources/storage/models/workspace.ts
+++ b/front/lib/resources/storage/models/workspace.ts
@@ -34,6 +34,12 @@ export class WorkspaceModel extends BaseModel<WorkspaceModel> {
   declare subscriptions: NonAttribute<SubscriptionModel[]>;
   declare whiteListedProviders: ModelProviderIdType[] | null;
   declare defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  // modelId of the workspace default model used by the "auto" tier (null => Dust
+  // default). Validated in lib/api; stored as a free-form modelId string.
+  declare defaultModelId: string | null;
+  // modelId of the workspace backup model used as a cross-provider fallback on
+  // provider outages (null => no backup). Validated in lib/api.
+  declare backupModelId: string | null;
   declare metadata: Record<string, string | number | boolean | object> | null;
   declare sharingPolicy: CreationOptional<WorkspaceSharingPolicy>;
   declare conversationsRetentionDays: number | null;
@@ -109,6 +115,16 @@ WorkspaceModel.init(
       validate: {
         isIn: [modelProviders],
       },
+    },
+    defaultModelId: {
+      type: DataTypes.STRING,
+      defaultValue: null,
+      allowNull: true,
+    },
+    backupModelId: {
+      type: DataTypes.STRING,
+      defaultValue: null,
+      allowNull: true,
     },
     metadata: {
       type: DataTypes.JSONB,

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -74,6 +74,8 @@ type CachedWorkspaceData = {
   workOSOrganizationId: string | null;
   whiteListedProviders: ModelProviderIdType[] | null;
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  defaultModelId: string | null;
+  backupModelId: string | null;
   metadata: Record<string, string | number | boolean | object> | null;
   sharingPolicy: WorkspaceSharingPolicy;
   conversationsRetentionDays: number | null;
@@ -211,6 +213,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       workOSOrganizationId: workspace.workOSOrganizationId,
       whiteListedProviders: whiteListedProviders,
       defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
+      defaultModelId: workspace.defaultModelId,
+      backupModelId: workspace.backupModelId,
       metadata: workspace.metadata,
       sharingPolicy: workspace.sharingPolicy,
       conversationsRetentionDays: workspace.conversationsRetentionDays,
@@ -254,6 +258,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       workOSOrganizationId: data.workOSOrganizationId,
       whiteListedProviders: data.whiteListedProviders,
       defaultEmbeddingProvider: data.defaultEmbeddingProvider,
+      defaultModelId: data.defaultModelId,
+      backupModelId: data.backupModelId,
       metadata: data.metadata,
       sharingPolicy: data.sharingPolicy,
       conversationsRetentionDays: data.conversationsRetentionDays,
@@ -542,6 +548,8 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         | "regionalModelsOnly"
         | "whiteListedProviders"
         | "defaultEmbeddingProvider"
+        | "defaultModelId"
+        | "backupModelId"
         | "workOSOrganizationId"
         | "metadata"
         | "sharingPolicy"

--- a/front/lib/workspace.ts
+++ b/front/lib/workspace.ts
@@ -21,6 +21,8 @@ export function renderLightWorkspaceType({
 }): LightWorkspaceType {
   return {
     defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
+    defaultModelId: workspace.defaultModelId,
+    backupModelId: workspace.backupModelId,
     id: workspace.id,
     metadata: workspace.metadata,
     name: workspace.name,

--- a/front/migrations/20260618_migrate_default_sonnet_agents_to_auto.ts
+++ b/front/migrations/20260618_migrate_default_sonnet_agents_to_auto.ts
@@ -1,0 +1,57 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeScript } from "@app/scripts/helpers";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/types/assistant/models/anthropic";
+import {
+  AUTO_MODEL_ID,
+  AUTO_PROVIDER_ID,
+} from "@app/types/assistant/models/dust";
+
+// Moves active agents still on the previous default (Anthropic Claude Sonnet
+// 4.6) onto the "auto" tier, so Dust picks the model at runtime with outage
+// backup. Idempotent: rows already on "auto" are not matched. Run on demand,
+// after customers have been notified.
+const AgentConfigurationModelWithBypass: ModelStaticWorkspaceAware<AgentConfigurationModel> =
+  AgentConfigurationModel;
+
+makeScript({}, async ({ execute }, logger) => {
+  const agents = await AgentConfigurationModelWithBypass.findAll({
+    where: {
+      providerId: "anthropic",
+      modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+      status: "active",
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  logger.info(
+    {
+      count: agents.length,
+      from: CLAUDE_SONNET_4_6_MODEL_ID,
+      to: AUTO_MODEL_ID,
+    },
+    `Found ${agents.length} active agents on the previous default Sonnet 4.6, migrating to "auto".`
+  );
+
+  for (const agent of agents) {
+    logger.info(
+      {
+        sId: agent.sId,
+        version: agent.version,
+        workspaceId: agent.workspaceId,
+      },
+      `Migrating agent ${agent.sId} (version ${agent.version}) to "auto".`
+    );
+
+    if (execute) {
+      await agent.update({
+        providerId: AUTO_PROVIDER_ID,
+        modelId: AUTO_MODEL_ID,
+      });
+    }
+  }
+
+  logger.info("Migration complete.");
+});

--- a/front/migrations/pre-deploy/20260618211424_add_default_and_backup_model_to_workspaces.sql
+++ b/front/migrations/pre-deploy/20260618211424_add_default_and_backup_model_to_workspaces.sql
@@ -1,0 +1,9 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspaces"
+    ADD COLUMN "defaultModelId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."workspaces"
+    ADD COLUMN "backupModelId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying;

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -5,6 +5,13 @@ export const QUEUE_NAME = `agent-loop-queue-v${QUEUE_VERSION}`;
 // Max retry attempts for the runModelAndCreateActions activity.
 export const RUN_MODEL_MAX_RETRIES = 5;
 
+// Number of attempts that run on the primary model before failing over to the
+// workspace backup model (when configured). Attempts beyond this run on the
+// backup model, up to RUN_MODEL_MAX_RETRIES. This reuses Temporal's existing
+// retry: once the primary has failed RUN_MODEL_PRIMARY_ATTEMPTS times, the next
+// retries re-resolve to the backup model.
+export const RUN_MODEL_PRIMARY_ATTEMPTS = 3;
+
 // Leave room for our code to surface a retryable agent error before Temporal enforces StartToClose.
 export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -30,6 +30,7 @@ import {
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
+import { resolveAgentModelConfiguration } from "@app/lib/api/assistant/models";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { renderEquippedSkillsUserMessage } from "@app/lib/api/assistant/skills_rendering";
 import {
@@ -52,7 +53,6 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -69,7 +69,10 @@ import {
   updateResourceAndPublishEvent,
 } from "@app/temporal/agent_loop/activities/common";
 import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
-import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
+import {
+  RUN_MODEL_MAX_RETRIES,
+  RUN_MODEL_PRIMARY_ATTEMPTS,
+} from "@app/temporal/agent_loop/config";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import { makeRunModelLLMError } from "@app/temporal/agent_loop/lib/run_model_errors";
@@ -169,7 +172,20 @@ export async function runModel(
 
   localLogger.info("Starting multi-action loop iteration");
 
-  const model = getSupportedModelConfig(agentConfiguration.model);
+  // Fail over to the workspace backup model once the primary has exhausted its
+  // allotted attempts. Temporal re-runs this activity from the top on retry, so
+  // we derive the failover purely from the attempt counter — no extra state.
+  const currentAttempt = Context.current().info.attempt;
+  const useBackup = currentAttempt > RUN_MODEL_PRIMARY_ATTEMPTS;
+
+  const resolvedModel = resolveAgentModelConfiguration(
+    auth,
+    agentConfiguration.model,
+    { useBackup }
+  );
+  const model = resolvedModel?.modelConfig ?? null;
+  const effectiveModel =
+    resolvedModel?.effectiveModel ?? agentConfiguration.model;
 
   async function publishAgentError(
     error: {
@@ -536,11 +552,13 @@ export async function runModel(
 
   const llm = await getStreamLLM(auth, {
     credentials,
-    modelId: model.modelId,
-    temperature: agentConfiguration.model.temperature,
-    reasoningEffort: agentConfiguration.model.reasoningEffort,
-    responseFormat: agentConfiguration.model.responseFormat,
-    metaData: agentConfiguration.model.metaData,
+    // Use the resolved model: "auto" is mapped to the workspace default (or the
+    // backup on failover), with the reasoning effort clamped to what it supports.
+    modelId: effectiveModel.modelId,
+    temperature: effectiveModel.temperature,
+    reasoningEffort: effectiveModel.reasoningEffort,
+    responseFormat: effectiveModel.responseFormat,
+    metaData: effectiveModel.metaData,
     context: traceContext,
     omittedThinking: agentConfiguration.omittedThinking,
     // Custom trace input: show only the last user message instead of full conversation.
@@ -582,7 +600,10 @@ export async function runModel(
 
   localLogger.info(
     {
+      requestedModelId: agentConfiguration.model.modelId,
       modelId: model.modelId,
+      usingBackupModel: useBackup,
+      attempt: currentAttempt,
       messageCount:
         modelConversationRes.value.modelConversation.messages.length,
       toolCount: specifications.length,

--- a/front/tests/utils/LightWorkspaceFactory.ts
+++ b/front/tests/utils/LightWorkspaceFactory.ts
@@ -18,6 +18,8 @@ export class LightWorkspaceFactory {
       segmentation: null,
       whiteListedProviders: null,
       defaultEmbeddingProvider: null,
+      defaultModelId: null,
+      backupModelId: null,
       regionalModelsOnly: false,
       metadata: {},
       sharingPolicy: "workspace_only",

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -21,6 +21,8 @@ import { expect } from "vitest";
 interface WorkspaceOverrides {
   whiteListedProviders?: ModelProviderIdType[] | null;
   metronomeCustomerId?: string | null;
+  defaultModelId?: string | null;
+  backupModelId?: string | null;
 }
 
 export class WorkspaceFactory {
@@ -104,6 +106,12 @@ export class WorkspaceFactory {
       metronomeCustomerId: overrides?.metronomeCustomerId ?? null,
       ...(overrides?.whiteListedProviders !== undefined && {
         whiteListedProviders: overrides.whiteListedProviders,
+      }),
+      ...(overrides?.defaultModelId !== undefined && {
+        defaultModelId: overrides.defaultModelId,
+      }),
+      ...(overrides?.backupModelId !== undefined && {
+        backupModelId: overrides.backupModelId,
       }),
     });
 

--- a/front/tests/utils/conversation_test_factories.ts
+++ b/front/tests/utils/conversation_test_factories.ts
@@ -163,6 +163,8 @@ export function mockConversation(
       segmentation: null,
       whiteListedProviders: null,
       defaultEmbeddingProvider: null,
+      defaultModelId: null,
+      backupModelId: null,
       sharingPolicy: "workspace_only",
       metronomeCustomerId: null,
       regionalModelsOnly: false,

--- a/front/types/assistant/models/dust.ts
+++ b/front/types/assistant/models/dust.ts
@@ -1,0 +1,51 @@
+import type { ModelConfigurationType } from "./types";
+
+// "dust" is a meta-provider: it never reaches an inference provider. The single
+// model it exposes, "auto", is a sentinel that is resolved at runtime to the
+// workspace's configured default model (with an outage backup). Mirrors the
+// existing "noop" meta-provider/model treatment.
+export const AUTO_PROVIDER_ID = "dust" as const;
+export const AUTO_MODEL_ID = "auto" as const;
+
+export const AUTO_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: AUTO_PROVIDER_ID,
+  modelId: AUTO_MODEL_ID,
+  displayName: "Auto",
+  // Advertised capabilities are a superset; the resolved model's capabilities
+  // are what actually apply at runtime. Mirrors Claude Sonnet 4.6 (the initial
+  // default) so token-budget math in the builder stays sensible.
+  contextSize: 250_000,
+  recommendedTopK: 16,
+  recommendedExhaustiveTopK: 64,
+  largeModel: true,
+  description:
+    "Dust picks the best model for you at runtime and automatically fails over to a backup model during provider outages.",
+  shortDescription: "Dust-managed model with automatic backup.",
+  isLegacy: false,
+  isLatest: true,
+  generationTokensCount: 64_000,
+  supportsVision: true,
+  supportsResponseFormat: true,
+  supportedReasoningEfforts: {
+    none: false,
+    light: true,
+    medium: true,
+    high: true,
+  },
+  defaultReasoningEffort: "medium",
+  tokenizer: { type: "tiktoken", base: "anthropic_base" },
+  availableIfOneOf: {
+    featureFlag: "auto_model_tier",
+  },
+  regionalAvailability: {
+    "us-central1": true,
+    "europe-west1": true,
+  },
+};
+
+export function isAutoModel(m: {
+  providerId: string;
+  modelId: string;
+}): boolean {
+  return m.providerId === AUTO_PROVIDER_ID && m.modelId === AUTO_MODEL_ID;
+}

--- a/front/types/assistant/models/models.ts
+++ b/front/types/assistant/models/models.ts
@@ -42,6 +42,7 @@ import {
   CUSTOM_MODEL_IDS,
 } from "./custom_models.generated";
 import { DEEPSEEK_CHAT_MODEL_CONFIG, DEEPSEEK_CHAT_MODEL_ID } from "./deepseek";
+import { AUTO_MODEL_CONFIG, AUTO_MODEL_ID } from "./dust";
 import {
   FIREWORKS_DEEPSEEK_V3P2_MODEL_CONFIG,
   FIREWORKS_DEEPSEEK_V3P2_MODEL_ID,
@@ -247,8 +248,15 @@ export const STATIC_MODEL_IDS = [
 // Type for static model IDs only (excludes custom models from GCS).
 export type StaticModelIdType = (typeof STATIC_MODEL_IDS)[number];
 
-// Combined model IDs: static + custom (custom models generated at build time from GCS).
-export const MODEL_IDS = [...STATIC_MODEL_IDS, ...CUSTOM_MODEL_IDS] as const;
+// Combined model IDs: static + the "auto" sentinel + custom (custom models
+// generated at build time from GCS). "auto" is intentionally NOT in
+// STATIC_MODEL_IDS: it never reaches a provider and must not require a pricing
+// entry (CURRENT_MODEL_PRICING is keyed by StaticModelIdType).
+export const MODEL_IDS = [
+  ...STATIC_MODEL_IDS,
+  AUTO_MODEL_ID,
+  ...CUSTOM_MODEL_IDS,
+] as const;
 
 export const isModelId = (modelId: string): modelId is ModelIdType =>
   MODEL_IDS.includes(modelId as ModelIdType);
@@ -343,6 +351,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GROK_4_1_FAST_REASONING_MODEL_CONFIG,
   GROK_4_1_FAST_NON_REASONING_MODEL_CONFIG,
   NOOP_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
   // Custom models (generated at build time from GCS).
   ...CUSTOM_MODEL_CONFIGS,
 ];

--- a/front/types/assistant/models/providers.ts
+++ b/front/types/assistant/models/providers.ts
@@ -18,6 +18,9 @@ export const MODEL_PROVIDER_IDS = [
   "fireworks",
   "xai",
   "noop",
+  // Meta-provider for the "auto" sentinel model; never reaches an inference
+  // provider (resolved to a concrete model at runtime).
+  "dust",
 ] as const;
 
 export const BYOK_MODEL_PROVIDER_IDS = [
@@ -48,6 +51,8 @@ export function getProviderDisplayName(
       return "xAI";
     case "noop":
       return "noop";
+    case "dust":
+      return "Auto";
     default:
       return providerId;
   }

--- a/front/types/provider_selection.ts
+++ b/front/types/provider_selection.ts
@@ -12,6 +12,7 @@ export const ALL_PROVIDERS_SELECTED: ProvidersSelection = {
   fireworks: true,
   xai: true,
   noop: true,
+  dust: true,
 };
 
 export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
@@ -24,6 +25,7 @@ export const NO_PROVIDERS_SELECTED: ProvidersSelection = {
   fireworks: false,
   xai: false,
   noop: false,
+  dust: false,
 };
 
 export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
@@ -36,4 +38,5 @@ export const PRETTIFIED_PROVIDER_NAMES: Record<ModelProviderIdType, string> = {
   fireworks: "Fireworks",
   xai: "xAI",
   noop: "noop",
+  dust: "Auto",
 };

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -160,6 +160,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to noop model in the agent builder",
     stage: "dust_only",
   },
+  auto_model_tier: {
+    description:
+      "Access to the Auto model tier (runtime-selected default model with outage backup) in the agent builder",
+    stage: "on_demand",
+  },
   gemini_3_1_pro_feature: {
     description: "Access to Gemini 3.1 Pro model in the agent builder",
     stage: "on_demand",

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -68,6 +68,12 @@ export type LightWorkspaceType = {
   segmentation: WorkspaceSegmentationType;
   whiteListedProviders: ModelProviderIdType[] | null;
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  // modelId of the workspace default model used by the "auto" tier (null => Dust
+  // default).
+  defaultModelId: string | null;
+  // modelId of the workspace backup model used as a cross-provider fallback on
+  // provider outages (null => no backup).
+  backupModelId: string | null;
   regionalModelsOnly: boolean;
   metadata?: {
     [key: string]: string | number | boolean | object | undefined;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -24,6 +24,7 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "fireworks"
   | "xai"
   | "noop"
+  | "dust" // meta-provider for the "auto" sentinel model
 >();
 
 export type KnownModelLLMId =
@@ -99,7 +100,8 @@ export type KnownModelLLMId =
   | "grok-4-fast-reasoning-latest"
   | "grok-4-1-fast-non-reasoning-latest"
   | "grok-4-1-fast-reasoning-latest"
-  | "noop"; // Noop
+  | "noop" // Noop
+  | "auto"; // Auto: Dust-managed runtime model selection
 
 // Cast to allow custom/unknown model IDs while preserving autocomplete.
 const ModelLLMIdSchema = FlexibleEnumSchema<KnownModelLLMId>() as z.ZodType<
@@ -732,6 +734,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_dust_apps"
   | "netsuite_mcp"
   | "noop_model_feature"
+  | "auto_model_tier"
   | "notion_private_integration"
   | "allow_old_notion_mcp"
   | "openai_o1_feature"


### PR DESCRIPTION
## Description

Introduces an **"Auto" model tier** for agents, decoupling them from a single inference provider, plus admin-configurable workspace **default** and **backup** models.

- **Auto tier**: a `dust`/`auto` sentinel model (mirroring the existing `noop` meta-provider) that is resolved at runtime to the workspace's default model — initially Claude Sonnet 4.6, matching today's behavior — and is surfaced first in the agent builder picker. Gated behind the `auto_model_tier` feature flag, so it ships dark.
- **Workspace default model**: admin setting on the Models page; used by the Auto tier.
- **Workspace backup model**: admin setting applied as an automatic cross-provider fallback for **all** agents (Auto or fixed) during provider outages — once the primary model exhausts its retries in the agent loop, subsequent retries re-resolve to the backup model.

Resolution is centralized in `resolveAgentModelConfiguration` (`lib/api/assistant/models.ts`), which also clamps a stored reasoning effort to what the resolved model supports. All consumers of an agent's stored model (run loop, availability guard, compaction, tool servers) route through it so the `auto` sentinel never reaches a provider.

A separate, on-demand backfill script (`migrations/20260618_migrate_default_sonnet_agents_to_auto.ts`) moves active agents still on the previous default (Sonnet 4.6) onto the Auto tier; it is idempotent and `--execute`-gated, to be run after customers have been notified.

## Tests

- New unit tests in `lib/api/assistant/models.test.ts` cover the resolver (auto → default → Sonnet fallback, concrete passthrough, backup failover, reasoning-effort clamping) and the admin settings validation (rejects `auto`/unknown models, accepts enabled models, null clears). Existing `getWhitelistedProviders` tests updated for the `dust` meta-provider.
- `tsgo` clean across `front`, `front-api`, and the SDK; biome and audit-log schema lint pass; the pre-deploy migration applies locally.

## Deploy Plan

1. Pre-deploy migration `20260618211424_add_default_and_backup_model_to_workspaces.sql` adds two nullable columns to `workspaces` (safe, additive).
2. After merge, register the new audit action with WorkOS: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`.
3. Enable `auto_model_tier` per workspace to roll out the tier and the admin settings UI.
4. Once customers are notified, run the `migrate_default_sonnet_agents_to_auto` backfill to move existing default-Sonnet agents onto Auto.
