### PR TITLE
ext: add Alan VisualForce domain to externally_connectable

### DIFF
--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -53,7 +53,8 @@
     "matches": [
       "https://dust.tt/*",
       "https://alan.com/sales-tools/*",
-      "https://alanhealth.lightning.force.com/*"
+      "https://alanhealth.lightning.force.com/*",
+      "https://alanhealth--c.vf.force.com/*"
     ]
   }
 }


### PR DESCRIPTION
## Description

Add Alan's Salesforce VisualForce domain (`alanhealth--c.vf.force.com`) to the `externally_connectable` matches list in the Chrome extension manifest.

Alan's team is building a Salesforce VisualForce page that triggers the Dust extension via `chrome.runtime.sendMessage`. Without whitelisting this domain, `chrome.runtime` is not available from the VisualForce context and the call silently fails.

The Lightning domain (`alanhealth.lightning.force.com`) was already whitelisted. This PR adds the corresponding VisualForce domain (`alanhealth--c.vf.force.com`).

Validated by Thomas Vicaire (LGTM in internal Slack thread).

## Tests

Manual validation not run locally — change is a one-line JSON addition to the manifest. Validation delegated to PR CI.

## Risk

Low. This is a targeted, additive change to the `externally_connectable` allowlist — it does not modify any extension logic or permissions. It only allows the extension to receive messages from that specific Salesforce VisualForce domain.

## Deploy Plan

Standard extension release after merge. No special ordering required.