### PR TITLE
[front] add free-seats endpoint + use it in FreePlanSeatsSection

### DIFF
--- a/front-api/routes/w/[wId]/members/free-seats.ts
+++ b/front-api/routes/w/[wId]/members/free-seats.ts
@@ -1,0 +1,23 @@
+import type { GetFreeSeatCountsResponseBody } from "@app/lib/api/members";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+// Mounted at /api/w/:wId/members/free-seats.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (ctx): HandlerResult<GetFreeSeatCountsResponseBody> => {
+    const auth = ctx.get("auth");
+    const freeSeatCounts = await MembershipResource.getFreeSeatCounts({
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    return ctx.json({ freeSeatCounts });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/members/index.ts
+++ b/front-api/routes/w/[wId]/members/index.ts
@@ -9,6 +9,7 @@ import type { Context } from "hono";
 import { z } from "zod";
 
 import member from "./[uId]";
+import freeSeats from "./free-seats";
 import lookup from "./lookup";
 import me from "./me";
 import search from "./search";
@@ -80,6 +81,7 @@ app.get(
   }
 );
 
+app.route("/free-seats", freeSeats);
 app.route("/lookup", lookup);
 app.route("/me", me);
 app.route("/search", search);

--- a/front/components/workspace/billing/FreePlanSeatsSection.tsx
+++ b/front/components/workspace/billing/FreePlanSeatsSection.tsx
@@ -1,4 +1,4 @@
-import { useMembers } from "@app/lib/swr/memberships";
+import { useFreeSeatCounts } from "@app/lib/swr/memberships";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Icon, InfoSquare, Spinner } from "@dust-tt/sparkle";
@@ -12,14 +12,16 @@ export function FreePlanSeatsSection({
   owner,
   subscription,
 }: FreePlanSeatsSectionProps) {
-  const { total, isMembersLoading } = useMembers({ workspaceId: owner.sId });
-  const maxSeats = subscription.plan.limits.users.maxUsers;
+  const { freeSeatCounts, isFreeSeatCountsLoading } = useFreeSeatCounts({
+    workspaceId: owner.sId,
+  });
+  const maxLifetimeSeats = subscription.plan.limits.users.maxLifetimeFreeUsers;
 
-  if (maxSeats <= 0) {
+  if (maxLifetimeSeats <= 0) {
     return null;
   }
 
-  if (isMembersLoading) {
+  if (isFreeSeatCountsLoading) {
     return (
       <div className="flex items-center justify-center rounded-2xl bg-muted-background p-4 dark:bg-muted-background-night">
         <Spinner />
@@ -27,17 +29,17 @@ export function FreePlanSeatsSection({
     );
   }
 
-  const isAtCapacity = total >= maxSeats;
-  const fillPercent =
-    maxSeats > 0 ? Math.min((total / maxSeats) * 100, 100) : 0;
+  const lifetimeCount = freeSeatCounts?.lifetime ?? 0;
+  const isAtCapacity = lifetimeCount >= maxLifetimeSeats;
+  const fillPercent = Math.min((lifetimeCount / maxLifetimeSeats) * 100, 100);
 
   const heading = isAtCapacity
-    ? `You've used all ${maxSeats} free seats`
-    : `${total} of ${maxSeats} free seats used`;
+    ? `You've used all ${maxLifetimeSeats} free seats`
+    : `${lifetimeCount} of ${maxLifetimeSeats} free seats used`;
 
   const description = isAtCapacity
-    ? "You can't invite anyone else on the free plan. Upgrade a member to a Pro or Max seat on the Members page to add more, the cap lifts instantly."
-    : `Free workspaces include ${maxSeats} members. Upgrade a member to a Pro or Max seat anytime to go beyond the cap and unlock paid models.`;
+    ? "Your workspace has reached its free seat limit. Upgrade a member to a Pro or Max seat on the Members page to add more, the cap lifts instantly."
+    : `Free workspaces include ${maxLifetimeSeats} free seats. Once used, free seats are permanent. Upgrade a member to a Pro or Max seat anytime to go beyond the cap.`;
 
   return (
     <div className="flex flex-col gap-3 rounded-2xl bg-muted-background p-4 dark:bg-muted-background-night">

--- a/front/lib/api/members.ts
+++ b/front/lib/api/members.ts
@@ -11,3 +11,7 @@ export type MembersLookupResponseBody = {
 export type MembersLookupAdminResponseBody = {
   users: UserType[];
 };
+
+export type GetFreeSeatCountsResponseBody = {
+  freeSeatCounts: { active: number; lifetime: number };
+};

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -1,7 +1,10 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/lib/api/invitation";
-import type { MembersLookupResponseBody } from "@app/lib/api/members";
+import type {
+  GetFreeSeatCountsResponseBody,
+  MembersLookupResponseBody,
+} from "@app/lib/api/members";
 import type {
   GetUserSpendLimitResponseBody,
   PutUserSpendLimitResponseBody,
@@ -475,4 +478,26 @@ export function useUpdateUserSpendLimit({
   );
 
   return { doUpdateSpendLimit };
+}
+
+export function useFreeSeatCounts({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const freeSeatCountsFetcher: Fetcher<GetFreeSeatCountsResponseBody> = fetcher;
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/members/free-seats`,
+    freeSeatCountsFetcher,
+    { disabled }
+  );
+
+  return {
+    freeSeatCounts: data?.freeSeatCounts,
+    isFreeSeatCountsLoading: !error && !data && !disabled,
+    isFreeSeatCountsError: !!error,
+  };
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9081

The FreePlanSeatsSection was comparing current active member count against maxUsers, which doesn't correctly model the free plan's seat semantics: a free seat is consumed permanently, even if the member later leaves the workspace.

This PR introduces a dedicated endpoint that returns both active and lifetime free seat counts, and updates the component to show lifetime usage against maxLifetimeFreeUsers.

### Changes
* New endpoint — GET /api/w/:wId/members/free-seats (admin-only) => Returns { freeSeatCounts: { active: number; lifetime: number } } where:
  * active: current members with a free seat
  * lifetime: distinct users who have ever held a free seat (the permanent counter)
* New SWR hook — useFreeSeatCounts memberships.ts]
* FreePlanSeatsSection update
  * Replaced useMembers + maxUsers with useFreeSeatCounts + maxLifetimeFreeUsers
  * Progress bar and capacity check now use the lifetime counter
  * Updated copy to communicate that free seats are permanent once used

## Tests

Tested locally

## Risk

Low, new endpoint used in a dedicated UI

## Deploy Plan

Deploy front