### PR TITLE
Flav/defer cold tool behind anthropic tool search

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -254,7 +254,8 @@ const MAX_DESCRIPTION_LENGTH = 1024;
  * Builds a tool specification for the given MCP action configuration.
  */
 export function buildToolSpecification(
-  actionConfiguration: MCPToolConfigurationType
+  actionConfiguration: MCPToolConfigurationType,
+  { deferLoading }: { deferLoading?: boolean } = {}
 ): AgentActionSpecification {
   // Internal tools: hide required tool-input configuration from the model.
   // External/client tools: black-box — pass the schema through as-is.
@@ -269,6 +270,7 @@ export function buildToolSpecification(
     description:
       actionConfiguration.description?.slice(0, MAX_DESCRIPTION_LENGTH) ?? "",
     inputSchema,
+    ...(deferLoading ? { deferLoading: true } : {}),
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   INTERNAL_MCP_SERVERS,
+  isHotMCPServerName,
   LEGACY_INTERNAL_MCP_SERVER_IDS,
 } from "./constants";
 import {
@@ -79,5 +80,36 @@ describe("AVAILABLE_INTERNAL_MCP_SERVER_NAMES", () => {
     const unique = [...new Set(names)];
 
     expect(names).toStrictEqual(unique);
+  });
+});
+
+describe("isHotMCPServerName", () => {
+  // Derive expectations from the availability source of truth so the test stays
+  // valid as servers are added or their availability changes.
+  it("treats every auto / auto_hidden_builder internal server as hot", () => {
+    const autoNames = Object.entries(INTERNAL_MCP_SERVERS)
+      .filter(([, server]) => server.availability !== "manual")
+      .map(([name]) => name);
+
+    expect(autoNames.length).toBeGreaterThan(0);
+    for (const name of autoNames) {
+      expect(isHotMCPServerName(name)).toBe(true);
+    }
+  });
+
+  it("treats every manual internal server as cold", () => {
+    const manualNames = Object.entries(INTERNAL_MCP_SERVERS)
+      .filter(([, server]) => server.availability === "manual")
+      .map(([name]) => name);
+
+    expect(manualNames.length).toBeGreaterThan(0);
+    for (const name of manualNames) {
+      expect(isHotMCPServerName(name)).toBe(false);
+    }
+  });
+
+  it("treats unknown or non-internal server names as cold", () => {
+    expect(isHotMCPServerName("not_a_real_server")).toBe(false);
+    expect(isHotMCPServerName("")).toBe(false);
   });
 });

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1264,6 +1264,22 @@ export function isAutoInternalMCPServerName(
   );
 }
 
+// A "hot" tool is one served by a default-attached internal MCP server (an
+// `auto` / `auto_hidden_builder` server, present from the first agent-loop step).
+// These stay non-deferred so they form a stable, cacheable tools prefix. Every
+// other tool (`manual` internal servers, remote servers, client-side tools, and
+// anything enabled mid-run via discover_tools) is cold and gets deferred behind
+// Anthropic's tool search, so it appends inline on discovery instead of mutating
+// the prefix. `mcpServerName` on a tool config is a bare string (only internal
+// server-side configs carry an internal name), so guard the name before the
+// availability lookup.
+export function isHotMCPServerName(mcpServerName: string): boolean {
+  return (
+    isInternalMCPServerName(mcpServerName) &&
+    isAutoInternalMCPServerName(mcpServerName)
+  );
+}
+
 export function getAvailabilityOfInternalMCPServerByName(
   name: InternalMCPServerNameType
 ): MCPServerAvailability {

--- a/front/lib/actions/types/agent.ts
+++ b/front/lib/actions/types/agent.ts
@@ -52,6 +52,10 @@ export type AgentActionSpecification = {
   name: string;
   description: string;
   inputSchema: JSONSchema;
+  // When true, this tool is deferred: providers that support tool search (e.g.
+  // Anthropic) keep its schema out of the cached prefix and load it on demand.
+  // Providers without that capability ignore the hint and send the tool eagerly.
+  deferLoading?: boolean;
 };
 
 export function dustAppRunInputsToInputSchema(

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -244,8 +244,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       ? [TOOL_SEARCH_TOOL, ...tools]
       : tools;
 
-    console.log(">> toolsWithSearch", toolsWithSearch);
-
     return {
       model: this.modelId,
       ...thinkingConfig,
@@ -321,12 +319,6 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     payload: BetaMessageStreamParams
   ): AsyncGenerator<LLMEvent> {
     try {
-      // DEBUG: dump the exact payload sent to Anthropic (tools + defer_loading).
-      // Remove before shipping.
-      // console.log(
-      //   "[anthropic][debug] request payload",
-      //   JSON.stringify(payload, null, 2)
-      // );
       const events = this.inferenceClient.beta.messages.stream(payload);
 
       yield* streamLLMEvents(events, this.metadata);

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -19,7 +19,7 @@ import {
 } from "@app/lib/api/llm/clients/anthropic/utils/anthropic_to_events";
 import {
   toMessage,
-  toTool,
+  toToolsParam,
 } from "@app/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic";
 import {
   handleError,
@@ -68,15 +68,6 @@ const CACHE_DIAGNOSTICS_BETA_HEADER = "cache-diagnosis-2026-04-07";
 type AnthropicStreamPayload = BetaMessageStreamParams & {
   fallbacks?: { model: string }[];
 };
-
-// Tool search lets the model discover deferred (cold) tools on demand without
-// loading their schemas into the cached prefix. It's injected only when at least
-// one tool is deferred. bm25 uses natural-language queries, which match well
-// across diverse MCP tool names and descriptions.
-const TOOL_SEARCH_TOOL = {
-  type: "tool_search_tool_bm25_20251119",
-  name: "tool_search_tool_bm25",
-} as const;
 
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
@@ -227,30 +218,13 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       hasConditionalJITTools,
     });
 
-    const tools = specifications.map((spec) => {
-      const tool = toTool(spec);
-      // A force-called tool must be loaded (non-deferred): the model cannot be
-      // forced to call a tool it would first have to discover via tool search.
-      if (tool.defer_loading && spec.name === forceToolCall) {
-        return { ...tool, defer_loading: false };
-      }
-      return tool;
-    });
-
-    // When any tool is deferred, expose the tool search tool so the model can
-    // discover cold tools on demand. Anthropic requires at least one
-    // non-deferred tool, and the hot tools (and any forced tool) satisfy that.
-    const toolsWithSearch = tools.some((t) => t.defer_loading)
-      ? [TOOL_SEARCH_TOOL, ...tools]
-      : tools;
-
     return {
       model: this.modelId,
       ...thinkingConfig,
       system,
       messages,
       temperature: this.temperature ?? undefined,
-      tools: toolsWithSearch,
+      tools: toToolsParam(specifications, forceToolCall),
       max_tokens: this.modelConfig.generationTokensCount,
       tool_choice: toToolChoiceParam(specifications, forceToolCall),
     };

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -69,6 +69,15 @@ type AnthropicStreamPayload = BetaMessageStreamParams & {
   fallbacks?: { model: string }[];
 };
 
+// Tool search lets the model discover deferred (cold) tools on demand without
+// loading their schemas into the cached prefix. It's injected only when at least
+// one tool is deferred. bm25 uses natural-language queries, which match well
+// across diverse MCP tool names and descriptions.
+const TOOL_SEARCH_TOOL = {
+  type: "tool_search_tool_bm25_20251119",
+  name: "tool_search_tool_bm25",
+} as const;
+
 /**
  * Maps prompt tiers to Anthropic system blocks with cache breakpoints.
  *
@@ -218,13 +227,32 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
       hasConditionalJITTools,
     });
 
+    const tools = specifications.map((spec) => {
+      const tool = toTool(spec);
+      // A force-called tool must be loaded (non-deferred): the model cannot be
+      // forced to call a tool it would first have to discover via tool search.
+      if (tool.defer_loading && spec.name === forceToolCall) {
+        return { ...tool, defer_loading: false };
+      }
+      return tool;
+    });
+
+    // When any tool is deferred, expose the tool search tool so the model can
+    // discover cold tools on demand. Anthropic requires at least one
+    // non-deferred tool, and the hot tools (and any forced tool) satisfy that.
+    const toolsWithSearch = tools.some((t) => t.defer_loading)
+      ? [TOOL_SEARCH_TOOL, ...tools]
+      : tools;
+
+    console.log(">> toolsWithSearch", toolsWithSearch);
+
     return {
       model: this.modelId,
       ...thinkingConfig,
       system,
       messages,
       temperature: this.temperature ?? undefined,
-      tools: specifications.map(toTool),
+      tools: toolsWithSearch,
       max_tokens: this.modelConfig.generationTokensCount,
       tool_choice: toToolChoiceParam(specifications, forceToolCall),
     };
@@ -293,6 +321,12 @@ export class AnthropicLLM extends LLM<BetaMessageStreamParams> {
     payload: BetaMessageStreamParams
   ): AsyncGenerator<LLMEvent> {
     try {
+      // DEBUG: dump the exact payload sent to Anthropic (tools + defer_loading).
+      // Remove before shipping.
+      // console.log(
+      //   "[anthropic][debug] request payload",
+      //   JSON.stringify(payload, null, 2)
+      // );
       const events = this.inferenceClient.beta.messages.stream(payload);
 
       yield* streamLLMEvents(events, this.metadata);

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.test.ts
@@ -1,0 +1,86 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { describe, expect, it } from "vitest";
+
+import { toTool, toToolsParam } from "./conversation_to_anthropic";
+
+const TOOL_SEARCH_TYPE = "tool_search_tool_bm25_20251119";
+
+const hotSpec: AgentActionSpecification = {
+  name: "hot",
+  description: "A hot tool.",
+  inputSchema: { type: "object", properties: {} },
+};
+
+const coldSpec: AgentActionSpecification = {
+  name: "cold",
+  description: "A cold tool.",
+  inputSchema: { type: "object", properties: {} },
+  deferLoading: true,
+};
+
+const baseSpec: AgentActionSpecification = {
+  name: "do_thing",
+  description: "Does a thing.",
+  inputSchema: { type: "object", properties: {} },
+};
+
+describe("toTool", () => {
+  it("omits defer_loading for a non-deferred tool", () => {
+    const tool = toTool(baseSpec);
+
+    expect(tool.defer_loading).toBeUndefined();
+    expect(tool.name).toBe("do_thing");
+    expect(tool.input_schema.type).toBe("object");
+  });
+
+  it("marks a deferred tool with defer_loading", () => {
+    const tool = toTool({ ...baseSpec, deferLoading: true });
+
+    expect(tool.defer_loading).toBe(true);
+  });
+});
+
+describe("toToolsParam", () => {
+  it("does not inject the search tool when nothing is deferred", () => {
+    const tools = toToolsParam(
+      [hotSpec, { ...hotSpec, name: "hot2" }],
+      undefined
+    );
+
+    expect(tools).toHaveLength(2);
+    expect(tools.some((t) => t.type === TOOL_SEARCH_TYPE)).toBe(false);
+  });
+
+  it("prepends the search tool when at least one tool is deferred", () => {
+    const tools = toToolsParam([hotSpec, coldSpec], undefined);
+
+    expect(tools).toHaveLength(3);
+    expect(tools[0].type).toBe(TOOL_SEARCH_TYPE);
+    expect(tools[0].name).toBe("tool_search_tool_bm25");
+  });
+
+  it("un-defers a force-called tool so no search tool is needed", () => {
+    // The only deferred tool is force-called, so after un-deferring it nothing
+    // remains deferred and the search tool must not be injected.
+    const tools = toToolsParam([coldSpec], "cold");
+
+    expect(tools).toHaveLength(1);
+    expect(tools.some((t) => t.type === TOOL_SEARCH_TYPE)).toBe(false);
+    expect(tools[0].name).toBe("cold");
+  });
+
+  it("keeps the search tool when other tools stay deferred", () => {
+    const tools = toToolsParam(
+      [coldSpec, { ...coldSpec, name: "cold2" }],
+      "cold"
+    );
+
+    // cold2 is still deferred, so the search tool is present...
+    expect(tools[0].type).toBe(TOOL_SEARCH_TYPE);
+    // ...but the force-called tool was un-deferred.
+    const forced = tools.find((t) => t.name === "cold");
+    expect(forced && "defer_loading" in forced && forced.defer_loading).toBe(
+      false
+    );
+  });
+});

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -276,3 +276,34 @@ export function toTool(tool: AgentActionSpecification): Tool {
     ...(tool.deferLoading ? { defer_loading: true } : {}),
   };
 }
+
+// Tool search lets the model discover deferred (cold) tools on demand without
+// loading their schemas into the cached prefix. bm25 uses natural-language
+// queries, which match well across diverse MCP tool names and descriptions.
+const TOOL_SEARCH_TOOL = {
+  type: "tool_search_tool_bm25_20251119",
+  name: "tool_search_tool_bm25",
+} as const;
+
+// Builds the Anthropic `tools` array from the agent's tool specifications.
+// Cold specs carry `deferLoading`, which toTool maps to `defer_loading`. When
+// any tool is deferred, the tool search tool is prepended so the model can
+// discover those tools on demand; otherwise the array is identical to before.
+// A force-called tool is never deferred, since the model cannot be forced to
+// call a tool it would first have to discover via search.
+export function toToolsParam(
+  specifications: AgentActionSpecification[],
+  forceToolCall: string | undefined
+) {
+  const tools = specifications.map((spec) => {
+    const tool = toTool(spec);
+    if (tool.defer_loading && spec.name === forceToolCall) {
+      return { ...tool, defer_loading: false };
+    }
+    return tool;
+  });
+
+  return tools.some((t) => t.defer_loading)
+    ? [TOOL_SEARCH_TOOL, ...tools]
+    : tools;
+}

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -270,5 +270,9 @@ export function toTool(tool: AgentActionSpecification): Tool {
     // See https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming#handling-invalid-json-in-tool-responses
     eager_input_streaming: true,
     input_schema: { ...tool.inputSchema, type: "object" },
+    // Deferred (cold) tools are kept out of the cached prefix and loaded on
+    // demand via the tool search tool. Only set when true so non-deferred tools
+    // serialize identically to before (stable prefix bytes).
+    ...(tool.deferLoading ? { defer_loading: true } : {}),
   };
 }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -2,6 +2,7 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isHotMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
@@ -422,9 +423,16 @@ export async function runModel(
     renderEquippedSkillsUserMessage(equippedSkills),
   ]);
 
+  // Hot (default-attached) tools stay non-deferred so they form a stable,
+  // cacheable tools prefix. Cold tools are deferred behind Anthropic's tool
+  // search (when the flag is on) so mid-run additions append inline on discovery
+  // instead of mutating the prefix and busting the cache.
+  const toolSearchEnabled = featureFlags.includes("anthropic_tool_search");
   const specifications: AgentActionSpecification[] = [];
   for (const a of availableActions) {
-    specifications.push(buildToolSpecification(a));
+    const deferLoading =
+      toolSearchEnabled && !isHotMCPServerName(a.mcpServerName);
+    specifications.push(buildToolSpecification(a, { deferLoading }));
   }
 
   // Count the number of tokens used by the functions presented to the model.

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -18,6 +18,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Opt into Anthropic prompt-cache diagnostics to report cache-miss reasons on agent-loop steps",
     stage: "dust_only",
   },
+  anthropic_tool_search: {
+    description:
+      "Defer non-default (cold) MCP tools via Anthropic's tool search tool so mid-run tool additions append inline instead of mutating the cached prefix",
+    stage: "dust_only",
+  },
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -702,6 +702,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
   | "anthropic_cache_diagnostics"
+  | "anthropic_tool_search"
   | "audit_logs"
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
> [!NOTE]
> This is an experiment gated behind a FF but highly recommended by the Anthropic's team.
 
Anthropic builds its prompt cache as a prefix match, and tool definitions sit at the very front of that prefix, ahead of the system prompt and the entire conversation. Because of that ordering, any change to the set of tools we send (a tool added, or removed between steps of an agent run) invalidates the cache for everything that follows it, forcing the whole request to be reprocessed at full cost. Prompt-cache diagnostics in production confirmed this is by far the most frequent cause of cache misses for us: an agent that enables a new toolset partway through a conversation, or that picks up a just-in-time tool based on context, pays to re-read its full system prompt and history on the next step purely because the tool list moved.

This change adopts Anthropic's tool search tool to remove that coupling. The idea, as described in their documentation, is that you can hand the model a large catalog of tools without loading every definition into the context window upfront. Tools that aren't needed immediately are marked as deferred. The model searches the catalog and the API loads only the few it actually needs for a given request, expanding them inline in the conversation rather than at the front of the prefix. Their guidance notes this both keeps the context window small and preserves prompt caching, since the cached prefix is left untouched and discovered tools are appended after it.

Concretely, we split the tools an agent has into two groups. The ones served by default-attached servers (the tools that are present from the first step of a run and stay stable throughout) remain loaded normally and form a steady, cacheable prefix. Everything else, including anything that can appear partway through a run, is marked as deferred. When at least one tool is deferred, we also expose the search tool so the model can pull in the cold tools on demand. The effect is that enabling a tool mid-conversation becomes an append-only event instead of a rewrite of the cached prefix, so the cache survives across steps. Tools the model can be compelled to call are always kept loaded, since a deferred tool cannot be force-called before it has been discovered.

Beyond the cache, this also cuts the base token cost of every request. Tool definitions are part of the input on each call, and a fully equipped agent can carry a large catalog whose schemas add up quickly. Anthropic's documentation puts a typical multi-server setup at tens of thousands of tokens of definitions before the model does any work, and reports that deferring unused tools commonly removes the large majority of that. By keeping only the stable, frequently used tools in context and loading the rest on demand, we pay for far fewer tool schemas on the average request. The same reduction tends to improve tool selection as well, since the model chooses from a smaller, more relevant set rather than scanning a long list on every turn.

The behavior is gated behind a feature flag and is a no-op when the flag is off. The request is byte-for-byte identical to before. It is also expressed as a provider-neutral hint, so providers that have no equivalent capability simply ignore it and continue sending every tool as they do today.

> [!WARNING]
> Heads-up: the provider's tool-search and discovery events are intentionally not persisted to the conversation. This is a proof of concept, and saving provider-specific blocks is risky since the same conversation may later be replayed on a different model that wouldn't understand them. The tradeoff is that the model may occasionally rediscover a tool it already used earlier in the conversation. We'll watch whether this causes any confusion and course-correct if it does.

Reference: https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
