### PR TITLE
chore(analytics): drop the obsolete zendesk programmatic-usage exception

### DIFF
--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -85,20 +85,15 @@ export type UsageAggregations = {
 };
 
 /**
- * Query-side mirror of isProgrammaticUsage: API-key requests (except Zendesk),
- * messages with no context origin, or a listed programmatic origin. Single
- * source of truth for splitting analytics docs into programmatic vs user.
+ * Query-side mirror of isProgrammaticUsage: API-key requests, messages with no
+ * context origin, or a listed programmatic origin. Single source of truth for
+ * splitting analytics docs into programmatic vs user.
  */
 export function getProgrammaticUsageFilterClause(): estypes.QueryDslQueryContainer {
   return {
     bool: {
       should: [
-        {
-          bool: {
-            must: [{ term: { auth_method: "api_key" } }],
-            must_not: [{ term: { context_origin: "zendesk" } }],
-          },
-        },
+        { term: { auth_method: "api_key" } },
         { bool: { must_not: { exists: { field: "context_origin" } } } },
         { terms: { context_origin: PROGRAMMATIC_USAGE_ORIGINS } },
       ],
@@ -110,7 +105,7 @@ export function getProgrammaticUsageFilterClause(): estypes.QueryDslQueryContain
 /**
  * Build ES filter for programmatic usage tracking.
  * Matches messages that should be tracked for billing:
- * - API key requests (except Zendesk)
+ * - API key requests
  * - Unspecified context origins
  * - Programmatic origins (api, zapier, make, slack, etc.)
  */

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -40,13 +40,6 @@ export function isProgrammaticUsage(
   auth: Authenticator,
   { userMessageOrigin }: { userMessageOrigin: UserMessageOrigin }
 ): boolean {
-  // TODO(PPUL): this is a temporary fix to allow zendesk to not be tracked as
-  // programmatic usage, despite it relying on a custom API key. This should be
-  // removed once we have a proper solution for zendesk.
-  if (userMessageOrigin === "zendesk") {
-    return false;
-  }
-
   if (
     auth.authMethod() === "api_key" ||
     USAGE_ORIGINS_CLASSIFICATION[userMessageOrigin] === "programmatic"


### PR DESCRIPTION
## Description

Remove dead logic in programmatic usage tracking. Zendesk no longer uses this path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front