### PR TITLE
fix(tools): add sdks-js health dependency to front processes in process-compose

### DIFF
--- a/tools/process-compose.yaml
+++ b/tools/process-compose.yaml
@@ -145,6 +145,8 @@ processes:
     depends_on:
       sparkle:
         condition: process_healthy
+      sdks-js:
+        condition: process_healthy
 
   front-poke:
     command: "npm run dev:poke"
@@ -152,6 +154,8 @@ processes:
     namespace: front
     depends_on:
       sparkle:
+        condition: process_healthy
+      sdks-js:
         condition: process_healthy
 
   # --- Optional services --------------------------------------------------


### PR DESCRIPTION
## Description

`front` and `front-poke` processes were missing `sdks-js` as a health dependency in `process-compose.yaml`. This caused them to start before the JS SDK build was ready, leading to startup failures. This adds `sdks-js: condition: process_healthy` to both processes, matching the existing `sparkle` dependency pattern.

PMRR.

## Tests

Tested locally with process-compose — `front` and `front-poke` now wait for `sdks-js` to be healthy before starting.

## Risk

Low — config-only change, no code affected.

## Deploy Plan

N/A — dev tooling only.
