### PR TITLE
fix(slack): render block-only messages for the agents

### DIFF
--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,7 +1,10 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { formatSlackMessageForLLM } from "@app/lib/api/actions/servers/slack/message_formatter";
+import {
+  formatSlackMessageForLLM,
+  renderFormattedMessage,
+} from "@app/lib/api/actions/servers/slack/message_formatter";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { removeDiacritics } from "@app/lib/utils";
@@ -1664,14 +1667,16 @@ export async function executeReadThreadMessages({
     parent_message: {
       // Rendered text reconstructs content from blocks/attachments when the top-level
       // `text` is empty (common for app/bot alerts). `raw_text` keeps the original.
-      text: parentMessage ? formatSlackMessageForLLM(parentMessage) : "",
+      text: parentMessage
+        ? renderFormattedMessage(formatSlackMessageForLLM(parentMessage))
+        : "",
       raw_text: parentMessage?.text ?? "",
       user: parentMessage?.user ?? "",
       ts: parentMessage?.ts ?? "",
       reply_count: parentMessage?.reply_count ?? 0,
     },
     thread_replies: threadReplies.map((msg) => ({
-      text: formatSlackMessageForLLM(msg),
+      text: renderFormattedMessage(formatSlackMessageForLLM(msg)),
       raw_text: msg.text ?? "",
       user: msg.user ?? "",
       ts: msg.ts ?? "",

--- a/front/lib/api/actions/servers/slack/helpers.ts
+++ b/front/lib/api/actions/servers/slack/helpers.ts
@@ -1,6 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { formatSlackMessageForLLM } from "@app/lib/api/actions/servers/slack/message_formatter";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { removeDiacritics } from "@app/lib/utils";
@@ -1661,15 +1662,17 @@ export async function executeReadThreadMessages({
 
   const formattedOutput = {
     parent_message: {
-      text: parentMessage?.text ?? "",
-      blocks: parentMessage?.blocks,
+      // Rendered text reconstructs content from blocks/attachments when the top-level
+      // `text` is empty (common for app/bot alerts). `raw_text` keeps the original.
+      text: parentMessage ? formatSlackMessageForLLM(parentMessage) : "",
+      raw_text: parentMessage?.text ?? "",
       user: parentMessage?.user ?? "",
       ts: parentMessage?.ts ?? "",
       reply_count: parentMessage?.reply_count ?? 0,
     },
     thread_replies: threadReplies.map((msg) => ({
-      text: msg.text ?? "",
-      blocks: msg.blocks,
+      text: formatSlackMessageForLLM(msg),
+      raw_text: msg.text ?? "",
       user: msg.user ?? "",
       ts: msg.ts ?? "",
     })),

--- a/front/lib/api/actions/servers/slack/message_formatter.test.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.test.ts
@@ -37,46 +37,52 @@ describe("formatSlackMessageForLLM", () => {
       ],
     });
 
-    expect(result).toContain("Triggered: API Errors");
-    expect(result).toContain("Service: backend");
-    expect(result).toContain("Env: production");
-    expect(result).toContain("Status: Triggered");
-    expect(result).toContain("Priority: P1");
-    expect(result).toContain("View in Datadog");
-    expect(result).toContain("https://app.datadoghq.com/monitors/123");
+    // Top-level text was empty; all content was reconstructed from the blocks.
+    expect(result.text).toBe("(empty)");
+    expect(result.blocks).toContain("Triggered: API Errors");
+    expect(result.blocks).toContain("Service: backend");
+    expect(result.blocks).toContain("Env: production");
+    expect(result.blocks).toContain("Status: Triggered");
+    expect(result.blocks).toContain("Priority: P1");
+    expect(result.blocks).toContain("View in Datadog");
+    expect(result.blocks).toContain("https://app.datadoghq.com/monitors/123");
   });
 
   it("returns the plain text when there are no blocks", () => {
-    expect(formatSlackMessageForLLM({ text: "hello world", blocks: [] })).toBe(
-      "hello world"
-    );
+    const result = formatSlackMessageForLLM({
+      text: "hello world",
+      blocks: [],
+    });
+    expect(result.text).toBe("hello world");
+    expect(result.blocks).toBe("(empty)");
   });
 
-  it("returns empty string for an empty message", () => {
-    expect(formatSlackMessageForLLM({ text: "", blocks: [] })).toBe("");
-    expect(formatSlackMessageForLLM({})).toBe("");
+  it("marks every source as empty for an empty message", () => {
+    const result = formatSlackMessageForLLM({});
+    expect(result.text).toBe("(empty)");
+    expect(result.blocks).toBe("(empty)");
+    expect(result.attachments).toBe("(empty)");
+    expect(result.files).toBe("(empty)");
   });
 
-  it("does not duplicate content shared between text and blocks", () => {
+  it("keeps text and block content in separate fields", () => {
     const result = formatSlackMessageForLLM({
       text: "Deploy finished",
       blocks: [
         {
           type: "section",
-          text: { type: "mrkdwn", text: "Deploy finished" },
+          text: { type: "mrkdwn", text: "Service A healthy" },
         },
         {
           type: "section",
-          text: { type: "mrkdwn", text: "All services healthy" },
+          text: { type: "mrkdwn", text: "Service B healthy" },
         },
       ],
     });
 
-    const occurrences = result
-      .split("\n")
-      .filter((line) => line === "Deploy finished").length;
-    expect(occurrences).toBe(1);
-    expect(result).toContain("All services healthy");
+    expect(result.text).toBe("Deploy finished");
+    expect(result.blocks).toContain("Service A healthy");
+    expect(result.blocks).toContain("Service B healthy");
   });
 
   it("renders rich_text blocks including links and mentions", () => {
@@ -118,9 +124,11 @@ describe("formatSlackMessageForLLM", () => {
       ],
     });
 
-    expect(result).toContain("See the report (https://example.com) cc @U123");
-    expect(result).toContain("- first item");
-    expect(result).toContain("- second item");
+    expect(result.blocks).toContain(
+      "See the report (https://example.com) cc @U123"
+    );
+    expect(result.blocks).toContain("- first item");
+    expect(result.blocks).toContain("- second item");
   });
 
   it("extracts content from attachments (pretext, title, text, fields)", () => {
@@ -140,11 +148,11 @@ describe("formatSlackMessageForLLM", () => {
       ],
     });
 
-    expect(result).toContain("New ticket");
-    expect(result).toContain("Login broken");
-    expect(result).toContain("Users cannot log in");
-    expect(result).toContain("Severity: High");
-    expect(result).toContain("Assignee: Jane");
+    expect(result.attachments).toContain("New ticket");
+    expect(result.attachments).toContain("Login broken");
+    expect(result.attachments).toContain("Users cannot log in");
+    expect(result.attachments).toContain("Severity: High");
+    expect(result.attachments).toContain("Assignee: Jane");
   });
 
   it("cleans Slack mrkdwn links and user mentions in plain text", () => {
@@ -152,25 +160,30 @@ describe("formatSlackMessageForLLM", () => {
       text: "Ping <@U050CALAKFD|someone> see <https://dust.tt|docs>",
     });
 
-    expect(result).toBe("Ping @someone see docs (https://dust.tt)");
+    expect(result.text).toBe("Ping @someone see docs (https://dust.tt)");
   });
 
-  it("appends file info when present", () => {
+  it("exposes file info in the files field", () => {
     const result = formatSlackMessageForLLM({
       text: "Report attached",
       files: [{ name: "report.pdf", mimetype: "application/pdf" }],
     });
 
-    expect(result).toContain("Report attached");
-    expect(result).toContain("Attached file: report.pdf (application/pdf)");
+    expect(result.text).toBe("Report attached");
+    expect(result.files).toContain(
+      "Attached file: report.pdf (application/pdf)"
+    );
   });
 
-  it("ignores malformed blocks without throwing", () => {
+  it("falls back to the text when blocks fail schema validation", () => {
     const result = formatSlackMessageForLLM({
       text: "ok",
-      blocks: [null, "nope", 42, { type: "section" }, { type: "divider" }],
+      blocks: [null, "nope", 42],
     });
 
-    expect(result).toBe("ok");
+    // Malformed blocks no longer pass zod validation: we surface the raw text
+    // instead of silently dropping content (and log a warning).
+    expect(result.text).toBe("ok");
+    expect(result.blocks).toContain("could not parse");
   });
 });

--- a/front/lib/api/actions/servers/slack/message_formatter.test.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.test.ts
@@ -1,0 +1,176 @@
+import { formatSlackMessageForLLM } from "@app/lib/api/actions/servers/slack/message_formatter";
+import { describe, expect, it } from "vitest";
+
+describe("formatSlackMessageForLLM", () => {
+  it("renders a Datadog-like block-only alert (text empty)", () => {
+    const result = formatSlackMessageForLLM({
+      text: "",
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: "Triggered: API Errors" },
+        },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "*Service:* backend\n*Env:* production",
+          },
+        },
+        {
+          type: "section",
+          fields: [
+            { type: "mrkdwn", text: "*Status:*\nTriggered" },
+            { type: "mrkdwn", text: "*Priority:*\nP1" },
+          ],
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "View in Datadog" },
+              url: "https://app.datadoghq.com/monitors/123",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toContain("Triggered: API Errors");
+    expect(result).toContain("Service: backend");
+    expect(result).toContain("Env: production");
+    expect(result).toContain("Status: Triggered");
+    expect(result).toContain("Priority: P1");
+    expect(result).toContain("View in Datadog");
+    expect(result).toContain("https://app.datadoghq.com/monitors/123");
+  });
+
+  it("returns the plain text when there are no blocks", () => {
+    expect(formatSlackMessageForLLM({ text: "hello world", blocks: [] })).toBe(
+      "hello world"
+    );
+  });
+
+  it("returns empty string for an empty message", () => {
+    expect(formatSlackMessageForLLM({ text: "", blocks: [] })).toBe("");
+    expect(formatSlackMessageForLLM({})).toBe("");
+  });
+
+  it("does not duplicate content shared between text and blocks", () => {
+    const result = formatSlackMessageForLLM({
+      text: "Deploy finished",
+      blocks: [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Deploy finished" },
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "All services healthy" },
+        },
+      ],
+    });
+
+    const occurrences = result
+      .split("\n")
+      .filter((line) => line === "Deploy finished").length;
+    expect(occurrences).toBe(1);
+    expect(result).toContain("All services healthy");
+  });
+
+  it("renders rich_text blocks including links and mentions", () => {
+    const result = formatSlackMessageForLLM({
+      text: "",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "See " },
+                {
+                  type: "link",
+                  url: "https://example.com",
+                  text: "the report",
+                },
+                { type: "text", text: " cc " },
+                { type: "user", user_id: "U123" },
+              ],
+            },
+            {
+              type: "rich_text_list",
+              style: "bullet",
+              elements: [
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "first item" }],
+                },
+                {
+                  type: "rich_text_section",
+                  elements: [{ type: "text", text: "second item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toContain("See the report (https://example.com) cc @U123");
+    expect(result).toContain("- first item");
+    expect(result).toContain("- second item");
+  });
+
+  it("extracts content from attachments (pretext, title, text, fields)", () => {
+    const result = formatSlackMessageForLLM({
+      text: "",
+      attachments: [
+        {
+          pretext: "New ticket",
+          title: "Login broken",
+          text: "Users cannot log in",
+          fallback: "Login broken - Users cannot log in",
+          fields: [
+            { title: "Severity", value: "High" },
+            { title: "Assignee", value: "Jane" },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toContain("New ticket");
+    expect(result).toContain("Login broken");
+    expect(result).toContain("Users cannot log in");
+    expect(result).toContain("Severity: High");
+    expect(result).toContain("Assignee: Jane");
+  });
+
+  it("cleans Slack mrkdwn links and user mentions in plain text", () => {
+    const result = formatSlackMessageForLLM({
+      text: "Ping <@U050CALAKFD|someone> see <https://dust.tt|docs>",
+    });
+
+    expect(result).toBe("Ping @someone see docs (https://dust.tt)");
+  });
+
+  it("appends file info when present", () => {
+    const result = formatSlackMessageForLLM({
+      text: "Report attached",
+      files: [{ name: "report.pdf", mimetype: "application/pdf" }],
+    });
+
+    expect(result).toContain("Report attached");
+    expect(result).toContain("Attached file: report.pdf (application/pdf)");
+  });
+
+  it("ignores malformed blocks without throwing", () => {
+    const result = formatSlackMessageForLLM({
+      text: "ok",
+      blocks: [null, "nope", 42, { type: "section" }, { type: "divider" }],
+    });
+
+    expect(result).toBe("ok");
+  });
+});

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -1,19 +1,9 @@
-// Reconstructs a readable plain-text/markdown representation from a Slack message.
-//
-// Many app/bot messages (Datadog, Zendesk, PagerDuty, ...) ship an empty top-level
-// `text` field and put the actual content in `blocks[]` (Block Kit) and/or
-// `attachments[]`. Relying on `message.text` alone makes those messages look empty to
-// LLMs. This formatter walks blocks and attachments to extract their textual content.
-//
-// It is intentionally read-only and best-effort. Slack's SDK does not provide complete
-// types for Block Kit inside message responses (the generated `AssistantAppThreadBlock`
-// type is flattened and even omits `header`), so we accept loosely typed input and narrow
-// defensively with type guards rather than trusting the SDK types. The structure handled
-// here matches the official Block Kit reference:
-// https://docs.slack.dev/reference/block-kit/blocks
+// Reconstructs readable text from a Slack message: app/bot messages (Datadog, Zendesk, ...)
+// often have an empty top-level `text` and put their content in `blocks[]`/`attachments[]`.
+// Block Kit is loosely typed in the SDK (the `header` block is even missing), so we read
+// `unknown` and narrow with type guards. mrkdwn cleanup is delegated to `slack_mrkdwn.ts`.
+import { slackMrkdwnToText } from "@app/lib/api/actions/servers/slack/slack_mrkdwn";
 
-// Minimal type guards (avoids relying on the SDK's incomplete block types and avoids
-// non-type-safe `as` casts per [GEN4]).
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -34,34 +24,7 @@ function readTextObject(value: unknown): string | undefined {
   return asString(value.text);
 }
 
-// Converts Slack mrkdwn to lightweight plain text: resolves links/mentions and strips
-// bold/strikethrough markers so content reads cleanly for an LLM.
-function cleanSlackMrkdwn(text: string): string {
-  return (
-    text
-      // <https://url|label> -> label (https://url)
-      .replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, "$2 ($1)")
-      // <https://url> -> https://url
-      .replace(/<(https?:\/\/[^|>]+)>/g, "$1")
-      // <mailto:foo@bar|label> -> label
-      .replace(/<mailto:[^|>]+\|([^>]+)>/g, "$1")
-      // <@U123|name> -> @name ; <@U123> -> @U123
-      .replace(/<@[UW][A-Z0-9]+\|([^>]+)>/g, "@$1")
-      .replace(/<@([UW][A-Z0-9]+)>/g, "@$1")
-      // <#C123|name> -> #name ; <#C123> -> #C123
-      .replace(/<#[A-Z0-9]+\|([^>]+)>/g, "#$1")
-      .replace(/<#([A-Z0-9]+)>/g, "#$1")
-      // <!subteam^S123|@group> -> @group ; <!here>/<!channel> -> @here/@channel
-      .replace(/<!subteam\^[A-Z0-9]+\|([^>]+)>/g, "$1")
-      .replace(/<!(here|channel|everyone)>/g, "@$1")
-      // *bold* -> bold ; ~strike~ -> strike
-      .replace(/\*([^*\n]+)\*/g, "$1")
-      .replace(/~([^~\n]+)~/g, "$1")
-  );
-}
-
-// Collapses internal newlines/whitespace into single spaces (used for field values that
-// Slack renders on a single visual line, e.g. "*Status:*\nTriggered").
+// Collapses whitespace/newlines into single spaces (for field values shown on one line).
 function toSingleLine(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
@@ -146,14 +109,14 @@ function extractLinesFromBlock(block: unknown): string[] {
   switch (type) {
     case "header": {
       const text = readTextObject(block.text);
-      return text ? [cleanSlackMrkdwn(text)] : [];
+      return text ? [text] : [];
     }
 
     case "section": {
       const lines: string[] = [];
       const main = readTextObject(block.text);
       if (main) {
-        lines.push(cleanSlackMrkdwn(main));
+        lines.push(main);
       }
       // `fields` is an array of text objects rendered in a compact 2-column layout.
       const fields = asArray(block.fields);
@@ -161,7 +124,7 @@ function extractLinesFromBlock(block: unknown): string[] {
         for (const field of fields) {
           const fieldText = readTextObject(field);
           if (fieldText) {
-            lines.push(toSingleLine(cleanSlackMrkdwn(fieldText)));
+            lines.push(toSingleLine(fieldText));
           }
         }
       }
@@ -170,9 +133,9 @@ function extractLinesFromBlock(block: unknown): string[] {
         const label = readTextObject(block.accessory.text);
         const url = asString(block.accessory.url);
         if (label && url) {
-          lines.push(`${cleanSlackMrkdwn(label)} (${url})`);
+          lines.push(`${label} (${url})`);
         } else if (label) {
-          lines.push(cleanSlackMrkdwn(label));
+          lines.push(label);
         }
       }
       return lines;
@@ -193,7 +156,7 @@ function extractLinesFromBlock(block: unknown): string[] {
         }
       }
       const joined = toSingleLine(parts.join(" "));
-      return joined ? [cleanSlackMrkdwn(joined)] : [];
+      return joined ? [joined] : [];
     }
 
     case "actions": {
@@ -206,9 +169,9 @@ function extractLinesFromBlock(block: unknown): string[] {
         const label = readTextObject(element.text);
         const url = asString(element.url);
         if (label && url) {
-          lines.push(`${cleanSlackMrkdwn(label)} (${url})`);
+          lines.push(`${label} (${url})`);
         } else if (label) {
-          lines.push(cleanSlackMrkdwn(label));
+          lines.push(label);
         } else if (url) {
           lines.push(url);
         }
@@ -220,11 +183,11 @@ function extractLinesFromBlock(block: unknown): string[] {
       const lines: string[] = [];
       const title = readTextObject(block.title);
       if (title) {
-        lines.push(cleanSlackMrkdwn(title));
+        lines.push(title);
       }
       const alt = asString(block.alt_text);
       if (alt) {
-        lines.push(cleanSlackMrkdwn(alt));
+        lines.push(alt);
       }
       return lines;
     }
@@ -240,7 +203,7 @@ function extractLinesFromBlock(block: unknown): string[] {
     default: {
       // Best-effort fallback for unknown block types that still carry a text object.
       const text = readTextObject(block.text);
-      return text ? [cleanSlackMrkdwn(text)] : [];
+      return text ? [text] : [];
     }
   }
 }
@@ -255,7 +218,7 @@ function extractLinesFromAttachment(attachment: unknown): string[] {
   const pushIfPresent = (value: unknown) => {
     const text = asString(value);
     if (text && text.trim()) {
-      lines.push(cleanSlackMrkdwn(text));
+      lines.push(text);
     }
   };
 
@@ -277,11 +240,11 @@ function extractLinesFromAttachment(attachment: unknown): string[] {
       const title = asString(field.title)?.trim();
       const value = asString(field.value)?.trim();
       if (title && value) {
-        lines.push(toSingleLine(cleanSlackMrkdwn(`${title}: ${value}`)));
+        lines.push(toSingleLine(`${title}: ${value}`));
       } else if (title) {
-        lines.push(cleanSlackMrkdwn(title));
+        lines.push(title);
       } else if (value) {
-        lines.push(cleanSlackMrkdwn(value));
+        lines.push(value);
       }
     }
   }
@@ -303,22 +266,24 @@ export interface FormattableSlackMessage {
 export function formatSlackMessageForLLM(
   message: FormattableSlackMessage
 ): string {
-  const lines: string[] = [];
+  // Phase 1 — extraction: collect raw lines (still containing Slack mrkdwn tokens) from
+  // every source. Extractors only locate text; they do not normalize it.
+  const rawLines: string[] = [];
 
-  const text = asString(message.text)?.trim();
+  const text = asString(message.text);
   if (text) {
-    lines.push(cleanSlackMrkdwn(text));
+    rawLines.push(text);
   }
 
   if (Array.isArray(message.blocks)) {
     for (const block of message.blocks) {
-      lines.push(...extractLinesFromBlock(block));
+      rawLines.push(...extractLinesFromBlock(block));
     }
   }
 
   if (Array.isArray(message.attachments)) {
     for (const attachment of message.attachments) {
-      lines.push(...extractLinesFromAttachment(attachment));
+      rawLines.push(...extractLinesFromAttachment(attachment));
     }
   }
 
@@ -330,17 +295,19 @@ export function formatSlackMessageForLLM(
       const name = asString(file.name);
       const mimetype = asString(file.mimetype);
       if (name) {
-        lines.push(`Attached file: ${name}${mimetype ? ` (${mimetype})` : ""}`);
+        rawLines.push(
+          `Attached file: ${name}${mimetype ? ` (${mimetype})` : ""}`
+        );
       }
     }
   }
 
-  // Split multi-line entries, trim, drop empties, then dedupe exact lines while preserving
-  // order.
+  // Phase 2 — normalization: split multi-line entries, clean Slack mrkdwn once per line,
+  // trim, drop empties, then dedupe exact lines while preserving order.
   const seen = new Set<string>();
   const deduped: string[] = [];
-  for (const rawLine of lines.flatMap((line) => line.split("\n"))) {
-    const line = rawLine.trim();
+  for (const rawLine of rawLines.flatMap((line) => line.split("\n"))) {
+    const line = slackMrkdwnToText(rawLine).trim();
     if (line.length > 0 && !seen.has(line)) {
       seen.add(line);
       deduped.push(line);

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -1,13 +1,11 @@
 // Reconstructs readable text from a Slack message: app/bot messages (Datadog, Zendesk, ...)
-// often have an empty top-level `text` and put their content in `blocks[]`/`attachments[]`.
-// Block Kit is loosely typed in the SDK (the `header` block is even missing), so we read
-// `unknown` and narrow with type guards. mrkdwn cleanup is delegated to `slack_mrkdwn.ts`.
+// often have an empty top-level `text` and carry their content in `blocks`/`attachments`.
+// Blocks are validated with zod; mrkdwn cleanup is delegated to `slack_mrkdwn.ts`.
 import { slackMrkdwnToText } from "@app/lib/api/actions/servers/slack/slack_mrkdwn";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
-// A Slack "text object", e.g. { type: "mrkdwn", text: "..." }. We only need `text`.
 const TextObjectSchema = z.object({ text: z.string() });
 
 const HeaderBlockSchema = z.object({
@@ -19,17 +17,17 @@ const SectionBlockSchema = z.object({
   type: z.literal("section"),
   text: TextObjectSchema.optional(),
   fields: z.array(TextObjectSchema).optional(),
-  accessory: z.unknown().optional(),
+  accessory: z.record(z.string(), z.unknown()).optional(),
 });
 
 const ContextBlockSchema = z.object({
   type: z.literal("context"),
-  elements: z.array(z.unknown()).optional(),
+  elements: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 const ActionsBlockSchema = z.object({
   type: z.literal("actions"),
-  elements: z.array(z.unknown()).optional(),
+  elements: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 const ImageBlockSchema = z.object({
@@ -59,7 +57,6 @@ const SlackBlockSchema = z.discriminatedUnion("type", [
 
 type SlackBlock = z.infer<typeof SlackBlockSchema>;
 
-// Attachments are the legacy message format; we read a handful of plain-text fields.
 const AttachmentFieldSchema = z.object({
   title: z.string().optional(),
   value: z.string().optional(),
@@ -99,7 +96,6 @@ function asArray(value: unknown): unknown[] | undefined {
   return Array.isArray(value) ? value : undefined;
 }
 
-// Reads the `.text` string out of a Slack text object (e.g. { type: "mrkdwn", text }).
 function readTextObject(value: unknown): string | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -107,12 +103,10 @@ function readTextObject(value: unknown): string | undefined {
   return isString(value.text) ? value.text : undefined;
 }
 
-// Collapses whitespace/newlines into single spaces (for field values shown on one line).
 function toSingleLine(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
-// Renders a leaf element of a rich_text section.
 function renderRichTextLeaf(element: Record<string, unknown>): string {
   const type = isString(element.type) ? element.type : undefined;
   switch (type) {
@@ -142,8 +136,6 @@ function renderRichTextLeaf(element: Record<string, unknown>): string {
   }
 }
 
-// Renders a rich_text sub-section (rich_text_section, rich_text_list, rich_text_quote,
-// rich_text_preformatted) into one or more lines.
 function renderRichTextSection(section: unknown): string[] {
   if (!isRecord(section)) {
     return [];
@@ -172,7 +164,6 @@ function renderRichTextSection(section: unknown): string[] {
   return [joined];
 }
 
-// Extracts readable lines from a single Block Kit block.
 function extractLinesFromBlock(block: SlackBlock): string[] {
   switch (block.type) {
     case "header": {
@@ -196,7 +187,7 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
         }
       }
       // A section can carry an accessory (often a button with a label and url).
-      if (isRecord(block.accessory)) {
+      if (block.accessory) {
         const label = readTextObject(block.accessory.text);
         const url = isString(block.accessory.url)
           ? block.accessory.url
@@ -215,9 +206,6 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
 
       const parts: string[] = [];
       for (const element of elements) {
-        if (!isRecord(element)) {
-          continue;
-        }
         let text: string | undefined;
         if (isString(element.text)) {
           text = element.text;
@@ -237,9 +225,6 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
 
       const lines: string[] = [];
       for (const element of elements) {
-        if (!isRecord(element)) {
-          continue;
-        }
         const label = readTextObject(element.text);
         const url = isString(element.url) ? element.url : undefined;
         if (label && url) {
@@ -279,7 +264,6 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
   }
 }
 
-// Extracts readable lines from a single message attachment.
 function extractLinesFromAttachment(attachment: SlackAttachment): string[] {
   const lines: string[] = [];
 
@@ -328,7 +312,6 @@ export interface FormattedSlackMessage {
 
 const EMPTY_SECTION = "(empty)";
 
-// Cleans Slack mrkdwn in each line and joins them, or returns "(empty)" when there is none.
 function renderSection(rawLines: string[]): string {
   const cleaned = rawLines
     .flatMap((line) => line.split("\n"))
@@ -347,8 +330,6 @@ export function renderFormattedMessage(m: FormattedSlackMessage): string {
   ].join("\n\n");
 }
 
-// Reconstructs a Slack message as readable text grouped by source. App/bot messages often
-// have an empty top-level `text` and carry their content in `blocks`/`attachments`.
 export function formatSlackMessageForLLM(
   message: FormattableSlackMessage
 ): FormattedSlackMessage {

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -77,7 +77,7 @@ const RichTextElementSchema: z.ZodType<RichTextElement> = z.lazy(() =>
   })
 );
 
-type t = z.infer<typeof RichTextElementSchema>
+type t = z.infer<typeof RichTextElementSchema>;
 
 const RichTextBlockSchema = z.object({
   type: z.literal("rich_text"),
@@ -139,7 +139,7 @@ function renderRichTextLeaf(element: RichTextElement): string {
     case "link":
       return element.text
         ? `${element.text} (${element.url ?? ""})`
-         : (element.url ?? "");
+        : (element.url ?? "");
 
     case "user":
       return element.user_id ? `@${element.user_id}` : "";
@@ -176,12 +176,14 @@ function renderRichTextSection(section: RichTextElement): string[] {
       .map((line) => `- ${line}`);
   }
 
-  const joined = elements.map((element) => renderRichTextLeaf(element)).join("");
+  const joined = elements
+    .map((element) => renderRichTextLeaf(element))
+    .join("");
 
   if (!joined) {
     return [];
   }
-  
+
   if (section.type === "rich_text_quote") {
     return [`> ${joined}`];
   }

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -3,13 +3,96 @@
 // Block Kit is loosely typed in the SDK (the `header` block is even missing), so we read
 // `unknown` and narrow with type guards. mrkdwn cleanup is delegated to `slack_mrkdwn.ts`.
 import { slackMrkdwnToText } from "@app/lib/api/actions/servers/slack/slack_mrkdwn";
+import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { z } from "zod";
+
+// A Slack "text object", e.g. { type: "mrkdwn", text: "..." }. We only need `text`.
+const TextObjectSchema = z.object({ text: z.string() });
+
+const HeaderBlockSchema = z.object({
+  type: z.literal("header"),
+  text: TextObjectSchema,
+});
+
+const SectionBlockSchema = z.object({
+  type: z.literal("section"),
+  text: TextObjectSchema.optional(),
+  fields: z.array(TextObjectSchema).optional(),
+  accessory: z.unknown().optional(),
+});
+
+const ContextBlockSchema = z.object({
+  type: z.literal("context"),
+  elements: z.array(z.unknown()).optional(),
+});
+
+const ActionsBlockSchema = z.object({
+  type: z.literal("actions"),
+  elements: z.array(z.unknown()).optional(),
+});
+
+const ImageBlockSchema = z.object({
+  type: z.literal("image"),
+  title: TextObjectSchema.optional(),
+  alt_text: z.string().optional(),
+});
+
+const RichTextBlockSchema = z.object({
+  type: z.literal("rich_text"),
+  elements: z.array(z.unknown()).optional(),
+});
+
+const DividerBlockSchema = z.object({
+  type: z.literal("divider"),
+});
+
+const SlackBlockSchema = z.discriminatedUnion("type", [
+  HeaderBlockSchema,
+  SectionBlockSchema,
+  ContextBlockSchema,
+  ActionsBlockSchema,
+  ImageBlockSchema,
+  RichTextBlockSchema,
+  DividerBlockSchema,
+]);
+
+type SlackBlock = z.infer<typeof SlackBlockSchema>;
+
+// Attachments are the legacy message format; we read a handful of plain-text fields.
+const AttachmentFieldSchema = z.object({
+  title: z.string().optional(),
+  value: z.string().optional(),
+});
+
+const AttachmentSchema = z.object({
+  pretext: z.string().optional(),
+  title: z.string().optional(),
+  text: z.string().optional(),
+  fallback: z.string().optional(),
+  fields: z.array(AttachmentFieldSchema).optional(),
+});
+
+type SlackAttachment = z.infer<typeof AttachmentSchema>;
+
+const FileSchema = z.object({
+  name: z.string().optional(),
+  mimetype: z.string().optional(),
+});
+
+const SlackMessageSchema = z.object({
+  text: z.string().optional(),
+  blocks: z.array(SlackBlockSchema).optional(),
+  attachments: z.array(AttachmentSchema).optional(),
+  files: z.array(FileSchema).optional(),
+});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
+function isString(value: unknown): value is string {
+  return typeof value === "string";
 }
 
 function asArray(value: unknown): unknown[] | undefined {
@@ -21,7 +104,7 @@ function readTextObject(value: unknown): string | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
-  return asString(value.text);
+  return isString(value.text) ? value.text : undefined;
 }
 
 // Collapses whitespace/newlines into single spaces (for field values shown on one line).
@@ -31,41 +114,31 @@ function toSingleLine(text: string): string {
 
 // Renders a leaf element of a rich_text section.
 function renderRichTextLeaf(element: Record<string, unknown>): string {
-  const type = asString(element.type);
+  const type = isString(element.type) ? element.type : undefined;
   switch (type) {
     case "text":
-      return asString(element.text) ?? "";
+      return isString(element.text) ? element.text : "";
     case "link": {
-      const url = asString(element.url) ?? "";
-      const label = asString(element.text);
+      const url = isString(element.url) ? element.url : "";
+      const label = isString(element.text) ? element.text : undefined;
       return label ? `${label} (${url})` : url;
     }
-    case "user": {
-      const userId = asString(element.user_id);
-      return userId ? `@${userId}` : "";
-    }
-    case "usergroup": {
-      const groupId = asString(element.usergroup_id);
-      return groupId ? `@${groupId}` : "";
-    }
-    case "channel": {
-      const channelId = asString(element.channel_id);
-      return channelId ? `#${channelId}` : "";
-    }
-    case "emoji": {
-      const name = asString(element.name);
-      return name ? `:${name}:` : "";
-    }
-    case "broadcast": {
-      const range = asString(element.range);
-      return range ? `@${range}` : "";
-    }
+    case "user":
+      return isString(element.user_id) ? `@${element.user_id}` : "";
+    case "usergroup":
+      return isString(element.usergroup_id) ? `@${element.usergroup_id}` : "";
+    case "channel":
+      return isString(element.channel_id) ? `#${element.channel_id}` : "";
+    case "emoji":
+      return isString(element.name) ? `:${element.name}:` : "";
+    case "broadcast":
+      return isString(element.range) ? `@${element.range}` : "";
     case "date":
       // `date` carries a fallback string suitable for display.
-      return asString(element.fallback) ?? "";
+      return isString(element.fallback) ? element.fallback : "";
     default:
       // Unknown leaf type (e.g. `color`): fall back to any `text` it might carry.
-      return asString(element.text) ?? "";
+      return isString(element.text) ? element.text : "";
   }
 }
 
@@ -75,7 +148,7 @@ function renderRichTextSection(section: unknown): string[] {
   if (!isRecord(section)) {
     return [];
   }
-  const type = asString(section.type);
+  const type = isString(section.type) ? section.type : undefined;
   const elements = asArray(section.elements) ?? [];
 
   // Lists nest one rich_text_section per item.
@@ -100,38 +173,34 @@ function renderRichTextSection(section: unknown): string[] {
 }
 
 // Extracts readable lines from a single Block Kit block.
-function extractLinesFromBlock(block: unknown): string[] {
-  if (!isRecord(block)) {
-    return [];
-  }
-  const type = asString(block.type);
-
-  switch (type) {
+function extractLinesFromBlock(block: SlackBlock): string[] {
+  switch (block.type) {
     case "header": {
-      const text = readTextObject(block.text);
+      const { text } = block.text;
       return text ? [text] : [];
     }
 
     case "section": {
       const lines: string[] = [];
-      const main = readTextObject(block.text);
+      const main = block.text?.text;
       if (main) {
         lines.push(main);
       }
-      // `fields` is an array of text objects rendered in a compact 2-column layout.
-      const fields = asArray(block.fields);
+      const fields = block.fields;
+
       if (fields) {
         for (const field of fields) {
-          const fieldText = readTextObject(field);
-          if (fieldText) {
-            lines.push(toSingleLine(fieldText));
+          if (field.text) {
+            lines.push(toSingleLine(field.text));
           }
         }
       }
       // A section can carry an accessory (often a button with a label and url).
       if (isRecord(block.accessory)) {
         const label = readTextObject(block.accessory.text);
-        const url = asString(block.accessory.url);
+        const url = isString(block.accessory.url)
+          ? block.accessory.url
+          : undefined;
         if (label && url) {
           lines.push(`${label} (${url})`);
         } else if (label) {
@@ -142,15 +211,19 @@ function extractLinesFromBlock(block: unknown): string[] {
     }
 
     case "context": {
-      // In a context block, `elements` are text objects (text at element level) or image
-      // elements (alt_text). They render inline, so we join them on one line.
-      const elements = asArray(block.elements) ?? [];
+      const elements = block.elements ?? [];
+
       const parts: string[] = [];
       for (const element of elements) {
         if (!isRecord(element)) {
           continue;
         }
-        const text = asString(element.text) ?? asString(element.alt_text);
+        let text: string | undefined;
+        if (isString(element.text)) {
+          text = element.text;
+        } else if (isString(element.alt_text)) {
+          text = element.alt_text;
+        }
         if (text) {
           parts.push(text);
         }
@@ -160,14 +233,15 @@ function extractLinesFromBlock(block: unknown): string[] {
     }
 
     case "actions": {
-      const elements = asArray(block.elements) ?? [];
+      const elements = block.elements ?? [];
+
       const lines: string[] = [];
       for (const element of elements) {
         if (!isRecord(element)) {
           continue;
         }
         const label = readTextObject(element.text);
-        const url = asString(element.url);
+        const url = isString(element.url) ? element.url : undefined;
         if (label && url) {
           lines.push(`${label} (${url})`);
         } else if (label) {
@@ -181,11 +255,11 @@ function extractLinesFromBlock(block: unknown): string[] {
 
     case "image": {
       const lines: string[] = [];
-      const title = readTextObject(block.title);
+      const title = block.title?.text;
       if (title) {
         lines.push(title);
       }
-      const alt = asString(block.alt_text);
+      const alt = block.alt_text;
       if (alt) {
         lines.push(alt);
       }
@@ -193,59 +267,45 @@ function extractLinesFromBlock(block: unknown): string[] {
     }
 
     case "rich_text": {
-      const elements = asArray(block.elements) ?? [];
+      const elements = block.elements ?? [];
       return elements.flatMap((section) => renderRichTextSection(section));
     }
 
     case "divider":
       return [];
 
-    default: {
-      // Best-effort fallback for unknown block types that still carry a text object.
-      const text = readTextObject(block.text);
-      return text ? [text] : [];
-    }
+    default:
+      return assertNever(block);
   }
 }
 
 // Extracts readable lines from a single message attachment.
-function extractLinesFromAttachment(attachment: unknown): string[] {
-  if (!isRecord(attachment)) {
-    return [];
-  }
+function extractLinesFromAttachment(attachment: SlackAttachment): string[] {
   const lines: string[] = [];
 
-  const pushIfPresent = (value: unknown) => {
-    const text = asString(value);
-    if (text && text.trim()) {
-      lines.push(text);
+  const pushIfPresent = (value: string | undefined) => {
+    if (value && value.trim()) {
+      lines.push(value);
     }
   };
 
   pushIfPresent(attachment.pretext);
   pushIfPresent(attachment.title);
   pushIfPresent(attachment.text);
-  // `fallback` is the plaintext alternative to the rich content; only use it when there is
-  // no `text` to avoid duplicating the same content twice.
-  if (!asString(attachment.text)) {
+  // `fallback` duplicates the rich content; only use it when there is no `text`.
+  if (!attachment.text) {
     pushIfPresent(attachment.fallback);
   }
 
-  const fields = asArray(attachment.fields);
-  if (fields) {
-    for (const field of fields) {
-      if (!isRecord(field)) {
-        continue;
-      }
-      const title = asString(field.title)?.trim();
-      const value = asString(field.value)?.trim();
-      if (title && value) {
-        lines.push(toSingleLine(`${title}: ${value}`));
-      } else if (title) {
-        lines.push(title);
-      } else if (value) {
-        lines.push(value);
-      }
+  for (const field of attachment.fields ?? []) {
+    const title = field.title?.trim();
+    const value = field.value?.trim();
+    if (title && value) {
+      lines.push(toSingleLine(`${title}: ${value}`));
+    } else if (title) {
+      lines.push(title);
+    } else if (value) {
+      lines.push(value);
     }
   }
 
@@ -259,60 +319,73 @@ export interface FormattableSlackMessage {
   files?: unknown[];
 }
 
-// Reconstructs a readable plain-text/markdown representation of a Slack message, pulling
-// content out of blocks and attachments when the top-level `text` is empty or
-// insufficient. Deduplicates exact-duplicate lines (Slack often repeats content across
-// `text`, `blocks`, and attachment `fallback`).
+export interface FormattedSlackMessage {
+  text: string;
+  blocks: string;
+  attachments: string;
+  files: string;
+}
+
+const EMPTY_SECTION = "(empty)";
+
+// Cleans Slack mrkdwn in each line and joins them, or returns "(empty)" when there is none.
+function renderSection(rawLines: string[]): string {
+  const cleaned = rawLines
+    .flatMap((line) => line.split("\n"))
+    .map((line) => slackMrkdwnToText(line).trim())
+    .filter((line) => line.length > 0);
+  return cleaned.length > 0 ? cleaned.join("\n") : EMPTY_SECTION;
+}
+
+// Flattens a FormattedSlackMessage into a single labeled string for tools that emit text.
+export function renderFormattedMessage(m: FormattedSlackMessage): string {
+  return [
+    `Text: ${m.text}`,
+    `Blocks: ${m.blocks}`,
+    `Attachments: ${m.attachments}`,
+    `Files: ${m.files}`,
+  ].join("\n\n");
+}
+
+// Reconstructs a Slack message as readable text grouped by source. App/bot messages often
+// have an empty top-level `text` and carry their content in `blocks`/`attachments`.
 export function formatSlackMessageForLLM(
   message: FormattableSlackMessage
-): string {
-  // Phase 1 — extraction: collect raw lines (still containing Slack mrkdwn tokens) from
-  // every source. Extractors only locate text; they do not normalize it.
-  const rawLines: string[] = [];
-
-  const text = asString(message.text);
-  if (text) {
-    rawLines.push(text);
+): FormattedSlackMessage {
+  const parsed = SlackMessageSchema.safeParse(message);
+  if (!parsed.success) {
+    logger.warn(
+      { error: parsed.error.format() },
+      "Slack message failed schema validation"
+    );
+    const { text } = message;
+    return {
+      text: renderSection(text ? [text] : []),
+      blocks: "(could not parse)",
+      attachments: "(could not parse)",
+      files: "(could not parse)",
+    };
   }
+  const { text, blocks, attachments, files } = parsed.data;
 
-  if (Array.isArray(message.blocks)) {
-    for (const block of message.blocks) {
-      rawLines.push(...extractLinesFromBlock(block));
-    }
-  }
+  const blockLines = (blocks ?? []).flatMap((block) =>
+    extractLinesFromBlock(block)
+  );
+  const attachmentLines = (attachments ?? []).flatMap((attachment) =>
+    extractLinesFromAttachment(attachment)
+  );
+  const fileLines = (files ?? []).flatMap((file) =>
+    file.name
+      ? [
+          `Attached file: ${file.name}${file.mimetype ? ` (${file.mimetype})` : ""}`,
+        ]
+      : []
+  );
 
-  if (Array.isArray(message.attachments)) {
-    for (const attachment of message.attachments) {
-      rawLines.push(...extractLinesFromAttachment(attachment));
-    }
-  }
-
-  if (Array.isArray(message.files)) {
-    for (const file of message.files) {
-      if (!isRecord(file)) {
-        continue;
-      }
-      const name = asString(file.name);
-      const mimetype = asString(file.mimetype);
-      if (name) {
-        rawLines.push(
-          `Attached file: ${name}${mimetype ? ` (${mimetype})` : ""}`
-        );
-      }
-    }
-  }
-
-  // Phase 2 — normalization: split multi-line entries, clean Slack mrkdwn once per line,
-  // trim, drop empties, then dedupe exact lines while preserving order.
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-  for (const rawLine of rawLines.flatMap((line) => line.split("\n"))) {
-    const line = slackMrkdwnToText(rawLine).trim();
-    if (line.length > 0 && !seen.has(line)) {
-      seen.add(line);
-      deduped.push(line);
-    }
-  }
-
-  return deduped.join("\n");
+  return {
+    text: renderSection(text ? [text] : []),
+    blocks: renderSection(blockLines),
+    attachments: renderSection(attachmentLines),
+    files: renderSection(fileLines),
+  };
 }

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -1,0 +1,351 @@
+// Reconstructs a readable plain-text/markdown representation from a Slack message.
+//
+// Many app/bot messages (Datadog, Zendesk, PagerDuty, ...) ship an empty top-level
+// `text` field and put the actual content in `blocks[]` (Block Kit) and/or
+// `attachments[]`. Relying on `message.text` alone makes those messages look empty to
+// LLMs. This formatter walks blocks and attachments to extract their textual content.
+//
+// It is intentionally read-only and best-effort. Slack's SDK does not provide complete
+// types for Block Kit inside message responses (the generated `AssistantAppThreadBlock`
+// type is flattened and even omits `header`), so we accept loosely typed input and narrow
+// defensively with type guards rather than trusting the SDK types. The structure handled
+// here matches the official Block Kit reference:
+// https://docs.slack.dev/reference/block-kit/blocks
+
+// Minimal type guards (avoids relying on the SDK's incomplete block types and avoids
+// non-type-safe `as` casts per [GEN4]).
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asArray(value: unknown): unknown[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+// Reads the `.text` string out of a Slack text object (e.g. { type: "mrkdwn", text }).
+function readTextObject(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return asString(value.text);
+}
+
+// Converts Slack mrkdwn to lightweight plain text: resolves links/mentions and strips
+// bold/strikethrough markers so content reads cleanly for an LLM.
+function cleanSlackMrkdwn(text: string): string {
+  return (
+    text
+      // <https://url|label> -> label (https://url)
+      .replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, "$2 ($1)")
+      // <https://url> -> https://url
+      .replace(/<(https?:\/\/[^|>]+)>/g, "$1")
+      // <mailto:foo@bar|label> -> label
+      .replace(/<mailto:[^|>]+\|([^>]+)>/g, "$1")
+      // <@U123|name> -> @name ; <@U123> -> @U123
+      .replace(/<@[UW][A-Z0-9]+\|([^>]+)>/g, "@$1")
+      .replace(/<@([UW][A-Z0-9]+)>/g, "@$1")
+      // <#C123|name> -> #name ; <#C123> -> #C123
+      .replace(/<#[A-Z0-9]+\|([^>]+)>/g, "#$1")
+      .replace(/<#([A-Z0-9]+)>/g, "#$1")
+      // <!subteam^S123|@group> -> @group ; <!here>/<!channel> -> @here/@channel
+      .replace(/<!subteam\^[A-Z0-9]+\|([^>]+)>/g, "$1")
+      .replace(/<!(here|channel|everyone)>/g, "@$1")
+      // *bold* -> bold ; ~strike~ -> strike
+      .replace(/\*([^*\n]+)\*/g, "$1")
+      .replace(/~([^~\n]+)~/g, "$1")
+  );
+}
+
+// Collapses internal newlines/whitespace into single spaces (used for field values that
+// Slack renders on a single visual line, e.g. "*Status:*\nTriggered").
+function toSingleLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+// Renders a leaf element of a rich_text section.
+function renderRichTextLeaf(element: Record<string, unknown>): string {
+  const type = asString(element.type);
+  switch (type) {
+    case "text":
+      return asString(element.text) ?? "";
+    case "link": {
+      const url = asString(element.url) ?? "";
+      const label = asString(element.text);
+      return label ? `${label} (${url})` : url;
+    }
+    case "user": {
+      const userId = asString(element.user_id);
+      return userId ? `@${userId}` : "";
+    }
+    case "usergroup": {
+      const groupId = asString(element.usergroup_id);
+      return groupId ? `@${groupId}` : "";
+    }
+    case "channel": {
+      const channelId = asString(element.channel_id);
+      return channelId ? `#${channelId}` : "";
+    }
+    case "emoji": {
+      const name = asString(element.name);
+      return name ? `:${name}:` : "";
+    }
+    case "broadcast": {
+      const range = asString(element.range);
+      return range ? `@${range}` : "";
+    }
+    case "date":
+      // `date` carries a fallback string suitable for display.
+      return asString(element.fallback) ?? "";
+    default:
+      // Unknown leaf type (e.g. `color`): fall back to any `text` it might carry.
+      return asString(element.text) ?? "";
+  }
+}
+
+// Renders a rich_text sub-section (rich_text_section, rich_text_list, rich_text_quote,
+// rich_text_preformatted) into one or more lines.
+function renderRichTextSection(section: unknown): string[] {
+  if (!isRecord(section)) {
+    return [];
+  }
+  const type = asString(section.type);
+  const elements = asArray(section.elements) ?? [];
+
+  // Lists nest one rich_text_section per item.
+  if (type === "rich_text_list") {
+    return elements
+      .flatMap((item) => renderRichTextSection(item))
+      .filter((line) => line.length > 0)
+      .map((line) => `- ${line}`);
+  }
+
+  const joined = elements
+    .map((element) => (isRecord(element) ? renderRichTextLeaf(element) : ""))
+    .join("");
+
+  if (!joined) {
+    return [];
+  }
+  if (type === "rich_text_quote") {
+    return [`> ${joined}`];
+  }
+  return [joined];
+}
+
+// Extracts readable lines from a single Block Kit block.
+function extractLinesFromBlock(block: unknown): string[] {
+  if (!isRecord(block)) {
+    return [];
+  }
+  const type = asString(block.type);
+
+  switch (type) {
+    case "header": {
+      const text = readTextObject(block.text);
+      return text ? [cleanSlackMrkdwn(text)] : [];
+    }
+
+    case "section": {
+      const lines: string[] = [];
+      const main = readTextObject(block.text);
+      if (main) {
+        lines.push(cleanSlackMrkdwn(main));
+      }
+      // `fields` is an array of text objects rendered in a compact 2-column layout.
+      const fields = asArray(block.fields);
+      if (fields) {
+        for (const field of fields) {
+          const fieldText = readTextObject(field);
+          if (fieldText) {
+            lines.push(toSingleLine(cleanSlackMrkdwn(fieldText)));
+          }
+        }
+      }
+      // A section can carry an accessory (often a button with a label and url).
+      if (isRecord(block.accessory)) {
+        const label = readTextObject(block.accessory.text);
+        const url = asString(block.accessory.url);
+        if (label && url) {
+          lines.push(`${cleanSlackMrkdwn(label)} (${url})`);
+        } else if (label) {
+          lines.push(cleanSlackMrkdwn(label));
+        }
+      }
+      return lines;
+    }
+
+    case "context": {
+      // In a context block, `elements` are text objects (text at element level) or image
+      // elements (alt_text). They render inline, so we join them on one line.
+      const elements = asArray(block.elements) ?? [];
+      const parts: string[] = [];
+      for (const element of elements) {
+        if (!isRecord(element)) {
+          continue;
+        }
+        const text = asString(element.text) ?? asString(element.alt_text);
+        if (text) {
+          parts.push(text);
+        }
+      }
+      const joined = toSingleLine(parts.join(" "));
+      return joined ? [cleanSlackMrkdwn(joined)] : [];
+    }
+
+    case "actions": {
+      const elements = asArray(block.elements) ?? [];
+      const lines: string[] = [];
+      for (const element of elements) {
+        if (!isRecord(element)) {
+          continue;
+        }
+        const label = readTextObject(element.text);
+        const url = asString(element.url);
+        if (label && url) {
+          lines.push(`${cleanSlackMrkdwn(label)} (${url})`);
+        } else if (label) {
+          lines.push(cleanSlackMrkdwn(label));
+        } else if (url) {
+          lines.push(url);
+        }
+      }
+      return lines;
+    }
+
+    case "image": {
+      const lines: string[] = [];
+      const title = readTextObject(block.title);
+      if (title) {
+        lines.push(cleanSlackMrkdwn(title));
+      }
+      const alt = asString(block.alt_text);
+      if (alt) {
+        lines.push(cleanSlackMrkdwn(alt));
+      }
+      return lines;
+    }
+
+    case "rich_text": {
+      const elements = asArray(block.elements) ?? [];
+      return elements.flatMap((section) => renderRichTextSection(section));
+    }
+
+    case "divider":
+      return [];
+
+    default: {
+      // Best-effort fallback for unknown block types that still carry a text object.
+      const text = readTextObject(block.text);
+      return text ? [cleanSlackMrkdwn(text)] : [];
+    }
+  }
+}
+
+// Extracts readable lines from a single message attachment.
+function extractLinesFromAttachment(attachment: unknown): string[] {
+  if (!isRecord(attachment)) {
+    return [];
+  }
+  const lines: string[] = [];
+
+  const pushIfPresent = (value: unknown) => {
+    const text = asString(value);
+    if (text && text.trim()) {
+      lines.push(cleanSlackMrkdwn(text));
+    }
+  };
+
+  pushIfPresent(attachment.pretext);
+  pushIfPresent(attachment.title);
+  pushIfPresent(attachment.text);
+  // `fallback` is the plaintext alternative to the rich content; only use it when there is
+  // no `text` to avoid duplicating the same content twice.
+  if (!asString(attachment.text)) {
+    pushIfPresent(attachment.fallback);
+  }
+
+  const fields = asArray(attachment.fields);
+  if (fields) {
+    for (const field of fields) {
+      if (!isRecord(field)) {
+        continue;
+      }
+      const title = asString(field.title)?.trim();
+      const value = asString(field.value)?.trim();
+      if (title && value) {
+        lines.push(toSingleLine(cleanSlackMrkdwn(`${title}: ${value}`)));
+      } else if (title) {
+        lines.push(cleanSlackMrkdwn(title));
+      } else if (value) {
+        lines.push(cleanSlackMrkdwn(value));
+      }
+    }
+  }
+
+  return lines;
+}
+
+export interface FormattableSlackMessage {
+  text?: string;
+  blocks?: unknown[];
+  attachments?: unknown[];
+  files?: unknown[];
+}
+
+// Reconstructs a readable plain-text/markdown representation of a Slack message, pulling
+// content out of blocks and attachments when the top-level `text` is empty or
+// insufficient. Deduplicates exact-duplicate lines (Slack often repeats content across
+// `text`, `blocks`, and attachment `fallback`).
+export function formatSlackMessageForLLM(
+  message: FormattableSlackMessage
+): string {
+  const lines: string[] = [];
+
+  const text = asString(message.text)?.trim();
+  if (text) {
+    lines.push(cleanSlackMrkdwn(text));
+  }
+
+  if (Array.isArray(message.blocks)) {
+    for (const block of message.blocks) {
+      lines.push(...extractLinesFromBlock(block));
+    }
+  }
+
+  if (Array.isArray(message.attachments)) {
+    for (const attachment of message.attachments) {
+      lines.push(...extractLinesFromAttachment(attachment));
+    }
+  }
+
+  if (Array.isArray(message.files)) {
+    for (const file of message.files) {
+      if (!isRecord(file)) {
+        continue;
+      }
+      const name = asString(file.name);
+      const mimetype = asString(file.mimetype);
+      if (name) {
+        lines.push(`Attached file: ${name}${mimetype ? ` (${mimetype})` : ""}`);
+      }
+    }
+  }
+
+  // Split multi-line entries, trim, drop empties, then dedupe exact lines while preserving
+  // order.
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const rawLine of lines.flatMap((line) => line.split("\n"))) {
+    const line = rawLine.trim();
+    if (line.length > 0 && !seen.has(line)) {
+      seen.add(line);
+      deduped.push(line);
+    }
+  }
+
+  return deduped.join("\n");
+}

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -77,8 +77,6 @@ const RichTextElementSchema: z.ZodType<RichTextElement> = z.lazy(() =>
   })
 );
 
-type t = z.infer<typeof RichTextElementSchema>;
-
 const RichTextBlockSchema = z.object({
   type: z.literal("rich_text"),
   elements: z.array(RichTextElementSchema).optional(),

--- a/front/lib/api/actions/servers/slack/message_formatter.ts
+++ b/front/lib/api/actions/servers/slack/message_formatter.ts
@@ -8,6 +8,19 @@ import { z } from "zod";
 
 const TextObjectSchema = z.object({ text: z.string() });
 
+// Interactive elements (buttons in `actions` blocks or a section `accessory`): a `text`
+// object and an optional url. Other element kinds (datepicker, select) leave these unset.
+const InteractiveElementSchema = z.object({
+  text: TextObjectSchema.optional(),
+  url: z.string().optional(),
+});
+
+// Context elements are text objects (text at element level) or images (alt_text).
+const ContextElementSchema = z.object({
+  text: z.string().optional(),
+  alt_text: z.string().optional(),
+});
+
 const HeaderBlockSchema = z.object({
   type: z.literal("header"),
   text: TextObjectSchema,
@@ -17,17 +30,17 @@ const SectionBlockSchema = z.object({
   type: z.literal("section"),
   text: TextObjectSchema.optional(),
   fields: z.array(TextObjectSchema).optional(),
-  accessory: z.record(z.string(), z.unknown()).optional(),
+  accessory: InteractiveElementSchema.optional(),
 });
 
 const ContextBlockSchema = z.object({
   type: z.literal("context"),
-  elements: z.array(z.record(z.string(), z.unknown())).optional(),
+  elements: z.array(ContextElementSchema).optional(),
 });
 
 const ActionsBlockSchema = z.object({
   type: z.literal("actions"),
-  elements: z.array(z.record(z.string(), z.unknown())).optional(),
+  elements: z.array(InteractiveElementSchema).optional(),
 });
 
 const ImageBlockSchema = z.object({
@@ -36,9 +49,39 @@ const ImageBlockSchema = z.object({
   alt_text: z.string().optional(),
 });
 
+type RichTextElement = {
+  type?: string;
+  text?: string;
+  url?: string;
+  user_id?: string;
+  channel_id?: string;
+  usergroup_id?: string;
+  name?: string;
+  range?: string;
+  fallback?: string;
+  elements?: RichTextElement[];
+};
+
+const RichTextElementSchema: z.ZodType<RichTextElement> = z.lazy(() =>
+  z.object({
+    type: z.string().optional(),
+    text: z.string().optional(),
+    url: z.string().optional(),
+    user_id: z.string().optional(),
+    channel_id: z.string().optional(),
+    usergroup_id: z.string().optional(),
+    name: z.string().optional(),
+    range: z.string().optional(),
+    fallback: z.string().optional(),
+    elements: z.array(RichTextElementSchema).optional(),
+  })
+);
+
+type t = z.infer<typeof RichTextElementSchema>
+
 const RichTextBlockSchema = z.object({
   type: z.literal("rich_text"),
-  elements: z.array(z.unknown()).optional(),
+  elements: z.array(RichTextElementSchema).optional(),
 });
 
 const DividerBlockSchema = z.object({
@@ -84,83 +127,65 @@ const SlackMessageSchema = z.object({
   files: z.array(FileSchema).optional(),
 });
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === "string";
-}
-
-function asArray(value: unknown): unknown[] | undefined {
-  return Array.isArray(value) ? value : undefined;
-}
-
-function readTextObject(value: unknown): string | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  return isString(value.text) ? value.text : undefined;
-}
-
 function toSingleLine(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }
 
-function renderRichTextLeaf(element: Record<string, unknown>): string {
-  const type = isString(element.type) ? element.type : undefined;
-  switch (type) {
+function renderRichTextLeaf(element: RichTextElement): string {
+  switch (element.type) {
     case "text":
-      return isString(element.text) ? element.text : "";
-    case "link": {
-      const url = isString(element.url) ? element.url : "";
-      const label = isString(element.text) ? element.text : undefined;
-      return label ? `${label} (${url})` : url;
-    }
+      return element.text ?? "";
+
+    case "link":
+      return element.text
+        ? `${element.text} (${element.url ?? ""})`
+         : (element.url ?? "");
+
     case "user":
-      return isString(element.user_id) ? `@${element.user_id}` : "";
+      return element.user_id ? `@${element.user_id}` : "";
+
     case "usergroup":
-      return isString(element.usergroup_id) ? `@${element.usergroup_id}` : "";
+      return element.usergroup_id ? `@${element.usergroup_id}` : "";
+
     case "channel":
-      return isString(element.channel_id) ? `#${element.channel_id}` : "";
+      return element.channel_id ? `#${element.channel_id}` : "";
+
     case "emoji":
-      return isString(element.name) ? `:${element.name}:` : "";
+      return element.name ? `:${element.name}:` : "";
+
     case "broadcast":
-      return isString(element.range) ? `@${element.range}` : "";
+      return element.range ? `@${element.range}` : "";
+
     case "date":
-      // `date` carries a fallback string suitable for display.
-      return isString(element.fallback) ? element.fallback : "";
+      return element.fallback ?? "";
+
     default:
       // Unknown leaf type (e.g. `color`): fall back to any `text` it might carry.
-      return isString(element.text) ? element.text : "";
+      return element.text ?? "";
   }
 }
 
-function renderRichTextSection(section: unknown): string[] {
-  if (!isRecord(section)) {
-    return [];
-  }
-  const type = isString(section.type) ? section.type : undefined;
-  const elements = asArray(section.elements) ?? [];
+function renderRichTextSection(section: RichTextElement): string[] {
+  const elements = section.elements ?? [];
 
   // Lists nest one rich_text_section per item.
-  if (type === "rich_text_list") {
+  if (section.type === "rich_text_list") {
     return elements
       .flatMap((item) => renderRichTextSection(item))
       .filter((line) => line.length > 0)
       .map((line) => `- ${line}`);
   }
 
-  const joined = elements
-    .map((element) => (isRecord(element) ? renderRichTextLeaf(element) : ""))
-    .join("");
+  const joined = elements.map((element) => renderRichTextLeaf(element)).join("");
 
   if (!joined) {
     return [];
   }
-  if (type === "rich_text_quote") {
+  
+  if (section.type === "rich_text_quote") {
     return [`> ${joined}`];
   }
+
   return [joined];
 }
 
@@ -188,10 +213,8 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
       }
       // A section can carry an accessory (often a button with a label and url).
       if (block.accessory) {
-        const label = readTextObject(block.accessory.text);
-        const url = isString(block.accessory.url)
-          ? block.accessory.url
-          : undefined;
+        const label = block.accessory.text?.text;
+        const url = block.accessory.url;
         if (label && url) {
           lines.push(`${label} (${url})`);
         } else if (label) {
@@ -206,12 +229,7 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
 
       const parts: string[] = [];
       for (const element of elements) {
-        let text: string | undefined;
-        if (isString(element.text)) {
-          text = element.text;
-        } else if (isString(element.alt_text)) {
-          text = element.alt_text;
-        }
+        const text = element.text ?? element.alt_text;
         if (text) {
           parts.push(text);
         }
@@ -225,8 +243,8 @@ function extractLinesFromBlock(block: SlackBlock): string[] {
 
       const lines: string[] = [];
       for (const element of elements) {
-        const label = readTextObject(element.text);
-        const url = isString(element.url) ? element.url : undefined;
+        const label = element.text?.text;
+        const url = element.url;
         if (label && url) {
           lines.push(`${label} (${url})`);
         } else if (label) {

--- a/front/lib/api/actions/servers/slack/slack_mrkdwn.ts
+++ b/front/lib/api/actions/servers/slack/slack_mrkdwn.ts
@@ -1,0 +1,119 @@
+// Slack mrkdwn → readable plain text. Slack's mrkdwn is not standard Markdown (bold is
+// `*x*`, links/mentions are `<@U|name>`, `<#C|name>`, `<url|label>`, ...), so we extend
+// `marked` with one inline extension per Slack token and render to plain text.
+
+import type { TokenizerAndRendererExtension } from "marked";
+import { Marked } from "marked";
+
+// Builds an inline extension matching a Slack token and rendering it to plain text.
+function slackInlineToken(
+  name: string,
+  prefixHint: string,
+  pattern: RegExp,
+  render: (match: RegExpExecArray) => string
+): TokenizerAndRendererExtension {
+  return {
+    name,
+    level: "inline",
+    start(src: string) {
+      const index = src.indexOf(prefixHint);
+      return index < 0 ? undefined : index;
+    },
+    tokenizer(src: string) {
+      const match = pattern.exec(src);
+      if (match) {
+        return { type: name, raw: match[0], match };
+      }
+      return undefined;
+    },
+    renderer(token) {
+      return render(token.match);
+    },
+  };
+}
+
+// One extension per Slack token. Patterns are anchored (`^`): marked feeds the tokenizer
+// the source starting at the candidate position.
+const SLACK_EXTENSIONS: TokenizerAndRendererExtension[] = [
+  // <@U123> or <@U123|name> -> @name (falls back to the id when no label).
+  slackInlineToken(
+    "slackUser",
+    "<@",
+    /^<@([UW][A-Z0-9]+)(?:\|([^>]+))?>/,
+    (m) => `@${m[2] ?? m[1]}`
+  ),
+  // <#C123> or <#C123|name> -> #name.
+  slackInlineToken(
+    "slackChannel",
+    "<#",
+    /^<#([A-Z0-9]+)(?:\|([^>]+))?>/,
+    (m) => `#${m[2] ?? m[1]}`
+  ),
+  // <!subteam^S123|@group> -> @group ; <!subteam^S123> -> @S123.
+  slackInlineToken(
+    "slackSubteam",
+    "<!subteam",
+    /^<!subteam\^([A-Z0-9]+)(?:\|([^>]+))?>/,
+    (m) => m[2] ?? `@${m[1]}`
+  ),
+  // <!here> / <!channel> / <!everyone> -> @here / @channel / @everyone.
+  slackInlineToken(
+    "slackBroadcast",
+    "<!",
+    /^<!(here|channel|everyone)>/,
+    (m) => `@${m[1]}`
+  ),
+  // <mailto:foo@bar|label> -> label ; <mailto:foo@bar> -> foo@bar.
+  slackInlineToken(
+    "slackMailto",
+    "<mailto:",
+    /^<mailto:([^|>]+)(?:\|([^>]+))?>/,
+    (m) => m[2] ?? m[1]
+  ),
+  // <https://url|label> -> label (https://url) ; <https://url> -> https://url.
+  slackInlineToken(
+    "slackLink",
+    "<http",
+    /^<(https?:\/\/[^|>]+)(?:\|([^>]+))?>/,
+    (m) => (m[2] ? `${m[2]} (${m[1]})` : m[1])
+  ),
+];
+
+// marked instance for Slack: renderers drop HTML markup and emit inner text; `text` uses
+// `raw` so literal `&`/`<`/`>` are kept rather than turned into HTML entities.
+const slackMarked = new Marked({
+  extensions: SLACK_EXTENSIONS,
+  renderer: {
+    strong(token) {
+      return this.parser.parseInline(token.tokens);
+    },
+    em(token) {
+      return this.parser.parseInline(token.tokens);
+    },
+    del(token) {
+      return this.parser.parseInline(token.tokens);
+    },
+    codespan(token) {
+      return token.text;
+    },
+    link(token) {
+      return token.text;
+    },
+    text(token) {
+      return "tokens" in token && token.tokens
+        ? this.parser.parseInline(token.tokens)
+        : token.raw;
+    },
+  },
+});
+
+// Converts a Slack mrkdwn string to readable plain text. Inline parsing avoids
+// re-interpreting block markers we emit ourselves ("- ", "> "). Never throws: on error it
+// falls back to the original string.
+export function slackMrkdwnToText(text: string): string {
+  try {
+    return slackMarked.parseInline(text, { async: false }).trim();
+  } catch {
+    return text;
+  }
+}

--- a/front/lib/api/actions/servers/slack/slack_mrkdwn.ts
+++ b/front/lib/api/actions/servers/slack/slack_mrkdwn.ts
@@ -5,7 +5,6 @@
 import type { TokenizerAndRendererExtension } from "marked";
 import { Marked } from "marked";
 
-// Builds an inline extension matching a Slack token and rendering it to plain text.
 function slackInlineToken(
   name: string,
   prefixHint: string,
@@ -32,8 +31,7 @@ function slackInlineToken(
   };
 }
 
-// One extension per Slack token. Patterns are anchored (`^`): marked feeds the tokenizer
-// the source starting at the candidate position.
+// Patterns are anchored (`^`): marked feeds the tokenizer the source from the match start.
 const SLACK_EXTENSIONS: TokenizerAndRendererExtension[] = [
   // <@U123> or <@U123|name> -> @name (falls back to the id when no label).
   slackInlineToken(

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -29,7 +29,10 @@ import {
   resolveUserDisplayName,
   SLACK_THREAD_LISTING_LIMIT,
 } from "@app/lib/api/actions/servers/slack/helpers";
-import { formatSlackMessageForLLM } from "@app/lib/api/actions/servers/slack/message_formatter";
+import {
+  formatSlackMessageForLLM,
+  renderFormattedMessage,
+} from "@app/lib/api/actions/servers/slack/message_formatter";
 import { SLACK_PERSONAL_TOOLS_METADATA } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
@@ -796,16 +799,18 @@ export function createSlackPersonalTools(
               })
             : null;
           return {
-            ...match,
+            ts: match.ts,
+            reply_count: match.reply_count,
             authorName: authorName ?? "Unknown",
             // Reconstruct readable text from blocks/attachments: app/bot messages
             // (Datadog, Zendesk, ...) often have an empty `text` and put content in
             // `blocks[]`, which would otherwise render as empty for the agent.
-            renderedText: formatSlackMessageForLLM(match),
+            renderedText: renderFormattedMessage(
+              formatSlackMessageForLLM(match)
+            ),
           };
         })
       );
-
       const searchResults = buildSearchResults<{
         permalink?: string;
         renderedText: string;

--- a/front/lib/api/actions/servers/slack_personal/tools/index.ts
+++ b/front/lib/api/actions/servers/slack_personal/tools/index.ts
@@ -29,6 +29,7 @@ import {
   resolveUserDisplayName,
   SLACK_THREAD_LISTING_LIMIT,
 } from "@app/lib/api/actions/servers/slack/helpers";
+import { formatSlackMessageForLLM } from "@app/lib/api/actions/servers/slack/message_formatter";
 import { SLACK_PERSONAL_TOOLS_METADATA } from "@app/lib/api/actions/servers/slack_personal/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
@@ -797,13 +798,17 @@ export function createSlackPersonalTools(
           return {
             ...match,
             authorName: authorName ?? "Unknown",
+            // Reconstruct readable text from blocks/attachments: app/bot messages
+            // (Datadog, Zendesk, ...) often have an empty `text` and put content in
+            // `blocks[]`, which would otherwise render as empty for the agent.
+            renderedText: formatSlackMessageForLLM(match),
           };
         })
       );
 
       const searchResults = buildSearchResults<{
         permalink?: string;
-        text?: string;
+        renderedText: string;
         ts?: string;
         authorName: string;
         reply_count?: number;
@@ -814,10 +819,10 @@ export function createSlackPersonalTools(
           const prefix = hasReplies
             ? `[Thread: ${match.ts}]`
             : `[Message: ${match.ts}]`;
-          return `${prefix} From ${match.authorName} in ${displayName}: ${match.text ?? ""}`;
+          return `${prefix} From ${match.authorName} in ${displayName}: ${match.renderedText}`;
         },
         id: (match) => match.ts ?? "",
-        content: (match) => match.text ?? "",
+        content: (match) => match.renderedText,
       });
 
       return new Ok(


### PR DESCRIPTION
## Description

App/bot messages (Datadog, Zendesk, …) often have an empty top-level text and put their content in blocks[], so the Slack personal MCP tools returned empty content for those alerts. Adds formatSlackMessageForLLM, a read-only formatter that reconstructs readable text from blocks (header, section + fields, context, actions, image, rich_text) and attachments, cleans Slack mrkdwn, and dedupes lines. Wired into list_messages and read_thread_messages (parent + replies, original kept under raw_text). 

Fixes [dust-tt/tasks#8940](https://github.com/dust-tt/tasks/issues/8940).

## Tests

Unit tests and tested manually.

## Risk

Low. Doesn't touch existing infrastructure. Falls back to existing behavior for plaint-text messages. 

## Deploy Plan

Deploy to front-edge first to validate against real Slack data without touching prod.
