### PR TITLE
feat(front): add gpt-5.1 stream endpoint to new llm router

### DIFF
--- a/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_one.ts
@@ -1,0 +1,15 @@
+export function WithDustGptFiveDotOneConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGptFiveDotOne extends Base {
+    static readonly displayName = "GPT-5.1";
+    static readonly description =
+      "OpenAI's GPT-5.1 reasoning model (400k context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+  }
+
+  return DustGptFiveDotOne;
+}

--- a/front/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_one.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_one.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotOneConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_one";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one";
+
+export class DustOpenAIResponsesGlobalGptFiveDotOneStream extends WithDustGptFiveDotOneConfig(
+  OpenAIResponsesGlobalGptFiveDotOneStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesGlobalGptFiveDotOneStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -5,6 +5,7 @@ import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/s
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { DustOpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_one";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -24,6 +25,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustGoogleAiStudioGlobalGemini31ProStream,
   [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
+  [DustOpenAIResponsesGlobalGptFiveDotOneStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotOneStream,
   [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_one.ts
@@ -1,0 +1,50 @@
+import {
+  type InputConfig,
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { GPT_5_1_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// https://developers.openai.com/api/docs/models/gpt-5.1
+const CONTEXT_SIZE = 400_000;
+const MAX_OUTPUT_TOKENS = 128_000;
+const DEFAULT_REASONING_EFFORT = "medium";
+
+// gpt-5.1 accepts none/low/medium/high/xhigh. "minimal" and the universal
+// "maximal" are unsupported and surface as an input configuration error.
+const GPT_5_1_REASONING_EFFORTS = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+
+// gpt-5.1 rejects temperature entirely (unlike gpt-5.5 which allows it with reasoning: none).
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.enum(GPT_5_1_REASONING_EFFORTS) })
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+  // The Responses API rejects temperature for gpt-5.1 regardless of reasoning effort.
+  temperature: temperatureSchema.optional().transform(() => undefined),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithOpenAIGptFiveDotOneConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class OpenAIGptFiveDotOne extends Base {
+    static readonly modelId = GPT_5_1_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<InputConfig> = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return OpenAIGptFiveDotOne;
+}

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one.ts
@@ -1,0 +1,21 @@
+import { WithOpenAIGptFiveDotOneConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_one";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesGlobalGptFiveDotOneStream extends WithOpenAIGptFiveDotOneConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.1
+  static readonly tokenPricing = {
+    cacheHit: 0.125,
+    standardInput: 1.25,
+    standardOutput: 10.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+OpenAIResponsesGlobalGptFiveDotOneStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -5,6 +5,7 @@ import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_cons
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one";
 
 export const STREAM_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
@@ -17,6 +18,8 @@ export const STREAM_ENDPOINTS = {
     GoogleAiStudioGlobalGemini31ProStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
+  [OpenAIResponsesGlobalGptFiveDotOneStream.id]:
+    OpenAIResponsesGlobalGptFiveDotOneStream,
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_one";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesGlobalGptFiveDotOneStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    // Unlike Anthropic, the Responses API accepts a forced tool without
+    // requiring reasoning "none", so this is a normal tool call.
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_one.test.ts
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotOneStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -1,5 +1,6 @@
 export const GPT_5_5_MODEL_ID = "gpt-5.5" as const;
 export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
+export const GPT_5_1_MODEL_ID = "gpt-5.1" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
 export const CLAUDE_OPUS_4_8_MODEL_ID = "claude-opus-4-8" as const;
@@ -11,6 +12,7 @@ export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
   GPT_5_2_MODEL_ID,
+  GPT_5_1_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_HAIKU_4_5_MODEL_ID,
@@ -27,5 +29,6 @@ export const ORDERED_LARGE_MODEL_IDS = [
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   GPT_5_5_MODEL_ID,
+  GPT_5_1_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
 ];


### PR DESCRIPTION
## Description

Adds the `feat(front): add gpt-5.1 stream endpoint to new llm router` to the new `model_constructors` LLM router. Mirrors the existing gpt-5.5 endpoint across both router layers: the `model_constructors` layer (model id, config mixin, endpoint class, `STREAM_ENDPOINTS` registry) and the `lib/llms` integration layer (Dust config mixin, Dust wrapper, `DUST_STREAM_ENDPOINTS` registry).

The model's input config schema was characterized test-first against the live OpenAI Responses API:

- Reasoning efforts: `none/low/medium/high/xhigh`. `minimal` and `maximal` are rejected as input configuration errors.
- Temperature is never accepted (rejected even with `reasoning: none`) and is always stripped — stricter than gpt-5.5.

## Tests

New live integration test under `lib/model_constructors/test/endpoints/` (gated on `NODE_ENV=test RUN_LLM_TEST=true`, never runs in CI). Full suite passes 40/40 against the live API, covering the gpt-5.5 key set (reasoning efforts, temperatures, tool calls, forced tools, JSON output format, instruction following, prompt caching).

## Risk

Low. Additive only — a new endpoint class plus two registry entries; no existing model behavior changes. The schema rejects unsupported configs locally before any API call. Safe to roll back by reverting the commit.

## Deploy Plan

Standard deploy. No migrations, no env changes.