### PR TITLE
feat(model_constructors): add GLM-5.2 Fireworks endpoint with parity coverage

### DIFF
--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -1,5 +1,7 @@
 import { AnthropicLLM } from "@app/lib/api/llm/clients/anthropic";
 import { isAnthropicWhitelistedModelId } from "@app/lib/api/llm/clients/anthropic/types";
+import { FireworksLLM } from "@app/lib/api/llm/clients/fireworks";
+import { isFireworksWhitelistedModelId } from "@app/lib/api/llm/clients/fireworks/types";
 import { GoogleLLM } from "@app/lib/api/llm/clients/google";
 import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
 import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
@@ -22,6 +24,7 @@ export const PARITY_CREDENTIALS: LLMCredentialsType = {
   ANTHROPIC_API_KEY: "test-anthropic-key",
   GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
   OPENAI_API_KEY: "test-openai-key",
+  FIREWORKS_API_KEY: "test-fireworks-key",
 };
 
 /** Per-call parameters shared by both routers for one parity case. */
@@ -68,6 +71,9 @@ export interface SdkCaptures {
   // OpenAI's legacy and new routers both call `client.responses.create`, so a
   // single bucket holds both requests, split by call order (see the adapter).
   openai: unknown[];
+  // Fireworks' legacy and new routers both call `client.chat.completions.create`,
+  // so a single bucket holds both requests, split by call order.
+  openai_chat: unknown[];
 }
 
 function first(arr: unknown[]): unknown {
@@ -205,10 +211,46 @@ const openaiProvider: ParityProvider = {
   },
 };
 
+const fireworksProvider: ParityProvider = {
+  toModelId(raw) {
+    if (!isModelId(raw) || !isFireworksWhitelistedModelId(raw)) {
+      throw new Error(`${raw} is not a whitelisted Fireworks model.`);
+    }
+    return raw;
+  },
+  buildLegacyLLM(auth, _endpoint, params) {
+    if (
+      !isModelId(params.modelId) ||
+      !isFireworksWhitelistedModelId(params.modelId)
+    ) {
+      throw new Error(
+        `${params.modelId} is not a whitelisted Fireworks model.`
+      );
+    }
+    return new FireworksLLM(auth, {
+      credentials: PARITY_CREDENTIALS,
+      modelId: params.modelId,
+      temperature: params.temperature,
+      reasoningEffort: params.reasoningEffort,
+      responseFormat: params.responseFormat,
+      bypassFeatureFlag: true,
+    });
+  },
+  // Both routers hit the same `chat.completions.create`; the test drains the
+  // legacy stream before the new one, so the first capture is legacy, last new.
+  selectOldRequest(_endpoint, captures) {
+    return first(captures.openai_chat);
+  },
+  selectNewRequest(_endpoint, captures) {
+    return last(captures.openai_chat);
+  },
+};
+
 const PARITY_PROVIDERS: Partial<Record<ProviderId, ParityProvider>> = {
   anthropic: anthropicProvider,
   google_ai_studio: googleProvider,
   openai: openaiProvider,
+  fireworks: fireworksProvider,
 };
 
 export function getParityProvider(providerId: ProviderId): ParityProvider {

--- a/front/lib/api/llm/tests/router_parity.test.ts
+++ b/front/lib/api/llm/tests/router_parity.test.ts
@@ -44,6 +44,7 @@ const kit = vi.hoisted(() => {
     anthropic: { ga: [] as unknown[], beta: [] as unknown[] },
     google: [] as unknown[],
     openai: [] as unknown[],
+    openai_chat: [] as unknown[],
   });
   const state = { captures: freshCaptures() };
   const makeClient = () =>
@@ -74,14 +75,22 @@ const kit = vi.hoisted(() => {
         },
       };
     };
-  // Both the legacy and new OpenAI routers call `client.responses.create`, so
-  // one bucket records both; the adapter splits them by call order.
+  // The default client serves both `responses.create` (OpenAI Responses) and
+  // `chat.completions.create` (Fireworks); one bucket per surface.
   const makeOpenAIClient = () =>
     class {
       responses = {
         create: (input: unknown) => {
           state.captures.openai.push(input);
           return emptyStream();
+        },
+      };
+      chat = {
+        completions: {
+          create: (input: unknown) => {
+            state.captures.openai_chat.push(input);
+            return emptyStream();
+          },
         },
       };
     };

--- a/front/lib/llms/providers/fireworks/models/glm_five_dot_two.ts
+++ b/front/lib/llms/providers/fireworks/models/glm_five_dot_two.ts
@@ -1,0 +1,15 @@
+export function WithDustFireworksGlm52Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustFireworksGlm52 extends Base {
+    static readonly displayName = "GLM-5.2 (Fireworks)";
+    static readonly description =
+      "Z.ai's GLM-5.2 Mixture-of-Experts model with advanced coding and long-horizon agentic capabilities (1M context, served via Fireworks).";
+    static readonly defaultReasoningEffort = "low";
+    static readonly byok = false;
+  }
+
+  return DustFireworksGlm52;
+}

--- a/front/lib/llms/stream/endpoints/fireworks_global_glm_five_dot_two.ts
+++ b/front/lib/llms/stream/endpoints/fireworks_global_glm_five_dot_two.ts
@@ -1,0 +1,11 @@
+import { WithDustFireworksGlm52Config } from "@app/lib/llms/providers/fireworks/models/glm_five_dot_two";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
+
+export class DustFireworksGlobalGlmFiveDotTwoStream extends WithDustFireworksGlm52Config(
+  FireworksGlobalGlmFiveDotTwoStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustFireworksGlobalGlmFiveDotTwoStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -5,6 +5,7 @@ import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/s
 import { DustAnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { DustAnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustFireworksGlobalGlmFiveDotTwoStream } from "@app/lib/llms/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
@@ -62,6 +63,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream,
   [DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
     DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
+  [DustFireworksGlobalGlmFiveDotTwoStream.id]:
+    DustFireworksGlobalGlmFiveDotTwoStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/providers/fireworks/models/glm_five_dot_two.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/glm_five_dot_two.ts
@@ -1,0 +1,36 @@
+import { fireworksConfigSchema } from "@app/lib/model_constructors/providers/fireworks/inputConfig";
+import { FIREWORKS_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/fireworks/reasoning_efforts";
+import { FIREWORKS_GLM_5P2_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import { z } from "zod";
+
+const CONTEXT_SIZE = 1_000_000;
+const MAX_OUTPUT_TOKENS = 64_000;
+
+// GLM-5.2 has no native light reasoning, so none/low must drop reasoning_effort
+// (the legacy client does the same); only medium/high reach the model.
+const configSchema = fireworksConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.enum(FIREWORKS_SUPPORTED_REASONING_EFFORTS) })
+    .optional()
+    .transform((r) =>
+      r && (r.effort === "medium" || r.effort === "high") ? r : undefined
+    ),
+});
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithFireworksGlm52Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class FireworksGlm52 extends Base {
+    static readonly modelId = FIREWORKS_GLM_5P2_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return FireworksGlm52;
+}

--- a/front/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two.ts
+++ b/front/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two.ts
@@ -1,0 +1,21 @@
+import { WithFireworksGlm52Config } from "@app/lib/model_constructors/providers/fireworks/models/glm_five_dot_two";
+import { FireworksStream } from "@app/lib/model_constructors/stream/clients/fireworks";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class FireworksGlobalGlmFiveDotTwoStream extends WithFireworksGlm52Config(
+  FireworksStream
+) {
+  // https://fireworks.ai/models/fireworks/glm-5p2
+  static readonly tokenPricing = {
+    cacheHit: 0.26,
+    standardInput: 1.4,
+    standardOutput: 4.4,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+FireworksGlobalGlmFiveDotTwoStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -5,6 +5,7 @@ import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_cons
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
@@ -54,6 +55,7 @@ export const STREAM_ENDPOINTS = {
     AgentPlatformEuropeClaudeHaikuFourDotFiveStream,
   [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
+  [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
+import {
+  HAS_REASONING,
+  INPUT_CONFIGURATION_ERROR,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new FireworksGlobalGlmFiveDotTwoStream({
+      FIREWORKS_API_KEY: process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
+    }),
+  tests: {
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    // GLM always reasons, so `none` still yields reasoning content.
+    "reasoning/no-tools/t-default/r-none": [HAS_REASONING],
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts
+runStreamEndpointTests(FireworksGlobalGlmFiveDotTwoStream, setup);


### PR DESCRIPTION
## Description

First Fireworks model on the new per-endpoint LLM router (`model_constructors`), piloting the chat-completions plumbing landed in #27699.

- Adds the `fireworks/fireworks/global/accounts/fireworks/models/glm-5p2` stream endpoint, with the model config carried in a reusable mixin so subsequent Fireworks models can share the surrounding wiring.
- GLM-5.2 reasons natively only at `medium`/`high`; `none`/`low` fall back to its default chain-of-thought with no `reasoning_effort` sent — matching the legacy `FireworksLLM`, which has no native light reasoning for this model.
- Registers the model in both the `model_constructors` (`STREAM_ENDPOINTS`) and dust-layer (`DUST_STREAM_ENDPOINTS`) registries, so it is reachable behind the `use_new_llm_router` flag. Served through Dust's managed Fireworks key (not BYOK).
- Adds a Fireworks adapter to the router parity suite (`chat.completions.create` capture bucket + SDK mock + provider adapter).

## Tests

- **Live API characterization** (`lib/model_constructors/test/endpoints/fireworks_global_glm_five_dot_two.test.ts`, gated on `RUN_LLM_TEST`): 40/40 cases pass against the live Fireworks API. Characterized contract: GLM always reasons (`none`/`low` just drop the param), `minimal`/`maximal` are rejected by the config schema, and `r-none` still yields reasoning content.
- **Router parity** (`lib/api/llm/tests/router_parity.test.ts`): all 14 GLM-5.2 matrix cases produce a chat-completions request identical to the legacy `FireworksLLM`, including reasoning efforts and structured output. No allowlist normalizer was needed.
- `tsgo` clean, formatted.

## Risk

Low. The new router path is gated behind the `use_new_llm_router` feature flag; the legacy `FireworksLLM` remains the default and is unchanged. Request parity with the legacy router is verified by the parity suite, so behavior behind the flag matches today's output. Rollback is reverting this PR.

## Deploy Plan

Standard deploy. The endpoint only becomes reachable for workspaces with `use_new_llm_router` enabled; ramp via the flag.