### PR TITLE
feat(analytics): agent credits table on the new Analytics page

### DIFF
--- a/front-api/routes/w/[wId]/analytics/agent-credits.ts
+++ b/front-api/routes/w/[wId]/analytics/agent-credits.ts
@@ -1,0 +1,49 @@
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { GetAgentCreditsResponse } from "@app/lib/api/assistant/observability/agent_credits";
+import { fetchAgentCreditBreakdown } from "@app/lib/api/assistant/observability/agent_credits";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureHasPermission } from "@front-api/middlewares/ensure_role";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+export type { GetAgentCreditsResponse };
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  limit: z.coerce.number().positive().max(200).optional().default(100),
+  search: z.string().optional(),
+});
+
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureHasPermission("workspace:view_analytics"),
+  validate("query", QuerySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { days, limit, search } = ctx.req.valid("query");
+
+    const result = await fetchAgentCreditBreakdown(auth, {
+      days,
+      limit,
+      search,
+    });
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to retrieve agent credits: ${result.error.message}`,
+        },
+      });
+    }
+
+    const body: GetAgentCreditsResponse = { agents: result.value };
+    return ctx.json(body);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/analytics/index.ts
@@ -1,6 +1,7 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import activeUsers from "./active-users";
 import activeUsersExport from "./active-users-export";
+import agentCredits from "./agent-credits";
 import agentsExport from "./agents-export";
 import awuUsage from "./awu-usage";
 import awuUsageAnalytics from "./awu-usage-analytics";
@@ -29,6 +30,7 @@ const app = workspaceApp();
 
 app.route("/active-users-export", activeUsersExport);
 app.route("/active-users", activeUsers);
+app.route("/agent-credits", agentCredits);
 app.route("/agents-export", agentsExport);
 app.route("/awu-usage", awuUsage);
 app.route("/awu-usage-analytics", awuUsageAnalytics);

--- a/front/components/pages/workspace/NewAnalyticsPage.tsx
+++ b/front/components/pages/workspace/NewAnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { WorkspaceAgentCreditsTable } from "@app/components/workspace/analytics/WorkspaceAgentCreditsTable";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
 import { WorkspaceUserCreditsTable } from "@app/components/workspace/analytics/WorkspaceUserCreditsTable";
@@ -97,6 +98,7 @@ export function NewAnalyticsPage() {
           <AwuUsageFromAnalyticsChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>
         <WorkspaceUserCreditsTable workspaceId={owner.sId} period={period} />
+        <WorkspaceAgentCreditsTable workspaceId={owner.sId} period={period} />
         <SafeSuspense fallback={<ChartFallback />}>
           <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
         </SafeSuspense>

--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -42,17 +42,17 @@ function TopSkillsCell({ skills }: { skills: AgentCreditSkill[] }) {
   return (
     <EntityList
       items={skills}
-      renderItem={(skill, index) => {
+      renderItem={(skill) => {
         const label = <span className="truncate text-sm">{skill.name}</span>;
         return skill.description ? (
           <Tooltip
-            key={`${skill.name}-${index}`}
+            key={skill.skillId}
             label={skill.description}
             tooltipTriggerAsChild
             trigger={label}
           />
         ) : (
-          <span key={`${skill.name}-${index}`} className="truncate text-sm">
+          <span key={skill.skillId} className="truncate text-sm">
             {skill.name}
           </span>
         );

--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -1,0 +1,218 @@
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
+import { useDebounce } from "@app/hooks/useDebounce";
+import type {
+  AgentCreditRow,
+  AgentCreditSkill,
+  AgentCreditUser,
+} from "@app/lib/api/assistant/observability/agent_credits";
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import { useWorkspaceAgentCredits } from "@app/lib/swr/workspaces";
+import { Avatar, DataTable, Tooltip } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+
+interface AgentCreditRowData extends AgentCreditRow {
+  onClick?: () => void;
+  onDoubleClick?: () => void;
+}
+
+type AgentCreditInfo = CellContext<AgentCreditRowData, unknown>;
+
+function TopUsersCell({ users }: { users: AgentCreditUser[] }) {
+  if (users.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        —
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2 py-1">
+      {users.slice(0, 3).map((user) => (
+        <div key={user.userId} className="flex items-center gap-1.5">
+          <Avatar
+            name={user.name}
+            visual={user.imageUrl ?? undefined}
+            size="xs"
+            isRounded
+          />
+          <span className="truncate text-sm">{user.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TopSkillsCell({ skills }: { skills: AgentCreditSkill[] }) {
+  if (skills.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        —
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2 py-1">
+      {skills.slice(0, 3).map((skill, index) => {
+        const label = <span className="truncate text-sm">{skill.name}</span>;
+        return skill.description ? (
+          <Tooltip
+            key={`${skill.name}-${index}`}
+            label={skill.description}
+            tooltipTriggerAsChild
+            trigger={label}
+          />
+        ) : (
+          <span key={`${skill.name}-${index}`} className="truncate text-sm">
+            {skill.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+const columns: ColumnDef<AgentCreditRowData>[] = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: "Agent",
+    meta: { sizeRatio: 16 },
+    cell: (info: AgentCreditInfo) => {
+      const { name, pictureUrl } = info.row.original;
+      return (
+        <DataTable.CellContent>
+          <div className="flex items-center gap-2">
+            <Avatar
+              name={name}
+              visual={pictureUrl ?? undefined}
+              size="xs"
+              isRounded
+            />
+            <span className="truncate text-sm">{name}</span>
+          </div>
+        </DataTable.CellContent>
+      );
+    },
+  },
+  {
+    id: "modelDisplayName",
+    accessorKey: "modelDisplayName",
+    header: "Model",
+    meta: { sizeRatio: 11 },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.BasicCellContent label={info.row.original.modelDisplayName} />
+    ),
+  },
+  {
+    id: "description",
+    header: "Description",
+    meta: { sizeRatio: 20 },
+    cell: (info: AgentCreditInfo) => {
+      const { description } = info.row.original;
+      if (!description) {
+        return (
+          <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            —
+          </span>
+        );
+      }
+      return (
+        <DataTable.CellContent>
+          <Tooltip
+            label={description}
+            tooltipTriggerAsChild
+            trigger={
+              <span className="line-clamp-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {description}
+              </span>
+            }
+          />
+        </DataTable.CellContent>
+      );
+    },
+  },
+  {
+    id: "credits",
+    accessorKey: "credits",
+    header: "Credits",
+    meta: { sizeRatio: 8 },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.CellContent>
+        <Tooltip
+          label={`${formatCredits(info.row.original.credits)} credits`}
+          tooltipTriggerAsChild
+          trigger={
+            <span className="text-sm">
+              {formatCreditsCompact(info.row.original.credits)}
+            </span>
+          }
+        />
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "topUsers",
+    header: "Top users",
+    meta: { sizeRatio: 23 },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.CellContent>
+        <TopUsersCell users={info.row.original.topUsers} />
+      </DataTable.CellContent>
+    ),
+  },
+  {
+    id: "topSkills",
+    header: "Top skills",
+    meta: { sizeRatio: 22 },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.CellContent>
+        <TopSkillsCell skills={info.row.original.topSkills} />
+      </DataTable.CellContent>
+    ),
+  },
+];
+
+interface WorkspaceAgentCreditsTableProps {
+  workspaceId: string;
+  period: ObservabilityTimeRangeType;
+}
+
+export function WorkspaceAgentCreditsTable({
+  workspaceId,
+  period,
+}: WorkspaceAgentCreditsTableProps) {
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: 300,
+  });
+
+  const { agentCredits, isAgentCreditsLoading, isAgentCreditsError } =
+    useWorkspaceAgentCredits({
+      workspaceId,
+      days: period,
+      limit: 100,
+      search: debouncedValue || undefined,
+      disabled: !workspaceId,
+    });
+
+  return (
+    <CreditsTableCard<AgentCreditRowData>
+      title="Agents by credits"
+      description={`Top 100 agents by credits over the last ${period} days, with their top users and skills.`}
+      searchName="agent-credits-search"
+      searchPlaceholder="Search an agent…"
+      searchValue={inputValue}
+      onSearchChange={setValue}
+      isLoading={isAgentCreditsLoading}
+      isError={Boolean(isAgentCreditsError)}
+      errorMessage="Failed to load agent credits."
+      emptyMessage={
+        debouncedValue
+          ? `No agent matches "${inputValue}".`
+          : "No agent activity for this selection."
+      }
+      columns={columns}
+      data={agentCredits}
+    />
+  );
+}

--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -1,14 +1,19 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
+import {
+  AvatarNameCell,
+  CreditsCell,
+  EmptyCell,
+  EntityList,
+} from "@app/components/workspace/analytics/creditsTableCells";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type {
   AgentCreditRow,
   AgentCreditSkill,
   AgentCreditUser,
 } from "@app/lib/api/assistant/observability/agent_credits";
-import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { useWorkspaceAgentCredits } from "@app/lib/swr/workspaces";
-import { Avatar, DataTable, Tooltip } from "@dust-tt/sparkle";
+import { DataTable, Tooltip } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 
 interface AgentCreditRowData extends AgentCreditRow {
@@ -19,41 +24,25 @@ interface AgentCreditRowData extends AgentCreditRow {
 type AgentCreditInfo = CellContext<AgentCreditRowData, unknown>;
 
 function TopUsersCell({ users }: { users: AgentCreditUser[] }) {
-  if (users.length === 0) {
-    return (
-      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-        —
-      </span>
-    );
-  }
   return (
-    <div className="flex flex-col gap-2 py-1">
-      {users.slice(0, 3).map((user) => (
-        <div key={user.userId} className="flex items-center gap-1.5">
-          <Avatar
-            name={user.name}
-            visual={user.imageUrl ?? undefined}
-            size="xs"
-            isRounded
-          />
-          <span className="truncate text-sm">{user.name}</span>
-        </div>
-      ))}
-    </div>
+    <EntityList
+      items={users}
+      renderItem={(user) => (
+        <AvatarNameCell
+          key={user.userId}
+          name={user.name}
+          imageUrl={user.imageUrl}
+        />
+      )}
+    />
   );
 }
 
 function TopSkillsCell({ skills }: { skills: AgentCreditSkill[] }) {
-  if (skills.length === 0) {
-    return (
-      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-        —
-      </span>
-    );
-  }
   return (
-    <div className="flex flex-col gap-2 py-1">
-      {skills.slice(0, 3).map((skill, index) => {
+    <EntityList
+      items={skills}
+      renderItem={(skill, index) => {
         const label = <span className="truncate text-sm">{skill.name}</span>;
         return skill.description ? (
           <Tooltip
@@ -67,8 +56,8 @@ function TopSkillsCell({ skills }: { skills: AgentCreditSkill[] }) {
             {skill.name}
           </span>
         );
-      })}
-    </div>
+      }}
+    />
   );
 }
 
@@ -78,22 +67,14 @@ const columns: ColumnDef<AgentCreditRowData>[] = [
     accessorKey: "name",
     header: "Agent",
     meta: { sizeRatio: 16 },
-    cell: (info: AgentCreditInfo) => {
-      const { name, pictureUrl } = info.row.original;
-      return (
-        <DataTable.CellContent>
-          <div className="flex items-center gap-2">
-            <Avatar
-              name={name}
-              visual={pictureUrl ?? undefined}
-              size="xs"
-              isRounded
-            />
-            <span className="truncate text-sm">{name}</span>
-          </div>
-        </DataTable.CellContent>
-      );
-    },
+    cell: (info: AgentCreditInfo) => (
+      <DataTable.CellContent>
+        <AvatarNameCell
+          name={info.row.original.name}
+          imageUrl={info.row.original.pictureUrl}
+        />
+      </DataTable.CellContent>
+    ),
   },
   {
     id: "modelDisplayName",
@@ -111,11 +92,7 @@ const columns: ColumnDef<AgentCreditRowData>[] = [
     cell: (info: AgentCreditInfo) => {
       const { description } = info.row.original;
       if (!description) {
-        return (
-          <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            —
-          </span>
-        );
+        return <EmptyCell />;
       }
       return (
         <DataTable.CellContent>
@@ -139,15 +116,7 @@ const columns: ColumnDef<AgentCreditRowData>[] = [
     meta: { sizeRatio: 8 },
     cell: (info: AgentCreditInfo) => (
       <DataTable.CellContent>
-        <Tooltip
-          label={`${formatCredits(info.row.original.credits)} credits`}
-          tooltipTriggerAsChild
-          trigger={
-            <span className="text-sm">
-              {formatCreditsCompact(info.row.original.credits)}
-            </span>
-          }
-        />
+        <CreditsCell credits={info.row.original.credits} />
       </DataTable.CellContent>
     ),
   },

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -1,11 +1,15 @@
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import { CreditsTableCard } from "@app/components/workspace/analytics/CreditsTableCard";
+import {
+  AvatarNameCell,
+  CreditsCell,
+  EntityList,
+} from "@app/components/workspace/analytics/creditsTableCells";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type {
   UserCreditAgent,
   UserCreditRow,
 } from "@app/lib/api/assistant/observability/user_credits";
-import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { useWorkspaceUserCredits } from "@app/lib/swr/workspaces";
 import { Avatar, DataTable, Tooltip } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
@@ -18,16 +22,10 @@ interface UserCreditRowData extends UserCreditRow {
 type UserCreditInfo = CellContext<UserCreditRowData, unknown>;
 
 function TopAgentsCell({ agents }: { agents: UserCreditAgent[] }) {
-  if (agents.length === 0) {
-    return (
-      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-        —
-      </span>
-    );
-  }
   return (
-    <div className="flex flex-col gap-2 py-1">
-      {agents.slice(0, 3).map((agent) => {
+    <EntityList
+      items={agents}
+      renderItem={(agent) => {
         const row = (
           <div className="flex items-center gap-1.5">
             <Avatar
@@ -54,8 +52,8 @@ function TopAgentsCell({ agents }: { agents: UserCreditAgent[] }) {
         ) : (
           <div key={agent.agentId}>{row}</div>
         );
-      })}
-    </div>
+      }}
+    />
   );
 }
 
@@ -65,22 +63,14 @@ const columns: ColumnDef<UserCreditRowData>[] = [
     accessorKey: "name",
     header: "User",
     meta: { sizeRatio: 30 },
-    cell: (info: UserCreditInfo) => {
-      const { name, imageUrl } = info.row.original;
-      return (
-        <DataTable.CellContent>
-          <div className="flex items-center gap-2">
-            <Avatar
-              name={name}
-              visual={imageUrl ?? undefined}
-              size="xs"
-              isRounded
-            />
-            <span className="truncate text-sm">{name}</span>
-          </div>
-        </DataTable.CellContent>
-      );
-    },
+    cell: (info: UserCreditInfo) => (
+      <DataTable.CellContent>
+        <AvatarNameCell
+          name={info.row.original.name}
+          imageUrl={info.row.original.imageUrl}
+        />
+      </DataTable.CellContent>
+    ),
   },
   {
     id: "messageCount",
@@ -100,15 +90,7 @@ const columns: ColumnDef<UserCreditRowData>[] = [
     meta: { sizeRatio: 13 },
     cell: (info: UserCreditInfo) => (
       <DataTable.CellContent>
-        <Tooltip
-          label={`${formatCredits(info.row.original.credits)} credits`}
-          tooltipTriggerAsChild
-          trigger={
-            <span className="text-sm">
-              {formatCreditsCompact(info.row.original.credits)}
-            </span>
-          }
-        />
+        <CreditsCell credits={info.row.original.credits} />
       </DataTable.CellContent>
     ),
   },

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -1,0 +1,56 @@
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import { Avatar, Tooltip } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+export function EmptyCell() {
+  return (
+    <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+      —
+    </span>
+  );
+}
+
+export function AvatarNameCell({
+  name,
+  imageUrl,
+}: {
+  name: string;
+  imageUrl: string | null;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Avatar name={name} visual={imageUrl ?? undefined} size="xs" isRounded />
+      <span className="truncate text-sm">{name}</span>
+    </div>
+  );
+}
+
+export function CreditsCell({ credits }: { credits: number }) {
+  return (
+    <Tooltip
+      label={`${formatCredits(credits)} credits`}
+      tooltipTriggerAsChild
+      trigger={<span className="text-sm">{formatCreditsCompact(credits)}</span>}
+    />
+  );
+}
+
+// Vertical list of up to 3 entities (top agents/users/skills) with the shared
+// empty-state placeholder. Per-item rendering is left to the caller since the
+// item content differs (avatar, secondary text, tooltip).
+export function EntityList<I>({
+  items,
+  renderItem,
+}: {
+  items: I[];
+  renderItem: (item: I, index: number) => ReactNode;
+}) {
+  if (items.length === 0) {
+    return <EmptyCell />;
+  }
+  return (
+    <div className="flex flex-col gap-2 py-1">
+      {items.slice(0, 3).map((item, index) => renderItem(item, index))}
+    </div>
+  );
+}

--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -1,0 +1,244 @@
+import {
+  getAgentConfigurations,
+  searchAgentConfigurationsByName,
+} from "@app/lib/api/assistant/configuration/agent";
+import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import {
+  buildAgentAnalyticsBaseQuery,
+  daysToInstantRange,
+} from "@app/lib/api/assistant/observability/utils";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { FREE_ORIGINS } from "@app/lib/metronome/events";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type AgentCreditUser = {
+  userId: string;
+  name: string;
+  imageUrl: string | null;
+};
+
+// description is set only when the admin can read the skill.
+export type AgentCreditSkill = {
+  name: string;
+  description: string | null;
+};
+
+export type AgentCreditRow = {
+  agentId: string;
+  name: string;
+  pictureUrl: string | null;
+  modelDisplayName: string;
+  description: string;
+  credits: number;
+  topUsers: AgentCreditUser[];
+  topSkills: AgentCreditSkill[];
+};
+
+export type GetAgentCreditsResponse = { agents: AgentCreditRow[] };
+
+type SubBucket = { key: string };
+
+type SkillBucket = {
+  key: string;
+  name?: estypes.AggregationsMultiBucketAggregateBase<SubBucket>;
+};
+
+type AgentBucket = {
+  key: string;
+  credits?: estypes.AggregationsSumAggregate;
+  top_users?: estypes.AggregationsMultiBucketAggregateBase<SubBucket>;
+  top_skills?: {
+    by_skill?: estypes.AggregationsMultiBucketAggregateBase<SkillBucket>;
+  };
+};
+
+type AgentCreditAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<AgentBucket>;
+};
+
+function userDisplayName(user: UserResource | undefined): string {
+  return user?.fullName() || user?.username || user?.email || "Unknown user";
+}
+
+// Per-agent AWU credits (cost.full_awu) over the last `days`: the agent's
+// current model and description, its top 3 users (by cost) and top 3 skills (by
+// execution count — skills carry no per-skill cost). Ranked by credits desc.
+// Non-free scope; the programmatic "unknown" user is excluded from the top
+// users (but its usage still counts toward the agent's credits). When `search`
+// is set, the ranking is scoped to the matching agents so matches outside the
+// top `limit` still surface.
+export async function fetchAgentCreditBreakdown(
+  auth: Authenticator,
+  { days, limit, search }: { days: number; limit: number; search?: string }
+): Promise<Result<AgentCreditRow[], ElasticsearchError>> {
+  const owner = auth.getNonNullableWorkspace();
+  const { startDate, endDate } = daysToInstantRange(days, "UTC");
+
+  let includeAgentIds: string[] | undefined;
+  if (search) {
+    const normalized = search.trim().toLowerCase();
+    const [workspaceMatches, globalAgents] = await Promise.all([
+      searchAgentConfigurationsByName(auth, search),
+      getGlobalAgents(auth, undefined, "light"),
+    ]);
+    const globalMatches = globalAgents.filter((agent) =>
+      agent.name.toLowerCase().includes(normalized)
+    );
+    includeAgentIds = Array.from(
+      new Set([...workspaceMatches, ...globalMatches].map((agent) => agent.sId))
+    ).slice(0, limit);
+    if (includeAgentIds.length === 0) {
+      return new Ok([]);
+    }
+  }
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: owner.sId,
+    startDate,
+    endDate,
+  });
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [baseQuery, { exists: { field: "agent_id" } }],
+      must_not: [{ terms: { context_origin: [...FREE_ORIGINS] } }],
+    },
+  };
+
+  const result = await searchAnalytics<never, AgentCreditAggs>(query, {
+    aggregations: {
+      by_agent: {
+        terms: {
+          field: "agent_id",
+          size: limit,
+          order: { credits: "desc" },
+          ...(includeAgentIds ? { include: includeAgentIds } : {}),
+        },
+        aggs: {
+          credits: { sum: { field: "cost.full_awu" } },
+          top_users: {
+            terms: {
+              field: "user_id",
+              size: 3,
+              exclude: ["unknown"],
+              order: { user_credits: "desc" },
+            },
+            aggs: { user_credits: { sum: { field: "cost.full_awu" } } },
+          },
+          top_skills: {
+            nested: { path: "skills_used" },
+            aggs: {
+              by_skill: {
+                terms: { field: "skills_used.skill_id", size: 3 },
+                aggs: {
+                  name: { terms: { field: "skills_used.skill_name", size: 1 } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const buckets = bucketsToArray<AgentBucket>(
+    result.value.aggregations?.by_agent?.buckets
+  );
+  if (buckets.length === 0) {
+    return new Ok([]);
+  }
+
+  const agentIds = buckets.map((bucket) => String(bucket.key));
+  const userIds = Array.from(
+    new Set(
+      buckets.flatMap((bucket) =>
+        bucketsToArray<SubBucket>(bucket.top_users?.buckets).map((user) =>
+          String(user.key)
+        )
+      )
+    )
+  );
+  const skillIds = Array.from(
+    new Set(
+      buckets.flatMap((bucket) =>
+        bucketsToArray<SkillBucket>(bucket.top_skills?.by_skill?.buckets).map(
+          (skill) => String(skill.key)
+        )
+      )
+    )
+  );
+
+  const [agents, users, skills] = await Promise.all([
+    getAgentConfigurations(auth, { agentIds, variant: "light" }),
+    userIds.length > 0 ? UserResource.fetchByIds(userIds) : Promise.resolve([]),
+    skillIds.length > 0
+      ? SkillResource.fetchByIds(auth, skillIds)
+      : Promise.resolve([]),
+  ]);
+
+  const agentsById = new Map(agents.map((agent) => [agent.sId, agent]));
+  const usersById = new Map(users.map((user) => [user.sId, user]));
+  // fetchByIds only returns skills the admin can read; others get no description.
+  const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
+
+  const rows: AgentCreditRow[] = buckets.map((bucket) => {
+    const agentId = String(bucket.key);
+    const agent = agentsById.get(agentId);
+
+    const topUsers: AgentCreditUser[] = bucketsToArray<SubBucket>(
+      bucket.top_users?.buckets
+    ).map((userBucket) => {
+      const userId = String(userBucket.key);
+      const user = usersById.get(userId);
+      return {
+        userId,
+        name: userDisplayName(user),
+        imageUrl: user?.imageUrl ?? null,
+      };
+    });
+
+    const topSkills: AgentCreditSkill[] = bucketsToArray<SkillBucket>(
+      bucket.top_skills?.by_skill?.buckets
+    ).map((skillBucket) => {
+      const skill = skillsById.get(String(skillBucket.key));
+      const docName = bucketsToArray<SubBucket>(skillBucket.name?.buckets)[0]
+        ?.key;
+      return {
+        name: skill?.name ?? docName ?? "Unknown skill",
+        description: skill?.userFacingDescription || null,
+      };
+    });
+
+    return {
+      agentId,
+      name: agent?.name ?? "Unknown agent",
+      pictureUrl: agent?.pictureUrl ?? null,
+      modelDisplayName: agent
+        ? (getSupportedModelConfig(agent.model)?.displayName ??
+          agent.model.modelId)
+        : "—",
+      // Only surface the description for agents this admin can read; private
+      // agents owned by others appear in usage but their description must not.
+      description:
+        agent && !agent.canRead
+          ? "Private agent: description unavailable"
+          : (agent?.description ?? ""),
+      credits: Math.round(bucket.credits?.value ?? 0),
+      topUsers,
+      topSkills,
+    };
+  });
+
+  return new Ok(rows);
+}

--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -4,14 +4,16 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
 import {
-  buildAgentAnalyticsBaseQuery,
+  getAgentModelDisplayName,
+  getUserDisplayName,
+} from "@app/lib/api/assistant/observability/credit_labels";
+import {
+  buildCreditsScopeQuery,
   daysToInstantRange,
 } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import { FREE_ORIGINS } from "@app/lib/metronome/events";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Result } from "@app/types/shared/result";
@@ -63,10 +65,6 @@ type AgentCreditAggs = {
   by_agent?: estypes.AggregationsMultiBucketAggregateBase<AgentBucket>;
 };
 
-function userDisplayName(user: UserResource | undefined): string {
-  return user?.fullName() || user?.username || user?.email || "Unknown user";
-}
-
 // Per-agent AWU credits (cost.full_awu) over the last `days`: the agent's
 // current model and description, its top 3 users (by cost) and top 3 skills (by
 // execution count — skills carry no per-skill cost). Ranked by credits desc.
@@ -78,7 +76,6 @@ export async function fetchAgentCreditBreakdown(
   auth: Authenticator,
   { days, limit, search }: { days: number; limit: number; search?: string }
 ): Promise<Result<AgentCreditRow[], ElasticsearchError>> {
-  const owner = auth.getNonNullableWorkspace();
   const { startDate, endDate } = daysToInstantRange(days, "UTC");
 
   let includeAgentIds: string[] | undefined;
@@ -99,17 +96,11 @@ export async function fetchAgentCreditBreakdown(
     }
   }
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const query = buildCreditsScopeQuery(auth, {
     startDate,
     endDate,
+    extraFilters: [{ exists: { field: "agent_id" } }],
   });
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter: [baseQuery, { exists: { field: "agent_id" } }],
-      must_not: [{ terms: { context_origin: [...FREE_ORIGINS] } }],
-    },
-  };
 
   const result = await searchAnalytics<never, AgentCreditAggs>(query, {
     aggregations: {
@@ -203,7 +194,7 @@ export async function fetchAgentCreditBreakdown(
       const user = usersById.get(userId);
       return {
         userId,
-        name: userDisplayName(user),
+        name: getUserDisplayName(user),
         imageUrl: user?.imageUrl ?? null,
       };
     });
@@ -224,10 +215,7 @@ export async function fetchAgentCreditBreakdown(
       agentId,
       name: agent?.name ?? "Unknown agent",
       pictureUrl: agent?.pictureUrl ?? null,
-      modelDisplayName: agent
-        ? (getSupportedModelConfig(agent.model)?.displayName ??
-          agent.model.modelId)
-        : "—",
+      modelDisplayName: getAgentModelDisplayName(agent?.model),
       // Only surface the description for agents this admin can read; private
       // agents owned by others appear in usage but their description must not.
       description:

--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -28,6 +28,7 @@ export type AgentCreditUser = {
 
 // description is set only when the admin can read the skill.
 export type AgentCreditSkill = {
+  skillId: string;
   name: string;
   description: string | null;
 };
@@ -202,10 +203,12 @@ export async function fetchAgentCreditBreakdown(
     const topSkills: AgentCreditSkill[] = bucketsToArray<SkillBucket>(
       bucket.top_skills?.by_skill?.buckets
     ).map((skillBucket) => {
-      const skill = skillsById.get(String(skillBucket.key));
+      const skillId = String(skillBucket.key);
+      const skill = skillsById.get(skillId);
       const docName = bucketsToArray<SubBucket>(skillBucket.name?.buckets)[0]
         ?.key;
       return {
+        skillId,
         name: skill?.name ?? docName ?? "Unknown skill",
         description: skill?.userFacingDescription || null,
       };

--- a/front/lib/api/assistant/observability/credit_labels.ts
+++ b/front/lib/api/assistant/observability/credit_labels.ts
@@ -1,0 +1,16 @@
+import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
+
+export function getUserDisplayName(user: UserResource | undefined): string {
+  return user?.fullName() || user?.username || user?.email || "Unknown user";
+}
+
+export function getAgentModelDisplayName(
+  model: AgentModelConfigurationType | undefined
+): string {
+  if (!model) {
+    return "—";
+  }
+  return getSupportedModelConfig(model)?.displayName ?? model.modelId;
+}

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -1,5 +1,5 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { buildCreditsScopeQuery } from "@app/lib/api/assistant/observability/utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
   bucketsToArray,
@@ -8,7 +8,6 @@ import {
 } from "@app/lib/api/elasticsearch";
 import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
-import { FREE_ORIGINS } from "@app/lib/metronome/events";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -99,42 +98,6 @@ const creditSubAggs = {
 
 function totalCreditsFromSlice(slice: CreditSlice): number {
   return Math.round(slice.total_cost?.value ?? 0);
-}
-
-// Workspace query scoped to the window/filters, with free origins excluded to
-// mirror the non-free billed scope. Shared by both credit fetchers so the scope
-// stays identical.
-function buildCreditQuery(
-  auth: Authenticator,
-  {
-    startDate,
-    endDate,
-    contextOrigin,
-    agentIds,
-    userIds,
-  }: {
-    startDate: string;
-    endDate: string;
-    contextOrigin?: string | string[];
-    agentIds?: string[];
-    userIds?: string[];
-  },
-  extraFilters: estypes.QueryDslQueryContainer[] = []
-): estypes.QueryDslQueryContainer {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: auth.getNonNullableWorkspace().sId,
-    startDate,
-    endDate,
-    contextOrigin,
-    agentIds,
-    userIds,
-  });
-  return {
-    bool: {
-      filter: [baseQuery, ...extraFilters],
-      must_not: [{ terms: { context_origin: [...FREE_ORIGINS] } }],
-    },
-  };
 }
 
 function groupFieldFor(
@@ -269,11 +232,15 @@ export async function fetchCreditUsage(
     };
   }
 
-  const query = buildCreditQuery(
-    auth,
-    { startDate, endDate, contextOrigin, agentIds, userIds },
-    groupBy === "none" ? [] : [{ exists: { field: groupFieldFor(groupBy) } }]
-  );
+  const query = buildCreditsScopeQuery(auth, {
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+    extraFilters:
+      groupBy === "none" ? [] : [{ exists: { field: groupFieldFor(groupBy) } }],
+  });
 
   const result = await searchAnalytics<never, CreditUsageAggs>(query, {
     aggregations,
@@ -337,7 +304,7 @@ export async function fetchCreditTimeseries(
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditTimeseriesPoint[], ElasticsearchError>> {
-  const query = buildCreditQuery(auth, {
+  const query = buildCreditsScopeQuery(auth, {
     startDate,
     endDate,
     contextOrigin,
@@ -405,7 +372,7 @@ export async function fetchCreditTimeseriesByUsageType(
     fillWindow?: boolean;
   }
 ): Promise<Result<CreditUsageTypePoint[], ElasticsearchError>> {
-  const query = buildCreditQuery(auth, {
+  const query = buildCreditsScopeQuery(auth, {
     startDate,
     endDate,
     contextOrigin,
@@ -510,7 +477,7 @@ export async function fetchCreditTimeseriesBreakdown(
   }
 
   const groupKeys = groups.map((group) => group.groupKey);
-  const query = buildCreditQuery(auth, {
+  const query = buildCreditsScopeQuery(auth, {
     startDate,
     endDate,
     contextOrigin,

--- a/front/lib/api/assistant/observability/user_credits.ts
+++ b/front/lib/api/assistant/observability/user_credits.ts
@@ -1,12 +1,14 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
-  buildAgentAnalyticsBaseQuery,
+  getAgentModelDisplayName,
+  getUserDisplayName,
+} from "@app/lib/api/assistant/observability/credit_labels";
+import {
+  buildCreditsScopeQuery,
   daysToInstantRange,
 } from "@app/lib/api/assistant/observability/utils";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
-import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
-import { FREE_ORIGINS } from "@app/lib/metronome/events";
 import { UserResource } from "@app/lib/resources/user_resource";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -54,7 +56,6 @@ export async function fetchUserCreditBreakdown(
   auth: Authenticator,
   { days, limit, search }: { days: number; limit: number; search?: string }
 ): Promise<Result<UserCreditRow[], Error>> {
-  const owner = auth.getNonNullableWorkspace();
   const { startDate, endDate } = daysToInstantRange(days, "UTC");
 
   let includeUserIds: string[] | undefined;
@@ -73,20 +74,11 @@ export async function fetchUserCreditBreakdown(
     }
   }
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const query = buildCreditsScopeQuery(auth, {
     startDate,
     endDate,
+    extraMustNot: [{ term: { user_id: "unknown" } }],
   });
-  const query: estypes.QueryDslQueryContainer = {
-    bool: {
-      filter: [baseQuery],
-      must_not: [
-        { terms: { context_origin: [...FREE_ORIGINS] } },
-        { term: { user_id: "unknown" } },
-      ],
-    },
-  };
 
   const result = await searchAnalytics<never, UserCreditAggs>(query, {
     aggregations: {
@@ -158,17 +150,14 @@ export async function fetchUserCreditBreakdown(
         agentId,
         name: agent?.name ?? "Unknown agent",
         pictureUrl: agent?.pictureUrl ?? null,
-        modelDisplayName: agent
-          ? (getSupportedModelConfig(agent.model)?.displayName ??
-            agent.model.modelId)
-          : "—",
+        modelDisplayName: getAgentModelDisplayName(agent?.model),
         description: agent?.description ?? "",
       };
     });
 
     return {
       userId,
-      name: user?.fullName() || user?.username || user?.email || "Unknown user",
+      name: getUserDisplayName(user),
       imageUrl: user?.imageUrl ?? null,
       messageCount: bucket.doc_count,
       credits: Math.round(bucket.credits?.value ?? 0),

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -1,4 +1,6 @@
 import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
+import type { Authenticator } from "@app/lib/auth";
+import { FREE_ORIGINS } from "@app/lib/metronome/events";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -101,6 +103,50 @@ export function buildAgentAnalyticsBaseQuery({
   return {
     bool: {
       filter: filters,
+    },
+  };
+}
+
+// Workspace query scoped to the window, with free origins excluded to mirror the
+// non-free billed scope. Shared by the credit fetchers (timeseries, breakdown,
+// per-user and per-agent tables) so the scope stays identical across them.
+// `extraFilters` / `extraMustNot` carry per-caller constraints (e.g. requiring
+// an agent_id, or excluding the programmatic "unknown" user).
+export function buildCreditsScopeQuery(
+  auth: Authenticator,
+  {
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+    extraFilters = [],
+    extraMustNot = [],
+  }: {
+    startDate: string;
+    endDate: string;
+    contextOrigin?: string | string[];
+    agentIds?: string[];
+    userIds?: string[];
+    extraFilters?: estypes.QueryDslQueryContainer[];
+    extraMustNot?: estypes.QueryDslQueryContainer[];
+  }
+): estypes.QueryDslQueryContainer {
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    startDate,
+    endDate,
+    contextOrigin,
+    agentIds,
+    userIds,
+  });
+  return {
+    bool: {
+      filter: [baseQuery, ...extraFilters],
+      must_not: [
+        { terms: { context_origin: [...FREE_ORIGINS] } },
+        ...extraMustNot,
+      ],
     },
   };
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -18,6 +18,7 @@ import type {
   GetWorkspaceTopUsersResponse,
 } from "@app/lib/api/analytics/workspace_analytics";
 import type { GetWorkspaceActiveUsersResponse } from "@app/lib/api/assistant/observability/active_users_metrics";
+import type { GetAgentCreditsResponse } from "@app/lib/api/assistant/observability/agent_credits";
 import type { GetWorkspaceContextOriginResponse } from "@app/lib/api/assistant/observability/context_origin";
 import type { GetWorkspaceUsageMetricsResponse } from "@app/lib/api/assistant/observability/messages_metrics";
 import type { GetWorkspaceSkillsResponse } from "@app/lib/api/assistant/observability/skill_usage";
@@ -490,6 +491,37 @@ export function useWorkspaceUserCredits({
     isUserCreditsLoading: !error && !data && !disabled,
     isUserCreditsError: error,
     isUserCreditsValidating: isValidating,
+  };
+}
+
+export function useWorkspaceAgentCredits({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  limit = 100,
+  search,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  limit?: number;
+  search?: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetAgentCreditsResponse> = fetcher;
+  const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
+  const key = `/api/w/${workspaceId}/analytics/agent-credits?days=${days}&limit=${limit}${searchParam}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    agentCredits: data?.agents ?? emptyArray(),
+    isAgentCreditsLoading: !error && !data && !disabled,
+    isAgentCreditsError: error,
+    isAgentCreditsValidating: isValidating,
   };
 }
 


### PR DESCRIPTION
## Description

Add an "Agents by credits" table below the users table: per-agent AWU credits (cost.full_awu), current model, description, top 3 users (by cost) and top 3 skills (by execution count, via a nested skills_used aggregation). Ranked by credits desc, follows the page time-range selector, with server-side debounced search.

## Tests

Local

## Risk

None, feature flagged

## Deploy Plan

front