### PR TITLE
fix(lefthook): only block additions in frozen migration directories, not deletions

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -154,29 +154,35 @@ pre-commit:
     no-legacy-db-migration-connectors:
       glob: "connectors/migrations/db/*.sql"
       run: |
-        echo ""
-        echo "ERROR: connectors/migrations/db/ is frozen. Do not add files here."
-        echo ""
-        echo "Use the new phased migration system instead:"
-        echo "  npm run -w connectors migration:generate:pre-deploy <description>"
-        echo "  npm run -w connectors migration:generate:post-deploy <description>"
-        echo ""
-        echo "See: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
-        exit 1
+        added=$(git diff --name-only --diff-filter=AM --cached | grep "^connectors/migrations/db/.*\.sql$" || true)
+        if [ -n "$added" ]; then
+          echo ""
+          echo "ERROR: connectors/migrations/db/ is frozen. Do not add files here."
+          echo ""
+          echo "Use the new phased migration system instead:"
+          echo "  npm run -w connectors migration:generate:pre-deploy <description>"
+          echo "  npm run -w connectors migration:generate:post-deploy <description>"
+          echo ""
+          echo "See: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
+          exit 1
+        fi
       priority: 1
 
     no-legacy-db-migration-front:
       glob: "front/migrations/db/*.sql"
       run: |
-        echo ""
-        echo "ERROR: front/migrations/db/ is frozen. Do not add files here."
-        echo ""
-        echo "Use the new phased migration system instead:"
-        echo "  npm run -w front migration:generate:pre-deploy <description>"
-        echo "  npm run -w front migration:generate:post-deploy <description>"
-        echo ""
-        echo "See: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
-        exit 1
+        added=$(git diff --name-only --diff-filter=AM --cached | grep "^front/migrations/db/.*\.sql$" || true)
+        if [ -n "$added" ]; then
+          echo ""
+          echo "ERROR: front/migrations/db/ is frozen. Do not add files here."
+          echo ""
+          echo "Use the new phased migration system instead:"
+          echo "  npm run -w front migration:generate:pre-deploy <description>"
+          echo "  npm run -w front migration:generate:post-deploy <description>"
+          echo ""
+          echo "See: https://app.notion.com/p/dust-tt/Runbook-Deploy-Run-migrations-5669e328475d489ba16298a77f2aa45c?source=copy_link#36728599d94180898358cf59a8725740"
+          exit 1
+        fi
       priority: 1
 
     # Biome checks (all JS/TS files in monorepo)


### PR DESCRIPTION
## Description

The `no-legacy-db-migration-front` and `no-legacy-db-migration-connectors` lefthook hooks triggered on any staged change to files in those directories — including deletions. This meant removing old migration files (e.g. as cleanup after switching to the phased migration system) was blocked.

Both hooks now use `--diff-filter=AM` to only inspect added or modified files, so deletions are allowed while new additions are still blocked.
