### PR TITLE
Fix agent batch edit checkboxes

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -105,7 +105,7 @@ const getTableColumns = ({
               </DataTable.CellContent>
             ),
             meta: {
-              className: "w-8",
+              className: "w-10",
               tooltip: "Select",
             },
             sortable: false,


### PR DESCRIPTION
## Description

The checkbox column in the agents table (`AssistantsTable`) was too narrow (`w-8`), causing the checkboxes to be clipped or not fully visible. This bumps the column width to `w-10` to give the checkboxes enough room to render correctly.

<img width="1354" height="188" alt="image" src="https://github.com/user-attachments/assets/e4eda974-2a74-4fe6-9193-daa94c1ec3c6" />


## Tests

Visually verified that checkboxes in the agent batch edit table are no longer clipped.

## Risk

None

## Deploy Plan

Deploy front.