### PR TITLE
ext: bump extension version to 0.1.10

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/extension",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Dust Chrome Extension",
   "scripts": {
     "clean": "rm -rf build/*",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",


### PR DESCRIPTION
## Description

Bump Chrome extension version from `0.1.9` to `0.1.10` in `manifest.base.json` and `package.json`.

Required to publish a new version to the Chrome Web Store following the merge of #27695 (add Alan VisualForce domain to `externally_connectable`).

## Tests

N/A — version bump only.

## Risk

Low.

## Deploy Plan

After merge:
1. Run the **Package Extension** workflow with `chrome:production`
2. Upload the generated zip to the Chrome Web Store Dev Console
3. Submit for review