### PR TITLE
feat(llm): add Claude Opus 4.6 to the new LLM router

### DIFF
--- a/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,0 +1,15 @@
+export function WithDustClaudeOpusFourDotSixConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustClaudeOpusFourDotSix extends Base {
+    static readonly displayName = "Claude Opus 4.6";
+    static readonly description =
+      "Anthropic's Claude Opus 4.6 model, an advanced model with enhanced reasoning capabilities (200k context).";
+    static readonly defaultReasoningEffort = "medium";
+    static readonly byok = true;
+  }
+
+  return DustClaudeOpusFourDotSix;
+}

--- a/front/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
+++ b/front/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
@@ -1,0 +1,11 @@
+import { WithDustClaudeOpusFourDotSixConfig } from "@app/lib/llms/providers/anthropic/models/claude_opus_four_dot_six";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
+
+export class DustAnthropicGlobalClaudeOpusFourDotSixStream extends WithDustClaudeOpusFourDotSixConfig(
+  AnthropicGlobalClaudeOpusFourDotSixStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustAnthropicGlobalClaudeOpusFourDotSixStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -3,6 +3,7 @@ import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/ll
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
+import { DustAnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
@@ -31,6 +32,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicGlobalClaudeOpusFourDotEightStream,
   [DustAnthropicGlobalClaudeOpusFourDotSevenStream.id]:
     DustAnthropicGlobalClaudeOpusFourDotSevenStream,
+  [DustAnthropicGlobalClaudeOpusFourDotSixStream.id]:
+    DustAnthropicGlobalClaudeOpusFourDotSixStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [DustGoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,0 +1,35 @@
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import {
+  type AnthropicOpusInputConfig,
+  OPUS_CONTEXT_SIZE,
+  OPUS_MAX_OUTPUT_TOKENS,
+  opusConfigSchema,
+} from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { CLAUDE_OPUS_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+import type { z } from "zod";
+
+export function WithAnthropicClaudeOpusFourDotSixConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class AnthropicClaudeOpusFourDotSix extends Base {
+    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
+    // instance type carries the Opus config (not the wide `InputConfig`).
+    declare ["constructor"]: BaseEndpointConfiguration<AnthropicOpusInputConfig>;
+
+    static readonly modelId = CLAUDE_OPUS_4_6_MODEL_ID;
+
+    static readonly configSchema: z.ZodType<
+      AnthropicOpusInputConfig,
+      z.ZodTypeDef,
+      unknown
+    > = opusConfigSchema;
+
+    static readonly contextSize = OPUS_CONTEXT_SIZE;
+    static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
+  }
+
+  return AnthropicClaudeOpusFourDotSix;
+}

--- a/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts
@@ -1,0 +1,34 @@
+import type {
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+} from "@anthropic-ai/sdk/resources";
+import { WithAnthropicClaudeOpusFourDotSixConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six";
+import type { AnthropicOpusInputConfig } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { AnthropicStream } from "@app/lib/model_constructors/stream/clients/anthropic";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class AnthropicGlobalClaudeOpusFourDotSixStream extends WithAnthropicClaudeOpusFourDotSixConfig(
+  AnthropicStream
+) {
+  // https://platform.claude.com/docs/en/about-claude/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 6.25,
+    // 5m cache write = 1.25x base input; 1h cache write = 2x base input.
+    shortCacheCreated: 6.25,
+    longCacheCreated: 10.0,
+    cacheHit: 0.5,
+    standardInput: 5.0,
+    standardOutput: 25.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+AnthropicGlobalClaudeOpusFourDotSixStream satisfies StreamEndpointConstructor<
+  MessageCreateParamsNonStreaming,
+  RawMessageStreamEvent,
+  AnthropicOpusInputConfig
+>;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -3,6 +3,7 @@ import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
+import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
@@ -24,6 +25,8 @@ export const STREAM_ENDPOINTS = {
     AnthropicGlobalClaudeOpusFourDotEightStream,
   [AnthropicGlobalClaudeOpusFourDotSevenStream.id]:
     AnthropicGlobalClaudeOpusFourDotSevenStream,
+  [AnthropicGlobalClaudeOpusFourDotSixStream.id]:
+    AnthropicGlobalClaudeOpusFourDotSixStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
   [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:

--- a/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
+++ b/front/lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+
+import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  SUCCESS,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AnthropicGlobalClaudeOpusFourDotSixStream({
+      ANTHROPIC_API_KEY: process.env.DUST_MANAGED_ANTHROPIC_API_KEY ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Minimal reasoning effort is not supported by the model.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    // When forcing tool use, reasoning must be set to none.
+    "calc/calc/t-default/r-default/force-tool": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+    // Opus 4.6's adaptive thinking declines to reason at `low` effort on this
+    // prompt, so we only assert the stream completes.
+    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/anthropic_claude_opus_four_dot_six.test.ts
+runStreamEndpointTests(AnthropicGlobalClaudeOpusFourDotSixStream, setup);

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -9,6 +9,7 @@ export const GPT_5_MINI_MODEL_ID = "gpt-5-mini" as const;
 export const GPT_5_NANO_MODEL_ID = "gpt-5-nano" as const;
 
 export const CLAUDE_SONNET_4_6_MODEL_ID = "claude-sonnet-4-6" as const;
+export const CLAUDE_OPUS_4_6_MODEL_ID = "claude-opus-4-6" as const;
 export const CLAUDE_OPUS_4_7_MODEL_ID = "claude-opus-4-7" as const;
 export const CLAUDE_OPUS_4_8_MODEL_ID = "claude-opus-4-8" as const;
 export const CLAUDE_HAIKU_4_5_MODEL_ID = "claude-haiku-4-5-20251001" as const;
@@ -34,6 +35,7 @@ export const MODEL_IDS = [
   GPT_5_MINI_MODEL_ID,
   GPT_5_NANO_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_6_MODEL_ID,
   CLAUDE_OPUS_4_7_MODEL_ID,
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_HAIKU_4_5_MODEL_ID,
@@ -55,6 +57,7 @@ export function isModelId(value: string): value is ModelId {
 export const ORDERED_LARGE_MODEL_IDS = [
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_OPUS_4_6_MODEL_ID,
   CLAUDE_SONNET_4_6_MODEL_ID,
   GPT_5_5_MODEL_ID,
   GPT_5_4_MODEL_ID,


### PR DESCRIPTION
  ## What

  Adds **Claude Opus 4.6** (`claude-opus-4-6`) to the new `model_constructors` / `lib/llms`
  router on the `anthropic/global` endpoint, matching the model we already serve through the
  legacy router.

  Follows the same pattern as Opus 4.7/4.8 and reuses the shared
  `claude_opus_four_shared_config.ts` — Opus 4.6 has identical context size, max output
  tokens, pricing, and reasoning-effort behavior, so no new config schema is introduced.

  ## Changes

  **Opus 4.6 (new)**
  - `types/model_ids.ts`: `CLAUDE_OPUS_4_6_MODEL_ID`, registered in `MODEL_IDS` and
    `ORDERED_LARGE_MODEL_IDS`.
  - `providers/anthropic/models/claude_opus_four_dot_six.ts`: model mixin (consumes
    `claude_opus_four_shared_config.ts`).
  - `stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts`: `anthropic/global`
    endpoint with token pricing.
  - `stream/index.ts`: registered in `STREAM_ENDPOINTS`.
  - `lib/llms/providers/anthropic/models/claude_opus_four_dot_six.ts`: Dust wrapper
    (display name + canonical description from the legacy config, default reasoning effort
    `medium`, BYOK).
  - `lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six.ts` +
    `lib/llms/stream/index.ts`: registered in `DUST_STREAM_ENDPOINTS`.

  **Tests**
  - `test/endpoints/anthropic_claude_opus_four_dot_six.test.ts` (new): mirrors the 4.7/4.8
    suites (40 cases). The `reasoning/no-tools/t-default/r-low` case asserts only that the
    stream completes — Opus 4.6's adaptive thinking reliably declines to surface reasoning
    at `low` effort on that prompt.

  ## Testing

  - `npx tsgo --noEmit`: clean.
  - `biome check`: clean.
  - Opus 4.6 live endpoint suite: **40/40 passing**.