### PR TITLE
[front] do not trigger payment failure flow for credits purchase

### DIFF
--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -925,6 +925,12 @@ export async function processStripeWebhookEvent({
         break;
       }
 
+      // Credit (AWU) purchase invoices are directly handled using
+      // Metronome "payment_gate.payment_status" webhook
+      if (isAwuPurchaseInvoice(invoice)) {
+        break;
+      }
+
       const ctx = await resolveInvoiceCtx(invoice);
       if (!ctx) {
         break;


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/9105

Currently, on a stripe invoice payment failure for credits purchase, we trigger the whole behavior for payment failure (notification, banner, workspace downgrade, ...)
We only want this behavior for monthly (subscription) payment  failure.
=> break directly in stripe "invoice.payment_failed" webhook for credit purchase invoice to avoid this behavior

## Tests

## Risk

Low, specific to credit purchase

## Deploy Plan

Deploy front
