### PR TITLE
Change billing anchor date to contract start

### DIFF
--- a/front-api/routes/poke/metronome/packages.test.ts
+++ b/front-api/routes/poke/metronome/packages.test.ts
@@ -33,6 +33,7 @@ describe("GET /api/poke/metronome/packages", () => {
           tier: "enterprise",
           currency: "usd",
           seats: [],
+          billingAnchor: "contract_start_date" as const,
         },
       ])
     );
@@ -54,6 +55,7 @@ describe("GET /api/poke/metronome/packages", () => {
           tier: "enterprise",
           currency: "usd",
           seats: [],
+          billingAnchor: "contract_start_date" as const,
         },
       ],
     });

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -215,6 +215,7 @@ beforeEach(() => {
         tier: "enterprise",
         currency: "usd",
         seats: [],
+        billingAnchor: "contract_start_date" as const,
       },
       {
         id: PRO_PACKAGE_ID,
@@ -223,6 +224,7 @@ beforeEach(() => {
         tier: "pro",
         currency: "usd",
         seats: [],
+        billingAnchor: "contract_start_date" as const,
       },
       {
         id: BUSINESS_PACKAGE_ID,
@@ -231,6 +233,7 @@ beforeEach(() => {
         tier: "business",
         currency: "usd",
         seats: [],
+        billingAnchor: "contract_start_date" as const,
       },
     ])
   );

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -210,22 +210,50 @@ function validatePlanPackageCompat(
 }
 
 /**
- * First-period proration for a seat commitment. The seat billing period is
- * anchored to the 1st of the contract-start month; when the contract starts
- * mid-period the slice already elapsed (1st of month → contract start) is
- * removed from the granted credit.
+ * First-period seat commitment bounds.
  *
- * Returns the remaining `fraction` of the period (computed at hour
- * granularity) and `periodEnd` — the next 1st-of-month boundary the commit
- * should end before, so the prorated credit covers exactly the partial term.
+ * - `contract_start_date` anchor: billing periods run from the contract start,
+ *   so the first period is always full. Returns fraction=1 and periodEnd one
+ *   period after `startingAt`.
+ * - `first_billing_period` anchor: billing periods align to calendar month
+ *   boundaries (1st → 1st). The first period is a partial stub from contract
+ *   start to the next 1st-of-month. Returns the remaining fraction and the
+ *   next 1st-of-month as periodEnd.
  */
-function firstPeriodProration(
+function firstPeriodCommitment(
   startingAt: Date,
-  frequency: "MONTHLY" | "ANNUAL"
+  frequency: "MONTHLY" | "ANNUAL",
+  billingAnchor: "contract_start_date" | "first_billing_period"
 ): { fraction: number; periodEnd: Date } {
-  const HOUR_MS = 60 * 60 * 1000;
   const year = startingAt.getUTCFullYear();
   const month = startingAt.getUTCMonth();
+  if (billingAnchor === "contract_start_date") {
+    const hh = startingAt.getUTCHours();
+    const mm = startingAt.getUTCMinutes();
+    const ss = startingAt.getUTCSeconds();
+
+    // Clamp day to the last day of the target month to avoid overflow:
+    // e.g. Jan 31 + 1 month must land on Feb 28/29, not Mar 3.
+    const clampToMonth = (y: number, m: number, d: number): number =>
+      Math.min(d, new Date(Date.UTC(y, m + 1, 0)).getUTCDate());
+
+    const [ty, tm] =
+      frequency === "ANNUAL" ? [year + 1, month] : [year, month + 1];
+    const periodEnd = new Date(
+      Date.UTC(
+        ty,
+        tm,
+        clampToMonth(ty, tm, startingAt.getUTCDate()),
+        hh,
+        mm,
+        ss
+      )
+    );
+    return { fraction: 1, periodEnd };
+  }
+
+  // first_billing_period: prorate from contract start to next 1st-of-month.
+  const HOUR_MS = 60 * 60 * 1000;
   const periodStartMs = Date.UTC(year, month, 1);
   const periodEndMs =
     frequency === "ANNUAL"
@@ -767,11 +795,9 @@ export async function switchContract({
 
       // One-off seat commitment: grant `minSeats * rate` of contract credit
       // (the list value of the committed seats), invoiced at the negotiated
-      // `commitmentPrice`. Not recurring — renegotiated at renewal. The access
-      // credit is prorated to the first partial period (the slice from the 1st
-      // of the month to the contract start is removed) and ends at the next
-      // 1st-of-month boundary. `rateNative`/`commitmentPriceNative` are already
-      // in the contract's fiat unit (matching the fiat credit type).
+      // `commitmentPrice`. Not recurring — renegotiated at renewal.
+      // `rateNative`/`commitmentPriceNative` are already in the contract's fiat
+      // unit (matching the fiat credit type).
       if (
         seat.selected &&
         seat.commitmentPrice &&
@@ -782,13 +808,13 @@ export async function switchContract({
         pkgSeat
       ) {
         const fiatCreditTypeId = CURRENCY_TO_CREDIT_TYPE_ID[resolvedCurrency];
-        const { fraction, periodEnd } = firstPeriodProration(
+        const { fraction, periodEnd } = firstPeriodCommitment(
           alignedStart,
-          billingFrequency
+          billingFrequency,
+          pkg.billingAnchor
         );
-        // Access credit (the committed seats' list value) and the negotiated
-        // invoice price, both in the contract's fiat unit (cents for USD, whole
-        // units for EUR — the unit the fiat credit type expects).
+        // Access credit prorated by the billing anchor: full period for
+        // contract_start_date (fraction=1), partial stub for first_billing_period.
         const accessAmountNative =
           Math.round(seat.minSeats * rateNative * fraction * 100) / 100;
         const seatInvoiceScheduleItems = buildInvoiceScheduleItems({

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -485,6 +485,7 @@ export interface MetronomePackageSummary {
   tier: MetronomePackageTier;
   currency: SupportedCurrency;
   seats: PackageSeatConfig[];
+  billingAnchor: "contract_start_date" | "first_billing_period";
 }
 
 /**
@@ -674,6 +675,9 @@ export async function listMetronomePackages(): Promise<
         tier,
         currency: classifyMetronomePackageCurrencyByName(name),
         seats: seatConfigsFromPackageOverrides(pkg.overrides, productSeatTypes),
+        // billing_anchor_date is not exposed on PackageListResponse; default to
+        // contract_start_date which all current packages use.
+        billingAnchor: "contract_start_date" as const,
       });
     }
     packages.sort(comparePackagesForDisplay);

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -25,18 +25,17 @@ import { Err, Ok } from "@app/types/shared/result";
  * Usage is now folded on the invoice (no per-user line item), so we read it
  * straight from the grouped usage API instead of walking draft invoices.
  *
- * Billing periods always start on the 1st of the month at UTC midnight, so
- * `cycleStart`/`cycleEnd` already satisfy the usage endpoint's two constraints:
- *   - `current_period: true` is rejected ("must have an active plan") — that
- *     flag keys off Metronome's legacy v1 Plan entity, and we provision
- *     customers exclusively via Contracts, so no Plan exists. We pass explicit
- *     `starting_on`/`ending_before` instead.
- *   - explicit `starting_on`/`ending_before` must be UTC midnight — which the
- *     period bounds already are.
- * So we query `[cycleStart, cycleEnd)` directly with `window_size: "DAY"`; every
- * returned bucket falls inside the period, no trimming needed. The request end
- * is capped at the next midnight after `now` so we don't fetch the period's
- * future days.
+ * Billing periods are anchored to the contract start date (e.g. June 15 15:00),
+ * so bounds are non-midnight. The usage endpoint requires midnight-aligned
+ * `starting_on`/`ending_before`, so we floor/ceil to midnight and use
+ * `window_size: "HOUR"` to get per-hour buckets. Pre-period and post-period
+ * buckets are filtered out in code so only usage within `[cycleStart, cycleEnd)`
+ * is counted.
+ *
+ * `current_period: true` is rejected ("must have an active plan") — that flag
+ * keys off Metronome's legacy v1 Plan entity, and we provision customers
+ * exclusively via Contracts, so no Plan exists. We always pass explicit
+ * `starting_on`/`ending_before`.
  *
  * AWU spend has two sources, both priced in the AWU credit type:
  *   - AI Usage: the `cost_awu` metric, priced 1 AWU per unit, so the metric
@@ -81,13 +80,11 @@ export async function fetchPerUserAwuUsage({
   const cycleEndMs = cycleEnd.getTime();
   const cycleStartMs = cycleStart.getTime();
 
-  // The usage endpoint requires midnight-aligned bounds, so we always query from
-  // the floored start. When the period start is not itself midnight (e.g. a
-  // contract that started mid-day), the floored start pulls in usage from before
-  // the period began. Query at HOUR granularity in that case and drop the
-  // pre-start buckets below, so we count exactly the period — matching the
-  // Metronome spend alert and the seat grant. Steady-state periods start at
-  // midnight, so this stays on DAY.
+  // The usage endpoint requires midnight-aligned bounds. Billing periods are
+  // anchored to the contract start date (e.g. June 15 15:00), so the period
+  // bounds are typically non-midnight. Floor/ceil to midnight for the query
+  // and use HOUR granularity so individual buckets can be trimmed: drop
+  // pre-start buckets (< cycleStart) and post-end buckets (>= cycleEnd) below.
   const startingOn = floorToMidnightUTC(cycleStart).toISOString();
   const requestEnd = new Date(Math.min(cycleEndMs, Date.now()));
   const endingBefore = ceilToMidnightUTC(requestEnd).toISOString();
@@ -130,7 +127,8 @@ export async function fetchPerUserAwuUsage({
       !userId ||
       entry.value === null ||
       entry.group?.[USAGE_TYPE_GROUP_KEY] === USAGE_TYPE_FREE ||
-      new Date(entry.startingOn).getTime() < cycleStartMs
+      new Date(entry.startingOn).getTime() < cycleStartMs ||
+      new Date(entry.startingOn).getTime() >= cycleEndMs
     ) {
       continue;
     }
@@ -147,6 +145,7 @@ export async function fetchPerUserAwuUsage({
       entry.value === null ||
       entry.group?.[USAGE_TYPE_GROUP_KEY] === USAGE_TYPE_FREE ||
       new Date(entry.startingOn).getTime() < cycleStartMs ||
+      new Date(entry.startingOn).getTime() >= cycleEndMs ||
       !category ||
       !isToolCategory(category)
     ) {

--- a/front/lib/metronome/setup_new_pricing.ts
+++ b/front/lib/metronome/setup_new_pricing.ts
@@ -26,7 +26,7 @@ import {
 } from "@app/lib/metronome/constants";
 import { TOOL_CATEGORIES } from "@app/lib/metronome/events";
 import {
-  BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+  BILLING_CYCLE_CONFIG,
   FREE_SEAT_PRODUCT_NAME,
   getCreditTypeAwuId,
   getFreeExcessRecurringCredits,
@@ -533,7 +533,7 @@ export function getNewPackages(): PackageDef[] {
           price: CP_ENTERPRISE_BASIS * 12 * 100,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
     {
       name: "Enterprise Pooled EUR",
@@ -550,7 +550,7 @@ export function getNewPackages(): PackageDef[] {
           price: CP_ENTERPRISE_BASIS * 12,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
     {
       name: "Enterprise Seat-based USD",
@@ -570,7 +570,7 @@ export function getNewPackages(): PackageDef[] {
           price: (CP_ENTERPRISE_BASIS + CP_MAX_SEAT_COST_YEARLY) * 12 * 100,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
     {
       name: "Enterprise Seat-based EUR",
@@ -590,7 +590,7 @@ export function getNewPackages(): PackageDef[] {
           price: (CP_ENTERPRISE_BASIS + CP_MAX_SEAT_COST_YEARLY) * 12,
         },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
     // Business USD / EUR — Pro and Max seats (plus the free starter seat) priced
     // via overrides; per-seat INDIVIDUAL AWU credit allocations (Pro: 8000 /
@@ -622,7 +622,7 @@ export function getNewPackages(): PackageDef[] {
         },
         { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
     {
       name: "Business EUR",
@@ -650,7 +650,7 @@ export function getNewPackages(): PackageDef[] {
         },
         { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
     // Free plan — entitles only the Free Seat.
     {
@@ -663,7 +663,7 @@ export function getNewPackages(): PackageDef[] {
       overrides: buildSeatEntitlementOverrides(CREDIT_TYPE_USD_ID, [
         { product_name: FREE_SEAT_PRODUCT_NAME, price: 0 },
       ]),
-      ...BILLING_CYCLE_CONFIG_FIRST_OF_MONTH,
+      ...BILLING_CYCLE_CONFIG,
     },
   ];
 }


### PR DESCRIPTION
## Description

Aligns recurring seat credits with billing periods by switching all new-pricing Metronome packages from `first_billing_period` to `contract_start_date` billing anchor. Also makes the per-user spend commitment in `switch_contract` anchor-aware.

### Problem

New-pricing packages used `first_billing_period` as the billing anchor: periods align to calendar month boundaries (1st → 1st) regardless of when the contract starts. For a contract starting June 15 15:00:

- **Billing period**: July 1 00:00 → August 1 00:00
- **Recurring seat credits**: anchored at June 15 15:00, reset monthly on the 15th
- **Spend alerts** (`spend_threshold_reached`): evaluate against the billing period (July 1 →)
- **`fetchPerUserAwuUsage`**: queries from `billing_periods.current.starting_at` = July 1

Three different windows — the usage bar, the spend alert, and the credit reset were all misaligned.

### Fix

Switch all new-pricing packages to `contract_start_date`. Periods now run June 15 → July 15 matching the credit recurrence anchor exactly. Spend alert, usage query, and credit reset all evaluate against the same window.

`fetchPerUserAwuUsage` already handled non-midnight period starts via HOUR granularity + pre-period bucket trimming. A post-period bucket filter (`>= cycleEndMs`) is added — previously unnecessary with midnight-aligned ends.

As a side-effect, this fixes https://github.com/dust-tt/tasks/issues/8963

### Changes

**`setup_new_pricing.ts`**: All new-pricing packages (`BILLING_CYCLE_CONFIG_FIRST_OF_MONTH` → `BILLING_CYCLE_CONFIG`). Takes effect when packages are re-provisioned via the setup script.

**`switch_contract.ts`**: `firstPeriodProration` → `firstPeriodCommitment(startingAt, frequency, pkg.billingAnchor)`. Handles both anchors: `contract_start_date` → full first period (fraction=1), `first_billing_period` → partial stub fraction. Currently always takes the full-period path since no package uses `first_billing_period` anymore, but the logic is correct and future-proof.

**`client.ts`**: `MetronomePackageSummary` gains `billingAnchor: "contract_start_date" | "first_billing_period"`. Defaults to `"contract_start_date"` since the Metronome listing API does not expose the billing anchor on `PackageListResponse`.

**`per_user_usage.ts`**: Updated comment, added `>= cycleEndMs` post-period filter, kept the DAY/HOUR granularity optimization (DAY when period starts at midnight, HOUR otherwise).

## Tests

Tested manually on existing Business workspace — usage bar correctly reflects consumption within the billing period.

## Risk

Medium. Package definition change requires re-running the setup script (`npx tsx front/admin/setup_metronome_new_pricing.ts`) to take effect on new contracts. Existing contracts are unaffected — they keep their current billing anchor.

## Deploy Plan

1. Deploy code.
2. Re-provision Metronome packages via the setup script.
3. New contracts created after step 2 will use contract-start billing. Existing contracts are unchanged.