### PR TITLE
feat(assistant): add @dust-c global agent that uses headroom compression

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -500,6 +500,24 @@ export function _getDustGlobalAgent(
   });
 }
 
+// Exact clone of @dust (same model, reasoning effort, instructions, tools). The
+// only difference is that @dust-c routes its conversation through headroom
+// compression, gated on the agent id in StreamEndpointTransition. Gated behind
+// the headroom_compression feature flag in getGlobalAgents.
+export function _getDustCGlobalAgent(
+  auth: Authenticator,
+  args: DustLikeGlobalAgentArgs
+): AgentConfigurationType | null {
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_C,
+    name: "dust-c",
+    preferredModelConfiguration: args.preferGpt55DefaultModel
+      ? GPT_5_5_MODEL_CONFIG
+      : CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+    preferredReasoningEffort: "medium",
+  });
+}
+
 export function _getDustHighGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -660,6 +660,15 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "An agent with context on your company data.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_C:
+      // Identical to @dust; the only difference is that @dust-c compresses its
+      // conversation via headroom (see StreamEndpointTransition).
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_C,
+        name: "dust-c",
+        description: "An agent with context on your company data.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST_HIGH:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_HIGH,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -22,6 +22,7 @@ import {
   _getDustAntHighOmittedGlobalAgent,
   _getDustAntMediumGlobalAgent,
   _getDustAntMediumOmittedGlobalAgent,
+  _getDustCGlobalAgent,
   _getDustDeepseekGlobalAgent,
   _getDustEdgeGlobalAgent,
   _getDustGlmGlobalAgent,
@@ -138,6 +139,12 @@ const GLOBAL_AGENT_FLAGS: Record<
   }
 > = {
   [GLOBAL_AGENTS_SID.DUST]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+    injectsUserContext: false,
+    injectsWorkspaceContext: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_C]: {
     injectsMemory: true,
     injectsToolsets: true,
     injectsUserContext: false,
@@ -941,6 +948,17 @@ function getGlobalAgent({
         preferGpt55DefaultModel,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_C:
+      agentConfiguration = _getDustCGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        hasDeepDive,
+        globalAgentContext,
+        excludeProviders,
+        preferGpt55DefaultModel,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DUST_HIGH:
       agentConfiguration = _getDustHighGlobalAgent(auth, {
         settings,
@@ -1472,6 +1490,11 @@ export async function getGlobalAgents(
 
   const flags = await getFeatureFlags(auth);
 
+  if (!flags.includes("headroom_compression")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_C
+    );
+  }
   if (!flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.O1

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -23,7 +23,7 @@ import {
   extractEncryptedContentFromMetadata,
   parseResponseFormatSchema,
 } from "@app/lib/api/llm/utils";
-import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
 import type {
   BatchEndpoint,
@@ -57,6 +57,7 @@ import type {
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types/assistant/generation";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -566,12 +567,13 @@ export class StreamEndpointTransition extends BaseTransition {
   ) {
     const { conversation } = this.buildPayload(streamParameters);
 
-    // Optionally route the conversation turns through the local headroom-ai
-    // proxy to compress them before dispatch. Gated by a feature flag and scoped
-    // to the streaming surface; the system prompt is intentionally left intact to
-    // preserve agent behavior.
+    // Compression is opt-in per agent: only the @dust-c global agent routes its
+    // conversation through the local headroom-ai proxy. @dust and every other
+    // agent are left untouched, so compression is @dust-c's only difference from
+    // @dust. @dust-c only exists when the headroom_compression flag is enabled
+    // (see getGlobalAgents). The system prompt is intentionally left intact.
     let messages = conversation.messages;
-    if (await hasFeatureFlag(this.authenticator, "headroom_compression")) {
+    if (this.context?.agentConfigurationId === GLOBAL_AGENTS_SID.DUST_C) {
       const compression = await compressConversationMessages(
         conversation.messages,
         {

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -53,6 +53,7 @@ export function isSupportingResponseFormat(modelId: ModelIdType) {
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
+  DUST_C = "dust-c",
   DUST_OMITTED = "dust-omitted",
   DUST_HIGH = "dust-high",
   DUST_HIGH_OMITTED = "dust-high-omitted",
@@ -218,6 +219,7 @@ export function getGlobalAgentAuthorName(agentId: string): string {
 // Not exhaustive.
 const GLOBAL_AGENTS_SORT_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
+  GLOBAL_AGENTS_SID.DUST_C,
   GLOBAL_AGENTS_SID.DEEP_DIVE,
   GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET,
   GLOBAL_AGENTS_SID.GPT5,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -337,7 +337,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   headroom_compression: {
     description:
-      "Compress conversation messages through the local headroom-ai proxy before sending them to the LLM (new router, streaming path only).",
+      "Enable the @dust-c global agent: a copy of @dust that compresses its " +
+      "conversation through the local headroom-ai proxy before sending it to " +
+      "the LLM (new router, streaming path only).",
     stage: "dust_only",
   },
 } as const satisfies Record<string, FeatureFlag>;


### PR DESCRIPTION
## Description

Stacked on #27649. Adds a new global agent `@dust-c` — an exact copy of `@dust` whose **only** difference is that it compresses its conversation through the local headroom-ai proxy.

`@dust-c` is gated behind the `headroom_compression` feature flag (it only appears when the flag is enabled for the workspace) and reuses the exact `@dust` configuration — model, reasoning effort, instructions, tools, skills — via `_getDustCGlobalAgent` (a clone of `_getDustGlobalAgent`). Compression is now scoped per agent: `StreamEndpointTransition` invokes headroom only when `context.agentConfigurationId === "dust-c"`, so `@dust` and every other agent are left untouched.

Changes:
- New `GLOBAL_AGENTS_SID.DUST_C` enum value, sort-order entry, and `GLOBAL_AGENT_FLAGS` entry (all mirroring `@dust`).
- `_getDustCGlobalAgent` + metadata case (handle `dust-c`, same description/avatar) + registry switch case.
- `getGlobalAgents` filters `@dust-c` out when `headroom_compression` is off.
- Compression gate in `StreamEndpointTransition` changed from the workspace flag to the `@dust-c` agent id (drops the per-call `hasFeatureFlag`), so `@dust` no longer compresses.
- Updated the `headroom_compression` flag description to reflect that it gates `@dust-c`.

## Tests

Manual: with `headroom_compression` enabled, `@dust-c` appears alongside `@dust`; using it produces `[headroom] Compressed conversation messages.` logs and `compressionSavedTokens` on its run-usage rows, while `@dust` does not compress. With the flag off, `@dust-c` is not listed.

## Risk

Low. Additive global agent behind a default-off `dust_only` flag. The one behavioral change to existing code narrows compression from the workspace flag to the `@dust-c` agent — note this adjusts behavior introduced earlier in the stack (#27628, where the flag compressed all calls); since the branches merge together, the end state is "compression via `@dust-c` only," which is the intended design.
