### PR TITLE
Usage cost category naming

### DIFF
--- a/front/components/assistant/conversation/useCreditCostMenuItem.ts
+++ b/front/components/assistant/conversation/useCreditCostMenuItem.ts
@@ -4,7 +4,7 @@ import { isCreditPricedPlan } from "@app/types/plan";
 import type { DropdownMenuItemProps } from "@dust-tt/sparkle";
 
 const BEGINNING_AGENT_TOOLTIP =
-  "Credits used for this message (intelligence and tools).";
+  "Credits used for this message (tokens and actions).";
 
 const ITEM_CLASS_NAME =
   "cursor-default font-normal text-muted-foreground hover:bg-transparent focus:bg-transparent dark:text-muted-foreground-night dark:hover:bg-transparent dark:focus:bg-transparent";

--- a/front/components/workspace/AwuUsageChart.tsx
+++ b/front/components/workspace/AwuUsageChart.tsx
@@ -67,7 +67,7 @@ const GROUP_BY_OPTIONS: {
   { value: "api_key", label: "By API Key" },
   { value: "model", label: "By Model" },
   { value: "origin", label: "By Source" },
-  { value: "tool_category", label: "By category (LLM & tools)" },
+  { value: "tool_category", label: "By category (tokens & actions)" },
 ];
 
 const TOP_K_OPTIONS = [

--- a/front/lib/api/analytics/awu_usage.ts
+++ b/front/lib/api/analytics/awu_usage.ts
@@ -65,11 +65,11 @@ const USAGE_TYPE_LABELS: Record<string, string> = {
 
 // Human-readable labels for the "tool_category" grouping. Besides the real
 // tool_category values, it carries a synthetic "llm" bucket for all LLM usage,
-// so the breakdown reads LLM / Basic tools / Advanced tools.
+// so the breakdown reads Tokens / Basic actions / Advanced actions.
 const TOOL_CATEGORY_LABELS: Record<string, string> = {
-  llm: "LLM",
-  basic: "Basic tools",
-  advanced: "Advanced tools",
+  llm: "Tokens",
+  basic: "Basic actions",
+  advanced: "Advanced actions",
 };
 
 // Synthetic bucket key for the LLM slice of the tool_category grouping.


### PR DESCRIPTION
## Description

Rename credit cost categories in the UI to use consistent terminology: "tokens" instead of "LLM/intelligence" and "actions" instead of "tools".

Fixes https://github.com/dust-tt/tasks/issues/9017

## Tests

Manual — copy-only change, no logic affected.

## Risk

Low — UI labels only.

## Deploy Plan

Standard deploy, no migration needed.