### PR TITLE
Upg: switch to a flat result list when searching in a datasource.

### DIFF
--- a/front/components/InfiniteScroll.tsx
+++ b/front/components/InfiniteScroll.tsx
@@ -1,5 +1,6 @@
+import { useSheetViewport } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { IntersectionOptions } from "react-intersection-observer";
 import { useInView } from "react-intersection-observer";
 
@@ -11,10 +12,32 @@ export type InfiniteScrollProps = {
   options?: IntersectionOptions;
 };
 
+function getBottomRootMargin(rootMargin?: string): number {
+  if (!rootMargin) {
+    return 0;
+  }
+
+  const parts = rootMargin.trim().split(/\s+/);
+  if (parts.length === 1) {
+    return Number.parseFloat(parts[0]) || 0;
+  }
+  if (parts.length === 4) {
+    return Number.parseFloat(parts[2]) || 0;
+  }
+
+  return 0;
+}
+
+function isScrollContainer(
+  root: IntersectionObserverInit["root"]
+): root is HTMLElement {
+  return root instanceof HTMLElement && root.isConnected;
+}
+
 /**
- * The sentinel div has 1px height becase when you zoom out the container can have a fractional pixel
- * and if it happens browsers will round it to determine the maximum scrollable position and you will not reach out
- * the bottom of the container if the element height is 0px.
+ * Infinite scroll helper. When `options.root` is a scroll container, uses scroll
+ * position (reliable with Radix ScrollArea). Otherwise falls back to an
+ * intersection observer sentinel.
  */
 export const InfiniteScroll = ({
   nextPage,
@@ -23,17 +46,74 @@ export const InfiniteScroll = ({
   loader,
   options,
 }: InfiniteScrollProps) => {
-  const { ref, inView } = useInView(options);
+  const sheetViewport = useSheetViewport();
+  const scrollRootCandidate = options?.root ?? sheetViewport;
+  const scrollRoot = isScrollContainer(scrollRootCandidate)
+    ? scrollRootCandidate
+    : null;
+  const bottomMargin = getBottomRootMargin(
+    typeof options?.rootMargin === "string" ? options.rootMargin : undefined
+  );
+
+  const nextPageRef = useRef(nextPage);
+  nextPageRef.current = nextPage;
+
+  const hasMoreRef = useRef(hasMore);
+  hasMoreRef.current = hasMore;
+
+  const checkScrollPosition = useCallback(() => {
+    if (!scrollRoot || !hasMoreRef.current) {
+      return;
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollRoot;
+    if (scrollHeight - scrollTop - clientHeight <= bottomMargin) {
+      void nextPageRef.current();
+    }
+  }, [scrollRoot, bottomMargin]);
 
   useEffect(() => {
-    if (inView && hasMore) {
-      void nextPage();
+    if (!scrollRoot) {
+      return;
     }
-  }, [inView, hasMore, nextPage]);
+
+    scrollRoot.addEventListener("scroll", checkScrollPosition, {
+      passive: true,
+    });
+
+    const resizeObserver = new ResizeObserver(() => {
+      checkScrollPosition();
+    });
+    resizeObserver.observe(scrollRoot);
+    const content = scrollRoot.firstElementChild;
+    if (content) {
+      resizeObserver.observe(content);
+    }
+
+    checkScrollPosition();
+
+    return () => {
+      scrollRoot.removeEventListener("scroll", checkScrollPosition);
+      resizeObserver.disconnect();
+    };
+  }, [scrollRoot, checkScrollPosition]);
+
+  // Intersection observer sentinel — only used when there is no explicit scroll root,
+  // because IntersectionObserver is unreliable inside Radix ScrollArea viewports.
+  const { ref, inView } = useInView(scrollRoot ? undefined : options);
+
+  useEffect(() => {
+    if (scrollRoot) {
+      return;
+    }
+    if (inView && hasMoreRef.current) {
+      void nextPageRef.current();
+    }
+  }, [scrollRoot, inView]);
 
   return (
     <>
-      {hasMore && <div ref={ref} className="h-px" />}
+      {!scrollRoot && hasMore && <div ref={ref} className="h-px shrink-0" />}
       {showLoader && loader}
     </>
   );

--- a/front/components/InfiniteScroll.tsx
+++ b/front/components/InfiniteScroll.tsx
@@ -61,16 +61,23 @@ export const InfiniteScroll = ({
   const hasMoreRef = useRef(hasMore);
   hasMoreRef.current = hasMore;
 
+  const scrollRootRef = useRef(scrollRoot);
+  scrollRootRef.current = scrollRoot;
+
+  const bottomMarginRef = useRef(bottomMargin);
+  bottomMarginRef.current = bottomMargin;
+
   const checkScrollPosition = useCallback(() => {
-    if (!scrollRoot || !hasMoreRef.current) {
+    const root = scrollRootRef.current;
+    if (!root || !hasMoreRef.current) {
       return;
     }
 
-    const { scrollTop, scrollHeight, clientHeight } = scrollRoot;
-    if (scrollHeight - scrollTop - clientHeight <= bottomMargin) {
+    const { scrollTop, scrollHeight, clientHeight } = root;
+    if (scrollHeight - scrollTop - clientHeight <= bottomMarginRef.current) {
       void nextPageRef.current();
     }
-  }, [scrollRoot, bottomMargin]);
+  }, []);
 
   useEffect(() => {
     if (!scrollRoot) {

--- a/front/components/data_source_view/DataSourceSelectionSearchResults.tsx
+++ b/front/components/data_source_view/DataSourceSelectionSearchResults.tsx
@@ -1,0 +1,449 @@
+import type { ItemSelectionState } from "@app/components/data_source_view/update_selection";
+import { InfiniteScroll } from "@app/components/InfiniteScroll";
+import { NodePathTooltip } from "@app/components/NodePathTooltip";
+import { useCursorPaginationForDataTable } from "@app/hooks/useCursorPaginationForDataTable";
+import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
+import {
+  getViewTypeForURLNodeCandidateAccountingForNotion,
+  isNodeCandidate,
+  isUrlCandidate,
+} from "@app/lib/connectors";
+import {
+  getLocationForDataSourceViewContentNode,
+  getVisualForDataSourceViewContentNode,
+} from "@app/lib/content_nodes";
+import { getDisplayTitleForDataSourceViewContentNode } from "@app/lib/providers/content_nodes_display";
+import { useSpacesSearch } from "@app/lib/swr/spaces";
+import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
+import type { SearchWarningCode } from "@app/types/core/core_api";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewType,
+} from "@app/types/data_source_view";
+import type { SpaceType } from "@app/types/space";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  AnimatedText,
+  Button,
+  Checkbox,
+  ContentMessage,
+  cn,
+  Icon,
+  InfoCircle,
+  Separator,
+  Spinner,
+  useSheetViewport,
+} from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const PAGE_SIZE = 25;
+
+export type SearchResultsLayoutParts = {
+  warning: ReactNode;
+  summary: ReactNode;
+  list: ReactNode;
+};
+
+interface DataSourceSelectionSearchResultsProps {
+  owner: LightWorkspaceType;
+  space: SpaceType;
+  dataSourceViews: DataSourceViewType[];
+  viewType: ContentNodesViewType;
+  allowAdminSearch?: boolean;
+  searchQuery: string;
+  nodeOrUrlCandidate: UrlCandidate | NodeCandidate | null;
+  filterTranscriptsProcessing?: boolean;
+  selectionMode: "checkbox" | "radio";
+  getItemSelectionState: (
+    item: DataSourceViewContentNode
+  ) => ItemSelectionState;
+  isItemCheckboxDisabled: (item: DataSourceViewContentNode) => boolean;
+  onToggleSelection: (item: DataSourceViewContentNode) => void;
+  onSelectAll?: () => void;
+  displaySelectAllButton?: boolean;
+  renderLayout?: (parts: SearchResultsLayoutParts) => ReactNode;
+}
+
+function SearchWarningMessage({
+  warningCode,
+}: {
+  warningCode: SearchWarningCode;
+}) {
+  switch (warningCode) {
+    case "truncated-query-clauses":
+      return (
+        <ContentMessage
+          title="Search results are partial due to the large amount of data."
+          variant="golden"
+          icon={InfoCircle}
+          className="w-full"
+          size="lg"
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+function SearchResultRow({
+  node,
+  owner,
+  selectionMode,
+  selectionState,
+  checkboxDisabled,
+  onToggleSelection,
+}: {
+  node: DataSourceViewContentNode;
+  owner: LightWorkspaceType;
+  selectionMode: "checkbox" | "radio";
+  selectionState: ItemSelectionState;
+  checkboxDisabled: boolean;
+  onToggleSelection: (item: DataSourceViewContentNode) => void;
+}) {
+  const Visual = getVisualForDataSourceViewContentNode(node);
+  const location =
+    node.dataSourceView.category === "folder"
+      ? node.dataSourceView.dataSource.name
+      : getLocationForDataSourceViewContentNode(node);
+
+  return (
+    <NodePathTooltip node={node} owner={owner}>
+      <div
+        role="button"
+        tabIndex={checkboxDisabled ? -1 : 0}
+        aria-disabled={checkboxDisabled}
+        onClick={() => {
+          if (!checkboxDisabled) {
+            onToggleSelection(node);
+          }
+        }}
+        onKeyDown={(event) => {
+          if (
+            !checkboxDisabled &&
+            (event.key === "Enter" || event.key === " ")
+          ) {
+            event.preventDefault();
+            onToggleSelection(node);
+          }
+        }}
+        className={cn(
+          "flex w-full items-center gap-3 p-3 text-left hover:bg-muted/60 hover:dark:bg-muted/10",
+          checkboxDisabled ? "cursor-default" : "cursor-pointer"
+        )}
+      >
+        <Checkbox
+          checked={selectionState}
+          disabled={checkboxDisabled}
+          className={selectionMode === "radio" ? "rounded-full" : undefined}
+          onCheckedChange={() => onToggleSelection(node)}
+          onClick={(event) => event.stopPropagation()}
+        />
+        <Icon size="sm" visual={Visual} />
+        <div className="min-w-0 flex-1 truncate text-sm text-foreground dark:text-foreground-night">
+          {getDisplayTitleForDataSourceViewContentNode(node, {
+            disambiguate: true,
+          })}
+        </div>
+        <div className="hidden min-w-0 flex-1 truncate text-sm text-muted-foreground dark:text-muted-foreground-night sm:block">
+          {location}
+        </div>
+      </div>
+    </NodePathTooltip>
+  );
+}
+
+function defaultRenderLayout({
+  warning,
+  summary,
+  list,
+}: SearchResultsLayoutParts) {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {warning}
+      {summary}
+      {list}
+    </div>
+  );
+}
+
+function ScrollSearchToTop() {
+  const sheetViewport = useSheetViewport();
+
+  useEffect(() => {
+    sheetViewport?.scrollTo({ top: 0 });
+  }, [sheetViewport]);
+
+  return null;
+}
+
+export function DataSourceSelectionSearchResults({
+  owner,
+  space,
+  dataSourceViews,
+  viewType,
+  allowAdminSearch = false,
+  searchQuery,
+  nodeOrUrlCandidate,
+  filterTranscriptsProcessing = false,
+  selectionMode,
+  getItemSelectionState,
+  isItemCheckboxDisabled,
+  onToggleSelection,
+  onSelectAll,
+  displaySelectAllButton = false,
+  renderLayout = defaultRenderLayout,
+}: DataSourceSelectionSearchResultsProps) {
+  const [accumulatedResults, setAccumulatedResults] = useState<
+    DataSourceViewContentNode[]
+  >([]);
+  const [stableResultsCount, setStableResultsCount] = useState<number | null>(
+    null
+  );
+  const stableHasMoreRef = useRef(false);
+  const isLoadingMoreRef = useRef(false);
+
+  const {
+    cursorPagination,
+    resetPagination,
+    handlePaginationChange,
+    tablePagination,
+  } = useCursorPaginationForDataTable(PAGE_SIZE);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset pagination when search query changes
+  useEffect(() => {
+    resetPagination();
+    setAccumulatedResults([]);
+    setStableResultsCount(null);
+    stableHasMoreRef.current = false;
+  }, [searchQuery, resetPagination]);
+
+  const commonSearchParams = {
+    owner,
+    spaceIds: [space.sId],
+    disabled: !searchQuery,
+    pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
+    dataSourceViewIdsBySpaceId:
+      dataSourceViews.length > 0
+        ? {
+            [space.sId]: dataSourceViews.map((dsv) => dsv.sId),
+          }
+        : undefined,
+    allowAdminSearch,
+  };
+
+  const {
+    searchResultNodes: rawSearchResultNodes,
+    isSearchLoading,
+    isSearchValidating,
+    nextPageCursor,
+    resultsCount,
+    warningCode,
+  } = useSpacesSearch(
+    isNodeCandidate(nodeOrUrlCandidate) && nodeOrUrlCandidate.node
+      ? {
+          ...commonSearchParams,
+          nodeIds: [nodeOrUrlCandidate.node],
+          includeDataSources: false,
+          viewType: getViewTypeForURLNodeCandidateAccountingForNotion(
+            viewType,
+            nodeOrUrlCandidate.node
+          ),
+        }
+      : {
+          ...commonSearchParams,
+          search: searchQuery,
+          searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
+          includeDataSources: true,
+          viewType,
+        }
+  );
+
+  const processedPageResults = useMemo(() => {
+    const processedResults = rawSearchResultNodes.flatMap((node) => {
+      const { dataSourceViews: nodeViews, ...rest } = node;
+      const filteredViews = nodeViews.filter((view) =>
+        dataSourceViews.some((dsv) => dsv.sId === view.sId)
+      );
+      return filteredViews.map((view) => ({
+        ...rest,
+        dataSourceView: view,
+      }));
+    });
+
+    if (filterTranscriptsProcessing) {
+      return processedResults.filter((node) => !node.dataSource.connectorId);
+    }
+
+    return nodeOrUrlCandidate && !isNodeCandidate(nodeOrUrlCandidate)
+      ? processedResults.filter(
+          (node) => node.sourceUrl === nodeOrUrlCandidate.url
+        )
+      : processedResults;
+  }, [
+    rawSearchResultNodes,
+    dataSourceViews,
+    nodeOrUrlCandidate,
+    filterTranscriptsProcessing,
+  ]);
+
+  // Accumulate paginated search results across pages.
+  useEffect(() => {
+    if (tablePagination.pageIndex === 0) {
+      setAccumulatedResults(processedPageResults);
+    } else if (processedPageResults.length > 0) {
+      setAccumulatedResults((prev) => {
+        const existingIds = new Set(
+          prev.map((node) => `${node.dataSourceView.sId}:${node.internalId}`)
+        );
+        const newNodes = processedPageResults.filter(
+          (node) =>
+            !existingIds.has(`${node.dataSourceView.sId}:${node.internalId}`)
+        );
+        return [...prev, ...newNodes];
+      });
+    }
+  }, [processedPageResults, tablePagination.pageIndex]);
+
+  const loadedCount = accumulatedResults.length;
+
+  useEffect(() => {
+    if (resultsCount !== null) {
+      setStableResultsCount(resultsCount);
+    }
+    if (nextPageCursor !== null) {
+      stableHasMoreRef.current = true;
+    } else if (!isSearchValidating) {
+      stableHasMoreRef.current = false;
+    }
+  }, [resultsCount, nextPageCursor, isSearchValidating]);
+
+  const displayResultsCount = resultsCount ?? stableResultsCount;
+  const hasMore =
+    nextPageCursor !== null || (isSearchValidating && stableHasMoreRef.current);
+  const isLoading = isSearchLoading || isSearchValidating;
+  isLoadingMoreRef.current = isSearchValidating;
+  const isSearchPending =
+    searchQuery.length > 0 &&
+    displayResultsCount === null &&
+    loadedCount === 0 &&
+    isLoading;
+
+  const handleLoadMore = useCallback(() => {
+    if (!nextPageCursor || isLoadingMoreRef.current) {
+      return;
+    }
+
+    handlePaginationChange(
+      {
+        pageIndex: tablePagination.pageIndex + 1,
+        pageSize: PAGE_SIZE,
+      },
+      nextPageCursor
+    );
+  }, [nextPageCursor, handlePaginationChange, tablePagination.pageIndex]);
+
+  const summaryLabel = useMemo(() => {
+    if (displayResultsCount === 0 && !isSearchPending) {
+      return "0 results found";
+    }
+
+    const displayTotal = displayResultsCount ?? 0;
+    const resultLabel = displayTotal === 1 ? "result" : "results";
+    const base = `Showing ${loadedCount} of ${displayTotal} ${resultLabel}`;
+    return hasMore ? `${base} · scroll for more` : base;
+  }, [displayResultsCount, hasMore, isSearchPending, loadedCount]);
+
+  const warning = warningCode ? (
+    <SearchWarningMessage warningCode={warningCode} />
+  ) : null;
+
+  const summary = (
+    <div className="flex items-center justify-between text-sm text-muted-foreground dark:text-muted-foreground-night">
+      <span className="min-h-5">
+        {isSearchPending ? (
+          <AnimatedText variant="muted">{summaryLabel}</AnimatedText>
+        ) : (
+          summaryLabel
+        )}
+      </span>
+      {displaySelectAllButton && onSelectAll && loadedCount > 0 && (
+        <Button
+          variant="ghost"
+          size="xs"
+          label="Select all"
+          onClick={onSelectAll}
+        />
+      )}
+    </div>
+  );
+
+  if (displayResultsCount === 0 && !isSearchPending && loadedCount === 0) {
+    return renderLayout({
+      warning,
+      summary: (
+        <div className="text-end text-sm text-muted-foreground dark:text-muted-foreground-night">
+          0 results found
+        </div>
+      ),
+      list: (
+        <div className="flex items-center justify-center p-8 text-center">
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            No matching results found. Try different search terms.
+          </p>
+        </div>
+      ),
+    });
+  }
+
+  const list = (
+    <div
+      className={
+        isSearchPending && loadedCount === 0
+          ? "pointer-events-none opacity-50"
+          : undefined
+      }
+    >
+      <ScrollSearchToTop />
+      <div className="flex items-center gap-3 p-3 text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+        <div className="w-5" />
+        <div className="min-w-0 flex-1">Name</div>
+        <div className="hidden min-w-0 flex-1 truncate sm:block">Location</div>
+      </div>
+      <Separator />
+      {accumulatedResults.map((node) => {
+        const itemId = `${node.dataSourceView.sId}:${node.internalId}`;
+
+        return (
+          <div key={itemId}>
+            <SearchResultRow
+              node={node}
+              owner={owner}
+              selectionMode={selectionMode}
+              selectionState={getItemSelectionState(node)}
+              checkboxDisabled={isItemCheckboxDisabled(node)}
+              onToggleSelection={onToggleSelection}
+            />
+            <Separator />
+          </div>
+        );
+      })}
+      <InfiniteScroll
+        nextPage={handleLoadMore}
+        hasMore={hasMore}
+        showLoader={isLoading && loadedCount > 0}
+        loader={
+          <div className="flex justify-center py-4">
+            <Spinner size="sm" />
+          </div>
+        }
+        options={{
+          rootMargin: "0px 0px 100px 0px",
+          threshold: 0,
+        }}
+      />
+    </div>
+  );
+
+  return renderLayout({ warning, summary, list });
+}

--- a/front/components/data_source_view/DataSourceSelectionSearchResults.tsx
+++ b/front/components/data_source_view/DataSourceSelectionSearchResults.tsx
@@ -20,6 +20,7 @@ import type {
   DataSourceViewContentNode,
   DataSourceViewType,
 } from "@app/types/data_source_view";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -82,6 +83,7 @@ function SearchWarningMessage({
         />
       );
     default:
+      assertNeverAndIgnore(warningCode);
       return null;
   }
 }

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -5,21 +5,22 @@ import type {
   TreeSelectionModelUpdater,
 } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
+import type { SearchResultsLayoutParts } from "@app/components/data_source_view/DataSourceSelectionSearchResults";
+import { DataSourceSelectionSearchResults } from "@app/components/data_source_view/DataSourceSelectionSearchResults";
+import {
+  deselectDescendants,
+  getItemSelectionState,
+  isItemCheckboxDisabled,
+  updateSelection,
+} from "@app/components/data_source_view/update_selection";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import {
-  getViewTypeForURLNodeCandidateAccountingForNotion,
-  isNodeCandidate,
-  isUrlCandidate,
   nodeCandidateFromUrl,
   orderDatasourceViewByImportance,
 } from "@app/lib/connectors";
-import {
-  getLocationForDataSourceViewContentNode,
-  getVisualForDataSourceViewContentNode,
-} from "@app/lib/content_nodes";
 import {
   canBeExpanded,
   getDisplayNameForDataSource,
@@ -31,9 +32,8 @@ import {
 import { getDisplayTitleForDataSourceViewContentNode } from "@app/lib/providers/content_nodes_display";
 import type { UseInfiniteContentNodes } from "@app/lib/swr/data_source_views";
 import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
-import { useSpacesSearch } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
-import type { SearchWarningCode } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type {
   DataSourceViewContentNode,
@@ -42,28 +42,22 @@ import type {
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import { defaultSelectionConfiguration } from "@app/types/data_source_view";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
-import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 import {
   Button,
   CheckDone01,
   CloudArrowLeftRight,
-  cn,
   Folder,
   Globe01,
-  InfoCircle,
-  SearchInputWithPopover,
+  ScrollArea,
+  SearchInput,
+  SheetViewportProvider,
   Tree,
 } from "@dust-tt/sparkle";
-import type { ContentMessageProps } from "@dust-tt/sparkle/dist/esm/components/ContentMessage";
-import cloneDeep from "lodash/cloneDeep";
 import omit from "lodash/omit";
 import type { Dispatch, SetStateAction } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 100;
@@ -174,81 +168,6 @@ const getNodesFromConfig = (
     {}
   );
 
-const updateSelection = ({
-  item,
-  prevState,
-  selectionMode = "checkbox",
-  onlyAdd = false,
-}: {
-  item: DataSourceViewContentNode;
-  prevState: DataSourceViewSelectionConfigurations;
-  selectionMode: "checkbox" | "radio";
-  onlyAdd?: boolean;
-}): DataSourceViewSelectionConfigurations => {
-  const { dataSourceView: dsv } = item;
-  const prevConfig = prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
-
-  const exists = prevConfig.selectedResources.some(
-    (r) => r.internalId === item.internalId
-  );
-
-  if (onlyAdd && exists) {
-    return cloneDeep(prevState);
-  }
-
-  if (item.mimeType === DATA_SOURCE_MIME_TYPE) {
-    return {
-      ...prevState,
-      [dsv.sId]: {
-        ...prevConfig,
-        selectedResources: [],
-        isSelectAll: true,
-      },
-    };
-  }
-
-  if (selectionMode === "radio" && !exists) {
-    return {
-      ...prevState,
-      [dsv.sId]: {
-        ...prevConfig,
-        selectedResources: [
-          {
-            ...item,
-            dataSourceView: dsv,
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            parentInternalIds: item.parentInternalIds || [],
-          },
-        ],
-        isSelectAll: false,
-      },
-    };
-  }
-
-  const newResources = exists
-    ? prevConfig.selectedResources.filter(
-        (r) => r.internalId !== item.internalId
-      )
-    : [
-        ...prevConfig.selectedResources,
-        {
-          ...item,
-          dataSourceView: dsv,
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          parentInternalIds: item.parentInternalIds || [],
-        },
-      ];
-
-  return {
-    ...prevState,
-    [dsv.sId]: {
-      ...prevConfig,
-      selectedResources: newResources,
-      isSelectAll: false,
-    },
-  };
-};
-
 const applySelectionConfigUpdate = ({
   prevState,
   dataSourceView,
@@ -299,6 +218,8 @@ interface DataSourceViewsSelectorProps {
   selectionMode?: "checkbox" | "radio";
   allowAdminSearch?: boolean;
   useContentNodes?: UseInfiniteContentNodes;
+  fixedSearchLayout?: boolean;
+  focusSearchOnOpen?: boolean;
 }
 
 export function DataSourceViewsSelector({
@@ -313,14 +234,14 @@ export function DataSourceViewsSelector({
   selectionMode = "checkbox",
   allowAdminSearch = false,
   useContentNodes,
+  fixedSearchLayout = false,
+  focusSearchOnOpen = false,
 }: DataSourceViewsSelectorProps) {
-  const [searchResult, setSearchResult] = useState<
-    DataSourceViewContentNode | undefined
-  >();
+  const isMobile = useIsMobile();
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const {
     inputValue: searchSpaceText,
     debouncedValue: debouncedSearch,
-    isDebouncing,
     setValue: setSearchSpaceText,
   } = useDebounce("", {
     delay: 300,
@@ -390,247 +311,118 @@ export function DataSourceViewsSelector({
     }
   }, [debouncedSearch]);
 
-  const commonSearchParams = {
-    owner,
-    spaceIds: [space.sId],
-    disabled: !debouncedSearch,
-    dataSourceViewIdsBySpaceId:
-      filteredDSVs.length > 0
-        ? {
-            [space.sId]: filteredDSVs.map((dsv) => dsv.sId),
-          }
-        : undefined,
-    allowAdminSearch,
-  };
+  const isSearching = debouncedSearch.length >= MIN_SEARCH_QUERY_SIZE;
 
-  const {
-    searchResultNodes: rawSearchResultNodes,
-    isSearchLoading,
-    warningCode,
-  } = useSpacesSearch(
-    isNodeCandidate(nodeOrUrlCandidate) && nodeOrUrlCandidate.node
-      ? {
-          ...commonSearchParams,
-          nodeIds: [nodeOrUrlCandidate.node],
-          includeDataSources: false,
-          viewType: getViewTypeForURLNodeCandidateAccountingForNotion(
-            viewType,
-            nodeOrUrlCandidate.node
-          ),
-        }
-      : {
-          ...commonSearchParams,
-          search: debouncedSearch,
-          searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
-          includeDataSources: true,
-          viewType,
-        }
+  const getSearchItemSelectionState = useCallback(
+    (item: DataSourceViewContentNode) =>
+      getItemSelectionState(
+        item,
+        selectionConfigurations[item.dataSourceView.sId]
+      ),
+    [selectionConfigurations]
   );
 
-  // Process search results to convert them to DataSourceViewContentNode format
-  const searchResultNodes = useMemo(() => {
-    const processedResults = rawSearchResultNodes.flatMap((node) => {
-      const { dataSourceViews, ...rest } = node;
-      // Note: The workspace search API returns results from all data source views in the space.
-      // We filter here to only show results from the data source views that are currently
-      // displayed in the UI (filteredDSVs), which respects the assistant builder's filtering logic.
-      const filteredViews = dataSourceViews.filter((view) =>
-        filteredDSVs.some((dsv) => dsv.sId === view.sId)
-      );
-      return filteredViews.map((view) => ({
-        ...rest,
-        dataSourceView: view,
-      }));
-    });
+  const getSearchItemCheckboxDisabled = useCallback(
+    (item: DataSourceViewContentNode) =>
+      isItemCheckboxDisabled(
+        item,
+        selectionConfigurations[item.dataSourceView.sId]
+      ),
+    [selectionConfigurations]
+  );
 
-    if (useCase === "transcriptsProcessing") {
-      return processedResults.filter((node) => !node.dataSource.connectorId);
-    }
-
-    // Filter results based on URL match if we have a URL candidate
-    return nodeOrUrlCandidate && !isNodeCandidate(nodeOrUrlCandidate)
-      ? processedResults.filter(
-          (node) => node.sourceUrl === nodeOrUrlCandidate.url
-        )
-      : processedResults;
-  }, [rawSearchResultNodes, filteredDSVs, nodeOrUrlCandidate, useCase]);
-
-  useEffect(() => {
-    if (searchResult) {
-      setTimeout(() => {
-        const node = document.getElementById(
-          `tree-node-${searchResult.internalId}`
+  const onToggleSelection = useCallback(
+    (item: DataSourceViewContentNode) => {
+      setSelectionConfigurations((prevState) => {
+        const selectionState = getItemSelectionState(
+          item,
+          prevState[item.dataSourceView.sId]
         );
-        node?.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
+
+        if (selectionState === "partial") {
+          return deselectDescendants({ item, prevState });
+        }
+
+        return updateSelection({
+          item,
+          prevState,
+          selectionMode,
         });
-      }, 100);
-    }
-  }, [searchResult]);
+      });
+    },
+    [setSelectionConfigurations, selectionMode]
+  );
 
   const displayManagedDsv =
     filteredGroups.managedDsv.length > 0 &&
     (useCase === "assistantBuilder" || useCase === "trackerBuilder");
 
-  const contentMessage = warningCode
-    ? LimitedSearchContentMessage({ warningCode })
-    : undefined;
+  const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(
+    null
+  );
+  const scrollViewportRef = useCallback((node: HTMLDivElement | null) => {
+    setScrollViewport(node);
+  }, []);
 
-  // We want to allow a "Select all" results from the search results in the Assistant Builder.
-  // We think to make it a good XP we need to add some additional filters per data source.
-  // Since this is something that we really need for Salesforce, we will start with this.
-  const displaySelectAllButton = useMemo(() => {
-    if (useCase !== "assistantBuilder" || searchResultNodes.length === 0) {
-      return false;
+  useEffect(() => {
+    if (focusSearchOnOpen) {
+      return;
     }
 
-    const isAllSalesforce = searchResultNodes.every(
-      (r) => r.dataSourceView.dataSource.connectorProvider === "salesforce"
-    );
-    return isAllSalesforce;
-
-    // TODO: Replace with this once we are ready to select all from the search results for all data sources.
-    // if (viewType !== "table") {
-    //   return true;
-    // }
-    // const hasRemote = searchResultNodes.some((r) =>
-    //   isRemoteDatabase(r.dataSourceView.dataSource)
-    // );
-    // const hasNonRemote = searchResultNodes.some(
-    //   (r) => !isRemoteDatabase(r.dataSourceView.dataSource)
-    // );
-    // return hasRemote !== hasNonRemote;
-  }, [searchResultNodes, useCase]);
-
-  const handleSelectAll = useCallback(() => {
     setSearchSpaceText("");
+    setNodeOrUrlCandidate(null);
+  }, [focusSearchOnOpen, setSearchSpaceText]);
 
-    // Update all selections in a single state update.
-    setSelectionConfigurations((prevState) => {
-      const newState = searchResultNodes.reduce(
-        (acc, item) =>
-          updateSelection({
-            item,
-            prevState: acc,
-            selectionMode,
-            onlyAdd: true,
-          }),
-        prevState
-      );
-      return newState;
+  useEffect(() => {
+    if (!focusSearchOnOpen || isMobile) {
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
     });
 
-    // Scroll to last item if there are results. Not perfect but no perfect solution here.
-    if (searchResultNodes.length > 0) {
-      setSearchResult(searchResultNodes[searchResultNodes.length - 1]);
-    }
-  }, [
-    setSearchSpaceText,
-    setSelectionConfigurations,
-    searchResultNodes,
-    selectionMode,
-  ]);
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [focusSearchOnOpen, isMobile]);
 
-  return (
-    <div className="dd-privacy-mask">
-      <SearchInputWithPopover
-        value={searchSpaceText}
-        onChange={setSearchSpaceText}
-        name="search-dsv"
-        open={searchSpaceText.length >= MIN_SEARCH_QUERY_SIZE}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSearchSpaceText("");
-          }
-        }}
-        isLoading={isSearchLoading || isDebouncing}
-        items={searchResultNodes}
-        onItemSelect={(item) => {
-          setSearchResult(item);
-          setSearchSpaceText("");
-          setSelectionConfigurations((prevState) =>
-            updateSelection({
-              item,
-              prevState,
-              selectionMode,
-            })
-          );
-        }}
-        displayItemCount={useCase === "assistantBuilder"}
-        onSelectAll={displaySelectAllButton ? handleSelectAll : undefined}
-        contentMessage={contentMessage}
-        renderItem={(item, selected) => {
-          return (
-            <div
-              className={cn(
-                "m-1 flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 hover:bg-background dark:hover:bg-background-night",
-                selected && "bg-background dark:bg-background-night"
-              )}
-              onClick={() => {
-                setSearchResult(item);
-                setSearchSpaceText("");
-                setSelectionConfigurations((prevState) =>
-                  updateSelection({
-                    item,
-                    prevState,
-                    selectionMode,
-                  })
-                );
-              }}
-            >
-              {getVisualForDataSourceViewContentNode(item)({
-                className: "min-w-4",
-              })}
-              <span className="copy-sm flex-shrink truncate">{item.title}</span>
-              {item.parentTitle && (
-                <div className="copy-sm ml-auto flex-none text-primary-500">
-                  {getLocationForDataSourceViewContentNode(item)}
-                </div>
-              )}
-            </div>
-          );
-        }}
-        noResults="No results found"
-      />
-      <Tree
-        isLoading={false}
-        key={`dataSourceViewsSelector-${searchResult ? searchResult.internalId : ""}`}
-      >
-        {displayManagedDsv && (
-          <Tree.Item
-            key="connected"
-            label="Connected Data"
-            visual={CloudArrowLeftRight}
-            type="node"
-            defaultCollapsed={
-              !searchResult ||
-              !isManaged(searchResult.dataSourceView.dataSource)
-            }
-          >
-            {filteredGroups.managedDsv.map((dataSourceView) => (
-              <DataSourceViewSelector
-                key={dataSourceView.sId}
-                owner={owner}
-                selectionConfiguration={
-                  selectionConfigurations[dataSourceView.sId] ??
-                  defaultSelectionConfiguration(dataSourceView)
-                }
-                setSelectionConfigurations={setSelectionConfigurations}
-                viewType={viewType}
-                isRootSelectable={isRootSelectable}
-                defaultCollapsed={filteredGroups.managedDsv.length > 1}
-                useCase={useCase}
-                searchResult={searchResult}
-                selectionMode={selectionMode}
-                useContentNodes={useContentNodes}
-              />
-            ))}
-          </Tree.Item>
-        )}
-        {filteredGroups.managedDsv.length > 0 &&
-          useCase === "spaceDatasourceManagement" &&
-          filteredGroups.managedDsv.map((dataSourceView) => (
+  const searchInput = (
+    <SearchInput
+      ref={searchInputRef}
+      name="search-dsv"
+      placeholder={`Search in ${space.name}`}
+      value={searchSpaceText}
+      onChange={setSearchSpaceText}
+    />
+  );
+
+  const searchResultsProps = {
+    owner,
+    space,
+    dataSourceViews: filteredDSVs,
+    viewType,
+    allowAdminSearch,
+    searchQuery: debouncedSearch,
+    nodeOrUrlCandidate,
+    filterTranscriptsProcessing: useCase === "transcriptsProcessing",
+    selectionMode,
+    getItemSelectionState: getSearchItemSelectionState,
+    isItemCheckboxDisabled: getSearchItemCheckboxDisabled,
+    onToggleSelection,
+  };
+
+  const treeContent = (
+    <Tree isLoading={false} overflowVisible>
+      {displayManagedDsv && (
+        <Tree.Item
+          key="connected"
+          label="Connected Data"
+          visual={CloudArrowLeftRight}
+          type="node"
+          defaultCollapsed
+        >
+          {filteredGroups.managedDsv.map((dataSourceView) => (
             <DataSourceViewSelector
               key={dataSourceView.sId}
               owner={owner}
@@ -640,25 +432,71 @@ export function DataSourceViewsSelector({
               }
               setSelectionConfigurations={setSelectionConfigurations}
               viewType={viewType}
-              isRootSelectable={false}
+              isRootSelectable={isRootSelectable}
               defaultCollapsed={filteredGroups.managedDsv.length > 1}
               useCase={useCase}
-              searchResult={searchResult}
               selectionMode={selectionMode}
               useContentNodes={useContentNodes}
             />
           ))}
-        {filteredGroups.folders.length > 0 && (
-          <Tree.Item
-            key="folders"
-            label="Folders"
-            visual={Folder}
-            type="node"
-            defaultCollapsed={
-              !searchResult || !isFolder(searchResult.dataSourceView.dataSource)
+        </Tree.Item>
+      )}
+      {filteredGroups.managedDsv.length > 0 &&
+        useCase === "spaceDatasourceManagement" &&
+        filteredGroups.managedDsv.map((dataSourceView) => (
+          <DataSourceViewSelector
+            key={dataSourceView.sId}
+            owner={owner}
+            selectionConfiguration={
+              selectionConfigurations[dataSourceView.sId] ??
+              defaultSelectionConfiguration(dataSourceView)
             }
+            setSelectionConfigurations={setSelectionConfigurations}
+            viewType={viewType}
+            isRootSelectable={false}
+            defaultCollapsed={filteredGroups.managedDsv.length > 1}
+            useCase={useCase}
+            selectionMode={selectionMode}
+            useContentNodes={useContentNodes}
+          />
+        ))}
+      {filteredGroups.folders.length > 0 && (
+        <Tree.Item
+          key="folders"
+          label="Folders"
+          visual={Folder}
+          type="node"
+          defaultCollapsed
+        >
+          {filteredGroups.folders.map((dataSourceView) => (
+            <DataSourceViewSelector
+              key={dataSourceView.sId}
+              owner={owner}
+              selectionConfiguration={
+                selectionConfigurations[dataSourceView.sId] ??
+                defaultSelectionConfiguration(dataSourceView)
+              }
+              setSelectionConfigurations={setSelectionConfigurations}
+              viewType={viewType}
+              isRootSelectable={isRootSelectable}
+              defaultCollapsed={filteredGroups.folders.length > 1}
+              useCase={useCase}
+              selectionMode={selectionMode}
+              useContentNodes={useContentNodes}
+            />
+          ))}
+        </Tree.Item>
+      )}
+      {filteredGroups.websites.length > 0 &&
+        useCase !== "transcriptsProcessing" && (
+          <Tree.Item
+            key="websites"
+            label="Websites"
+            visual={Globe01}
+            type="node"
+            defaultCollapsed
           >
-            {filteredGroups.folders.map((dataSourceView) => (
+            {filteredGroups.websites.map((dataSourceView) => (
               <DataSourceViewSelector
                 key={dataSourceView.sId}
                 owner={owner}
@@ -669,70 +507,72 @@ export function DataSourceViewsSelector({
                 setSelectionConfigurations={setSelectionConfigurations}
                 viewType={viewType}
                 isRootSelectable={isRootSelectable}
-                defaultCollapsed={filteredGroups.folders.length > 1}
+                defaultCollapsed={filteredGroups.websites.length > 1}
                 useCase={useCase}
-                searchResult={searchResult}
                 selectionMode={selectionMode}
                 useContentNodes={useContentNodes}
               />
             ))}
           </Tree.Item>
         )}
-        {filteredGroups.websites.length > 0 &&
-          useCase !== "transcriptsProcessing" && (
-            <Tree.Item
-              key="websites"
-              label="Websites"
-              visual={Globe01}
-              type="node"
-              defaultCollapsed={
-                !searchResult ||
-                !isWebsite(searchResult.dataSourceView.dataSource)
-              }
-            >
-              {filteredGroups.websites.map((dataSourceView) => (
-                <DataSourceViewSelector
-                  key={dataSourceView.sId}
-                  owner={owner}
-                  selectionConfiguration={
-                    selectionConfigurations[dataSourceView.sId] ??
-                    defaultSelectionConfiguration(dataSourceView)
-                  }
-                  setSelectionConfigurations={setSelectionConfigurations}
-                  viewType={viewType}
-                  isRootSelectable={isRootSelectable}
-                  defaultCollapsed={filteredGroups.websites.length > 1}
-                  useCase={useCase}
-                  searchResult={searchResult}
-                  selectionMode={selectionMode}
-                  useContentNodes={useContentNodes}
-                />
-              ))}
-            </Tree.Item>
-          )}
-      </Tree>
+    </Tree>
+  );
+
+  const renderFixedSearchLayout = useCallback(
+    ({ warning, summary, list }: SearchResultsLayoutParts) => (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {warning && <div className="flex-none px-5 pt-1">{warning}</div>}
+        <div className="flex-none shrink-0 px-5 pb-2">{summary}</div>
+        <ScrollArea
+          className="min-h-0 w-full flex-1"
+          viewportRef={scrollViewportRef}
+        >
+          <SheetViewportProvider value={scrollViewport}>
+            <div className="px-5 pb-4 pt-1">{list}</div>
+          </SheetViewportProvider>
+        </ScrollArea>
+      </div>
+    ),
+    [scrollViewport, scrollViewportRef]
+  );
+
+  if (fixedSearchLayout) {
+    return (
+      <div className="dd-privacy-mask flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex-none shrink-0 px-5 pb-4 pt-3">{searchInput}</div>
+        {isSearching ? (
+          <DataSourceSelectionSearchResults
+            {...searchResultsProps}
+            renderLayout={renderFixedSearchLayout}
+          />
+        ) : (
+          <ScrollArea
+            className="min-h-0 w-full flex-1"
+            viewportRef={scrollViewportRef}
+          >
+            <SheetViewportProvider value={scrollViewport}>
+              <div className="px-5 pb-4 pt-1">{treeContent}</div>
+            </SheetViewportProvider>
+          </ScrollArea>
+        )}
+      </div>
+    );
+  }
+
+  const selectorContent = isSearching ? (
+    <DataSourceSelectionSearchResults {...searchResultsProps} />
+  ) : (
+    treeContent
+  );
+
+  return (
+    <div className="dd-privacy-mask">
+      <div className="sticky top-0 z-10 -mt-3 bg-background pb-4 pt-3 dark:bg-background-night">
+        {searchInput}
+      </div>
+      {selectorContent}
     </div>
   );
-}
-
-function LimitedSearchContentMessage({
-  warningCode,
-}: {
-  warningCode: SearchWarningCode;
-}): ContentMessageProps | undefined {
-  switch (warningCode) {
-    case "truncated-query-clauses":
-      return {
-        title: "Search results are partial due to the large amount of data.",
-        variant: "golden",
-        icon: InfoCircle,
-        className: "w-full",
-        size: "lg",
-      };
-
-    default:
-      assertNeverAndIgnore(warningCode);
-  }
 }
 
 interface DataSourceViewSelectorProps {
@@ -746,7 +586,6 @@ interface DataSourceViewSelectorProps {
   isRootSelectable: boolean;
   defaultCollapsed?: boolean;
   useCase?: DataSourceViewsSelectorProps["useCase"];
-  searchResult?: DataSourceViewContentNode;
   selectionMode?: "checkbox" | "radio";
   useContentNodes?: UseInfiniteContentNodes;
 }
@@ -765,7 +604,6 @@ export function DataSourceViewSelector({
   isRootSelectable,
   defaultCollapsed = true,
   useCase,
-  searchResult,
   selectionMode = "checkbox",
   useContentNodes = useInfiniteDataSourceViewContentNodes,
 }: DataSourceViewSelectorProps) {
@@ -868,6 +706,9 @@ export function DataSourceViewSelector({
   // Show the checkbox by default. Hide it only for tables view where no child items are partially checked.
   const hideCheckbox = readonly || (isTableView && isChecked !== "partial");
 
+  const isExpandableRoot = canBeExpanded(dataSourceView.dataSource);
+  const [isRootCollapsed, setIsRootCollapsed] = useState(defaultCollapsed);
+
   const selectedNodes = useMemo(
     () => getNodesFromConfig(selectionConfiguration),
     [selectionConfiguration]
@@ -946,46 +787,42 @@ export function DataSourceViewSelector({
     [owner, dataSourceView, viewType, useContentNodes]
   );
 
-  const isExpanded = searchResult
-    ? searchResult.dataSourceView.sId === dataSourceView.sId
-    : false;
-
-  const defaultExpandedIds = useMemo(
-    () =>
-      searchResult && isExpanded
-        ? removeNulls([
-            ...new Set(
-              searchResult.parentInternalIds?.filter(
-                (id) =>
-                  searchResult.expandable || id !== searchResult.internalId
-              )
-            ),
-          ])
-        : undefined,
-    [searchResult, isExpanded]
-  );
-
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>
       <Tree.Item
         key={dataSourceView.dataSource.id}
         label={getDisplayNameForDataSource(dataSourceView.dataSource)}
         visual={LogoComponent}
-        defaultCollapsed={defaultCollapsed && !isExpanded}
-        type={canBeExpanded(dataSourceView.dataSource) ? "node" : "leaf"}
+        defaultCollapsed={
+          isRootSelectable || !isExpandableRoot ? defaultCollapsed : undefined
+        }
+        collapsed={
+          !isRootSelectable && isExpandableRoot ? isRootCollapsed : undefined
+        }
+        onChevronClick={
+          !isRootSelectable && isExpandableRoot
+            ? () => setIsRootCollapsed((collapsed) => !collapsed)
+            : undefined
+        }
+        onItemClick={
+          !isRootSelectable
+            ? isExpandableRoot
+              ? () => setIsRootCollapsed((collapsed) => !collapsed)
+              : () => {}
+            : undefined
+        }
+        type={isExpandableRoot ? "node" : "leaf"}
         checkbox={
-          hideCheckbox || (!isRootSelectable && !hasActiveSelection)
+          hideCheckbox
             ? undefined
             : selectionMode === "radio"
               ? {
                   checked: isChecked === true,
-                  disabled: !isRootSelectable,
                   onCheckedChange: handleSelectAll,
                   className: "rounded-full",
                 }
               : {
                   checked: isChecked,
-                  disabled: !isRootSelectable,
                   onCheckedChange: handleSelectAll,
                 }
         }
@@ -1025,7 +862,6 @@ export function DataSourceViewSelector({
                 <Tree.Empty label="No documents" />
               )
             }
-            defaultExpandedIds={defaultExpandedIds}
             getLabel={(n) =>
               getDisplayTitleForDataSourceViewContentNode(
                 n as DataSourceViewContentNode

--- a/front/components/data_source_view/update_selection.ts
+++ b/front/components/data_source_view/update_selection.ts
@@ -1,0 +1,181 @@
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewSelectionConfiguration,
+  DataSourceViewSelectionConfigurations,
+} from "@app/types/data_source_view";
+import { defaultSelectionConfiguration } from "@app/types/data_source_view";
+// biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
+import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
+import cloneDeep from "lodash/cloneDeep";
+import omit from "lodash/omit";
+
+export type ItemSelectionState = boolean | "partial";
+
+export function getItemSelectionState(
+  item: DataSourceViewContentNode,
+  config: DataSourceViewSelectionConfiguration | undefined
+): ItemSelectionState {
+  if (!config) {
+    return false;
+  }
+  if (config.isSelectAll) {
+    return true;
+  }
+
+  const directlySelected = config.selectedResources.some(
+    (resource) => resource.internalId === item.internalId
+  );
+  if (directlySelected) {
+    return true;
+  }
+
+  const selectedIds = new Set(
+    config.selectedResources.map((resource) => resource.internalId)
+  );
+
+  if (item.parentInternalIds?.some((id) => selectedIds.has(id))) {
+    return true;
+  }
+
+  if (
+    config.selectedResources.some((resource) =>
+      resource.parentInternalIds?.includes(item.internalId)
+    )
+  ) {
+    return "partial";
+  }
+
+  return false;
+}
+
+export function isItemCheckboxDisabled(
+  item: DataSourceViewContentNode,
+  config: DataSourceViewSelectionConfiguration | undefined
+): boolean {
+  if (!config) {
+    return false;
+  }
+  if (config.isSelectAll) {
+    return true;
+  }
+
+  if (
+    config.selectedResources.some(
+      (resource) => resource.internalId === item.internalId
+    )
+  ) {
+    return false;
+  }
+
+  const selectedIds = new Set(
+    config.selectedResources.map((resource) => resource.internalId)
+  );
+
+  return item.parentInternalIds?.some((id) => selectedIds.has(id)) ?? false;
+}
+
+export function deselectDescendants({
+  item,
+  prevState,
+}: {
+  item: DataSourceViewContentNode;
+  prevState: DataSourceViewSelectionConfigurations;
+}): DataSourceViewSelectionConfigurations {
+  const { dataSourceView: dsv } = item;
+  const prevConfig = prevState[dsv.sId];
+  if (!prevConfig) {
+    return cloneDeep(prevState);
+  }
+
+  const newResources = prevConfig.selectedResources.filter(
+    (resource) => !resource.parentInternalIds?.includes(item.internalId)
+  );
+
+  if (newResources.length === 0) {
+    return omit(prevState, dsv.sId);
+  }
+
+  return {
+    ...prevState,
+    [dsv.sId]: {
+      ...prevConfig,
+      selectedResources: newResources,
+      isSelectAll: false,
+    },
+  };
+}
+
+export function updateSelection({
+  item,
+  prevState,
+  selectionMode = "checkbox",
+  onlyAdd = false,
+}: {
+  item: DataSourceViewContentNode;
+  prevState: DataSourceViewSelectionConfigurations;
+  selectionMode: "checkbox" | "radio";
+  onlyAdd?: boolean;
+}): DataSourceViewSelectionConfigurations {
+  const { dataSourceView: dsv } = item;
+  const prevConfig = prevState[dsv.sId] ?? defaultSelectionConfiguration(dsv);
+
+  const exists = prevConfig.selectedResources.some(
+    (r) => r.internalId === item.internalId
+  );
+
+  if (onlyAdd && exists) {
+    return cloneDeep(prevState);
+  }
+
+  if (item.mimeType === DATA_SOURCE_MIME_TYPE) {
+    return {
+      ...prevState,
+      [dsv.sId]: {
+        ...prevConfig,
+        selectedResources: [],
+        isSelectAll: true,
+      },
+    };
+  }
+
+  if (selectionMode === "radio" && !exists) {
+    return {
+      ...prevState,
+      [dsv.sId]: {
+        ...prevConfig,
+        selectedResources: [
+          {
+            ...item,
+            dataSourceView: dsv,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            parentInternalIds: item.parentInternalIds || [],
+          },
+        ],
+        isSelectAll: false,
+      },
+    };
+  }
+
+  const newResources = exists
+    ? prevConfig.selectedResources.filter(
+        (r) => r.internalId !== item.internalId
+      )
+    : [
+        ...prevConfig.selectedResources,
+        {
+          ...item,
+          dataSourceView: dsv,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          parentInternalIds: item.parentInternalIds || [],
+        },
+      ];
+
+  return {
+    ...prevState,
+    [dsv.sId]: {
+      ...prevConfig,
+      selectedResources: newResources,
+      isSelectAll: false,
+    },
+  };
+}

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -18,24 +18,37 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { SetStateAction } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
-// We need to stabilize the initial state of the selection configurations,
-// to avoid resetting state when swr revalidates initialSelectedDataSources
+// Capture the selection snapshot when the modal opens and keep it stable while open,
+// even if the parent props refresh from SWR revalidation.
 function useStabilizedValue<T>(
   initialValue: T,
   isOpen: boolean,
   defaultValue: T
 ): T {
   const [value, setValue] = useState<T | undefined>();
-  useEffect(() => {
-    if (isOpen && !value) {
+
+  useLayoutEffect(() => {
+    if (isOpen && value === undefined) {
       setValue(initialValue);
     } else if (!isOpen) {
       setValue(undefined);
     }
   }, [isOpen, initialValue, value]);
-  return value ?? defaultValue;
+
+  if (!isOpen) {
+    return defaultValue;
+  }
+
+  return value ?? initialValue;
 }
 
 interface SpaceManagedDataSourcesViewsModalProps {
@@ -107,35 +120,113 @@ export default function SpaceManagedDataSourcesViewsModal({
     useState<DataSourceViewSelectionConfigurations>({});
 
   const [hasChanged, setHasChanged] = useState(false);
-  useEffect(() => {
-    if (
-      !initialConfigurations.isNodesLoading &&
-      !initialConfigurations.isNodesError
-    ) {
-      const converted = initialConfigurations.dataSourceViewsAndNodes.reduce(
-        (acc, config) => {
-          // config.dataSourceView is the system dataSourceView,
-          // searching back the original dataSourceView from initialSelectedDataSources
-          const dataSourceView =
-            spaceDataSourceViews[config.dataSourceView.dataSource.sId];
+  const initializedForKeyRef = useRef<string | null>(null);
+  const [selectorKey, setSelectorKey] = useState(0);
+  const wasOpenRef = useRef(isOpen);
 
-          const isSelectAll = dataSourceView.parentsIn === null;
-          const selectedResources = isSelectAll ? [] : config.nodes;
-
-          acc[config.dataSourceView.sId] = {
-            dataSourceView: config.dataSourceView,
-            selectedResources,
-            excludedResources: [],
-            isSelectAll,
-            tagsFilter: null, // No tags filters needed to list data source views
-          };
-          return acc;
-        },
-        {} as DataSourceViewSelectionConfigurations
-      );
-      setSelectionConfigurations(converted);
+  useLayoutEffect(() => {
+    if (isOpen && !wasOpenRef.current) {
+      setSelectorKey((key) => key + 1);
     }
-  }, [initialConfigurations, spaceDataSourceViews]);
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const initializationKey = useMemo(
+    () =>
+      JSON.stringify(
+        dataSourceViewsAndInternalIds.map(
+          ({ dataSourceView, internalIds }) => ({
+            dsvId: dataSourceView.sId,
+            internalIds: [...internalIds].sort(),
+          })
+        )
+      ),
+    [dataSourceViewsAndInternalIds]
+  );
+
+  const showInitialLoading =
+    dataSourceViewsAndInternalIds.length > 0 &&
+    initialConfigurations.dataSourceViewsAndNodes.length === 0 &&
+    !initialConfigurations.isNodesError;
+
+  useEffect(() => {
+    if (isOpen) {
+      initialConfigurations.refetch();
+    }
+  }, [isOpen, initialConfigurations.refetch]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      initializedForKeyRef.current = null;
+      setHasChanged(false);
+      setSelectionConfigurations({});
+      return;
+    }
+
+    if (initializedForKeyRef.current === initializationKey) {
+      return;
+    }
+
+    // Wait for useStabilizedValue to populate before treating "no selections" as final.
+    if (
+      initialSelectedDataSources.length > 0 &&
+      dataSourceViewsAndInternalIds.length === 0
+    ) {
+      return;
+    }
+
+    // Wait until content nodes have been fetched (isNodesLoading is false before fetch starts).
+    if (
+      dataSourceViewsAndInternalIds.length > 0 &&
+      initialConfigurations.dataSourceViewsAndNodes.length === 0
+    ) {
+      return;
+    }
+
+    if (initialConfigurations.isNodesError) {
+      return;
+    }
+
+    if (dataSourceViewsAndInternalIds.length === 0) {
+      initializedForKeyRef.current = initializationKey;
+      setSelectionConfigurations({});
+      return;
+    }
+
+    const converted = initialConfigurations.dataSourceViewsAndNodes.reduce(
+      (acc, config) => {
+        const dataSourceView =
+          spaceDataSourceViews[config.dataSourceView.dataSource.sId];
+        if (!dataSourceView) {
+          return acc;
+        }
+
+        const isSelectAll = dataSourceView.parentsIn === null;
+        const selectedResources = isSelectAll ? [] : config.nodes;
+
+        acc[config.dataSourceView.sId] = {
+          dataSourceView: config.dataSourceView,
+          selectedResources,
+          excludedResources: [],
+          isSelectAll,
+          tagsFilter: null,
+        };
+        return acc;
+      },
+      {} as DataSourceViewSelectionConfigurations
+    );
+
+    initializedForKeyRef.current = initializationKey;
+    setSelectionConfigurations(converted);
+  }, [
+    isOpen,
+    initializationKey,
+    initialSelectedDataSources.length,
+    dataSourceViewsAndInternalIds.length,
+    initialConfigurations.isNodesError,
+    initialConfigurations.dataSourceViewsAndNodes,
+    spaceDataSourceViews,
+  ]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const setSelectionConfigurationsCallback = useCallback(
@@ -164,26 +255,31 @@ export default function SpaceManagedDataSourcesViewsModal({
             {title ?? `Add connected data to space "${space.name}"`}
           </SheetTitle>
         </SheetHeader>
-        <SheetContainer>
-          <div className="overflow-x-auto">
-            {initialConfigurations.isNodesLoading ? (
-              <div className="flex items-center justify-center">
-                <Spinner />
-              </div>
-            ) : (
-              <DataSourceViewsSelector
-                useCase="spaceDatasourceManagement"
-                dataSourceViews={systemSpaceDataSourceViews}
-                owner={owner}
-                selectionConfigurations={selectionConfigurations}
-                setSelectionConfigurations={setSelectionConfigurationsCallback}
-                viewType="all"
-                isRootSelectable={isRootSelectable}
-                space={systemSpace}
-                allowAdminSearch={isAdmin(owner)}
-              />
-            )}
-          </div>
+        <SheetContainer
+          noScroll
+          isListSelector
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
+          {showInitialLoading ? (
+            <div className="flex items-center justify-center">
+              <Spinner />
+            </div>
+          ) : (
+            <DataSourceViewsSelector
+              key={selectorKey}
+              useCase="spaceDatasourceManagement"
+              dataSourceViews={systemSpaceDataSourceViews}
+              owner={owner}
+              selectionConfigurations={selectionConfigurations}
+              setSelectionConfigurations={setSelectionConfigurationsCallback}
+              viewType="all"
+              isRootSelectable={isRootSelectable}
+              space={systemSpace}
+              allowAdminSearch={isAdmin(owner)}
+              fixedSearchLayout
+              focusSearchOnOpen={isOpen}
+            />
+          )}
         </SheetContainer>
         <SheetFooter
           leftButtonProps={{

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -137,7 +137,7 @@ export default function SpaceManagedDataSourcesViewsModal({
         dataSourceViewsAndInternalIds.map(
           ({ dataSourceView, internalIds }) => ({
             dsvId: dataSourceView.sId,
-            internalIds: [...internalIds].sort(),
+            internalIds: internalIds.toSorted(),
           })
         )
       ),

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -20,7 +20,7 @@ import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 import type { SWRInfiniteKeyedMutator } from "swr/infinite";
 
@@ -73,16 +73,37 @@ export function useMultipleDataSourceViewsContentNodes({
   dataSourceViewsAndNodes: DataSourceViewsAndNodes[];
   isNodesLoading: boolean;
   isNodesError: boolean;
+  refetch: () => void;
   // We need to return an invalidation function to avoid stale data.
   invalidate: () => void;
 } {
   const { fetcherWithBody } = useFetcher();
+  const fetcherWithBodyRef = useRef(fetcherWithBody);
+  fetcherWithBodyRef.current = fetcherWithBody;
+
   const [dataSourceViewsAndNodes, setDataSourceViewsAndNodes] = useState<
     DataSourceViewsAndNodes[]
   >(emptyArray());
   const [isNodesLoading, setIsNodesLoading] = useState(false);
   const [isNodesError, setIsNodesError] = useState(false);
+  const [fetchGeneration, setFetchGeneration] = useState(0);
 
+  const fetchRequestKey = useMemo(
+    () =>
+      JSON.stringify({
+        ownerId: owner.sId,
+        viewType,
+        requests: dataSourceViewsAndInternalIds.map(
+          ({ dataSourceView, internalIds }) => ({
+            dsvId: dataSourceView.sId,
+            internalIds: [...internalIds].sort(),
+          })
+        ),
+      }),
+    [dataSourceViewsAndInternalIds, owner.sId, viewType]
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetchRequestKey encodes owner, viewType, and selection identity
   useEffect(() => {
     const fetchData = async () => {
       setIsNodesLoading(true);
@@ -146,7 +167,11 @@ export function useMultipleDataSourceViewsContentNodes({
           const r = await concurrentExecutor(
             urlAndBodies,
             async (urlAndBody) => {
-              return fetcherWithBody([urlAndBody.url, urlAndBody.body, "POST"]);
+              return fetcherWithBodyRef.current([
+                urlAndBody.url,
+                urlAndBody.body,
+                "POST",
+              ]);
             },
             {
               concurrency: 8,
@@ -184,21 +209,30 @@ export function useMultipleDataSourceViewsContentNodes({
 
     if (dataSourceViewsAndInternalIds.length > 0) {
       void fetchData();
+    } else {
+      setDataSourceViewsAndNodes(emptyArray());
+      setIsNodesLoading(false);
+      setIsNodesError(false);
     }
-  }, [dataSourceViewsAndInternalIds, owner.sId, viewType, fetcherWithBody]);
+  }, [fetchRequestKey, dataSourceViewsAndInternalIds, fetchGeneration]);
+
+  const refetch = useCallback(() => {
+    setFetchGeneration((generation) => generation + 1);
+  }, []);
 
   return useMemo(
     () => ({
       dataSourceViewsAndNodes,
       isNodesLoading,
       isNodesError,
+      refetch,
       invalidate: () => {
         setDataSourceViewsAndNodes(emptyArray());
         setIsNodesLoading(false);
         setIsNodesError(false);
       },
     }),
-    [dataSourceViewsAndNodes, isNodesLoading, isNodesError]
+    [dataSourceViewsAndNodes, isNodesLoading, isNodesError, refetch]
   );
 }
 

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -96,7 +96,7 @@ export function useMultipleDataSourceViewsContentNodes({
         requests: dataSourceViewsAndInternalIds.map(
           ({ dataSourceView, internalIds }) => ({
             dsvId: dataSourceView.sId,
-            internalIds: [...internalIds].sort(),
+            internalIds: internalIds.toSorted(),
           })
         ),
       }),

--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -9,7 +9,7 @@ interface ScrollAreaProps
   orientation?: "vertical" | "horizontal";
   scrollBarClassName?: string;
   viewportClassName?: string;
-  viewportRef?: React.RefObject<HTMLDivElement>;
+  viewportRef?: React.Ref<HTMLDivElement>;
 }
 
 const ScrollArea = React.forwardRef<

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -225,7 +225,7 @@ const ScrollContainer = ({
   const value = React.useMemo(() => viewport, [viewport]);
 
   if (noScroll) {
-    return <div className={className}>{children}</div>;
+    return <div className={cn(className, "s-flex s-flex-col")}>{children}</div>;
   }
 
   return (
@@ -245,14 +245,14 @@ const SheetContainer = ({
     <ScrollContainer
       noScroll={noScroll}
       className={cn(
-        "s-h-full s-w-full s-flex-grow",
+        "s-min-h-0 s-w-full s-flex-1 s-overflow-hidden",
         "s-border-t s-border-border/60 s-transition-all s-duration-300 dark:s-border-border-night/60"
       )}
     >
       <div
         className={cn(
-          "s-relative s-flex s-h-full s-flex-col s-gap-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night",
-          !isListSelector && "s-px-5 s-pt-3",
+          "s-relative s-flex s-min-h-0 s-flex-1 s-flex-col s-overflow-hidden s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night",
+          !isListSelector && "s-gap-5 s-px-5 s-pt-3",
           className
         )}
       >
@@ -363,7 +363,10 @@ const SheetDescription = React.forwardRef<
 ));
 SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
-export { useSheetViewport } from "@sparkle/components/SheetViewportContext";
+export {
+  SheetViewportProvider,
+  useSheetViewport,
+} from "@sparkle/components/SheetViewportContext";
 export {
   Sheet,
   SheetClose,

--- a/sparkle/src/components/Tree.tsx
+++ b/sparkle/src/components/Tree.tsx
@@ -23,6 +23,7 @@ export interface TreeProps {
   children?: ReactNode;
   isBoxed?: boolean;
   isLoading?: boolean;
+  overflowVisible?: boolean;
   tailwindIconTextColor?: string;
   variant?: "navigator" | "finder";
   className?: string;
@@ -32,6 +33,7 @@ export function Tree({
   children,
   isLoading,
   isBoxed = false,
+  overflowVisible = false,
   tailwindIconTextColor,
   variant = "finder",
   className,
@@ -60,7 +62,8 @@ export function Tree({
     <>
       <div
         className={cn(
-          "s-flex s-flex-col s-gap-0.5 s-overflow-hidden",
+          "s-flex s-flex-col s-gap-0.5",
+          overflowVisible ? "s-overflow-visible" : "s-overflow-hidden",
           isBoxed &&
             "s-rounded-xl s-border s-border-border s-bg-muted-background s-px-3 s-py-2 dark:s-border-border-night dark:s-bg-muted-background-night",
           className
@@ -217,21 +220,35 @@ Tree.Item = React.forwardRef<
             className
           )}
           onClick={
-            onItemClick ||
-            ((e) => {
-              // Skip if click on checkbox or any button
-              if (
-                e.target instanceof HTMLElement &&
-                e.target.tagName !== "BUTTON"
-              ) {
-                e.stopPropagation();
-                if (checkbox?.onCheckedChange) {
-                  checkbox.onCheckedChange?.(!checkbox.checked);
-                } else if (canExpand) {
-                  effectiveOnChevronClick();
+            onItemClick
+              ? (e) => {
+                  if (
+                    e.target instanceof HTMLElement &&
+                    (e.target.closest('[role="checkbox"]') ||
+                      e.target.tagName === "BUTTON")
+                  ) {
+                    return;
+                  }
+                  e.stopPropagation();
+                  onItemClick();
                 }
-              }
-            })
+              : (e) => {
+                  if (!(e.target instanceof HTMLElement)) {
+                    return;
+                  }
+                  if (
+                    e.target.tagName === "BUTTON" ||
+                    e.target.closest('[role="checkbox"]')
+                  ) {
+                    return;
+                  }
+                  e.stopPropagation();
+                  if (checkbox?.onCheckedChange) {
+                    checkbox.onCheckedChange?.(!checkbox.checked);
+                  } else if (canExpand) {
+                    effectiveOnChevronClick();
+                  }
+                }
           }
         >
           {type === "node" && (

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -235,6 +235,7 @@ export {
   SheetPortal,
   SheetTitle,
   SheetTrigger,
+  SheetViewportProvider,
   useSheetViewport,
 } from "./Sheet";
 export type { SidebarLayoutProps, SidebarLayoutRef } from "./SidebarLayout";

--- a/sparkle/src/styles/tailwind.css
+++ b/sparkle/src/styles/tailwind.css
@@ -36,6 +36,6 @@
 @layer utilities {
   .s-scrollarea-viewport > div {
     display: block !important;
-    height: 100%;
+    min-height: 100%;
   }
 }


### PR DESCRIPTION
## Description

Replaces the `SearchInputWithPopover` dropdown in `DataSourceViewsSelector` with a new `DataSourceSelectionSearchResults` component that renders a flat, infinitely-scrollable list when searching in a datasource. Results are paginated (25/page) using cursor-based pagination via `useSpacesSearch`, accumulated across pages, and deduplicated by `dataSourceView.sId:internalId`. Each row shows name + location with checkbox/radio selection, a live count summary ("Showing X of Y · scroll for more"), and a `SearchWarningMessage` for `truncated-query-clauses`.

- Extracted selection helpers (`updateSelection`, `getItemSelectionState`, `isItemCheckboxDisabled`, `deselectDescendants`) into `update_selection.ts`.
- Added `fixedSearchLayout` prop (sheet/drawer mode using `ScrollArea` + `SheetViewportProvider`) and `focusSearchOnOpen` prop.
- Overhauled `InfiniteScroll` to use scroll position + `ResizeObserver` when inside a Radix `ScrollArea` viewport (`useSheetViewport`), falling back to `IntersectionObserver` sentinel otherwise — fixes unreliable trigger inside Radix scroll containers.



https://github.com/user-attachments/assets/81555e06-a9eb-4f4a-86fd-3e9c9b636ff6


## Tests

Tested manually in the assistant builder datasource selector and tracker builder. Verified infinite scroll triggers on Radix `ScrollArea` viewports and falls back correctly without one.

Tested multiple sheets (agents, builder, preview) to make sure they still worked.

## Risk

Medium. This is a significant refactor of the datasource selection search flow used across assistant builder, tracker builder, transcripts processing, and space datasource management. The tree expand-on-select-from-search behaviour is intentionally removed. Rollback is safe — front-only, no DB changes.

## Deploy Plan

Deploy `front`.
