### PR TITLE
Use dedicated user id for free users

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -21,6 +21,7 @@ import {
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   FREE_SEAT_LIFETIME_AWU_CREDITS,
   getCreditTypeAwuId,
+  toFreeMetronomeUserId,
 } from "@app/lib/metronome/constants";
 import {
   fetchPerUserAwuUsage,
@@ -577,6 +578,8 @@ export async function fetchRemainingCapCreditsPercentageForUser({
     : null;
   const metronomeContractId = contract?.id ?? null;
 
+  const metronomeUserId =
+    seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
   const [
     perUserTotalConsumedCredits,
     { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
@@ -584,7 +587,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
     fetchPerUserUsageCreditsForMembersTable({
       metronomeCustomerId,
       metronomeContractId,
-      userIds: [userId],
+      userIds: [metronomeUserId],
     }),
     fetchEffectivePerUserSpendLimits({
       metronomeCustomerId,
@@ -618,7 +621,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
     return null;
   }
 
-  const consumed = perUserTotalConsumedCredits.get(userId) ?? 0;
+  const consumed = perUserTotalConsumedCredits.get(metronomeUserId) ?? 0;
   return Math.max(0, (spendLimitAwuCredits - consumed) / spendLimitAwuCredits);
 }
 
@@ -661,7 +664,9 @@ export async function getMemberUsage({
     fetchPerUserUsageCreditsForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
-      userIds: [userId],
+      // Include both forms; seat type is resolved from the membership fetched
+      // in the same Promise.all, so the correct key is picked after resolution.
+      userIds: [userId, toFreeMetronomeUserId(userId)],
     }),
     fetchSeatDataForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,
@@ -685,7 +690,10 @@ export async function getMemberUsage({
     return { member: null };
   }
 
-  const totalConsumedCredits = perUserTotalConsumedCredits.get(userId) ?? 0;
+  const metronomeUserId =
+    membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
+  const totalConsumedCredits =
+    perUserTotalConsumedCredits.get(metronomeUserId) ?? 0;
   const seatData = seatDataByUserId.get(userId);
   const awuAllocation = seatData?.awuAllocation ?? 0;
 
@@ -856,7 +864,9 @@ export async function getMembersUsage({
     fetchPerUserUsageCreditsForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
-      userIds: users.map((u) => u.sId),
+      // Include both the raw sId and the free-prefixed form: free-seat users'
+      // usage is keyed by the prefixed id in Metronome, regular users by sId.
+      userIds: users.flatMap((u) => [u.sId, toFreeMetronomeUserId(u.sId)]),
     }),
     fetchSeatDataForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,
@@ -924,7 +934,11 @@ export async function getMembersUsage({
       return [];
     }
     const userId = u.sId;
-    const totalConsumedCredits = perUserTotalConsumedCredits.get(userId) ?? 0;
+    // Free-seat users' usage is stored under the prefixed Metronome user id.
+    const metronomeUserId =
+      membership.seatType === "free" ? toFreeMetronomeUserId(userId) : userId;
+    const totalConsumedCredits =
+      perUserTotalConsumedCredits.get(metronomeUserId) ?? 0;
     const seatData = seatDataByUserId.get(userId);
     const awuAllocation = seatData?.awuAllocation ?? 0;
     const scheduled = scheduledByUserId.get(membership.userId);
@@ -982,10 +996,11 @@ export async function getMembersUsage({
       : null;
 
     // Free-seat balance-alert deep links (poke-only). Only free seats have
-    // these per-user credit-balance alerts.
+    // these per-user credit-balance alerts. Alerts are keyed by the
+    // free-prefixed Metronome user id.
     const freeCreditAlerts =
       membership.seatType === "free"
-        ? (freeCreditAlertIds?.get(userId) ?? null)
+        ? (freeCreditAlertIds?.get(metronomeUserId) ?? null)
         : null;
 
     return [
@@ -999,7 +1014,9 @@ export async function getMembersUsage({
         seatType: membership.seatType ?? null,
         memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
         seatBalanceAwu:
-          awuAllocation > 0 ? (seatBalanceByUserId.get(userId) ?? null) : null,
+          awuAllocation > 0
+            ? (seatBalanceByUserId.get(metronomeUserId) ?? null)
+            : null,
         consumedAwuCredits: totalConsumedCredits,
         consumedFromAllowanceAwuCredits,
         consumedFromPoolAwuCredits,

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -59,6 +59,7 @@ import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_EXCESS,
   CONTRACT_CREDIT_TYPE_POOL,
+  fromFreeMetronomeUserId,
   getCreditTypeAwuId,
   getProductExcessCreditsId,
   PAYMENT_GATE_TYPE_CUSTOM_FIELD_KEY,
@@ -1003,13 +1004,17 @@ export async function processMetronomeWebhook({
     // `threshold === 0` → exhausted (→ capped), else → near-limit flag set.
     case "alerts.low_remaining_contract_credit_balance_reached": {
       const { alert_id: alertId, threshold } = event.properties;
-      const userId = await resolvePerUserCreditAlertUserId({
+      const metronomeUserId = await resolvePerUserCreditAlertUserId({
         metronomeCustomerId: event.properties.customer_id,
         alertId,
       });
-      if (!userId || threshold === null || threshold === undefined) {
+      if (!metronomeUserId || threshold === null || threshold === undefined) {
         break;
       }
+      // Alerts are keyed by the free-prefixed Metronome user id; strip the
+      // prefix to recover the raw sId used everywhere else.
+      const userId =
+        fromFreeMetronomeUserId(metronomeUserId) ?? metronomeUserId;
       if (threshold === 0) {
         await dispatchSeatBalanceExhausted({ workspace, userId });
         logger.info(
@@ -1030,13 +1035,17 @@ export async function processMetronomeWebhook({
       break;
     }
     case "alerts.low_remaining_contract_credit_balance_resolved": {
-      const userId = await resolvePerUserCreditAlertUserId({
+      const metronomeUserId = await resolvePerUserCreditAlertUserId({
         metronomeCustomerId: event.properties.customer_id,
         alertId: event.properties.alert_id,
       });
-      if (!userId) {
+      if (!metronomeUserId) {
         break;
       }
+      // Alerts are keyed by the free-prefixed Metronome user id; strip the
+      // prefix to recover the raw sId used everywhere else.
+      const userId =
+        fromFreeMetronomeUserId(metronomeUserId) ?? metronomeUserId;
       void setUserNearLimit(workspace.sId, userId, false);
       await dispatchSeatBalanceResolved({ workspace, userId });
       logger.info(

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2582,10 +2582,10 @@ export async function addPerUserCreditToCustomer({
  */
 export async function listCustomerPerUserCreditUserIds({
   metronomeCustomerId,
-  creditName,
+  contractCreditType,
 }: {
   metronomeCustomerId: string;
-  creditName: string;
+  contractCreditType: ContractCreditType;
 }): Promise<Result<Set<string>, Error>> {
   if (!config.getMetronomeApiKey()) {
     return new Ok(new Set());
@@ -2600,7 +2600,11 @@ export async function listCustomerPerUserCreditUserIds({
       include_balance: false,
       include_archived: true,
     })) {
-      if (entry.contract || entry.name !== creditName) {
+      if (
+        entry.contract ||
+        entry.custom_fields?.[CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY] !==
+          contractCreditType
+      ) {
         continue;
       }
       for (const specifier of entry.specifiers ?? []) {
@@ -2693,8 +2697,11 @@ export async function listCustomerPerUserCreditBalances({
 }
 
 /**
- * Revoke a per-user customer credit by setting its end date to now. The
- * uniqueness key is untouched so the user can never re-claim the same credit.
+ * Revoke a per-user customer credit by setting its end date to the next round
+ * hour. Metronome requires hour-aligned timestamps; ceiling to the next hour is
+ * safe here because the credit is keyed on the free-seat Metronome user id
+ * ("free-<sId>") and no new usage events will be emitted for that id once the
+ * user has left the free seat.
  */
 export async function revokePerUserCustomerCredit({
   metronomeCustomerId,
@@ -2706,7 +2713,7 @@ export async function revokePerUserCustomerCredit({
   return updateMetronomeCreditEndDate({
     metronomeCustomerId,
     creditId,
-    accessEndingBefore: new Date().toISOString(),
+    accessEndingBefore: ceilToHourISO(new Date()),
   });
 }
 

--- a/front/lib/metronome/constants.ts
+++ b/front/lib/metronome/constants.ts
@@ -169,6 +169,28 @@ export const FOREVER_ENDING_BEFORE = new Date("2999-01-01T00:00:00.000Z");
 export const PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY =
   "DUST_PER_USER_CREDIT_USER";
 
+// Prefix applied to user sIds when emitting Metronome usage events for users on
+// a free seat, and when creating their per-user credits and alerts. This
+// decorrelates free-seat credit consumption from regular usage: the free credit
+// specifier filters on `presentation_group_values.user_id = "free-<sId>"`, so
+// it only drains against events emitted with that exact value.
+export const FREE_SEAT_METRONOME_USER_ID_PREFIX = "free-";
+
+export function toFreeMetronomeUserId(sId: string): string {
+  return `${FREE_SEAT_METRONOME_USER_ID_PREFIX}${sId}`;
+}
+
+// Strip the free-seat prefix from a Metronome user id to recover the raw sId.
+// Returns null when the value doesn't carry the prefix (i.e. not a free-seat id).
+export function fromFreeMetronomeUserId(
+  metronomeUserId: string
+): string | null {
+  if (metronomeUserId.startsWith(FREE_SEAT_METRONOME_USER_ID_PREFIX)) {
+    return metronomeUserId.slice(FREE_SEAT_METRONOME_USER_ID_PREFIX.length);
+  }
+  return null;
+}
+
 // Pricing/billable-metric group key that splits AWU usage into "user",
 // "programmatic", and "free" slices. Emitted on every usage event and used
 // by pricing rules, per-user reporting, and spend-threshold alerts.

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -7,6 +7,7 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { createHash } from "crypto";
 
 import {
+  toFreeMetronomeUserId,
   USAGE_TYPE_FREE,
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
@@ -290,6 +291,7 @@ export function buildLlmUsageEvents({
   isByok,
   conversationId,
   userId,
+  isFreeSeatedUser,
   agentMessageId,
   agentId,
   subAgentId,
@@ -308,6 +310,7 @@ export function buildLlmUsageEvents({
   isByok: boolean;
   conversationId: string;
   userId: string | null;
+  isFreeSeatedUser: boolean;
   agentMessageId: string;
   agentId: string | null;
   subAgentId: string | null;
@@ -366,7 +369,11 @@ export function buildLlmUsageEvents({
     timestamp,
     properties: {
       workspace_id: workspaceId,
-      user_id: userId ?? "unknown",
+      user_id: userId
+        ? isFreeSeatedUser
+          ? toFreeMetronomeUserId(userId)
+          : userId
+        : "unknown",
       is_byok: isByok ? "true" : "false",
       agent_message_id: agentMessageId,
       conversation_id: conversationId,
@@ -421,6 +428,7 @@ export function buildToolUseEvents({
   workspaceId,
   conversationId,
   userId,
+  isFreeSeatedUser,
   agentMessageId,
   agentId,
   subAgentId,
@@ -438,6 +446,7 @@ export function buildToolUseEvents({
   workspaceId: string;
   conversationId: string;
   userId: string | null;
+  isFreeSeatedUser: boolean;
   agentMessageId: string;
   agentId: string | null;
   subAgentId: string | null;
@@ -486,7 +495,11 @@ export function buildToolUseEvents({
       timestamp,
       properties: {
         workspace_id: workspaceId,
-        user_id: userId ?? "unknown",
+        user_id: userId
+          ? isFreeSeatedUser
+            ? toFreeMetronomeUserId(userId)
+            : userId
+          : "unknown",
         agent_message_id: agentMessageId,
         conversation_id: conversationId,
         agent_id: agentId ?? "unknown",

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -21,8 +21,10 @@ import {
   AWU_PRIORITY_FREE_SEAT_CREDIT,
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   FREE_SEAT_LIFETIME_AWU_CREDITS,
+  fromFreeMetronomeUserId,
   getCreditTypeAwuId,
   getProductSeatSubscriptionCreditsId,
+  toFreeMetronomeUserId,
 } from "@app/lib/metronome/constants";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
@@ -543,7 +545,7 @@ async function grantFreeSeatCredits({
   // key, so we never double-grant, only make redundant (no-op) API calls.
   const alreadyGranted = await listCustomerPerUserCreditUserIds({
     metronomeCustomerId,
-    creditName: FREE_SEAT_CREDIT_NAME,
+    contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
   if (alreadyGranted.isErr()) {
     logger.warn(
@@ -554,22 +556,27 @@ async function grantFreeSeatCredits({
   const grantedUserIds = alreadyGranted.isOk()
     ? alreadyGranted.value
     : new Set<string>();
-  const toGrant = userIds.filter((userId) => !grantedUserIds.has(userId));
+  // Credits are stored in Metronome with the free-prefixed user id; compare
+  // against the same form so already-granted users are skipped correctly.
+  const toGrant = userIds.filter(
+    (userId) => !grantedUserIds.has(toFreeMetronomeUserId(userId))
+  );
 
   // Grant the credit only for users that don't have one yet.
   await concurrentExecutor(
     toGrant,
     async (userId) => {
+      const freeMetronomeId = toFreeMetronomeUserId(userId);
       const result = await addPerUserCreditToCustomer({
         metronomeCustomerId,
         productId: getProductSeatSubscriptionCreditsId(),
         creditTypeId: getCreditTypeAwuId(),
         contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
         amount: FREE_SEAT_LIFETIME_AWU_CREDITS,
-        userId,
+        userId: freeMetronomeId,
         productTags: [USAGE_TAG],
         startingAt,
-        name: FREE_SEAT_CREDIT_NAME,
+        name: `${FREE_SEAT_CREDIT_NAME} ${userId}`,
         priority: AWU_PRIORITY_FREE_SEAT_CREDIT,
         // Workspace+user scoped: customer credits survive across contracts, so
         // there is no need to scope per-contract. A given user in a workspace
@@ -598,7 +605,7 @@ async function grantFreeSeatCredits({
       const alertResult = await upsertPerUserCreditBalanceAlerts({
         metronomeCustomerId,
         workspaceId,
-        userId,
+        userId: toFreeMetronomeUserId(userId),
         allowanceAwu: FREE_SEAT_LIFETIME_AWU_CREDITS,
       });
       if (alertResult.isErr()) {
@@ -637,8 +644,13 @@ async function revokeFreeSeatCreditsForExFreeUsers({
     );
     return;
   }
+  // Only process new-format credits (keyed by "free-<sId>"); old-format credits
+  // (plain sId) are ignored — they will eventually expire naturally.
   const toRevoke = [...activeCreditsResult.value.entries()].filter(
-    ([userId]) => !currentFreeUserIds.has(userId)
+    ([metronomeUserId]) => {
+      const rawUserId = fromFreeMetronomeUserId(metronomeUserId);
+      return rawUserId !== null && !currentFreeUserIds.has(rawUserId);
+    }
   );
   if (toRevoke.length === 0) {
     return;

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -28,9 +28,11 @@ import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { reportUsageForSubscriptionItems } from "@app/lib/plans/usage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -267,6 +269,23 @@ export async function emitMetronomeUsageEventsActivity(
   const userId =
     userMessageRow?.userMessage?.user?.sId ?? auth.user()?.sId ?? null;
 
+  // Determine if the user holds a free seat. Free-seat events use a prefixed
+  // user_id ("free-<sId>") so Metronome's free-credit specifier only drains
+  // against those events, keeping free credit consumption decoupled from the
+  // user's regular billable usage.
+  let isFreeSeatedUser = false;
+  if (userId) {
+    const userResource = await UserResource.fetchById(userId);
+    if (userResource) {
+      const membership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: userResource,
+          workspace: renderLightWorkspaceType({ workspace }),
+        });
+      isFreeSeatedUser = membership?.seatType === "free";
+    }
+  }
+
   // Sub-agent messages have agenticMessageType set (e.g. "run_agent", "agent_handover").
   // agenticOriginMessageId is the sId of the parent agent message that spawned this one.
   const userMessage = userMessageRow?.userMessage;
@@ -378,6 +397,7 @@ export async function emitMetronomeUsageEventsActivity(
     isByok,
     conversationId,
     userId,
+    isFreeSeatedUser,
     agentMessageId,
     agentId,
     subAgentId,
@@ -397,6 +417,7 @@ export async function emitMetronomeUsageEventsActivity(
     workspaceId: workspace.sId,
     conversationId,
     userId,
+    isFreeSeatedUser,
     agentMessageId,
     agentId,
     subAgentId,


### PR DESCRIPTION
## Problem

When a user held a free seat, their AWU usage was recorded in Metronome under their regular \`sId\`. The free credit's specifier filtered on \`presentation_group_values.user_id = sId\`, so it drained against the same events as their regular billable usage.

This caused two issues:
1. **Wrong usage display after upgrade**: usage spent while on the free seat was still counted toward the new seat's allowance in the members table and \`UserSettingsPopover\`, triggering low-balance / cap alerts before the user had actually spent anything from their paid allowance.
2. **Lifetime credit spans billing periods**: the free credit is a one-shot lifetime grant, not a per-period credit, making it even harder to reconcile — there's no clean period boundary to exclude past free usage from.

## Solution

Attribute all usage emitted while a user is on a free seat to a synthetic Metronome user id \`free-<sId>\` instead of the raw \`sId\`. The free credit's specifier is updated to filter on \`free-<sId>\`, so it only drains against events tagged with that value. Regular paid-seat usage always uses the raw \`sId\` and is therefore completely decoupled from the free credit.

Changes:
- **Events** (\`buildLlmUsageEvents\`, \`buildToolUseEvents\`): add \`isFreeSeatedUser\` flag; emit \`user_id: "free-<sId>"\` when true.
- **Activity** (\`emitMetronomeUsageEventsActivity\`): resolve seat type from membership and set \`isFreeSeatedUser\`.
- **Credit grant** (\`grantFreeSeatCredits\`): create the credit and its balance alerts under \`free-<sId>\`. Switch the already-granted dedup check from name-match to \`CONTRACT_CREDIT_TYPE_FREE_SEAT\` custom field (name is now per-user: \`"Free Seat Credits <sId>"\`).
- **Credit revocation** (\`revokeFreeSeatCreditsForExFreeUsers\`): only processes new-format \`free-<sId>\` credits; old-format credits are ignored and expire naturally. Uses \`ceilToHourISO\` for the end date (Metronome requires hour-aligned timestamps).
- **Usage display** (\`getMembersUsage\`, \`getMemberUsage\`, \`fetchRemainingCapCreditsPercentageForUser\`): query and look up consumed credits under \`free-<sId>\` for free-seat users.
- **Webhook** (\`process_webhook.ts\`): strip \`free-\` prefix from the alert's user id before dispatching credit-state transitions.

## Tests

Manually verified seat sync and event emission paths. No new unit tests — the logic is covered by the existing seat sync and credit state integration tests.

## Risk

Low. Old-format credits (plain \`sId\`) are left untouched and will expire naturally. The uniqueness key on the credit grant is unchanged, so no double-grants can occur during the transition. New usage events for free users will immediately use \`free-<sId>\`, so the decoupling is effective from the first deploy.

## Deploy Plan

Standard deploy — no migration required. Old free-seat credits will stop receiving new usage (events now go to \`free-<sId>\`) but remain in Metronome until their end date.