### PR TITLE
feat(llm): persist headroom compression tokens on run usage

### DIFF
--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -1,6 +1,7 @@
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import { recordLoopCompressionMetrics } from "@app/lib/api/llm/headroom";
 import type { Authenticator } from "@app/lib/auth";
 import {
   intelligenceAwuFromRunUsages,
@@ -90,6 +91,33 @@ export async function computeAndStoreAgentMessageCredits(
     fetchRunUsagesForAgentMessage(auth, runIds),
     AgentMCPActionResource.listByAgentMessageIds(auth, [agentMessageModelId]),
   ]);
+
+  // Roll up headroom compression across every LLM call in the loop. Summing
+  // per-call mirrors how prompt tokens are summed (each turn re-sends the
+  // growing context), so this is the loop's total input-token saving.
+  const compressionInputTokens = runUsages.reduce(
+    (sum, usage) => sum + (usage.compressionInputTokens ?? 0),
+    0
+  );
+  const compressionSavedTokens = runUsages.reduce(
+    (sum, usage) => sum + (usage.compressionSavedTokens ?? 0),
+    0
+  );
+  if (compressionInputTokens > 0) {
+    recordLoopCompressionMetrics({
+      inputTokens: compressionInputTokens,
+      savedTokens: compressionSavedTokens,
+    });
+    logger.info(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        agentMessageId,
+        compressionInputTokens,
+        compressionSavedTokens,
+      },
+      "[headroom] Agent loop compression totals."
+    );
+  }
 
   const costCredits = computeAgentMessageCredits({
     runUsages,

--- a/front/lib/api/llm/headroom.ts
+++ b/front/lib/api/llm/headroom.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import type { BaseMessage } from "@app/lib/model_constructors/types/input/messages";
+import type { CompressionUsage } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -55,6 +56,33 @@ function recordCompressionMetrics(
       tags
     );
   }
+}
+
+// Emit the per-agent-loop compression rollup (summed across every LLM call in
+// the loop) to Datadog. Called once when the agentic loop finalizes; no-ops when
+// the loop had no compression. Untagged by model on purpose — a loop is a single
+// aggregate and may span more than one model.
+export function recordLoopCompressionMetrics({
+  inputTokens,
+  savedTokens,
+}: CompressionUsage): void {
+  if (inputTokens <= 0) {
+    return;
+  }
+
+  const client = getStatsDClient();
+  client.distribution(
+    `${HEADROOM_METRIC_PREFIX}.loop.tokens_before`,
+    inputTokens
+  );
+  client.distribution(
+    `${HEADROOM_METRIC_PREFIX}.loop.tokens_saved`,
+    savedTokens
+  );
+  client.distribution(
+    `${HEADROOM_METRIC_PREFIX}.loop.ratio`,
+    savedTokens / inputTokens
+  );
 }
 
 // Maps Dust internal model ids to the model names headroom-ai / LiteLLM expect
@@ -263,9 +291,9 @@ interface CompressConversationOptions {
 export async function compressConversationMessages(
   messages: BaseMessage[],
   { modelId, workspaceId }: CompressConversationOptions
-): Promise<BaseMessage[]> {
+): Promise<{ messages: BaseMessage[]; usage: CompressionUsage | null }> {
   if (messages.length === 0) {
-    return messages;
+    return { messages, usage: null };
   }
 
   const openAIMessages = messages.map(baseMessageToOpenAI);
@@ -299,7 +327,7 @@ export async function compressConversationMessages(
         "[headroom] Skipping compression: result is not a 1:1 message array."
       );
       recordCompressionMetrics(modelId, "skipped");
-      return messages;
+      return { messages, usage: null };
     }
 
     const rewritten = messages.map((message, i) => {
@@ -329,13 +357,19 @@ export async function compressConversationMessages(
     );
     recordCompressionMetrics(modelId, "applied", result);
 
-    return rewritten;
+    return {
+      messages: rewritten,
+      usage: {
+        inputTokens: result.tokensBefore,
+        savedTokens: result.tokensSaved,
+      },
+    };
   } catch (err) {
     logger.error(
       { workspaceId, modelId, err: normalizeError(err) },
       "[headroom] Compression failed; using uncompressed messages."
     );
     recordCompressionMetrics(modelId, "error");
-    return messages;
+    return { messages, usage: null };
   }
 }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -23,7 +23,10 @@ import type {
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import type { RunUsageType } from "@app/lib/resources/run_resource";
+import type {
+  CompressionUsage,
+  RunUsageType,
+} from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
@@ -338,7 +341,10 @@ export abstract class LLM<TPayload = unknown> {
             this.authenticator,
             buffer.runTokenUsage,
             this.modelId,
-            { inferenceRegion: this.metadata.inferenceRegion }
+            {
+              inferenceRegion: this.metadata.inferenceRegion,
+              compression: this.getCompressionUsage(),
+            }
           );
         }
 
@@ -674,6 +680,14 @@ export abstract class LLM<TPayload = unknown> {
    * Called after the stream completes; returned entries are recorded via recordRunUsage.
    */
   protected getSimulatedRunUsages(): RunUsageType[] | null {
+    return null;
+  }
+
+  /**
+   * Override to attach compression accounting (e.g. headroom) to the run usage
+   * row recorded for this call. Returns null when no compression was applied.
+   */
+  protected getCompressionUsage(): CompressionUsage | null {
     return null;
   }
 

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -51,6 +51,7 @@ import type {
   ToolCallEvent as NewToolCallEvent,
   NonDeltaResponseEvent,
 } from "@app/lib/model_constructors/types/output/events";
+import type { CompressionUsage } from "@app/lib/resources/run_resource";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
@@ -539,6 +540,11 @@ abstract class BaseTransition extends LLM {
 export class StreamEndpointTransition extends BaseTransition {
   private model: StreamEndpoint;
 
+  // Headroom compression usage from the most recent buildStreamRequestPayload,
+  // surfaced to the run usage row via getCompressionUsage() so it persists per
+  // call and rolls up per agent loop.
+  private compressionUsage: CompressionUsage | null = null;
+
   constructor(
     auth: Authenticator,
     llmParameters: LLMParameters,
@@ -564,20 +570,27 @@ export class StreamEndpointTransition extends BaseTransition {
     // proxy to compress them before dispatch. Gated by a feature flag and scoped
     // to the streaming surface; the system prompt is intentionally left intact to
     // preserve agent behavior.
-    const messages = (await hasFeatureFlag(
-      this.authenticator,
-      "headroom_compression"
-    ))
-      ? await compressConversationMessages(conversation.messages, {
+    let messages = conversation.messages;
+    if (await hasFeatureFlag(this.authenticator, "headroom_compression")) {
+      const compression = await compressConversationMessages(
+        conversation.messages,
+        {
           modelId: this.modelId,
           workspaceId: this.authenticator.getNonNullableWorkspace().sId,
-        })
-      : conversation.messages;
+        }
+      );
+      messages = compression.messages;
+      this.compressionUsage = compression.usage;
+    }
 
     return this.model.buildRequestPayload(
       { conversation: { ...conversation, messages } },
       this.buildConfig(streamParameters, this.model.constructor.configSchema)
     );
+  }
+
+  protected getCompressionUsage(): CompressionUsage | null {
+    return this.compressionUsage;
   }
 
   protected async *sendRequest(payload: unknown): AsyncGenerator<LLMEvent> {

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -47,6 +47,7 @@ export type FetchRunOptions<T extends boolean> = {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface RunResource extends ReadonlyAttributesType<RunModel> {}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class RunResource extends BaseResource<RunModel> {
   static model: ModelStatic<RunModel> = RunModel;
@@ -200,6 +201,8 @@ export class RunResource extends BaseResource<RunModel> {
       providerId: usage.providerId as ModelProviderIdType,
       cachedTokens: usage.cachedTokens,
       cacheCreationTokens: usage.cacheCreationTokens,
+      compressionInputTokens: usage.compressionInputTokens,
+      compressionSavedTokens: usage.compressionSavedTokens,
       costMicroUsd: usage.costMicroUsd,
       isBatch: usage.isBatch,
     }));
@@ -323,6 +326,8 @@ export class RunResource extends BaseResource<RunModel> {
           completionTokens,
           cachedTokens,
           cacheCreationTokens,
+          compressionInputTokens,
+          compressionSavedTokens,
           costMicroUsd,
           isBatch,
         }) => ({
@@ -334,6 +339,8 @@ export class RunResource extends BaseResource<RunModel> {
           completionTokens,
           cachedTokens,
           cacheCreationTokens: cacheCreationTokens ?? null,
+          compressionInputTokens: compressionInputTokens ?? null,
+          compressionSavedTokens: compressionSavedTokens ?? null,
           costMicroUsd,
           isBatch,
         })
@@ -386,7 +393,12 @@ export class RunResource extends BaseResource<RunModel> {
     {
       isBatch = false,
       inferenceRegion = "global",
-    }: { isBatch?: boolean; inferenceRegion?: InferenceRegionType } = {}
+      compression,
+    }: {
+      isBatch?: boolean;
+      inferenceRegion?: InferenceRegionType;
+      compression?: CompressionUsage | null;
+    } = {}
   ) {
     const modelConfig = getModelConfigByModelId(modelId);
 
@@ -413,6 +425,8 @@ export class RunResource extends BaseResource<RunModel> {
         modelId: modelConfig.modelId,
         promptTokens: usage.inputTokens,
         providerId: modelConfig.providerId,
+        compressionInputTokens: compression?.inputTokens ?? null,
+        compressionSavedTokens: compression?.savedTokens ?? null,
         costMicroUsd: usageCostMicroUsd,
         isBatch,
       },
@@ -445,6 +459,17 @@ export interface RunUsageType {
   cachedTokens: number | null;
   // Optional: tokens spent writing to cache (e.g., Anthropic cache creation)
   cacheCreationTokens?: number | null;
+  // Headroom compression accounting (null when compression was not applied).
+  // Estimates from headroom's tokenizer, not the provider's billed counts.
+  compressionInputTokens?: number | null;
+  compressionSavedTokens?: number | null;
   costMicroUsd: number;
   isBatch: boolean;
+}
+
+// Per-LLM-call headroom compression usage, plumbed from the LLM layer into the
+// run usage row so it rolls up per agent loop.
+export interface CompressionUsage {
+  inputTokens: number;
+  savedTokens: number;
 }

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -72,6 +72,11 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   declare cachedTokens: number | null;
   declare cacheCreationTokens: number | null;
 
+  // Headroom compression accounting (null when compression was not applied).
+  // These are headroom tokenizer estimates, not the provider's billed counts.
+  declare compressionInputTokens: number | null;
+  declare compressionSavedTokens: number | null;
+
   declare costMicroUsd: number;
   declare isBatch: boolean;
 }
@@ -100,6 +105,16 @@ RunUsageModel.init(
       allowNull: true,
     },
     cacheCreationTokens: {
+      type: DataTypes.INTEGER,
+      defaultValue: null,
+      allowNull: true,
+    },
+    compressionInputTokens: {
+      type: DataTypes.INTEGER,
+      defaultValue: null,
+      allowNull: true,
+    },
+    compressionSavedTokens: {
       type: DataTypes.INTEGER,
       defaultValue: null,
       allowNull: true,

--- a/front/migrations/pre-deploy/20260619142548_add_compression_tokens_to_run_usages.sql
+++ b/front/migrations/pre-deploy/20260619142548_add_compression_tokens_to_run_usages.sql
@@ -1,0 +1,13 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "compressionInputTokens" integer;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."run_usages" ADD COLUMN "compressionSavedTokens" integer;


### PR DESCRIPTION
## Description

Stacked on #27628. Persists headroom compression accounting on the run-usage row so it rolls up per agent loop, not just per LLM call.

Each LLM call already writes a `run_usages` row. This adds nullable `compressionInputTokens` / `compressionSavedTokens` columns (headroom tokenizer estimates; `NULL` when compression didn't run). The streaming transition stashes the headroom result and exposes it via a `getCompressionUsage()` hook that `recordTokenUsage` writes onto the row. Since `AgentMessage` already accumulates all its `runIds` and `computeAndStoreAgentMessageCredits` already sums `RunUsage` across the whole loop, the per-loop total falls out of the existing aggregation: it sums the new columns and emits a per-loop Datadog metric (`headroom_compression.loop.*`) plus a log line once when the loop finalizes.

Changes:
- Migration (pre-deploy): nullable `compressionInputTokens` / `compressionSavedTokens` on `run_usages`.
- `RunUsageModel` / `RunUsageType` + a `CompressionUsage` type, threaded through `recordTokenUsage` → `recordRunUsage` → `listRunUsagesForRuns`.
- `getCompressionUsage()` hook on the LLM base, overridden by `StreamEndpointTransition`; `compressConversationMessages` now returns the usage alongside the messages.
- Per-loop sum + `recordLoopCompressionMetrics` emit in `computeAndStoreAgentMessageCredits`.

## Tests

Manual, with the proxy + `headroom_compression` + `use_new_llm_router` enabled: confirm `run_usages` rows carry `compressionSavedTokens`, and that the `[headroom] Agent loop compression totals.` log + `headroom_compression.loop.*` metrics fire once per loop. Columns stay `NULL` when the flag is off.

## Risk

Low. Additive nullable columns; values are headroom estimates kept in their own columns, separate from the billed `promptTokens`, and credit/cost math is unchanged.

## Deploy Plan

Pre-deploy migration (`ADD COLUMN`, nullable) runs ahead of the code, as usual — no special steps.
