### PR TITLE
feat(llm): add Gemini batch mode to the new LLM router

### DIFF
--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -8,8 +8,8 @@ import {
 } from "@app/types/assistant/models/anthropic";
 import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
+  GEMINI_3_1_PRO_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
-  GEMINI_3_PRO_MODEL_CONFIG,
 } from "@app/types/assistant/models/google_ai_studio";
 import {
   MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
@@ -157,7 +157,7 @@ function _getSmallWhitelistedModel(
 const ORDERED_LARGE_MODEL_CONFIGS: ModelConfigurationType[] = [
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   GPT_5_5_MODEL_CONFIG,
-  GEMINI_3_PRO_MODEL_CONFIG,
+  GEMINI_3_1_PRO_MODEL_CONFIG,
   MISTRAL_MEDIUM_3_5_MODEL_CONFIG,
   GROK_4_MODEL_CONFIG,
 ];

--- a/front/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,10 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+
+export class DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch extends GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch {
+  static readonly endpointFilter = {};
+}
+
+defineDustBatchEndpoint(
+  DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch
+);

--- a/front/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -1,0 +1,8 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
+
+export class DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch extends GoogleAiStudioGlobalGeminiThreeDotOneProBatch {
+  static readonly endpointFilter = {};
+}
+
+defineDustBatchEndpoint(DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch);

--- a/front/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,0 +1,8 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
+
+export class DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch extends GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch {
+  static readonly endpointFilter = {};
+}
+
+defineDustBatchEndpoint(DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch);

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -1,5 +1,8 @@
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/llms/batch/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+import { DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -11,6 +14,12 @@ import type { BatchEndpointId } from "@app/lib/model_constructors/batch";
 export const DUST_BATCH_ENDPOINTS = {
   [DustAnthropicGlobalClaudeSonnetFourDotSixBatch.id]:
     DustAnthropicGlobalClaudeSonnetFourDotSixBatch,
+  [DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch,
+  [DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch,
+  [DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch.id]:
+    DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch,
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;
 
 export function getBatchEndpoints(

--- a/front/lib/model_constructors/batch/clients/google_ai_studio.ts
+++ b/front/lib/model_constructors/batch/clients/google_ai_studio.ts
@@ -1,0 +1,149 @@
+import {
+  BatchEndpoint,
+  type BatchRequest,
+  type BatchStatus,
+} from "@app/lib/model_constructors/batch/endpoint";
+import type { GoogleAiStudioInputConfig } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
+import { WithGoogleGenAIInputConverter } from "@app/lib/model_constructors/sdk/google_genai/converters/input";
+import { WithGoogleGenAIOutputConverter } from "@app/lib/model_constructors/sdk/google_genai/converters/output";
+import { responseToEvents } from "@app/lib/model_constructors/sdk/google_genai/converters/output/utils";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { GOOGLE_AI_STUDIO_API } from "@app/lib/model_constructors/types/provider_apis";
+import { GOOGLE_AI_STUDIO_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type {
+  GenerateContentParameters,
+  InlinedRequest,
+  InlinedResponse,
+} from "@google/genai";
+import { GoogleGenAI, JobState } from "@google/genai";
+
+// Custom-id round-trips through each request's `metadata`, so results can be
+// correlated back even though the batch API also preserves request order.
+const CUSTOM_ID_METADATA_KEY = "custom_id";
+
+// How many request payloads to build concurrently (each may fetch image parts).
+const BUILD_PAYLOAD_CONCURRENCY = 8;
+
+// Terminal job states: the batch has finished and results can be read.
+const TERMINAL_JOB_STATES: ReadonlySet<JobState> = new Set([
+  JobState.JOB_STATE_SUCCEEDED,
+  JobState.JOB_STATE_PARTIALLY_SUCCEEDED,
+  JobState.JOB_STATE_FAILED,
+  JobState.JOB_STATE_CANCELLED,
+  JobState.JOB_STATE_EXPIRED,
+]);
+
+/**
+ * The batch sibling of `GoogleAiStudioStream`: same input/output converters (so
+ * batch requests and event conversion match streaming), but it talks to the
+ * Gemini Batches API with inlined requests and defines `sendBatch` instead of
+ * `streamRaw`.
+ */
+export abstract class GoogleAiStudioBatch extends WithGoogleGenAIInputConverter(
+  WithGoogleGenAIOutputConverter(
+    BatchEndpoint<
+      GenerateContentParameters,
+      InlinedResponse,
+      GoogleAiStudioInputConfig
+    >
+  )
+) {
+  static readonly providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
+  static readonly api = GOOGLE_AI_STUDIO_API;
+
+  private readonly client: GoogleGenAI;
+
+  constructor({ GOOGLE_AI_STUDIO_API_KEY }: Credentials) {
+    super();
+    this.client = new GoogleGenAI({ apiKey: GOOGLE_AI_STUDIO_API_KEY });
+  }
+
+  rawBatchOutputToEvents(result: InlinedResponse): NonDeltaResponseEvent[] {
+    if (result.error) {
+      return [
+        buildErrorEvent({
+          metadata: this.metadata(),
+          type: "server_error",
+          message:
+            result.error.message ?? "The batch request failed without details.",
+          originalError: result.error,
+        }),
+      ];
+    }
+    if (!result.response) {
+      return [
+        buildErrorEvent({
+          metadata: this.metadata(),
+          type: "unknown_error",
+          message:
+            "The batch request returned neither a response nor an error.",
+        }),
+      ];
+    }
+    return responseToEvents(result.response, this.metadata(), this);
+  }
+
+  async sendBatch(
+    requests: Map<string, BatchRequest<GoogleAiStudioInputConfig>>
+  ): Promise<string> {
+    const entries = Array.from(requests.entries());
+    const inlinedRequests: InlinedRequest[] = await concurrentExecutor(
+      entries,
+      async ([customId, { payload, config }]) => {
+        const { contents, config: requestConfig } =
+          await this.buildRequestPayload(payload, config);
+        return {
+          model: this.constructor.modelId,
+          contents,
+          config: requestConfig,
+          metadata: { [CUSTOM_ID_METADATA_KEY]: customId },
+        };
+      },
+      { concurrency: BUILD_PAYLOAD_CONCURRENCY }
+    );
+
+    const batch = await this.client.batches.create({
+      model: this.constructor.modelId,
+      src: inlinedRequests,
+    });
+
+    if (!batch.name) {
+      throw new Error("Gemini batch creation did not return a job name.");
+    }
+    return batch.name;
+  }
+
+  async getBatchStatus(batchId: string): Promise<BatchStatus> {
+    const batch = await this.client.batches.get({ name: batchId });
+    return batch.state && TERMINAL_JOB_STATES.has(batch.state)
+      ? "ready"
+      : "computing";
+  }
+
+  async getBatchResult(
+    batchId: string
+  ): Promise<Map<string, NonDeltaResponseEvent[]>> {
+    const batch = await this.client.batches.get({ name: batchId });
+    const inlinedResponses = batch.dest?.inlinedResponses ?? [];
+
+    const batchResult = new Map<string, NonDeltaResponseEvent[]>();
+    for (const response of inlinedResponses) {
+      const customId = response.metadata?.[CUSTOM_ID_METADATA_KEY];
+      if (!customId) {
+        throw new Error(
+          "Gemini batch response is missing its custom_id metadata."
+        );
+      }
+      batchResult.set(customId, this.rawBatchOutputToEvents(response));
+    }
+    return batchResult;
+  }
+
+  async deleteBatch(batchId: string): Promise<boolean> {
+    await this.client.batches.delete({ name: batchId });
+    return true;
+  }
+}

--- a/front/lib/model_constructors/batch/endpoint.ts
+++ b/front/lib/model_constructors/batch/endpoint.ts
@@ -23,5 +23,6 @@ export abstract class BatchEndpoint<
   ): Promise<Map<string, NonDeltaResponseEvent[]>>;
   abstract deleteBatch(batchId: string): Promise<boolean>;
   abstract rawBatchOutputToEvents(raw: R): NonDeltaResponseEvent[];
-  abstract buildRequestPayload(payload: Payload, config: C): I;
+  // May be async (e.g. converters that fetch image parts); awaited in `sendBatch`.
+  abstract buildRequestPayload(payload: Payload, config: C): Promise<I> | I;
 }

--- a/front/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.ts
@@ -1,0 +1,20 @@
+import { GoogleAiStudioBatch } from "@app/lib/model_constructors/batch/clients/google_ai_studio";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  GoogleAiStudioBatch
+) {
+  // Batch pricing is half the standard Gemini rate.
+  static readonly tokenPricing = {
+    standardInput: 0.125,
+    standardOutput: 0.75,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_pro.ts
@@ -1,0 +1,20 @@
+import { GoogleAiStudioBatch } from "@app/lib/model_constructors/batch/clients/google_ai_studio";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { WithGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGeminiThreeDotOneProBatch extends WithGoogleAiStudioGeminiThreeDotOneProConfig(
+  GoogleAiStudioBatch
+) {
+  // Batch pricing is half the standard Gemini rate.
+  static readonly tokenPricing = {
+    standardInput: 2.0,
+    standardOutput: 9.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGeminiThreeDotOneProBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_5_flash.ts
@@ -1,0 +1,20 @@
+import { GoogleAiStudioBatch } from "@app/lib/model_constructors/batch/clients/google_ai_studio";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { WithGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  GoogleAiStudioBatch
+) {
+  // Batch pricing is half the standard Gemini rate.
+  static readonly tokenPricing = {
+    standardInput: 0.75,
+    standardOutput: 4.5,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/index.ts
+++ b/front/lib/model_constructors/batch/index.ts
@@ -1,9 +1,18 @@
 import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
 import { AnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/model_constructors/batch/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
+import { GoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
+import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
 
 export const BATCH_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixBatch.id]:
     AnthropicGlobalClaudeSonnetFourDotSixBatch,
+  [GoogleAiStudioGlobalGeminiThreeDotOneProBatch.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneProBatch,
+  [GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch.id]:
+    GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch,
+  [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch.id]:
+    GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch,
 } as const satisfies Record<string, BatchEndpointConstructor>;
 
 export type BatchEndpointId = keyof typeof BATCH_ENDPOINTS;

--- a/front/lib/model_constructors/sdk/google_genai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/output/utils.ts
@@ -2,6 +2,7 @@ import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoin
 import type {
   ErrorEvent,
   ModelResponseEvent,
+  NonDeltaResponseEvent,
   ReasoningDeltaEvent,
   ReasoningEvent,
   ResponseIdEvent,
@@ -508,4 +509,89 @@ export async function* rawOutputToEvents(
         : {}),
     },
   };
+}
+
+// -- Non-streaming entry point: a complete batch response → events --
+
+function isNonDeltaEvent(
+  event: ModelResponseEvent
+): event is NonDeltaResponseEvent {
+  return (
+    event.type !== "text_delta" &&
+    event.type !== "reasoning_delta" &&
+    event.type !== "tool_call_delta"
+  );
+}
+
+// Turns a single complete `GenerateContentResponse` (as returned by the batch
+// API) into the unified event array, mirroring `rawOutputToEvents` minus the
+// streaming-only delta events. Reuses `partToEvents`/`flushAccumulated` so part
+// semantics (thought signatures, tool-call id fallback) stay single-sourced.
+export function responseToEvents(
+  response: GenerateContentResponse,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): NonDeltaResponseEvent[] {
+  const events: NonDeltaResponseEvent[] = [];
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const acc: Accumulator = {
+    textParts: "",
+    reasoningParts: "",
+    toolCallIndex: 0,
+  };
+
+  if (response.responseId) {
+    events.push(
+      converters.responseIdToResponseIdEvent(metadata, response.responseId)
+    );
+  }
+
+  const candidate = response.candidates?.[0];
+
+  for (const part of candidate?.content?.parts ?? []) {
+    for (const event of partToEvents(
+      part,
+      acc,
+      metadata,
+      converters,
+      aggregated
+    )) {
+      if (isNonDeltaEvent(event)) {
+        events.push(event);
+      }
+    }
+  }
+
+  for (const event of flushAccumulated(acc, metadata, converters, aggregated)) {
+    if (isNonDeltaEvent(event)) {
+      events.push(event);
+    }
+  }
+
+  if (candidate?.finishReason) {
+    const errorEvent = converters.finishReasonToErrorEvent(
+      metadata,
+      candidate.finishReason
+    );
+    if (errorEvent) {
+      events.push(errorEvent);
+    }
+  }
+
+  events.push(
+    converters.usageToTokenUsageEvent(metadata, response.usageMetadata)
+  );
+
+  events.push({
+    type: "success",
+    content: { aggregated },
+    metadata: {
+      ...metadata,
+      ...(acc.thoughtSignature
+        ? { content: { signature: acc.thoughtSignature } }
+        : {}),
+    },
+  });
+
+  return events;
 }


### PR DESCRIPTION
  ## What

  Adds **batch-mode** support for Gemini in the new `model_constructors` / `lib/llms` router,
  covering all three router Gemini models — **3.1 Pro**, **3.5 Flash**, and **3.1 Flash-Lite**
  (all `supportsBatchProcessing` in the legacy router). Until now Anthropic (Sonnet 4.6) was
  the only batch provider; this brings Google to parity.

  ## Changes

  **Core plumbing**
  - `batch/endpoint.ts`: widened `buildRequestPayload` to `Promise<I> | I` — the Gemini input
    converter is async (it may fetch image parts), mirroring what the stream endpoint already
    does. Anthropic batch is unaffected (its converter is synchronous).
  - `sdk/google_genai/converters/output/utils.ts`: added a non-streaming `responseToEvents(...)`
    converter (+ an `isNonDeltaEvent` type guard). It reuses the existing
    `partToEvents`/`flushAccumulated`, so Gemini's part semantics (thought signatures,
    tool-call id fallback) stay single-sourced — effectively `rawOutputToEvents` minus the
    streaming-only delta events.

  **Batch client** — `batch/clients/google_ai_studio.ts` (`GoogleAiStudioBatch`)
  - The batch sibling of `GoogleAiStudioStream`: same input/output converters, but talks to the
    Gemini Batches API with inlined requests.
  - `sendBatch` builds request payloads concurrently (`concurrentExecutor`, not `Promise.all`),
    round-trips the `custom_id` through each request's `metadata` for result correlation, and
    creates the job.
  - `getBatchStatus` maps `JobState` → `ready`/`computing`; `getBatchResult` reads
    `dest.inlinedResponses`; `deleteBatch` deletes the job. Per-response errors and empty
    responses are surfaced as unified error events.

  **Endpoints**
  - `batch/endpoints/google_ai_studio_global_gemini_3_1_pro.ts`,
    `..._3_5_flash.ts`, `..._3_1_flash_lite.ts`: each reuses the model's existing config mixin
    (Gemini batch supports the same config as streaming, so no schema override — unlike
    Anthropic) with batch pricing at 50% of the standard rate.
  - Dust wrappers under `lib/llms/batch/endpoints/` (just `endpointFilter`, matching the Sonnet
    wrapper).
  - Registered in `BATCH_ENDPOINTS` and `DUST_BATCH_ENDPOINTS`.

  ## Testing

  - `npx tsgo --noEmit`: clean.
  - `biome check`: clean.
  - Runtime check: all three Gemini batch endpoints register in both registries with correct
    ids (`google_ai_studio/google-ai-studio/global/gemini-3.{1-pro-preview,5-flash,1-flash-lite}`).