### PR TITLE
feat(input-bar): layered slash commands with inline capability search

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -13,10 +13,25 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { useInputBarOverlayTracker } from "@app/components/assistant/conversation/input_bar/useInputBarOverlayTracker";
-import type {
-  InputBarSlashCommand,
-  InputBarSlashSuggestionCapability,
-} from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import {
+  ADD_CAPABILITY_SLASH_COMMAND_ACTION,
+  type AddCapabilitySlashCommand,
+  INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION,
+  type InsertKnowledgeSlashCommand,
+  isAddCapabilitySlashCommand,
+  isInsertKnowledgeSlashCommand,
+  isRunCommandSlashCommand,
+  isSkillSlashCommand,
+  isToolSlashCommand,
+  RUN_COMMAND_SLASH_COMMAND_ACTION,
+  type RunCommandSlashCommand,
+  SELECT_SKILL_SLASH_COMMAND_ACTION,
+  SELECT_TOOL_SLASH_COMMAND_ACTION,
+  type SkillSlashCommand,
+  type ToolSlashCommand,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
@@ -96,6 +111,34 @@ import React, {
   useState,
 } from "react";
 import { InputBarContext } from "./InputBarContext";
+
+type KnownSlashCommand =
+  | RunCommandSlashCommand<InputBarSlashCommand>
+  | SkillSlashCommand
+  | ToolSlashCommand
+  | AddCapabilitySlashCommand
+  | InsertKnowledgeSlashCommand;
+
+function narrowToKnownSlashCommand(
+  item: SlashCommand
+): KnownSlashCommand | null {
+  if (isRunCommandSlashCommand<InputBarSlashCommand>(item)) {
+    return item;
+  }
+  if (isSkillSlashCommand(item)) {
+    return item;
+  }
+  if (isToolSlashCommand(item)) {
+    return item;
+  }
+  if (isAddCapabilitySlashCommand(item)) {
+    return item;
+  }
+  if (isInsertKnowledgeSlashCommand(item)) {
+    return item;
+  }
+  return null;
+}
 
 const COLLAPSE_TRANSITION = "200ms cubic-bezier(0.34, 1.15, 0.64, 1)";
 
@@ -281,11 +324,20 @@ const InputBarContainer = ({
   // conversation may only be created after the first message; the ref keeps it current.
   const conversationIdRef = useRef<string | null>(conversation?.sId ?? null);
   conversationIdRef.current = conversation?.sId ?? null;
-  const onSelectRef = useRef<
-    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+  const onSelectRef = useRef<((item: SlashCommand) => void) | undefined>(
+    undefined
+  );
+  const onDetailsRef = useRef<((item: SlashCommand) => void) | undefined>(
+    undefined
+  );
+  const onSelectToolRef = useRef<
+    ((tool: MCPServerViewType) => void) | undefined
   >(undefined);
-  const onDetailsRef = useRef<
-    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+  const onCapabilitySkillDetailsRef = useRef<
+    ((skill: { sId: string }) => void) | undefined
+  >(undefined);
+  const onCapabilityToolDetailsRef = useRef<
+    ((tool: MCPServerViewType) => void) | undefined
   >(undefined);
   const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
     string | null
@@ -495,7 +547,7 @@ const InputBarContainer = ({
     sId: skillId,
     name: skillName,
     icon: skillIcon,
-  }: SkillWithoutInstructionsAndToolsType) => {
+  }: Pick<SkillWithoutInstructionsAndToolsType, "sId" | "name" | "icon">) => {
     editorRef.current
       ?.chain()
       .focus()
@@ -536,37 +588,59 @@ const InputBarContainer = ({
     }
   };
 
-  onSelectRef.current = (capability: InputBarSlashSuggestionCapability) => {
-    switch (capability.kind) {
-      case "command":
-        handleSlashCommandSelect(capability.command);
+  onSelectToolRef.current = onMCPServerViewSelect;
+  onCapabilitySkillDetailsRef.current = (skill) => {
+    setSelectedSkillIdForDetails(skill.sId);
+  };
+  onCapabilityToolDetailsRef.current = setSelectedServerViewForDetails;
+
+  onSelectRef.current = (rawItem: SlashCommand) => {
+    const item = narrowToKnownSlashCommand(rawItem);
+    if (!item) {
+      return;
+    }
+
+    switch (item.action) {
+      case RUN_COMMAND_SLASH_COMMAND_ACTION:
+        handleSlashCommandSelect(item.data.command);
         break;
-      case "skill":
-        handleSkillSelect(capability.skill);
+      case SELECT_SKILL_SLASH_COMMAND_ACTION:
+        handleSkillSelect(item.data.skill);
         break;
-      case "tool":
-        onMCPServerViewSelect(capability.serverView);
+      case SELECT_TOOL_SLASH_COMMAND_ACTION:
+        onMCPServerViewSelect(item.data.tool.view);
+        break;
+      case ADD_CAPABILITY_SLASH_COMMAND_ACTION:
+      case INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION:
         break;
       default:
-        assertNeverAndIgnore(capability);
+        assertNeverAndIgnore(item);
     }
 
     queueMicrotask(() => editorRef.current?.commands.focus());
   };
 
-  onDetailsRef.current = (capability: InputBarSlashSuggestionCapability) => {
-    switch (capability.kind) {
-      case "command":
+  onDetailsRef.current = (rawItem: SlashCommand) => {
+    const item = narrowToKnownSlashCommand(rawItem);
+    if (!item) {
+      return;
+    }
+
+    switch (item.action) {
+      case RUN_COMMAND_SLASH_COMMAND_ACTION:
         // Static commands have no details sheet.
         break;
-      case "skill":
-        setSelectedSkillIdForDetails(capability.skill.sId);
+      case SELECT_SKILL_SLASH_COMMAND_ACTION:
+        setSelectedSkillIdForDetails(item.data.skill.sId);
         break;
-      case "tool":
-        setSelectedServerViewForDetails(capability.serverView);
+      case SELECT_TOOL_SLASH_COMMAND_ACTION:
+        setSelectedServerViewForDetails(item.data.tool.view);
+        break;
+      case ADD_CAPABILITY_SLASH_COMMAND_ACTION:
+      case INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION:
         break;
       default:
-        assertNeverAndIgnore(capability);
+        assertNeverAndIgnore(item);
     }
   };
 
@@ -589,6 +663,9 @@ const InputBarContainer = ({
       enabledRef: shouldEnableSlashSuggestionRef,
       onSelectRef,
       onDetailsRef,
+      onSelectToolRef,
+      onCapabilitySkillDetailsRef,
+      onCapabilityToolDetailsRef,
       onSkillDetails: setSelectedSkillIdForDetails,
       selectedMCPServerViewIdsRef,
     },

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -1,113 +1,75 @@
-import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
-import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
-import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import {
+  ADD_CAPABILITY_SLASH_COMMAND_ACTION,
+  isRunCommandSlashCommand,
+  RUN_COMMAND_SLASH_COMMAND_ACTION,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import { describe, expect, it } from "vitest";
 
-import { filterInputBarSlashSuggestions } from "./InputBarSlashSuggestionDropdown";
-import { INPUT_BAR_SLASH_COMMANDS } from "./InputBarSlashSuggestionTypes";
+import { buildInputBarSlashCommandItems } from "./InputBarSlashSuggestionItems";
+import {
+  INPUT_BAR_SLASH_COMMANDS,
+  type InputBarSlashCommand,
+} from "./InputBarSlashSuggestionTypes";
 
-describe("filterInputBarSlashSuggestions", () => {
-  it("filters capabilities by name only", async () => {
-    const { auth, globalSpace, workspace } =
-      await createPrivateApiMockRequest();
-    const skill = await SkillFactory.create(auth, {
-      name: "Summarize",
-      userFacingDescription: "Search spreadsheets and documents.",
-    });
-    const calendarServer = await RemoteMCPServerFactory.create(workspace, {
-      name: "Calendar",
-      description: "Search spreadsheets and documents.",
-    });
-    const calendarServerView = await MCPServerViewFactory.create(
-      workspace,
-      calendarServer.sId,
-      globalSpace
-    );
-
-    const result = filterInputBarSlashSuggestions({
+describe("buildInputBarSlashCommandItems", () => {
+  it("always includes the add capability command", () => {
+    const result = buildInputBarSlashCommandItems({
       commands: [],
-      query: "spreadsheet",
-      selectedMCPServerViewIds: new Set(),
-      serverViews: [calendarServerView.toJSON()],
-      skills: [skill.toJSON(auth)],
+      query: "",
     });
 
-    expect(result).toEqual([]);
+    expect(result.map((item) => item.action)).toEqual([
+      ADD_CAPABILITY_SLASH_COMMAND_ACTION,
+    ]);
   });
 
-  it("orders non-substring matches by fuzzy relevance", async () => {
-    const { auth } = await createPrivateApiMockRequest();
-    const generateDailyReportSkill = await SkillFactory.create(auth, {
-      name: "Generate Daily Report",
-      userFacingDescription: "",
-    });
-    const googleDriveSkill = await SkillFactory.create(auth, {
-      name: "Google Drive",
-      userFacingDescription: "",
-    });
-
-    const result = filterInputBarSlashSuggestions({
-      commands: [],
-      query: "gd",
-      selectedMCPServerViewIds: new Set(),
-      serverViews: [],
-      skills: [
-        generateDailyReportSkill.toJSON(auth),
-        googleDriveSkill.toJSON(auth),
-      ],
-    });
-
-    expect(
-      result.map((capability) =>
-        capability.kind === "skill" ? capability.skill.name : ""
-      )
-    ).toEqual(["Google Drive", "Generate Daily Report"]);
-  });
-
-  it("lists commands ahead of capabilities", async () => {
-    const { auth } = await createPrivateApiMockRequest();
-    const skill = await SkillFactory.create(auth, {
-      name: "Aardvark Facts",
-      userFacingDescription: "",
-    });
-
-    const result = filterInputBarSlashSuggestions({
+  it("lists static commands ahead of add capability", () => {
+    const result = buildInputBarSlashCommandItems({
       commands: INPUT_BAR_SLASH_COMMANDS,
       query: "",
-      selectedMCPServerViewIds: new Set(),
-      serverViews: [],
-      skills: [skill.toJSON(auth)],
     });
 
-    expect(result.map((capability) => capability.kind)).toEqual([
-      "command",
-      "skill",
+    expect(result.map((item) => item.action)).toEqual([
+      RUN_COMMAND_SLASH_COMMAND_ACTION,
+      ADD_CAPABILITY_SLASH_COMMAND_ACTION,
     ]);
   });
 
   it("filters commands by the query", async () => {
-    const result = filterInputBarSlashSuggestions({
+    const result = buildInputBarSlashCommandItems({
       commands: INPUT_BAR_SLASH_COMMANDS,
       query: "comp",
-      selectedMCPServerViewIds: new Set(),
-      serverViews: [],
-      skills: [],
     });
 
     expect(
-      result.map((capability) =>
-        capability.kind === "command" ? capability.command.id : ""
+      result.map((item) =>
+        item.action === RUN_COMMAND_SLASH_COMMAND_ACTION &&
+        isRunCommandSlashCommand<InputBarSlashCommand>(item)
+          ? item.data.command.id
+          : item.action
       )
     ).toEqual(["compact"]);
 
     expect(
-      filterInputBarSlashSuggestions({
+      buildInputBarSlashCommandItems({
         commands: INPUT_BAR_SLASH_COMMANDS,
         query: "zzz",
-        selectedMCPServerViewIds: new Set(),
-        serverViews: [],
-        skills: [],
+      })
+    ).toEqual([]);
+  });
+
+  it("filters add capability by the query", () => {
+    expect(
+      buildInputBarSlashCommandItems({
+        commands: [],
+        query: "cap",
+      }).map((item) => item.label)
+    ).toEqual(["Add capability"]);
+
+    expect(
+      buildInputBarSlashCommandItems({
+        commands: [],
+        query: "zzz",
       })
     ).toEqual([]);
   });

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -1,23 +1,10 @@
-import {
-  getSkillSlashCommandItem,
-  getToolSlashCommandItem,
-  getToolSlashCommandLabel,
-  matchesSlashCommandCapabilityQuery,
-  sortSlashCommandCapabilityMatches,
-} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import { buildInputBarSlashCommandItems } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionItems";
+import { INPUT_BAR_SLASH_COMMANDS } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
-import { ResourceAvatar } from "@app/components/resources/resources_icons";
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
-import { useSkills } from "@app/lib/swr/skill_configurations";
-import { useSpaces } from "@app/lib/swr/spaces";
-import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import {
@@ -27,105 +14,17 @@ import {
   useMemo,
   useRef,
 } from "react";
-import {
-  INPUT_BAR_SLASH_COMMANDS,
-  type InputBarSlashCommand,
-  type InputBarSlashSuggestionCapability,
-  isInputBarSlashSuggestionCapability,
-} from "./InputBarSlashSuggestionTypes";
-
-// Rare case where we need a Tailwind arbitrary value: after the fixed search bar, the scrollable list should fit
-// exactly seven 3.25rem rows without showing a partial row or leaving extra bottom space.
-const LIST_MAX_HEIGHT_CLASS_NAME = "max-h-[22.75rem]";
-
-export function filterInputBarSlashSuggestions({
-  commands,
-  query,
-  selectedMCPServerViewIds,
-  serverViews,
-  skills,
-}: {
-  commands: InputBarSlashCommand[];
-  query: string;
-  selectedMCPServerViewIds: Set<string>;
-  serverViews: MCPServerViewType[];
-  skills: SkillWithoutInstructionsAndToolsType[];
-}): InputBarSlashSuggestionCapability[] {
-  const normalizedQuery = query.trim().toLowerCase();
-
-  // Static commands form their own section ahead of capabilities; both are filtered by the query
-  // but sorted independently so command relevance is never weighed against capability names.
-  const commandMatches: (InputBarSlashSuggestionCapability & {
-    sortName: string;
-  })[] = commands
-    .filter((command) =>
-      matchesSlashCommandCapabilityQuery({
-        label: command.label,
-        query: normalizedQuery,
-      })
-    )
-    .map((command) => ({
-      kind: "command" as const,
-      command,
-      sortName: command.label.toLowerCase(),
-    }));
-
-  const capabilities: (InputBarSlashSuggestionCapability & {
-    sortName: string;
-  })[] = [
-    ...skills
-      .filter((skill) =>
-        matchesSlashCommandCapabilityQuery({
-          label: skill.name,
-          query: normalizedQuery,
-        })
-      )
-      .map((skill) => ({
-        kind: "skill" as const,
-        skill,
-        sortName: skill.name.toLowerCase(),
-      })),
-    ...serverViews
-      .filter((serverView) => isJITMCPServerView(serverView))
-      .filter((serverView) => !selectedMCPServerViewIds.has(serverView.sId))
-      .filter((serverView) =>
-        matchesSlashCommandCapabilityQuery({
-          label: getToolSlashCommandLabel(serverView),
-          query: normalizedQuery,
-        })
-      )
-      .map((serverView) => ({
-        kind: "tool" as const,
-        serverView,
-        sortName: getToolSlashCommandLabel(serverView).toLowerCase(),
-      })),
-  ];
-
-  return [
-    ...sortSlashCommandCapabilityMatches({
-      items: commandMatches,
-      normalizedQuery,
-    }),
-    ...sortSlashCommandCapabilityMatches({
-      items: capabilities,
-      normalizedQuery,
-    }),
-  ].map(({ sortName: _sortName, ...capability }) => capability);
-}
 
 export const InputBarSlashSuggestionDropdown = forwardRef<
   SlashCommandDropdownRef,
   Pick<
-    SuggestionProps<InputBarSlashSuggestionCapability>,
+    SuggestionProps<SlashCommand>,
     "clientRect" | "command" | "editor" | "query" | "range"
   > & {
     conversationIdRef?: RefObject<string | null>;
     onClose: () => void;
-    onDetailsRef?: RefObject<
-      ((capability: InputBarSlashSuggestionCapability) => void) | undefined
-    >;
+    onDetailsRef?: RefObject<((item: SlashCommand) => void) | undefined>;
     owner: LightWorkspaceType;
-    selectedMCPServerViewIdsRef: RefObject<Set<string>>;
   }
 >(
   (
@@ -138,99 +37,28 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       range,
       onClose,
       onDetailsRef,
-      owner,
-      selectedMCPServerViewIdsRef,
     },
     ref
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
-    const isOpen = Boolean(clientRect);
-    const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
-      disabled: !isOpen,
-      workspaceId: owner.sId,
-      kinds: ["global"],
-    });
-    const { skills, isSkillsLoading } = useSkills({
-      disabled: !isOpen,
-      owner,
-      status: "active",
-      globalSpaceOnly: true,
-    });
-    const { serverViews, isLoading: isServerViewsLoading } =
-      useMCPServerViewsFromSpaces(owner, globalSpaces, { disabled: !isOpen });
-
-    // Static commands operate on the current conversation, so they are only offered once one
-    // exists.
     const hasConversation = Boolean(conversationIdRef?.current);
 
-    const filteredCapabilities = useMemo(
+    const commandItems = useMemo(
       () =>
-        filterInputBarSlashSuggestions({
+        buildInputBarSlashCommandItems({
           commands: hasConversation ? INPUT_BAR_SLASH_COMMANDS : [],
           query,
-          selectedMCPServerViewIds:
-            selectedMCPServerViewIdsRef.current ?? new Set<string>(),
-          serverViews,
-          skills,
         }),
-      [hasConversation, query, selectedMCPServerViewIdsRef, serverViews, skills]
+      [hasConversation, query]
     );
-
-    // Items carry their capability in `data` so selection and details handlers can recover it
-    // without a reverse lookup. Ids are prefixed by kind to stay unique across capability kinds.
-    const capabilityItems = useMemo<SlashCommand[]>(
-      () =>
-        filteredCapabilities.flatMap((capability): SlashCommand[] => {
-          switch (capability.kind) {
-            case "command":
-              return [
-                {
-                  action: "run-command",
-                  data: capability,
-                  description: capability.command.description,
-                  icon: () => (
-                    <ResourceAvatar icon={capability.command.icon} size="sm" />
-                  ),
-                  id: `command-${capability.command.id}`,
-                  label: capability.command.label,
-                },
-              ];
-            case "skill":
-              return [
-                {
-                  ...getSkillSlashCommandItem(capability.skill),
-                  data: capability,
-                  id: `skill-${capability.skill.sId}`,
-                },
-              ];
-            case "tool":
-              return [
-                {
-                  ...getToolSlashCommandItem(capability.serverView),
-                  data: capability,
-                  id: `tool-${capability.serverView.sId}`,
-                },
-              ];
-            default:
-              assertNeverAndIgnore(capability);
-              return [];
-          }
-        }),
-      [filteredCapabilities]
-    );
-
-    const isCapabilitiesLoading =
-      isSkillsLoading || isSpacesLoading || isServerViewsLoading;
 
     useImperativeHandle(
       ref,
       () => ({
         onKeyDown: ({ event }) => {
-          // Static commands are shown while capabilities load, so selection is only blocked when
-          // the list has nothing to select.
           if (
             (event.key === "Enter" || event.key === "Tab") &&
-            capabilityItems.length === 0
+            commandItems.length === 0
           ) {
             event.preventDefault();
             return true;
@@ -239,38 +67,22 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
           return dropdownRef.current?.onKeyDown({ event }) ?? false;
         },
       }),
-      [capabilityItems.length]
+      [commandItems.length]
     );
 
     return (
       <SlashCommandDropdown
-        key={
-          isSkillsLoading && isSpacesLoading && isServerViewsLoading
-            ? "loading"
-            : "loaded"
-        }
         ref={dropdownRef}
-        items={capabilityItems}
-        command={(item) => {
-          if (isInputBarSlashSuggestionCapability(item.data)) {
-            command(item.data);
-          }
-        }}
+        items={commandItems}
+        command={command}
         clientRect={clientRect}
-        emptyMessage={
-          isCapabilitiesLoading ? "Loading capabilities…" : "No matches found"
-        }
-        listMaxHeightClassName={LIST_MAX_HEIGHT_CLASS_NAME}
+        emptyMessage="No commands found"
         onClose={onClose}
         onItemDetails={
           onDetailsRef
             ? (item) => {
-                if (!isInputBarSlashSuggestionCapability(item.data)) {
-                  return;
-                }
-
                 editor.chain().focus().deleteRange(range).run();
-                onDetailsRef.current?.(item.data);
+                onDetailsRef.current?.(item);
                 onClose();
               }
             : undefined

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -1,5 +1,6 @@
 import { InputBarSlashSuggestionDropdown } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown";
-import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import { isAddCapabilitySlashCommand } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { createSlashSuggestionExtension } from "@app/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension";
 import { isAllowedSlashQuery } from "@app/components/editor/extensions/shared/slash_suggestion/slashSuggestionUtils";
 import type { WorkspaceType } from "@app/types/user";
@@ -19,12 +20,8 @@ export interface InputBarSlashSuggestionExtensionOptions {
   conversationIdRef?: RefObject<string | null>;
   enabledRef: RefObject<boolean>;
   onActiveChangeRef?: RefObject<((active: boolean) => void) | undefined>;
-  onDetailsRef?: RefObject<
-    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
-  >;
-  onSelectRef: RefObject<
-    ((capability: InputBarSlashSuggestionCapability) => void) | undefined
-  >;
+  onDetailsRef?: RefObject<((item: SlashCommand) => void) | undefined>;
+  onSelectRef: RefObject<((item: SlashCommand) => void) | undefined>;
   owner?: WorkspaceType;
   selectedMCPServerViewIdsRef: RefObject<Set<string>>;
 }
@@ -32,7 +29,7 @@ export interface InputBarSlashSuggestionExtensionOptions {
 export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
   InputBarSlashSuggestionExtensionOptions,
   InputBarSlashSuggestionStorage,
-  InputBarSlashSuggestionCapability
+  SlashCommand
 >({
   name: "inputBarSlashSuggestion",
   pluginKey: inputBarSlashSuggestionPluginKey,
@@ -63,6 +60,17 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
   items: () => [],
   command: ({ editor, range, props, options, storage }) => {
     storage.dismissedTriggerStart = null;
+
+    if (isAddCapabilitySlashCommand(props)) {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertCapabilitySearchNode()
+        .run();
+      return;
+    }
+
     editor.chain().focus().deleteRange(range).run();
     options.onSelectRef.current?.(props);
   },
@@ -72,7 +80,6 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
     conversationIdRef: options.conversationIdRef,
     onDetailsRef: options.onDetailsRef,
     owner: options.owner,
-    selectedMCPServerViewIdsRef: options.selectedMCPServerViewIdsRef,
   }),
   notifyActiveChange: (active, options) => {
     options.onActiveChangeRef?.current?.(active);

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionItems.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionItems.tsx
@@ -1,0 +1,57 @@
+import {
+  matchesSlashCommandCapabilityQuery,
+  RUN_COMMAND_SLASH_COMMAND_ACTION,
+  sortSlashCommandCapabilityMatches,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import { filterSlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { getSlashCommandAvatarIcon } from "@app/components/editor/extensions/shared/slash_suggestion/slashCommandIcons";
+import { createAddCapabilitySlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/slashStaticCommands";
+import type { InputBarSlashCommand } from "./InputBarSlashSuggestionTypes";
+
+const ADD_CAPABILITY_SLASH_COMMAND = createAddCapabilitySlashCommand(
+  "Add a skill or tool to your message"
+);
+
+function getInputBarRunCommandSlashCommandItem(
+  command: InputBarSlashCommand
+): SlashCommand {
+  return {
+    action: RUN_COMMAND_SLASH_COMMAND_ACTION,
+    data: { command },
+    description: command.description,
+    icon: getSlashCommandAvatarIcon(command.icon),
+    id: `command-${command.id}`,
+    label: command.label,
+  };
+}
+
+export function buildInputBarSlashCommandItems({
+  commands,
+  query,
+}: {
+  commands: InputBarSlashCommand[];
+  query: string;
+}): SlashCommand[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const commandItems = sortSlashCommandCapabilityMatches({
+    items: commands
+      .filter((command) =>
+        matchesSlashCommandCapabilityQuery({
+          label: command.label,
+          query: normalizedQuery,
+        })
+      )
+      .map((command) => ({
+        command,
+        sortName: command.label.toLowerCase(),
+      })),
+    normalizedQuery,
+  }).map(({ command }) => getInputBarRunCommandSlashCommandItem(command));
+
+  return filterSlashCommandItems(
+    [...commandItems, ADD_CAPABILITY_SLASH_COMMAND],
+    query
+  );
+}

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -1,4 +1,3 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import { Minimize01 } from "@dust-tt/sparkle";
 import type React from "react";
@@ -25,29 +24,4 @@ export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
   },
 ];
 
-export type InputBarSlashSuggestionCapability =
-  | {
-      kind: "command";
-      command: InputBarSlashCommand;
-    }
-  | {
-      kind: "skill";
-      skill: SkillWithoutInstructionsAndToolsType;
-    }
-  | {
-      kind: "tool";
-      serverView: MCPServerViewType;
-    };
-
-// Narrows the opaque `data` payload of a SlashCommand item back to a capability. Only used on
-// items the input bar dropdown built itself, so checking the discriminant is sufficient.
-export function isInputBarSlashSuggestionCapability(
-  data: unknown
-): data is InputBarSlashSuggestionCapability {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "kind" in data &&
-    (data.kind === "command" || data.kind === "skill" || data.kind === "tool")
-  );
-}
+export type InputBarSlashCommandSkill = SkillWithoutInstructionsAndToolsType;

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -5,13 +5,15 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
-import type { InputBarSlashSuggestionCapability } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
 import { PastedAttachmentExtension } from "@app/components/editor/extensions/input_bar/PastedAttachmentExtension";
 import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode";
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
+import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { InputBarCapabilitySearchNode } from "@app/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView";
 import { VoicePartialNode } from "@app/components/editor/extensions/VoicePartialExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
@@ -21,6 +23,7 @@ import {
   createMentionSuggestion,
   mentionPluginKey,
 } from "@app/components/editor/input_bar/mentionSuggestion";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { extractFromEditorJSON } from "@app/lib/mentions/format";
@@ -304,13 +307,18 @@ export interface CustomEditorProps {
     // The conversation may only exist after the editor is initialized, hence the ref.
     conversationIdRef?: React.RefObject<string | null>;
     enabledRef: React.RefObject<boolean>;
-    onSelectRef: React.RefObject<
-      ((capability: InputBarSlashSuggestionCapability) => void) | undefined
-    >;
-    onDetailsRef?: React.RefObject<
-      ((capability: InputBarSlashSuggestionCapability) => void) | undefined
+    onSelectRef: React.RefObject<((item: SlashCommand) => void) | undefined>;
+    onDetailsRef?: React.RefObject<((item: SlashCommand) => void) | undefined>;
+    onSelectToolRef?: React.RefObject<
+      ((tool: MCPServerViewType) => void) | undefined
     >;
     onSkillDetails?: (skillId: string) => void;
+    onCapabilitySkillDetailsRef?: React.RefObject<
+      ((skill: SlashCommandSkillSuggestion) => void) | undefined
+    >;
+    onCapabilityToolDetailsRef?: React.RefObject<
+      ((tool: MCPServerViewType) => void) | undefined
+    >;
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
   };
   // Override the default editor placeholder (e.g. to show a blocked-state reason).
@@ -453,14 +461,27 @@ export const buildEditorExtensions = ({
 
   if (slashSuggestion) {
     extensions.push(
+      InputBarCapabilitySearchNode.configure({
+        onSelectToolRef: slashSuggestion.onSelectToolRef ?? {
+          current: undefined,
+        },
+        onSkillDetailsRef: slashSuggestion.onCapabilitySkillDetailsRef ?? {
+          current: undefined,
+        },
+        onToolDetailsRef: slashSuggestion.onCapabilityToolDetailsRef ?? {
+          current: undefined,
+        },
+        owner,
+        selectedMCPServerViewIdsRef:
+          slashSuggestion.selectedMCPServerViewIdsRef,
+        variant: "input-bar",
+      }),
       InputBarSlashSuggestionExtension.configure({
         owner,
         conversationIdRef: slashSuggestion.conversationIdRef,
         enabledRef: slashSuggestion.enabledRef,
         onSelectRef: slashSuggestion.onSelectRef,
         onDetailsRef: slashSuggestion.onDetailsRef,
-        selectedMCPServerViewIdsRef:
-          slashSuggestion.selectedMCPServerViewIdsRef,
         onActiveChangeRef: onSuggestionActiveChangeRef,
       })
     );


### PR DESCRIPTION
## Description

Splits the input bar slash menu into two layers: a lightweight first layer showing only static commands (e.g., compact) plus an "Add capability" entry, and an inline second layer that opens `InputBarCapabilitySearchNode` directly inside the editor when "Add capability" is selected.

Previously the slash dropdown fetched skills, spaces, and MCP server views on every open and rendered them all inline. Now the dropdown is data-fetch-free — `buildInputBarSlashCommandItems` in `InputBarSlashSuggestionItems.tsx` only filters static commands and the single "Add capability" item. Selecting it calls `insertCapabilitySearchNode()` which injects the existing capability search TipTap node inline, with `onSelectToolRef`, `onCapabilitySkillDetailsRef`, and `onCapabilityToolDetailsRef` wired through `useCustomEditor`/`InputBarContainer`. The old `InputBarSlashSuggestionCapability` discriminated union is replaced by the shared `SlashCommand` type throughout.

<img width="386" height="479" alt="file-600baec24bc906a5d7bf2e04afcfb6a4" src="https://github.com/user-attachments/assets/bb97156e-a1e1-4eee-9a05-f6268fb6014b" />


## Tests

- Updated `InputBarSlashSuggestionDropdown.test.ts`: replaced DB-factory-backed integration tests with pure unit tests on `buildInputBarSlashCommandItems` (no async, no factories). Covers: always includes "Add capability", static commands ordered first, query filtering for both commands and the capability entry.
- Tested locally via manual interaction with the input bar.

## Risk

Low. The change is purely front-end and additive in behavior — the capability search node existed before; only the trigger path changes. The dropdown no longer blocks on data fetching, which improves perceived responsiveness. Rollback is safe (revert front deploy).

## Deploy Plan

Deploy `front`.
