### PR TITLE
feat(input-bar): add upload file slash command

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -13,7 +13,10 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
 import { useInputBarOverlayTracker } from "@app/components/assistant/conversation/input_bar/useInputBarOverlayTracker";
-import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import {
+  getAvailableInputBarSlashCommands,
+  type InputBarSlashCommand,
+} from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import {
   ADD_CAPABILITY_SLASH_COMMAND_ACTION,
   type AddCapabilitySlashCommand,
@@ -324,6 +327,12 @@ const InputBarContainer = ({
   // conversation may only be created after the first message; the ref keeps it current.
   const conversationIdRef = useRef<string | null>(conversation?.sId ?? null);
   conversationIdRef.current = conversation?.sId ?? null;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const slashCommandsRef = useRef<InputBarSlashCommand[]>([]);
+  slashCommandsRef.current = getAvailableInputBarSlashCommands({
+    hasAttachment: actions.includes("attachment"),
+    hasConversation: Boolean(conversation?.sId),
+  });
   const onSelectRef = useRef<((item: SlashCommand) => void) | undefined>(
     undefined
   );
@@ -561,6 +570,11 @@ const InputBarContainer = ({
 
   const handleSlashCommandSelect = (command: InputBarSlashCommand) => {
     switch (command.id) {
+      case "upload-file":
+        if (!fileUploaderService.isProcessingFiles) {
+          fileInputRef.current?.click();
+        }
+        break;
       case "compact":
         if (isCompacting) {
           break;
@@ -668,6 +682,7 @@ const InputBarContainer = ({
       onCapabilityToolDetailsRef,
       onSkillDetails: setSelectedSkillIdForDetails,
       selectedMCPServerViewIdsRef,
+      slashCommandsRef,
     },
     placeholderOverride: disableInput ? submitBlockMessage : placeholder,
     onSuggestionActiveChangeRef,
@@ -1300,8 +1315,6 @@ const InputBarContainer = ({
   const buttonSize = useMemo(() => {
     return isMobile ? "sm" : "xs";
   }, [isMobile]);
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const isSubmitDisabled =
     (isEmpty && !canSubmitEmpty) ||

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -2,14 +2,41 @@ import {
   ADD_CAPABILITY_SLASH_COMMAND_ACTION,
   isRunCommandSlashCommand,
   RUN_COMMAND_SLASH_COMMAND_ACTION,
+  type RunCommandSlashCommand,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import { describe, expect, it } from "vitest";
 
 import { buildInputBarSlashCommandItems } from "./InputBarSlashSuggestionItems";
 import {
+  getAvailableInputBarSlashCommands,
   INPUT_BAR_SLASH_COMMANDS,
   type InputBarSlashCommand,
 } from "./InputBarSlashSuggestionTypes";
+
+const ALL_COMMANDS = getAvailableInputBarSlashCommands({
+  hasAttachment: true,
+  hasConversation: true,
+});
+
+describe("getAvailableInputBarSlashCommands", () => {
+  it("includes upload file when attachments are enabled", () => {
+    expect(
+      getAvailableInputBarSlashCommands({
+        hasAttachment: true,
+        hasConversation: false,
+      }).map((command) => command.id)
+    ).toEqual(["upload-file"]);
+  });
+
+  it("includes compact only when a conversation exists", () => {
+    expect(
+      getAvailableInputBarSlashCommands({
+        hasAttachment: true,
+        hasConversation: true,
+      }).map((command) => command.id)
+    ).toEqual(["upload-file", "compact"]);
+  });
+});
 
 describe("buildInputBarSlashCommandItems", () => {
   it("always includes the add capability command", () => {
@@ -25,11 +52,12 @@ describe("buildInputBarSlashCommandItems", () => {
 
   it("lists static commands ahead of add capability", () => {
     const result = buildInputBarSlashCommandItems({
-      commands: INPUT_BAR_SLASH_COMMANDS,
+      commands: ALL_COMMANDS,
       query: "",
     });
 
     expect(result.map((item) => item.action)).toEqual([
+      RUN_COMMAND_SLASH_COMMAND_ACTION,
       RUN_COMMAND_SLASH_COMMAND_ACTION,
       ADD_CAPABILITY_SLASH_COMMAND_ACTION,
     ]);
@@ -37,7 +65,7 @@ describe("buildInputBarSlashCommandItems", () => {
 
   it("filters commands by the query", async () => {
     const result = buildInputBarSlashCommandItems({
-      commands: INPUT_BAR_SLASH_COMMANDS,
+      commands: ALL_COMMANDS,
       query: "comp",
     });
 
@@ -53,6 +81,18 @@ describe("buildInputBarSlashCommandItems", () => {
     expect(
       buildInputBarSlashCommandItems({
         commands: INPUT_BAR_SLASH_COMMANDS,
+        query: "upload",
+      }).map((item) =>
+        item.action === RUN_COMMAND_SLASH_COMMAND_ACTION
+          ? (item as RunCommandSlashCommand<InputBarSlashCommand>).data.command
+              .id
+          : item.action
+      )
+    ).toEqual(["upload-file"]);
+
+    expect(
+      buildInputBarSlashCommandItems({
+        commands: ALL_COMMANDS,
         query: "zzz",
       })
     ).toEqual([]);

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -1,5 +1,5 @@
 import { buildInputBarSlashCommandItems } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionItems";
-import { INPUT_BAR_SLASH_COMMANDS } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
@@ -25,31 +25,31 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     onClose: () => void;
     onDetailsRef?: RefObject<((item: SlashCommand) => void) | undefined>;
     owner: LightWorkspaceType;
+    slashCommandsRef: RefObject<InputBarSlashCommand[]>;
   }
 >(
   (
     {
       clientRect,
       command,
-      conversationIdRef,
       editor,
       query,
       range,
       onClose,
       onDetailsRef,
+      slashCommandsRef,
     },
     ref
   ) => {
     const dropdownRef = useRef<SlashCommandDropdownRef>(null);
-    const hasConversation = Boolean(conversationIdRef?.current);
 
     const commandItems = useMemo(
       () =>
         buildInputBarSlashCommandItems({
-          commands: hasConversation ? INPUT_BAR_SLASH_COMMANDS : [],
+          commands: slashCommandsRef.current ?? [],
           query,
         }),
-      [hasConversation, query]
+      [query, slashCommandsRef]
     );
 
     useImperativeHandle(

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -1,4 +1,5 @@
 import { InputBarSlashSuggestionDropdown } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown";
+import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { isAddCapabilitySlashCommand } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { createSlashSuggestionExtension } from "@app/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension";
@@ -24,6 +25,7 @@ export interface InputBarSlashSuggestionExtensionOptions {
   onSelectRef: RefObject<((item: SlashCommand) => void) | undefined>;
   owner?: WorkspaceType;
   selectedMCPServerViewIdsRef: RefObject<Set<string>>;
+  slashCommandsRef: RefObject<InputBarSlashCommand[]>;
 }
 
 export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
@@ -47,6 +49,7 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
     onSelectRef: { current: undefined },
     onDetailsRef: { current: undefined },
     selectedMCPServerViewIdsRef: { current: new Set<string>() },
+    slashCommandsRef: { current: [] },
   },
   allow: ({ editor, state, range, isActive, options, storage }) =>
     Boolean(options.owner) &&
@@ -80,6 +83,7 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
     conversationIdRef: options.conversationIdRef,
     onDetailsRef: options.onDetailsRef,
     owner: options.owner,
+    slashCommandsRef: options.slashCommandsRef,
   }),
   notifyActiveChange: (active, options) => {
     options.onActiveChangeRef?.current?.(active);

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -1,8 +1,8 @@
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
-import { Minimize01 } from "@dust-tt/sparkle";
+import { Minimize01, UploadCloud02 } from "@dust-tt/sparkle";
 import type React from "react";
 
-export type InputBarSlashCommandId = "compact";
+export type InputBarSlashCommandId = "compact" | "upload-file";
 
 // Static command offered by the input bar `/` dropdown, as opposed to workspace capabilities
 // (skills and tools) which are fetched.
@@ -13,9 +13,13 @@ export interface InputBarSlashCommand {
   label: string;
 }
 
-// Static commands require an existing conversation to operate on; the dropdown only offers them
-// when one is present.
 export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
+  {
+    description: "Upload a file from your device",
+    icon: UploadCloud02,
+    id: "upload-file",
+    label: "Upload file",
+  },
   {
     description: "Free up context by summarizing conversation",
     icon: Minimize01,
@@ -23,5 +27,25 @@ export const INPUT_BAR_SLASH_COMMANDS: InputBarSlashCommand[] = [
     label: "compact",
   },
 ];
+
+export function getAvailableInputBarSlashCommands({
+  hasAttachment,
+  hasConversation,
+}: {
+  hasAttachment: boolean;
+  hasConversation: boolean;
+}): InputBarSlashCommand[] {
+  return INPUT_BAR_SLASH_COMMANDS.filter((command) => {
+    if (command.id === "upload-file") {
+      return hasAttachment;
+    }
+
+    if (command.id === "compact") {
+      return hasConversation;
+    }
+
+    return true;
+  });
+}
 
 export type InputBarSlashCommandSkill = SkillWithoutInstructionsAndToolsType;

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -33,6 +33,7 @@ describe("buildEditorExtensions", () => {
           enabledRef: { current: true },
           onSelectRef: { current: undefined },
           selectedMCPServerViewIdsRef: { current: new Set<string>() },
+          slashCommandsRef: { current: [] },
         }),
       ],
     });

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -5,6 +5,7 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
+import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
 import { PastedAttachmentExtension } from "@app/components/editor/extensions/input_bar/PastedAttachmentExtension";
 import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode";
@@ -320,6 +321,7 @@ export interface CustomEditorProps {
       ((tool: MCPServerViewType) => void) | undefined
     >;
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
+    slashCommandsRef: React.RefObject<InputBarSlashCommand[]>;
   };
   // Override the default editor placeholder (e.g. to show a blocked-state reason).
   placeholderOverride?: string | null;
@@ -483,6 +485,7 @@ export const buildEditorExtensions = ({
         onSelectRef: slashSuggestion.onSelectRef,
         onDetailsRef: slashSuggestion.onDetailsRef,
         onActiveChangeRef: onSuggestionActiveChangeRef,
+        slashCommandsRef: slashSuggestion.slashCommandsRef,
       })
     );
   }


### PR DESCRIPTION
## Description

Adds an `upload-file` entry to the input bar's `/` slash command menu. Selecting it triggers `fileInputRef.current?.click()` to open the native file picker, gated on `fileUploaderService.isProcessingFiles`. The command is only surfaced when `actions` includes `"attachment"` (i.e. the input bar is configured to accept uploads).

Refactors command availability out of `InputBarSlashSuggestionDropdown` (where it was hardcoded against `conversationIdRef`) into `getAvailableInputBarSlashCommands({ hasAttachment, hasConversation })` in `InputBarSlashSuggestionTypes`. A `slashCommandsRef` is now threaded through `InputBarSlashSuggestionExtension` and `InputBarSlashSuggestionDropdown` to carry the pre-filtered command list.

<img width="434" height="388" alt="image" src="https://github.com/user-attachments/assets/81e4b7b1-93e0-4d2f-bd18-e8003a67aaaf" />


## Tests

- Added unit tests for `getAvailableInputBarSlashCommands` covering the `hasAttachment`/`hasConversation` filtering combinations.
- Updated existing `buildInputBarSlashCommandItems` tests to use the full `ALL_COMMANDS` set (reflecting the new `upload-file` entry).
- Tested locally: slash menu shows "Upload file" when attachment is enabled, opens file picker on selection.

## Risk

Low. Change is purely front-end and additive — no new API calls or data model changes. The `upload-file` command reuses the existing `fileInputRef` / `fileUploaderService` path already wired for file upload. Rollback is safe (revert front deploy).

## Deploy Plan

Deploy `front`.
