### PR TITLE
Keep the tool section out of the long-lived system prompt cache tier

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -484,17 +484,17 @@ export function constructPromptMultiActions(
   if (hasStaticInstructions) {
     // Structured form with 3 cache tiers, ordered from most stable to most volatile.
     //
-    // Instructions (long cache): stable per agent config — agent instructions,
-    // tools (directives + server listing), skills, format docs, and guidelines.
+    // Instructions (long cache): stable per agent config, covering agent instructions, skills,
+    // format docs, and guidelines.
     //
-    // Shared context (short cache): workspace-scoped data shared across users — date, toolsets,
-    // workspace info. A cache breakpoint here lets different users in the same workspace share
-    // this prefix.
+    // Shared context (short cache): workspace-scoped data shared across users, covering the tools
+    // section (directives + server listing), date, toolsets, and workspace info. A cache breakpoint
+    // here lets different users in the same workspace share this prefix.
     //
-    // Ephemeral context (no breakpoint): per-call data — branch lineage, memories, user profile.
+    // Ephemeral context (no breakpoint): per-call data, covering branch lineage, memories, and user
+    // profile.
     const fullInstructions = [
       instructionsContent,
-      toolsSection,
       skillsSection,
       attachmentsSection,
       pastedContentSection,
@@ -503,7 +503,12 @@ export function constructPromptMultiActions(
       .filter((s) => s.trim() !== "")
       .join("\n");
 
+    // The tools section (directives + available-servers overview) lives in the shared-context
+    // (5min) tier rather than the instructions (1h) tier: its per-server listing and instructions
+    // change whenever a (conditional) JIT server is added mid-run, so keeping it out of the
+    // instructions block lets that block stay cache-stable across server additions.
     const sharedContext: SystemPromptContext[] = [
+      { role: "context" as const, content: toolsSection },
       { role: "context" as const, content: contextSection },
       { role: "context" as const, content: toolsetsContext ?? "" },
       { role: "context" as const, content: workspaceContext ?? "" },

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -108,6 +108,11 @@ function buildSystemBlocks(
   if (instructionsText) {
     // If we have conditional JIT tools, we expect more variability in the instructions, so we keep
     // the default ephemeral cache. Otherwise, we can set a longer TTL to maximize cache hits.
+    //
+    // TODO: the tool directives and available-servers overview (the main source of JIT-driven
+    // variability in this block) now live in the shared-context block instead, so this downgrade
+    // should eventually be removable in favor of always using the 1h TTL, once we validate that no
+    // other conditional-JIT content remains in the instructions block.
     const ttl: "1h" | undefined = hasConditionalJITTools ? undefined : "1h";
     system.push({
       type: "text",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
A recent change (see https://github.com/dust-tt/dust/pull/27655) deferred cold tools behind Anthropic's tool search so that adding a tool server mid-run appends to the tool list rather than mutating it, which kept the tool definitions from busting the prompt cache. That fixed the tools, but not the system prompt. The system prompt for static-instruction agents is split into cache tiers, with the most stable content held under a one-hour breakpoint and more volatile content under a shorter five-minute one, and the available tool servers overview was still sitting in the long-lived tier. That overview lists each server and its instructions, so it changes whenever a server is added during a run. The net effect was that we preserved the tool definitions but still invalidated the entire expensive instructions prefix on every mid-run server addition, forcing the whole agent prompt to be reprocessed and leaving the dominant prompt-cache buster only half addressed.

This moves the tool section into the shared-context tier so it now sits behind the shorter breakpoint, in line with the deferral work. Adding a server mid-run churns only that cheaper block, while the stable prefix made of the agent instructions, skills, and guidelines survives on the long-lived breakpoint. The tool section now renders slightly later in the prompt, after the guidelines rather than right after the instructions, which is harmless for order-insensitive tool directives.

Behavior is unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
