### PR TITLE
[front] UsagePage: enable hook useCreditPurchaseInfo only when necessary

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -399,6 +399,7 @@ export function UsagePage() {
 
   const { billingCycleStartDay } = useCreditPurchaseInfo({
     workspaceId: owner.sId,
+    disabled: !isReadOnly,
   });
 
   // Legacy contracts have no pool credits or commits, so the pool summary's


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9043

In UsagePage, call useCreditPurchaseInfo only when needed, by useAwuUsage => same disabled condition for the 2 hooks


## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front