### PR TITLE
[front] UsagePage: do not display TopUp for free plan

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -588,7 +588,7 @@ export function UsagePage() {
       <div className="flex flex-col items-stretch gap-10 pb-20">
         <div className="flex items-center justify-between">
           <Page.Header title="Usage" icon={PieChart01} />
-          {!isReadOnly && !isEnterprise && (
+          {!isReadOnly && !isFreePlanWorkspace && !isEnterprise && (
             <Button
               label="Top up"
               icon={ArrowUp}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8926
* remove "Top Up" in UsagePage for free plan

## Tests

Tested locally

## Risk

Low, only UI for free plan

## Deploy Plan

Deploy front