### PR TITLE
[core & front] handle too_many_pending_upserts error 

### DIFF
--- a/core/src/api/tables.rs
+++ b/core/src/api/tables.rs
@@ -767,12 +767,20 @@ pub async fn tables_rows_delete(
                     .delete_row(state.databases_store.clone(), &row_id)
                     .await
                 {
-                    Err(e) => error_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "internal_server_error",
-                        "Failed to delete row",
-                        Some(e),
-                    ),
+                    Err(e) => match e.downcast_ref::<TableUpsertError>() {
+                        Some(TableUpsertError::TooManyPendingUpserts { .. }) => error_response(
+                            StatusCode::TOO_MANY_REQUESTS,
+                            "too_many_pending_upserts",
+                            "Too many pending upserts for this table, retry later",
+                            Some(e),
+                        ),
+                        None => error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "internal_server_error",
+                            "Failed to delete row",
+                            Some(e),
+                        ),
+                    },
                     Ok(_) => (
                         StatusCode::OK,
                         Json(APIResponse {

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -5388,6 +5388,9 @@
           },
           "404": {
             "description": "The row was not found"
+          },
+          "429": {
+            "description": "Too many pending table updates are queued for this table. Retry later."
           }
         }
       }
@@ -5612,6 +5615,9 @@
           },
           "404": {
             "description": "Data source or workspace not found."
+          },
+          "429": {
+            "description": "Too many pending table updates are queued for this table. Retry later."
           },
           "500": {
             "description": "Internal Server Error."

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -110,6 +110,8 @@ const ParamsSchema = z.object({
  *         description: The row was deleted
  *       404:
  *         description: The row was not found
+ *       429:
+ *         description: Too many pending table updates are queued for this table. Retry later.
  */
 const app = publicApiApp();
 
@@ -269,6 +271,19 @@ app.delete(
           },
         });
       }
+
+      if (deleteRes.error.code === "too_many_pending_upserts") {
+        return apiError(ctx, {
+          status_code: 429,
+          api_error: {
+            type: "rate_limit_error",
+            message:
+              "Too many pending table updates are queued for this table. " +
+              "Please retry later.",
+          },
+        });
+      }
+
       logger.error(
         {
           dataSourceId: dataSource.sId,

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -162,6 +162,8 @@ const ParamsSchema = z.object({
  *        description: Bad Request. Missing or invalid parameters.
  *      401:
  *        description: Unauthorized. Invalid or missing authentication token.
+ *      429:
+ *        description: Too many pending table updates are queued for this table. Retry later.
  *      500:
  *        description: Internal Server Error.
  *      404:
@@ -353,6 +355,18 @@ app.post(
     });
 
     if (upsertRes.isErr()) {
+      if (upsertRes.error.code === "too_many_pending_upserts") {
+        return apiError(ctx, {
+          status_code: 429,
+          api_error: {
+            type: "rate_limit_error",
+            message:
+              "Too many pending table updates are queued for this table. " +
+              "Please retry later.",
+          },
+        });
+      }
+
       logger.error(
         {
           dataSourceId: dataSource.sId,


### PR DESCRIPTION
## Description
This PR is to stop throwing 500 errors when core returns ```Failed to delete row (error: Too many pending upserts queued for this table (limit 200); retry later)``` ([logs](https://app.datadoghq.eu/logs?query=%22Failed%20to%20delete%20row%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ628CIia_cjIwAAABhBWjYyOENRR0FBRFdXdmlCb3FBZzN3QjgAAAAkMDE5ZWI2ZjYtOWM0NC00ZmY1LTg2NWQtNGYwODkzYWYwYWQ4AAjH5w&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1781164800000&to_ts=1781193600000&live=false)) so it won't trigger the monitor. Inspiration came from [this PR](https://github.com/dust-tt/dust/issues/26587)   


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
