### PR TITLE
Use customer level free credits

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -14,7 +14,7 @@ import {
 } from "@app/lib/metronome/alerts/spend_limits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import {
-  listContractPerUserCreditBalances,
+  listCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
 import {
@@ -312,9 +312,8 @@ async function fetchSeatBalancesForMembersTable({
   // balance: a user who switched free → pro/max still has a leftover free
   // credit, and it must not overwrite their (real) pro/max seat balance.
   // Degrades silently on read failure.
-  const perUserCreditBalances = await listContractPerUserCreditBalances({
+  const perUserCreditBalances = await listCustomerPerUserCreditBalances({
     metronomeCustomerId,
-    metronomeContractId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
   if (perUserCreditBalances.isOk()) {

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -228,7 +228,7 @@ async function stampContractCreditType({
     }
 
     // Per-user free-seat credits are stamped "free_seat" at creation (see
-    // `addPerUserCreditToContract`), so they hit the already-stamped early
+    // `addPerUserCreditToCustomer`), so they hit the already-stamped early
     // return above and are never re-stamped "pool" here.
 
     if (credit.product.id === getProductExcessCreditsId()) {

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -3,7 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { WARNING_BALANCE_RATIO } from "@app/lib/metronome/alerts/programmatic_cap";
 import {
-  listContractPerUserCreditBalances,
+  listCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
 import { CONTRACT_CREDIT_TYPE_FREE_SEAT } from "@app/lib/metronome/constants";
@@ -450,9 +450,8 @@ export async function reconcileWorkspaceUserCreditStates({
   // free user with credit remaining lands on `user_seat` (not `on_pool`) and is
   // moved to `capped` once exhausted. A read failure leaves the map empty —
   // free users then fall back to the seat-balance path (null) as before.
-  const perUserCreditBalancesResult = await listContractPerUserCreditBalances({
+  const perUserCreditBalancesResult = await listCustomerPerUserCreditBalances({
     metronomeCustomerId,
-    metronomeContractId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
   if (perUserCreditBalancesResult.isErr()) {

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2488,33 +2488,13 @@ export async function updateMetronomeCreditSegmentAmount({
 }
 
 /**
- * Add a one-time credit scoped to a single seat (user) on a contract via
- * `v2.contracts.edit` (`add_credits`).
- *
- * The credit is scoped to one seat through a `user_id` presentation specifier:
- * only usage tagged for that `userId` draws it down. This is how we express a
- * per-seat credit that the recurring INDIVIDUAL credit mechanism cannot — a
- * grant issued exactly once per seat, whenever that seat first appears, with no
- * periodic refill. Idempotency is enforced through `uniquenessKey`: a repeated
- * edit with the same key returns the existing edit (surfaced here as `Ok(null)`)
- * rather than granting twice.
- *
- * `specifiers` is mutually exclusive with `applicable_product_ids` /
- * `applicable_product_tags`, so the usage-product scope is passed as
- * `product_tags` *inside* the specifier rather than as a top-level applicable
- * filter.
- *
- * The `userId` is also stamped as the `DUST_PER_USER_CREDIT_USER` custom field.
- * Metronome alerts can filter on custom fields but not on a credit's
- * presentation specifier, so this is what lets a per-user
- * `low_remaining_contract_credit_balance_reached` alert fire as the user
- * depletes their credit. The key must be registered with Metronome (see
- * `scripts/metronome_setup.ts`) or the edit is rejected with "Invalid custom
- * field keys".
+ * Add a per-user credit directly on a Metronome customer (not a contract).
+ * Customer credits survive contract transitions automatically — no carry-over
+ * needed. Semantically identical to `addPerUserCreditToContract` but uses
+ * `v1.customers.credits.create` instead of `v2.contracts.edit`.
  */
-export async function addPerUserCreditToContract({
+export async function addPerUserCreditToCustomer({
   metronomeCustomerId,
-  metronomeContractId,
   productId,
   creditTypeId,
   contractCreditType,
@@ -2522,13 +2502,11 @@ export async function addPerUserCreditToContract({
   userId,
   productTags,
   startingAt,
-  endingBefore,
   name,
   priority,
   uniquenessKey,
 }: {
   metronomeCustomerId: string;
-  metronomeContractId: string;
   productId: string;
   creditTypeId: string;
   contractCreditType: ContractCreditType;
@@ -2536,110 +2514,77 @@ export async function addPerUserCreditToContract({
   userId: string;
   productTags: string[];
   startingAt: Date;
-  endingBefore: Date;
   name: string;
   priority: number;
   uniquenessKey: string;
-}): Promise<Result<{ editId: string } | null, Error>> {
-  // Metronome requires dates on hour boundaries — floor both to the hour.
+}): Promise<Result<{ id: string } | null, Error>> {
   const roundedStartingAt = floorToHourISO(startingAt);
-  const roundedEndingBefore = floorToHourISO(endingBefore);
+  const fiveYearsLater = new Date(startingAt);
+  fiveYearsLater.setFullYear(fiveYearsLater.getFullYear() + 5);
+  const roundedEndingBefore = floorToHourISO(fiveYearsLater);
 
   try {
-    const response = await getMetronomeClient().v2.contracts.edit({
+    const response = await getMetronomeClient().v1.customers.credits.create({
       customer_id: metronomeCustomerId,
-      contract_id: metronomeContractId,
-      uniqueness_key: uniquenessKey,
-      add_credits: [
+      product_id: productId,
+      name,
+      priority,
+      custom_fields: {
+        [PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY]: userId,
+        [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: contractCreditType,
+      },
+      access_schedule: {
+        credit_type_id: creditTypeId,
+        schedule_items: [
+          {
+            amount,
+            starting_at: roundedStartingAt,
+            ending_before: roundedEndingBefore,
+          },
+        ],
+      },
+      specifiers: [
         {
-          product_id: productId,
-          name,
-          priority,
-          custom_fields: {
-            [PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY]: userId,
-            [CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY]: contractCreditType,
-          },
-          access_schedule: {
-            credit_type_id: creditTypeId,
-            schedule_items: [
-              {
-                amount,
-                starting_at: roundedStartingAt,
-                ending_before: roundedEndingBefore,
-              },
-            ],
-          },
-          specifiers: [
-            {
-              presentation_group_values: { user_id: userId },
-              product_tags: productTags,
-            },
-          ],
+          presentation_group_values: { user_id: userId },
+          product_tags: productTags,
         },
       ],
+      uniqueness_key: uniquenessKey,
     });
 
     logger.info(
-      {
-        metronomeCustomerId,
-        metronomeContractId,
-        userId,
-        editId: response.data.id,
-        amount,
-      },
-      "[Metronome] Per-user seat credit added to contract"
+      { metronomeCustomerId, userId, creditId: response.data.id, amount },
+      "[Metronome] Per-user seat credit added to customer"
     );
 
-    return new Ok({ editId: response.data.id });
+    return new Ok(response.data);
   } catch (err) {
-    const error = normalizeError(err);
-    // Idempotency conflict on the uniqueness key — the credit was already
-    // granted. Metronome surfaces this as a 409 (`ConflictError`) on some
-    // endpoints and as a 422 "Uniqueness key already exists" on
-    // `v2.contracts.edit`, so match both.
-    if (
-      err instanceof ConflictError ||
-      error.message.includes("Uniqueness key already exists")
-    ) {
+    if (err instanceof ConflictError) {
       logger.info(
-        { metronomeCustomerId, metronomeContractId, userId, uniquenessKey },
+        { metronomeCustomerId, userId, uniquenessKey },
         "[Metronome] Per-user seat credit already exists (idempotent)"
       );
       return new Ok(null);
     }
-
+    const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, metronomeContractId, userId, amount },
-      "[Metronome] Failed to add per-user seat credit to contract"
+      { error, metronomeCustomerId, userId, amount },
+      "[Metronome] Failed to add per-user seat credit to customer"
     );
     return new Err(error);
   }
 }
 
 /**
- * Return the set of seat user sIds that already have a per-user credit named
- * `creditName` on the contract. The seat sId is read back from the credit's
- * `user_id` presentation specifier — the same specifier that scopes the credit
- * to the seat (no separate custom field, which would require registering a
- * managed-field key with Metronome).
- *
- * `covering_date` is intentionally dropped and archived credits are included so
- * EXPIRED and archived grants still count — a per-user credit is once-ever, and
- * a user whose grant has lapsed must not be re-credited. (The grant's
- * `uniqueness_key` enforces this server-side regardless; this pre-check just
- * avoids the redundant edit call.)
- *
- * Uses the credits-list endpoint (not `listBalances`): it returns only credits
- * (no commits) and we pass `include_balance: false`, so Metronome skips balance
- * computation — lighter than the balances endpoint for this identity-only read.
+ * Return the set of seat user sIds that already have a per-user customer credit
+ * named `creditName`. Includes archived/expired credits so past grants are not
+ * re-issued — the uniqueness key also enforces this server-side.
  */
-export async function listContractPerUserCreditUserIds({
+export async function listCustomerPerUserCreditUserIds({
   metronomeCustomerId,
-  metronomeContractId,
   creditName,
 }: {
   metronomeCustomerId: string;
-  metronomeContractId: string;
   creditName: string;
 }): Promise<Result<Set<string>, Error>> {
   if (!config.getMetronomeApiKey()) {
@@ -2653,13 +2598,9 @@ export async function listContractPerUserCreditUserIds({
     for await (const entry of client.v1.customers.credits.list({
       customer_id: metronomeCustomerId,
       include_balance: false,
-      include_contract_credits: true,
       include_archived: true,
     })) {
-      if (
-        entry.contract?.id !== metronomeContractId ||
-        entry.name !== creditName
-      ) {
+      if (entry.contract || entry.name !== creditName) {
         continue;
       }
       for (const specifier of entry.specifiers ?? []) {
@@ -2673,34 +2614,23 @@ export async function listContractPerUserCreditUserIds({
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, metronomeContractId },
-      "[Metronome] Failed to list per-user contract credits"
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to list per-user customer credits"
     );
     return new Err(error);
   }
 }
 
 /**
- * Return the live AWU balance of each free-seat per-user credit on the contract,
- * keyed by the seat's user sId (read from the `DUST_PER_USER_CREDIT_USER` custom
- * field). `balanceAwu` is the amount remaining now; `startingBalanceAwu` is the
- * full granted allocation (the access-schedule total). Per-user credits aren't
- * seat balances, so they don't appear in `listMetronomeSeatBalances` — this is
- * how the seat↔pool/capped state for free seats reads their remaining balance.
- *
- * `covering_date` defaults to now and archived credits are excluded, so the
- * balance reflects only the currently-active credit.
- *
- * Uses the credits-list endpoint (not `listBalances`) so Metronome returns only
- * credits, not commits.
+ * Return the live AWU balance of each free-seat per-user customer credit, keyed
+ * by user sId (from the `DUST_PER_USER_CREDIT_USER` custom field). Only active
+ * (not yet expired or archived) credits are included.
  */
-export async function listContractPerUserCreditBalances({
+export async function listCustomerPerUserCreditBalances({
   metronomeCustomerId,
-  metronomeContractId,
   contractCreditType,
 }: {
   metronomeCustomerId: string;
-  metronomeContractId: string;
   contractCreditType: ContractCreditType;
 }): Promise<
   Result<
@@ -2718,9 +2648,6 @@ export async function listContractPerUserCreditBalances({
   const client = getMetronomeClient();
 
   try {
-    // A user could in theory hold more than one per-user credit of the same type
-    // on a contract, so we accumulate a list of credit ids and sum their
-    // balances per user.
     const byUser = new Map<
       string,
       { creditIds: string[]; balanceAwu: number; startingBalanceAwu: number }
@@ -2728,9 +2655,8 @@ export async function listContractPerUserCreditBalances({
     for await (const entry of client.v1.customers.credits.list({
       customer_id: metronomeCustomerId,
       include_balance: true,
-      include_contract_credits: true,
     })) {
-      if (entry.contract?.id !== metronomeContractId) {
+      if (entry.contract) {
         continue;
       }
       const userId =
@@ -2738,8 +2664,6 @@ export async function listContractPerUserCreditBalances({
       if (!userId) {
         continue;
       }
-      // Only the requested credit type — a per-user credit of another type must
-      // not be counted here (nor archived by the revoke path).
       if (
         entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
         contractCreditType
@@ -2761,49 +2685,29 @@ export async function listContractPerUserCreditBalances({
   } catch (err) {
     const error = normalizeError(err);
     logger.error(
-      { error, metronomeCustomerId, metronomeContractId },
-      "[Metronome] Failed to list per-user contract credit balances"
+      { error, metronomeCustomerId },
+      "[Metronome] Failed to list per-user customer credit balances"
     );
     return new Err(error);
   }
 }
 
 /**
- * Archive a contract credit (e.g. a free-seat per-user credit when the user
- * leaves the free seat) so it stops drawing against usage. This is a fresh
- * `v2.contracts.edit` with no `uniqueness_key`, so it does NOT release the
- * original grant edit's key — the user can never re-claim a free credit on this
- * contract (re-grant 409/422s, and the archived credit still satisfies the
- * dedup check).
+ * Revoke a per-user customer credit by setting its end date to now. The
+ * uniqueness key is untouched so the user can never re-claim the same credit.
  */
-export async function archiveContractCredit({
+export async function revokePerUserCustomerCredit({
   metronomeCustomerId,
-  metronomeContractId,
   creditId,
 }: {
   metronomeCustomerId: string;
-  metronomeContractId: string;
   creditId: string;
-}): Promise<Result<undefined, Error>> {
-  try {
-    await getMetronomeClient().v2.contracts.edit({
-      customer_id: metronomeCustomerId,
-      contract_id: metronomeContractId,
-      archive_credits: [{ id: creditId }],
-    });
-    logger.info(
-      { metronomeCustomerId, metronomeContractId, creditId },
-      "[Metronome] Archived contract credit"
-    );
-    return new Ok(undefined);
-  } catch (err) {
-    const error = normalizeError(err);
-    logger.error(
-      { error, metronomeCustomerId, metronomeContractId, creditId },
-      "[Metronome] Failed to archive contract credit"
-    );
-    return new Err(error);
-  }
+}): Promise<Result<void, Error>> {
+  return updateMetronomeCreditEndDate({
+    metronomeCustomerId,
+    creditId,
+    accessEndingBefore: new Date().toISOString(),
+  });
 }
 
 /**

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -11,7 +11,7 @@
 // reconcile module back.
 
 import {
-  listContractPerUserCreditBalances,
+  listCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
 import {
@@ -94,42 +94,39 @@ export async function fetchLiveUserCreditInputs({
   // contract credit instead (not a seat balance), so read that.
   let seatBalanceAwu: number | null = null;
   let seatStartingBalanceAwu: number | null = null;
-  if (metronomeContractId) {
-    if (seatType === "free") {
-      const creditBalancesResult = await listContractPerUserCreditBalances({
-        metronomeCustomerId,
-        metronomeContractId,
-        contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
-      });
-      if (creditBalancesResult.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to read per-user credit balances: ${creditBalancesResult.error.message}`
-          )
-        );
-      }
-      const credit = creditBalancesResult.value.get(userId);
-      if (credit) {
-        seatBalanceAwu = credit.balanceAwu;
-        seatStartingBalanceAwu = credit.startingBalanceAwu;
-      }
-    } else {
-      const seatBalancesResult = await listMetronomeSeatBalances({
-        metronomeCustomerId,
-        metronomeContractId,
-      });
-      if (seatBalancesResult.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to read seat balances: ${seatBalancesResult.error.message}`
-          )
-        );
-      }
-      const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
-      if (seat) {
-        seatBalanceAwu = seat.balanceAwu;
-        seatStartingBalanceAwu = seat.startingBalanceAwu;
-      }
+  if (seatType === "free") {
+    const creditBalancesResult = await listCustomerPerUserCreditBalances({
+      metronomeCustomerId,
+      contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+    });
+    if (creditBalancesResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to read per-user credit balances: ${creditBalancesResult.error.message}`
+        )
+      );
+    }
+    const credit = creditBalancesResult.value.get(userId);
+    if (credit) {
+      seatBalanceAwu = credit.balanceAwu;
+      seatStartingBalanceAwu = credit.startingBalanceAwu;
+    }
+  } else if (metronomeContractId) {
+    const seatBalancesResult = await listMetronomeSeatBalances({
+      metronomeCustomerId,
+      metronomeContractId,
+    });
+    if (seatBalancesResult.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to read seat balances: ${seatBalancesResult.error.message}`
+        )
+      );
+    }
+    const seat = awuSeatBalanceForUser(seatBalancesResult.value, userId);
+    if (seat) {
+      seatBalanceAwu = seat.balanceAwu;
+      seatStartingBalanceAwu = seat.startingBalanceAwu;
     }
   }
 

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -3,17 +3,17 @@ import {
   upsertPerUserCreditBalanceAlerts,
 } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import {
-  addPerUserCreditToContract,
+  addPerUserCreditToCustomer,
   adjustSeatCreditBalances,
-  archiveContractCredit,
   findSeatCreditSegmentForPeriod,
   getMetronomeContractById,
   getMetronomeSeatActiveSince,
   getMetronomeSubscriptionAssignedSeatIds,
   getMetronomeSubscriptionSeatState,
-  listContractPerUserCreditBalances,
-  listContractPerUserCreditUserIds,
+  listCustomerPerUserCreditBalances,
+  listCustomerPerUserCreditUserIds,
   listMetronomeSeatBalances,
+  revokePerUserCustomerCredit,
   updateSubscriptionQuantity,
   updateSubscriptionSeats,
 } from "@app/lib/metronome/client";
@@ -57,7 +57,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
-import { addYears } from "date-fns";
 
 /**
  * Returns true if the contract is seat-billed (any subscription should be
@@ -510,29 +509,27 @@ export async function remapMembershipSeatTypesForContract({
 // The free seat AWU grant is anchored on per-seat first-appearance, not on a
 // recurring schedule: a recurring INDIVIDUAL credit either refills every period
 // or closes its issuance window, so it can't grant "once per seat, ever,
-// whenever the seat is assigned". Instead we grant a standalone contract credit
+// whenever the seat is assigned". Instead we grant a standalone customer credit
 // scoped to the user via a `user_id` presentation specifier, idempotent on
-// (workspaceId, userId), valid for one year from the grant.
+// (workspaceId, userId). Customer credits survive contract transitions
+// automatically — no carry-over needed, no expiry.
 //
 // `syncSeatCount` runs on every membership change and reconciles full state, so
 // it calls this for ALL currently-free users on each sync. We first list the
-// contract's existing per-user credits and skip users already granted — so a
-// steady-state sync makes a single read instead of one edit call per free user.
+// customer's existing per-user credits and skip users already granted — so a
+// steady-state sync makes a single read instead of one API call per free user.
 // The grant's `uniqueness_key` still guards against double-granting on the race
 // between the read and a concurrent sync (a 409 returns `Ok(null)`). Listing
-// includes expired/archived credits so a lapsed grant is not re-issued. This
-// self-heals a grant that failed on a previous sync — a delta-only grant could
-// miss a user permanently once their seat is assigned. Best-effort: a failure
-// is logged but never fails (and retries) the seat reconciliation.
+// includes archived credits so a past grant is not re-issued. This self-heals a
+// grant that failed on a previous sync. Best-effort: a failure is logged but
+// never fails (and retries) the seat reconciliation.
 async function grantFreeSeatCredits({
   metronomeCustomerId,
-  contractId,
   workspaceId,
   userIds,
   startingAt,
 }: {
   metronomeCustomerId: string;
-  contractId: string;
   workspaceId: string;
   userIds: string[];
   startingAt: Date;
@@ -543,15 +540,14 @@ async function grantFreeSeatCredits({
 
   // Skip users that already have a credit. On a read failure we fall back to
   // attempting every user — the grant is still idempotent via its uniqueness
-  // key, so we never double-grant, only make redundant (no-op) edit calls.
-  const alreadyGranted = await listContractPerUserCreditUserIds({
+  // key, so we never double-grant, only make redundant (no-op) API calls.
+  const alreadyGranted = await listCustomerPerUserCreditUserIds({
     metronomeCustomerId,
-    metronomeContractId: contractId,
     creditName: FREE_SEAT_CREDIT_NAME,
   });
   if (alreadyGranted.isErr()) {
     logger.warn(
-      { workspaceId, contractId, error: alreadyGranted.error },
+      { workspaceId, error: alreadyGranted.error },
       "[Metronome] Could not list existing free seat credits; attempting all grants (idempotent)"
     );
   }
@@ -564,9 +560,8 @@ async function grantFreeSeatCredits({
   await concurrentExecutor(
     toGrant,
     async (userId) => {
-      const result = await addPerUserCreditToContract({
+      const result = await addPerUserCreditToCustomer({
         metronomeCustomerId,
-        metronomeContractId: contractId,
         productId: getProductSeatSubscriptionCreditsId(),
         creditTypeId: getCreditTypeAwuId(),
         contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
@@ -574,18 +569,16 @@ async function grantFreeSeatCredits({
         userId,
         productTags: [USAGE_TAG],
         startingAt,
-        endingBefore: addYears(startingAt, 1),
         name: FREE_SEAT_CREDIT_NAME,
         priority: AWU_PRIORITY_FREE_SEAT_CREDIT,
-        // Scope the key to the contract, not just the workspace+user: each
-        // contract holds its own credit, so a switch-contract must be able to
-        // grant a fresh credit on the new contract. A workspace+user key would
-        // collide with the prior contract's grant and 422.
-        uniquenessKey: `free-seat-credit:${contractId}:${userId}`,
+        // Workspace+user scoped: customer credits survive across contracts, so
+        // there is no need to scope per-contract. A given user in a workspace
+        // gets exactly one lifetime free credit regardless of contract changes.
+        uniquenessKey: `free-seat-credit:${workspaceId}:${userId}`,
       });
       if (result.isErr()) {
         logger.error(
-          { workspaceId, contractId, userId, error: result.error },
+          { workspaceId, userId, error: result.error },
           "[Metronome] Failed to grant free seat credit"
         );
       }
@@ -610,7 +603,7 @@ async function grantFreeSeatCredits({
       });
       if (alertResult.isErr()) {
         logger.error(
-          { workspaceId, contractId, userId, error: alertResult.error },
+          { workspaceId, userId, error: alertResult.error },
           "[Metronome] Failed to upsert per-user free credit alerts"
         );
       }
@@ -620,29 +613,26 @@ async function grantFreeSeatCredits({
 }
 
 // Revoke free-seat credits for users who once had one but are no longer on a
-// free seat (e.g. upgraded to pro): archive the now-stale credit so it stops
-// drawing against their usage, and drop its low/empty alerts. The grant's
-// uniqueness key is left untouched (archive is a separate edit), so the user can
-// never re-claim a free credit on this contract. Best-effort; runs each sync.
+// free seat (e.g. upgraded to pro): end the credit early so it stops drawing
+// against their usage, and drop its low/empty alerts. The grant's uniqueness key
+// is untouched so the user can never re-claim the same credit. Best-effort; runs
+// each sync.
 async function revokeFreeSeatCreditsForExFreeUsers({
   metronomeCustomerId,
-  contractId,
   workspaceId,
   currentFreeUserIds,
 }: {
   metronomeCustomerId: string;
-  contractId: string;
   workspaceId: string;
   currentFreeUserIds: Set<string>;
 }): Promise<void> {
-  const activeCreditsResult = await listContractPerUserCreditBalances({
+  const activeCreditsResult = await listCustomerPerUserCreditBalances({
     metronomeCustomerId,
-    metronomeContractId: contractId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
   if (activeCreditsResult.isErr()) {
     logger.warn(
-      { workspaceId, contractId, error: activeCreditsResult.error },
+      { workspaceId, error: activeCreditsResult.error },
       "[Metronome] Could not list per-user credits to revoke; skipping"
     );
     return;
@@ -658,21 +648,14 @@ async function revokeFreeSeatCreditsForExFreeUsers({
     toRevoke,
     async ([userId, { creditIds }]) => {
       for (const creditId of creditIds) {
-        const archiveResult = await archiveContractCredit({
+        const revokeResult = await revokePerUserCustomerCredit({
           metronomeCustomerId,
-          metronomeContractId: contractId,
           creditId,
         });
-        if (archiveResult.isErr()) {
+        if (revokeResult.isErr()) {
           logger.error(
-            {
-              workspaceId,
-              contractId,
-              userId,
-              creditId,
-              error: archiveResult.error,
-            },
-            "[Metronome] Failed to archive ex-free-seat credit"
+            { workspaceId, userId, creditId, error: revokeResult.error },
+            "[Metronome] Failed to revoke ex-free-seat credit"
           );
         }
       }
@@ -683,7 +666,7 @@ async function revokeFreeSeatCreditsForExFreeUsers({
       });
       if (clearResult.isErr()) {
         logger.error(
-          { workspaceId, contractId, userId, error: clearResult.error },
+          { workspaceId, userId, error: clearResult.error },
           "[Metronome] Failed to clear ex-free-seat credit alerts"
         );
       }
@@ -1508,14 +1491,12 @@ export async function syncSeatCount({
     const currentFreeUserIds = new Set(desiredSIdsAt("free", baseMs));
     await grantFreeSeatCredits({
       metronomeCustomerId,
-      contractId,
       workspaceId: workspace.sId,
       userIds: [...currentFreeUserIds],
       startingAt: new Date(baseMs),
     });
     await revokeFreeSeatCreditsForExFreeUsers({
       metronomeCustomerId,
-      contractId,
       workspaceId: workspace.sId,
       currentFreeUserIds,
     });

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -16,7 +16,7 @@ const {
   mockListPerUserCreditUserIds,
   mockListPerUserCreditBalances,
   mockAddPerUserCredit,
-  mockArchiveContractCredit,
+  mockRevokePerUserCustomerCredit,
   mockUpsertPerUserCreditAlerts,
   mockClearPerUserCreditAlerts,
   mockListSeatBalances,
@@ -32,7 +32,7 @@ const {
   mockListPerUserCreditUserIds: vi.fn(),
   mockListPerUserCreditBalances: vi.fn(),
   mockAddPerUserCredit: vi.fn(),
-  mockArchiveContractCredit: vi.fn(),
+  mockRevokePerUserCustomerCredit: vi.fn(),
   mockUpsertPerUserCreditAlerts: vi.fn(),
   mockClearPerUserCreditAlerts: vi.fn(),
   mockListSeatBalances: vi.fn(),
@@ -45,10 +45,10 @@ vi.mock("@app/lib/metronome/client", () => ({
   updateSubscriptionSeats: mockUpdateSubscriptionSeats,
   getMetronomeSubscriptionSeatState: mockGetSeatState,
   getMetronomeSubscriptionAssignedSeatIds: mockGetAssignedSeatIds,
-  listContractPerUserCreditUserIds: mockListPerUserCreditUserIds,
-  listContractPerUserCreditBalances: mockListPerUserCreditBalances,
-  addPerUserCreditToContract: mockAddPerUserCredit,
-  archiveContractCredit: mockArchiveContractCredit,
+  listCustomerPerUserCreditUserIds: mockListPerUserCreditUserIds,
+  listCustomerPerUserCreditBalances: mockListPerUserCreditBalances,
+  addPerUserCreditToCustomer: mockAddPerUserCredit,
+  revokePerUserCustomerCredit: mockRevokePerUserCustomerCredit,
   // Seat-credit transfer path (no-op in these tests: empty balances ⇒ no
   // transfers ⇒ the segment-find / adjust helpers are never reached).
   listMetronomeSeatBalances: mockListSeatBalances,
@@ -117,7 +117,7 @@ describe("syncSeatCount min clamping", () => {
     mockListPerUserCreditUserIds.mockResolvedValue(new Ok(new Set()));
     mockListPerUserCreditBalances.mockResolvedValue(new Ok(new Map()));
     mockAddPerUserCredit.mockResolvedValue(new Ok(null));
-    mockArchiveContractCredit.mockResolvedValue(new Ok(undefined));
+    mockRevokePerUserCustomerCredit.mockResolvedValue(new Ok(undefined));
     mockUpsertPerUserCreditAlerts.mockResolvedValue(new Ok(undefined));
     mockClearPerUserCreditAlerts.mockResolvedValue(new Ok(undefined));
     // No seat balances / assignments ⇒ the credit-transfer reconciliation

--- a/front/scripts/metronome_setup.ts
+++ b/front/scripts/metronome_setup.ts
@@ -1472,7 +1472,7 @@ const CUSTOM_FIELD_KEYS: Array<{
     key: CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   },
   // Stamped per-instance on each free-seat per-user credit, carrying the seat's
-  // user sId (see `addPerUserCreditToContract`). Lets a per-user
+  // user sId (see `addPerUserCreditToCustomer`). Lets a per-user
   // `low_remaining_contract_credit_balance_reached` alert filter on the
   // custom field (the only filter a credit-balance alert supports — presentation
   // specifiers can't be filtered) so it fires as each free user depletes their


### PR DESCRIPTION
## Description

Switch per-seat free credits from contract-level to customer-level in Metronome.

Previously, free seat credits were created via `v2.contracts.edit` (contract-level). This meant:
- Credits were tied to a specific contract and did not survive contract transitions
- Renewals required re-granting fresh credits (losing remaining balance from the old contract)
- The complex `carryOverContractBalancesOnRenewal` mechanism was needed to preserve balances

Customer-level credits (`v1.customers.credits.create`) survive all contract transitions automatically. The filtering/specifier/alert mechanism is identical — Metronome's `ContractCredit` entity type applies to customer credits too.

**Changes:**
- `client.ts`: Add `addPerUserCreditToCustomer`, `listCustomerPerUserCreditUserIds`, `listCustomerPerUserCreditBalances`, `revokePerUserCustomerCredit`; remove the four old contract-scoped equivalents
- `seats.ts`: `grantFreeSeatCredits` and `revokeFreeSeatCreditsForExFreeUsers` drop `contractId`, use customer credit functions; uniqueness key is now `free-seat-credit:{workspaceId}:{userId}` (workspace-scoped, survives contracts); credit window is 5 years instead of 1 year
- `live_user_credit_inputs.ts`, `members_usage.ts`, `reconcile_credit_state.ts`: switch to `listCustomerPerUserCreditBalances`, removing the `metronomeContractId` dependency from the free-seat balance reads

## Tests

Tested manually. No unit test changes needed — the behavior is the same, only the Metronome API endpoint changes.

## Risk

Low. The new pricing / AWU contracts have no real customers yet (test-only). Existing contract credits on any test contracts will expire naturally; new grants will be customer-level from next seat sync.

The uniqueness key changes from `free-seat-credit:{contractId}:{userId}` to `free-seat-credit:{workspaceId}:{userId}`, so old contract-credit uniqueness keys do not conflict with the new customer-credit grants.

## Deploy Plan

Standard deploy. No migration needed — the next seat sync for each workspace will grant customer-level credits to all current free seat users.