### PR TITLE
Log and trace previousMessageId on prompt cache miss

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -131,7 +131,8 @@ export abstract class LLM<TPayload = unknown> {
       yield* this.completeStream(streamParameters, metadata);
       return;
     }
-    const { conversation, prompt, specifications } = streamParameters;
+    const { conversation, prompt, specifications, previousMessageId } =
+      streamParameters;
 
     const workspaceId = this.authenticator.getNonNullableWorkspace().sId;
     const buffer = new LLMTraceBuffer(
@@ -162,6 +163,9 @@ export abstract class LLM<TPayload = unknown> {
       name: startCase(this.context.operationType),
       metadata: {
         dustTraceId: this.traceId,
+        // Prompt-cache diagnostics: the previous response id we threaded into this
+        // request (the current one is added below from the `interaction_id` event).
+        ...(previousMessageId && { previousMessageId }),
         // All contextual data as key-value pairs for better filtering in Langfuse UI.
         ...(this.authenticator.user()?.sId && {
           actualUserId: this.authenticator.user()!.sId,

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -504,6 +504,7 @@ export async function getOutputFromLLMStream(
               {
                 ...logContext,
                 modelInteractionId,
+                previousMessageId,
                 cacheMissReasonType: cacheMissReason.type,
                 cacheMissedInputTokens: cacheMissReason.cacheMissedInputTokens,
               },


### PR DESCRIPTION
On a prompt cache miss we already log the returned `modelInteractionId` and the miss reason. This adds the `previousMessageId` we threaded into the request to that log line, so both ends of the cache-correlation chain show up together.

It also wires `previousMessageId` into the Langfuse trace metadata (the current `modelInteractionId` was already there), so the cache chain can be followed across steps directly in the Langfuse UI.