### PR TITLE
feat(front): add list_ticket_requested_items tool to Freshservice MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -155,6 +155,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "list_solution_categories": "never_ask",
     "list_solution_folders": "never_ask",
     "list_ticket_approvals": "never_ask",
+    "list_ticket_requested_items": "never_ask",
     "list_ticket_tasks": "never_ask",
     "list_tickets": "never_ask",
     "request_service_approval": "low",

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -189,6 +189,20 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
   },
 
+  // Service request items
+  list_ticket_requested_items: {
+    description:
+      "Lists the service request items nested under a Service Request ticket. Returns each item's metadata along with its custom fields. Use this after get_ticket when the ticket is a Service Request and you need values from custom fields on the nested items.",
+    schema: {
+      ticket_id: z.number().describe("The ID of the ticket"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing Freshservice ticket requested items",
+      done: "List Freshservice ticket requested items",
+    },
+  },
+
   // Ticket tasks
   list_ticket_tasks: {
     description: "Lists all tasks associated with a ticket",

--- a/front/lib/api/actions/servers/freshservice/tools/index.ts
+++ b/front/lib/api/actions/servers/freshservice/tools/index.ts
@@ -415,6 +415,40 @@ const handlers: ToolHandlers<typeof FRESHSERVICE_TOOLS_METADATA> = {
     }
   },
 
+  list_ticket_requested_items: async ({ ticket_id }, { authInfo }) => {
+    const clientResult = createFreshserviceClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    try {
+      const result = await client.request<{ requested_items: unknown[] }>(
+        `tickets/${ticket_id}/requested_items`
+      );
+
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const requestedItems = result?.requested_items || [];
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: `Retrieved ${requestedItems.length} requested items for ticket ${ticket_id}`,
+        },
+        {
+          type: "text" as const,
+          text: JSON.stringify(requestedItems, null, 2),
+        },
+      ]);
+    } catch (error) {
+      return new Err(
+        new MCPError(
+          `API request failed: ${error instanceof Error ? error.message : "Unknown error"}`
+        )
+      );
+    }
+  },
+
   list_ticket_tasks: async ({ ticket_id }, { authInfo }) => {
     const clientResult = createFreshserviceClient(authInfo);
     if (clientResult.isErr()) {


### PR DESCRIPTION
## Description
- Adds a new `list_ticket_requested_items` tool to the Freshservice MCP server that fetches the service request items
nested under a Service Request ticket via `GET tickets/{id}/requested_items`.
- Returns each item's metadata together with its custom fields, so agents can read custom field values from service
request items after calling `get_ticket`.
- Registers the tool's metadata (description, schema, stake, display labels) and updates the MCP server metadata
snapshot accordingly.

## Tests
- [ ] Run a Freshservice MCP agent against a Service Request ticket and confirm `list_ticket_requested_items` returns
the nested items with their custom fields.
- [ ] Verify it returns an empty list (no error) for a ticket with no requested items / non-Service-Request tickets.
- [ ] Confirm metadata snapshot test passes (`mcp_servers_metadata.test.ts`).

## Risk
Low - new MCP tool.

## Deploy Plan
N/A