### PR TITLE
feat(front): add gpt-5.4-mini stream endpoint to new llm router

### DIFF
--- a/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -1,0 +1,15 @@
+export function WithDustGptFiveDotFourMiniConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGptFiveDotFourMini extends Base {
+    static readonly displayName = "GPT-5.4 Mini";
+    static readonly description =
+      "OpenAI's faster, cost-efficient GPT-5.4 for well-defined tasks (400k context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+  }
+
+  return DustGptFiveDotFourMini;
+}

--- a/front/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini.ts
+++ b/front/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini.ts
@@ -1,0 +1,11 @@
+import { WithDustGptFiveDotFourMiniConfig } from "@app/lib/llms/providers/openai/models/gpt_five_dot_four_mini";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { OpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
+
+export class DustOpenAIResponsesGlobalGptFiveDotFourMiniStream extends WithDustGptFiveDotFourMiniConfig(
+  OpenAIResponsesGlobalGptFiveDotFourMiniStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustOpenAIResponsesGlobalGptFiveDotFourMiniStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -5,6 +5,7 @@ import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/s
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { DustOpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -24,6 +25,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustGoogleAiStudioGlobalGemini31ProStream,
   [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
+  [DustOpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFourMiniStream,
   [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini.ts
@@ -1,0 +1,54 @@
+import {
+  type InputConfig,
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { GPT_5_4_MINI_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// https://developers.openai.com/api/docs/models/gpt-5.4-mini
+const CONTEXT_SIZE = 400_000;
+const MAX_OUTPUT_TOKENS = 128_000;
+const DEFAULT_REASONING_EFFORT = "medium";
+
+// gpt-5.4-mini accepts none/low/medium/high/xhigh. "minimal" and the universal
+// "maximal" are unsupported and surface as an input configuration error.
+const GPT_5_4_MINI_REASONING_EFFORTS = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+
+const configSchema = z.union([
+  inputConfigSchema.extend({
+    reasoning: z
+      .object({ effort: z.enum(GPT_5_4_MINI_REASONING_EFFORTS) })
+      .default({ effort: DEFAULT_REASONING_EFFORT }),
+    // The Responses API rejects an explicit temperature while reasoning is on.
+    temperature: temperatureSchema.optional().transform(() => undefined),
+  }),
+  inputConfigSchema.extend({
+    reasoning: z.object({ effort: z.literal("none") }),
+    temperature: temperatureSchema.optional(),
+  }),
+]);
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithOpenAIGptFiveDotFourMiniConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class OpenAIGptFiveDotFourMini extends Base {
+    static readonly modelId = GPT_5_4_MINI_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<InputConfig> = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return OpenAIGptFiveDotFourMini;
+}

--- a/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini.ts
+++ b/front/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini.ts
@@ -1,0 +1,21 @@
+import { WithOpenAIGptFiveDotFourMiniConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_four_mini";
+import { OpenAIResponsesStream } from "@app/lib/model_constructors/stream/clients/openai_responses";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesGlobalGptFiveDotFourMiniStream extends WithOpenAIGptFiveDotFourMiniConfig(
+  OpenAIResponsesStream
+) {
+  // https://developers.openai.com/api/docs/models/gpt-5.4-mini
+  static readonly tokenPricing = {
+    cacheHit: 0.075,
+    standardInput: 0.75,
+    standardOutput: 4.5,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+OpenAIResponsesGlobalGptFiveDotFourMiniStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -5,6 +5,7 @@ import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_cons
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
+import { OpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
 
 export const STREAM_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
@@ -17,6 +18,8 @@ export const STREAM_ENDPOINTS = {
     GoogleAiStudioGlobalGemini31ProStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
+  [OpenAIResponsesGlobalGptFiveDotFourMiniStream.id]:
+    OpenAIResponsesGlobalGptFiveDotFourMiniStream,
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;

--- a/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
+++ b/front/lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { OpenAIResponsesGlobalGptFiveDotFourMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four_mini";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new OpenAIResponsesGlobalGptFiveDotFourMiniStream({
+      OPENAI_API_KEY: process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // "minimal" and "maximal" reasoning efforts are not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/openai_responses_global_gpt_five_dot_four_mini.test.ts
+runStreamEndpointTests(OpenAIResponsesGlobalGptFiveDotFourMiniStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -1,4 +1,5 @@
 export const GPT_5_5_MODEL_ID = "gpt-5.5" as const;
+export const GPT_5_4_MINI_MODEL_ID = "gpt-5.4-mini" as const;
 export const GPT_5_2_MODEL_ID = "gpt-5.2" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
@@ -10,6 +11,7 @@ export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 // Include a few examples for now
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
+  GPT_5_4_MINI_MODEL_ID,
   GPT_5_2_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   CLAUDE_OPUS_4_8_MODEL_ID,


### PR DESCRIPTION
## Description

Adds the `feat(front): add gpt-5.4-mini stream endpoint to new llm router` to the new `model_constructors` LLM router. Mirrors the existing gpt-5.5 endpoint across both router layers: the `model_constructors` layer (model id, config mixin, endpoint class, `STREAM_ENDPOINTS` registry) and the `lib/llms` integration layer (Dust config mixin, Dust wrapper, `DUST_STREAM_ENDPOINTS` registry).

The model's input config schema was characterized test-first against the live OpenAI Responses API:

- Reasoning efforts: `none/low/medium/high/xhigh`. `minimal` and `maximal` are rejected as input configuration errors.
- Temperature is allowed only with `reasoning: none` and stripped otherwise (same as gpt-5.5).

## Tests

New live integration test under `lib/model_constructors/test/endpoints/` (gated on `NODE_ENV=test RUN_LLM_TEST=true`, never runs in CI). Full suite passes 40/40 against the live API, covering the gpt-5.5 key set (reasoning efforts, temperatures, tool calls, forced tools, JSON output format, instruction following, prompt caching).

## Risk

Low. Additive only — a new endpoint class plus two registry entries; no existing model behavior changes. The schema rejects unsupported configs locally before any API call. Safe to roll back by reverting the commit.

## Deploy Plan

Standard deploy. No migrations, no env changes.