### PR TITLE
feat(analytics): usage-type breakdown and legend drilldown on the credit chart

### DIFF
--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -22,7 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
@@ -32,13 +32,14 @@ interface AwuUsageFromAnalyticsChartProps {
 }
 
 type Granularity = "day" | "week" | "month";
-type AnalyticsGroupBy = "agent" | "user" | "origin";
+type AnalyticsGroupBy = "usage_type" | "agent" | "user" | "origin";
 
 const GROUP_BY_OPTIONS: {
   value: AnalyticsGroupBy | undefined;
   label: string;
 }[] = [
   { value: undefined, label: "Total" },
+  { value: "usage_type", label: "By Usage Type" },
   { value: "agent", label: "By Agent" },
   { value: "user", label: "By User" },
   { value: "origin", label: "By Source" },
@@ -87,6 +88,29 @@ export function AwuUsageFromAnalyticsChart({
     undefined
   );
   const [groupByCount, setGroupByCount] = useState<number>(5);
+  // Legend-driven drilldown: when non-null, only these series are shown.
+  const [enabledKeys, setEnabledKeys] = useState<string[] | null>(null);
+
+  const handleGroupByChange = (value: AnalyticsGroupBy | undefined) => {
+    setGroupBy(value);
+    setEnabledKeys(null);
+  };
+
+  const handleGroupByCountChange = (value: number) => {
+    setGroupByCount(value);
+    setEnabledKeys(null);
+  };
+
+  const toggleGroup = useCallback((key: string) => {
+    setEnabledKeys((prev) => {
+      const current = prev ?? [];
+      if (current.includes(key)) {
+        const next = current.filter((k) => k !== key);
+        return next.length === 0 ? null : next;
+      }
+      return [...current, key];
+    });
+  }, []);
 
   const { awuUsageData, isAwuUsageLoading, isAwuUsageError } =
     useAwuUsageFromAnalytics({
@@ -100,6 +124,17 @@ export function AwuUsageFromAnalyticsChart({
   const groups = useMemo(() => awuUsageData?.groups ?? [], [awuUsageData]);
   const points = useMemo(() => awuUsageData?.points ?? [], [awuUsageData]);
   const allKeys = useMemo(() => groups.map((g) => g.groupKey), [groups]);
+
+  // Intersect the drilldown selection with the keys actually returned: a series
+  // that drops out of the top-N (e.g. after a period change) must not blank the
+  // chart, so an empty intersection falls back to showing everything.
+  const effectiveEnabledKeys = useMemo(() => {
+    if (!enabledKeys) {
+      return null;
+    }
+    const available = enabledKeys.filter((key) => allKeys.includes(key));
+    return available.length > 0 ? available : null;
+  }, [enabledKeys, allKeys]);
 
   const chartData = useMemo(
     () =>
@@ -119,13 +154,29 @@ export function AwuUsageFromAnalyticsChart({
         ) {
           label = USER_MESSAGE_ORIGIN_LABELS[group.groupKey].label;
         }
+        const canFilter =
+          !!groupBy &&
+          group.groupKey !== "others" &&
+          group.groupKey !== "total";
         return {
           key: group.groupKey,
           label,
           colorClassName: getColorClassName(groupBy, group.groupKey, allKeys),
+          onClick: canFilter ? () => toggleGroup(group.groupKey) : undefined,
+          isActive:
+            !effectiveEnabledKeys ||
+            effectiveEnabledKeys.includes(group.groupKey),
         };
       }),
-    [groups, groupBy, allKeys]
+    [groups, groupBy, allKeys, effectiveEnabledKeys, toggleGroup]
+  );
+
+  const visibleKeys = useMemo(
+    () =>
+      allKeys.filter(
+        (key) => !effectiveEnabledKeys || effectiveEnabledKeys.includes(key)
+      ),
+    [allKeys, effectiveEnabledKeys]
   );
 
   return (
@@ -138,6 +189,14 @@ export function AwuUsageFromAnalyticsChart({
       }
       additionalControls={
         <div className="flex items-center gap-2">
+          {effectiveEnabledKeys && (
+            <Button
+              label="Clear filters"
+              size="xs"
+              variant="ghost"
+              onClick={() => setEnabledKeys(null)}
+            />
+          )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -177,7 +236,7 @@ export function AwuUsageFromAnalyticsChart({
                 <DropdownMenuItem
                   key={o.value ?? "total"}
                   label={o.label}
-                  onClick={() => setGroupBy(o.value)}
+                  onClick={() => handleGroupByChange(o.value)}
                 />
               ))}
             </DropdownMenuContent>
@@ -197,7 +256,7 @@ export function AwuUsageFromAnalyticsChart({
                   <DropdownMenuItem
                     key={value}
                     label={`Top ${value}`}
-                    onClick={() => setGroupByCount(value)}
+                    onClick={() => handleGroupByCountChange(value)}
                   />
                 ))}
               </DropdownMenuContent>
@@ -252,7 +311,7 @@ export function AwuUsageFromAnalyticsChart({
             boxShadow: "none",
           }}
         />
-        {allKeys.map((groupKey) => (
+        {visibleKeys.map((groupKey) => (
           <Bar
             key={groupKey}
             dataKey={groupKey}

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -2,6 +2,7 @@ import type { CreditBreakdownBy } from "@app/lib/api/assistant/observability/cre
 import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
+  fetchCreditTimeseriesByUsageType,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { daysToInstantRange } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
@@ -10,11 +11,15 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
 
-const ANALYTICS_GROUP_BY_KEYS = [
+const TERMS_GROUP_BY_KEYS = [
   "agent",
   "user",
   "origin",
 ] as const satisfies readonly CreditBreakdownBy[];
+
+// usage_type is derived (no stored field): User vs Programmatic, split on
+// user_id. The other groupings map directly to CreditBreakdownBy.
+const ANALYTICS_GROUP_BY_KEYS = ["usage_type", ...TERMS_GROUP_BY_KEYS] as const;
 
 export const AwuUsageAnalyticsQuerySchema = z.object({
   groupBy: z.enum(ANALYTICS_GROUP_BY_KEYS).optional(),
@@ -79,6 +84,36 @@ export async function getAwuUsageFromAnalytics(
     return new Ok({
       granularity,
       groups: [{ groupKey: "total", name: "Total usage" }],
+      points,
+    });
+  }
+
+  if (groupBy === "usage_type") {
+    const result = await fetchCreditTimeseriesByUsageType(auth, {
+      startDate,
+      endDate,
+      granularity,
+      timezone: "UTC",
+      fillWindow: true,
+    });
+    if (result.isErr()) {
+      return new Err(toError(result.error));
+    }
+
+    const points: AwuUsageAnalyticsPoint[] = result.value.map((point) => ({
+      timestamp: point.timestamp,
+      values: {
+        user: point.userCredits,
+        programmatic: point.programmaticCredits,
+      },
+    }));
+
+    return new Ok({
+      granularity,
+      groups: [
+        { groupKey: "user", name: "User" },
+        { groupKey: "programmatic", name: "Programmatic" },
+      ],
       points,
     });
   }

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -6,6 +6,7 @@ import {
   formatDateFromMillis,
   searchAnalytics,
 } from "@app/lib/api/elasticsearch";
+import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import { FREE_ORIGINS } from "@app/lib/metronome/events";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -73,6 +74,23 @@ export type CreditTimeseriesBreakdownPoint = {
 export type CreditTimeseriesBreakdown = {
   groups: { groupKey: string; name: string }[];
   points: CreditTimeseriesBreakdownPoint[];
+};
+
+export type CreditUsageTypePoint = {
+  timestamp: number;
+  date: string;
+  userCredits: number;
+  programmaticCredits: number;
+};
+
+type UsageTypeDateBucket = {
+  key: number;
+  user?: CreditSlice;
+  programmatic?: CreditSlice;
+};
+
+type CreditUsageTypeAggs = {
+  by_date?: estypes.AggregationsMultiBucketAggregateBase<UsageTypeDateBucket>;
 };
 
 const creditSubAggs = {
@@ -356,6 +374,86 @@ export async function fetchCreditTimeseries(
       timestamp: bucket.key,
       date: formatDateFromMillis(bucket.key, timezone),
       totalCredits: totalCreditsFromSlice(bucket),
+    }))
+  );
+}
+
+// Credits over time split by usage type: Programmatic (API key / programmatic
+// origin, per getProgrammaticUsageFilterClause) vs User (everything else).
+// usage_type isn't a stored field, so it's derived with filter sub-aggs. Free
+// usage is already out of scope, so the two series partition the total. Same
+// source and scope as fetchCreditTimeseries.
+export async function fetchCreditTimeseriesByUsageType(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    granularity,
+    timezone,
+    contextOrigin,
+    agentIds,
+    userIds,
+    fillWindow,
+  }: {
+    startDate: string;
+    endDate: string;
+    granularity: "day" | "week" | "month";
+    timezone: string;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+    fillWindow?: boolean;
+  }
+): Promise<Result<CreditUsageTypePoint[], ElasticsearchError>> {
+  const query = buildCreditQuery(auth, {
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+
+  const programmaticFilter = getProgrammaticUsageFilterClause();
+
+  const result = await searchAnalytics<never, CreditUsageTypeAggs>(query, {
+    aggregations: {
+      by_date: {
+        date_histogram: buildCreditDateHistogram({
+          granularity,
+          timezone,
+          startDate,
+          endDate,
+          fillWindow,
+        }),
+        aggs: {
+          programmatic: {
+            filter: programmaticFilter,
+            aggs: { ...creditSubAggs },
+          },
+          user: {
+            filter: { bool: { must_not: [programmaticFilter] } },
+            aggs: { ...creditSubAggs },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<UsageTypeDateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  return new Ok(
+    buckets.map((bucket) => ({
+      timestamp: bucket.key,
+      date: formatDateFromMillis(bucket.key, timezone),
+      userCredits: totalCreditsFromSlice(bucket.user ?? {}),
+      programmaticCredits: totalCreditsFromSlice(bucket.programmatic ?? {}),
     }))
   );
 }

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -85,6 +85,29 @@ export type UsageAggregations = {
 };
 
 /**
+ * Query-side mirror of isProgrammaticUsage: API-key requests (except Zendesk),
+ * messages with no context origin, or a listed programmatic origin. Single
+ * source of truth for splitting analytics docs into programmatic vs user.
+ */
+export function getProgrammaticUsageFilterClause(): estypes.QueryDslQueryContainer {
+  return {
+    bool: {
+      should: [
+        {
+          bool: {
+            must: [{ term: { auth_method: "api_key" } }],
+            must_not: [{ term: { context_origin: "zendesk" } }],
+          },
+        },
+        { bool: { must_not: { exists: { field: "context_origin" } } } },
+        { terms: { context_origin: PROGRAMMATIC_USAGE_ORIGINS } },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+}
+
+/**
  * Build ES filter for programmatic usage tracking.
  * Matches messages that should be tracked for billing:
  * - API key requests (except Zendesk)
@@ -96,29 +119,12 @@ export function getShouldTrackTokenUsageCostsESFilter(
 ): estypes.QueryDslQueryContainer {
   const workspace = auth.getNonNullableWorkspace();
 
-  // Track for API keys, listed programmatic origins or unspecified user message origins.
-  const shouldClauses: estypes.QueryDslQueryContainer[] = [
-    {
-      bool: {
-        must: [{ term: { auth_method: "api_key" } }],
-        must_not: [{ term: { context_origin: "zendesk" } }],
-      },
-    },
-    { bool: { must_not: { exists: { field: "context_origin" } } } },
-    { terms: { context_origin: PROGRAMMATIC_USAGE_ORIGINS } },
-  ];
-
   return {
     bool: {
       filter: [
         { term: { workspace_id: workspace.sId } },
         { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
-        {
-          bool: {
-            should: shouldClauses,
-            minimum_should_match: 1,
-          },
-        },
+        getProgrammaticUsageFilterClause(),
       ],
     },
   };

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -710,7 +710,7 @@ export function useAwuUsageFromAnalytics({
   disabled,
 }: {
   workspaceId: string;
-  groupBy?: "agent" | "user" | "origin";
+  groupBy?: "usage_type" | "agent" | "user" | "origin";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
   days?: number;


### PR DESCRIPTION
## Description

Add a "By Usage Type" grouping to the new credit chart: User (user_id != "unknown") vs Programmatic (user_id == "unknown"). usage_type isn't a stored field, so it's derived with filter sub-aggs in a new credit_usage.ts timeseries fetcher (fetchCreditTimeseriesByUsageType), reusing the shared scope, fillWindow and credit sub-agg helpers so it stays consistent with the other groupings. Free usage is already out of scope, so the two series partition the total.

Also make the chart legend groups clickable to filter/drilldown (with a Clear filters control), matching the former Metronome usage chart.

## Tests

Local
## Risk

Low, feature flagged
## Deploy Plan

Front
