### PR TITLE
handle dsync.user.updated inactive state as membership revocation

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -1086,11 +1086,12 @@ async function handleCreateOrUpdateWorkOSUser(
   }
   const workOSUser = workOSUserRes.value;
 
+  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+
   // Entra (and other IdPs) disable users via SCIM PATCH active=false, which WorkOS translates
   // into dsync.user.updated with state='inactive' rather than dsync.user.deleted. Treat this
   // the same as deletion: revoke membership and remove from all groups.
   if (eventData.state === "inactive") {
-    const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
     if (!user) {
       logger.info(
         { workspaceId: workspace.sId, workOSUserId: workOSUser.id },
@@ -1106,8 +1107,6 @@ async function handleCreateOrUpdateWorkOSUser(
     );
     return;
   }
-
-  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
   const externalUser: ExternalUser = {
     email: workOSUser.email,
     email_verified: true,

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -1086,6 +1086,27 @@ async function handleCreateOrUpdateWorkOSUser(
   }
   const workOSUser = workOSUserRes.value;
 
+  // Entra (and other IdPs) disable users via SCIM PATCH active=false, which WorkOS translates
+  // into dsync.user.updated with state='inactive' rather than dsync.user.deleted. Treat this
+  // the same as deletion: revoke membership and remove from all groups.
+  if (eventData.state === "inactive") {
+    const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+    if (!user) {
+      logger.info(
+        { workspaceId: workspace.sId, workOSUserId: workOSUser.id },
+        "Inactive user not found in workspace, skipping revocation"
+      );
+      return;
+    }
+    await revokeWorkOSUserMembership(
+      workspace,
+      user,
+      eventData.directoryId,
+      false
+    );
+    return;
+  }
+
   const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
   const externalUser: ExternalUser = {
     email: workOSUser.email,
@@ -1210,30 +1231,12 @@ async function handleCreateOrUpdateWorkOSUser(
   });
 }
 
-async function handleDeleteWorkOSUser(
+async function revokeWorkOSUserMembership(
   workspace: LightWorkspaceType,
-  event: DsyncUserDeletedEvent
+  user: UserResource,
+  directoryId: string | null | undefined,
+  triggersDeleted: boolean
 ) {
-  const { data: eventData } = event;
-  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
-    workspace,
-    workOSUser: eventData,
-  });
-  if (workOSUserRes.isErr()) {
-    throw workOSUserRes.error;
-  }
-  const workOSUser = workOSUserRes.value;
-
-  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
-  if (!user) {
-    throw new Error(
-      `Did not find user to delete for workOSUserId "${workOSUser.id}" in workspace "${workspace.sId}"`
-    );
-  }
-
-  // Clear WorkOS custom attributes before revoking membership.
-  await clearCustomAttributesFromUserMetadata(user, workspace);
-
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   const groups = await GroupResource.listUserGroupsInWorkspace({
     user,
@@ -1265,7 +1268,7 @@ async function handleDeleteWorkOSUser(
     allowLastAdminRevocation: true,
     auditActor: {
       type: "system",
-      id: String(eventData.directoryId ?? "directory_sync"),
+      id: String(directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
   });
@@ -1273,10 +1276,7 @@ async function handleDeleteWorkOSUser(
   if (membershipRevokeResult.isErr()) {
     if (membershipRevokeResult.error.type === "already_revoked") {
       logger.info(
-        {
-          userId: user.sId,
-          workspaceId: workspace.sId,
-        },
+        { userId: user.sId, workspaceId: workspace.sId },
         "User membership already revoked, skipping"
       );
       return;
@@ -1290,7 +1290,7 @@ async function handleDeleteWorkOSUser(
     action: "scim.user_deprovisioned",
     actor: {
       type: "system",
-      id: String(eventData.directoryId ?? "directory_sync"),
+      id: String(directoryId ?? "directory_sync"),
       name: "Directory Sync",
     },
     targets: [
@@ -1303,10 +1303,42 @@ async function handleDeleteWorkOSUser(
     context: { location: "system" },
     metadata: {
       email: user.email,
-      directory_id: String(eventData.directoryId ?? "unknown"),
-      triggers_deleted: "true",
+      directory_id: String(directoryId ?? "unknown"),
+      triggers_deleted: String(triggersDeleted),
     },
   });
+}
+
+async function handleDeleteWorkOSUser(
+  workspace: LightWorkspaceType,
+  event: DsyncUserDeletedEvent
+) {
+  const { data: eventData } = event;
+  const workOSUserRes = await fetchOrCreateWorkOSUserWithEmail({
+    workspace,
+    workOSUser: eventData,
+  });
+  if (workOSUserRes.isErr()) {
+    throw workOSUserRes.error;
+  }
+  const workOSUser = workOSUserRes.value;
+
+  const user = await UserResource.fetchByWorkOSUserId(workOSUser.id);
+  if (!user) {
+    throw new Error(
+      `Did not find user to delete for workOSUserId "${workOSUser.id}" in workspace "${workspace.sId}"`
+    );
+  }
+
+  // Clear WorkOS custom attributes before revoking membership.
+  await clearCustomAttributesFromUserMetadata(user, workspace);
+
+  await revokeWorkOSUserMembership(
+    workspace,
+    user,
+    eventData.directoryId,
+    true
+  );
 }
 
 async function handleGroupDelete(


### PR DESCRIPTION
## Description

Entra ID (and other IdPs) deprovision users via SCIM `PATCH active=false`, which WorkOS translates into a `dsync.user.updated` event with `state='inactive'` instead of a `dsync.user.deleted` event. Previously, this path was handled as a regular user update, so deactivated users remained active members in Dust.

This PR adds an early-exit check in `handleCreateOrUpdateWorkOSUser`: when `eventData.state === "inactive"`, membership is revoked immediately (groups removed + workspace membership revoked), treating the event the same as a `dsync.user.deleted`. The shared revocation logic is extracted into a new `revokeWorkOSUserMembership` helper used by both code paths. The audit log `triggers_deleted` field is also fixed to correctly reflect `false` for deactivation-triggered revocations vs. `true` for actual deletions.

## Tests

Manually tested. The flow is exercised through the WorkOS Temporal activity path.

## Risk

Low. Only affects users with `state === 'inactive'` on a `dsync.user.updated` event, which were previously silently ignored. No schema migration.

## Deploy Plan

Deploy front.