### PR TITLE
feat(front): weight prompt-cache miss reasons by lost input tokens

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -509,10 +509,26 @@ export async function getOutputFromLLMStream(
               },
               "[LLM stream] prompt cache miss"
             );
-            getStatsDClient().increment("llm.cache_miss_reason.count", 1, [
+            const reasonTags = [
               `model_id:${model.modelId}`,
               `reason:${cacheMissReason.type}`,
-            ]);
+            ];
+            // Count: how often each reason occurs.
+            getStatsDClient().increment(
+              "llm.cache_miss_reason.count",
+              1,
+              reasonTags
+            );
+            // Weighted by lost-cache tokens: which reason actually costs the most,
+            // not just which happens most. Only the `*_changed` reasons carry this
+            // (the inconclusive ones have no diverged prefix to measure).
+            if (cacheMissReason.cacheMissedInputTokens !== undefined) {
+              getStatsDClient().distribution(
+                "llm.cache_miss_reason.missed_input_tokens",
+                cacheMissReason.cacheMissedInputTokens,
+                reasonTags
+              );
+            }
           }
         }
         continue;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This adds a second metric that records the estimated lost-cache input tokens per miss, tagged by model and reason, so the same data can be viewed weighted by cost rather than by frequency.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
