### PR TITLE
[front] checkout: fix payment-gated contract to preserve free plan contract

### DIFF
--- a/front/lib/api/checkout/business_activation.test.ts
+++ b/front/lib/api/checkout/business_activation.test.ts
@@ -1,0 +1,425 @@
+import {
+  createPaymentGatedBusinessActivation,
+  handleSubscriptionActivationFailure,
+  handleSubscriptionActivationSuccess,
+} from "@app/lib/api/checkout/business_activation";
+import { ensureWorkOSOrganizationForPaidPlan } from "@app/lib/api/workos/organization";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockSetCheckoutPaymentPending,
+  mockGetCheckoutPaymentStatus,
+  mockMarkCheckoutPaymentSucceeded,
+  mockMarkCheckoutPaymentFailed,
+  mockRecordCheckoutPaymentSyncFailure,
+  mockSwapMetronomeContract,
+  mockFetchActiveSubscription,
+  mockEnsureMetronomeCustomer,
+  mockProvisionActivationContract,
+  mockScheduleContractEnd,
+  mockAddPaymentGatedCommit,
+  mockUpdateMembershipSeat,
+  mockRestoreWorkspace,
+  mockInvalidateCache,
+  mockFetchUser,
+} = vi.hoisted(() => ({
+  mockSetCheckoutPaymentPending: vi.fn(),
+  mockGetCheckoutPaymentStatus: vi.fn(),
+  mockMarkCheckoutPaymentSucceeded: vi.fn(),
+  mockMarkCheckoutPaymentFailed: vi.fn(),
+  mockRecordCheckoutPaymentSyncFailure: vi.fn(),
+  mockSwapMetronomeContract: vi.fn(),
+  mockFetchActiveSubscription: vi.fn(),
+  mockEnsureMetronomeCustomer: vi.fn(),
+  mockProvisionActivationContract: vi.fn(),
+  mockScheduleContractEnd: vi.fn(),
+  mockAddPaymentGatedCommit: vi.fn(),
+  mockUpdateMembershipSeat: vi.fn(),
+  mockRestoreWorkspace: vi.fn(),
+  mockInvalidateCache: vi.fn(),
+  mockFetchUser: vi.fn(),
+}));
+
+vi.mock("@app/lib/credits/checkout_payment_status", () => ({
+  setCheckoutPaymentPending: mockSetCheckoutPaymentPending,
+  getCheckoutPaymentStatus: mockGetCheckoutPaymentStatus,
+  markCheckoutPaymentSucceeded: mockMarkCheckoutPaymentSucceeded,
+  markCheckoutPaymentFailed: mockMarkCheckoutPaymentFailed,
+  recordCheckoutPaymentSyncFailure: mockRecordCheckoutPaymentSyncFailure,
+}));
+
+vi.mock("@app/lib/metronome/client", () => ({
+  floorToHourISO: (d: Date) => d.toISOString(),
+  scheduleMetronomeContractEnd: mockScheduleContractEnd,
+  addPaymentGatedCommitToContract: mockAddPaymentGatedCommit,
+  getMetronomeClient: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/contracts", () => ({
+  ensureMetronomeCustomerForWorkspace: mockEnsureMetronomeCustomer,
+  provisionPaymentGatedActivationContract: mockProvisionActivationContract,
+}));
+
+vi.mock("@app/lib/resources/subscription_resource", () => ({
+  SubscriptionResource: {
+    fetchActiveByWorkspaceModelId: mockFetchActiveSubscription,
+  },
+}));
+
+vi.mock("@app/lib/resources/user_resource", () => ({
+  UserResource: {
+    fetchById: mockFetchUser,
+  },
+}));
+
+vi.mock("@app/lib/resources/coupon_resource", () => ({
+  CouponResource: {
+    findByCode: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock("@app/lib/resources/coupon_redemption_resource", () => ({
+  CouponRedemptionResource: {
+    findActiveOrPendingByCouponAndWorkspace: vi.fn().mockResolvedValue(null),
+    fetchById: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock("@app/lib/api/membership", () => ({
+  updateMembershipSeatAndTrack: mockUpdateMembershipSeat,
+}));
+
+vi.mock("@app/lib/api/subscription", () => ({
+  isMetronomeBillingEnabled: vi.fn().mockResolvedValue(true),
+  restoreWorkspaceAfterSubscription: mockRestoreWorkspace,
+}));
+
+vi.mock("@app/lib/metronome/plan_type", () => ({
+  invalidateContractCache: mockInvalidateCache,
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  Authenticator: {
+    internalAdminForWorkspace: vi.fn().mockResolvedValue({
+      getNonNullableWorkspace: () => ({
+        sId: "w_test",
+        name: "Test Workspace",
+      }),
+    }),
+    fromUserIdAndWorkspaceId: vi.fn().mockResolvedValue({
+      getNonNullableWorkspace: () => ({
+        sId: "w_test",
+        name: "Test Workspace",
+      }),
+    }),
+  },
+}));
+
+vi.mock("@app/lib/metronome/audit", () => ({
+  emitSubscriptionChangedAuditEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/workos/organization", () => ({
+  ensureWorkOSOrganizationForPaidPlan: vi.fn(),
+}));
+
+vi.mock("@app/lib/workspace", () => ({
+  renderLightWorkspaceType: ({
+    workspace,
+  }: {
+    workspace: { sId: string };
+  }) => ({
+    sId: workspace.sId,
+    name: "Test Workspace",
+  }),
+}));
+
+vi.mock("@app/lib/plans/billing_currency", () => ({
+  getBillingCurrencyForCountry: vi.fn().mockReturnValue("usd"),
+  resolvePackageAliasForCurrency: vi
+    .fn()
+    .mockImplementation((alias: string) => alias),
+}));
+
+vi.mock("@app/lib/plans/plan_codes", () => ({
+  CREDIT_PRICED_FREE_PLAN_CODE: "CP_FREE_PLAN",
+  CREDIT_PRICED_BUSINESS_PLAN_CODE: "CP_BUSINESS_PLAN",
+  FREE_NO_PLAN_CODE: "FREE_NO_PLAN",
+  isFreePlan: (code: string) =>
+    code === "CP_FREE_PLAN" || code === "FREE_NO_PLAN",
+}));
+
+vi.mock("@app/lib/metronome/constants", () => ({
+  PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY: "DUST_PAYMENT_GATE_TYPE",
+  PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION: "subscription_activation",
+  CURRENCY_TO_CREDIT_TYPE_ID: { usd: "usd-credit", eur: "eur-credit" },
+  FOREVER_ENDING_BEFORE: "9999-12-31T00:00:00.000Z",
+  CARRY_ON_RENEWAL_CUSTOM_FIELD_KEY: "CARRY_ON_RENEWAL",
+  CARRY_ON_RENEWAL_FOREVER_VALUE: "forever",
+  SEAT_PRIORITY_SUBSCRIPTION_COMMIT: 100,
+  getProductSeatSubscriptionCommitId: () => "seat-commit-product",
+}));
+
+vi.mock("@app/lib/metronome/amounts", () => ({
+  metronomeAmount: vi.fn().mockImplementation((cents: number) => cents),
+}));
+
+vi.mock("@app/lib/metronome/coupons", () => ({
+  createCouponCredit: vi.fn(),
+  getCreditTypeFromPackage: vi.fn(),
+}));
+
+vi.mock("@app/lib/metronome/setup_common", () => ({
+  SEAT_TAG: "seat",
+}));
+
+vi.mock("@app/lib/plans/stripe", () => ({
+  getStripeClient: vi.fn(),
+  setStripeCustomerDefaultPaymentMethod: vi.fn(),
+}));
+
+vi.mock("@app/logger/logger", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const WORKSPACE = {
+  sId: "w_test",
+  id: 1,
+  metronomeCustomerId: "m-customer",
+  name: "Test Workspace",
+} as unknown as WorkspaceResource;
+
+const FREE_SUBSCRIPTION = {
+  sId: "sub_free",
+  metronomeContractId: "previous-contract-id",
+  getPlan: () => ({ code: "CP_FREE_PLAN" }),
+  swapMetronomeContract: mockSwapMetronomeContract,
+};
+
+const CHECKOUT_PAYMENT_PENDING = {
+  status: "pending" as const,
+  workspaceId: "w_test",
+  metronomeCustomerId: "m-customer",
+  contractId: "activation-contract-id",
+  userId: "user_test",
+  targetUserId: "target_user",
+  seatType: "pro" as const,
+  billingPeriod: "monthly" as const,
+  currency: "usd" as const,
+  initialAmountCents: 3000,
+  metronomePackageAlias: "business-usd",
+  planCode: "CP_BUSINESS_PLAN",
+  uniquenessKey: "key",
+  createdAtMs: 1000000,
+  previousSubscriptionSId: "sub_free",
+  previousMetronomeContractId: "previous-contract-id",
+};
+
+function makeActivationInput() {
+  return {
+    workspace: WORKSPACE,
+    stripeCustomerId: "cus_test",
+    setupSessionId: "setup_test",
+    targetUserId: "target_user",
+    seatType: "pro" as const,
+    billingPeriod: "monthly" as const,
+    currency: "usd" as const,
+    pricePerSeatCents: 3000,
+    metronomePackageAlias: "business-usd",
+    userId: "user_test",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockFetchActiveSubscription.mockResolvedValue(FREE_SUBSCRIPTION);
+  mockEnsureMetronomeCustomer.mockResolvedValue(
+    new Ok({ metronomeCustomerId: "m-customer" })
+  );
+  mockProvisionActivationContract.mockResolvedValue(
+    new Ok({ metronomeContractId: "activation-contract-id" })
+  );
+  mockSetCheckoutPaymentPending.mockResolvedValue(undefined);
+  mockAddPaymentGatedCommit.mockResolvedValue(new Ok({ editId: "edit_1" }));
+  mockScheduleContractEnd.mockResolvedValue(new Ok(undefined));
+  mockGetCheckoutPaymentStatus.mockResolvedValue(CHECKOUT_PAYMENT_PENDING);
+  mockMarkCheckoutPaymentSucceeded.mockResolvedValue(undefined);
+  mockMarkCheckoutPaymentFailed.mockResolvedValue(undefined);
+  mockRecordCheckoutPaymentSyncFailure.mockResolvedValue(undefined);
+  mockSwapMetronomeContract.mockResolvedValue(undefined);
+  mockInvalidateCache.mockResolvedValue(undefined);
+  mockFetchUser.mockResolvedValue({ sId: "target_user" });
+  mockUpdateMembershipSeat.mockResolvedValue(new Ok(undefined));
+  mockRestoreWorkspace.mockResolvedValue(undefined);
+  vi.mocked(ensureWorkOSOrganizationForPaidPlan).mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// createPaymentGatedBusinessActivation
+// ---------------------------------------------------------------------------
+
+describe("createPaymentGatedBusinessActivation", () => {
+  it("stores previous subscription snapshot in Redis pending state", async () => {
+    const result = await createPaymentGatedBusinessActivation(
+      makeActivationInput()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockSetCheckoutPaymentPending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previousSubscriptionSId: "sub_free",
+        previousMetronomeContractId: "previous-contract-id",
+      })
+    );
+  });
+
+  it("does not end the previous contract during checkout creation", async () => {
+    await createPaymentGatedBusinessActivation(makeActivationInput());
+
+    expect(mockScheduleContractEnd).not.toHaveBeenCalled();
+  });
+
+  it("ends only the activation contract when commit creation fails", async () => {
+    mockAddPaymentGatedCommit.mockResolvedValue(
+      new Err(new Error("commit failed"))
+    );
+
+    const result = await createPaymentGatedBusinessActivation(
+      makeActivationInput()
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(mockScheduleContractEnd).toHaveBeenCalledTimes(1);
+    expect(mockScheduleContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "activation-contract-id" })
+    );
+    expect(mockScheduleContractEnd).not.toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "previous-contract-id" })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSubscriptionActivationSuccess
+// ---------------------------------------------------------------------------
+
+describe("handleSubscriptionActivationSuccess", () => {
+  it("swaps to activation contract, updates seat, ends previous contract", async () => {
+    mockFetchActiveSubscription.mockResolvedValue({
+      sId: "sub_free",
+      metronomeContractId: "previous-contract-id",
+      getPlan: () => ({ code: "CP_FREE_PLAN" }),
+      swapMetronomeContract: mockSwapMetronomeContract,
+    });
+
+    await handleSubscriptionActivationSuccess({
+      workspace: WORKSPACE,
+      contractId: "activation-contract-id",
+      invoiceId: "inv_123",
+    });
+
+    expect(mockSwapMetronomeContract).toHaveBeenCalledWith({
+      metronomeContractId: "activation-contract-id",
+      planCode: "CP_BUSINESS_PLAN",
+    });
+    expect(mockUpdateMembershipSeat).toHaveBeenCalled();
+    expect(mockMarkCheckoutPaymentSucceeded).toHaveBeenCalledWith({
+      workspaceId: "w_test",
+      contractId: "activation-contract-id",
+      invoiceId: "inv_123",
+    });
+    expect(mockScheduleContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "previous-contract-id" })
+    );
+    expect(mockScheduleContractEnd).not.toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "activation-contract-id" })
+    );
+  });
+
+  it("is idempotent when Redis status is already succeeded", async () => {
+    mockGetCheckoutPaymentStatus.mockResolvedValue({
+      ...CHECKOUT_PAYMENT_PENDING,
+      status: "succeeded",
+    });
+
+    await handleSubscriptionActivationSuccess({
+      workspace: WORKSPACE,
+      contractId: "activation-contract-id",
+      invoiceId: "inv_123",
+    });
+
+    expect(mockSwapMetronomeContract).not.toHaveBeenCalled();
+    expect(mockScheduleContractEnd).not.toHaveBeenCalled();
+    expect(mockMarkCheckoutPaymentSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("marks failed and ends activation contract when active subscription has changed", async () => {
+    mockFetchActiveSubscription.mockResolvedValue({
+      sId: "sub_different",
+      metronomeContractId: "different-contract-id",
+      getPlan: () => ({ code: "CP_BUSINESS_PLAN" }),
+      swapMetronomeContract: mockSwapMetronomeContract,
+    });
+
+    await handleSubscriptionActivationSuccess({
+      workspace: WORKSPACE,
+      contractId: "activation-contract-id",
+      invoiceId: "inv_123",
+    });
+
+    expect(mockSwapMetronomeContract).not.toHaveBeenCalled();
+    expect(mockScheduleContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "activation-contract-id" })
+    );
+    expect(mockScheduleContractEnd).not.toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "different-contract-id" })
+    );
+    expect(mockMarkCheckoutPaymentFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "w_test",
+        contractId: "activation-contract-id",
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSubscriptionActivationFailure
+// ---------------------------------------------------------------------------
+
+describe("handleSubscriptionActivationFailure", () => {
+  it("ends only the activation contract, not the previous free contract", async () => {
+    await handleSubscriptionActivationFailure({
+      workspace: WORKSPACE,
+      contractId: "activation-contract-id",
+      invoiceId: "inv_123",
+      errorMessage: "Payment declined",
+    });
+
+    expect(mockMarkCheckoutPaymentFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "w_test",
+        contractId: "activation-contract-id",
+        errorMessage: "Payment declined",
+      })
+    );
+    expect(mockScheduleContractEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "activation-contract-id" })
+    );
+    expect(mockScheduleContractEnd).not.toHaveBeenCalledWith(
+      expect.objectContaining({ contractId: "previous-contract-id" })
+    );
+    expect(mockSwapMetronomeContract).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/checkout/business_activation.test.ts
+++ b/front/lib/api/checkout/business_activation.test.ts
@@ -144,9 +144,7 @@ vi.mock("@app/lib/plans/billing_currency", () => ({
 }));
 
 vi.mock("@app/lib/plans/plan_codes", () => ({
-  CREDIT_PRICED_FREE_PLAN_CODE: "CP_FREE_PLAN",
   CREDIT_PRICED_BUSINESS_PLAN_CODE: "CP_BUSINESS_PLAN",
-  FREE_NO_PLAN_CODE: "FREE_NO_PLAN",
   isFreePlan: (code: string) =>
     code === "CP_FREE_PLAN" || code === "FREE_NO_PLAN",
 }));
@@ -180,13 +178,16 @@ vi.mock("@app/lib/plans/stripe", () => ({
   setStripeCustomerDefaultPaymentMethod: vi.fn(),
 }));
 
-vi.mock("@app/logger/logger", () => ({
-  default: {
+vi.mock("@app/logger/logger", () => {
+  const logger = {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
-  },
-}));
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return { default: logger };
+});
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -221,7 +222,6 @@ const CHECKOUT_PAYMENT_PENDING = {
   planCode: "CP_BUSINESS_PLAN",
   uniquenessKey: "key",
   createdAtMs: 1000000,
-  previousSubscriptionSId: "sub_free",
   previousMetronomeContractId: "previous-contract-id",
 };
 
@@ -278,7 +278,6 @@ describe("createPaymentGatedBusinessActivation", () => {
     expect(result.isOk()).toBe(true);
     expect(mockSetCheckoutPaymentPending).toHaveBeenCalledWith(
       expect.objectContaining({
-        previousSubscriptionSId: "sub_free",
         previousMetronomeContractId: "previous-contract-id",
       })
     );

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -48,8 +48,7 @@ import {
 } from "@app/lib/plans/billing_currency";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
-  CREDIT_PRICED_FREE_PLAN_CODE,
-  FREE_NO_PLAN_CODE,
+  isFreePlan,
 } from "@app/lib/plans/plan_codes";
 import {
   getStripeClient,
@@ -154,15 +153,10 @@ export async function createPaymentGatedBusinessActivation({
     validCurrency
   );
 
-  // Step 1: workspace must be on CP_FREE_PLAN.
+  // Step 1: workspace must be on a free plan.
   const activeSubscription =
     await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
-  const planCode = activeSubscription?.getPlan().code;
-  if (
-    !activeSubscription ||
-    (planCode !== CREDIT_PRICED_FREE_PLAN_CODE &&
-      planCode !== FREE_NO_PLAN_CODE)
-  ) {
+  if (!activeSubscription || !isFreePlan(activeSubscription.getPlan().code)) {
     return new Err({ type: "not_on_free_plan" });
   }
 
@@ -187,9 +181,8 @@ export async function createPaymentGatedBusinessActivation({
   const now = new Date(floorToHourISO(new Date()));
   const uniquenessKey = `subscription-activation-${workspace.sId}-${setupSessionId}`;
 
-  // Snapshot the current subscription so the success handler can validate the
-  // workspace hasn't changed and can end the exact previous contract.
-  const previousSubscriptionSId = activeSubscription.sId;
+  // Snapshot the current Metronome contract so the success handler can validate
+  // the workspace state hasn't changed and can end the exact previous contract.
   const previousMetronomeContractId =
     activeSubscription.metronomeContractId ?? undefined;
 
@@ -278,7 +271,6 @@ export async function createPaymentGatedBusinessActivation({
     couponCode,
     couponRedemptionId: pendingRedemption?.sId,
     uniquenessKey,
-    previousSubscriptionSId,
     previousMetronomeContractId,
   });
 
@@ -497,7 +489,7 @@ export async function handleSubscriptionActivationSuccess({
     }
   }
 
-  // Switch workspace DB subscription from CP_FREE_PLAN to CP_BUSINESS_PLAN.
+  // Switch workspace DB subscription to CP_BUSINESS_PLAN.
   const activeSubscription =
     await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
   if (!activeSubscription) {
@@ -508,52 +500,47 @@ export async function handleSubscriptionActivationSuccess({
     return;
   }
 
-  // Snapshot validation: ensure the active subscription still matches what was
-  // captured at checkout time. If another checkout or admin action changed the
-  // subscription in the meantime, do not blindly swap — end the activation
-  // contract and mark the checkout failed instead.
-  if (checkoutPayment.previousSubscriptionSId !== undefined) {
-    const contractMismatch =
-      activeSubscription.sId !== checkoutPayment.previousSubscriptionSId ||
-      activeSubscription.metronomeContractId !==
-        (checkoutPayment.previousMetronomeContractId ?? null);
-    if (contractMismatch) {
-      logger.error(
-        {
-          panic: true,
-          workspaceId: workspace.sId,
-          contractId,
-          currentSubscriptionSId: activeSubscription.sId,
-          expectedSubscriptionSId: checkoutPayment.previousSubscriptionSId,
-          currentMetronomeContractId: activeSubscription.metronomeContractId,
-          expectedMetronomeContractId:
-            checkoutPayment.previousMetronomeContractId,
-        },
-        "[Business Activation] Subscription mismatch during activation — another change occurred, ending activation contract"
-      );
-      await markCheckoutPaymentFailed({
+  // Snapshot validation: ensure the Metronome contract on the active subscription
+  // still matches what was captured at checkout time. If another checkout already
+  // swapped the workspace to a paid contract, or an admin changed the free
+  // contract, the IDs won't match and we abort.
+  const contractMismatch =
+    activeSubscription.metronomeContractId !==
+    (checkoutPayment.previousMetronomeContractId ?? null);
+  if (contractMismatch) {
+    logger.error(
+      {
+        panic: true,
         workspaceId: workspace.sId,
         contractId,
-        errorMessage:
-          "Subscription changed during activation — activation contract ended",
-      });
-      const endMismatchResult = await scheduleMetronomeContractEnd({
-        metronomeCustomerId: checkoutPayment.metronomeCustomerId,
-        contractId,
-        endingBefore: new Date(floorToHourISO(new Date())),
-      });
-      if (endMismatchResult.isErr()) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            contractId,
-            error: endMismatchResult.error.message,
-          },
-          "[Business Activation] Failed to end activation contract on subscription mismatch — manual cleanup may be required"
-        );
-      }
-      return;
+        currentMetronomeContractId: activeSubscription.metronomeContractId,
+        expectedMetronomeContractId:
+          checkoutPayment.previousMetronomeContractId,
+      },
+      "[Business Activation] Subscription mismatch during activation — another change occurred, ending activation contract"
+    );
+    await markCheckoutPaymentFailed({
+      workspaceId: workspace.sId,
+      contractId,
+      errorMessage:
+        "Subscription changed during activation — activation contract ended",
+    });
+    const endMismatchResult = await scheduleMetronomeContractEnd({
+      metronomeCustomerId: checkoutPayment.metronomeCustomerId,
+      contractId,
+      endingBefore: new Date(floorToHourISO(new Date())),
+    });
+    if (endMismatchResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          contractId,
+          error: endMismatchResult.error.message,
+        },
+        "[Business Activation] Failed to end activation contract on subscription mismatch — manual cleanup may be required"
+      );
     }
+    return;
   }
 
   const previousPlanCode = activeSubscription.getPlan().code;

--- a/front/lib/api/checkout/business_activation.ts
+++ b/front/lib/api/checkout/business_activation.ts
@@ -4,6 +4,7 @@ import {
   isMetronomeBillingEnabled,
   restoreWorkspaceAfterSubscription,
 } from "@app/lib/api/subscription";
+import { ensureWorkOSOrganizationForPaidPlan } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
 import {
   type CheckoutPayment,
@@ -14,6 +15,7 @@ import {
   setCheckoutPaymentPending,
 } from "@app/lib/credits/checkout_payment_status";
 import { metronomeAmount } from "@app/lib/metronome/amounts";
+import { emitSubscriptionChangedAuditEvent } from "@app/lib/metronome/audit";
 import {
   addPaymentGatedCommitToContract,
   floorToHourISO,
@@ -32,7 +34,7 @@ import {
 } from "@app/lib/metronome/constants";
 import {
   ensureMetronomeCustomerForWorkspace,
-  provisionMetronomeContract,
+  provisionPaymentGatedActivationContract,
 } from "@app/lib/metronome/contracts";
 import {
   createCouponCredit,
@@ -180,9 +182,18 @@ export async function createPaymentGatedBusinessActivation({
   // Step 3: provision Business Metronome contract.
   // The PAYMENT_GATE_TYPE custom field tells the contract.start webhook to skip
   // the automatic subscription swap — payment_gate.payment_status handles it.
+  // We use the dedicated helper that does NOT sunset overlapping contracts so the
+  // current free contract remains live until payment succeeds.
   const now = new Date(floorToHourISO(new Date()));
   const uniquenessKey = `subscription-activation-${workspace.sId}-${setupSessionId}`;
-  const contractResult = await provisionMetronomeContract({
+
+  // Snapshot the current subscription so the success handler can validate the
+  // workspace hasn't changed and can end the exact previous contract.
+  const previousSubscriptionSId = activeSubscription.sId;
+  const previousMetronomeContractId =
+    activeSubscription.metronomeContractId ?? undefined;
+
+  const contractResult = await provisionPaymentGatedActivationContract({
     metronomeCustomerId,
     workspace: lightWorkspace,
     packageAlias: resolvedPackageAlias,
@@ -193,7 +204,6 @@ export async function createPaymentGatedBusinessActivation({
       [PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY]:
         PAYMENT_GATE_TYPE_SUBSCRIPTION_ACTIVATION,
     },
-    enableSeatSync: false,
   });
   if (contractResult.isErr()) {
     return new Err({
@@ -268,6 +278,8 @@ export async function createPaymentGatedBusinessActivation({
     couponCode,
     couponRedemptionId: pendingRedemption?.sId,
     uniquenessKey,
+    previousSubscriptionSId,
+    previousMetronomeContractId,
   });
 
   // Step 6: zero-amount fast path — no invoice to create, activate immediately.
@@ -343,6 +355,24 @@ export async function createPaymentGatedBusinessActivation({
       contractId: metronomeContractId,
       errorMessage: commitResult.error.message,
     });
+    // End the activation contract since no payment webhook will arrive to clean
+    // it up. The previous free contract is NOT touched here.
+    const endResult = await scheduleMetronomeContractEnd({
+      metronomeCustomerId,
+      contractId: metronomeContractId,
+      endingBefore: new Date(floorToHourISO(new Date())),
+    });
+    if (endResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          metronomeCustomerId,
+          metronomeContractId,
+          error: endResult.error.message,
+        },
+        "[Business Activation] Failed to end activation contract after commit failure — manual cleanup may be required"
+      );
+    }
     return new Err({
       type: "metronome_error",
       message: commitResult.error.message,
@@ -477,11 +507,78 @@ export async function handleSubscriptionActivationSuccess({
     );
     return;
   }
+
+  // Snapshot validation: ensure the active subscription still matches what was
+  // captured at checkout time. If another checkout or admin action changed the
+  // subscription in the meantime, do not blindly swap — end the activation
+  // contract and mark the checkout failed instead.
+  if (checkoutPayment.previousSubscriptionSId !== undefined) {
+    const contractMismatch =
+      activeSubscription.sId !== checkoutPayment.previousSubscriptionSId ||
+      activeSubscription.metronomeContractId !==
+        (checkoutPayment.previousMetronomeContractId ?? null);
+    if (contractMismatch) {
+      logger.error(
+        {
+          panic: true,
+          workspaceId: workspace.sId,
+          contractId,
+          currentSubscriptionSId: activeSubscription.sId,
+          expectedSubscriptionSId: checkoutPayment.previousSubscriptionSId,
+          currentMetronomeContractId: activeSubscription.metronomeContractId,
+          expectedMetronomeContractId:
+            checkoutPayment.previousMetronomeContractId,
+        },
+        "[Business Activation] Subscription mismatch during activation — another change occurred, ending activation contract"
+      );
+      await markCheckoutPaymentFailed({
+        workspaceId: workspace.sId,
+        contractId,
+        errorMessage:
+          "Subscription changed during activation — activation contract ended",
+      });
+      const endMismatchResult = await scheduleMetronomeContractEnd({
+        metronomeCustomerId: checkoutPayment.metronomeCustomerId,
+        contractId,
+        endingBefore: new Date(floorToHourISO(new Date())),
+      });
+      if (endMismatchResult.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            contractId,
+            error: endMismatchResult.error.message,
+          },
+          "[Business Activation] Failed to end activation contract on subscription mismatch — manual cleanup may be required"
+        );
+      }
+      return;
+    }
+  }
+
+  const previousPlanCode = activeSubscription.getPlan().code;
+
   await activeSubscription.swapMetronomeContract({
     metronomeContractId: contractId,
     planCode: checkoutPayment.planCode,
   });
   await invalidateContractCache(workspace.sId);
+
+  // Restore workspace (unblock connectors, triggers, cancel scrub).
+  await restoreWorkspaceAfterSubscription(auth);
+
+  emitSubscriptionChangedAuditEvent({
+    auth,
+    planCode: checkoutPayment.planCode,
+    previousPlanCode,
+    metronomeContractId: contractId,
+  });
+
+  await ensureWorkOSOrganizationForPaidPlan({
+    workspace: lightWorkspace,
+    planCode: checkoutPayment.planCode,
+    contractId,
+  });
 
   logger.info(
     { workspaceId: workspace.sId, contractId },
@@ -548,15 +645,37 @@ export async function handleSubscriptionActivationSuccess({
     }
   }
 
-  // Restore workspace (unblock connectors, triggers, cancel scrub).
-  await restoreWorkspaceAfterSubscription(auth);
-
   // Mark Redis activation succeeded.
   await markCheckoutPaymentSucceeded({
     workspaceId: workspace.sId,
     contractId,
     invoiceId,
   });
+
+  // End the previous free contract now that the workspace has been swapped to
+  // the paid activation contract. We do this after the DB swap and Redis mark so
+  // the workspace is never left in an unactivated state if this step fails.
+  if (
+    checkoutPayment.previousMetronomeContractId &&
+    checkoutPayment.previousMetronomeContractId !== contractId
+  ) {
+    const endPreviousResult = await scheduleMetronomeContractEnd({
+      metronomeCustomerId: checkoutPayment.metronomeCustomerId,
+      contractId: checkoutPayment.previousMetronomeContractId,
+      endingBefore: new Date(floorToHourISO(new Date())),
+    });
+    if (endPreviousResult.isErr()) {
+      logger.error(
+        {
+          workspaceId: workspace.sId,
+          previousMetronomeContractId:
+            checkoutPayment.previousMetronomeContractId,
+          error: endPreviousResult.error.message,
+        },
+        "[Business Activation] Failed to end previous free contract after activation — manual cleanup may be required"
+      );
+    }
+  }
 
   logger.info(
     { workspaceId: workspace.sId, contractId, invoiceId },

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -23,7 +23,7 @@ import {
 } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
-import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
+import { ensureWorkOSOrganizationForPaidPlan } from "@app/lib/api/workos/organization";
 import { Authenticator } from "@app/lib/auth";
 import {
   markAwuPurchaseAttemptFailed,
@@ -76,7 +76,6 @@ import { setUserNearLimit } from "@app/lib/metronome/user_block";
 import type { MetronomeWebhookEvent } from "@app/lib/metronome/webhook_events";
 import { PlanModel } from "@app/lib/models/plan";
 import { notifyUserAwuCapReached } from "@app/lib/notifications/workflows/user-awu-cap-reached";
-import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
@@ -538,40 +537,6 @@ export async function handleFreeCreditSegmentGrant({
   );
 
   return new Ok(undefined);
-}
-
-// Ensure the workspace has a WorkOS organization once it lands on a paid plan
-// via `contract.start`. Idempotent — `switch_contract` already runs this on
-// the synchronous path, but the webhook covers contracts created outside that
-// flow (manual provisioning, legacy migrations). Failures are logged but do
-// not fail the webhook: the contract is already active and the org can be
-// created later by the `/w/[wId]/domains` endpoint or a re-trigger.
-async function ensureWorkOSOrganizationForPaidPlan({
-  workspace,
-  planCode,
-  contractId,
-}: {
-  workspace: WorkspaceResource;
-  planCode: string;
-  contractId: string;
-}): Promise<void> {
-  if (isFreePlan(planCode)) {
-    return;
-  }
-  const workosResult = await getOrCreateWorkOSOrganization(
-    renderLightWorkspaceType({ workspace })
-  );
-  if (workosResult.isErr()) {
-    logger.error(
-      {
-        contractId,
-        planCode,
-        workspaceId: workspace.sId,
-        err: workosResult.error,
-      },
-      "[Metronome Webhook] contract.start: failed to provision WorkOS organization"
-    );
-  }
 }
 
 type SpendThresholdEvent = Extract<
@@ -1536,7 +1501,7 @@ export async function processMetronomeWebhook({
         );
         await restoreWorkspaceAfterSubscription(auth);
         await ensureWorkOSOrganizationForPaidPlan({
-          workspace,
+          workspace: renderLightWorkspaceType({ workspace }),
           planCode: targetPlan.code,
           contractId,
         });
@@ -1597,7 +1562,7 @@ export async function processMetronomeWebhook({
       });
 
       await ensureWorkOSOrganizationForPaidPlan({
-        workspace,
+        workspace: renderLightWorkspaceType({ workspace }),
         planCode: targetPlan.code,
         contractId,
       });

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -3,6 +3,7 @@ import { config } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { invalidateWorkOSOrganizationsCacheForUserId } from "@app/lib/api/workos/organization_membership";
 import { getWorkOSOrganization } from "@app/lib/api/workos/organization_primitives";
+import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkOSPortalIntent } from "@app/lib/types/workos";
@@ -523,5 +524,36 @@ export async function deleteWorksOSOrganizationWithWorkspace(
     return new Ok(undefined);
   } catch (err) {
     return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Ensure the workspace has a WorkOS organization once it lands on a paid plan.
+ * Idempotent — failures are logged but do not fail the caller: the org can be
+ * created later by the `/w/[wId]/domains` endpoint or a re-trigger.
+ */
+export async function ensureWorkOSOrganizationForPaidPlan({
+  workspace,
+  planCode,
+  contractId,
+}: {
+  workspace: LightWorkspaceType;
+  planCode: string;
+  contractId: string;
+}): Promise<void> {
+  if (isFreePlan(planCode)) {
+    return;
+  }
+  const workosResult = await getOrCreateWorkOSOrganization(workspace);
+  if (workosResult.isErr()) {
+    logger.error(
+      {
+        contractId,
+        planCode,
+        workspaceId: workspace.sId,
+        err: workosResult.error,
+      },
+      "[WorkOS] Failed to provision organization for paid plan"
+    );
   }
 }

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -29,6 +29,8 @@ export const CheckoutPaymentSchema = z.object({
   createdAtMs: z.number(),
   invoiceId: z.string().optional(),
   errorMessage: z.string().optional(),
+  previousSubscriptionSId: z.string().optional(),
+  previousMetronomeContractId: z.string().optional(),
 });
 
 export type CheckoutPayment = z.infer<typeof CheckoutPaymentSchema>;

--- a/front/lib/credits/checkout_payment_status.ts
+++ b/front/lib/credits/checkout_payment_status.ts
@@ -29,7 +29,6 @@ export const CheckoutPaymentSchema = z.object({
   createdAtMs: z.number(),
   invoiceId: z.string().optional(),
   errorMessage: z.string().optional(),
-  previousSubscriptionSId: z.string().optional(),
   previousMetronomeContractId: z.string().optional(),
 });
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -866,10 +866,13 @@ export async function createMetronomeContract({
   }
 
   if (enableStripeBilling) {
-    addStripeMetronomeBillingConfig({
+    const billingResult = await addStripeMetronomeBillingConfig({
       metronomeCustomerId,
       metronomeContractId: contractId,
     });
+    if (billingResult.isErr()) {
+      return new Err(billingResult.error);
+    }
   }
 
   const customFieldsResult = await setMetronomeContractCustomFields({

--- a/front/lib/metronome/contracts.test.ts
+++ b/front/lib/metronome/contracts.test.ts
@@ -3,6 +3,7 @@ import {
   buildEnterpriseOverrides,
   extractEnterprisePricing,
   provisionMetronomeContract,
+  provisionPaymentGatedActivationContract,
   resolveCurrencyForExistingMetronomeCustomer,
 } from "@app/lib/metronome/contracts";
 import { Err, Ok } from "@app/types/shared/result";
@@ -884,6 +885,93 @@ describe("provisionMetronomeContract — overlap sunset", () => {
       throw new Error("expected error");
     }
     expect(result.error.message).toContain("failed to list");
+  });
+});
+
+describe("provisionPaymentGatedActivationContract", () => {
+  it("creates a contract with the expected custom fields", async () => {
+    const result = await provisionPaymentGatedActivationContract({
+      metronomeCustomerId: "m-customer",
+      workspace: WORKSPACE,
+      packageAlias: "business-usd",
+      uniquenessKey: "activation-w_123-setup_xyz",
+      startingAt: new Date(START_DATE),
+      planCode: "CP_BUSINESS_PLAN",
+      additionalCustomFields: {
+        DUST_PAYMENT_GATE_TYPE: "subscription_activation",
+      },
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockCreateMetronomeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metronomeCustomerId: "m-customer",
+        packageAlias: "business-usd",
+        planCode: "CP_BUSINESS_PLAN",
+        additionalCustomFields: {
+          DUST_PAYMENT_GATE_TYPE: "subscription_activation",
+        },
+        enableStripeBilling: true,
+      })
+    );
+  });
+
+  it("does not sunset any overlapping existing contracts", async () => {
+    mockListMetronomeContracts.mockResolvedValue(
+      new Ok([
+        {
+          id: "existing-free-contract",
+          starting_at: "2026-03-01T00:00:00.000Z",
+          ending_before: null,
+          archived_at: null,
+        },
+      ])
+    );
+
+    const result = await provisionPaymentGatedActivationContract({
+      metronomeCustomerId: "m-customer",
+      workspace: WORKSPACE,
+      packageAlias: "business-usd",
+      startingAt: new Date(START_DATE),
+      planCode: "CP_BUSINESS_PLAN",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockScheduleMetronomeContractEnd).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when contract creation fails", async () => {
+    mockCreateMetronomeContract.mockResolvedValue(
+      new Err(new Error("Metronome API error"))
+    );
+
+    const result = await provisionPaymentGatedActivationContract({
+      metronomeCustomerId: "m-customer",
+      workspace: WORKSPACE,
+      packageAlias: "business-usd",
+      startingAt: new Date(START_DATE),
+      planCode: "CP_BUSINESS_PLAN",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      throw new Error("expected error");
+    }
+    expect(result.error.message).toBe("Metronome API error");
+  });
+
+  it("does not run seat sync", async () => {
+    await provisionPaymentGatedActivationContract({
+      metronomeCustomerId: "m-customer",
+      workspace: WORKSPACE,
+      packageAlias: "business-usd",
+      startingAt: new Date(START_DATE),
+      planCode: "CP_BUSINESS_PLAN",
+    });
+
+    expect(mockSyncSeatCount).not.toHaveBeenCalled();
+    expect(mockSyncMauCount).not.toHaveBeenCalled();
+    expect(mockRemapMembershipSeatTypesForContract).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -369,6 +369,66 @@ export async function provisionMetronomeContract({
   return new Ok({ metronomeContractId });
 }
 
+/**
+ * Create a Metronome contract for a payment-gated subscription activation without
+ * touching any existing active contract.
+ *
+ * Unlike `provisionMetronomeContract`, this helper does NOT sunset overlapping
+ * contracts. The free-plan contract must remain active until payment succeeds;
+ * if payment fails, the activation contract is ended and the workspace stays on
+ * the free contract. Only the payment success handler should end the previous
+ * contract.
+ *
+ * No seat sync is performed — the checkout contract is a candidate until payment
+ * succeeds, at which point `handleSubscriptionActivationSuccess` does the swap
+ * and triggers seat sync.
+ */
+export async function provisionPaymentGatedActivationContract({
+  metronomeCustomerId,
+  workspace,
+  packageAlias,
+  uniquenessKey,
+  startingAt,
+  planCode,
+  additionalCustomFields,
+}: {
+  metronomeCustomerId: string;
+  workspace: LightWorkspaceType;
+  packageAlias: string;
+  uniquenessKey?: string;
+  startingAt: Date;
+  planCode: string;
+  additionalCustomFields?: Record<string, string>;
+}): Promise<Result<{ metronomeContractId: string }, Error>> {
+  const alignedStart = new Date(floorToHourISO(startingAt));
+
+  logger.info(
+    {
+      metronomeCustomerId,
+      workspaceId: workspace.sId,
+      packageAlias,
+      startingAt: alignedStart.toISOString(),
+    },
+    "[Metronome] Provisioning payment-gated activation contract"
+  );
+
+  const contractResult = await createMetronomeContract({
+    metronomeCustomerId,
+    packageAlias,
+    uniquenessKey,
+    startingAt: alignedStart,
+    enableStripeBilling: true,
+    planCode,
+    additionalCustomFields,
+  });
+  if (contractResult.isErr()) {
+    return new Err(contractResult.error);
+  }
+  const { contractId: metronomeContractId } = contractResult.value;
+
+  return new Ok({ metronomeContractId });
+}
+
 // ---------------------------------------------------------------------------
 // Enterprise contract provisioning from Stripe pricing
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8958

The checkout flow creates a temporary "activation" Metronome contract before payment succeeds, then swaps the workspace onto it once payment is confirmed. The bug: the helper used to create that contract (provisionMetronomeContract) also silently sunsets any overlapping contracts on the customer — including the workspace's existing free-plan contract. If payment failed, the failure handler would end the activation contract, but the free-plan contract could already be gone, leaving the workspace with no live Metronome contract.

The fix introduces a clear lifecycle for the three contracts in play:
* Free-plan contract — created when the workspace is provisioned; must remain untouched until payment succeeds.
* Activation contract — a temporary candidate created at checkout time, without touching any existing contract.
* Previous contract — retired only after the DB subscription has been successfully swapped to the activation contract.

To enforce this, the checkout pending state now snapshots the previous contract IDs. The success handler validates the active subscription still matches that snapshot before swapping (detecting cases where another action changed the subscription in the meantime), then ends the previous contract only after the swap succeeds. The failure handler ends only the activation contract and leaves everything else untouched.

A second bug was fixed alongside: addStripeMetronomeBillingConfig was called fire-and-forget inside createMetronomeContract, which caused an immediate "contract without Stripe billing provider configuration" error when the caller proceeded to add a payment-gated commit without any async work in between to let the config land.

### Changes
* contracts.ts: new provisionPaymentGatedActivationContract — creates an activation contract without sunsetting existing ones, no seat sync.
* checkout_payment_status.ts: add previousMetronomeContractId to the Redis pending state.
* business_activation.ts: use the new helper; validate snapshot on success before swapping; end the previous contract only after swap; end the activation contract on commit failure or snapshot mismatch.
* client.ts: await addStripeMetronomeBillingConfig in createMetronomeContract.
* organization.ts: extract ensureWorkOSOrganizationForPaidPlan as a shared function called from both process_webhook.ts and business_activation.ts.
* Tests: new business_activation.test.ts; extended contracts.test.ts.

## Tests

Tested locally with :
* checkout failure or success on top of a free plan (CP_FREE_PLAN)
* checkout failure or success on signup (FREE_NO_PLAN)

## Risk

Medium, impacts the checkout flow that will be soon released

## Deploy Plan

Deploy front