### PR TITLE
[Pods] Updating pods level default agent feature to also work on tasks

### DIFF
--- a/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/projectTasksPanelTypes.ts
@@ -23,6 +23,7 @@ export type PodTasksPanelData = {
   combinedGroupedTasksByUser: CombinedGroupedTasksByUser;
   activeAgents: LightAgentConfigurationType[];
   isAgentsLoading: boolean;
+  defaultAgentId: string | null;
   agentNameById: Map<string, string>;
   newItemKeys: Set<string>;
   doneFlashKeys: Set<string>;

--- a/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
+++ b/front/components/assistant/conversation/space/conversations/project_tasks/useProjectTasksPanelState.ts
@@ -19,6 +19,7 @@ import type {
   BulkActionsBody,
   GetPodTasksResponseBody,
 } from "@app/lib/api/projects/tasks";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { comparePodTaskAssignees } from "@app/lib/project_task/display_order";
@@ -27,6 +28,7 @@ import {
   useCreatePodTask,
   useDeletePodTask,
   useMarkPodTasksRead,
+  usePodMetadata,
   usePodTasks,
   useStartPodTaskConversation,
   useUpdatePodTask,
@@ -103,6 +105,12 @@ export function usePodTasksPanelState({
     agents.sort(compareAgentsForSort);
     return agents;
   }, [agentConfigurations]);
+
+  const { hasFeature } = useFeatureFlags();
+  const { podMetadata } = usePodMetadata({ workspaceId: owner.sId, podId });
+  const defaultAgentId = hasFeature("pod_default_agent")
+    ? (podMetadata?.defaultAgentId ?? null)
+    : null;
 
   const podMembers = useMemo(() => {
     const members = spaceInfo?.members ?? [];
@@ -495,6 +503,7 @@ export function usePodTasksPanelState({
 
   return {
     activeAgents,
+    defaultAgentId,
     agentNameById,
     assigneeScopedTasks,
     combinedGroupedTasksByUser,

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -1,9 +1,11 @@
 import { ConversationSidebarStatusDot } from "@app/components/assistant/conversation/ConversationSidebarStatusDot";
 import { PodTaskStartWorkingDropdown } from "@app/components/pod/tasks/PodTaskStartWorkingDropdown";
 import type { GetWorkspacePodTaskResponseBody } from "@app/lib/api/projects/tasks";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
+  usePodMetadata,
   useStartPodTaskConversation,
   useWorkspacePodTask,
 } from "@app/lib/swr/pods";
@@ -92,6 +94,12 @@ function TaskMarkdownPopoverStartChrome({
   const doStart = useStartPodTaskConversation({ owner, podId: podId });
   const [isStarting, setIsStarting] = useState(false);
 
+  const { hasFeature } = useFeatureFlags();
+  const { podMetadata } = usePodMetadata({ workspaceId: owner.sId, podId });
+  const defaultAgentId = hasFeature("pod_default_agent")
+    ? (podMetadata?.defaultAgentId ?? null)
+    : null;
+
   const hasConversationLink =
     (task.status === "in_progress" || task.status === "done") &&
     !!task.conversationId;
@@ -114,6 +122,7 @@ function TaskMarkdownPopoverStartChrome({
       isFirstOnboardingTask={false}
       context="conversation"
       defaultGoToConversation={false}
+      defaultAgentId={defaultAgentId}
       triggerClassName="shrink-0"
       triggerSize={triggerSize}
       onStart={async (opts) => {

--- a/front/components/markdown/TaskDirectiveBlock.tsx
+++ b/front/components/markdown/TaskDirectiveBlock.tsx
@@ -405,6 +405,12 @@ function TaskDirectiveChipInner({
           className="w-[min(22rem,calc(100vw-1.5rem))] overflow-hidden rounded-xl border border-border/70 p-0 shadow-xl ring-1 ring-black/[0.04] dark:border-border-night/70 dark:ring-white/[0.06]"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
+          {/*
+            Visibility-gated mount: the popover content (and all its SWR hooks —
+            useWorkspacePodTask, useUnifiedAgentConfigurations, usePodMetadata,
+            useStartPodTaskConversation) only exists in the tree while `open` is true,
+            so no `disabled` flag is needed on those hooks — they never run while closed.
+          */}
           {open ? (
             <TaskDirectivePopoverContent owner={owner} taskSId={sId} />
           ) : null}

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -404,7 +404,7 @@ export function PodSettingsTab({
             <div className="heading-lg">Default agent</div>
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               The agent pre-selected when anyone starts a new conversation in
-              this Pod. Defaults to @dust.
+              this Pod.
             </p>
             <div className="flex items-center gap-2">
               {isPodEditor ? (

--- a/front/components/pod/tasks/EditableTaskItem.tsx
+++ b/front/components/pod/tasks/EditableTaskItem.tsx
@@ -38,6 +38,7 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
     viewerUserId,
     owner,
     activeAgents,
+    defaultAgentId,
     isAgentsLoading,
     agentNameById,
     newItemKeys,
@@ -234,6 +235,7 @@ export function EditableTaskItem({ task }: EditableTaskItemProps) {
                 isStarting={isStarting}
                 isFirstOnboardingTask={isFirstOnboardingTask}
                 defaultGoToConversation={!!task.agentInstructions?.trim()}
+                defaultAgentId={defaultAgentId}
                 onOpenChange={setStartMenuOpen}
                 onStart={(opts) => handleStartWorking(task, opts)}
               />

--- a/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
+++ b/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
@@ -249,8 +249,8 @@ export function PodTaskStartWorkingDropdown({
                 size="xs"
                 onItemClick={(agent) => setSelectedStartAgent(agent)}
                 pickerButton={
-                  <div
-                    role="button"
+                  <button
+                    type="button"
                     aria-label={`Selected agent: ${selectedStartAgent?.name ?? "Agent"}`}
                     className={cn(
                       "inline-flex box-border max-w-full min-w-0 items-center rounded-lg h-7 heading-xs px-2 gap-1.5 text-primary-900 dark:text-primary-900-night transition-colors duration-200",
@@ -296,7 +296,7 @@ export function PodTaskStartWorkingDropdown({
                       size="xs"
                       className="-mr-1 text-faint dark:text-faint-night"
                     />
-                  </div>
+                  </button>
                 }
               />
             </div>

--- a/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
+++ b/front/components/pod/tasks/PodTaskStartWorkingDropdown.tsx
@@ -10,11 +10,13 @@ import {
   ButtonGroupDropdown,
   Check,
   ChevronDown,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   type DropdownMenuItemProps,
   DropdownMenuTrigger,
   Icon,
+  InfoCircle,
   Play,
   Robot,
   TextArea,
@@ -69,6 +71,7 @@ export function PodTaskStartWorkingDropdown({
   isStarting,
   isFirstOnboardingTask = false,
   defaultGoToConversation = false,
+  defaultAgentId = null,
   context = "tasks_page",
   onOpenChange,
   onStart,
@@ -85,6 +88,7 @@ export function PodTaskStartWorkingDropdown({
   isStarting: boolean;
   isFirstOnboardingTask?: boolean;
   defaultGoToConversation?: boolean;
+  defaultAgentId?: string | null;
   context?: ProjectTaskStartWorkingContext;
   onOpenChange?: (open: boolean) => void;
   onStart: (options: ProjectTaskStartWorkingOptions) => Promise<void>;
@@ -109,8 +113,10 @@ export function PodTaskStartWorkingDropdown({
     if (open) {
       setStartCustomMessage("");
       const defaultAgent =
-        activeAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ??
-        activeAgents[0] ??
+        (defaultAgentId &&
+          activeAgents.find((a) => a.sId === defaultAgentId)) ||
+        activeAgents.find((a) => a.sId === GLOBAL_AGENTS_SID.DUST) ||
+        activeAgents[0] ||
         null;
       setSelectedStartAgent(defaultAgent);
     }
@@ -127,16 +133,18 @@ export function PodTaskStartWorkingDropdown({
   const handleConfirmStart = async () => {
     setStartMenuOpen(false);
     onOpenChange?.(false);
-    const agentConfigurationId =
-      selectedStartAgent && selectedStartAgent.sId !== GLOBAL_AGENTS_SID.DUST
-        ? selectedStartAgent.sId
-        : undefined;
     await onStart({
       customMessage: startCustomMessage.trim() || undefined,
-      agentConfigurationId,
+      agentConfigurationId: selectedStartAgent?.sId,
       goToConversation: goToConversationAfterStart,
     });
   };
+
+  const isDefaultAgentUnavailable =
+    !agentsLoading &&
+    !!defaultAgentId &&
+    defaultAgentId !== GLOBAL_AGENTS_SID.DUST &&
+    !activeAgents.some((a) => a.sId === defaultAgentId);
 
   const redirectMenuLabels = startRedirectMenuLabels(context);
 
@@ -235,29 +243,60 @@ export function PodTaskStartWorkingDropdown({
                 disabled={agentsLoading}
                 isLoading={agentsLoading}
                 mountPortal
-                showDropdownArrow
+                showDropdownArrow={false}
                 showFooterButtons={false}
                 side="bottom"
                 size="xs"
                 onItemClick={(agent) => setSelectedStartAgent(agent)}
                 pickerButton={
-                  <Button
-                    variant="ghost-secondary"
-                    size="xs"
-                    isSelect
-                    icon={
-                      selectedStartAgent
-                        ? () => (
-                            <Avatar
-                              size="xxs"
-                              visual={selectedStartAgent.pictureUrl}
-                            />
-                          )
-                        : Robot
-                    }
-                    label={selectedStartAgent?.name ?? "Agent"}
-                    className="max-w-full min-w-0"
-                  />
+                  <div
+                    role="button"
+                    aria-label={`Selected agent: ${selectedStartAgent?.name ?? "Agent"}`}
+                    className={cn(
+                      "inline-flex box-border max-w-full min-w-0 items-center rounded-lg h-7 heading-xs px-2 gap-1.5 text-primary-900 dark:text-primary-900-night transition-colors duration-200",
+                      agentsLoading
+                        ? "opacity-50 pointer-events-none"
+                        : "cursor-pointer hover:bg-muted-background dark:hover:bg-muted-background-night"
+                    )}
+                  >
+                    {selectedStartAgent ? (
+                      <Avatar
+                        size="xxs"
+                        visual={selectedStartAgent.pictureUrl}
+                      />
+                    ) : (
+                      <Icon visual={Robot} size="xs" />
+                    )}
+                    <span className="grow truncate notranslate">
+                      {selectedStartAgent?.name ?? "Agent"}
+                    </span>
+                    {isDefaultAgentUnavailable && (
+                      <Tooltip
+                        tooltipTriggerAsChild
+                        trigger={
+                          <span
+                            className="flex items-center text-warning dark:text-warning-night"
+                            onPointerDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                            }}
+                          >
+                            <Icon visual={InfoCircle} size="xs" />
+                          </span>
+                        }
+                        label="This Pod's default agent isn't available to you, so @dust is used instead. Discuss with your Pod editors if you think this is an error."
+                      />
+                    )}
+                    <Icon
+                      visual={ChevronDown}
+                      size="xs"
+                      className="-mr-1 text-faint dark:text-faint-night"
+                    />
+                  </div>
                 }
               />
             </div>

--- a/front/lib/api/projects/default_agent.ts
+++ b/front/lib/api/projects/default_agent.ts
@@ -1,0 +1,34 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+
+// Resolves the agent a conversation started in this pod should kick off with
+// when the caller didn't pick one explicitly: the pod's configured default
+// agent, else @dust.
+export async function resolvePodDefaultAgentId(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<string> {
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("pod_default_agent")) {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+  const candidateId = metadata?.defaultAgentId ?? null;
+  if (!candidateId || candidateId === GLOBAL_AGENTS_SID.DUST) {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+
+  const agent = await getAgentConfiguration(auth, {
+    agentId: candidateId,
+    variant: "extra_light",
+  });
+  if (!agent || agent.status !== "active") {
+    return GLOBAL_AGENTS_SID.DUST;
+  }
+  return candidateId;
+}

--- a/front/lib/project_task/start_agent.ts
+++ b/front/lib/project_task/start_agent.ts
@@ -9,11 +9,11 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { resolvePodDefaultAgentId } from "@app/lib/api/projects/default_agent";
 import type { Authenticator } from "@app/lib/auth";
 import { serializeProjectTaskDirective } from "@app/lib/project_task/format";
 import { ProjectTaskResource } from "@app/lib/resources/project_task_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { APIErrorType } from "@app/types/error";
 import type { PodTaskSourceInfo, PodTaskType } from "@app/types/project_task";
 import type { Result } from "@app/types/shared/result";
@@ -274,12 +274,18 @@ export async function startAgentForProjectTask(
     "\n\n" +
     "Read the attached file in full for more instructions.";
 
+  // When the caller didn't pick an agent, kick off with the pod's default
+  // agent instead of hardcoded @dust, so the configured default applies to
+  // task conversations the same way it does to new conversations.
+  const resolvedAgentConfigurationId =
+    agentConfigurationId ?? (await resolvePodDefaultAgentId(auth, space));
+
   const messageRes = await postUserMessage(auth, {
     conversation,
     content,
     mentions: [
       {
-        configurationId: agentConfigurationId ?? GLOBAL_AGENTS_SID.DUST,
+        configurationId: resolvedAgentConfigurationId,
       },
     ],
     context: {


### PR DESCRIPTION
## Description
Context: https://dust4ai.slack.com/archives/C09T7N4S6GG/p1781853023433559
When opening up a conversation for a task in pods, the default agent is the same as the pod level default agent. Update is under the feature flag "pod_default_agent"
<img width="944" height="273" alt="Screenshot 2026-06-19 at 17 15 37" src="https://github.com/user-attachments/assets/856c1c1e-0a1a-4f4e-bb65-15c74c0f04ed" />

## Tests
Manual Testing- Same UI as before. When default agent permissions are incorrect, the same warning sign that appears in a Pod conversation appears in the task.

## Risk
Low risk, default agent is currently being used in Dust.

## Deploy Plan
- Updated as part of "pod_default_agent" feature flag
- Deploy to prod w/o feature flag
