### PR TITLE
fix: extension sidebar and topbar ui

### DIFF
--- a/extension/config/tailwind.config.js
+++ b/extension/config/tailwind.config.js
@@ -6,6 +6,10 @@ module.exports = {
   presets: [preset],
   theme: {
     extend: {
+      height: {
+        title: "3rem",
+        panel: "var(--panel-height)", // defined in global.css,
+      },
       fontWeight: {
         medium: "450",
         semibold: "550",

--- a/extension/ui/components/conversation/ConversationLayout.tsx
+++ b/extension/ui/components/conversation/ConversationLayout.tsx
@@ -39,7 +39,10 @@ export const ConversationLayout = ({
   return (
     <FileDropProvider>
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent side="left" className="flex w-full max-w-72 flex-1">
+        <SheetContent
+          side="left"
+          className="flex w-full max-w-72 flex-1 bg-app-background dark:bg-app-background-night"
+        >
           <SheetHeader className="bg-muted-background p-0" hideButton>
             <SheetTitle className="hidden" />
           </SheetHeader>

--- a/extension/ui/css/global.css
+++ b/extension/ui/css/global.css
@@ -3,6 +3,11 @@
 
 /* Custom scrollbar styles */
 @layer base {
+  :root {
+    --banner-height: 0px;
+    --panel-height: calc(100dvh - var(--banner-height));
+  }
+
   * {
     scrollbar-width: thin;
   }

--- a/extension/ui/pages/PodMainPage.tsx
+++ b/extension/ui/pages/PodMainPage.tsx
@@ -84,7 +84,7 @@ export const PodMainPage = () => {
       <ConversationLayout
         title=""
         centerActions={
-          <div className="flex h-14 items-end">
+          <div className="flex h-title items-end">
             <TabsList border={false}>
               <TabsTrigger
                 value="conversations"


### PR DESCRIPTION
## Description

This PR fixes UI styling issues in the browser extension's sidebar and topbar components.

- Adds explicit background color (`bg-app-background` / `bg-app-background-night`) to the `SheetContent` sidebar to ensure correct theming in both light and dark modes.
- Defines a `--panel-height` CSS variable in `global.css` and exposes it as a `panel` height utility in the Tailwind config, along with a `title` height (`3rem`) to match what was done for front in https://github.com/dust-tt/dust/pull/26995.

## Tests

Manually.

## Risks

Low — purely cosmetic/styling changes scoped to the browser extension.

## Deploy Plan

Standard deployment.
