### PR TITLE
feat(analytics): user credits table on the new Analytics page

### DIFF
--- a/front-api/routes/w/[wId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/analytics/index.ts
@@ -20,6 +20,7 @@ import topAgents from "./top-agents";
 import topUsers from "./top-users";
 import usageMetrics from "./usage-metrics";
 import usageMetricsExport from "./usage-metrics-export";
+import userCredits from "./user-credits";
 import usersExport from "./users-export";
 
 // Mounted at /api/w/:wId/analytics. workspaceAuth is applied by the parent
@@ -47,6 +48,7 @@ app.route("/top-agents", topAgents);
 app.route("/top-users", topUsers);
 app.route("/usage-metrics-export", usageMetricsExport);
 app.route("/usage-metrics", usageMetrics);
+app.route("/user-credits", userCredits);
 app.route("/users-export", usersExport);
 
 export default app;

--- a/front-api/routes/w/[wId]/analytics/user-credits.ts
+++ b/front-api/routes/w/[wId]/analytics/user-credits.ts
@@ -1,0 +1,49 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetUserCreditsResponse } from "@app/lib/api/assistant/observability/user_credits";
+import { fetchUserCreditBreakdown } from "@app/lib/api/assistant/observability/user_credits";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasPermission } from "@front-api/middlewares/ensure_role";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+export type { GetUserCreditsResponse };
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  limit: z.coerce.number().positive().max(200).optional().default(100),
+  search: z.string().optional(),
+});
+
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureHasPermission("workspace:view_analytics"),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { days, limit, search } = ctx.req.valid("query");
+
+    const result = await fetchUserCreditBreakdown(auth, {
+      days,
+      limit,
+      search,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve user credits: ${result.error.message}`,
+        },
+      });
+    }
+
+    const body: GetUserCreditsResponse = { users: result.value };
+    return ctx.json(body);
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/NewAnalyticsPage.tsx
+++ b/front/components/pages/workspace/NewAnalyticsPage.tsx
@@ -2,6 +2,7 @@ import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/o
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
+import { WorkspaceUserCreditsTable } from "@app/components/workspace/analytics/WorkspaceUserCreditsTable";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { BarChart01, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
@@ -95,6 +96,7 @@ export function NewAnalyticsPage() {
         <SafeSuspense fallback={<ChartFallback />}>
           <AwuUsageFromAnalyticsChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>
+        <WorkspaceUserCreditsTable workspaceId={owner.sId} period={period} />
         <SafeSuspense fallback={<ChartFallback />}>
           <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>

--- a/front/components/workspace/analytics/CreditsTableCard.tsx
+++ b/front/components/workspace/analytics/CreditsTableCard.tsx
@@ -7,6 +7,51 @@ type CreditsTableRow = {
   onDoubleClick?: () => void;
 };
 
+function CreditsTableMessage({ children }: { children: string }) {
+  return (
+    <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+      {children}
+    </div>
+  );
+}
+
+interface CreditsTableBodyProps<T extends CreditsTableRow> {
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string;
+  emptyMessage: string;
+  columns: ColumnDef<T>[];
+  data: T[];
+}
+
+function CreditsTableBody<T extends CreditsTableRow>({
+  isLoading,
+  isError,
+  errorMessage,
+  emptyMessage,
+  columns,
+  data,
+}: CreditsTableBodyProps<T>) {
+  if (isLoading) {
+    return (
+      <div className="flex h-48 items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+  if (isError) {
+    return <CreditsTableMessage>{errorMessage}</CreditsTableMessage>;
+  }
+  if (data.length === 0) {
+    return <CreditsTableMessage>{emptyMessage}</CreditsTableMessage>;
+  }
+  return (
+    <div className="max-h-[44rem] overflow-y-auto [&_tbody_tr:last-child]:border-b-0">
+      <DataTable<T> data={data} columns={columns} />
+    </div>
+  );
+}
+
 interface CreditsTableCardProps<T extends CreditsTableRow> {
   title: string;
   description: string;
@@ -20,14 +65,6 @@ interface CreditsTableCardProps<T extends CreditsTableRow> {
   emptyMessage: string;
   columns: ColumnDef<T>[];
   data: T[];
-}
-
-function CreditsTableMessage({ children }: { children: string }) {
-  return (
-    <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-      {children}
-    </div>
-  );
 }
 
 export function CreditsTableCard<T extends CreditsTableRow>({
@@ -44,27 +81,6 @@ export function CreditsTableCard<T extends CreditsTableRow>({
   columns,
   data,
 }: CreditsTableCardProps<T>) {
-  function renderContent() {
-    if (isLoading) {
-      return (
-        <div className="flex h-48 items-center justify-center">
-          <Spinner size="lg" />
-        </div>
-      );
-    }
-    if (isError) {
-      return <CreditsTableMessage>{errorMessage}</CreditsTableMessage>;
-    }
-    if (data.length === 0) {
-      return <CreditsTableMessage>{emptyMessage}</CreditsTableMessage>;
-    }
-    return (
-      <div className="max-h-[44rem] overflow-y-auto [&_tbody_tr:last-child]:border-b-0">
-        <DataTable<T> data={data} columns={columns} />
-      </div>
-    );
-  }
-
   return (
     <div className="rounded-lg border border-border bg-card p-4 dark:border-border-night">
       <div className="mb-3 flex items-center justify-between gap-4">
@@ -84,7 +100,14 @@ export function CreditsTableCard<T extends CreditsTableRow>({
           className="w-64"
         />
       </div>
-      {renderContent()}
+      <CreditsTableBody
+        isLoading={isLoading}
+        isError={isError}
+        errorMessage={errorMessage}
+        emptyMessage={emptyMessage}
+        columns={columns}
+        data={data}
+      />
     </div>
   );
 }

--- a/front/components/workspace/analytics/CreditsTableCard.tsx
+++ b/front/components/workspace/analytics/CreditsTableCard.tsx
@@ -1,0 +1,90 @@
+import { DataTable, SearchInput, Spinner } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+// Minimal row shape DataTable accepts (its optional row-interaction fields).
+type CreditsTableRow = {
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+};
+
+interface CreditsTableCardProps<T extends CreditsTableRow> {
+  title: string;
+  description: string;
+  searchName: string;
+  searchPlaceholder: string;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string;
+  emptyMessage: string;
+  columns: ColumnDef<T>[];
+  data: T[];
+}
+
+function CreditsTableMessage({ children }: { children: string }) {
+  return (
+    <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+      {children}
+    </div>
+  );
+}
+
+export function CreditsTableCard<T extends CreditsTableRow>({
+  title,
+  description,
+  searchName,
+  searchPlaceholder,
+  searchValue,
+  onSearchChange,
+  isLoading,
+  isError,
+  errorMessage,
+  emptyMessage,
+  columns,
+  data,
+}: CreditsTableCardProps<T>) {
+  function renderContent() {
+    if (isLoading) {
+      return (
+        <div className="flex h-48 items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      );
+    }
+    if (isError) {
+      return <CreditsTableMessage>{errorMessage}</CreditsTableMessage>;
+    }
+    if (data.length === 0) {
+      return <CreditsTableMessage>{emptyMessage}</CreditsTableMessage>;
+    }
+    return (
+      <div className="max-h-[44rem] overflow-y-auto [&_tbody_tr:last-child]:border-b-0">
+        <DataTable<T> data={data} columns={columns} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 dark:border-border-night">
+      <div className="mb-3 flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-base font-medium text-foreground dark:text-foreground-night">
+            {title}
+          </h3>
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {description}
+          </p>
+        </div>
+        <SearchInput
+          name={searchName}
+          placeholder={searchPlaceholder}
+          value={searchValue}
+          onChange={onSearchChange}
+          className="w-64"
+        />
+      </div>
+      {renderContent()}
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -1,0 +1,169 @@
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
+import { useDebounce } from "@app/hooks/useDebounce";
+import type {
+  UserCreditAgent,
+  UserCreditRow,
+} from "@app/lib/api/assistant/observability/user_credits";
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import { useWorkspaceUserCredits } from "@app/lib/swr/workspaces";
+import { Avatar, DataTable, Tooltip } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+
+interface UserCreditRowData extends UserCreditRow {
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+}
+
+type UserCreditInfo = CellContext<UserCreditRowData, unknown>;
+
+function TopAgentsCell({ agents }: { agents: UserCreditAgent[] }) {
+  if (agents.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        —
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2 py-1">
+      {agents.slice(0, 3).map((agent) => {
+        const row = (
+          <div className="flex items-center gap-1.5">
+            <Avatar
+              name={agent.name}
+              visual={agent.pictureUrl ?? undefined}
+              size="xs"
+              isRounded
+            />
+            <span className="flex min-w-0 items-baseline gap-1.5">
+              <span className="truncate text-sm">{agent.name}</span>
+              <span className="shrink-0 text-xs text-muted-foreground dark:text-muted-foreground-night">
+                {agent.modelDisplayName}
+              </span>
+            </span>
+          </div>
+        );
+        return agent.description ? (
+          <Tooltip
+            key={agent.agentId}
+            label={agent.description}
+            trigger={row}
+            tooltipTriggerAsChild
+          />
+        ) : (
+          <div key={agent.agentId}>{row}</div>
+        );
+      })}
+    </div>
+  );
+}
+
+const columns: ColumnDef<UserCreditRowData>[] = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: "User",
+    meta: { sizeRatio: 30 },
+    cell: (info: UserCreditInfo) => {
+      const { name, imageUrl } = info.row.original;
+      return (
+        <DataTable.CellContent>
+          <div className="flex items-center gap-2">
+            <Avatar
+              name={name}
+              visual={imageUrl ?? undefined}
+              size="xs"
+              isRounded
+            />
+            <span className="truncate text-sm">{name}</span>
+          </div>
+        </DataTable.CellContent>
+      );
+    },
+  },
+  {
+    id: "messageCount",
+    accessorKey: "messageCount",
+    header: "Messages",
+    meta: { sizeRatio: 13 },
+    cell: (info: UserCreditInfo) => (
+      <DataTable.BasicCellContent
+        label={info.row.original.messageCount.toLocaleString()}
+      />
+    ),
+  },
+  {
+    id: "credits",
+    accessorKey: "credits",
+    header: "Credits",
+    meta: { sizeRatio: 13 },
+    cell: (info: UserCreditInfo) => (
+      <DataTable.CellContent>
+        <Tooltip
+          label={`${formatCredits(info.row.original.credits)} credits`}
+          tooltipTriggerAsChild
+          trigger={
+            <span className="text-sm">
+              {formatCreditsCompact(info.row.original.credits)}
+            </span>
+          }
+        />
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "topAgents",
+    header: "Top agents",
+    meta: { sizeRatio: 44 },
+    cell: (info: UserCreditInfo) => (
+      <DataTable.CellContent>
+        <TopAgentsCell agents={info.row.original.topAgents} />
+      </DataTable.CellContent>
+    ),
+  },
+];
+
+interface WorkspaceUserCreditsTableProps {
+  workspaceId: string;
+  period: ObservabilityTimeRangeType;
+}
+
+export function WorkspaceUserCreditsTable({
+  workspaceId,
+  period,
+}: WorkspaceUserCreditsTableProps) {
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: 300,
+  });
+
+  const { userCredits, isUserCreditsLoading, isUserCreditsError } =
+    useWorkspaceUserCredits({
+      workspaceId,
+      days: period,
+      limit: 100,
+      search: debouncedValue || undefined,
+      disabled: !workspaceId,
+    });
+
+  return (
+    <CreditsTableCard<UserCreditRowData>
+      title="Users by credits"
+      description={`Top 100 users by credits over the last ${period} days, with their most-used agents.`}
+      searchName="user-credits-search"
+      searchPlaceholder="Search a user…"
+      searchValue={inputValue}
+      onSearchChange={setValue}
+      isLoading={isUserCreditsLoading}
+      isError={Boolean(isUserCreditsError)}
+      errorMessage="Failed to load user credits."
+      emptyMessage={
+        debouncedValue
+          ? `No user matches "${inputValue}".`
+          : "No user activity for this selection."
+      }
+      columns={columns}
+      data={userCredits}
+    />
+  );
+}

--- a/front/lib/api/assistant/observability/user_credits.ts
+++ b/front/lib/api/assistant/observability/user_credits.ts
@@ -1,0 +1,180 @@
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import {
+  buildAgentAnalyticsBaseQuery,
+  daysToInstantRange,
+} from "@app/lib/api/assistant/observability/utils";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { FREE_ORIGINS } from "@app/lib/metronome/events";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type UserCreditAgent = {
+  agentId: string;
+  name: string;
+  pictureUrl: string | null;
+  modelDisplayName: string;
+  description: string;
+};
+
+export type UserCreditRow = {
+  userId: string;
+  name: string;
+  imageUrl: string | null;
+  messageCount: number;
+  credits: number;
+  topAgents: UserCreditAgent[];
+};
+
+export type GetUserCreditsResponse = { users: UserCreditRow[] };
+
+type AgentBucket = { key: string; doc_count: number };
+
+type UserBucket = {
+  key: string;
+  doc_count: number;
+  credits?: estypes.AggregationsSumAggregate;
+  top_agents?: estypes.AggregationsMultiBucketAggregateBase<AgentBucket>;
+};
+
+type UserCreditAggs = {
+  by_user?: estypes.AggregationsMultiBucketAggregateBase<UserBucket>;
+};
+
+// Per-user AWU credits (cost.full_awu) over the last `days`: message count,
+// credits, and the user's top 3 agents (with each agent's current model and
+// description). Ranked by credits desc. Non-free scope and the programmatic
+// "unknown" user (no attributable person) are excluded to keep this a
+// real-users table. When `search` is set, the ranking is scoped to the matching
+// users so matches outside the top `limit` still surface.
+export async function fetchUserCreditBreakdown(
+  auth: Authenticator,
+  { days, limit, search }: { days: number; limit: number; search?: string }
+): Promise<Result<UserCreditRow[], Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const { startDate, endDate } = daysToInstantRange(days, "UTC");
+
+  let includeUserIds: string[] | undefined;
+  if (search) {
+    const matches = await UserResource.searchUsers(auth, {
+      searchTerm: search,
+      offset: 0,
+      limit,
+    });
+    if (matches.isErr()) {
+      return matches;
+    }
+    includeUserIds = matches.value.users.map((user) => user.sId);
+    if (includeUserIds.length === 0) {
+      return new Ok([]);
+    }
+  }
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    startDate,
+    endDate,
+  });
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [baseQuery],
+      must_not: [
+        { terms: { context_origin: [...FREE_ORIGINS] } },
+        { term: { user_id: "unknown" } },
+      ],
+    },
+  };
+
+  const result = await searchAnalytics<never, UserCreditAggs>(query, {
+    aggregations: {
+      by_user: {
+        terms: {
+          field: "user_id",
+          size: limit,
+          order: { credits: "desc" },
+          ...(includeUserIds ? { include: includeUserIds } : {}),
+        },
+        aggs: {
+          credits: { sum: { field: "cost.full_awu" } },
+          top_agents: {
+            terms: {
+              field: "agent_id",
+              size: 3,
+              order: { agent_credits: "desc" },
+            },
+            aggs: { agent_credits: { sum: { field: "cost.full_awu" } } },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<UserBucket>(
+    result.value.aggregations?.by_user?.buckets
+  );
+  if (buckets.length === 0) {
+    return new Ok([]);
+  }
+
+  const userIds = buckets.map((bucket) => String(bucket.key));
+  const agentIds = Array.from(
+    new Set(
+      buckets.flatMap((bucket) =>
+        bucketsToArray<AgentBucket>(bucket.top_agents?.buckets).map((agent) =>
+          String(agent.key)
+        )
+      )
+    )
+  );
+
+  const [users, agents] = await Promise.all([
+    UserResource.fetchByIds(userIds),
+    agentIds.length > 0
+      ? getAgentConfigurations(auth, { agentIds, variant: "light" })
+      : Promise.resolve([]),
+  ]);
+
+  const usersById = new Map(users.map((user) => [user.sId, user]));
+  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
+
+  const rows: UserCreditRow[] = buckets.map((bucket) => {
+    const userId = String(bucket.key);
+    const user = usersById.get(userId);
+
+    const topAgents: UserCreditAgent[] = bucketsToArray<AgentBucket>(
+      bucket.top_agents?.buckets
+    ).map((agentBucket) => {
+      const agentId = String(agentBucket.key);
+      const agent = agentsById.get(agentId);
+      return {
+        agentId,
+        name: agent?.name ?? "Unknown agent",
+        pictureUrl: agent?.pictureUrl ?? null,
+        modelDisplayName: agent
+          ? (getSupportedModelConfig(agent.model)?.displayName ??
+            agent.model.modelId)
+          : "—",
+        description: agent?.description ?? "",
+      };
+    });
+
+    return {
+      userId,
+      name: user?.fullName() || user?.username || user?.email || "Unknown user",
+      imageUrl: user?.imageUrl ?? null,
+      messageCount: bucket.doc_count,
+      credits: Math.round(bucket.credits?.value ?? 0),
+      topAgents,
+    };
+  });
+
+  return new Ok(rows);
+}

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -25,6 +25,7 @@ import type {
   GetWorkspaceToolsResponse,
   GetWorkspaceToolUsageResponse,
 } from "@app/lib/api/assistant/observability/tool_usage";
+import type { GetUserCreditsResponse } from "@app/lib/api/assistant/observability/user_credits";
 import type {
   GetNoWorkspaceAuthContextResponseType,
   GetWorkspaceAuthContextResponseType,
@@ -458,6 +459,37 @@ export function useWorkspaceTopUsers({
     isTopUsersLoading: !error && !data && !disabled,
     isTopUsersError: error,
     isTopUsersValidating: isValidating,
+  };
+}
+
+export function useWorkspaceUserCredits({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  limit = 100,
+  search,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  limit?: number;
+  search?: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetUserCreditsResponse> = fetcher;
+  const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
+  const key = `/api/w/${workspaceId}/analytics/user-credits?days=${days}&limit=${limit}${searchParam}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    userCredits: data?.users ?? emptyArray(),
+    isUserCreditsLoading: !error && !data && !disabled,
+    isUserCreditsError: error,
+    isUserCreditsValidating: isValidating,
   };
 }
 


### PR DESCRIPTION
## Description

Add a "Users by credits" table below the credit chart: per-user message count, AWU credits (cost.full_awu) and the user's top 3 agents (ranked by cost), each showing the agent's current model with its description on hover. Ranked by credits desc, following the page time-range selector, with server-side debounced search so matches outside the top 100 still surface. Free origins and the programmatic "unknown" user (no attributable person) are excluded to keep this a real-users table.

## Tests

Local

## Risk

None, feature flagged

## Deploy Plan

Front