### PR TITLE
feat(skill-builder): inline capability search from slash commands

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -1,5 +1,13 @@
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
-import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import {
+  isInsertKnowledgeSlashCommand,
+  isSkillSlashCommand,
+  isToolSlashCommand,
+  type SlashCommandSkillSuggestion,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import type { CapabilitySearchNodeOptions } from "@app/components/editor/extensions/skill_builder/CapabilitySearchNodeView";
+import { CapabilitySearchNodeWithView } from "@app/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
@@ -11,6 +19,7 @@ import {
 import { preprocessMarkdownForEditor } from "@app/lib/editor/skill_instructions_preprocessing";
 import type { LightWorkspaceType } from "@app/types/user";
 import { cn } from "@dust-tt/sparkle";
+import type { Range } from "@tiptap/core";
 import { CharacterCount, Placeholder } from "@tiptap/extensions";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -109,31 +118,18 @@ interface UseSkillInstructionsEditorProps {
 }
 
 function buildSkillInstructionsEditableExtensions({
-  currentSkillId,
-  includeSkillSuggestions,
-  onSelectSkill,
-  onSelectTool,
-  onSkillDetails,
-  onToolDetails,
-  owner,
+  capabilitySearchOptions,
+  onSelectRef,
 }: {
-  currentSkillId?: string | null;
-  includeSkillSuggestions: boolean;
-  onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
-  onSelectTool?: (tool: MCPServerViewType) => void;
-  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
-  onToolDetails?: (tool: MCPServerViewType) => void;
-  owner?: LightWorkspaceType;
+  capabilitySearchOptions: CapabilitySearchNodeOptions;
+  onSelectRef: React.RefObject<
+    ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
+  >;
 }) {
   return [
+    CapabilitySearchNodeWithView.configure(capabilitySearchOptions),
     SlashCommandExtension.configure({
-      currentSkillId: currentSkillId ?? null,
-      includeSkillSuggestions,
-      onSelectSkill,
-      onSelectTool,
-      onSkillDetails,
-      onToolDetails,
-      owner,
+      onSelectRef,
     }),
     AgentInstructionDiffExtension,
     Placeholder.configure({
@@ -163,27 +159,33 @@ export function useSkillInstructionsEditor({
   const onSkillNodeDetails = skillReferences?.onSkillNodeDetails;
   const onToolDetails = skillReferences?.onToolDetails;
   const owner = skillReferences?.owner;
-  const includeSkillSuggestions = !!owner;
+  const onSelectRef = useRef<
+    ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
+  >(undefined);
+  const onSelectSkillRef = useRef(onSelectSkill);
+  const onSelectToolRef = useRef(onSelectTool);
+  const onSkillDetailsRef = useRef(onSkillDetails);
+  const onToolDetailsRef = useRef(onToolDetails);
+  onSelectSkillRef.current = onSelectSkill;
+  onSelectToolRef.current = onSelectTool;
+  onSkillDetailsRef.current = onSkillDetails;
+  onToolDetailsRef.current = onToolDetails;
+
   const editableExtensions = useMemo(
     () =>
       buildSkillInstructionsEditableExtensions({
-        currentSkillId,
-        includeSkillSuggestions,
-        onSelectSkill,
-        onSelectTool,
-        onSkillDetails,
-        onToolDetails,
-        owner,
+        capabilitySearchOptions: {
+          currentSkillId,
+          onSelectSkillRef,
+          onSelectToolRef,
+          onSkillDetailsRef,
+          onToolDetailsRef,
+          owner,
+          variant: "skill-builder",
+        },
+        onSelectRef,
       }),
-    [
-      currentSkillId,
-      includeSkillSuggestions,
-      onSelectSkill,
-      onSelectTool,
-      onSkillDetails,
-      onToolDetails,
-      owner,
-    ]
+    [currentSkillId, owner]
   );
 
   const extensions = useMemo(
@@ -206,12 +208,59 @@ export function useSkillInstructionsEditor({
       immediatelyRender: false,
       onUpdate,
       onBlur,
-      onDelete: onDelete ? ({ editor }) => onDelete(editor) : undefined,
+      onDelete: onDelete
+        ? ({ editor: editorInstance }) => onDelete(editorInstance)
+        : undefined,
     },
     [extensions, isReadOnly]
   );
 
   const editorService = useEditorService(editor);
+
+  onSelectRef.current = (item, editorInstance, range) => {
+    if (editorInstance.isDestroyed) {
+      return;
+    }
+
+    if (isInsertKnowledgeSlashCommand(item)) {
+      editorInstance
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertKnowledgeNode()
+        .run();
+      return;
+    }
+
+    if (isSkillSlashCommand(item)) {
+      editorInstance
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertSkillNode({
+          skillId: item.data.skill.sId,
+          skillIcon: item.data.skill.icon,
+          skillName: item.data.skill.name,
+        })
+        .run();
+      onSelectSkill?.(item.data.skill);
+      return;
+    }
+
+    if (isToolSlashCommand(item)) {
+      editorInstance
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertToolNode({
+          mcpServerViewId: item.data.tool.id,
+          toolIcon: item.data.tool.icon,
+          toolName: item.data.tool.name,
+        })
+        .run();
+      onSelectTool?.(item.data.tool.view);
+    }
+  };
 
   // Set initial content after editor is created
   useEffect(() => {

--- a/front/components/editor/extensions/skill_builder/CapabilitySearchNode.ts
+++ b/front/components/editor/extensions/skill_builder/CapabilitySearchNode.ts
@@ -1,0 +1,36 @@
+import { Node } from "@tiptap/core";
+
+export const CAPABILITY_SEARCH_NODE_TYPE = "capabilitySearchNode";
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    capabilitySearchNode: {
+      insertCapabilitySearchNode: () => ReturnType;
+    };
+  }
+}
+
+export const CapabilitySearchNode = Node.create({
+  name: CAPABILITY_SEARCH_NODE_TYPE,
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+
+  parseHTML() {
+    return [];
+  },
+
+  renderHTML() {
+    return ["span", { "data-capability-search": "true" }];
+  },
+
+  addCommands() {
+    return {
+      insertCapabilitySearchNode:
+        () =>
+        ({ chain }) =>
+          chain().insertContent({ type: this.name }).run(),
+    };
+  },
+});

--- a/front/components/editor/extensions/skill_builder/CapabilitySearchNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/CapabilitySearchNodeView.tsx
@@ -1,0 +1,448 @@
+import {
+  getToolSlashCommandLabel,
+  isSkillSlashCommand,
+  isToolSlashCommand,
+  type SlashCommandSkillSuggestion,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import { buildCapabilitySlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems";
+import { InlineSlashSearch } from "@app/components/editor/extensions/shared/slash_suggestion/InlineSlashSearch";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
+import { useSkills } from "@app/lib/swr/skill_configurations";
+import { useSpaces } from "@app/lib/swr/spaces";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { isNumber } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  cn,
+  DotsHorizontal,
+  DropdownMenuItem,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { Editor } from "@tiptap/core";
+import type { NodeViewProps } from "@tiptap/react";
+import { NodeViewWrapper } from "@tiptap/react";
+import type { RefObject } from "react";
+import { useCallback, useMemo, useState } from "react";
+
+export interface CapabilitySearchNodeOptions {
+  currentSkillId?: string | null;
+  onSelectSkillRef?: RefObject<
+    ((skill: SlashCommandSkillSuggestion) => void) | undefined
+  >;
+  onSelectToolRef?: RefObject<((tool: MCPServerViewType) => void) | undefined>;
+  onSkillDetailsRef?: RefObject<
+    ((skill: SlashCommandSkillSuggestion) => void) | undefined
+  >;
+  onToolDetailsRef?: RefObject<((tool: MCPServerViewType) => void) | undefined>;
+  owner?: LightWorkspaceType;
+  selectedMCPServerViewIdsRef?: RefObject<Set<string>>;
+  variant?: "input-bar" | "skill-builder";
+}
+
+interface CapabilitySearchNodeViewProps extends NodeViewProps {
+  options: CapabilitySearchNodeOptions;
+}
+
+function getCapabilityItemDetailsHandler(
+  options: CapabilitySearchNodeOptions
+): ((item: SlashCommand) => void) | undefined {
+  if (!options.onSkillDetailsRef && !options.onToolDetailsRef) {
+    return undefined;
+  }
+
+  return (item) => {
+    if (isSkillSlashCommand(item)) {
+      options.onSkillDetailsRef?.current?.(item.data.skill);
+      return;
+    }
+
+    if (isToolSlashCommand(item)) {
+      options.onToolDetailsRef?.current?.(item.data.tool.view);
+    }
+  };
+}
+
+function replaceNodeWithSkill({
+  editor,
+  getPos,
+  nodeSize,
+  onSelectSkill,
+  skill,
+}: {
+  editor: Editor;
+  getPos: NodeViewProps["getPos"];
+  nodeSize: number;
+  onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
+  skill: SlashCommandSkillSuggestion;
+}) {
+  const pos = getPos();
+  if (!isNumber(pos)) {
+    return;
+  }
+
+  editor
+    .chain()
+    .focus()
+    .deleteRange({ from: pos, to: pos + nodeSize })
+    .insertSkillNode({
+      skillId: skill.sId,
+      skillIcon: skill.icon,
+      skillName: skill.name,
+    })
+    .insertContent(" ")
+    .run();
+
+  onSelectSkill?.(skill);
+}
+
+function replaceNodeWithTool({
+  editor,
+  getPos,
+  insertToolNode,
+  nodeSize,
+  onSelectTool,
+  tool,
+}: {
+  editor: Editor;
+  getPos: NodeViewProps["getPos"];
+  insertToolNode: boolean;
+  nodeSize: number;
+  onSelectTool?: (tool: MCPServerViewType) => void;
+  tool: MCPServerViewType;
+}) {
+  const pos = getPos();
+  if (!isNumber(pos)) {
+    return;
+  }
+
+  const chain = editor
+    .chain()
+    .focus()
+    .deleteRange({ from: pos, to: pos + nodeSize });
+
+  if (insertToolNode) {
+    chain
+      .insertToolNode({
+        mcpServerViewId: tool.sId,
+        toolIcon: tool.server.icon,
+        toolName: getToolSlashCommandLabel(tool),
+      })
+      .insertContent(" ");
+  }
+
+  chain.run();
+  onSelectTool?.(tool);
+
+  if (!insertToolNode) {
+    queueMicrotask(() => {
+      if (!editor.isDestroyed) {
+        editor.chain().focus().run();
+      }
+    });
+  }
+}
+
+function CapabilitySearchNodeViewInner({
+  capabilityItems,
+  deleteNode,
+  editor,
+  getPos,
+  insertToolNode,
+  isLoading,
+  node,
+  onItemDetails,
+  options,
+  searchQuery,
+  selectedIndex,
+  onSearchQueryChange,
+  onSelectedIndexChange,
+}: {
+  capabilityItems: SlashCommand[];
+  deleteNode: () => void;
+  editor: Editor;
+  getPos: NodeViewProps["getPos"];
+  insertToolNode: boolean;
+  isLoading: boolean;
+  node: NodeViewProps["node"];
+  onItemDetails?: (item: SlashCommand) => void;
+  options: CapabilitySearchNodeOptions;
+  searchQuery: string;
+  selectedIndex: number;
+  onSearchQueryChange: (query: string) => void;
+  onSelectedIndexChange: (index: number) => void;
+}) {
+  const handleCancel = useCallback(() => {
+    deleteNode();
+    queueMicrotask(() => {
+      if (!editor.isDestroyed) {
+        editor.chain().focus().run();
+      }
+    });
+  }, [deleteNode, editor]);
+
+  const handleSelectItem = useCallback(
+    (item: SlashCommand) => {
+      if (isSkillSlashCommand(item)) {
+        replaceNodeWithSkill({
+          editor,
+          getPos,
+          nodeSize: node.nodeSize,
+          onSelectSkill: options.onSelectSkillRef?.current ?? undefined,
+          skill: item.data.skill,
+        });
+        return;
+      }
+
+      if (isToolSlashCommand(item)) {
+        replaceNodeWithTool({
+          editor,
+          getPos,
+          insertToolNode,
+          nodeSize: node.nodeSize,
+          onSelectTool: options.onSelectToolRef?.current ?? undefined,
+          tool: item.data.tool.view,
+        });
+      }
+    },
+    [
+      editor,
+      getPos,
+      insertToolNode,
+      node.nodeSize,
+      options.onSelectSkillRef,
+      options.onSelectToolRef,
+    ]
+  );
+
+  const handleSelectIndex = useCallback(
+    (index: number) => {
+      const item = capabilityItems[index];
+      if (item) {
+        handleSelectItem(item);
+      }
+    },
+    [capabilityItems, handleSelectItem]
+  );
+
+  const dropdownContent =
+    isLoading && capabilityItems.length === 0 ? (
+      <div className="flex h-14 items-center justify-center">
+        <Spinner size="sm" />
+        <span className="ml-2 text-sm text-gray-500 dark:text-gray-500-night">
+          Loading capabilities…
+        </span>
+      </div>
+    ) : capabilityItems.length === 0 ? (
+      <div className="flex h-14 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-500-night">
+        No matches found
+      </div>
+    ) : (
+      <div className="max-h-96">
+        {capabilityItems.map((item, index) => {
+          const canShowDetails = !!item.hasDetails && !!onItemDetails;
+
+          return (
+            <DropdownMenuItem
+              key={item.id}
+              icon={item.icon}
+              itemId={item.id}
+              label={item.label}
+              description={item.description}
+              truncateText
+              endComponent={
+                canShowDetails ? (
+                  <Button
+                    icon={DotsHorizontal}
+                    variant="outline"
+                    size="mini"
+                    className={cn(
+                      "opacity-0 group-focus-within:opacity-100",
+                      index === selectedIndex && "opacity-100"
+                    )}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      event.preventDefault();
+                      onItemDetails(item);
+                    }}
+                  />
+                ) : undefined
+              }
+              onClick={() => handleSelectIndex(index)}
+              onPointerMove={(event) => {
+                event.preventDefault();
+                onSelectedIndexChange(index);
+              }}
+              onPointerLeave={(event) => event.preventDefault()}
+              className={cn(
+                "group",
+                index === selectedIndex &&
+                  "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+              )}
+            />
+          );
+        })}
+      </div>
+    );
+
+  return (
+    <NodeViewWrapper className="inline">
+      <InlineSlashSearch
+        deferDropdownUntilFocus
+        dropdownContent={dropdownContent}
+        isDropdownOpen={capabilityItems.length > 0 || isLoading}
+        itemCount={capabilityItems.length}
+        onCancel={handleCancel}
+        onSearchQueryChange={(query) => {
+          onSearchQueryChange(query);
+          onSelectedIndexChange(0);
+        }}
+        onSelectIndex={handleSelectIndex}
+        onSelectedIndexChange={onSelectedIndexChange}
+        placeholder="Search capabilities..."
+        searchQuery={searchQuery}
+        selectedIndex={selectedIndex}
+      />
+    </NodeViewWrapper>
+  );
+}
+
+function InputBarCapabilitySearchNodeView(
+  props: CapabilitySearchNodeViewProps & { owner: LightWorkspaceType }
+) {
+  const { deleteNode, editor, getPos, node, options, owner } = props;
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["global"],
+  });
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+    globalSpaceOnly: true,
+  });
+  const { serverViews, isLoading: isServerViewsLoading } =
+    useMCPServerViewsFromSpaces(owner, globalSpaces);
+
+  const capabilityItems = useMemo(
+    () =>
+      buildCapabilitySlashCommandItems({
+        excludeSkillId: options.currentSkillId,
+        query: searchQuery,
+        skills,
+        tools: serverViews,
+        toolFilter: (serverView) =>
+          isJITMCPServerView(serverView) &&
+          !(options.selectedMCPServerViewIdsRef?.current ?? new Set()).has(
+            serverView.sId
+          ),
+      }),
+    [
+      options.currentSkillId,
+      options.selectedMCPServerViewIdsRef,
+      searchQuery,
+      serverViews,
+      skills,
+    ]
+  );
+
+  return (
+    <CapabilitySearchNodeViewInner
+      capabilityItems={capabilityItems}
+      deleteNode={deleteNode}
+      editor={editor}
+      getPos={getPos}
+      insertToolNode={false}
+      isLoading={isSkillsLoading || isSpacesLoading || isServerViewsLoading}
+      node={node}
+      onItemDetails={getCapabilityItemDetailsHandler(options)}
+      options={options}
+      searchQuery={searchQuery}
+      selectedIndex={selectedIndex}
+      onSearchQueryChange={setSearchQuery}
+      onSelectedIndexChange={setSelectedIndex}
+    />
+  );
+}
+
+function SkillBuilderCapabilitySearchNodeView(
+  props: CapabilitySearchNodeViewProps & { owner: LightWorkspaceType }
+) {
+  const { deleteNode, editor, getPos, node, options, owner } = props;
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const mcpServerViewsContext = useMCPServerViewsContext();
+
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+  });
+
+  const tools = useMemo(() => {
+    if (mcpServerViewsContext.isMCPServerViewsError) {
+      return [];
+    }
+
+    return mcpServerViewsContext.mcpServerViewsWithoutKnowledge.filter(
+      (view) => getMCPServerRequirements(view).noRequirement
+    );
+  }, [mcpServerViewsContext]);
+
+  const capabilityItems = useMemo(
+    () =>
+      buildCapabilitySlashCommandItems({
+        excludeSkillId: options.currentSkillId,
+        query: searchQuery,
+        skills,
+        tools,
+        toolFilter: (serverView) =>
+          getMCPServerRequirements(serverView).noRequirement,
+      }),
+    [options.currentSkillId, searchQuery, skills, tools]
+  );
+
+  return (
+    <CapabilitySearchNodeViewInner
+      capabilityItems={capabilityItems}
+      deleteNode={deleteNode}
+      editor={editor}
+      getPos={getPos}
+      insertToolNode={true}
+      isLoading={
+        isSkillsLoading || mcpServerViewsContext.isMCPServerViewsLoading
+      }
+      node={node}
+      onItemDetails={getCapabilityItemDetailsHandler(options)}
+      options={options}
+      searchQuery={searchQuery}
+      selectedIndex={selectedIndex}
+      onSearchQueryChange={setSearchQuery}
+      onSelectedIndexChange={setSelectedIndex}
+    />
+  );
+}
+
+export function CapabilitySearchNodeView(props: CapabilitySearchNodeViewProps) {
+  const owner = props.options.owner;
+  if (!owner) {
+    return null;
+  }
+
+  switch (props.options.variant) {
+    case "input-bar":
+      return <InputBarCapabilitySearchNodeView {...props} owner={owner} />;
+    case "skill-builder":
+    case undefined:
+      return <SkillBuilderCapabilitySearchNodeView {...props} owner={owner} />;
+    default:
+      assertNeverAndIgnore(props.options.variant);
+      return <SkillBuilderCapabilitySearchNodeView {...props} owner={owner} />;
+  }
+}

--- a/front/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView.tsx
@@ -1,0 +1,48 @@
+import {
+  CAPABILITY_SEARCH_NODE_TYPE,
+  CapabilitySearchNode,
+} from "@app/components/editor/extensions/skill_builder/CapabilitySearchNode";
+import {
+  type CapabilitySearchNodeOptions,
+  CapabilitySearchNodeView,
+} from "@app/components/editor/extensions/skill_builder/CapabilitySearchNodeView";
+import type { NodeViewProps } from "@tiptap/react";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+export { CAPABILITY_SEARCH_NODE_TYPE };
+
+const DEFAULT_CAPABILITY_SEARCH_NODE_OPTIONS: CapabilitySearchNodeOptions = {
+  currentSkillId: null,
+  onSelectSkillRef: { current: undefined },
+  onSelectToolRef: { current: undefined },
+  onSkillDetailsRef: { current: undefined },
+  onToolDetailsRef: { current: undefined },
+  owner: undefined,
+  selectedMCPServerViewIdsRef: { current: new Set<string>() },
+  variant: "skill-builder",
+};
+
+function createCapabilitySearchNodeExtension(
+  variant: NonNullable<CapabilitySearchNodeOptions["variant"]>
+) {
+  return CapabilitySearchNode.extend<CapabilitySearchNodeOptions>({
+    addOptions() {
+      return {
+        ...DEFAULT_CAPABILITY_SEARCH_NODE_OPTIONS,
+        variant,
+      };
+    },
+
+    addNodeView() {
+      return ReactNodeViewRenderer((props: NodeViewProps) => (
+        <CapabilitySearchNodeView {...props} options={this.options} />
+      ));
+    },
+  });
+}
+
+export const CapabilitySearchNodeWithView =
+  createCapabilitySearchNodeExtension("skill-builder");
+
+export const InputBarCapabilitySearchNode =
+  createCapabilitySearchNodeExtension("input-bar");

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.test.ts
@@ -2,23 +2,21 @@ import type {
   SlashCommandSkillSuggestion,
   SlashCommandToolSuggestion,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
-import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { buildCapabilitySlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { Editor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { afterEach, describe, expect, it } from "vitest";
+import { CAPABILITY_SEARCH_NODE_TYPE } from "./CapabilitySearchNode";
+import { CapabilitySearchNodeWithView } from "./CapabilitySearchNodeWithView";
 import {
-  buildSkillBuilderSlashCommandItems,
   SlashCommandExtension,
   slashCommandPluginKey,
 } from "./SlashCommandExtension";
-
-const attachKnowledgeItem: SlashCommand = {
-  action: "insert-knowledge-node",
-  icon: () => null,
-  id: "add-knowledge",
-  label: "Attach knowledge",
-};
 
 const skillSuggestion = ({
   editedBy = 1,
@@ -75,28 +73,62 @@ const toolSuggestion = ({
   label,
 });
 
-describe("buildSkillBuilderSlashCommandItems", () => {
-  it("keeps the existing command when skill suggestions are disabled", () => {
-    const result = buildSkillBuilderSlashCommandItems({
-      baseItems: [attachKnowledgeItem],
-      includeSkillSuggestions: false,
-      query: "",
-      skills: [
-        skillSuggestion({
-          name: "Create memo",
-          sId: "skill_create_memo",
-        }),
-      ],
+describe("buildCapabilitySlashCommandItems", () => {
+  it("filters capabilities by name only", async () => {
+    const { auth, globalSpace, workspace } =
+      await createPrivateApiMockRequest();
+    const skill = await SkillFactory.create(auth, {
+      name: "Summarize",
+      userFacingDescription: "Search spreadsheets and documents.",
+    });
+    const calendarServer = await RemoteMCPServerFactory.create(workspace, {
+      name: "Calendar",
+      description: "Search spreadsheets and documents.",
+    });
+    const calendarServerView = await MCPServerViewFactory.create(
+      workspace,
+      calendarServer.sId,
+      globalSpace
+    );
+
+    const result = buildCapabilitySlashCommandItems({
+      query: "spreadsheet",
+      skills: [skill.toJSON(auth)],
+      tools: [calendarServerView.toJSON()],
     });
 
-    expect(result).toEqual([attachKnowledgeItem]);
+    expect(result).toEqual([]);
   });
 
-  it("adds filtered skills under the capabilities section", () => {
-    const result = buildSkillBuilderSlashCommandItems({
-      baseItems: [attachKnowledgeItem],
-      currentSkillId: "skill_current",
-      includeSkillSuggestions: true,
+  it("orders non-substring matches by fuzzy relevance", async () => {
+    const { auth } = await createPrivateApiMockRequest();
+    const generateDailyReportSkill = await SkillFactory.create(auth, {
+      name: "Generate Daily Report",
+      userFacingDescription: "",
+    });
+    const googleDriveSkill = await SkillFactory.create(auth, {
+      name: "Google Drive",
+      userFacingDescription: "",
+    });
+
+    const result = buildCapabilitySlashCommandItems({
+      query: "gd",
+      skills: [
+        generateDailyReportSkill.toJSON(auth),
+        googleDriveSkill.toJSON(auth),
+      ],
+      tools: [],
+    });
+
+    expect(result.map((item) => item.label)).toEqual([
+      "Google Drive",
+      "Generate Daily Report",
+    ]);
+  });
+
+  it("adds filtered skills and excludes the current skill", () => {
+    const result = buildCapabilitySlashCommandItems({
+      excludeSkillId: "skill_current",
       query: "memo",
       skills: [
         skillSuggestion({
@@ -113,6 +145,7 @@ describe("buildSkillBuilderSlashCommandItems", () => {
           sId: "skill_current",
         }),
       ],
+      tools: [],
     });
 
     expect(result.map((item) => item.id)).toEqual(["skill_create_memo"]);
@@ -137,9 +170,7 @@ describe("buildSkillBuilderSlashCommandItems", () => {
       sId: "mcp_server_view_search",
     });
 
-    const result = buildSkillBuilderSlashCommandItems({
-      baseItems: [attachKnowledgeItem],
-      includeSkillSuggestions: true,
+    const result = buildCapabilitySlashCommandItems({
       query: "",
       skills: [
         skillSuggestion({
@@ -151,11 +182,10 @@ describe("buildSkillBuilderSlashCommandItems", () => {
     });
 
     expect(result.map((item) => item.id)).toEqual([
-      "add-knowledge",
       "mcp_server_view_search",
       "skill_search_checklist",
     ]);
-    expect(result[1]).toMatchObject({
+    expect(result[0]).toMatchObject({
       action: "select-tool",
       data: {
         tool: {
@@ -164,27 +194,6 @@ describe("buildSkillBuilderSlashCommandItems", () => {
           view: tool,
         },
       },
-    });
-  });
-
-  it("includes tools when there are no matching skills", () => {
-    const result = buildSkillBuilderSlashCommandItems({
-      baseItems: [],
-      includeSkillSuggestions: true,
-      query: "search",
-      skills: [],
-      tools: [
-        toolSuggestion({
-          label: "Search docs",
-          name: null,
-          sId: "mcp_server_view_search",
-        }),
-      ],
-    });
-
-    expect(result[0]).toMatchObject({
-      id: "mcp_server_view_search",
-      action: "select-tool",
     });
   });
 });
@@ -201,8 +210,9 @@ describe("SlashCommandExtension", () => {
     editor = new Editor({
       extensions: [
         StarterKit,
+        CapabilitySearchNodeWithView,
         SlashCommandExtension.configure({
-          includeSkillSuggestions: false,
+          onSelectRef: { current: undefined },
         }),
       ],
     });
@@ -210,26 +220,34 @@ describe("SlashCommandExtension", () => {
     return editor;
   }
 
-  it("opens capabilities after marked text", () => {
+  it("opens capabilities search after marked text", () => {
     const editor = createEditor();
     editor.commands.setContent("<p><em>Italic text</em></p>");
     editor.commands.focus("end");
 
     editor.commands.openCapabilitiesSlashCommand();
 
-    expect(editor.getText()).toBe("Italic text /");
-    expect(slashCommandPluginKey.getState(editor.state)?.active).toBe(true);
+    expect(editor.getText()).toBe("Italic text");
+    expect(
+      editor.state.doc.content.firstChild?.content.content.some(
+        (node) => node.type.name === CAPABILITY_SEARCH_NODE_TYPE
+      )
+    ).toBe(true);
   });
 
-  it("opens capabilities after regular text", () => {
+  it("opens capabilities search after regular text", () => {
     const editor = createEditor();
     editor.commands.setContent("<p>regular text</p>");
     editor.commands.focus("end");
 
     editor.commands.openCapabilitiesSlashCommand();
 
-    expect(editor.getText()).toBe("regular text /");
-    expect(slashCommandPluginKey.getState(editor.state)?.active).toBe(true);
+    expect(editor.getText()).toBe("regular text");
+    expect(
+      editor.state.doc.content.firstChild?.content.content.some(
+        (node) => node.type.name === CAPABILITY_SEARCH_NODE_TYPE
+      )
+    ).toBe(true);
   });
 
   it("keeps typed slash closed after regular text", () => {

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -1,45 +1,30 @@
 import {
-  getSkillSlashCommandItem,
-  getToolSlashCommandItem,
-  getToolSlashCommandLabel,
-  isSkillSlashCommand,
-  isToolSlashCommand,
-  matchesSlashCommandCapabilityQuery,
-  type SlashCommandSkillSuggestion,
-  type SlashCommandToolSuggestion,
-  sortSlashCommandCapabilityMatches,
+  INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION,
+  isAddCapabilitySlashCommand,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import { filterSlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { createSlashSuggestionExtension } from "@app/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension";
-import { shouldInsertSlashBoundarySpace } from "@app/components/editor/extensions/shared/slash_suggestion/slashSuggestionUtils";
-import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useSkills } from "@app/lib/swr/skill_configurations";
-import type { LightWorkspaceType } from "@app/types/user";
+import { getSlashCommandAvatarIcon } from "@app/components/editor/extensions/shared/slash_suggestion/slashCommandIcons";
+import { createAddCapabilitySlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/slashStaticCommands";
 import { Attachment01 } from "@dust-tt/sparkle";
-import type { ChainedCommands } from "@tiptap/core";
-import type { Transaction } from "@tiptap/pm/state";
+import type { ChainedCommands, Editor, Range } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
-import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import { forwardRef, type RefObject, useImperativeHandle, useRef } from "react";
 
 export const slashCommandPluginKey = new PluginKey("slashCommand");
-const capabilitiesOnlySlashCommandMetaKey =
-  "skillBuilderCapabilitiesOnlySlashCommand";
 
-const INSERT_KNOWLEDGE_NODE_ACTION = "insert-knowledge-node";
-
-// Define available slash commands.
 const SLASH_COMMANDS: SlashCommand[] = [
   {
     id: "add-knowledge",
-    action: INSERT_KNOWLEDGE_NODE_ACTION,
-    icon: Attachment01,
+    action: INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION,
+    description: "Search and attach company knowledge for context",
+    icon: getSlashCommandAvatarIcon(Attachment01),
     label: "Attach knowledge",
     tooltip: {
       description: "Use company knowledge for context.",
@@ -52,261 +37,48 @@ const SLASH_COMMANDS: SlashCommand[] = [
       ),
     },
   },
+  createAddCapabilitySlashCommand("Add a skill or tool to these instructions"),
 ];
 
-function filterSlashCommands(query: string): SlashCommand[] {
-  if (!query || query.length === 0) {
-    return SLASH_COMMANDS;
-  }
-
-  return SLASH_COMMANDS.filter(
-    (command) =>
-      command.label.toLowerCase().includes(query.toLowerCase()) ||
-      command.tooltip?.description.toLowerCase().includes(query.toLowerCase())
-  );
+interface SkillBuilderSlashSuggestionStorage {
+  hasBeenFocused: boolean;
 }
-
-type SkillBuilderSlashCommandCapability =
-  | {
-      kind: "skill";
-      skill: SlashCommandSkillSuggestion;
-      sortName: string;
-    }
-  | {
-      kind: "tool";
-      tool: SlashCommandToolSuggestion;
-      sortName: string;
-    };
-
-function filterSkillBuilderSlashCommandCapabilities({
-  currentSkillId,
-  query,
-  skills,
-  tools,
-}: {
-  currentSkillId?: string | null;
-  query: string;
-  skills: SlashCommandSkillSuggestion[];
-  tools: SlashCommandToolSuggestion[];
-}): SkillBuilderSlashCommandCapability[] {
-  const normalizedQuery = query.trim().toLowerCase();
-
-  return sortSlashCommandCapabilityMatches({
-    normalizedQuery,
-    items: [
-      ...skills
-        .filter((skill) => skill.sId !== currentSkillId)
-        .filter((skill) =>
-          matchesSlashCommandCapabilityQuery({
-            label: skill.name,
-            query: normalizedQuery,
-          })
-        )
-        .map((skill) => ({
-          kind: "skill" as const,
-          skill,
-          sortName: skill.name.toLowerCase(),
-        })),
-      ...tools
-        .filter((tool) =>
-          matchesSlashCommandCapabilityQuery({
-            label: getToolSlashCommandLabel(tool),
-            query: normalizedQuery,
-          })
-        )
-        .map((tool) => ({
-          kind: "tool" as const,
-          tool,
-          sortName: getToolSlashCommandLabel(tool).toLowerCase(),
-        })),
-    ],
-  });
-}
-
-export function buildSkillBuilderSlashCommandItems({
-  baseItems,
-  currentSkillId,
-  includeSkillSuggestions,
-  query,
-  skills,
-  tools = [],
-}: {
-  baseItems: SlashCommand[];
-  currentSkillId?: string | null;
-  includeSkillSuggestions: boolean;
-  query: string;
-  skills: SlashCommandSkillSuggestion[];
-  tools?: SlashCommandToolSuggestion[];
-}): SlashCommand[] {
-  if (!includeSkillSuggestions) {
-    return baseItems;
-  }
-
-  const visibleBaseItems = query.trim().length === 0 ? baseItems : [];
-  const capabilityItems = filterSkillBuilderSlashCommandCapabilities({
-    currentSkillId,
-    query,
-    skills,
-    tools,
-  }).map((capability) =>
-    capability.kind === "skill"
-      ? getSkillSlashCommandItem(capability.skill)
-      : getToolSlashCommandItem(capability.tool)
-  );
-
-  return [...visibleBaseItems, ...capabilityItems];
-}
-
-interface SkillBuilderSlashCommandDropdownProps
-  extends Pick<
-    SuggestionProps<SlashCommand>,
-    "clientRect" | "command" | "editor" | "items" | "query" | "range"
-  > {
-  currentSkillId?: string | null;
-  includeSkillSuggestions: boolean;
-  onClose: () => void;
-  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
-  onToolDetails?: (tool: MCPServerViewType) => void;
-  owner?: LightWorkspaceType;
-  showCapabilitiesOnly: boolean;
-}
-
-interface SkillBuilderSlashCommandDropdownWithSkillsProps
-  extends SkillBuilderSlashCommandDropdownProps {
-  owner: LightWorkspaceType;
-}
-
-const SkillBuilderSlashCommandDropdownWithSkills = forwardRef<
-  SlashCommandDropdownRef,
-  SkillBuilderSlashCommandDropdownWithSkillsProps
->(
-  (
-    {
-      clientRect,
-      command,
-      currentSkillId,
-      editor,
-      items,
-      onClose,
-      onSkillDetails,
-      onToolDetails,
-      owner,
-      query,
-      range,
-      showCapabilitiesOnly,
-    },
-    ref
-  ) => {
-    const dropdownRef = useRef<SlashCommandDropdownRef>(null);
-    const isOpen = Boolean(clientRect);
-    const mcpServerViewsContext = useMCPServerViewsContext();
-    const { skills, isSkillsLoading } = useSkills({
-      disabled: !isOpen,
-      owner,
-      status: "active",
-    });
-    const tools = useMemo(() => {
-      if (mcpServerViewsContext.isMCPServerViewsError) {
-        return [];
-      }
-
-      return mcpServerViewsContext.mcpServerViewsWithoutKnowledge.filter(
-        (view) => getMCPServerRequirements(view).noRequirement
-      );
-    }, [mcpServerViewsContext]);
-    const isCapabilitiesLoading =
-      isSkillsLoading || mcpServerViewsContext.isMCPServerViewsLoading;
-
-    const slashCommandItems = useMemo(
-      () =>
-        buildSkillBuilderSlashCommandItems({
-          baseItems: showCapabilitiesOnly ? [] : items,
-          currentSkillId,
-          includeSkillSuggestions: true,
-          query,
-          skills,
-          tools,
-        }),
-      [currentSkillId, items, query, showCapabilitiesOnly, skills, tools]
-    );
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        onKeyDown: ({ event }) => {
-          if (
-            (event.key === "Enter" || event.key === "Tab") &&
-            (isCapabilitiesLoading || slashCommandItems.length === 0)
-          ) {
-            event.preventDefault();
-            return true;
-          }
-
-          return dropdownRef.current?.onKeyDown({ event }) ?? false;
-        },
-      }),
-      [isCapabilitiesLoading, slashCommandItems.length]
-    );
-
-    return (
-      <SlashCommandDropdown
-        key={isCapabilitiesLoading ? "loading" : "loaded"}
-        ref={dropdownRef}
-        items={slashCommandItems}
-        command={command}
-        clientRect={clientRect}
-        emptyMessage={
-          isCapabilitiesLoading ? "Loading capabilities…" : "No commands found"
-        }
-        onClose={onClose}
-        onItemDetails={
-          onSkillDetails || onToolDetails
-            ? (item) => {
-                if (isSkillSlashCommand(item)) {
-                  editor.chain().focus().deleteRange(range).run();
-                  onSkillDetails?.(item.data.skill);
-                  onClose();
-                  return;
-                }
-
-                if (isToolSlashCommand(item)) {
-                  editor.chain().focus().deleteRange(range).run();
-                  onToolDetails?.(item.data.tool.view);
-                  onClose();
-                }
-              }
-            : undefined
-        }
-        size="wide"
-      />
-    );
-  }
-);
-
-SkillBuilderSlashCommandDropdownWithSkills.displayName =
-  "SkillBuilderSlashCommandDropdownWithSkills";
 
 const SkillBuilderSlashCommandDropdown = forwardRef<
   SlashCommandDropdownRef,
-  SkillBuilderSlashCommandDropdownProps
->((props, ref) => {
-  if (props.includeSkillSuggestions && props.owner) {
-    return (
-      <SkillBuilderSlashCommandDropdownWithSkills
-        {...props}
-        owner={props.owner}
-        ref={ref}
-      />
-    );
+  Pick<SuggestionProps<SlashCommand>, "clientRect" | "command" | "items"> & {
+    onClose: () => void;
   }
+>(({ clientRect, command, items, onClose }, ref) => {
+  const dropdownRef = useRef<SlashCommandDropdownRef>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      onKeyDown: ({ event }) => {
+        if (
+          (event.key === "Enter" || event.key === "Tab") &&
+          items.length === 0
+        ) {
+          event.preventDefault();
+          return true;
+        }
+
+        return dropdownRef.current?.onKeyDown({ event }) ?? false;
+      },
+    }),
+    [items.length]
+  );
 
   return (
     <SlashCommandDropdown
-      ref={ref}
-      items={props.showCapabilitiesOnly ? [] : props.items}
-      command={props.command}
-      clientRect={props.clientRect}
-      onClose={props.onClose}
+      ref={dropdownRef}
+      items={items}
+      command={command}
+      clientRect={clientRect}
+      emptyMessage="No commands found"
+      onClose={onClose}
+      size="wide"
     />
   );
 });
@@ -315,19 +87,10 @@ SkillBuilderSlashCommandDropdown.displayName =
   "SkillBuilderSlashCommandDropdown";
 
 export interface SlashCommandExtensionOptions {
-  currentSkillId?: string | null;
-  includeSkillSuggestions: boolean;
-  onSkillDetails?: (skill: SlashCommandSkillSuggestion) => void;
-  onSelectSkill?: (skill: SlashCommandSkillSuggestion) => void;
-  onSelectTool?: (tool: MCPServerViewType) => void;
-  onToolDetails?: (tool: MCPServerViewType) => void;
-  owner?: LightWorkspaceType;
+  onSelectRef: RefObject<
+    ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
+  >;
   suggestion: Partial<SuggestionOptions>;
-}
-
-interface SkillBuilderSlashSuggestionStorage {
-  capabilitiesOnlyTriggerStart: number | null;
-  hasBeenFocused: boolean;
 }
 
 declare module "@tiptap/core" {
@@ -346,20 +109,12 @@ export const SlashCommandExtension = createSlashSuggestionExtension<
   name: "slashCommand",
   pluginKey: slashCommandPluginKey,
   cleanupPluginKeyName: "skillBuilderSlashCommandCleanup",
-  triggerCleanupStorageKey: "capabilitiesOnlyTriggerStart",
   DropdownComponent: SkillBuilderSlashCommandDropdown,
   createStorage: () => ({
     hasBeenFocused: false,
-    capabilitiesOnlyTriggerStart: null,
   }),
   defaultOptions: {
-    currentSkillId: null,
-    includeSkillSuggestions: false,
-    onSkillDetails: undefined,
-    onSelectSkill: undefined,
-    onSelectTool: undefined,
-    onToolDetails: undefined,
-    owner: undefined,
+    onSelectRef: { current: undefined },
     suggestion: {
       char: "/",
       pluginKey: slashCommandPluginKey,
@@ -367,79 +122,29 @@ export const SlashCommandExtension = createSlashSuggestionExtension<
       startOfLine: false,
     },
   },
-  addCommands: ({ editor, storage }) => ({
+  addCommands: ({ storage }) => ({
     openCapabilitiesSlashCommand:
       () =>
       ({ chain }: { chain: () => ChainedCommands }) => {
         storage.hasBeenFocused = true;
-        const triggerText = shouldInsertSlashBoundarySpace(editor.state)
-          ? " /"
-          : "/";
-
-        return chain()
-          .focus()
-          .command(({ tr }: { tr: Transaction }) => {
-            tr.setMeta(capabilitiesOnlySlashCommandMetaKey, true);
-            return true;
-          })
-          .insertContent(triggerText)
-          .run();
+        return chain().focus().insertCapabilitySearchNode().run();
       },
   }),
   allow: ({ storage }) => storage.hasBeenFocused,
-  shouldShow: ({ range, transaction, storage }) => {
-    if (transaction.getMeta(capabilitiesOnlySlashCommandMetaKey)) {
-      storage.capabilitiesOnlyTriggerStart = range.from;
-    }
-
-    return true;
-  },
-  items: ({ editor, query, storage }) => {
-    const state = slashCommandPluginKey.getState(editor.state);
-
-    return state?.range.from === storage.capabilitiesOnlyTriggerStart
-      ? []
-      : filterSlashCommands(query);
-  },
+  items: ({ query }) => filterSlashCommandItems(SLASH_COMMANDS, query),
   command: ({ editor, range, props, options }) => {
-    if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {
-      editor.chain().focus().deleteRange(range).insertKnowledgeNode().run();
-    } else if (isSkillSlashCommand(props)) {
-      const { skill } = props.data;
+    if (isAddCapabilitySlashCommand(props)) {
       editor
         .chain()
         .focus()
         .deleteRange(range)
-        .insertSkillNode({
-          skillId: skill.sId,
-          skillIcon: skill.icon,
-          skillName: skill.name,
-        })
+        .insertCapabilitySearchNode()
         .run();
-      options.onSelectSkill?.(skill);
-    } else if (isToolSlashCommand(props)) {
-      const { tool } = props.data;
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertToolNode({
-          mcpServerViewId: tool.id,
-          toolIcon: tool.icon,
-          toolName: tool.name,
-        })
-        .run();
-      options.onSelectTool?.(tool.view);
+      return;
     }
+
+    options.onSelectRef.current?.(props, editor, range);
   },
-  mapDropdownProps: ({ options, props, storage }) => ({
-    currentSkillId: options.currentSkillId,
-    includeSkillSuggestions: options.includeSkillSuggestions,
-    onSkillDetails: options.onSkillDetails,
-    onToolDetails: options.onToolDetails,
-    owner: options.owner,
-    showCapabilitiesOnly:
-      props.range.from === storage.capabilitiesOnlyTriggerStart,
-  }),
+  mapDropdownProps: () => ({}),
   shouldAppendDropdown: ({ props }) => Boolean(props.clientRect),
 });

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -2,6 +2,7 @@ import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { editorVariants } from "@app/components/editor/editorStyles";
 import { SKILL_NODE_TYPE } from "@app/components/editor/extensions/input_bar/SkillNode";
 import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import { CAPABILITY_SEARCH_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/CapabilitySearchNode";
 import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeView";
 import { TOOL_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/ToolNode";
@@ -583,7 +584,20 @@ export function SkillBuilderInstructionsEditor({
       return;
     }
 
-    editor.commands.openCapabilitiesSlashCommand();
+    let hasEmptyCapabilitySearchNode = false;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === CAPABILITY_SEARCH_NODE_TYPE) {
+        hasEmptyCapabilitySearchNode = true;
+        return false;
+      }
+      return true;
+    });
+
+    if (hasEmptyCapabilitySearchNode) {
+      return;
+    }
+
+    editor.chain().focus().insertCapabilitySearchNode().run();
   }, [editor]);
 
   const handleReferenceClick = useCallback(

--- a/front/lib/editor/build_skill_instructions_extensions_server.ts
+++ b/front/lib/editor/build_skill_instructions_extensions_server.ts
@@ -9,6 +9,7 @@ import { BlockIdExtension } from "@app/components/editor/extensions/instructions
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/instructions/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/instructions/InstructionsRootExtension";
 import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
+import { CapabilitySearchNode } from "@app/components/editor/extensions/skill_builder/CapabilitySearchNode";
 import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import {
   RawMarkdownBlock,
@@ -59,6 +60,7 @@ export function buildSkillInstructionsExtensionsForServer(): Extensions {
     }),
     BlockIdExtension,
     KnowledgeNode.configure({ readOnly: true }),
+    CapabilitySearchNode,
     ToolNode,
     SkillNode,
     InstructionSuggestionExtension.configure({ showBlockHighlight: false }),


### PR DESCRIPTION
## Description

Replaces the slash-command capability dropdown in the skill builder with an inline `CapabilitySearchNode` — a TipTap atom node rendered as a React node view containing `InlineSlashSearch`. This matches the knowledge attachment UX: triggering `/` via `openCapabilitiesSlashCommand` now inserts an inline search widget directly into editor content rather than opening a floating popup.

- `CapabilitySearchNode` / `CapabilitySearchNodeView` / `CapabilitySearchNodeWithView` are new; the node view dispatches to `SkillBuilderCapabilitySearchNodeView` or `InputBarCapabilitySearchNodeView` depending on the `variant` option, reusing the same filtering/rendering core (`CapabilitySearchNodeViewInner`).
- `SlashCommandExtension` strips out all capability filtering/rendering logic; it now accepts a single `onSelectRef` and registers a `createAddCapabilitySlashCommand` static entry.
- `SkillInstructionsEditor` / `useSkillInstructionsEditor` adopt a callback-ref pattern so the `useMemo` dep array collapses to `[currentSkillId, owner]`.
- `buildCapabilitySlashCommandItems` (shared) replaces `buildSkillBuilderSlashCommandItems` in `SlashCommandExtension`.

<img width="384" height="573" alt="file-9e749fc6cd308bf86bb90fd0e7ada851" src="https://github.com/user-attachments/assets/18304756-52c2-429f-88b2-63a78b41071e" />


## Tests

Tested locally. Unit tests in `SlashCommandExtension.test.ts` updated: `buildCapabilitySlashCommandItems` tests rewritten using `SkillFactory` / `MCPServerViewFactory` / `RemoteMCPServerFactory`; `openCapabilitiesSlashCommand` tests assert on node type insertion instead of inserted `/` character.

## Risk

Low. Pure frontend refactor in the skill builder editor path. No API or DB changes. The `CapabilitySearchNode` extension is opt-in via `variant: "skill-builder"` / `"input-bar"` so unrelated editor surfaces are unaffected. Rollback is a revert + front deploy.

## Deploy Plan

Deploy `front`.
