### PR TITLE
[front] InviteEmailButtonWithModal: limit to free seats on FreePlan

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -118,6 +118,7 @@ interface InviteEmailButtonWithModalProps {
   perSeatPricing: SubscriptionPerSeatPricing | null;
   onInviteClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
+  isFreePlan?: boolean;
 }
 
 export function InviteEmailButtonWithModal({
@@ -126,6 +127,7 @@ export function InviteEmailButtonWithModal({
   perSeatPricing,
   onInviteClick,
   disabled = false,
+  isFreePlan = false,
 }: InviteEmailButtonWithModalProps) {
   const [inviteEmails, setInviteEmails] = useState<string>("");
   const { inviteEmailsList, emailError } =
@@ -141,10 +143,12 @@ export function InviteEmailButtonWithModal({
     workspaceId: owner.sId,
     disabled: !open,
   });
-  const seatTypes = useMemo(
-    () => sortSeatTypes(Object.keys(seatPlans).filter(isMembershipSeatType)),
-    [seatPlans]
-  );
+  const seatTypes = useMemo(() => {
+    const all = sortSeatTypes(
+      Object.keys(seatPlans).filter(isMembershipSeatType)
+    );
+    return isFreePlan ? all.filter((s) => s === "free") : all;
+  }, [seatPlans, isFreePlan]);
   const seatTypesByFrequency = useMemo(
     () => groupSeatTypesByFrequency(seatTypes, seatPlans),
     [seatTypes, seatPlans]

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -9,7 +9,7 @@ import {
 import { MembersList } from "@app/components/members/MembersList";
 import { ChangeMemberModal } from "@app/components/workspace/ChangeMemberModal";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { isUpgraded } from "@app/lib/plans/plan_codes";
+import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSearchMembers } from "@app/lib/swr/memberships";
 import {
   usePerSeatPricing,
@@ -224,6 +224,7 @@ export function MembersPage() {
               prefillText=""
               perSeatPricing={perSeatPricing}
               onInviteClick={onInviteClick}
+              isFreePlan={isFreePlan(plan.code)}
             />
           )}
         </div>

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -512,6 +512,7 @@ export function UsagePage() {
           perSeatPricing={perSeatPricing}
           onInviteClick={onInviteClick}
           disabled={isReadOnly}
+          isFreePlan={isFreePlanWorkspace}
         />
       )}
     </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/8730
Limit invitations to free seats on free plans, in InviteEmailButtonWithModal

## Tests

Tested locally

## Risk

Low, UI only for free plans

## Deploy Plan

Deploy front
