### PR TITLE
feat(model_constructors): add Fireworks chat-completions plumbing

### DIFF
--- a/front/lib/model_constructors/providers/fireworks/inputConfig.ts
+++ b/front/lib/model_constructors/providers/fireworks/inputConfig.ts
@@ -1,0 +1,18 @@
+import { FIREWORKS_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/fireworks/reasoning_efforts";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { z } from "zod";
+
+// Widest Fireworks reasoning contract. Per-model schemas narrow it (and decide
+// whether `temperature` passes through), so the client-level schema only needs
+// to admit every effort some Fireworks model accepts.
+export const fireworksConfigSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum(FIREWORKS_SUPPORTED_REASONING_EFFORTS),
+    })
+    .optional(),
+  // Fireworks has no explicit prompt-cache key.
+  cacheKey: z.undefined(),
+});
+
+export type FireworksInputConfig = z.infer<typeof fireworksConfigSchema>;

--- a/front/lib/model_constructors/providers/fireworks/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/fireworks/reasoning_efforts.ts
@@ -1,0 +1,13 @@
+// Fireworks serves open models through the OpenAI chat-completions API, which
+// exposes reasoning via `reasoning_effort` (low/medium/high). `none` means no
+// reasoning and is dropped before the request. Per-model schemas narrow this set
+// (e.g. DeepSeek V3.2 only supports `none`, GLM-5.2 supports low/medium/high).
+export const FIREWORKS_SUPPORTED_REASONING_EFFORTS = [
+  "none",
+  "low",
+  "medium",
+  "high",
+] as const;
+
+export type FireworksSupportedReasoningEffort =
+  (typeof FIREWORKS_SUPPORTED_REASONING_EFFORTS)[number];

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/index.ts
@@ -1,0 +1,77 @@
+import type { Client } from "@app/lib/model_constructors/client";
+import type { FireworksInputConfig } from "@app/lib/model_constructors/providers/fireworks/inputConfig";
+import {
+  assistantReasoningMessageToMessage,
+  assistantTextMessageToMessage,
+  assistantToolCallRequestToMessage,
+  conversationToOpenAICompletionsMessages,
+  forceToolNameToToolChoice,
+  type OpenAICompletionsMessageConverters,
+  outputFormatToResponseFormat,
+  systemMessageToMessage,
+  toolCallResultMessageToMessage,
+  toReasoningEffortParam,
+  toTool,
+  userImageMessageToMessage,
+  userTextMessageToMessage,
+} from "@app/lib/model_constructors/sdk/openai_completions/converters/input/utils";
+import type { Payload } from "@app/lib/model_constructors/types/input/messages";
+import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions";
+
+type AbstractConstructor<T> = abstract new (...args: any[]) => T;
+
+// Turns our provider-agnostic conversation/config into the OpenAI
+// `chat.completions.create` request shape. Leaf converters are bound as class
+// fields and the composite routes through `this`, so an endpoint can override a
+// single leaf.
+export function WithOpenAICompletionsInputConverter<
+  TBase extends AbstractConstructor<Client<FireworksInputConfig>>,
+>(Base: TBase) {
+  abstract class WithOpenAICompletionsInputConverter
+    extends Base
+    implements OpenAICompletionsMessageConverters
+  {
+    systemMessageToMessage = systemMessageToMessage;
+    userTextMessageToMessage = userTextMessageToMessage;
+    userImageMessageToMessage = userImageMessageToMessage;
+    toolCallResultMessageToMessage = toolCallResultMessageToMessage;
+    assistantTextMessageToMessage = assistantTextMessageToMessage;
+    assistantReasoningMessageToMessage = assistantReasoningMessageToMessage;
+    assistantToolCallRequestToMessage = assistantToolCallRequestToMessage;
+
+    buildRequestPayload(
+      payload: Payload,
+      config: FireworksInputConfig
+    ): ChatCompletionCreateParamsNonStreaming {
+      const { conversation } = payload;
+      const {
+        tools = [],
+        temperature,
+        reasoning,
+        forceTool,
+        outputFormat,
+      } = config;
+
+      const reasoningEffort = reasoning
+        ? toReasoningEffortParam(reasoning.effort)
+        : undefined;
+
+      // `tool_choice` is always sent (matching the legacy client); `tools` is
+      // only sent when non-empty. Fireworks does not get an explicit max-output
+      // cap, matching the legacy client.
+      return {
+        model: this.constructor.modelId,
+        messages: conversationToOpenAICompletionsMessages(conversation, this),
+        temperature,
+        tool_choice: forceToolNameToToolChoice(tools, forceTool),
+        ...(tools.length > 0 ? { tools: tools.map(toTool) } : {}),
+        ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+        ...(outputFormat
+          ? { response_format: outputFormatToResponseFormat(outputFormat) }
+          : {}),
+      };
+    }
+  }
+
+  return WithOpenAICompletionsInputConverter;
+}

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/utils.ts
@@ -1,0 +1,275 @@
+import type {
+  OutputFormat,
+  ToolSpecification,
+} from "@app/lib/model_constructors/types/input/configuration";
+import type {
+  BaseAssistantMessage,
+  BaseAssistantReasoningMessage,
+  BaseAssistantTextMessage,
+  BaseAssistantToolCallRequestMessage,
+  BaseConversation,
+  BaseToolCallResultMessage,
+  BaseUserImageMessage,
+  BaseUserMessage,
+  BaseUserTextMessage,
+  SystemTextMessage,
+} from "@app/lib/model_constructors/types/input/messages";
+import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isRecord } from "@app/types/shared/utils/general";
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+  ChatCompletionToolChoiceOption,
+} from "openai/resources/chat/completions";
+import type {
+  ReasoningEffort as OpenAIReasoningEffort,
+  ResponseFormatJSONSchema,
+} from "openai/resources/shared";
+
+// The per-message leaf converters. The composite below routes through an object
+// satisfying this interface (`this`), so overriding one leaf on an endpoint
+// changes how the composite uses it.
+export interface OpenAICompletionsMessageConverters {
+  systemMessageToMessage(
+    message: SystemTextMessage
+  ): ChatCompletionMessageParam;
+  userTextMessageToMessage(
+    message: BaseUserTextMessage
+  ): ChatCompletionMessageParam;
+  userImageMessageToMessage(
+    message: BaseUserImageMessage
+  ): ChatCompletionMessageParam;
+  toolCallResultMessageToMessage(
+    message: BaseToolCallResultMessage
+  ): ChatCompletionMessageParam;
+  assistantTextMessageToMessage(
+    message: BaseAssistantTextMessage
+  ): ChatCompletionMessageParam;
+  assistantReasoningMessageToMessage(
+    message: BaseAssistantReasoningMessage
+  ): ChatCompletionMessageParam;
+  assistantToolCallRequestToMessage(
+    message: BaseAssistantToolCallRequestMessage
+  ): ChatCompletionMessageParam;
+}
+
+// -- Leaf converters: one chat-completions message per conversation message --
+
+// The system prompt is sent as a `developer` message, matching the legacy
+// Fireworks client (which used the shared openai-chat default role).
+export function systemMessageToMessage(
+  message: SystemTextMessage
+): ChatCompletionMessageParam {
+  return { role: "developer", content: message.content.value };
+}
+
+export function userTextMessageToMessage(
+  message: BaseUserTextMessage
+): ChatCompletionMessageParam {
+  return {
+    role: "user",
+    content: [{ type: "text", text: message.content.value }],
+  };
+}
+
+export function userImageMessageToMessage(
+  message: BaseUserImageMessage
+): ChatCompletionMessageParam {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "image_url",
+        image_url: { url: message.content.url, detail: "auto" },
+      },
+    ],
+  };
+}
+
+export function toolCallResultMessageToMessage(
+  message: BaseToolCallResultMessage
+): ChatCompletionMessageParam {
+  const content = message.content.parts
+    .map((part) => {
+      switch (part.type) {
+        case "text":
+          return part.text;
+        case "image_url":
+          return part.url;
+        default:
+          return assertNever(part);
+      }
+    })
+    .join("\n");
+
+  return {
+    role: "tool",
+    tool_call_id: message.content.callId,
+    content,
+  };
+}
+
+export function assistantTextMessageToMessage(
+  message: BaseAssistantTextMessage
+): ChatCompletionMessageParam {
+  return { role: "assistant", content: message.content.value };
+}
+
+// Prior reasoning is replayed as assistant text, matching the legacy client
+// (chat-completions has no dedicated field to send reasoning back).
+export function assistantReasoningMessageToMessage(
+  message: BaseAssistantReasoningMessage
+): ChatCompletionMessageParam {
+  return { role: "assistant", content: message.content.value };
+}
+
+export function assistantToolCallRequestToMessage(
+  message: BaseAssistantToolCallRequestMessage
+): ChatCompletionMessageParam {
+  return {
+    role: "assistant",
+    content: null,
+    tool_calls: [
+      {
+        id: message.content.callId,
+        type: "function",
+        function: {
+          name: message.content.toolName,
+          arguments: message.content.arguments,
+        },
+      },
+    ],
+  };
+}
+
+// -- Composite message converter --
+
+function userMessageToMessage(
+  message: BaseUserMessage,
+  converters: OpenAICompletionsMessageConverters
+): ChatCompletionMessageParam {
+  switch (message.type) {
+    case "text":
+      return converters.userTextMessageToMessage(message);
+    case "image_url":
+      return converters.userImageMessageToMessage(message);
+    case "tool_call_result":
+      return converters.toolCallResultMessageToMessage(message);
+    default:
+      assertNever(message);
+  }
+}
+
+function assistantMessageToMessage(
+  message: BaseAssistantMessage,
+  converters: OpenAICompletionsMessageConverters
+): ChatCompletionMessageParam {
+  switch (message.type) {
+    case "text":
+      return converters.assistantTextMessageToMessage(message);
+    case "reasoning":
+      return converters.assistantReasoningMessageToMessage(message);
+    case "tool_call_request":
+      return converters.assistantToolCallRequestToMessage(message);
+    default:
+      assertNever(message);
+  }
+}
+
+export function conversationToOpenAICompletionsMessages(
+  conversation: BaseConversation,
+  converters: OpenAICompletionsMessageConverters
+): ChatCompletionMessageParam[] {
+  const system = conversation.system.map((message) =>
+    converters.systemMessageToMessage(message)
+  );
+  const messages = conversation.messages.map((message) => {
+    switch (message.role) {
+      case "user":
+        return userMessageToMessage(message, converters);
+      case "assistant":
+        return assistantMessageToMessage(message, converters);
+      default:
+        assertNever(message);
+    }
+  });
+  return [...system, ...messages];
+}
+
+// -- Config converters (pure) --
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && isRecord(value)
+    ? value
+    : {};
+}
+
+export function toTool(tool: ToolSpecification): ChatCompletionTool {
+  const properties = asRecord(tool.inputSchema.properties);
+  return {
+    type: "function",
+    function: {
+      strict: true,
+      name: tool.name,
+      description: tool.description,
+      parameters: {
+        type: "object",
+        properties,
+        // OpenAI strict mode requires every property to be listed as required.
+        required: Object.keys(properties),
+        additionalProperties: false,
+      },
+    },
+  };
+}
+
+export function forceToolNameToToolChoice(
+  tools: ToolSpecification[],
+  forceTool: string | undefined
+): ChatCompletionToolChoiceOption {
+  return forceTool && tools.some((tool) => tool.name === forceTool)
+    ? { type: "function", function: { name: forceTool } }
+    : "auto";
+}
+
+// Maps our reasoning effort to the chat-completions `reasoning_effort` value, or
+// `undefined` to omit it. `none` is dropped (no reasoning); `maximal` has no
+// chat-completions equivalent. Fireworks models only ever send none/low/medium/
+// high, so the other branches are dead but kept for exhaustiveness.
+export function toReasoningEffortParam(
+  effort: ReasoningEffort
+): OpenAIReasoningEffort | undefined {
+  switch (effort) {
+    case "none":
+      return undefined;
+    case "minimal":
+      return "minimal";
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "xhigh":
+      return "xhigh";
+    case "maximal":
+      return undefined;
+    default:
+      return assertNever(effort);
+  }
+}
+
+export function outputFormatToResponseFormat(
+  outputFormat: OutputFormat
+): ResponseFormatJSONSchema {
+  return {
+    type: "json_schema",
+    json_schema: {
+      name: outputFormat.json_schema.name,
+      description: outputFormat.json_schema.description,
+      schema: outputFormat.json_schema.schema,
+      strict: outputFormat.json_schema.strict ?? undefined,
+    },
+  };
+}

--- a/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
@@ -8,9 +8,9 @@ import type {
   ToolCallEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isRecord, isString } from "@app/types/shared/utils/general";
+import { isNumber, isRecord, isString } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { APIError } from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions";
@@ -102,7 +102,7 @@ export function streamErrorToErrorEvent(
           originalError: error,
         });
       default:
-        if (typeof status === "number" && status >= 500 && status < 600) {
+        if (isNumber(status) && status >= 500 && status < 600) {
           return buildErrorEvent({
             metadata,
             type: "server_error",
@@ -304,7 +304,9 @@ export async function* rawOutputToEvents(
         // Legacy function calls are surfaced through tool_calls deltas.
         break;
       default:
-        assertNever(finishReason);
+        // finish_reason comes off the API stream; ignore unknown values rather
+        // than crashing the stream handler if the provider adds a new one.
+        assertNeverAndIgnore(finishReason);
     }
   }
 

--- a/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
@@ -1,0 +1,313 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ModelResponseEvent,
+  ReasoningEvent,
+  TextEvent,
+  TokenUsageEvent,
+  ToolCallEvent,
+} from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isRecord, isString } from "@app/types/shared/utils/general";
+import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+import { APIError } from "openai";
+import type { ChatCompletionChunk } from "openai/resources/chat/completions";
+
+// Parses tool-call arguments into an object, falling back to `{}` for malformed
+// or non-object JSON.
+function parseToolArguments(argumentsJson: string): Record<string, unknown> {
+  const parsed = safeParseJSON(argumentsJson);
+  if (parsed.isErr() || parsed.value === null || !isRecord(parsed.value)) {
+    return {};
+  }
+  return parsed.value;
+}
+
+// `reasoning_content` is a Fireworks/open-model extension absent from the OpenAI
+// chat-completions types, so read it defensively off the delta.
+function deltaReasoningContent(delta: object): string | undefined {
+  if (isRecord(delta) && isString(delta.reasoning_content)) {
+    return delta.reasoning_content;
+  }
+  return undefined;
+}
+
+function usageToTokenUsageEvent(
+  metadata: EndpointMetadata,
+  usage: ChatCompletionChunk["usage"]
+): TokenUsageEvent {
+  const cacheHit = usage?.prompt_tokens_details?.cached_tokens ?? 0;
+  const reasoning = usage?.completion_tokens_details?.reasoning_tokens ?? 0;
+  return {
+    type: "token_usage",
+    content: {
+      // OpenAI-style prompt caching has no separate creation cost or TTL buckets.
+      cacheCreated: 0,
+      longCacheCreated: 0,
+      shortCacheCreated: 0,
+      cacheHit,
+      // prompt_tokens includes cached; subtract to get the uncached portion.
+      standardInput: (usage?.prompt_tokens ?? 0) - cacheHit,
+      standardOutput: (usage?.completion_tokens ?? 0) - reasoning,
+      reasoning,
+    },
+    metadata,
+  };
+}
+
+// Maps any error thrown while streaming into a unified `ErrorEvent`, so
+// everything leaving the endpoint is an event, not an exception.
+export function streamErrorToErrorEvent(
+  metadata: EndpointMetadata,
+  error: unknown
+): ErrorEvent {
+  if (error instanceof APIError) {
+    const status = error.status;
+    switch (status) {
+      case 400:
+        return buildErrorEvent({
+          metadata,
+          type: "invalid_request_error",
+          message: `Invalid request to Fireworks: ${error.message}`,
+          originalError: error,
+        });
+      case 401:
+        return buildErrorEvent({
+          metadata,
+          type: "authentication_error",
+          message: `Authentication failed for Fireworks: ${error.message}`,
+          originalError: error,
+        });
+      case 403:
+        return buildErrorEvent({
+          metadata,
+          type: "permission_error",
+          message: `Permission denied for Fireworks: ${error.message}`,
+          originalError: error,
+        });
+      case 404:
+        return buildErrorEvent({
+          metadata,
+          type: "not_found_error",
+          message: `Resource not found for Fireworks: ${error.message}`,
+          originalError: error,
+        });
+      case 429:
+        return buildErrorEvent({
+          metadata,
+          type: "rate_limit_error",
+          message: `Rate limit exceeded for Fireworks/${metadata.modelId}: ${error.message}`,
+          originalError: error,
+        });
+      default:
+        if (typeof status === "number" && status >= 500 && status < 600) {
+          return buildErrorEvent({
+            metadata,
+            type: "server_error",
+            message: `Server error from Fireworks (${status}): ${error.message}`,
+            originalError: error,
+          });
+        }
+        return buildErrorEvent({
+          metadata,
+          type: "unknown_error",
+          message: `Error from Fireworks (${status}): ${error.message}`,
+          originalError: error,
+        });
+    }
+  }
+  return buildErrorEvent({
+    metadata,
+    type: "unknown_error",
+    message: `Unknown error from Fireworks: ${normalizeError(error).message}`,
+    originalError: error,
+  });
+}
+
+type Accumulator = { textParts: string; reasoningParts: string };
+
+type ToolCallAccumulator = {
+  id: string;
+  name: string;
+  arguments: string;
+  startedEmitted: boolean;
+};
+
+// Flushes pending reasoning then text as accumulated events, appending them to
+// `aggregated`. Reasoning is flushed before text so the final text block stays
+// last (checkers assert on the last aggregated event).
+function flushAccumulated(
+  acc: Accumulator,
+  metadata: EndpointMetadata,
+  aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[]
+): ModelResponseEvent[] {
+  const events: ModelResponseEvent[] = [];
+  if (acc.reasoningParts) {
+    const event: ReasoningEvent = {
+      type: "reasoning",
+      content: { value: acc.reasoningParts },
+      metadata,
+    };
+    aggregated.push(event);
+    events.push(event);
+    acc.reasoningParts = "";
+  }
+  if (acc.textParts) {
+    const event: TextEvent = {
+      type: "text",
+      content: { value: acc.textParts },
+      metadata,
+    };
+    aggregated.push(event);
+    events.push(event);
+    acc.textParts = "";
+  }
+  return events;
+}
+
+// -- Entry point: drive the raw chat-completions stream into unified events --
+
+export async function* rawOutputToEvents(
+  stream: AsyncGenerator<ChatCompletionChunk>,
+  metadata: EndpointMetadata
+): AsyncGenerator<ModelResponseEvent> {
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const acc: Accumulator = { textParts: "", reasoningParts: "" };
+  const toolCalls = new Map<number, ToolCallAccumulator>();
+  let hasYieldedResponseId = false;
+  let usage: ChatCompletionChunk["usage"];
+
+  while (true) {
+    let result: IteratorResult<ChatCompletionChunk>;
+    try {
+      result = await stream.next();
+    } catch (err) {
+      yield streamErrorToErrorEvent(metadata, err);
+      return;
+    }
+    if (result.done) {
+      break;
+    }
+
+    const chunk = result.value;
+    if (!hasYieldedResponseId && chunk.id) {
+      yield {
+        type: "response_id",
+        content: { responseId: chunk.id },
+        metadata,
+      };
+      hasYieldedResponseId = true;
+    }
+    usage = chunk.usage ?? usage;
+
+    const choice = chunk.choices[0];
+    if (!choice) {
+      continue;
+    }
+    const { delta, finish_reason: finishReason } = choice;
+
+    const reasoningContent = deltaReasoningContent(delta);
+    if (reasoningContent) {
+      acc.reasoningParts += reasoningContent;
+      yield {
+        type: "reasoning_delta",
+        content: { value: reasoningContent },
+        metadata,
+      };
+    }
+
+    if (delta.content) {
+      acc.textParts += delta.content;
+      yield { type: "text_delta", content: { value: delta.content }, metadata };
+    }
+
+    if (delta.tool_calls) {
+      // Flush any text/reasoning produced before the tool call.
+      for (const e of flushAccumulated(acc, metadata, aggregated)) {
+        yield e;
+      }
+      for (const toolCallDelta of delta.tool_calls) {
+        const { index } = toolCallDelta;
+        let entry = toolCalls.get(index);
+        if (!entry) {
+          entry = { id: "", name: "", arguments: "", startedEmitted: false };
+          toolCalls.set(index, entry);
+        }
+        if (toolCallDelta.id) {
+          entry.id = toolCallDelta.id;
+        }
+        if (toolCallDelta.function?.name) {
+          entry.name += toolCallDelta.function.name;
+        }
+        if (toolCallDelta.function?.arguments) {
+          entry.arguments += toolCallDelta.function.arguments;
+        }
+        if (entry.id && entry.name && !entry.startedEmitted) {
+          entry.startedEmitted = true;
+          yield {
+            type: "tool_call_started",
+            content: { id: entry.id, index, name: entry.name },
+            metadata,
+          };
+        }
+      }
+    }
+
+    if (!finishReason) {
+      continue;
+    }
+    switch (finishReason) {
+      case "stop":
+        for (const e of flushAccumulated(acc, metadata, aggregated)) {
+          yield e;
+        }
+        break;
+      case "tool_calls": {
+        for (const e of flushAccumulated(acc, metadata, aggregated)) {
+          yield e;
+        }
+        for (const entry of toolCalls.values()) {
+          if (!entry.id || !entry.name) {
+            continue;
+          }
+          const toolCallEvent: ToolCallEvent = {
+            type: "tool_call",
+            content: {
+              id: entry.id,
+              name: entry.name,
+              arguments: parseToolArguments(entry.arguments),
+            },
+            metadata,
+          };
+          aggregated.push(toolCallEvent);
+          yield toolCallEvent;
+        }
+        break;
+      }
+      case "length":
+        yield buildErrorEvent({
+          metadata,
+          type: "stop_error",
+          message: "The maximum response length was reached.",
+        });
+        return;
+      case "content_filter":
+        yield buildErrorEvent({
+          metadata,
+          type: "refusal_error",
+          message: "The response was filtered by the content policy.",
+        });
+        return;
+      case "function_call":
+        // Legacy function calls are surfaced through tool_calls deltas.
+        break;
+      default:
+        assertNever(finishReason);
+    }
+  }
+
+  yield usageToTokenUsageEvent(metadata, usage);
+  yield { type: "success", content: { aggregated }, metadata };
+}

--- a/front/lib/model_constructors/stream/clients/fireworks.ts
+++ b/front/lib/model_constructors/stream/clients/fireworks.ts
@@ -1,0 +1,64 @@
+import {
+  type FireworksInputConfig,
+  fireworksConfigSchema,
+} from "@app/lib/model_constructors/providers/fireworks/inputConfig";
+import { WithOpenAICompletionsInputConverter } from "@app/lib/model_constructors/sdk/openai_completions/converters/input";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_completions/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { FIREWORKS_API } from "@app/lib/model_constructors/types/provider_apis";
+import { FIREWORKS_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import OpenAI from "openai";
+import type {
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions";
+
+const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+
+export abstract class FireworksStream extends WithOpenAICompletionsInputConverter(
+  StreamEndpoint<
+    ChatCompletionCreateParamsNonStreaming,
+    ChatCompletionChunk,
+    FireworksInputConfig
+  >
+) {
+  static readonly providerId = FIREWORKS_PROVIDER_ID;
+  static readonly api = FIREWORKS_API;
+
+  static readonly configSchema = fireworksConfigSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ FIREWORKS_API_KEY }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      apiKey: FIREWORKS_API_KEY,
+      baseURL: FIREWORKS_BASE_URL,
+    });
+  }
+
+  async *streamRaw(
+    input: ChatCompletionCreateParamsNonStreaming
+  ): AsyncGenerator<ChatCompletionChunk> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ChatCompletionCreateParamsStreaming = {
+      ...input,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    const stream = await this.client.chat.completions.create(streamingInput);
+
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ChatCompletionChunk>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata());
+  }
+}

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -5,4 +5,5 @@ export type Credentials = {
   GOOGLE_AI_STUDIO_API_KEY?: string;
   AGENT_PLATFORM_PROJECT_ID?: string;
   MISTRAL_API_KEY?: string;
+  FIREWORKS_API_KEY?: string;
 };

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -21,6 +21,22 @@ export const MISTRAL_MEDIUM_3_5_MODEL_ID = "mistral-medium-3-5" as const;
 export const MISTRAL_SMALL_MODEL_ID = "mistral-small-latest" as const;
 export const MISTRAL_CODESTRAL_MODEL_ID = "codestral-latest" as const;
 
+// Fireworks-served models keep their full Fireworks model path as the id.
+export const FIREWORKS_DEEPSEEK_V3P2_MODEL_ID =
+  "accounts/fireworks/models/deepseek-v3p2" as const;
+export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_ID =
+  "accounts/fireworks/models/deepseek-v4-pro" as const;
+export const FIREWORKS_KIMI_K2_INSTRUCT_MODEL_ID =
+  "accounts/fireworks/models/kimi-k2-instruct-0905" as const;
+export const FIREWORKS_KIMI_K2P5_MODEL_ID =
+  "accounts/fireworks/models/kimi-k2p5" as const;
+export const FIREWORKS_MINIMAX_M2P5_MODEL_ID =
+  "accounts/fireworks/models/minimax-m2p5" as const;
+export const FIREWORKS_GLM_5_MODEL_ID =
+  "accounts/fireworks/models/glm-5" as const;
+export const FIREWORKS_GLM_5P2_MODEL_ID =
+  "accounts/fireworks/models/glm-5p2" as const;
+
 // Include a few examples for now
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
@@ -42,6 +58,13 @@ export const MODEL_IDS = [
   MISTRAL_MEDIUM_3_5_MODEL_ID,
   MISTRAL_SMALL_MODEL_ID,
   MISTRAL_CODESTRAL_MODEL_ID,
+  FIREWORKS_DEEPSEEK_V3P2_MODEL_ID,
+  FIREWORKS_DEEPSEEK_V4_PRO_MODEL_ID,
+  FIREWORKS_KIMI_K2_INSTRUCT_MODEL_ID,
+  FIREWORKS_KIMI_K2P5_MODEL_ID,
+  FIREWORKS_MINIMAX_M2P5_MODEL_ID,
+  FIREWORKS_GLM_5_MODEL_ID,
+  FIREWORKS_GLM_5P2_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -3,6 +3,7 @@ export const ANTHROPIC_API = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_API = "google-ai-studio" as const;
 export const AGENT_PLATFORM_API = "agent-platform" as const;
 export const MISTRAL_API = "mistral" as const;
+export const FIREWORKS_API = "fireworks" as const;
 
 const PROVIDER_APIS = [
   OPENAI_RESPONSES_API,
@@ -10,5 +11,6 @@ const PROVIDER_APIS = [
   GOOGLE_AI_STUDIO_API,
   AGENT_PLATFORM_API,
   MISTRAL_API,
+  FIREWORKS_API,
 ] as const;
 export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -4,6 +4,7 @@ export const OPENAI_PROVIDER_ID = "openai" as const;
 export const ANTHROPIC_PROVIDER_ID = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
 export const MISTRAL_PROVIDER_ID = "mistral" as const;
+export const FIREWORKS_PROVIDER_ID = "fireworks" as const;
 
 // `satisfies readonly ModelProviderIdType[]` guarantees every new-system
 // provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
@@ -15,6 +16,7 @@ const PROVIDER_IDS = [
   ANTHROPIC_PROVIDER_ID,
   GOOGLE_AI_STUDIO_PROVIDER_ID,
   MISTRAL_PROVIDER_ID,
+  FIREWORKS_PROVIDER_ID,
 ] as const satisfies readonly ModelProviderIdType[];
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 


### PR DESCRIPTION
## Description

First step of migrating the Fireworks provider into the new per-endpoint LLM router (`lib/model_constructors`). This PR adds only the shared plumbing — no endpoint is wired into the runtime registry yet, so it's inert until the follow-up.

Fireworks is the first provider in the new router to speak the **OpenAI chat-completions** wire format (every migrated provider so far uses a provider-native API or the OpenAI Responses API). It therefore needs a new `providerApi` and its own chat-completions converters, ported from the legacy `lib/api/llm/utils/openai_like/chat/*` path into the new event model.

What's included:
- Types: `fireworks` providerId + api, `FIREWORKS_API_KEY` credential, and the 7 Fireworks model ids.
- `sdk/openai_chat/converters/{input,output}`: the reusable chat-completions wire-format converters (leaf-based input mixin + standalone output `rawOutputToEvents`), mirroring `sdk/mistralai`.
- `providers/fireworks/`: reasoning-efforts list and the base input-config schema.
- `stream/clients/fireworks.ts`: the abstract `FireworksStream` client (OpenAI SDK pointed at the Fireworks base URL).

Naming follows the existing axes (`providerId` = catalog home, `api` = serving surface, `sdk/` = wire format): `providerId = api = fireworks`, `sdk = openai_chat`. Converters intentionally match the legacy client byte-for-byte (system prompt as `developer` role, `tool_choice` always sent, `tools` omitted when empty) so the upcoming parity test passes.

## Tests

`npx tsgo --noEmit` is clean and biome formatting passes (both also run as pre-commit hooks). No behavioral test in this PR by design — nothing is registered, so no model routes through this code yet. The follow-up PR adds the first endpoint (GLM-5.2) together with the new-vs-legacy non-regression (parity) test as the acceptance gate for these converters.

## Risk

Very low. All additions are new files or additive type-union members; no existing code path calls into this layer (no registry entry, no dust config). Fully inert until the follow-up wires an endpoint. Trivially reversible.

## Deploy Plan

Standard. No migrations, no env changes, no feature-flag changes. Safe to deploy independently of the follow-up.