### PR TITLE
[LLM] Support Mistral and Gemini models in the new router

### DIFF
--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -1,5 +1,7 @@
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import { isAnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
+import { GoogleLLM } from "@app/lib/api/llm/clients/google";
+import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
 import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
 import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
@@ -15,9 +17,10 @@ import type {
 import type { LLMCredentialsType } from "@app/types/provider_credential";
 
 // Test credentials. The SDKs are mocked, so values only need to be present
-// (the legacy Anthropic client asserts a non-empty ANTHROPIC_API_KEY).
+// (the legacy clients assert a non-empty API key for their provider).
 export const PARITY_CREDENTIALS: LLMCredentialsType = {
   ANTHROPIC_API_KEY: "test-anthropic-key",
+  GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
   OPENAI_API_KEY: "test-openai-key",
 };
 
@@ -58,6 +61,10 @@ export function readEndpointInfo(
  */
 export interface SdkCaptures {
   anthropic: { ga: unknown[]; beta: unknown[] };
+  // Both the legacy and the new Google routers call the same SDK method
+  // (`models.generateContentStream`), so calls land in one ordered bucket: the
+  // test drains the legacy stream first (index 0), then the new one (index 1).
+  google: unknown[];
   // OpenAI's legacy and new routers both call `client.responses.create`, so a
   // single bucket holds both requests, split by call order (see the adapter).
   openai: unknown[];
@@ -126,6 +133,43 @@ const anthropicProvider: ParityProvider = {
   },
 };
 
+const googleProvider: ParityProvider = {
+  toModelId(raw) {
+    if (!isModelId(raw) || !isGoogleAIStudioWhitelistedModelId(raw)) {
+      throw new Error(`${raw} is not a whitelisted Google AI Studio model.`);
+    }
+    return raw;
+  },
+  buildLegacyLLM(auth, _endpoint, params) {
+    if (
+      !isModelId(params.modelId) ||
+      !isGoogleAIStudioWhitelistedModelId(params.modelId)
+    ) {
+      throw new Error(
+        `${params.modelId} is not a whitelisted Google AI Studio model.`
+      );
+    }
+    // Only global endpoints are exercised locally, so the legacy counterpart is
+    // always the direct Google AI Studio API (no Vertex).
+    return new GoogleLLM(auth, {
+      credentials: PARITY_CREDENTIALS,
+      modelId: params.modelId,
+      temperature: params.temperature,
+      reasoningEffort: params.reasoningEffort,
+      responseFormat: params.responseFormat,
+      bypassFeatureFlag: true,
+    });
+  },
+  // Both routers call `models.generateContentStream`; the test drains legacy
+  // first (index 0), then new (index 1).
+  selectOldRequest(_endpoint, captures) {
+    return captures.google[0];
+  },
+  selectNewRequest(_endpoint, captures) {
+    return captures.google[1];
+  },
+};
+
 const openaiProvider: ParityProvider = {
   toModelId(raw) {
     if (!isModelId(raw) || !isOpenAIResponsesWhitelistedModelId(raw)) {
@@ -163,6 +207,7 @@ const openaiProvider: ParityProvider = {
 
 const PARITY_PROVIDERS: Partial<Record<ProviderId, ParityProvider>> = {
   anthropic: anthropicProvider,
+  google_ai_studio: googleProvider,
   openai: openaiProvider,
 };
 
@@ -175,11 +220,4 @@ export function getParityProvider(providerId: ProviderId): ParityProvider {
     );
   }
   return provider;
-}
-
-// Whether a provider has a parity adapter yet. Endpoints whose provider has no
-// adapter are skipped by the parity suite (rather than throwing) until their
-// adapter + SDK mock + normalizer are added.
-export function hasParityProvider(providerId: ProviderId): boolean {
-  return PARITY_PROVIDERS[providerId] !== undefined;
 }

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -23,7 +23,6 @@ import { normalizeRequest } from "@app/lib/api/llm/tests/parity/allowlist";
 import { buildParityMatrix } from "@app/lib/api/llm/tests/parity/matrix";
 import {
   getParityProvider,
-  hasParityProvider,
   PARITY_CREDENTIALS,
   readEndpointInfo,
 } from "@app/lib/api/llm/tests/parity/providers";
@@ -43,6 +42,7 @@ const kit = vi.hoisted(() => {
   const emptyStream = () => (async function* () {})();
   const freshCaptures = () => ({
     anthropic: { ga: [] as unknown[], beta: [] as unknown[] },
+    google: [] as unknown[],
     openai: [] as unknown[],
   });
   const state = { captures: freshCaptures() };
@@ -63,6 +63,17 @@ const kit = vi.hoisted(() => {
         },
       };
     };
+  // Both the legacy and new Google routers call `models.generateContentStream`,
+  // which the SDK exposes as async — return a resolved async iterator.
+  const makeGoogleClient = () =>
+    class {
+      models = {
+        generateContentStream: (input: unknown) => {
+          state.captures.google.push(input);
+          return Promise.resolve(emptyStream());
+        },
+      };
+    };
   // Both the legacy and new OpenAI routers call `client.responses.create`, so
   // one bucket records both; the adapter splits them by call order.
   const makeOpenAIClient = () =>
@@ -74,12 +85,17 @@ const kit = vi.hoisted(() => {
         },
       };
     };
-  return { state, makeClient, makeOpenAIClient, freshCaptures };
+  return { state, makeClient, makeGoogleClient, makeOpenAIClient, freshCaptures };
 });
 
 vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@anthropic-ai/sdk")>();
   return { ...actual, default: kit.makeClient() };
+});
+
+vi.mock("@google/genai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@google/genai")>();
+  return { ...actual, GoogleGenAI: kit.makeGoogleClient() };
 });
 
 vi.mock("openai", async (importOriginal) => {
@@ -102,11 +118,7 @@ async function drain(gen: AsyncGenerator<unknown>): Promise<Error | undefined> {
 // locally. Global agent-platform coverage can be added here once it exists.
 const ENDPOINTS = Object.values(DUST_STREAM_ENDPOINTS)
   .map(readEndpointInfo)
-  // Skip providers without a parity adapter yet (e.g. google_ai_studio).
-  .filter(
-    (endpoint) =>
-      endpoint.region === GLOBAL && hasParityProvider(endpoint.providerId)
-  );
+  .filter((endpoint) => endpoint.region === GLOBAL);
 const MATRIX = buildParityMatrix();
 
 describe.skipIf(process.env.RUN_LLM_TEST !== "true")(

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -85,7 +85,13 @@ const kit = vi.hoisted(() => {
         },
       };
     };
-  return { state, makeClient, makeGoogleClient, makeOpenAIClient, freshCaptures };
+  return {
+    state,
+    makeClient,
+    makeGoogleClient,
+    makeOpenAIClient,
+    freshCaptures,
+  };
 });
 
 vi.mock("@anthropic-ai/sdk", async (importOriginal) => {

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -117,6 +117,7 @@ function toBaseMessages(
           type: "tool_call_result",
           content: {
             callId: message.function_call_id,
+            toolName: message.name,
             parts,
             isError: false,
           },

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -1,4 +1,4 @@
-export function WithDustGoogleAiStudioGemini31FlashLiteConfig<
+export function WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -1,0 +1,16 @@
+export function WithDustGoogleAiStudioGemini31FlashLiteConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGoogleAiStudioGemini31FlashLite extends Base {
+    static readonly displayName = "Gemini 3.1 Flash Lite";
+    static readonly description =
+      "Google's latest lightweight model with a 1M-token context window.";
+    // Mirrors the legacy default reasoning effort ("light" → "low").
+    static readonly defaultReasoningEffort = "low";
+    static readonly byok = true;
+  }
+
+  return DustGoogleAiStudioGemini31FlashLite;
+}

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -6,7 +6,7 @@ export function WithDustGoogleAiStudioGemini31FlashLiteConfig<
   abstract class DustGoogleAiStudioGemini31FlashLite extends Base {
     static readonly displayName = "Gemini 3.1 Flash Lite";
     static readonly description =
-      "Google's latest lightweight model with a 1M-token context window.";
+      "Google's latest lightweight large context model (1m context).";
     // Mirrors the legacy default reasoning effort ("light" → "low").
     static readonly defaultReasoningEffort = "low";
     static readonly byok = true;

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -6,7 +6,7 @@ export function WithDustGoogleAiStudioGemini31ProConfig<
   abstract class DustGoogleAiStudioGemini31Pro extends Base {
     static readonly displayName = "Gemini 3.1 Pro (Preview)";
     static readonly description =
-      "Google's Gemini 3.1 Pro model, a state-of-the-art reasoning model with a 1M-token context window.";
+      "Google's latest powerful model with enhanced reasoning (1m context).";
     static readonly defaultReasoningEffort = "low";
     static readonly byok = true;
   }

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,9 +1,9 @@
-export function WithDustGoogleAiStudioGemini31ProConfig<
+export function WithDustGoogleAiStudioGeminiThreeDotOneProConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGoogleAiStudioGemini31Pro extends Base {
+  abstract class DustGoogleAiStudioGeminiThreeDotOnePro extends Base {
     static readonly displayName = "Gemini 3.1 Pro (Preview)";
     static readonly description =
       "Google's latest powerful model with enhanced reasoning (1m context).";
@@ -11,5 +11,5 @@ export function WithDustGoogleAiStudioGemini31ProConfig<
     static readonly byok = true;
   }
 
-  return DustGoogleAiStudioGemini31Pro;
+  return DustGoogleAiStudioGeminiThreeDotOnePro;
 }

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -1,9 +1,9 @@
-export function WithDustGoogleAiStudioGemini35FlashConfig<
+export function WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class DustGoogleAiStudioGemini35Flash extends Base {
+  abstract class DustGoogleAiStudioGeminiThreeDotFiveFlash extends Base {
     static readonly displayName = "Gemini 3.5 Flash";
     static readonly description =
       "Google's latest fast large context model (1m context).";
@@ -12,5 +12,5 @@ export function WithDustGoogleAiStudioGemini35FlashConfig<
     static readonly byok = true;
   }
 
-  return DustGoogleAiStudioGemini35Flash;
+  return DustGoogleAiStudioGeminiThreeDotFiveFlash;
 }

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -1,0 +1,16 @@
+export function WithDustGoogleAiStudioGemini35FlashConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustGoogleAiStudioGemini35Flash extends Base {
+    static readonly displayName = "Gemini 3.5 Flash";
+    static readonly description =
+      "Google's latest fast model with a 1M-token context window.";
+    // Mirrors the legacy default reasoning effort ("light" → "low").
+    static readonly defaultReasoningEffort = "low";
+    static readonly byok = true;
+  }
+
+  return DustGoogleAiStudioGemini35Flash;
+}

--- a/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -6,7 +6,7 @@ export function WithDustGoogleAiStudioGemini35FlashConfig<
   abstract class DustGoogleAiStudioGemini35Flash extends Base {
     static readonly displayName = "Gemini 3.5 Flash";
     static readonly description =
-      "Google's latest fast model with a 1M-token context window.";
+      "Google's latest fast large context model (1m context).";
     // Mirrors the legacy default reasoning effort ("light" → "low").
     static readonly defaultReasoningEffort = "low";
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -1,0 +1,15 @@
+export function WithDustMistralCodestralConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustMistralCodestral extends Base {
+    static readonly displayName = "Codestral";
+    static readonly description = "Mistral's code model (128k context).";
+    // Codestral is a non-reasoning model.
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = true;
+  }
+
+  return DustMistralCodestral;
+}

--- a/front/lib/llms/providers/mistral/models/codestral.ts
+++ b/front/lib/llms/providers/mistral/models/codestral.ts
@@ -4,8 +4,9 @@ export function WithDustMistralCodestralConfig<
   ) => object,
 >(Base: TBase) {
   abstract class DustMistralCodestral extends Base {
-    static readonly displayName = "Codestral";
-    static readonly description = "Mistral's code model (128k context).";
+    static readonly displayName = "Mistral Codestral";
+    static readonly description =
+      "Mistral's `codestral` model, specifically designed and optimized for code generation tasks.";
     // Codestral is a non-reasoning model.
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -1,0 +1,15 @@
+export function WithDustMistralLargeConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustMistralLarge extends Base {
+    static readonly displayName = "Mistral Large";
+    static readonly description = "Mistral's large model (256k context).";
+    // Mistral Large is a non-reasoning model.
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = true;
+  }
+
+  return DustMistralLarge;
+}

--- a/front/lib/llms/providers/mistral/models/mistral_large.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_large.ts
@@ -5,7 +5,7 @@ export function WithDustMistralLargeConfig<
 >(Base: TBase) {
   abstract class DustMistralLarge extends Base {
     static readonly displayName = "Mistral Large";
-    static readonly description = "Mistral's large model (256k context).";
+    static readonly description = "Mistral's `large` model (256k context).";
     // Mistral Large is a non-reasoning model.
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -1,0 +1,15 @@
+export function WithDustMistralMedium35Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustMistralMedium35 extends Base {
+    static readonly displayName = "Mistral Medium 3.5";
+    static readonly description =
+      "Mistral's medium reasoning model (256k context).";
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = true;
+  }
+
+  return DustMistralMedium35;
+}

--- a/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_medium_3_5.ts
@@ -6,7 +6,7 @@ export function WithDustMistralMedium35Config<
   abstract class DustMistralMedium35 extends Base {
     static readonly displayName = "Mistral Medium 3.5";
     static readonly description =
-      "Mistral's medium reasoning model (256k context).";
+      "Mistral's `medium 3.5` model, multimodal and optimized for agentic and coding use cases (256k context).";
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;
   }

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -5,7 +5,7 @@ export function WithDustMistralSmallConfig<
 >(Base: TBase) {
   abstract class DustMistralSmall extends Base {
     static readonly displayName = "Mistral Small";
-    static readonly description = "Mistral's small model (128k context).";
+    static readonly description = "Mistral's `small` model (128k context).";
     // Mistral Small is a non-reasoning model.
     static readonly defaultReasoningEffort = "none";
     static readonly byok = true;

--- a/front/lib/llms/providers/mistral/models/mistral_small.ts
+++ b/front/lib/llms/providers/mistral/models/mistral_small.ts
@@ -1,0 +1,15 @@
+export function WithDustMistralSmallConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustMistralSmall extends Base {
+    static readonly displayName = "Mistral Small";
+    static readonly description = "Mistral's small model (128k context).";
+    // Mistral Small is a non-reasoning model.
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = true;
+  }
+
+  return DustMistralSmall;
+}

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGemini31FlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+
+export class DustGoogleAiStudioGlobalGemini31FlashLiteStream extends WithDustGoogleAiStudioGemini31FlashLiteConfig(
+  GoogleAiStudioGlobalGemini31FlashLiteStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustGoogleAiStudioGlobalGemini31FlashLiteStream);

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,9 +1,9 @@
 import { WithDustGoogleAiStudioGemini31FlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
 import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
-import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 
 export class DustGoogleAiStudioGlobalGemini31FlashLiteStream extends WithDustGoogleAiStudioGemini31FlashLiteConfig(
-  GoogleAiStudioGlobalGemini31FlashLiteStream
+  GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream
 ) {
   static readonly endpointFilter = {};
 }

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,11 +1,13 @@
-import { WithDustGoogleAiStudioGemini31FlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
 import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 
-export class DustGoogleAiStudioGlobalGemini31FlashLiteStream extends WithDustGoogleAiStudioGemini31FlashLiteConfig(
+export class DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream extends WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
   GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream
 ) {
   static readonly endpointFilter = {};
 }
 
-defineDustStreamEndpoint(DustGoogleAiStudioGlobalGemini31FlashLiteStream);
+defineDustStreamEndpoint(
+  DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream
+);

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -1,11 +1,11 @@
-import { WithDustGoogleAiStudioGemini31ProConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro";
+import { WithDustGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro";
 import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
-import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 
-export class DustGoogleAiStudioGlobalGemini31ProStream extends WithDustGoogleAiStudioGemini31ProConfig(
-  GoogleAiStudioGlobalGemini31ProStream
+export class DustGoogleAiStudioGlobalGeminiThreeDotOneProStream extends WithDustGoogleAiStudioGeminiThreeDotOneProConfig(
+  GoogleAiStudioGlobalGeminiThreeDotOneProStream
 ) {
   static readonly endpointFilter = {};
 }
 
-defineDustStreamEndpoint(DustGoogleAiStudioGlobalGemini31ProStream);
+defineDustStreamEndpoint(DustGoogleAiStudioGlobalGeminiThreeDotOneProStream);

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,0 +1,11 @@
+import { WithDustGoogleAiStudioGemini35FlashConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+
+export class DustGoogleAiStudioGlobalGemini35FlashStream extends WithDustGoogleAiStudioGemini35FlashConfig(
+  GoogleAiStudioGlobalGemini35FlashStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustGoogleAiStudioGlobalGemini35FlashStream);

--- a/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,11 +1,11 @@
-import { WithDustGoogleAiStudioGemini35FlashConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash";
+import { WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash";
 import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
-import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 
-export class DustGoogleAiStudioGlobalGemini35FlashStream extends WithDustGoogleAiStudioGemini35FlashConfig(
-  GoogleAiStudioGlobalGemini35FlashStream
+export class DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream extends WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream
 ) {
   static readonly endpointFilter = {};
 }
 
-defineDustStreamEndpoint(DustGoogleAiStudioGlobalGemini35FlashStream);
+defineDustStreamEndpoint(DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream);

--- a/front/lib/llms/stream/endpoints/mistral_eu_codestral.ts
+++ b/front/lib/llms/stream/endpoints/mistral_eu_codestral.ts
@@ -1,0 +1,11 @@
+import { WithDustMistralCodestralConfig } from "@app/lib/llms/providers/mistral/models/codestral";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_codestral";
+
+export class DustMistralEuropeCodestralStream extends WithDustMistralCodestralConfig(
+  MistralEuropeCodestralStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustMistralEuropeCodestralStream);

--- a/front/lib/llms/stream/endpoints/mistral_eu_mistral_large.ts
+++ b/front/lib/llms/stream/endpoints/mistral_eu_mistral_large.ts
@@ -1,0 +1,11 @@
+import { WithDustMistralLargeConfig } from "@app/lib/llms/providers/mistral/models/mistral_large";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
+
+export class DustMistralEuropeMistralLargeStream extends WithDustMistralLargeConfig(
+  MistralEuropeMistralLargeStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustMistralEuropeMistralLargeStream);

--- a/front/lib/llms/stream/endpoints/mistral_eu_mistral_medium_3_5.ts
+++ b/front/lib/llms/stream/endpoints/mistral_eu_mistral_medium_3_5.ts
@@ -1,0 +1,11 @@
+import { WithDustMistralMedium35Config } from "@app/lib/llms/providers/mistral/models/mistral_medium_3_5";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
+
+export class DustMistralEuropeMistralMedium35Stream extends WithDustMistralMedium35Config(
+  MistralEuropeMistralMedium35Stream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustMistralEuropeMistralMedium35Stream);

--- a/front/lib/llms/stream/endpoints/mistral_eu_mistral_small.ts
+++ b/front/lib/llms/stream/endpoints/mistral_eu_mistral_small.ts
@@ -1,0 +1,11 @@
+import { WithDustMistralSmallConfig } from "@app/lib/llms/providers/mistral/models/mistral_small";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+
+export class DustMistralEuropeMistralSmallStream extends WithDustMistralSmallConfig(
+  MistralEuropeMistralSmallStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustMistralEuropeMistralSmallStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,8 +3,8 @@ import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
-import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
-import { DustGoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
@@ -21,10 +21,10 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicGlobalClaudeOpusFourDotEightStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
-  [DustGoogleAiStudioGlobalGemini31ProStream.id]:
-    DustGoogleAiStudioGlobalGemini31ProStream,
-  [DustGoogleAiStudioGlobalGemini35FlashStream.id]:
-    DustGoogleAiStudioGlobalGemini35FlashStream,
+  [DustGoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  [DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream,
   [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
   [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -4,6 +4,7 @@ import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/ll
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { DustGoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
@@ -22,6 +23,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [DustGoogleAiStudioGlobalGemini31ProStream.id]:
     DustGoogleAiStudioGlobalGemini31ProStream,
+  [DustGoogleAiStudioGlobalGemini35FlashStream.id]:
+    DustGoogleAiStudioGlobalGemini35FlashStream,
   [DustOpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
   [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,6 +3,7 @@ import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
@@ -29,6 +30,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustOpenAIResponsesGlobalGptFiveDotFiveStream,
   [DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  [DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,6 +3,7 @@ import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustGoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,7 +3,6 @@ import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
-import { DustGoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGemini31ProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
@@ -260,7 +260,12 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_err", toolName: "tool_err", parts: [], isError: true },
+      content: {
+        callId: "call_err",
+        toolName: "tool_err",
+        parts: [],
+        isError: true,
+      },
     };
     expect(toolCallResultMessageToToolResultBlock(message)).toEqual({
       type: "tool_result",
@@ -274,7 +279,12 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_ok", toolName: "tool_ok", parts: [], isError: false },
+      content: {
+        callId: "call_ok",
+        toolName: "tool_ok",
+        parts: [],
+        isError: false,
+      },
     };
     expect(toolCallResultMessageToToolResultBlock(message)).not.toHaveProperty(
       "is_error"
@@ -285,7 +295,12 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_c", toolName: "tool_c", parts: [], isError: false },
+      content: {
+        callId: "call_c",
+        toolName: "tool_c",
+        parts: [],
+        isError: false,
+      },
       cache: "short",
     };
     expect(toolCallResultMessageToToolResultBlock(message)).toMatchObject({
@@ -297,7 +312,12 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_empty", toolName: "tool_empty", parts: [], isError: false },
+      content: {
+        callId: "call_empty",
+        toolName: "tool_empty",
+        parts: [],
+        isError: false,
+      },
     };
     expect(toolCallResultMessageToToolResultBlock(message).content).toEqual([]);
   });

--- a/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/providers/anthropic/converters/input/utils.test.ts
@@ -235,6 +235,7 @@ describe("toolCallResultMessageToToolResultBlock", () => {
       type: "tool_call_result",
       content: {
         callId: "call_1",
+        toolName: "tool_1",
         parts: [
           { type: "text", text: "result text" },
           { type: "image_url", url: "https://example.com/img.png" },
@@ -259,7 +260,7 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_err", parts: [], isError: true },
+      content: { callId: "call_err", toolName: "tool_err", parts: [], isError: true },
     };
     expect(toolCallResultMessageToToolResultBlock(message)).toEqual({
       type: "tool_result",
@@ -273,7 +274,7 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_ok", parts: [], isError: false },
+      content: { callId: "call_ok", toolName: "tool_ok", parts: [], isError: false },
     };
     expect(toolCallResultMessageToToolResultBlock(message)).not.toHaveProperty(
       "is_error"
@@ -284,7 +285,7 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_c", parts: [], isError: false },
+      content: { callId: "call_c", toolName: "tool_c", parts: [], isError: false },
       cache: "short",
     };
     expect(toolCallResultMessageToToolResultBlock(message)).toMatchObject({
@@ -296,7 +297,7 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "call_empty", parts: [], isError: false },
+      content: { callId: "call_empty", toolName: "tool_empty", parts: [], isError: false },
     };
     expect(toolCallResultMessageToToolResultBlock(message).content).toEqual([]);
   });
@@ -406,7 +407,7 @@ describe("userMessageToContentBlocks", () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "c", parts: [], isError: false },
+      content: { callId: "c", toolName: "t", parts: [], isError: false },
     };
     userMessageToContentBlocks(message, stub);
     expect(stub.toolCallResultMessageToToolResultBlock).toHaveBeenCalledWith(

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/index.ts
@@ -5,9 +5,9 @@ import {
   assistantToolCallRequestToPart,
   type ContentBlockConverters,
   conversationToContents,
+  effortToThinkingLevel,
   forceToolNameToToolConfig,
   outputFormatToResponseSchema,
-  reasoningToThinkingConfig,
   systemMessagesToSystemInstruction,
   systemMessageToPart,
   toFunctionDeclaration,
@@ -83,7 +83,12 @@ export function WithGoogleAiStudioInputConverter<
               ? [{ functionDeclarations: tools.map(toFunctionDeclaration) }]
               : undefined,
           toolConfig: forceToolNameToToolConfig(tools, forceTool),
-          thinkingConfig: reasoningToThinkingConfig(reasoning),
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingLevel: reasoning
+              ? effortToThinkingLevel(reasoning.effort)
+              : undefined,
+          },
           maxOutputTokens: this.constructor.maxOutputTokens,
           ...(outputFormat
             ? {

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
@@ -1,4 +1,3 @@
-import type { GoogleAiStudioInputConfig } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
 import type { GeminiSupportedReasoningEffort } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import type {
   OutputFormat,
@@ -26,7 +25,6 @@ import type {
   FunctionDeclaration,
   Part,
   SchemaUnion,
-  ThinkingConfig,
   ToolConfig,
 } from "@google/genai";
 import { FunctionCallingConfigMode, ThinkingLevel } from "@google/genai";
@@ -328,7 +326,7 @@ export function forceToolNameToToolConfig(
     : undefined;
 }
 
-function effortToThinkingLevel(
+export function effortToThinkingLevel(
   effort: GeminiSupportedReasoningEffort
 ): ThinkingLevel {
   switch (effort) {
@@ -343,16 +341,4 @@ function effortToThinkingLevel(
     default:
       assertNever(effort);
   }
-}
-
-export function reasoningToThinkingConfig(
-  reasoning: GoogleAiStudioInputConfig["reasoning"]
-): ThinkingConfig | undefined {
-  if (!reasoning) {
-    return undefined;
-  }
-  return {
-    thinkingLevel: effortToThinkingLevel(reasoning.effort),
-    includeThoughts: true,
-  };
 }

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
@@ -139,6 +139,7 @@ export async function toolCallResultMessageToContent(
       {
         functionResponse: {
           id: message.content.callId,
+          name: message.content.toolName,
           response: message.content.isError ? { error: output } : { output },
         },
       },

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/input/utils.ts
@@ -228,15 +228,6 @@ function assistantMessageToContent(
   }
 }
 
-function isFunctionResponseContent(content: Content): boolean {
-  const parts = content.parts ?? [];
-  return (
-    content.role === "user" &&
-    parts.length > 0 &&
-    parts.every((part) => part.functionResponse !== undefined)
-  );
-}
-
 export async function conversationToContents(
   conversation: BaseConversation,
   converters: ContentBlockConverters
@@ -260,16 +251,21 @@ export async function conversationToContents(
     { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
   );
 
-  // Merge consecutive function-response turns into one user turn: Gemini
-  // requires the functionResponse part count to match the functionCall count of
-  // the preceding model turn.
+  // Merge consecutive same-role turns into a single Content. This serves two
+  // purposes:
+  // - Function-response turns: Gemini requires the functionResponse part count
+  //   to match the functionCall count of the preceding model turn.
+  // - Model turns: a single assistant turn is split into one BaseMessage per
+  //   content block (reasoning, tool call, text), so they arrive here as
+  //   separate model Contents. Gemini computes the tool call's thoughtSignature
+  //   over the whole turn (e.g. reasoning followed by the functionCall), so the
+  //   parts must be replayed together in one Content or the signature is
+  //   rejected as corrupted.
+  // Consecutive same-role Contents only arise from one logical turn being split:
+  // distinct assistant turns are always separated by a tool-result/user turn.
   return contents.reduce<Content[]>((merged, content) => {
     const previous = merged[merged.length - 1];
-    if (
-      previous &&
-      isFunctionResponseContent(previous) &&
-      isFunctionResponseContent(content)
-    ) {
+    if (previous && previous.role === content.role) {
       return [
         ...merged.slice(0, -1),
         {

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
@@ -328,11 +328,15 @@ function flushAccumulated(
 ): ModelResponseEvent[] {
   const events: ModelResponseEvent[] = [];
   if (acc.reasoningParts) {
-    // The turn's thought signature is carried on the success metadata (see
-    // rawOutputToEvents), not per reasoning block.
+    // Carry the turn's thought signature on the reasoning block so it is
+    // persisted with it and echoed back on replay. Gemini emits the signature
+    // on the thinking (or a trailing) part ahead of the function call, so it is
+    // captured in `acc.thoughtSignature` by the time we flush. Dropping it here
+    // makes Gemini reject the replayed turn as a corrupted thought signature.
     const event = converters.accumulatedReasoningToReasoningEvent(
       metadata,
-      acc.reasoningParts
+      acc.reasoningParts,
+      acc.thoughtSignature
     );
     aggregated.push(event);
     events.push(event);

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
@@ -55,7 +55,8 @@ export interface OutputEventConverters {
     metadata: EndpointMetadata,
     id: string,
     name: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    thoughtSignature?: string
   ): ToolCallEvent;
   usageToTokenUsageEvent(
     metadata: EndpointMetadata,
@@ -129,12 +130,18 @@ export function functionCallToToolCallEvent(
   metadata: EndpointMetadata,
   id: string,
   name: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  thoughtSignature?: string
 ): ToolCallEvent {
   return {
     type: "tool_call",
     content: { id, name, arguments: args },
-    metadata,
+    // Gemini 3 requires the thought signature to be echoed back in subsequent
+    // requests, so carry it on the tool call's metadata.
+    metadata: {
+      ...metadata,
+      ...(thoughtSignature ? { content: { thoughtSignature } } : {}),
+    },
   };
 }
 
@@ -319,10 +326,11 @@ function flushAccumulated(
 ): ModelResponseEvent[] {
   const events: ModelResponseEvent[] = [];
   if (acc.reasoningParts) {
+    // The turn's thought signature is carried on the success metadata (see
+    // rawOutputToEvents), not per reasoning block.
     const event = converters.accumulatedReasoningToReasoningEvent(
       metadata,
-      acc.reasoningParts,
-      acc.thoughtSignature
+      acc.reasoningParts
     );
     aggregated.push(event);
     events.push(event);
@@ -370,7 +378,8 @@ function partToEvents(
       metadata,
       callId,
       name,
-      args ?? {}
+      args ?? {},
+      part.thoughtSignature
     );
     aggregated.push(toolCallEvent);
     events.push(toolCallEvent);
@@ -378,12 +387,15 @@ function partToEvents(
     return events;
   }
 
-  if (!part.text) {
-    return [];
-  }
-
+  // Gemini 3 emits the turn's thought signature on a trailing part that often
+  // carries no text (alongside the STOP finish reason), so capture it before
+  // the empty-text early return below.
   if (part.thoughtSignature) {
     acc.thoughtSignature = part.thoughtSignature;
+  }
+
+  if (!part.text) {
+    return [];
   }
 
   if (part.thought) {
@@ -476,5 +488,18 @@ export async function* rawOutputToEvents(
   }
 
   yield converters.usageToTokenUsageEvent(metadata, usage);
-  yield { type: "success", content: { aggregated }, metadata };
+  // Gemini 3 returns a single turn-level thought signature (emitted on a
+  // trailing part with the STOP finish reason). The final text has no message
+  // slot to carry it and the turn may not include any reasoning, so carry it on
+  // the success metadata to be echoed back on the next request.
+  yield {
+    type: "success",
+    content: { aggregated },
+    metadata: {
+      ...metadata,
+      ...(acc.thoughtSignature
+        ? { content: { thoughtSignature: acc.thoughtSignature } }
+        : {}),
+    },
+  };
 }

--- a/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/converters/output/utils.ts
@@ -137,10 +137,12 @@ export function functionCallToToolCallEvent(
     type: "tool_call",
     content: { id, name, arguments: args },
     // Gemini 3 requires the thought signature to be echoed back in subsequent
-    // requests, so carry it on the tool call's metadata.
+    // requests, so carry it on the tool call's metadata. The signature is
+    // carried under the generic `signature` key (matching reasoning events and
+    // other providers); the transition layer persists it as `thoughtSignature`.
     metadata: {
       ...metadata,
-      ...(thoughtSignature ? { content: { thoughtSignature } } : {}),
+      ...(thoughtSignature ? { content: { signature: thoughtSignature } } : {}),
     },
   };
 }
@@ -498,7 +500,7 @@ export async function* rawOutputToEvents(
     metadata: {
       ...metadata,
       ...(acc.thoughtSignature
-        ? { content: { thoughtSignature: acc.thoughtSignature } }
+        ? { content: { signature: acc.thoughtSignature } }
         : {}),
     },
   };

--- a/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
@@ -1,5 +1,8 @@
 import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
 import { z } from "zod";
 
 // Provider-wide input config: the widest reasoning contract any Gemini model
@@ -11,6 +14,8 @@ export const googleAiStudioConfigSchema = inputConfigSchema.extend({
       effort: z.enum(GEMINI_SUPPORTED_REASONING_EFFORTS),
     })
     .optional(),
+  cacheKey: z.undefined(),
+  temperature: temperatureSchema.optional().transform(() => 1 as const),
 });
 
 export type GoogleAiStudioInputConfig = z.infer<

--- a/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
@@ -15,6 +15,7 @@ export const googleAiStudioConfigSchema = inputConfigSchema.extend({
     })
     .optional(),
   cacheKey: z.undefined(),
+  // Not required but strongly recommended by Google for Gemini 3
   temperature: temperatureSchema.optional().transform(() => 1 as const),
 });
 

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -1,0 +1,24 @@
+import {
+  GEMINI_3_CONTEXT_SIZE,
+  GEMINI_3_MAX_OUTPUT_TOKENS,
+  geminiV3ConfigSchema,
+} from "@app/lib/model_constructors/providers/google_ai_studio/models/shared";
+import { GEMINI_3_1_FLASH_LITE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithGoogleAiStudioGemini31FlashLiteConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class GoogleAiStudioGemini31FlashLite extends Base {
+    static readonly modelId = GEMINI_3_1_FLASH_LITE_MODEL_ID;
+
+    static readonly configSchema = geminiV3ConfigSchema;
+
+    static readonly contextSize = GEMINI_3_CONTEXT_SIZE;
+    static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
+  }
+
+  return GoogleAiStudioGemini31FlashLite;
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -6,12 +6,12 @@ import {
 import { GEMINI_3_1_FLASH_LITE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 // Mixin carrying shared config; runtime base differs per surface.
-export function WithGoogleAiStudioGemini31FlashLiteConfig<
+export function WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class GoogleAiStudioGemini31FlashLite extends Base {
+  abstract class GoogleAiStudioGeminiThreeDotOneFlashLite extends Base {
     static readonly modelId = GEMINI_3_1_FLASH_LITE_MODEL_ID;
 
     static readonly configSchema = geminiV3ConfigSchema;
@@ -20,5 +20,5 @@ export function WithGoogleAiStudioGemini31FlashLiteConfig<
     static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
   }
 
-  return GoogleAiStudioGemini31FlashLite;
+  return GoogleAiStudioGeminiThreeDotOneFlashLite;
 }

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -1,9 +1,20 @@
-import {
-  GEMINI_3_CONTEXT_SIZE,
-  GEMINI_3_MAX_OUTPUT_TOKENS,
-  geminiV3ConfigSchema,
-} from "@app/lib/model_constructors/providers/google_ai_studio/models/shared";
+import { googleAiStudioConfigSchema } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
+import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import { GEMINI_3_1_FLASH_LITE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import { z } from "zod";
+
+export const CONTEXT_SIZE = 1_000_000;
+export const MAX_OUTPUT_TOKENS = 65_536;
+
+const DEFAULT_REASONING_EFFORT = "minimal";
+
+export const configSchema = googleAiStudioConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum(GEMINI_SUPPORTED_REASONING_EFFORTS),
+    })
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+});
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig<
@@ -14,10 +25,10 @@ export function WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig<
   abstract class GoogleAiStudioGeminiThreeDotOneFlashLite extends Base {
     static readonly modelId = GEMINI_3_1_FLASH_LITE_MODEL_ID;
 
-    static readonly configSchema = geminiV3ConfigSchema;
+    static readonly configSchema = configSchema;
 
-    static readonly contextSize = GEMINI_3_CONTEXT_SIZE;
-    static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
   }
 
   return GoogleAiStudioGeminiThreeDotOneFlashLite;

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,3 +1,7 @@
+import {
+  GEMINI_3_CONTEXT_SIZE,
+  GEMINI_3_MAX_OUTPUT_TOKENS,
+} from "@app/lib/model_constructors/providers/google_ai_studio/models/shared";
 import { GEMINI_PRO_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import {
   inputConfigSchema,
@@ -7,10 +11,6 @@ import { GEMINI_3_1_PRO_MODEL_ID } from "@app/lib/model_constructors/types/model
 
 import { z } from "zod";
 
-// Verified against https://ai.google.dev/gemini-api/docs/models (2026-06-18):
-// Gemini 3 Pro has a 1M-token context window and up to 64k output tokens.
-const CONTEXT_SIZE = 1_000_000;
-const MAX_OUTPUT_TOKENS = 65_536;
 const DEFAULT_REASONING_EFFORT = "high";
 
 const baseConfig = inputConfigSchema.extend({
@@ -40,8 +40,8 @@ export function WithGoogleAiStudioGemini31ProConfig<
 
     static readonly configSchema = configSchema;
 
-    static readonly contextSize = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    static readonly contextSize = GEMINI_3_CONTEXT_SIZE;
+    static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
   }
 
   return GoogleAiStudioGemini31Pro;

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -30,12 +30,12 @@ const configSchema = baseConfig.extend({
 });
 
 // Mixin carrying shared config; runtime base differs per surface.
-export function WithGoogleAiStudioGemini31ProConfig<
+export function WithGoogleAiStudioGeminiThreeDotOneProConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class GoogleAiStudioGemini31Pro extends Base {
+  abstract class GoogleAiStudioGeminiThreeDotOnePro extends Base {
     static readonly modelId = GEMINI_3_1_PRO_MODEL_ID;
 
     static readonly configSchema = configSchema;
@@ -44,5 +44,5 @@ export function WithGoogleAiStudioGemini31ProConfig<
     static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
   }
 
-  return GoogleAiStudioGemini31Pro;
+  return GoogleAiStudioGeminiThreeDotOnePro;
 }

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro.ts
@@ -1,32 +1,23 @@
+import { googleAiStudioConfigSchema } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
 import {
   GEMINI_3_CONTEXT_SIZE,
   GEMINI_3_MAX_OUTPUT_TOKENS,
 } from "@app/lib/model_constructors/providers/google_ai_studio/models/shared";
 import { GEMINI_PRO_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
-import {
-  inputConfigSchema,
-  temperatureSchema,
-} from "@app/lib/model_constructors/types/input/configuration";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
 
 const DEFAULT_REASONING_EFFORT = "high";
 
-const baseConfig = inputConfigSchema.extend({
-  // Gemini uses implicit caching; we do not pass an explicit cache key.
-  cacheKey: z.undefined(),
-});
-
 // Pro supports the low/medium/high thinking levels (no `minimal`) and strongly
 // recommends `temperature: 1`, so we coerce temperature to 1.
-const configSchema = baseConfig.extend({
+const configSchema = googleAiStudioConfigSchema.extend({
   reasoning: z
     .object({
       effort: z.enum(GEMINI_PRO_SUPPORTED_REASONING_EFFORTS),
     })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
-  temperature: temperatureSchema.optional().transform(() => 1 as const),
 });
 
 // Mixin carrying shared config; runtime base differs per surface.

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -1,9 +1,25 @@
+import { googleAiStudioConfigSchema } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
 import {
   GEMINI_3_CONTEXT_SIZE,
   GEMINI_3_MAX_OUTPUT_TOKENS,
-  geminiV3ConfigSchema,
 } from "@app/lib/model_constructors/providers/google_ai_studio/models/shared";
+import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import { GEMINI_3_5_FLASH_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+export const CONTEXT_SIZE = 1_000_000;
+export const MAX_OUTPUT_TOKENS = 65_536;
+
+const DEFAULT_REASONING_EFFORT = "high";
+
+export const configSchema = googleAiStudioConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum(GEMINI_SUPPORTED_REASONING_EFFORTS),
+    })
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+});
 
 // Mixin carrying shared config; runtime base differs per surface.
 export function WithGoogleAiStudioGeminiThreeDotFiveFlashConfig<
@@ -14,7 +30,7 @@ export function WithGoogleAiStudioGeminiThreeDotFiveFlashConfig<
   abstract class GoogleAiStudioGeminiThreeDotFiveFlash extends Base {
     static readonly modelId = GEMINI_3_5_FLASH_MODEL_ID;
 
-    static readonly configSchema = geminiV3ConfigSchema;
+    static readonly configSchema = configSchema;
 
     static readonly contextSize = GEMINI_3_CONTEXT_SIZE;
     static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -1,0 +1,24 @@
+import {
+  GEMINI_3_CONTEXT_SIZE,
+  GEMINI_3_MAX_OUTPUT_TOKENS,
+  geminiV3ConfigSchema,
+} from "@app/lib/model_constructors/providers/google_ai_studio/models/shared";
+import { GEMINI_3_5_FLASH_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithGoogleAiStudioGemini35FlashConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class GoogleAiStudioGemini35Flash extends Base {
+    static readonly modelId = GEMINI_3_5_FLASH_MODEL_ID;
+
+    static readonly configSchema = geminiV3ConfigSchema;
+
+    static readonly contextSize = GEMINI_3_CONTEXT_SIZE;
+    static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
+  }
+
+  return GoogleAiStudioGemini35Flash;
+}

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash.ts
@@ -6,12 +6,12 @@ import {
 import { GEMINI_3_5_FLASH_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 // Mixin carrying shared config; runtime base differs per surface.
-export function WithGoogleAiStudioGemini35FlashConfig<
+export function WithGoogleAiStudioGeminiThreeDotFiveFlashConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class GoogleAiStudioGemini35Flash extends Base {
+  abstract class GoogleAiStudioGeminiThreeDotFiveFlash extends Base {
     static readonly modelId = GEMINI_3_5_FLASH_MODEL_ID;
 
     static readonly configSchema = geminiV3ConfigSchema;
@@ -20,5 +20,5 @@ export function WithGoogleAiStudioGemini35FlashConfig<
     static readonly maxOutputTokens = GEMINI_3_MAX_OUTPUT_TOKENS;
   }
 
-  return GoogleAiStudioGemini35Flash;
+  return GoogleAiStudioGeminiThreeDotFiveFlash;
 }

--- a/front/lib/model_constructors/providers/google_ai_studio/models/shared.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/shared.ts
@@ -1,0 +1,34 @@
+import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+
+import { z } from "zod";
+
+// Shared config for Gemini 3.x models that expose the full set of native
+// thinking levels (Flash, Flash-Lite). Pro narrows this further (no `minimal`),
+// so it defines its own schema; the capability constants are still reused.
+
+// Verified against https://ai.google.dev/gemini-api/docs/models (2026-06-18):
+// Gemini 3.x has a 1M-token context window and up to 64k output tokens.
+export const GEMINI_3_CONTEXT_SIZE = 1_000_000;
+export const GEMINI_3_MAX_OUTPUT_TOKENS = 65_536;
+
+const DEFAULT_REASONING_EFFORT = "high";
+
+const baseConfig = inputConfigSchema.extend({
+  // Gemini uses implicit caching; we do not pass an explicit cache key.
+  cacheKey: z.undefined(),
+});
+
+// Supports all native thinking levels (minimal/low/medium/high) and strongly
+// recommends `temperature: 1`, so we coerce temperature to 1.
+export const geminiV3ConfigSchema = baseConfig.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([...GEMINI_SUPPORTED_REASONING_EFFORTS]),
+    })
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+  temperature: temperatureSchema.optional().transform(() => 1 as const),
+});

--- a/front/lib/model_constructors/providers/mistral/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/input/index.ts
@@ -1,0 +1,63 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import {
+  assistantReasoningMessageToMessage,
+  assistantTextMessageToMessage,
+  assistantToolCallRequestToMessage,
+  conversationToMistralMessages,
+  forceToolNameToToolChoice,
+  type MistralMessageConverters,
+  outputFormatToResponseFormat,
+  systemMessageToMessage,
+  toolCallResultMessageToMessage,
+  toTool,
+  userImageMessageToMessage,
+  userTextMessageToMessage,
+} from "@app/lib/model_constructors/providers/mistral/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type { ChatCompletionStreamRequest } from "@mistralai/mistralai/models/components";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the Mistral
+// `chat.stream` request shape. Leaf converters are bound as class fields and the
+// composite routes through `this`, so an endpoint can override a single leaf.
+export function WithMistralInputConverter<
+  TBase extends AbstractConstructor<Client>,
+>(Base: TBase) {
+  abstract class WithMistralInputConverter
+    extends Base
+    implements MistralMessageConverters
+  {
+    systemMessageToMessage = systemMessageToMessage;
+    userTextMessageToMessage = userTextMessageToMessage;
+    userImageMessageToMessage = userImageMessageToMessage;
+    toolCallResultMessageToMessage = toolCallResultMessageToMessage;
+    assistantTextMessageToMessage = assistantTextMessageToMessage;
+    assistantReasoningMessageToMessage = assistantReasoningMessageToMessage;
+    assistantToolCallRequestToMessage = assistantToolCallRequestToMessage;
+
+    buildRequestPayload(
+      payload: Payload,
+      config: InputConfig
+    ): ChatCompletionStreamRequest {
+      const { conversation } = payload;
+      const { tools = [], temperature, forceTool, outputFormat } = config;
+
+      // Mistral is not sent an explicit max-output cap (matching the legacy
+      // client); it uses its own default.
+      return {
+        model: this.constructor.modelId,
+        messages: conversationToMistralMessages(conversation, this),
+        temperature,
+        tools: tools.map(toTool),
+        toolChoice: forceToolNameToToolChoice(tools, forceTool),
+        ...(outputFormat
+          ? { responseFormat: outputFormatToResponseFormat(outputFormat) }
+          : {}),
+      };
+    }
+  }
+
+  return WithMistralInputConverter;
+}

--- a/front/lib/model_constructors/providers/mistral/converters/input/index.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/input/index.ts
@@ -13,7 +13,7 @@ import {
   userImageMessageToMessage,
   userTextMessageToMessage,
 } from "@app/lib/model_constructors/providers/mistral/converters/input/utils";
-import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { MistralInputConfig } from "@app/lib/model_constructors/providers/mistral/inputConfig";
 import type { Payload } from "@app/lib/model_constructors/types/input/messages";
 import type { ChatCompletionStreamRequest } from "@mistralai/mistralai/models/components";
 
@@ -23,7 +23,7 @@ type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 // `chat.stream` request shape. Leaf converters are bound as class fields and the
 // composite routes through `this`, so an endpoint can override a single leaf.
 export function WithMistralInputConverter<
-  TBase extends AbstractConstructor<Client>,
+  TBase extends AbstractConstructor<Client<MistralInputConfig>>,
 >(Base: TBase) {
   abstract class WithMistralInputConverter
     extends Base
@@ -39,19 +39,27 @@ export function WithMistralInputConverter<
 
     buildRequestPayload(
       payload: Payload,
-      config: InputConfig
+      config: MistralInputConfig
     ): ChatCompletionStreamRequest {
       const { conversation } = payload;
-      const { tools = [], temperature, forceTool, outputFormat } = config;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        forceTool,
+        outputFormat,
+      } = config;
 
       // Mistral is not sent an explicit max-output cap (matching the legacy
-      // client); it uses its own default.
+      // client); it uses its own default. `reasoning_effort` is only sent when
+      // the model supports it — non-reasoning models drop it in their schema.
       return {
         model: this.constructor.modelId,
         messages: conversationToMistralMessages(conversation, this),
         temperature,
         tools: tools.map(toTool),
         toolChoice: forceToolNameToToolChoice(tools, forceTool),
+        ...(reasoning ? { reasoningEffort: reasoning.effort } : {}),
         ...(outputFormat
           ? { responseFormat: outputFormatToResponseFormat(outputFormat) }
           : {}),

--- a/front/lib/model_constructors/providers/mistral/converters/input/utils.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/input/utils.ts
@@ -1,0 +1,241 @@
+import type {
+  OutputFormat,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type {
+  ChatCompletionStreamRequest,
+  ResponseFormat,
+  Tool,
+  ToolChoice,
+} from "@mistralai/mistralai/models/components";
+
+type MistralMessage = ChatCompletionStreamRequest["messages"][number];
+
+const TOOL_CALL_ID_LENGTH = 9;
+
+// Mistral requires tool-call ids to be exactly 9 alphanumeric chars, but ids can
+// originate from other providers. Normalize to that shape deterministically.
+export function sanitizeToolCallId(id: string): string {
+  let s = id.replace(/[^a-zA-Z0-9]/g, "0");
+  if (s.length > TOOL_CALL_ID_LENGTH) {
+    s = s.slice(0, TOOL_CALL_ID_LENGTH);
+  }
+  if (s.length < TOOL_CALL_ID_LENGTH) {
+    s = s.padStart(TOOL_CALL_ID_LENGTH, "0");
+  }
+  return s;
+}
+
+// The per-message leaf converters. The composite below takes an object
+// satisfying this interface (`this`), so overriding one leaf on an endpoint
+// changes how the composite uses it.
+export interface MistralMessageConverters {
+  systemMessageToMessage(message: SystemTextMessage): MistralMessage;
+  userTextMessageToMessage(message: BaseUserTextMessage): MistralMessage;
+  userImageMessageToMessage(message: BaseUserImageMessage): MistralMessage;
+  toolCallResultMessageToMessage(
+    message: BaseToolCallResultMessage
+  ): MistralMessage;
+  assistantTextMessageToMessage(
+    message: BaseAssistantTextMessage
+  ): MistralMessage;
+  assistantReasoningMessageToMessage(
+    message: BaseAssistantReasoningMessage
+  ): MistralMessage;
+  assistantToolCallRequestToMessage(
+    message: BaseAssistantToolCallRequestMessage
+  ): MistralMessage;
+}
+
+// -- Leaf converters: one Mistral message per conversation message --
+
+export function systemMessageToMessage(
+  message: SystemTextMessage
+): MistralMessage {
+  return { role: "system", content: message.content.value };
+}
+
+export function userTextMessageToMessage(
+  message: BaseUserTextMessage
+): MistralMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: message.content.value }],
+  };
+}
+
+export function userImageMessageToMessage(
+  message: BaseUserImageMessage
+): MistralMessage {
+  return {
+    role: "user",
+    content: [{ type: "image_url", imageUrl: message.content.url }],
+  };
+}
+
+export function toolCallResultMessageToMessage(
+  message: BaseToolCallResultMessage
+): MistralMessage {
+  const content = message.content.parts
+    .map((part) => {
+      switch (part.type) {
+        case "text":
+          return part.text;
+        case "image_url":
+          return part.url;
+        default:
+          return assertNever(part);
+      }
+    })
+    .join("\n");
+
+  return {
+    role: "tool",
+    content,
+    toolCallId: sanitizeToolCallId(message.content.callId),
+  };
+}
+
+export function assistantTextMessageToMessage(
+  message: BaseAssistantTextMessage
+): MistralMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: message.content.value }],
+  };
+}
+
+export function assistantReasoningMessageToMessage(
+  message: BaseAssistantReasoningMessage
+): MistralMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "thinking",
+        thinking: [{ type: "text", text: message.content.value }],
+      },
+    ],
+  };
+}
+
+export function assistantToolCallRequestToMessage(
+  message: BaseAssistantToolCallRequestMessage
+): MistralMessage {
+  return {
+    role: "assistant",
+    toolCalls: [
+      {
+        id: sanitizeToolCallId(message.content.callId),
+        function: {
+          name: message.content.toolName,
+          arguments: message.content.arguments,
+        },
+      },
+    ],
+  };
+}
+
+// -- Composite message converter --
+
+function userMessageToMessage(
+  message: BaseUserMessage,
+  converters: MistralMessageConverters
+): MistralMessage {
+  switch (message.type) {
+    case "text":
+      return converters.userTextMessageToMessage(message);
+    case "image_url":
+      return converters.userImageMessageToMessage(message);
+    case "tool_call_result":
+      return converters.toolCallResultMessageToMessage(message);
+    default:
+      assertNever(message);
+  }
+}
+
+function assistantMessageToMessage(
+  message: BaseAssistantMessage,
+  converters: MistralMessageConverters
+): MistralMessage {
+  switch (message.type) {
+    case "text":
+      return converters.assistantTextMessageToMessage(message);
+    case "reasoning":
+      return converters.assistantReasoningMessageToMessage(message);
+    case "tool_call_request":
+      return converters.assistantToolCallRequestToMessage(message);
+    default:
+      assertNever(message);
+  }
+}
+
+export function conversationToMistralMessages(
+  conversation: BaseConversation,
+  converters: MistralMessageConverters
+): MistralMessage[] {
+  const system = conversation.system.map((message) =>
+    converters.systemMessageToMessage(message)
+  );
+  const messages = conversation.messages.map((message) => {
+    switch (message.role) {
+      case "user":
+        return userMessageToMessage(message, converters);
+      case "assistant":
+        return assistantMessageToMessage(message, converters);
+      default:
+        assertNever(message);
+    }
+  });
+  return [...system, ...messages];
+}
+
+// -- Config converters (pure) --
+
+export function toTool(tool: ToolSpecification): Tool {
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+      strict: false,
+    },
+  };
+}
+
+export function forceToolNameToToolChoice(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ToolChoice | "auto" {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? { type: "function", function: { name: forceTool } }
+    : "auto";
+}
+
+export function outputFormatToResponseFormat(
+  outputFormat: OutputFormat
+): ResponseFormat {
+  return {
+    type: "json_schema",
+    jsonSchema: {
+      name: outputFormat.json_schema.name,
+      description: outputFormat.json_schema.description,
+      schemaDefinition: outputFormat.json_schema.schema,
+      strict: outputFormat.json_schema.strict ?? undefined,
+    },
+  };
+}

--- a/front/lib/model_constructors/providers/mistral/converters/output/utils.ts
+++ b/front/lib/model_constructors/providers/mistral/converters/output/utils.ts
@@ -1,0 +1,335 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ModelResponseEvent,
+  ReasoningEvent,
+  TextEvent,
+  ToolCallEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isRecord, isString } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import type {
+  CompletionEvent,
+  ContentChunk,
+  ThinkChunk,
+  ToolCall,
+  UsageInfo,
+} from "@mistralai/mistralai/models/components";
+import { CompletionResponseStreamChoiceFinishReason } from "@mistralai/mistralai/models/components";
+import { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
+
+// Parses tool-call arguments into an object, falling back to `{}` for malformed
+// or non-object JSON.
+function parseToolArguments(argumentsJson: string): Record<string, unknown> {
+  const parsed = safeParseJSON(argumentsJson);
+  if (parsed.isErr() || parsed.value === null || !isRecord(parsed.value)) {
+    return {};
+  }
+  return parsed.value;
+}
+
+function thinkingChunkToText(thinking: ThinkChunk["thinking"]): string {
+  return thinking
+    .map((chunk) => (chunk.type === "text" ? chunk.text : ""))
+    .join("");
+}
+
+function usageToTokenUsageEvent(
+  metadata: EndpointMetadata,
+  usage: UsageInfo | undefined
+): ModelResponseEvent {
+  return {
+    type: "token_usage",
+    content: {
+      cacheCreated: 0,
+      longCacheCreated: 0,
+      shortCacheCreated: 0,
+      cacheHit: 0,
+      standardInput: usage?.promptTokens ?? 0,
+      standardOutput: usage?.completionTokens ?? 0,
+      reasoning: 0,
+    },
+    metadata,
+  };
+}
+
+// Maps any error thrown by the Mistral SDK while streaming into a unified
+// `ErrorEvent`, so everything leaving the endpoint is an event, not an exception.
+export function streamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  if (error instanceof MistralError) {
+    const status = error.statusCode;
+    switch (status) {
+      case 400:
+        return buildErrorEvent({
+          metadata,
+          type: "invalid_request_error",
+          message: `Invalid request to Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 401:
+        return buildErrorEvent({
+          metadata,
+          type: "authentication_error",
+          message: `Authentication failed for Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 403:
+        return buildErrorEvent({
+          metadata,
+          type: "permission_error",
+          message: `Permission denied for Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 404:
+        return buildErrorEvent({
+          metadata,
+          type: "not_found_error",
+          message: `Resource not found for Mistral: ${error.message}`,
+          originalError: error,
+        });
+      case 429:
+        return buildErrorEvent({
+          metadata,
+          type: "rate_limit_error",
+          message: `Rate limit exceeded for Mistral/${metadata.modelId}: ${error.message}`,
+          originalError: error,
+        });
+      default:
+        if (status >= 500 && status < 600) {
+          return buildErrorEvent({
+            metadata,
+            type: "server_error",
+            message: `Server error from Mistral (${status}): ${error.message}`,
+            originalError: error,
+          });
+        }
+        return buildErrorEvent({
+          metadata,
+          type: "unknown_error",
+          message: `Error from Mistral (${status}): ${error.message}`,
+          originalError: error,
+        });
+    }
+  }
+  return buildErrorEvent({
+    metadata,
+    type: "unknown_error",
+    message: `Unknown error from Mistral: ${normalizeError(error).message}`,
+    originalError: error,
+  });
+}
+
+type Accumulator = {
+  textParts: string;
+  reasoningParts: string;
+  toolCallIndex: number;
+};
+
+// Flushes pending reasoning then text as accumulated events, appending them to
+// `aggregated`. Reasoning is flushed before text so the final text block stays
+// last (checkers assert on the last aggregated event).
+function flushAccumulated(
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  const events: ModelResponseEvent[] = [];
+  if (acc.reasoningParts) {
+    const event: ReasoningEvent = {
+      type: "reasoning",
+      content: { value: acc.reasoningParts },
+      metadata,
+    };
+    aggregated.push(event);
+    events.push(event);
+    acc.reasoningParts = "";
+  }
+  if (acc.textParts) {
+    const event: TextEvent = {
+      type: "text",
+      content: { value: acc.textParts },
+      metadata,
+    };
+    aggregated.push(event);
+    events.push(event);
+    acc.textParts = "";
+  }
+  return events;
+}
+
+function contentToEvents(
+  content: string | ContentChunk[],
+  acc: Accumulator,
+  metadata: EndpointMetadata
+): ModelResponseEvent[] {
+  if (isString(content)) {
+    if (!content) {
+      return [];
+    }
+    acc.textParts += content;
+    return [{ type: "text_delta", content: { value: content }, metadata }];
+  }
+
+  const events: ModelResponseEvent[] = [];
+  for (const chunk of content) {
+    switch (chunk.type) {
+      case "text":
+        if (chunk.text) {
+          acc.textParts += chunk.text;
+          events.push({
+            type: "text_delta",
+            content: { value: chunk.text },
+            metadata,
+          });
+        }
+        break;
+      case "thinking": {
+        const text = thinkingChunkToText(chunk.thinking);
+        if (text) {
+          acc.reasoningParts += text;
+          events.push({
+            type: "reasoning_delta",
+            content: { value: text },
+            metadata,
+          });
+        }
+        break;
+      }
+      default:
+        // Only text and thinking chunks are surfaced.
+        break;
+    }
+  }
+  return events;
+}
+
+function toolCallToEvents(
+  toolCall: ToolCall,
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  if (!toolCall.id) {
+    return [];
+  }
+  const args = isString(toolCall.function.arguments)
+    ? parseToolArguments(toolCall.function.arguments)
+    : toolCall.function.arguments;
+
+  const events: ModelResponseEvent[] = [
+    {
+      type: "tool_call_started",
+      content: {
+        id: toolCall.id,
+        index: acc.toolCallIndex,
+        name: toolCall.function.name,
+      },
+      metadata,
+    },
+  ];
+  const toolCallEvent: ToolCallEvent = {
+    type: "tool_call",
+    content: { id: toolCall.id, name: toolCall.function.name, arguments: args },
+    metadata,
+  };
+  aggregated.push(toolCallEvent);
+  events.push(toolCallEvent);
+  acc.toolCallIndex += 1;
+  return events;
+}
+
+// -- Entry point: drive the raw Mistral stream into unified events --
+
+export async function* rawOutputToEvents(
+  stream: AsyncGenerator<CompletionEvent>,
+  metadata: EndpointMetadata
+): AsyncGenerator<ModelResponseEvent> {
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const acc: Accumulator = {
+    textParts: "",
+    reasoningParts: "",
+    toolCallIndex: 0,
+  };
+  let hasYieldedResponseId = false;
+  let usage: UsageInfo | undefined;
+
+  while (true) {
+    let result: IteratorResult<CompletionEvent>;
+    try {
+      result = await stream.next();
+    } catch (err) {
+      yield streamErrorToErrorEvent(metadata, err);
+      return;
+    }
+    if (result.done) {
+      break;
+    }
+
+    const event = result.value;
+    if (!hasYieldedResponseId && event.data.id) {
+      yield {
+        type: "response_id",
+        content: { responseId: event.data.id },
+        metadata,
+      };
+      hasYieldedResponseId = true;
+    }
+    usage = event.data.usage ?? usage;
+
+    const choice = event.data.choices?.[0];
+    if (!choice) {
+      continue;
+    }
+    const { delta, finishReason } = choice;
+
+    if (delta.toolCalls) {
+      // Flush any text/reasoning produced before the tool call.
+      for (const e of flushAccumulated(acc, metadata, aggregated)) {
+        yield e;
+      }
+      for (const toolCall of delta.toolCalls) {
+        for (const e of toolCallToEvents(toolCall, acc, metadata, aggregated)) {
+          yield e;
+        }
+      }
+    } else if (delta.content) {
+      for (const e of contentToEvents(delta.content, acc, metadata)) {
+        yield e;
+      }
+    }
+
+    if (!finishReason) {
+      continue;
+    }
+    switch (finishReason) {
+      case CompletionResponseStreamChoiceFinishReason.Length:
+        yield buildErrorEvent({
+          metadata,
+          type: "stop_error",
+          message: "The maximum response length was reached.",
+        });
+        return;
+      case CompletionResponseStreamChoiceFinishReason.Error:
+        yield buildErrorEvent({
+          metadata,
+          type: "server_error",
+          message: "Mistral reported an error during completion.",
+        });
+        return;
+      // Stop / ToolCalls: flush any pending text/reasoning before success.
+      default:
+        for (const e of flushAccumulated(acc, metadata, aggregated)) {
+          yield e;
+        }
+        break;
+    }
+  }
+
+  yield usageToTokenUsageEvent(metadata, usage);
+  yield { type: "success", content: { aggregated }, metadata };
+}

--- a/front/lib/model_constructors/providers/mistral/inputConfig.ts
+++ b/front/lib/model_constructors/providers/mistral/inputConfig.ts
@@ -1,0 +1,17 @@
+import { MISTRAL_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/mistral/reasoning_efforts";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { z } from "zod";
+
+// Widest Mistral reasoning contract (off/on). Per-model schemas narrow it:
+// Large is non-reasoning and drops the effort before it reaches the request.
+export const mistralConfigSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([...MISTRAL_SUPPORTED_REASONING_EFFORTS]),
+    })
+    .optional(),
+  // Mistral has no explicit prompt-cache key.
+  cacheKey: z.undefined(),
+});
+
+export type MistralInputConfig = z.infer<typeof mistralConfigSchema>;

--- a/front/lib/model_constructors/providers/mistral/inputConfig.ts
+++ b/front/lib/model_constructors/providers/mistral/inputConfig.ts
@@ -15,3 +15,14 @@ export const mistralConfigSchema = inputConfigSchema.extend({
 });
 
 export type MistralInputConfig = z.infer<typeof mistralConfigSchema>;
+
+// Schema for non-reasoning Mistral models (Large, Small): accept `none` but drop
+// it so the request omits `reasoning_effort` (the API rejects it on these
+// models). Temperature passes through unchanged.
+export const mistralNonReasoningConfigSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.literal("none") })
+    .optional()
+    .transform(() => undefined),
+  cacheKey: z.undefined(),
+});

--- a/front/lib/model_constructors/providers/mistral/models/codestral.ts
+++ b/front/lib/model_constructors/providers/mistral/models/codestral.ts
@@ -1,0 +1,29 @@
+import { mistralNonReasoningConfigSchema } from "@app/lib/model_constructors/providers/mistral/inputConfig";
+import { MISTRAL_CODESTRAL_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+// Verified against https://docs.mistral.ai/getting-started/models/models_overview
+// (2026-06-18): Codestral has a 128k-token context window. It is a code model
+// with no vision support (enforced at the model-config/agent layer).
+const CONTEXT_SIZE = 128_000;
+// Capability metadata only — the request does not send an explicit max (the
+// legacy client doesn't either), so Mistral uses its own default.
+const MAX_OUTPUT_TOKENS = 2_048;
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithMistralCodestralConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class MistralCodestral extends Base {
+    static readonly modelId = MISTRAL_CODESTRAL_MODEL_ID;
+
+    // Non-reasoning model: the API rejects `reasoning_effort`.
+    static readonly configSchema = mistralNonReasoningConfigSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return MistralCodestral;
+}

--- a/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
@@ -1,0 +1,39 @@
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { MISTRAL_LARGE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// Verified against https://docs.mistral.ai/getting-started/models/models_overview
+// (2026-06-18): Mistral Large (mistral-large-3) has a 256k-token context window.
+const CONTEXT_SIZE = 256_000;
+// Capability metadata only — the request does not send an explicit max (the
+// legacy client doesn't either), so Mistral uses its own default.
+const MAX_OUTPUT_TOKENS = 2_048;
+
+// Mistral Large is a non-reasoning model: it only accepts `none`, and the
+// request never sends a reasoning effort. Temperature passes through unchanged.
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.literal("none") })
+    .default({ effort: "none" }),
+  // Mistral has no explicit prompt-cache key.
+  cacheKey: z.undefined(),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithMistralLargeConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class MistralLarge extends Base {
+    static readonly modelId = MISTRAL_LARGE_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return MistralLarge;
+}

--- a/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_large.ts
@@ -10,12 +10,14 @@ const CONTEXT_SIZE = 256_000;
 // legacy client doesn't either), so Mistral uses its own default.
 const MAX_OUTPUT_TOKENS = 2_048;
 
-// Mistral Large is a non-reasoning model: it only accepts `none`, and the
-// request never sends a reasoning effort. Temperature passes through unchanged.
+// Mistral Large is a non-reasoning model: the API rejects `reasoning_effort`.
+// We accept `none` but drop it, so the converter omits `reasoning_effort`
+// entirely. Temperature passes through unchanged.
 const configSchema = inputConfigSchema.extend({
   reasoning: z
     .object({ effort: z.literal("none") })
-    .default({ effort: "none" }),
+    .optional()
+    .transform(() => undefined),
   // Mistral has no explicit prompt-cache key.
   cacheKey: z.undefined(),
 });

--- a/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_medium_3_5.ts
@@ -1,0 +1,49 @@
+import { MISTRAL_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/mistral/reasoning_efforts";
+import {
+  inputConfigSchema,
+  temperatureSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
+import { MISTRAL_MEDIUM_3_5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import { z } from "zod";
+
+// Verified against https://docs.mistral.ai/getting-started/models/models_overview
+// (2026-06-18): Mistral Medium 3.5 has a 256k-token context window.
+const CONTEXT_SIZE = 256_000;
+// Capability metadata only — the request does not send an explicit max (the
+// legacy client doesn't either), so Mistral uses its own default.
+const MAX_OUTPUT_TOKENS = 2_048;
+const DEFAULT_REASONING_EFFORT = "none";
+
+// Mistral Medium 3.5 is a reasoning model: it accepts `none` (off) and `high`
+// (on), sent as `reasoning_effort`. Temperature is dropped — Mistral rejects
+// greedy sampling (temperature 0) alongside reasoning, and the legacy client
+// also strips it for reasoning models.
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum([...MISTRAL_SUPPORTED_REASONING_EFFORTS]),
+    })
+    .default({ effort: DEFAULT_REASONING_EFFORT }),
+  temperature: temperatureSchema.optional().transform(() => undefined),
+  // Mistral has no explicit prompt-cache key.
+  cacheKey: z.undefined(),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithMistralMedium35Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class MistralMedium35 extends Base {
+    static readonly modelId = MISTRAL_MEDIUM_3_5_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return MistralMedium35;
+}

--- a/front/lib/model_constructors/providers/mistral/models/mistral_small.ts
+++ b/front/lib/model_constructors/providers/mistral/models/mistral_small.ts
@@ -1,21 +1,21 @@
 import { mistralNonReasoningConfigSchema } from "@app/lib/model_constructors/providers/mistral/inputConfig";
-import { MISTRAL_LARGE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import { MISTRAL_SMALL_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
 // Verified against https://docs.mistral.ai/getting-started/models/models_overview
-// (2026-06-18): Mistral Large (mistral-large-3) has a 256k-token context window.
-const CONTEXT_SIZE = 256_000;
+// (2026-06-18): Mistral Small has a 128k-token context window.
+const CONTEXT_SIZE = 128_000;
 // Capability metadata only — the request does not send an explicit max (the
 // legacy client doesn't either), so Mistral uses its own default.
 const MAX_OUTPUT_TOKENS = 2_048;
 
 // Mixin carrying shared config; runtime base differs per surface.
-export function WithMistralLargeConfig<
+export function WithMistralSmallConfig<
   TBase extends abstract new (
     ...args: any[]
   ) => object,
 >(Base: TBase) {
-  abstract class MistralLarge extends Base {
-    static readonly modelId = MISTRAL_LARGE_MODEL_ID;
+  abstract class MistralSmall extends Base {
+    static readonly modelId = MISTRAL_SMALL_MODEL_ID;
 
     // Non-reasoning model: the API rejects `reasoning_effort`.
     static readonly configSchema = mistralNonReasoningConfigSchema;
@@ -24,5 +24,5 @@ export function WithMistralLargeConfig<
     static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
   }
 
-  return MistralLarge;
+  return MistralSmall;
 }

--- a/front/lib/model_constructors/providers/mistral/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/mistral/reasoning_efforts.ts
@@ -1,0 +1,6 @@
+// Mistral exposes two reasoning levels: off (`none`) and on (`high`). The values
+// match Mistral's `ReasoningEffort` enum, so they are forwarded unchanged.
+export const MISTRAL_SUPPORTED_REASONING_EFFORTS = ["none", "high"] as const;
+
+export type MistralSupportedReasoningEffort =
+  (typeof MISTRAL_SUPPORTED_REASONING_EFFORTS)[number];

--- a/front/lib/model_constructors/stream/clients/mistral.ts
+++ b/front/lib/model_constructors/stream/clients/mistral.ts
@@ -1,8 +1,11 @@
 import { WithMistralInputConverter } from "@app/lib/model_constructors/providers/mistral/converters/input";
 import { rawOutputToEvents } from "@app/lib/model_constructors/providers/mistral/converters/output/utils";
+import {
+  type MistralInputConfig,
+  mistralConfigSchema,
+} from "@app/lib/model_constructors/providers/mistral/inputConfig";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
 import type { Credentials } from "@app/lib/model_constructors/types/credentials";
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { MISTRAL_API } from "@app/lib/model_constructors/types/provider_apis";
 import { MISTRAL_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
@@ -12,16 +15,17 @@ import type {
   CompletionEvent,
 } from "@mistralai/mistralai/models/components";
 
-import type { z } from "zod";
-
 export abstract class MistralStream extends WithMistralInputConverter(
-  StreamEndpoint<ChatCompletionStreamRequest, CompletionEvent>
+  StreamEndpoint<
+    ChatCompletionStreamRequest,
+    CompletionEvent,
+    MistralInputConfig
+  >
 ) {
   static readonly providerId = MISTRAL_PROVIDER_ID;
   static readonly api = MISTRAL_API;
 
-  static readonly configSchema: z.ZodType<z.infer<typeof inputConfigSchema>> =
-    inputConfigSchema;
+  static readonly configSchema = mistralConfigSchema;
 
   private readonly client: Mistral;
 

--- a/front/lib/model_constructors/stream/clients/mistral.ts
+++ b/front/lib/model_constructors/stream/clients/mistral.ts
@@ -1,0 +1,47 @@
+import { WithMistralInputConverter } from "@app/lib/model_constructors/providers/mistral/converters/input";
+import { rawOutputToEvents } from "@app/lib/model_constructors/providers/mistral/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { MISTRAL_API } from "@app/lib/model_constructors/types/provider_apis";
+import { MISTRAL_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { Mistral } from "@mistralai/mistralai";
+import type {
+  ChatCompletionStreamRequest,
+  CompletionEvent,
+} from "@mistralai/mistralai/models/components";
+
+import type { z } from "zod";
+
+export abstract class MistralStream extends WithMistralInputConverter(
+  StreamEndpoint<ChatCompletionStreamRequest, CompletionEvent>
+) {
+  static readonly providerId = MISTRAL_PROVIDER_ID;
+  static readonly api = MISTRAL_API;
+
+  static readonly configSchema: z.ZodType<z.infer<typeof inputConfigSchema>> =
+    inputConfigSchema;
+
+  private readonly client: Mistral;
+
+  constructor({ MISTRAL_API_KEY }: Credentials) {
+    super();
+    this.client = new Mistral({ apiKey: MISTRAL_API_KEY });
+  }
+
+  async *streamRaw(
+    input: ChatCompletionStreamRequest
+  ): AsyncGenerator<CompletionEvent> {
+    const stream = await this.client.chat.stream(input);
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<CompletionEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata());
+  }
+}

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,9 +1,9 @@
-import { WithGoogleAiStudioGemini31FlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
 import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 
-export class GoogleAiStudioGlobalGemini31FlashLiteStream extends WithGoogleAiStudioGemini31FlashLiteConfig(
+export class GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
   GoogleAiStudioStream
 ) {
   // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
@@ -19,4 +19,4 @@ export class GoogleAiStudioGlobalGemini31FlashLiteStream extends WithGoogleAiStu
   static readonly id = this.buildId();
 }
 
-GoogleAiStudioGlobalGemini31FlashLiteStream satisfies StreamEndpointConstructor;
+GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,22 @@
+import { WithGoogleAiStudioGemini31FlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGemini31FlashLiteStream extends WithGoogleAiStudioGemini31FlashLiteConfig(
+  GoogleAiStudioStream
+) {
+  // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 1.0,
+    cacheHit: 0.025,
+    standardInput: 0.25,
+    standardOutput: 1.5,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGemini31FlashLiteStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -1,9 +1,9 @@
-import { WithGoogleAiStudioGemini31ProConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro";
+import { WithGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro";
 import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 
-export class GoogleAiStudioGlobalGemini31ProStream extends WithGoogleAiStudioGemini31ProConfig(
+export class GoogleAiStudioGlobalGeminiThreeDotOneProStream extends WithGoogleAiStudioGeminiThreeDotOneProConfig(
   GoogleAiStudioStream
 ) {
   // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
@@ -20,4 +20,4 @@ export class GoogleAiStudioGlobalGemini31ProStream extends WithGoogleAiStudioGem
   static readonly id = this.buildId();
 }
 
-GoogleAiStudioGlobalGemini31ProStream satisfies StreamEndpointConstructor;
+GoogleAiStudioGlobalGeminiThreeDotOneProStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,0 +1,22 @@
+import { WithGoogleAiStudioGemini35FlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
+import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGemini35FlashStream extends WithGoogleAiStudioGemini35FlashConfig(
+  GoogleAiStudioStream
+) {
+  // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 1.0,
+    cacheHit: 0.15,
+    standardInput: 1.5,
+    standardOutput: 9.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGemini35FlashStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,9 +1,9 @@
-import { WithGoogleAiStudioGemini35FlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
+import { WithGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
 import { GoogleAiStudioStream } from "@app/lib/model_constructors/stream/clients/google_ai_studio";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 
-export class GoogleAiStudioGlobalGemini35FlashStream extends WithGoogleAiStudioGemini35FlashConfig(
+export class GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
   GoogleAiStudioStream
 ) {
   // https://ai.google.dev/gemini-api/docs/pricing (verify before launch).
@@ -19,4 +19,4 @@ export class GoogleAiStudioGlobalGemini35FlashStream extends WithGoogleAiStudioG
   static readonly id = this.buildId();
 }
 
-GoogleAiStudioGlobalGemini35FlashStream satisfies StreamEndpointConstructor;
+GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/mistral_eu_codestral.ts
+++ b/front/lib/model_constructors/stream/endpoints/mistral_eu_codestral.ts
@@ -1,0 +1,21 @@
+import { WithMistralCodestralConfig } from "@app/lib/model_constructors/providers/mistral/models/codestral";
+import { MistralStream } from "@app/lib/model_constructors/stream/clients/mistral";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class MistralEuropeCodestralStream extends WithMistralCodestralConfig(
+  MistralStream
+) {
+  // https://mistral.ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    standardInput: 0.3,
+    standardOutput: 0.9,
+  };
+
+  // Inference runs in the EU; the endpoint remains usable from both US and EU.
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+}
+
+MistralEuropeCodestralStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large.ts
+++ b/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large.ts
@@ -1,0 +1,21 @@
+import { WithMistralLargeConfig } from "@app/lib/model_constructors/providers/mistral/models/mistral_large";
+import { MistralStream } from "@app/lib/model_constructors/stream/clients/mistral";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class MistralEuropeMistralLargeStream extends WithMistralLargeConfig(
+  MistralStream
+) {
+  // https://mistral.ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    standardInput: 2.0,
+    standardOutput: 6.0,
+  };
+
+  // Inference runs in the EU; the endpoint remains usable from both US and EU.
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+}
+
+MistralEuropeMistralLargeStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5.ts
+++ b/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5.ts
@@ -1,0 +1,21 @@
+import { WithMistralMedium35Config } from "@app/lib/model_constructors/providers/mistral/models/mistral_medium_3_5";
+import { MistralStream } from "@app/lib/model_constructors/stream/clients/mistral";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class MistralEuropeMistralMedium35Stream extends WithMistralMedium35Config(
+  MistralStream
+) {
+  // https://mistral.ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    standardInput: 0.4,
+    standardOutput: 2.0,
+  };
+
+  // Inference runs in the EU; the endpoint remains usable from both US and EU.
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+}
+
+MistralEuropeMistralMedium35Stream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small.ts
+++ b/front/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small.ts
@@ -1,0 +1,21 @@
+import { WithMistralSmallConfig } from "@app/lib/model_constructors/providers/mistral/models/mistral_small";
+import { MistralStream } from "@app/lib/model_constructors/stream/clients/mistral";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class MistralEuropeMistralSmallStream extends WithMistralSmallConfig(
+  MistralStream
+) {
+  // https://mistral.ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    standardInput: 0.1,
+    standardOutput: 0.3,
+  };
+
+  // Inference runs in the EU; the endpoint remains usable from both US and EU.
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+}
+
+MistralEuropeMistralSmallStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,6 +3,7 @@ import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,6 +3,7 @@ import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
@@ -22,6 +23,8 @@ export const STREAM_ENDPOINTS = {
     OpenAIResponsesGlobalGptFiveDotFiveStream,
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:
     AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
+  [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,7 +3,6 @@ import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
-import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,8 +3,8 @@ import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
-import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
-import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const STREAM_ENDPOINTS = {
@@ -14,10 +14,10 @@ export const STREAM_ENDPOINTS = {
     AnthropicGlobalClaudeOpusFourDotEightStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
-  [GoogleAiStudioGlobalGemini31ProStream.id]:
-    GoogleAiStudioGlobalGemini31ProStream,
-  [GoogleAiStudioGlobalGemini35FlashStream.id]:
-    GoogleAiStudioGlobalGemini35FlashStream,
+  [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneProStream,
+  [GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:
+    GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -4,6 +4,7 @@ import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const STREAM_ENDPOINTS = {
@@ -15,6 +16,8 @@ export const STREAM_ENDPOINTS = {
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [GoogleAiStudioGlobalGemini31ProStream.id]:
     GoogleAiStudioGlobalGemini31ProStream,
+  [GoogleAiStudioGlobalGemini35FlashStream.id]:
+    GoogleAiStudioGlobalGemini35FlashStream,
   [OpenAIResponsesGlobalGptFiveDotFiveStream.id]:
     OpenAIResponsesGlobalGptFiveDotFiveStream,
   [AgentPlatformEuropeClaudeHaikuFourDotFiveStream.id]:

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import {
   INPUT_CONFIGURATION_ERROR,
   SUCCESS,
@@ -10,7 +10,7 @@ import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
 const setup: StreamSetup = {
   createInstance: () =>
-    new GoogleAiStudioGlobalGemini31FlashLiteStream({
+    new GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream({
       GOOGLE_AI_STUDIO_API_KEY:
         process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
     }),
@@ -74,4 +74,7 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
-runStreamEndpointTests(GoogleAiStudioGlobalGemini31FlashLiteStream, setup);
+runStreamEndpointTests(
+  GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
+  setup
+);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+
+import { GoogleAiStudioGlobalGemini31FlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  SUCCESS,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new GoogleAiStudioGlobalGemini31FlashLiteStream({
+      GOOGLE_AI_STUDIO_API_KEY:
+        process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Gemini 3 supports none/low/medium/high (+ maximal → high). The `minimal`
+    // effort is unsupported and rejected by the config schema.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    // Unlike Pro/Flash, this lightweight model does not reliably surface thought
+    // content at `low` effort, so we only assert the stream completes.
+    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+runStreamEndpointTests(GoogleAiStudioGlobalGemini31FlashLiteStream, setup);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
@@ -17,37 +17,41 @@ const setup: StreamSetup = {
   // `null` runs the case with its default checkers; a checker array overrides
   // them. Every case always runs.
   tests: {
-    // Gemini 3 supports none/low/medium/high (+ maximal → high). The `minimal`
+    // Gemini 3 supports none/low/medium/high (+ maximal → high). The `none`
     // effort is unsupported and rejected by the config schema.
-    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-1/r-minimal": null,
 
     "simple/no-tools/t-default/r-default": null,
-    "simple/no-tools/t-default/r-none": null,
     "simple/no-tools/t-default/r-low": null,
     "simple/no-tools/t-default/r-medium": null,
     "simple/no-tools/t-default/r-high": null,
-    "simple/no-tools/t-default/r-maximal": null,
     "simple/no-tools/t-0/r-default": null,
-    "simple/no-tools/t-0/r-none": null,
     "simple/no-tools/t-0/r-low": null,
     "simple/no-tools/t-0/r-medium": null,
     "simple/no-tools/t-0/r-high": null,
-    "simple/no-tools/t-0/r-maximal": null,
     "simple/no-tools/t-0.1/r-default": null,
-    "simple/no-tools/t-0.1/r-none": null,
     "simple/no-tools/t-0.1/r-low": null,
     "simple/no-tools/t-0.1/r-medium": null,
     "simple/no-tools/t-0.1/r-high": null,
-    "simple/no-tools/t-0.1/r-maximal": null,
     "simple/no-tools/t-1/r-default": null,
-    "simple/no-tools/t-1/r-none": null,
     "simple/no-tools/t-1/r-low": null,
     "simple/no-tools/t-1/r-medium": null,
     "simple/no-tools/t-1/r-high": null,
-    "simple/no-tools/t-1/r-maximal": null,
 
     // Gemini ignores the Anthropic-style cache markers (it uses implicit
     // caching), so this behaves like a plain "say Hi" prompt.
@@ -59,14 +63,11 @@ const setup: StreamSetup = {
 
     "calc/calc/t-default/r-default/force-tool-default": null,
     "calc/calc/t-default/r-default/force-tool": null,
-    "calc/calc/t-default/r-none/force-tool": null,
 
-    "reasoning/no-tools/t-default/r-none": null,
     // Unlike Pro/Flash, this lightweight model does not reliably surface thought
     // content at `low` effort, so we only assert the stream completes.
     "reasoning/no-tools/t-default/r-low": [SUCCESS],
 
-    "output-format/json-schema/t-default/r-none": null,
     "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
@@ -1,13 +1,13 @@
 // @vitest-environment node
 
-import { GoogleAiStudioGlobalGemini31ProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
 const setup: StreamSetup = {
   createInstance: () =>
-    new GoogleAiStudioGlobalGemini31ProStream({
+    new GoogleAiStudioGlobalGeminiThreeDotOneProStream({
       GOOGLE_AI_STUDIO_API_KEY:
         process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
     }),
@@ -69,4 +69,4 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_pro.test.ts
-runStreamEndpointTests(GoogleAiStudioGlobalGemini31ProStream, setup);
+runStreamEndpointTests(GoogleAiStudioGlobalGeminiThreeDotOneProStream, setup);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
@@ -1,13 +1,13 @@
 // @vitest-environment node
 
-import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
 const setup: StreamSetup = {
   createInstance: () =>
-    new GoogleAiStudioGlobalGemini35FlashStream({
+    new GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream({
       GOOGLE_AI_STUDIO_API_KEY:
         process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
     }),
@@ -69,4 +69,7 @@ const setup: StreamSetup = {
 };
 
 // NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
-runStreamEndpointTests(GoogleAiStudioGlobalGemini35FlashStream, setup);
+runStreamEndpointTests(
+  GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream,
+  setup
+);

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { GoogleAiStudioGlobalGemini35FlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new GoogleAiStudioGlobalGemini35FlashStream({
+      GOOGLE_AI_STUDIO_API_KEY:
+        process.env.DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Flash supports minimal/low/medium/high. `none` and `maximal` are
+    // unsupported and rejected by the config schema.
+    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-minimal": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_5_flash.test.ts
+runStreamEndpointTests(GoogleAiStudioGlobalGemini35FlashStream, setup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_codestral";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new MistralEuropeCodestralStream({
+      MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
+    }),
+  // Codestral is a non-reasoning model: only `none` is accepted, so every other
+  // reasoning effort is rejected by the config schema.
+  tests: {
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+
+    // Supported (`none`/default) cases run with their default checkers.
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_codestral.test.ts
+runStreamEndpointTests(MistralEuropeCodestralStream, setup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new MistralEuropeMistralLargeStream({
+      MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
+    }),
+  // Mistral Large is a non-reasoning model: only `none` is accepted, so every
+  // other reasoning effort is rejected by the config schema.
+  tests: {
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+
+    // Supported (`none`/default) cases run with their default checkers.
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_large.test.ts
+runStreamEndpointTests(MistralEuropeMistralLargeStream, setup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new MistralEuropeMistralMedium35Stream({
+      MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
+    }),
+  // Mistral Medium 3.5 is a reasoning model: it accepts `none` and `high`. Other
+  // reasoning efforts are rejected by the config schema.
+  tests: {
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+
+    // Supported (`none`/`high`/default) cases run with their default checkers.
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_medium_3_5.test.ts
+runStreamEndpointTests(MistralEuropeMistralMedium35Stream, setup);

--- a/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
+++ b/front/lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new MistralEuropeMistralSmallStream({
+      MISTRAL_API_KEY: process.env.DUST_MANAGED_MISTRAL_API_KEY ?? "",
+    }),
+  // Mistral Small is a non-reasoning model: only `none` is accepted, so every
+  // other reasoning effort is rejected by the config schema.
+  tests: {
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+
+    // Supported (`none`/default) cases run with their default checkers.
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/mistral_eu_mistral_small.test.ts
+runStreamEndpointTests(MistralEuropeMistralSmallStream, setup);

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -4,4 +4,5 @@ export type Credentials = {
   ANTHROPIC_API_KEY?: string;
   GOOGLE_AI_STUDIO_API_KEY?: string;
   AGENT_PLATFORM_PROJECT_ID?: string;
+  MISTRAL_API_KEY?: string;
 };

--- a/front/lib/model_constructors/types/input/messages.ts
+++ b/front/lib/model_constructors/types/input/messages.ts
@@ -26,6 +26,7 @@ export type BaseToolCallResultMessage = {
   type: "tool_call_result";
   content: {
     callId: string;
+    toolName: string;
     parts: ToolCallResultPart[];
     isError: boolean;
   };

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -9,6 +9,8 @@ export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 export const GEMINI_3_5_FLASH_MODEL_ID = "gemini-3.5-flash" as const;
 export const GEMINI_3_1_FLASH_LITE_MODEL_ID = "gemini-3.1-flash-lite" as const;
 
+export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
+
 // Include a few examples for now
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
@@ -19,6 +21,7 @@ export const MODEL_IDS = [
   GEMINI_3_1_PRO_MODEL_ID,
   GEMINI_3_5_FLASH_MODEL_ID,
   GEMINI_3_1_FLASH_LITE_MODEL_ID,
+  MISTRAL_LARGE_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -6,6 +6,7 @@ export const CLAUDE_OPUS_4_8_MODEL_ID = "claude-opus-4-8" as const;
 export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5-20251001" as const;
 
 export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
+export const GEMINI_3_5_FLASH_MODEL_ID = "gemini-3.5-flash" as const;
 
 // Include a few examples for now
 export const MODEL_IDS = [
@@ -15,6 +16,7 @@ export const MODEL_IDS = [
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_HAIKU_4_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
+  GEMINI_3_5_FLASH_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -10,6 +10,7 @@ export const GEMINI_3_5_FLASH_MODEL_ID = "gemini-3.5-flash" as const;
 export const GEMINI_3_1_FLASH_LITE_MODEL_ID = "gemini-3.1-flash-lite" as const;
 
 export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
+export const MISTRAL_MEDIUM_3_5_MODEL_ID = "mistral-medium-3-5" as const;
 
 // Include a few examples for now
 export const MODEL_IDS = [
@@ -22,6 +23,7 @@ export const MODEL_IDS = [
   GEMINI_3_5_FLASH_MODEL_ID,
   GEMINI_3_1_FLASH_LITE_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
+  MISTRAL_MEDIUM_3_5_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -12,6 +12,7 @@ export const GEMINI_3_1_FLASH_LITE_MODEL_ID = "gemini-3.1-flash-lite" as const;
 export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
 export const MISTRAL_MEDIUM_3_5_MODEL_ID = "mistral-medium-3-5" as const;
 export const MISTRAL_SMALL_MODEL_ID = "mistral-small-latest" as const;
+export const MISTRAL_CODESTRAL_MODEL_ID = "codestral-latest" as const;
 
 // Include a few examples for now
 export const MODEL_IDS = [
@@ -26,6 +27,7 @@ export const MODEL_IDS = [
   MISTRAL_LARGE_MODEL_ID,
   MISTRAL_MEDIUM_3_5_MODEL_ID,
   MISTRAL_SMALL_MODEL_ID,
+  MISTRAL_CODESTRAL_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -11,6 +11,7 @@ export const GEMINI_3_1_FLASH_LITE_MODEL_ID = "gemini-3.1-flash-lite" as const;
 
 export const MISTRAL_LARGE_MODEL_ID = "mistral-large-latest" as const;
 export const MISTRAL_MEDIUM_3_5_MODEL_ID = "mistral-medium-3-5" as const;
+export const MISTRAL_SMALL_MODEL_ID = "mistral-small-latest" as const;
 
 // Include a few examples for now
 export const MODEL_IDS = [
@@ -24,6 +25,7 @@ export const MODEL_IDS = [
   GEMINI_3_1_FLASH_LITE_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
   MISTRAL_MEDIUM_3_5_MODEL_ID,
+  MISTRAL_SMALL_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -7,6 +7,7 @@ export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5-20251001" as const;
 
 export const GEMINI_3_1_PRO_MODEL_ID = "gemini-3.1-pro-preview" as const;
 export const GEMINI_3_5_FLASH_MODEL_ID = "gemini-3.5-flash" as const;
+export const GEMINI_3_1_FLASH_LITE_MODEL_ID = "gemini-3.1-flash-lite" as const;
 
 // Include a few examples for now
 export const MODEL_IDS = [
@@ -17,6 +18,7 @@ export const MODEL_IDS = [
   CLAUDE_HAIKU_4_5_MODEL_ID,
   GEMINI_3_1_PRO_MODEL_ID,
   GEMINI_3_5_FLASH_MODEL_ID,
+  GEMINI_3_1_FLASH_LITE_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -2,11 +2,13 @@ export const OPENAI_RESPONSES_API = "openai-responses" as const;
 export const ANTHROPIC_API = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_API = "google-ai-studio" as const;
 export const AGENT_PLATFORM_API = "agent-platform" as const;
+export const MISTRAL_API = "mistral" as const;
 
 const PROVIDER_APIS = [
   OPENAI_RESPONSES_API,
   ANTHROPIC_API,
   GOOGLE_AI_STUDIO_API,
   AGENT_PLATFORM_API,
+  MISTRAL_API,
 ] as const;
 export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -3,6 +3,7 @@ import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 export const OPENAI_PROVIDER_ID = "openai" as const;
 export const ANTHROPIC_PROVIDER_ID = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
+export const MISTRAL_PROVIDER_ID = "mistral" as const;
 
 // `satisfies readonly ModelProviderIdType[]` guarantees every new-system
 // provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
@@ -13,6 +14,7 @@ const PROVIDER_IDS = [
   OPENAI_PROVIDER_ID,
   ANTHROPIC_PROVIDER_ID,
   GOOGLE_AI_STUDIO_PROVIDER_ID,
+  MISTRAL_PROVIDER_ID,
 ] as const satisfies readonly ModelProviderIdType[];
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 


### PR DESCRIPTION
## Description

Add Mistral (Large, Medium 3.5, Small, Codestral on the EU API) and Gemini (3.1 Flash Lite, 3.1 Pro, 3.5 Flash on Google AI Studio global) stream endpoints to the new model-constructors router, with their provider converters, configs, and parity coverage matching the old router.

## Tests

Added per-endpoint unit tests and extended the router parity suite; ran locally.

## Risk

Low.

## Deploy Plan

- Standard deploy, no migration needed
- Deploy `main` on `front`