### PR TITLE
Fix usage tab in user settings

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -5,17 +5,12 @@ import { PendingInvitationsTable } from "@app/components/me/PendingInvitationsTa
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
 import { useAuth } from "@app/lib/auth/AuthContext";
-import { formatCredits } from "@app/lib/client/credits";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
-import {
-  useAwuPoolSummary,
-  useCreditPurchaseInfo,
-  useMyUsage,
-  useSeatPlan,
-} from "@app/lib/swr/credits";
+import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
 import {
   usePatchUser,
   usePendingInvitations,
@@ -144,18 +139,9 @@ interface UsageSectionProps {
 
 function UsageSection({ owner, onClose }: UsageSectionProps) {
   const { isAdmin, subscription } = useAuth();
-  const { isCreditPurchaseInfoLoading, billingCycleStartDay } =
-    useCreditPurchaseInfo({
-      workspaceId: owner.sId,
-    });
-  const {
-    totalRemainingCredits,
-    totalActiveCredits,
-    overageCredits,
-    isAwuPoolSummaryLoading,
-    isAwuPoolSummaryError,
-  } = useAwuPoolSummary({ workspaceId: owner.sId });
-  const { myUsage, isMyUsageLoading } = useMyUsage({ workspaceId: owner.sId });
+  const { myUsage, nextCreditResetAt, isMyUsageLoading } = useMyUsage({
+    workspaceId: owner.sId,
+  });
   const { seatPlans } = useSeatPlan({ workspaceId: owner.sId });
 
   const { hasPendingUpgradeRequest } = useWorkspaceUsageStatus({
@@ -167,30 +153,11 @@ function UsageSection({ owner, onClose }: UsageSectionProps) {
     (myUsage?.seatType ? seatPlans[myUsage.seatType]?.name : null) ??
     subscription.plan.name;
 
-  const isLoading =
-    isAwuPoolSummaryLoading || isCreditPurchaseInfoLoading || isMyUsageLoading;
-  const totalConsumedCredits = Math.max(
-    0,
-    totalActiveCredits - totalRemainingCredits
-  );
-  const workspaceConsumedPercentage =
-    totalActiveCredits > 0
-      ? Math.min((totalConsumedCredits / totalActiveCredits) * 100, 100)
-      : 0;
+  const isLoading = isMyUsageLoading;
 
-  // User-level usage: prefer the total spend cap when set, otherwise use the
-  // seat allocation. The numerator must match the denominator choice.
-  const userLimit =
-    myUsage?.spendLimitAwuCredits ?? myUsage?.memberUsageLimit ?? null;
-  const userConsumed =
-    myUsage?.spendLimitAwuCredits != null
-      ? myUsage.consumedAwuCredits
-      : (myUsage?.consumedFromAllowanceAwuCredits ?? 0);
-  const hasPersonalUsage = userLimit !== null;
-  const userConsumedPercentage =
-    hasPersonalUsage && userLimit > 0
-      ? Math.min((userConsumed / userLimit) * 100, 100)
-      : 0;
+  const hasPersonalUsage =
+    (myUsage?.spendLimitAwuCredits ?? myUsage?.memberUsageLimit ?? null) !==
+    null;
 
   return (
     <SectionContent
@@ -220,63 +187,41 @@ function UsageSection({ owner, onClose }: UsageSectionProps) {
           <div className="flex justify-center py-2">
             <Spinner size="sm" />
           </div>
-        ) : isAwuPoolSummaryError ? (
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Failed to load credits data.
-          </p>
         ) : (
           <div className="flex flex-col gap-3">
-            {hasPersonalUsage && userLimit !== null ? (
+            {hasPersonalUsage ? (
               <>
-                <div className="flex items-center justify-between">
-                  <div className="flex flex-col gap-0.5">
-                    <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                      Your Credits
-                    </span>
-                    {billingCycleStartDay !== null && (
-                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                        Resets every {ordinalDay(billingCycleStartDay)} of the
-                        month
-                      </span>
-                    )}
-                  </div>
-                  <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                    {formatCredits(userConsumed)} / {formatCredits(userLimit)}
-                  </span>
-                </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
-                  <div
-                    className="h-full bg-highlight transition-all dark:bg-highlight-night"
-                    style={{ width: `${userConsumedPercentage}%` }}
-                  />
-                </div>
-              </>
-            ) : (
-              <>
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-0.5">
                   <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                    Workspace Credits Pool
+                    Your Credits
                   </span>
-                  <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
-                    {formatCredits(totalConsumedCredits)} /{" "}
-                    {formatCredits(totalActiveCredits)}
-                  </span>
+                  {nextCreditResetAt &&
+                    (() => {
+                      const d = new Date(nextCreditResetAt);
+                      const month = d.toLocaleDateString("en-US", {
+                        month: "long",
+                        timeZone: "UTC",
+                      });
+                      return (
+                        <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                          Resets on {month} {ordinalDay(d.getUTCDate())}
+                        </span>
+                      );
+                    })()}
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10 dark:bg-muted-foreground-night/10">
-                  <div
-                    className="h-full bg-highlight transition-all dark:bg-highlight-night"
-                    style={{ width: `${workspaceConsumedPercentage}%` }}
-                  />
-                </div>
-                <div className="flex items-center justify-between text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  {overageCredits !== null && overageCredits > 0 ? (
-                    <span>{formatCredits(overageCredits)} overage credits</span>
-                  ) : (
-                    <span />
-                  )}
-                </div>
+                <AwuUsageBar
+                  consumed={myUsage?.consumedAwuCredits ?? 0}
+                  consumedFromAllowance={
+                    myUsage?.consumedFromAllowanceAwuCredits ?? 0
+                  }
+                  consumedFromPool={myUsage?.consumedFromPoolAwuCredits ?? 0}
+                  memberUsageLimit={myUsage?.memberUsageLimit ?? null}
+                  effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
+                  seatType={myUsage?.seatType ?? null}
+                  isTotalAllowedUsagePending={false}
+                />
               </>
-            )}
+            ) : null}
           </div>
         )}
       </section>

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -97,6 +97,7 @@ function memberFromUpgradeRequest(
     consumedFromAllowanceAwuCredits: 0,
     consumedFromPoolAwuCredits: 0,
     billingFrequency: null,
+    nextCreditResetAt: null,
     scheduledSeatType: null,
     scheduledSeatChangeAt: null,
     spendLimitAwuCredits: null,

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -10,9 +10,7 @@ import {
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
-import { useDefaultUserSpendLimit } from "@app/lib/swr/usage_settings";
 import {
   type MembershipSeatType,
   SEAT_TYPE_ORDER,
@@ -103,7 +101,7 @@ function SeatTypeIcon({ seatType }: SeatTypeIconProps) {
   );
 }
 
-interface AwuUsageBarProps {
+export interface AwuUsageBarProps {
   consumed: number;
   // Of `consumed`, the part drawn from the seat allowance vs. the workspace
   // pool (+ overage). Provided by the API so the bar doesn't re-derive the
@@ -111,38 +109,32 @@ interface AwuUsageBarProps {
   consumedFromAllowance: number;
   consumedFromPool: number;
   memberUsageLimit: number | null;
-  limit: number | null;
+  // The fully-resolved spend cap from `spendLimitAwuCredits` (member override or
+  // workspace default, both including seat allowance). Always non-null for seated
+  // users — workspace default pool cap treats null as 0 (seat-only). Pass `?? 0`
+  // as a TypeScript guard only.
+  effectiveLimit: number;
   seatType: MembershipSeatType | null;
   isTotalAllowedUsagePending: boolean;
 }
 
-function AwuUsageBar({
+export function AwuUsageBar({
   consumed,
   consumedFromAllowance,
   consumedFromPool,
   memberUsageLimit,
-  limit,
+  effectiveLimit,
   seatType,
   isTotalAllowedUsagePending: isPending,
 }: AwuUsageBarProps) {
-  const { sId: workspaceId } = useWorkspace();
-  const { defaultUserSpendLimit } = useDefaultUserSpendLimit({ workspaceId });
-
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
-
-  // When no Metronome cap alert exists for this user (`limit` is null), fall
-  // back to displaying the workspace default: seat allowance + default pool.
-  const effectiveLimit =
-    limit ??
-    (defaultUserSpendLimit?.awuCredits != null
-      ? allowance + defaultUserSpendLimit.awuCredits
-      : null);
-
+  // Uncapped is not a real product state: fall back to seat allowance when no
+  // explicit spend limit is configured (no pool access).
   // The bar splits consumption into seat → pool → overage:
   //   seat consumed · seat remaining · pool consumed · pool remaining · overage
-  // `poolLimit` is the headroom on top of the seat allowance (null = uncapped).
-  // A seat with no pool (poolLimit === 0, e.g. free) shows no pool section —
+  // `poolLimit` is the headroom above the seat allowance (0 = seat-only, e.g. free).
+  // A seat with no pool (poolLimit === 0) shows no pool section —
   // any spend beyond the seat allowance is overage. Zero-width sections are
   // skipped. `pool remaining` is omitted when uncapped (no finite headroom).
   const seatConsumed = consumedFromAllowance;
@@ -298,7 +290,7 @@ function AwuUsageBar({
           <Spinner size="xs" />
         ) : (
           <span>
-            {effectiveLimit === null ? "∞" : formatCredits(effectiveLimit)}
+            {effectiveLimit !== null ? formatCredits(effectiveLimit) : "—"}
           </span>
         )}
       </div>
@@ -371,7 +363,7 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
         }
         consumedFromPool={info.row.original.consumedFromPoolAwuCredits}
         memberUsageLimit={info.row.original.memberUsageLimit}
-        limit={info.row.original.spendLimitAwuCredits}
+        effectiveLimit={info.row.original.spendLimitAwuCredits ?? 0}
         seatType={info.row.original.seatType}
         isTotalAllowedUsagePending={
           info.row.original.isTotalAllowedUsagePending

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -92,6 +92,9 @@ export type MemberUsageType = {
   consumedFromPoolAwuCredits: number;
   // Billing cadence for the seat subscription the user is assigned to; null when unknown.
   billingFrequency: BillingFrequency | null;
+  // ISO timestamp of when the seat credit resets (= next billing period start).
+  // Null for free seats (lifetime grant) or when no billing period is available.
+  nextCreditResetAt: string | null;
   // Set when a future seat change is scheduled (e.g. at the next credit refresh).
   scheduledSeatType: MembershipSeatType | null;
   scheduledSeatChangeAt: string | null;
@@ -432,7 +435,7 @@ async function fetchEffectivePerUserSpendLimits({
 }: {
   metronomeCustomerId: string | null;
   workspaceId: string;
-  defaultPoolCapAwuCredits: number | null;
+  defaultPoolCapAwuCredits: number;
   includeAlertLinks: boolean;
 }): Promise<{
   perUserOverrideAlerts: Map<string, MetronomeCapAlertIds>;
@@ -480,11 +483,9 @@ async function fetchEffectivePerUserSpendLimits({
   const defaultCapAwuCreditsBySeatType: Partial<
     Record<NormalizedPoolLimitSeatType, number>
   > = {};
-  if (defaultPoolCapAwuCredits !== null) {
-    for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
-      defaultCapAwuCreditsBySeatType[seatType] =
-        defaultPoolCapAwuCredits + (seatAllowanceBySeatType[seatType] ?? 0);
-    }
+  for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
+    defaultCapAwuCreditsBySeatType[seatType] =
+      defaultPoolCapAwuCredits + (seatAllowanceBySeatType[seatType] ?? 0);
   }
 
   return {
@@ -570,7 +571,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
   userId: string;
   seatType: MembershipSeatType | null | undefined;
   poolCapOverrideAwuCredits: number | null;
-  defaultPoolCapAwuCredits: number | null;
+  defaultPoolCapAwuCredits: number;
 }): Promise<number | null> {
   const contract = metronomeCustomerId
     ? await getActiveContract(workspaceId)
@@ -671,7 +672,7 @@ export async function getMemberUsage({
       metronomeCustomerId: metronomeCustomerId ?? null,
       workspaceId: workspace.sId,
       defaultPoolCapAwuCredits:
-        creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
+        creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
       includeAlertLinks: false,
     }),
   ]);
@@ -736,6 +737,7 @@ export async function getMemberUsage({
       billingFrequency:
         seatData?.billingFrequency ??
         deriveWorkspaceSeatBillingFrequency(membership.seatType ?? null),
+      nextCreditResetAt: seatData?.nextCreditResetAt ?? null,
       scheduledSeatType: null,
       scheduledSeatChangeAt: null,
       spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({
@@ -872,7 +874,7 @@ export async function getMembersUsage({
       metronomeCustomerId: metronomeCustomerId ?? null,
       workspaceId: workspace.sId,
       defaultPoolCapAwuCredits:
-        creditUsageConfig?.defaultPoolCapAwuCredits ?? null,
+        creditUsageConfig?.defaultPoolCapAwuCredits ?? 0,
       includeAlertLinks,
     }),
     // Free-seat balance-alert ids (low + empty) for deep-linking — poke-only,
@@ -1006,6 +1008,7 @@ export async function getMembersUsage({
         billingFrequency:
           seatData?.billingFrequency ??
           deriveWorkspaceSeatBillingFrequency(membership.seatType ?? null),
+        nextCreditResetAt: seatData?.nextCreditResetAt ?? null,
         scheduledSeatType: scheduled?.seatType ?? null,
         scheduledSeatChangeAt: scheduled?.startAt.toISOString() ?? null,
         spendLimitAwuCredits: resolveEffectiveSpendLimitAwuCredits({

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1671,6 +1671,10 @@ async function reconcileSeatBasedSegment({
 export type SeatData = {
   awuAllocation: number;
   billingFrequency: BillingFrequency | null;
+  // ISO timestamp of the next credit reset. Null when no current billing period
+  // is available. Equals billing_periods.current.ending_before since credits
+  // are now anchored to the contract start date (same as the billing period).
+  nextCreditResetAt: string | null;
 };
 
 /**
@@ -1742,10 +1746,13 @@ export async function buildSeatDataByUserId({
       }
 
       const freq = sub.subscription_rate.billing_frequency;
+      const nextCreditResetAt =
+        sub.billing_periods?.current?.ending_before ?? null;
       return new Ok({
         seatIds: seatIdsResult.value,
         awuAllocation,
         billingFrequency: freq === "MONTHLY" || freq === "ANNUAL" ? freq : null,
+        nextCreditResetAt,
       });
     },
     { concurrency: 10 }
@@ -1762,6 +1769,7 @@ export async function buildSeatDataByUserId({
         seatDataByUserId.set(seatId, {
           awuAllocation: subSeatData.awuAllocation,
           billingFrequency: subSeatData.billingFrequency,
+          nextCreditResetAt: subSeatData.nextCreditResetAt,
         });
       }
     }

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -346,6 +346,7 @@ export function useMyUsage({
 
   return {
     myUsage: data?.member ?? null,
+    nextCreditResetAt: data?.member?.nextCreditResetAt ?? null,
     isMyUsageLoading: !error && !data && !disabled,
     isMyUsageError: error,
   };


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/9070

## Description

Fixes the Usage tab in user settings for non-admin users, and improves the usage bar for all users.

### Issues fixed

- **Non-admin users got a 403** on `/credits/awu-pool-summary` and `/credits/purchase` (both require admin). Both hooks are now disabled for non-admins.
- **Infinite limit displayed**: `AwuUsageBar` showed ∞ when no spend alert was configured (no pool access). Falls back to `memberUsageLimit` (seat allowance) instead.
- **Wrong usage consumed**: the bar only showed seat allowance consumption, ignoring pool overflow. Now shows total `consumedAwuCredits` with the seat/pool split visible in the bar and tooltip.
- **Workspace Credits Pool fallback for admins**: removed — this belongs on the billing page, not in personal settings.

### Changes

**`MembersUsageTable.tsx`**
- `AwuUsageBar` and its props interface are now exported.
- `limit` prop renamed to `effectiveLimit`; fallback: `effectiveLimit ?? memberUsageLimit` (uncapped is not a real product state).
- ∞ display replaced with `—` as a safe last-resort fallback.
- Removed `useDefaultUserSpendLimit` dependency — `spendLimitAwuCredits` from the API is already the fully-resolved value.

**`UserSettingsPopover.tsx`**
- `useAwuPoolSummary` and `useCreditPurchaseInfo` removed entirely (both admin-only).
- Replaced plain progress bar + pool note with the shared `AwuUsageBar` (same segmented bar with colors and tooltips as the members table).
- "Resets on [Month] [Day]th" label restored, sourced from `nextCreditResetAt` (billing period end = credit reset, now that anchors are aligned).

**`seats.ts` / `members_usage.ts` / `credits.ts`**
- `SeatData` and `MemberUsageType` gain `nextCreditResetAt: string | null` — sourced from `billing_periods.current.ending_before` on the Metronome subscription (equals the credit reset date since billing and credit anchors are now aligned).
- `useMyUsage` exposes `nextCreditResetAt`.

## Tests

Tested manually: Usage tab renders correctly for both admin and non-admin users.

## Risk

Low. Display-only changes. The bar data (`myUsage`) was already being fetched; no new API calls for non-admins.

## Deploy Plan

Standard deploy, no migration needed.