### PR TITLE
Show banner for pro plans

### DIFF
--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -376,7 +376,9 @@ export function SubscriptionPage() {
   const isWorkspaceOnProPlan = isProPlan(plan);
   const isWorkspaceWhitelistedBusinessPlan = isWhitelistedBusinessPlan(owner);
   const canUpsellToBusinessPlan =
-    isWorkspaceOnProPlan && isWorkspaceWhitelistedBusinessPlan;
+    isWorkspaceOnProPlan &&
+    isWorkspaceWhitelistedBusinessPlan &&
+    !isMetronomeCheckout;
 
   const isProcessing =
     isSubscribingPlan || isGoingToStripePortal || isUpgradingToBusiness;
@@ -397,6 +399,27 @@ export function SubscriptionPage() {
         day: "numeric",
       })
     : null;
+
+  const migrationDate = (() => {
+    if (!isWorkspaceOnProPlan || !isMetronomeCheckout) {
+      return null;
+    }
+    const periodEndMs = perSeatPricing?.currentPeriodEndMs ?? null;
+    if (periodEndMs === null) {
+      return null;
+    }
+    const d = new Date(periodEndMs);
+    const day = d.getDate();
+    d.setDate(1);
+    d.setMonth(d.getMonth() + 1);
+    const daysInMonth = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+    d.setDate(Math.min(day, daysInMonth));
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  })();
 
   if (isLoading) {
     return (
@@ -463,6 +486,18 @@ export function SubscriptionPage() {
                   .
                 </>
               )}
+            </ContentMessage>
+          )}
+          {migrationDate && (
+            <ContentMessage
+              title="Your plan will be migrated to the new pricing."
+              variant="warning"
+            >
+              Your current plan will be automatically migrated to the new
+              credit-based pricing on{" "}
+              <span className="font-semibold">{migrationDate}</span>. You can
+              cancel your subscription at any time before that date from the
+              Stripe billing portal below.
             </ContentMessage>
           )}
           {useMetronomePanel ? (

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1432,6 +1432,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
       seatCurrency: currency,
       billingPeriod: recurring.interval === "year" ? "yearly" : "monthly",
       quantity: item.quantity,
+      currentPeriodEndMs: stripeSubscription.current_period_end * 1000,
     };
   }
 

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -155,6 +155,7 @@ export type SubscriptionPerSeatPricing = {
   seatCurrency: string;
   billingPeriod: BillingPeriod;
   quantity: number;
+  currentPeriodEndMs: number | null;
 };
 
 export const EnterpriseUpgradeFormSchema = z.object({


### PR DESCRIPTION
## Description

Closes http
<img width="844" height="544" alt="Screenshot 2026-06-22 at 09 31 45" src="https://github.com/user-attachments/assets/2fa5e86c-72ad-47c2-b59b-697155385a32" />
s://github.com/dust-tt/tasks/issues/8760

On the `/subscription` page, legacy Pro plan users (Stripe-billed) now see a warning banner when the new credit-based pricing (Metronome) is enabled. The banner shows the migration date — computed as end of the current billing period + 1 month — and directs them to the Stripe portal to cancel if they wish.

Changes:
- `SubscriptionPerSeatPricing` type extended with `currentPeriodEndMs` (sourced from the Stripe subscription object already fetched by `getPerSeatPricing`, no extra round-trip)
- `canUpsellToBusinessPlan` gated on `!isMetronomeCheckout` — hides the "Upgrade to Enterprise seat-based" option when new pricing is active, since that upgrade path no longer applies
- Migration banner rendered via `ContentMessage` when `isWorkspaceOnProPlan && isMetronomeCheckout`

## Tests

Tested manually with a Pro Stripe workspace and Metronome enabled: banner appears with the correct date, Enterprise upsell is hidden.

## Risk

Low. Banner and upsell suppression are both guarded by `useIsMetronomeCheckout()`; all other plan types and the legacy path are unaffected.

## Deploy Plan

Standard front deploy, no migrations.