### PR TITLE
feat(marketing): add Elias Nefzi and Tarishi Singh to team page

### DIFF
--- a/.authors
+++ b/.authors
@@ -50,3 +50,5 @@ thomasvicaire: thomas.vicaire@dust.tt
 Nils-Fedrigo: nils.fedrigo@dust.tt
 ClementAupiais: clement.aupiais@dust.tt
 xebeohp: phoebe@dust.tt
+EliasNef: elias@dust.tt
+tarishi-dust: tarishi@dust.tt

--- a/.authors
+++ b/.authors
@@ -51,4 +51,4 @@ Nils-Fedrigo: nils.fedrigo@dust.tt
 ClementAupiais: clement.aupiais@dust.tt
 xebeohp: phoebe@dust.tt
 EliasNef: elias@dust.tt
-tarishi-dust: tarishi@dust.tt
+tarishi-dust: tarishi.singh@dust.tt

--- a/marketing/components/home/content/shared/team.ts
+++ b/marketing/components/home/content/shared/team.ts
@@ -609,6 +609,20 @@ export const PEOPLE: Record<string, TeamMember> = {
     linkedIn: "https://www.linkedin.com/in/matthieu-haguenauer/",
     github: "https://github.com/matthieuhaguen",
   },
+  elias: {
+    name: "Elias Nefzi",
+    title: "Support Engineer",
+    image: "https://avatars.githubusercontent.com/u/144661830?v=4",
+    linkedIn: null,
+    github: "https://github.com/EliasNef",
+  },
+  tarishi: {
+    name: "Tarishi Singh",
+    title: "Support Engineer",
+    image: "https://avatars.githubusercontent.com/u/292186890?v=4",
+    linkedIn: null,
+    github: "https://github.com/tarishi-dust",
+  },
 };
 
 export const TEAM_AVATAR_URLS: string[] = Object.values(PEOPLE).map(


### PR DESCRIPTION
## Description

Add two new Support Engineers to the team page (`dust.tt/home/about`):

- **Elias Nefzi** ([@EliasNef](https://github.com/EliasNef))
- **Tarishi Singh** ([@tarishi-dust](https://github.com/tarishi-dust))

Both entries follow the existing `TeamMember` pattern in `team.ts`. LinkedIn URLs are set to `null` for now and can be updated in a follow-up once their profiles are available.

## Tests

No code logic changed — pure data addition. The about page renders all `Object.keys(PEOPLE)` automatically, so no template changes are needed. Local validation was not run in the Computer; validation is delegated to PR CI.

## Risk

Low. Adding two entries to a static data object with no side effects. Fully safe to rollback by reverting the two added entries.

## Deploy Plan

Standard deploy — no special ordering required. The marketing package will pick up the new entries on next build/deploy.
