### PR TITLE
refactor(editor): shared slash command item builders

### DIFF
--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -38,9 +38,6 @@ import {
 // exactly seven 3.25rem rows without showing a partial row or leaving extra bottom space.
 const LIST_MAX_HEIGHT_CLASS_NAME = "max-h-[22.75rem]";
 
-const COMMANDS_SECTION_LABEL = "Commands";
-const CAPABILITIES_SECTION_LABEL = "Capabilities";
-
 export function filterInputBarSlashSuggestions({
   commands,
   query,
@@ -196,15 +193,12 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
                   ),
                   id: `command-${capability.command.id}`,
                   label: capability.command.label,
-                  sectionLabel: COMMANDS_SECTION_LABEL,
                 },
               ];
             case "skill":
               return [
                 {
-                  ...getSkillSlashCommandItem(capability.skill, {
-                    sectionLabel: CAPABILITIES_SECTION_LABEL,
-                  }),
+                  ...getSkillSlashCommandItem(capability.skill),
                   data: capability,
                   id: `skill-${capability.skill.sId}`,
                 },
@@ -212,9 +206,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
             case "tool":
               return [
                 {
-                  ...getToolSlashCommandItem(capability.serverView, {
-                    sectionLabel: CAPABILITIES_SECTION_LABEL,
-                  }),
+                  ...getToolSlashCommandItem(capability.serverView),
                   data: capability,
                   id: `tool-${capability.serverView.sId}`,
                 },

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.test.ts
@@ -163,9 +163,7 @@ describe("getSkillSlashCommandItem", () => {
       userFacingDescription: "Draft structured memos.",
     });
 
-    const item = getSkillSlashCommandItem(skill, {
-      sectionLabel: "Capabilities",
-    });
+    const item = getSkillSlashCommandItem(skill);
 
     expect(item).toMatchObject({
       action: "select-skill",
@@ -176,7 +174,6 @@ describe("getSkillSlashCommandItem", () => {
       hasDetails: true,
       id: "skill_create_memo",
       label: "Create memo",
-      sectionLabel: "Capabilities",
     });
   });
 });
@@ -192,9 +189,7 @@ describe("getToolSlashCommandItem", () => {
       sId: "mcp_server_view_linear",
     });
 
-    const item = getToolSlashCommandItem(tool, {
-      sectionLabel: "Capabilities",
-    });
+    const item = getToolSlashCommandItem(tool);
 
     expect(item).toMatchObject({
       action: "select-tool",
@@ -210,7 +205,6 @@ describe("getToolSlashCommandItem", () => {
       hasDetails: true,
       id: "mcp_server_view_linear",
       label: "Create ticket (Product)",
-      sectionLabel: "Capabilities",
     });
   });
 });

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -11,6 +11,9 @@ import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/
 
 export const SELECT_SKILL_SLASH_COMMAND_ACTION = "select-skill";
 export const SELECT_TOOL_SLASH_COMMAND_ACTION = "select-tool";
+export const RUN_COMMAND_SLASH_COMMAND_ACTION = "run-command";
+export const INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION = "insert-knowledge-node";
+export const ADD_CAPABILITY_SLASH_COMMAND_ACTION = "add-capability";
 
 export type SlashCommandSkillSuggestion = Pick<
   SkillWithoutInstructionsAndToolsType,
@@ -47,6 +50,22 @@ export interface ToolSlashCommand extends SlashCommand {
   };
 }
 
+export interface RunCommandSlashCommand<TCommand = unknown>
+  extends SlashCommand {
+  action: typeof RUN_COMMAND_SLASH_COMMAND_ACTION;
+  data: {
+    command: TCommand;
+  };
+}
+
+export interface InsertKnowledgeSlashCommand extends SlashCommand {
+  action: typeof INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION;
+}
+
+export interface AddCapabilitySlashCommand extends SlashCommand {
+  action: typeof ADD_CAPABILITY_SLASH_COMMAND_ACTION;
+}
+
 export function isSkillSlashCommand(
   item: SlashCommand
 ): item is SkillSlashCommand {
@@ -57,6 +76,24 @@ export function isToolSlashCommand(
   item: SlashCommand
 ): item is ToolSlashCommand {
   return item.action === SELECT_TOOL_SLASH_COMMAND_ACTION;
+}
+
+export function isRunCommandSlashCommand<TCommand = unknown>(
+  item: SlashCommand
+): item is RunCommandSlashCommand<TCommand> {
+  return item.action === RUN_COMMAND_SLASH_COMMAND_ACTION;
+}
+
+export function isInsertKnowledgeSlashCommand(
+  item: SlashCommand
+): item is InsertKnowledgeSlashCommand {
+  return item.action === INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION;
+}
+
+export function isAddCapabilitySlashCommand(
+  item: SlashCommand
+): item is AddCapabilitySlashCommand {
+  return item.action === ADD_CAPABILITY_SLASH_COMMAND_ACTION;
 }
 
 export function matchesSlashCommandCapabilityQuery({
@@ -112,8 +149,7 @@ export function getToolSlashCommandLabel(tool: SlashCommandToolSuggestion) {
 }
 
 export function getSkillSlashCommandItem(
-  skill: SlashCommandSkillSuggestion,
-  { sectionLabel }: { sectionLabel?: string } = {}
+  skill: SlashCommandSkillSuggestion
 ): SkillSlashCommand {
   return {
     action: SELECT_SKILL_SLASH_COMMAND_ACTION,
@@ -125,13 +161,11 @@ export function getSkillSlashCommandItem(
     icon: getSkillAvatarIcon(skill),
     id: skill.sId,
     label: skill.name,
-    sectionLabel,
   };
 }
 
 export function getToolSlashCommandItem(
-  tool: SlashCommandToolSuggestion,
-  { sectionLabel }: { sectionLabel?: string } = {}
+  tool: SlashCommandToolSuggestion
 ): ToolSlashCommand {
   const name = getToolSlashCommandLabel(tool);
   const description = getMcpServerViewDescription(tool);
@@ -151,6 +185,5 @@ export function getToolSlashCommandItem(
     icon: () => getAvatar(tool.server),
     id: tool.sId,
     label: name,
-    sectionLabel,
   };
 }

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -40,7 +40,6 @@ export interface SlashCommand {
   icon: React.ComponentType<any>;
   id: string;
   label: string;
-  sectionLabel?: string;
   tooltip?: SlashCommandTooltip;
 }
 
@@ -197,11 +196,6 @@ export const SlashCommandDropdown = forwardRef<
           ) : (
             <div ref={listRef} className={listMaxHeightClassName}>
               {items.map((item, index) => {
-                const sectionLabel =
-                  item.sectionLabel &&
-                  items[index - 1]?.sectionLabel !== item.sectionLabel
-                    ? item.sectionLabel
-                    : undefined;
                 const canShowDetails = !!onItemDetails && !!item.hasDetails;
                 const menuItem = (
                   <DropdownMenuItem
@@ -260,16 +254,7 @@ export const SlashCommandDropdown = forwardRef<
                   menuItem
                 );
 
-                return (
-                  <Fragment key={item.id}>
-                    {sectionLabel ? (
-                      <div className="px-3 py-2 text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
-                        {sectionLabel}
-                      </div>
-                    ) : null}
-                    {itemContent}
-                  </Fragment>
-                );
+                return <Fragment key={item.id}>{itemContent}</Fragment>;
               })}
             </div>
           )}

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems.ts
@@ -1,0 +1,91 @@
+import {
+  getSkillSlashCommandItem,
+  getToolSlashCommandItem,
+  getToolSlashCommandLabel,
+  matchesSlashCommandCapabilityQuery,
+  type SlashCommandSkillSuggestion,
+  type SlashCommandToolSuggestion,
+  sortSlashCommandCapabilityMatches,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export function filterSlashCommandItems(
+  items: SlashCommand[],
+  query: string
+): SlashCommand[] {
+  if (!query) {
+    return items;
+  }
+
+  const normalizedQuery = query.toLowerCase();
+
+  return items.filter(
+    (command) =>
+      command.label.toLowerCase().includes(normalizedQuery) ||
+      command.description?.toLowerCase().includes(normalizedQuery) ||
+      command.tooltip?.description.toLowerCase().includes(normalizedQuery)
+  );
+}
+
+export function buildCapabilitySlashCommandItems({
+  excludeSkillId,
+  query,
+  skillFilter,
+  skills,
+  toolFilter,
+  tools,
+}: {
+  excludeSkillId?: string | null;
+  query: string;
+  skillFilter?: (skill: SlashCommandSkillSuggestion) => boolean;
+  skills: SlashCommandSkillSuggestion[];
+  toolFilter?: (tool: SlashCommandToolSuggestion) => boolean;
+  tools: SlashCommandToolSuggestion[];
+}): SlashCommand[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const matches = sortSlashCommandCapabilityMatches({
+    normalizedQuery,
+    items: [
+      ...skills
+        .filter((skill) => skill.sId !== excludeSkillId)
+        .filter((skill) => skillFilter?.(skill) ?? true)
+        .filter((skill) =>
+          matchesSlashCommandCapabilityQuery({
+            label: skill.name,
+            query: normalizedQuery,
+          })
+        )
+        .map((skill) => ({
+          kind: "skill" as const,
+          skill,
+          sortName: skill.name.toLowerCase(),
+        })),
+      ...tools
+        .filter((tool) => toolFilter?.(tool) ?? true)
+        .filter((tool) =>
+          matchesSlashCommandCapabilityQuery({
+            label: getToolSlashCommandLabel(tool),
+            query: normalizedQuery,
+          })
+        )
+        .map((tool) => ({
+          kind: "tool" as const,
+          tool,
+          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
+        })),
+    ],
+  });
+
+  return matches.map((match) => {
+    switch (match.kind) {
+      case "skill":
+        return getSkillSlashCommandItem(match.skill);
+      case "tool":
+        return getToolSlashCommandItem(match.tool);
+      default:
+        return assertNever(match);
+    }
+  });
+}

--- a/front/components/editor/extensions/shared/slash_suggestion/slashCommandIcons.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/slashCommandIcons.tsx
@@ -1,0 +1,6 @@
+import { ResourceAvatar } from "@app/components/resources/resources_icons";
+import type React from "react";
+
+export function getSlashCommandAvatarIcon(icon: React.ComponentType) {
+  return () => <ResourceAvatar icon={icon} size="sm" />;
+}

--- a/front/components/editor/extensions/shared/slash_suggestion/slashStaticCommands.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/slashStaticCommands.ts
@@ -1,0 +1,16 @@
+import { ADD_CAPABILITY_SLASH_COMMAND_ACTION } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { getSlashCommandAvatarIcon } from "@app/components/editor/extensions/shared/slash_suggestion/slashCommandIcons";
+import { ShapesPlus } from "@dust-tt/sparkle";
+
+export function createAddCapabilitySlashCommand(
+  description: string
+): SlashCommand {
+  return {
+    action: ADD_CAPABILITY_SLASH_COMMAND_ACTION,
+    description,
+    icon: getSlashCommandAvatarIcon(ShapesPlus),
+    id: "add-capability",
+    label: "Add capability",
+  };
+}

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -127,7 +127,6 @@ describe("buildSkillBuilderSlashCommandItems", () => {
         },
       },
       description: "Draft structured memos.",
-      sectionLabel: "Capabilities",
     });
   });
 
@@ -156,8 +155,6 @@ describe("buildSkillBuilderSlashCommandItems", () => {
       "mcp_server_view_search",
       "skill_search_checklist",
     ]);
-    expect(result[1]?.sectionLabel).toBe("Capabilities");
-    expect(result[2]?.sectionLabel).toBeUndefined();
     expect(result[1]).toMatchObject({
       action: "select-tool",
       data: {
@@ -170,7 +167,7 @@ describe("buildSkillBuilderSlashCommandItems", () => {
     });
   });
 
-  it("labels the first tool section when there are no matching skills", () => {
+  it("includes tools when there are no matching skills", () => {
     const result = buildSkillBuilderSlashCommandItems({
       baseItems: [],
       includeSkillSuggestions: true,
@@ -187,7 +184,7 @@ describe("buildSkillBuilderSlashCommandItems", () => {
 
     expect(result[0]).toMatchObject({
       id: "mcp_server_view_search",
-      sectionLabel: "Capabilities",
+      action: "select-tool",
     });
   });
 });

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -148,13 +148,11 @@ export function buildSkillBuilderSlashCommandItems({
     query,
     skills,
     tools,
-  }).map((capability, index) => {
-    const sectionLabel = index === 0 ? "Capabilities" : undefined;
-
-    return capability.kind === "skill"
-      ? getSkillSlashCommandItem(capability.skill, { sectionLabel })
-      : getToolSlashCommandItem(capability.tool, { sectionLabel });
-  });
+  }).map((capability) =>
+    capability.kind === "skill"
+      ? getSkillSlashCommandItem(capability.skill)
+      : getToolSlashCommandItem(capability.tool)
+  );
 
   return [...visibleBaseItems, ...capabilityItems];
 }


### PR DESCRIPTION
## Description

Extracts shared slash command item builders and typed action guards into the `slash_suggestion/` shared layer. `buildCapabilitySlashCommandItems` consolidates skill+tool filtering, query matching, and `sortSlashCommandCapabilityMatches` into a single reusable function consumed across editor extensions. `filterSlashCommandItems` handles generic label/description/tooltip filtering for non-capability command lists.

Three new action constants (`run-command`, `insert-knowledge-node`, `add-capability`), their typed interfaces (`RunCommandSlashCommand<TCommand>`, `InsertKnowledgeSlashCommand`, `AddCapabilitySlashCommand`), and narrowing guards (`isRunCommandSlashCommand`, `isInsertKnowledgeSlashCommand`, `isAddCapabilitySlashCommand`) are added to `SlashCommandCapabilitiesItems.ts`. `createAddCapabilitySlashCommand` and `getSlashCommandAvatarIcon` are extracted as shared static command factories.

`sectionLabel` is removed from the `SlashCommand` interface and the `SlashCommandDropdown` render loop — section headers are no longer a data concern mixed into item shape.

## Tests

Existing unit tests in `SlashCommandCapabilitiesItems.test.ts` updated to reflect the removed `sectionLabel` parameter — builders now have a cleaner single-argument API.

## Risk

Pure refactor of shared editor utilities. No runtime behavior change visible to users, no API or server-side impact. Safe to roll back.

## Deploy Plan

Deploy `front`.
