### PR TITLE
refactor(llm): factor the shared Claude Opus config mixin into a factory

### DIFF
--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_eight.ts
@@ -1,35 +1,5 @@
-import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import {
-  type AnthropicOpusInputConfig,
-  OPUS_CONTEXT_SIZE,
-  OPUS_MAX_OUTPUT_TOKENS,
-  opusConfigSchema,
-} from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { makeAnthropicOpusConfigMixin } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { CLAUDE_OPUS_4_8_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
-import type { z } from "zod";
-
-export function WithAnthropicClaudeOpusFourDotEightConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
->(Base: TBase) {
-  abstract class AnthropicClaudeOpusFourDotEight extends Base {
-    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
-    // instance type carries the Opus config (not the wide `InputConfig`).
-    declare ["constructor"]: BaseEndpointConfiguration<AnthropicOpusInputConfig>;
-
-    static readonly modelId = CLAUDE_OPUS_4_8_MODEL_ID;
-
-    static readonly configSchema: z.ZodType<
-      AnthropicOpusInputConfig,
-      z.ZodTypeDef,
-      unknown
-    > = opusConfigSchema;
-
-    static readonly contextSize = OPUS_CONTEXT_SIZE;
-    static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
-  }
-
-  return AnthropicClaudeOpusFourDotEight;
-}
+export const WithAnthropicClaudeOpusFourDotEightConfig =
+  makeAnthropicOpusConfigMixin(CLAUDE_OPUS_4_8_MODEL_ID);

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_seven.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_seven.ts
@@ -1,35 +1,5 @@
-import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import {
-  type AnthropicOpusInputConfig,
-  OPUS_CONTEXT_SIZE,
-  OPUS_MAX_OUTPUT_TOKENS,
-  opusConfigSchema,
-} from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { makeAnthropicOpusConfigMixin } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { CLAUDE_OPUS_4_7_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
-import type { z } from "zod";
-
-export function WithAnthropicClaudeOpusFourDotSevenConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
->(Base: TBase) {
-  abstract class AnthropicClaudeOpusFourDotSeven extends Base {
-    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
-    // instance type carries the Opus config (not the wide `InputConfig`).
-    declare ["constructor"]: BaseEndpointConfiguration<AnthropicOpusInputConfig>;
-
-    static readonly modelId = CLAUDE_OPUS_4_7_MODEL_ID;
-
-    static readonly configSchema: z.ZodType<
-      AnthropicOpusInputConfig,
-      z.ZodTypeDef,
-      unknown
-    > = opusConfigSchema;
-
-    static readonly contextSize = OPUS_CONTEXT_SIZE;
-    static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
-  }
-
-  return AnthropicClaudeOpusFourDotSeven;
-}
+export const WithAnthropicClaudeOpusFourDotSevenConfig =
+  makeAnthropicOpusConfigMixin(CLAUDE_OPUS_4_7_MODEL_ID);

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_dot_six.ts
@@ -1,35 +1,5 @@
-import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
-import {
-  type AnthropicOpusInputConfig,
-  OPUS_CONTEXT_SIZE,
-  OPUS_MAX_OUTPUT_TOKENS,
-  opusConfigSchema,
-} from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
+import { makeAnthropicOpusConfigMixin } from "@app/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config";
 import { CLAUDE_OPUS_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 
-import type { z } from "zod";
-
-export function WithAnthropicClaudeOpusFourDotSixConfig<
-  TBase extends abstract new (
-    ...args: any[]
-  ) => object,
->(Base: TBase) {
-  abstract class AnthropicClaudeOpusFourDotSix extends Base {
-    // Narrow `Client`'s `["constructor"]` to this model's precise config so the
-    // instance type carries the Opus config (not the wide `InputConfig`).
-    declare ["constructor"]: BaseEndpointConfiguration<AnthropicOpusInputConfig>;
-
-    static readonly modelId = CLAUDE_OPUS_4_6_MODEL_ID;
-
-    static readonly configSchema: z.ZodType<
-      AnthropicOpusInputConfig,
-      z.ZodTypeDef,
-      unknown
-    > = opusConfigSchema;
-
-    static readonly contextSize = OPUS_CONTEXT_SIZE;
-    static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
-  }
-
-  return AnthropicClaudeOpusFourDotSix;
-}
+export const WithAnthropicClaudeOpusFourDotSixConfig =
+  makeAnthropicOpusConfigMixin(CLAUDE_OPUS_4_6_MODEL_ID);

--- a/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
+++ b/front/lib/model_constructors/providers/anthropic/models/claude_opus_four_shared_config.ts
@@ -1,13 +1,15 @@
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import {
   inputConfigSchema,
   temperatureSchema,
 } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelId } from "@app/lib/model_constructors/types/model_ids";
 
 import { z } from "zod";
 
-// Shared input contract for the Claude Opus 4.x models (4.7, 4.8): same context
-// window, output cap, reasoning efforts, and temperature handling.
+// Shared input contract for the Claude Opus 4.x models (4.6, 4.7, 4.8): same
+// context window, output cap, reasoning efforts, and temperature handling.
 export const OPUS_CONTEXT_SIZE = 250_000;
 export const OPUS_MAX_OUTPUT_TOKENS = 64_000;
 
@@ -34,3 +36,35 @@ export const opusConfigSchema = z.union([
 ]);
 
 export type AnthropicOpusInputConfig = z.infer<typeof opusConfigSchema>;
+
+// Builds the config mixin shared by every Claude Opus 4.x model. The models
+// only differ by `modelId`; everything else (schema, context window, output
+// cap) is identical, so each model file is a one-line binding of this factory.
+export function makeAnthropicOpusConfigMixin<const M extends ModelId>(
+  modelId: M
+) {
+  return function WithAnthropicOpusConfig<
+    TBase extends abstract new (
+      ...args: any[]
+    ) => object,
+  >(Base: TBase) {
+    abstract class AnthropicClaudeOpus extends Base {
+      // Narrow `Client`'s `["constructor"]` to this model's precise config so
+      // the instance type carries the Opus config (not the wide `InputConfig`).
+      declare ["constructor"]: BaseEndpointConfiguration<AnthropicOpusInputConfig>;
+
+      static readonly modelId = modelId;
+
+      static readonly configSchema: z.ZodType<
+        AnthropicOpusInputConfig,
+        z.ZodTypeDef,
+        unknown
+      > = opusConfigSchema;
+
+      static readonly contextSize = OPUS_CONTEXT_SIZE;
+      static readonly maxOutputTokens = OPUS_MAX_OUTPUT_TOKENS;
+    }
+
+    return AnthropicClaudeOpus;
+  };
+}


### PR DESCRIPTION
  ## What

  The three Claude Opus provider model files (4.6, 4.7, 4.8) were identical except for their
  `modelId`. This factors the duplicated mixin body into a single
  `makeAnthropicOpusConfigMixin(modelId)` factory, so each model file becomes a one-line
  binding and the three can no longer drift apart.

  Pure refactor — no behavior change.

  ## Changes

  - `providers/anthropic/models/claude_opus_four_shared_config.ts`: added
    `makeAnthropicOpusConfigMixin<const M extends ModelId>(modelId)`, which builds the config
    mixin (`["constructor"]` narrowing, `configSchema`, `contextSize`, `maxOutputTokens`).
    Generic over `const M` so each model keeps its precise `modelId` literal type.
  - `providers/anthropic/models/claude_opus_four_dot_{six,seven,eight}.ts`: each reduced to a
    one-line `makeAnthropicOpusConfigMixin(...)` binding, preserving the same named
    `WithAnthropicClaudeOpusFourDot…Config` exports their endpoints import.

  ## Why

  The mixin body (schema, context window, output cap, constructor narrowing) is genuinely
  shared across all Opus 4.x models — the only per-model difference is `modelId`. Centralizing
  it removes copy-paste and guarantees the models stay in lockstep.

  The endpoint files (`anthropic_global_claude_opus_four_dot_*.ts`) were intentionally left
  as-is: their near-identity is the universal per-endpoint declaration boilerplate plus
  coincidentally-equal pricing (which is conceptually a per-model attribute), not shared
  behavior worth centralizing.

  ## Testing

  - `npx tsgo --noEmit`: clean.
  - `biome check`: clean.
  - Runtime check: all three Opus endpoints still register with correct distinct ids
    (`anthropic/anthropic/global/claude-opus-4-{6,7,8}`), confirming the factory captures each
    `modelId`.