### PR TITLE
feat(front): opt into Anthropic prompt-cache diagnostics to surface cache-miss reasons

### DIFF
--- a/front/lib/api/llm/cache_diagnostics.ts
+++ b/front/lib/api/llm/cache_diagnostics.ts
@@ -1,0 +1,73 @@
+import { runOnRedisCache } from "@app/lib/api/redis";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Anthropic prompt-cache diagnostics need the previous response id to compare
+// consecutive requests. We stash it in Redis (not a Temporal workflow variable,
+// which dies with the workflow, nor the DB, which outlives the data's usefulness)
+// keyed by conversation and agent so the chain survives across agent-loop steps
+// and across user turns (each turn is a fresh workflow). The short TTL matches
+// the lifetime of Anthropic's diagnostics fingerprint and the prompt cache
+// itself: once it expires, the previous id is worthless anyway, so we stop
+// sending it and the key cleans itself up. Sunsetting the feature needs no
+// migration: flip the flag off and the keys expire on their own.
+const CACHE_DIAGNOSTICS_TTL_SECONDS = 600;
+
+function makeCacheDiagnosticsKey({
+  conversationId,
+  agentConfigurationId,
+}: {
+  conversationId: string;
+  agentConfigurationId: string;
+}): string {
+  // Include the agent so concurrent agents answering in the same conversation
+  // (multiple mentions) keep independent chains instead of clobbering each other.
+  return `cache_diagnostics:${conversationId}:${agentConfigurationId}`;
+}
+
+// Returns the previous LLM call's response id for this conversation and agent,
+// or `null` when there is none yet (or it has expired). `null` is meaningful: it
+// is the opt-in-without-prior value Anthropic expects on the first call.
+//
+// Diagnostics is pure observability, so a Redis failure must never break
+// generation: on error we log and behave as if there were no prior id.
+export async function getPreviousMessageId(key: {
+  conversationId: string;
+  agentConfigurationId: string;
+}): Promise<string | null> {
+  try {
+    return await runOnRedisCache({ origin: "cache_diagnostics" }, (client) =>
+      client.get(makeCacheDiagnosticsKey(key))
+    );
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), ...key },
+      "[cache diagnostics] failed to read previous message id"
+    );
+    return null;
+  }
+}
+
+// Stores this call's response id so the next step or turn can compare against it.
+// Best-effort: a Redis failure is logged and swallowed so it cannot break the
+// agent loop.
+export async function setPreviousMessageId(
+  key: {
+    conversationId: string;
+    agentConfigurationId: string;
+  },
+  modelInteractionId: string
+): Promise<void> {
+  try {
+    await runOnRedisCache({ origin: "cache_diagnostics" }, (client) =>
+      client.set(makeCacheDiagnosticsKey(key), modelInteractionId, {
+        EX: CACHE_DIAGNOSTICS_TTL_SECONDS,
+      })
+    );
+  } catch (err) {
+    logger.warn(
+      { err: normalizeError(err), ...key },
+      "[cache diagnostics] failed to store previous message id"
+    );
+  }
+}

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -54,6 +54,12 @@ const BATCH_PAYLOAD_BUILD_CONCURRENCY = 10;
 // https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback#server-side-fallback
 const SERVER_SIDE_FALLBACK_BETA_HEADER = "server-side-fallback-2026-06-01";
 
+// Opts into prompt-cache diagnostics: the API compares this request's prefix
+// against the one identified by `diagnostics.previous_message_id` and returns a
+// `cache_miss_reason`. Claude API only (not supported on Vertex AI).
+// https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics
+const CACHE_DIAGNOSTICS_BETA_HEADER = "cache-diagnosis-2026-04-07";
+
 // Server-side fallback is a beta param not yet typed by the SDK (0.100.1). We
 // forward it as an extra body param on the streaming request. The list of
 // fallback model ids is driven by modelConfig.fallbackModels, so no fallback
@@ -243,26 +249,40 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     const outputFormat = toOutputFormatParam(this.responseFormat);
     const fallbacks = this.buildFallbacksParam();
 
+    // Prompt-cache diagnostics is Claude API only and is opted into per request
+    // by the caller passing `previousMessageId` (tri-state: undefined = off).
+    // `null` is a valid opt-in value (first call, nothing to compare yet).
+    // NOTE: when model_constructors goes live, this inject must move to its
+    // Anthropic request builder. This older client stack is the one in prod today.
+    const cacheDiagnosticsEnabled =
+      !this.useVertex && streamParameters.previousMessageId !== undefined;
+
     // The fallbacks param is rejected unless the request carries the
     // server-side fallback beta header, so the header is attached here rather
     // than left to customBetas (which could drift out of sync).
-    const betas = fallbacks
-      ? [
-          ...(this.modelConfig.customBetas ?? []),
-          SERVER_SIDE_FALLBACK_BETA_HEADER,
-        ]
-      : this.modelConfig.customBetas;
+    const betas = [
+      ...(this.modelConfig.customBetas ?? []),
+      ...(fallbacks ? [SERVER_SIDE_FALLBACK_BETA_HEADER] : []),
+      ...(cacheDiagnosticsEnabled ? [CACHE_DIAGNOSTICS_BETA_HEADER] : []),
+    ];
 
     const payload: AnthropicStreamPayload = {
       ...basePayload,
       stream: true,
-      betas,
+      betas: betas.length > 0 ? betas : undefined,
       output_config: outputFormat
         ? { ...basePayload.output_config, format: outputFormat }
         : basePayload.output_config,
       // Automatic caching is not supported on Vertex AI; the explicit breakpoints in
       // buildBaseRequestPayload (isFirst and isLast) cover Vertex instead.
       ...(!this.useVertex ? { cache_control: { type: "ephemeral" } } : {}),
+      ...(cacheDiagnosticsEnabled
+        ? {
+            diagnostics: {
+              previous_message_id: streamParameters.previousMessageId,
+            },
+          }
+        : {}),
       model: getModel(this.useVertex, { modelId: this.modelId }),
       ...(fallbacks ? { fallbacks } : {}),
     };

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert";
 import { AnthropicError, APIError } from "@anthropic-ai/sdk";
-import type { BetaRawMessageStreamEvent } from "@anthropic-ai/sdk/resources/beta.mjs";
+import type {
+  BetaMessage,
+  BetaRawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources/beta.mjs";
 import type { MessageBatchResult } from "@anthropic-ai/sdk/resources/messages/batches.mjs";
 import type {
   Message,
@@ -10,6 +13,7 @@ import { validateContentBlockIndex } from "@app/lib/api/llm/clients/anthropic/ut
 import type { StreamState } from "@app/lib/api/llm/clients/anthropic/utils/types";
 import { SuccessAggregate } from "@app/lib/api/llm/types/aggregates";
 import type {
+  CacheMissReason,
   LLMEvent,
   LLMOutputItem,
   ReasoningDeltaEvent,
@@ -35,6 +39,25 @@ import cloneDeep from "lodash/cloneDeep";
 const MAX_EAGER_VALIDATION_INPUT_LENGTH = 5_000;
 const INVALID_JSON_MARKER = "JSON: ";
 const INVALID_TOOL_JSON_NEEDLE = "Unable to parse tool parameter JSON";
+
+// Extract the prompt-cache diagnostics reason from a message_start, when the
+// request opted into diagnostics (beta header + `diagnostics.previous_message_id`).
+// `diagnostics` is null when there was nothing to compare or no divergence.
+// `cache_miss_reason` is null while the background comparison is still pending.
+function toCacheMissReason(message: BetaMessage): CacheMissReason | undefined {
+  const reason = message.diagnostics?.cache_miss_reason;
+  if (!reason) {
+    return undefined;
+  }
+  return {
+    type: reason.type,
+    // Only the `*_changed` reasons carry the lost-cache magnitude.
+    cacheMissedInputTokens:
+      "cache_missed_input_tokens" in reason
+        ? reason.cache_missed_input_tokens
+        : undefined,
+  };
+}
 
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,
@@ -129,6 +152,7 @@ function* handleMessageStreamEvent(
         type: "interaction_id",
         content: {
           modelInteractionId: messageStreamEvent.message.id,
+          cacheMissReason: toCacheMissReason(messageStreamEvent.message),
         },
         metadata,
       };

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -13,7 +13,7 @@ import type {
   BatchResultWithRunIds,
   BatchStatus,
 } from "@app/lib/api/llm/types/batch";
-import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type { LLMEvent, TokenUsage } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
@@ -39,6 +39,36 @@ import { type LangfuseGeneration, startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
 import startCase from "lodash/startCase";
+
+// Emit prompt-cache token magnitudes as Datadog distributions, tagged with the
+// same metricTags as the other llm.* metrics (model_id, inference_provider,
+// operation_type, ...). Slicing cache_creation vs cache_read by these tags
+// surfaces where prefixes are not being reused: a high cache_creation relative
+// to cache_read points at prefixes that keep changing between calls (e.g. tools
+// or system varying across agent-loop steps), and uncached_input flags traffic
+// that never benefits from caching at all (e.g. Vertex, which lacks automatic
+// caching). This is provider-agnostic: it reports whatever the client populated.
+function trackCacheTokenMetrics(
+  tokenUsage: TokenUsage,
+  metricTags: string[]
+): void {
+  const statsd = getStatsDClient();
+  statsd.distribution(
+    "llm.cache_read_tokens",
+    tokenUsage.cachedTokens ?? 0,
+    metricTags
+  );
+  statsd.distribution(
+    "llm.cache_creation_tokens",
+    tokenUsage.cacheCreationTokens ?? 0,
+    metricTags
+  );
+  statsd.distribution(
+    "llm.uncached_input_tokens",
+    tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
+    metricTags
+  );
+}
 
 export abstract class LLM<TPayload = unknown> {
   protected modelId: ModelIdType;
@@ -205,6 +235,10 @@ export abstract class LLM<TPayload = unknown> {
       `inference_provider:${this.metadata.inferenceProvider}`,
       ...(this.metadata.region ? [`region:${this.metadata.region}`] : []),
       `operation_type:${this.context.operationType}`,
+      // Conditional JIT tools make the tools array (and thus the cached prefix)
+      // vary between calls and downgrade the instructions cache TTL from 1h to
+      // 5min, so we tag it to isolate its impact on the cache_* metrics below.
+      `has_conditional_jit_tools:${streamParameters.hasConditionalJITTools ?? false}`,
     ];
 
     getStatsDClient().increment("llm_interaction.count", 1, metricTags);
@@ -299,6 +333,7 @@ export abstract class LLM<TPayload = unknown> {
         }
 
         if (tokenUsage) {
+          trackCacheTokenMetrics(tokenUsage, metricTags);
           this.generation.update({
             usageDetails: {
               // Report the uncached input tokens if provider supports it.
@@ -623,6 +658,7 @@ export abstract class LLM<TPayload = unknown> {
       }
 
       if (tokenUsage) {
+        trackCacheTokenMetrics(tokenUsage, metricTags);
         generation.update({
           usageDetails: {
             input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -13,7 +13,7 @@ import type {
   BatchResultWithRunIds,
   BatchStatus,
 } from "@app/lib/api/llm/types/batch";
-import type { LLMEvent, TokenUsage } from "@app/lib/api/llm/types/events";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type {
   LLMClientMetadata,
@@ -39,36 +39,6 @@ import { type LangfuseGeneration, startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
 import startCase from "lodash/startCase";
-
-// Emit prompt-cache token magnitudes as Datadog distributions, tagged with the
-// same metricTags as the other llm.* metrics (model_id, inference_provider,
-// operation_type, ...). Slicing cache_creation vs cache_read by these tags
-// surfaces where prefixes are not being reused: a high cache_creation relative
-// to cache_read points at prefixes that keep changing between calls (e.g. tools
-// or system varying across agent-loop steps), and uncached_input flags traffic
-// that never benefits from caching at all (e.g. Vertex, which lacks automatic
-// caching). This is provider-agnostic: it reports whatever the client populated.
-function trackCacheTokenMetrics(
-  tokenUsage: TokenUsage,
-  metricTags: string[]
-): void {
-  const statsd = getStatsDClient();
-  statsd.distribution(
-    "llm.cache_read_tokens",
-    tokenUsage.cachedTokens ?? 0,
-    metricTags
-  );
-  statsd.distribution(
-    "llm.cache_creation_tokens",
-    tokenUsage.cacheCreationTokens ?? 0,
-    metricTags
-  );
-  statsd.distribution(
-    "llm.uncached_input_tokens",
-    tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
-    metricTags
-  );
-}
 
 export abstract class LLM<TPayload = unknown> {
   protected modelId: ModelIdType;
@@ -235,10 +205,6 @@ export abstract class LLM<TPayload = unknown> {
       `inference_provider:${this.metadata.inferenceProvider}`,
       ...(this.metadata.region ? [`region:${this.metadata.region}`] : []),
       `operation_type:${this.context.operationType}`,
-      // Conditional JIT tools make the tools array (and thus the cached prefix)
-      // vary between calls and downgrade the instructions cache TTL from 1h to
-      // 5min, so we tag it to isolate its impact on the cache_* metrics below.
-      `has_conditional_jit_tools:${streamParameters.hasConditionalJITTools ?? false}`,
     ];
 
     getStatsDClient().increment("llm_interaction.count", 1, metricTags);
@@ -333,7 +299,6 @@ export abstract class LLM<TPayload = unknown> {
         }
 
         if (tokenUsage) {
-          trackCacheTokenMetrics(tokenUsage, metricTags);
           this.generation.update({
             usageDetails: {
               // Report the uncached input tokens if provider supports it.
@@ -658,7 +623,6 @@ export abstract class LLM<TPayload = unknown> {
       }
 
       if (tokenUsage) {
-        trackCacheTokenMetrics(tokenUsage, metricTags);
         generation.update({
           usageDetails: {
             input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -10,10 +10,18 @@ export type Text = {
   text: string;
 };
 
+// Prompt-cache diagnostics: why the cache prefix could not be reused vs. the
+// previous request. `type` is the reason. `cacheMissedInputTokens` is the
+// estimated lost-cache magnitude (only present on the `*_changed` reasons).
+export interface CacheMissReason {
+  type: string;
+  cacheMissedInputTokens?: number;
+}
+
 // Provider response identification event
 export interface ResponseIdEvent {
   type: "interaction_id";
-  content: { modelInteractionId: string };
+  content: { modelInteractionId: string; cacheMissReason?: CacheMissReason };
   metadata: LLMClientMetadata;
 }
 

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -139,6 +139,13 @@ export interface LLMStreamParameters {
    */
   forceToolCall?: ForceToolCall;
   omittedThinking?: boolean;
+  /**
+   * Opt into Anthropic prompt-cache diagnostics (Anthropic direct only). Tri-state:
+   * - `undefined`: feature off, send nothing.
+   * - `null`: feature on, first call with no prior to compare against.
+   * - `string`: feature on, the previous response id to compare this request against.
+   */
+  previousMessageId?: string | null;
 }
 
 export interface LLMStreamMetadata {

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -53,6 +53,7 @@ export type RedisUsageTagsType =
   | "agent_recent_authors"
   | "agent_usage"
   | "assistant_generation"
+  | "cache_diagnostics"
   | "cache_with_redis"
   | "cancel_message_generation"
   | "conversation_events"

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -1,7 +1,12 @@
+import {
+  getPreviousMessageId,
+  setPreviousMessageId,
+} from "@app/lib/api/llm/cache_diagnostics";
 import type { LLM } from "@app/lib/api/llm/llm";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
+import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import type {
   GetOutputRequestParams,
@@ -234,6 +239,7 @@ export async function getOutputFromLLMStream(
     modelConversationRes,
     conversation,
     hasConditionalJITTools,
+    cacheDiagnosticsEnabled,
     specifications,
     flushParserTokens,
     contentParser,
@@ -267,12 +273,25 @@ export async function getOutputFromLLMStream(
     return makeLLMTimeoutResponse("activity");
   }
 
+  // Prompt-cache diagnostics: thread the previous step's response id so Anthropic
+  // can report why the cache prefix diverged. Keyed by conversation and agent in
+  // Redis so the chain survives across steps and user turns. `null` (no prior, or
+  // expired) is still a valid opt-in value. `undefined` keeps the feature off.
+  const cacheDiagnosticsKey = {
+    conversationId: conversation.sId,
+    agentConfigurationId: agentConfiguration.sId,
+  };
+  const previousMessageId = cacheDiagnosticsEnabled
+    ? await getPreviousMessageId(cacheDiagnosticsKey)
+    : undefined;
+
   const events = llm.stream(
     {
       conversation: modelConversationRes.value.modelConversation,
       hasConditionalJITTools,
       prompt,
       specifications,
+      previousMessageId,
     },
     {
       conversationId: conversation.sId,
@@ -471,6 +490,32 @@ export async function getOutputFromLLMStream(
           metadata: event.metadata,
         });
         generation += event.content.text;
+      }
+
+      if (event.type === "interaction_id") {
+        if (cacheDiagnosticsEnabled) {
+          const { modelInteractionId, cacheMissReason } = event.content;
+
+          // Store this response id so the next step/turn can compare against it.
+          await setPreviousMessageId(cacheDiagnosticsKey, modelInteractionId);
+
+          if (cacheMissReason) {
+            logger.info(
+              {
+                ...logContext,
+                modelInteractionId,
+                cacheMissReasonType: cacheMissReason.type,
+                cacheMissedInputTokens: cacheMissReason.cacheMissedInputTokens,
+              },
+              "[LLM stream] prompt cache miss"
+            );
+            getStatsDClient().increment("llm.cache_miss_reason.count", 1, [
+              `model_id:${model.modelId}`,
+              `reason:${cacheMissReason.type}`,
+            ]);
+          }
+        }
+        continue;
       }
 
       if (event.type === "token_usage") {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -621,6 +621,9 @@ export async function runModel(
     modelConversationRes,
     conversation,
     hasConditionalJITTools,
+    cacheDiagnosticsEnabled: featureFlags.includes(
+      "anthropic_cache_diagnostics"
+    ),
     userMessage,
     specifications,
     flushParserTokens,

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -40,6 +40,9 @@ export type GetOutputRequestParams = {
   }>;
   conversation: ConversationType;
   hasConditionalJITTools: boolean;
+  // When true, opt this step's Anthropic call into prompt-cache diagnostics and
+  // thread the previous step's response id via Redis (see cache_diagnostics.ts).
+  cacheDiagnosticsEnabled: boolean;
   userMessage: UserMessageType;
   specifications: AgentActionSpecification[];
   flushParserTokens: () => Promise<void>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -16,7 +16,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   anthropic_cache_diagnostics: {
     description:
       "Opt into Anthropic prompt-cache diagnostics to report cache-miss reasons on agent-loop steps",
-    stage: "on_demand",
+    stage: "dust_only",
   },
   use_vertex_for_supported_models: {
     description:

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -13,6 +13,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
+  anthropic_cache_diagnostics: {
+    description:
+      "Opt into Anthropic prompt-cache diagnostics to report cache-miss reasons on agent-loop steps",
+    stage: "on_demand",
+  },
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -701,6 +701,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_shrink_wrap"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
+  | "anthropic_cache_diagnostics"
   | "audit_logs"
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
A large share of our LLM spend rides on prompt caching, almost all of it on Anthropic, and today we can see the magnitude of cache creation versus cache reads but not why a prefix failed to be reused. The billing console tells us a cache miss happened. It never tells us whether the tools array shifted between steps, a timestamp leaked into the system prompt, the history was re-serialized, or the model was swapped by a fallback. Without that, optimizing cache behavior is guesswork.

Anthropic recently shipped a diagnostics capability that closes exactly this gap. When a request opts in and points back at the previous response, the API compares the two prompt prefixes and reports the first point of divergence as a categorical reason (model changed, system changed, tools changed, messages changed, and a couple of inconclusive states). It is best-effort, never blocks or fails the underlying request, and is eligible for zero data retention since it only stores hashes rather than prompt content. The full behavior is documented here: https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics

This change opts into that capability for the agent loop, behind a feature flag and scoped to direct Anthropic traffic (the capability is not available on Vertex, so those requests are excluded). On each model call we now attach the previous response identifier so the API can run the comparison, and we read the reason back off the stream, log it, and emit it as a tagged metric so we can finally slice cache misses by reason and model and see which categories dominate our token burn.

The interesting design question was where to keep that previous response identifier between consecutive calls, and that is why this lands on Redis. The comparison is only meaningful between two calls that are close together in time, because both Anthropic's diagnostics fingerprint and the underlying prompt cache live for a short, ephemeral window. Once that window passes, the previous identifier is worthless. 

Redis with a short time-to-live is the natural fit precisely because the data is ephemeral, mirroring the lifetime of the thing it describes. Keying it by conversation and agent rather than by workflow lets the identifier chain survive both across the steps of one response and across user turns, while keeping concurrent agents in the same conversation independent. The expiry is chosen to track the cache and fingerprint window, so once a comparison can no longer succeed we simply stop sending a stale identifier instead of asking a question we already know will come back empty. It is also disposable in the way the feature itself is: we are not sure we will keep this around forever, and turning it off needs no migration because flipping the flag stops the writes and the keys expire on their own. Throughout, the identifier read and write are treated as pure observability and can never break generation; if Redis is unavailable we log and carry on as if there were no prior call, which matches the best-effort contract of the diagnostics capability itself.

> [!NOTE]
> Testing how it goes and will happily backport to the new constructor approach.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
