### PR TITLE
feat(migrations): add migration:mark:pre-deploy and migration:mark:post-deploy commands

### DIFF
--- a/connectors/package.json
+++ b/connectors/package.json
@@ -28,6 +28,8 @@
     "migration:check": "node ../scripts/db/run-migrate.cjs --command check --execute",
     "migration:check:pre-deploy": "node ../scripts/db/run-migrate.cjs --command check-pre-deploy --execute",
     "migration:check:post-deploy": "node ../scripts/db/run-migrate.cjs --command check-post-deploy --execute",
+    "migration:mark:pre-deploy": "node ../scripts/db/run-migrate.cjs --command mark-pre-deploy --execute",
+    "migration:mark:post-deploy": "node ../scripts/db/run-migrate.cjs --command mark-post-deploy --execute",
     "teams:create-app": "tsx ./scripts/create-teams-app.ts",
     "discord:register-commands": "tsx ./scripts/register-discord-commands.ts",
     "knip": "knip"

--- a/connectors/scripts/migrate.ts
+++ b/connectors/scripts/migrate.ts
@@ -15,12 +15,19 @@ makeScript(
         "check",
         "check-pre-deploy",
         "check-post-deploy",
+        "mark-pre-deploy",
+        "mark-post-deploy",
       ],
       demandOption: true,
       describe: "Migration command to run.",
     },
+    name: {
+      type: "string",
+      describe:
+        "Migration filename for mark commands (e.g. 20250101000000_my_migration or 20250101000000_my_migration.sql).",
+    },
   },
-  async ({ command, execute }) => {
+  async ({ command, name, execute }) => {
     if (!execute) {
       return;
     }
@@ -29,6 +36,7 @@ makeScript(
       getDatabaseURI: () => dbConfig.getRequiredDatabaseURI(),
       logger,
       command,
+      name,
     });
     await connectorsSequelize.close();
   }

--- a/front-api/package.json
+++ b/front-api/package.json
@@ -20,6 +20,8 @@
     "migration:check": "node ../scripts/db/run-migrate.cjs --command check --execute",
     "migration:check:pre-deploy": "node ../scripts/db/run-migrate.cjs --command check-pre-deploy --execute",
     "migration:check:post-deploy": "node ../scripts/db/run-migrate.cjs --command check-post-deploy --execute",
+    "migration:mark:pre-deploy": "node ../scripts/db/run-migrate.cjs --command mark-pre-deploy --execute",
+    "migration:mark:post-deploy": "node ../scripts/db/run-migrate.cjs --command mark-post-deploy --execute",
     "tsgo": "tsgo"
   },
   "dependencies": {

--- a/front-api/scripts/migrate.ts
+++ b/front-api/scripts/migrate.ts
@@ -15,12 +15,19 @@ makeScript(
         "check",
         "check-pre-deploy",
         "check-post-deploy",
+        "mark-pre-deploy",
+        "mark-post-deploy",
       ],
       demandOption: true,
       describe: "Migration command to run.",
     },
+    name: {
+      type: "string",
+      describe:
+        "Migration filename for mark commands (e.g. 20250101000000_my_migration or 20250101000000_my_migration.sql).",
+    },
   },
-  async ({ command, execute }) => {
+  async ({ command, name, execute }) => {
     if (!execute) {
       return;
     }
@@ -29,6 +36,7 @@ makeScript(
       getDatabaseURI: () => dbConfig.getRequiredFrontDatabaseURI(),
       logger,
       command,
+      name,
     });
     await frontSequelize.close();
   }

--- a/front/package.json
+++ b/front/package.json
@@ -33,6 +33,8 @@
     "migration:check": "node ../scripts/db/run-migrate.cjs --command check --execute",
     "migration:check:pre-deploy": "node ../scripts/db/run-migrate.cjs --command check-pre-deploy --execute",
     "migration:check:post-deploy": "node ../scripts/db/run-migrate.cjs --command check-post-deploy --execute",
+    "migration:mark:pre-deploy": "node ../scripts/db/run-migrate.cjs --command mark-pre-deploy --execute",
+    "migration:mark:post-deploy": "node ../scripts/db/run-migrate.cjs --command mark-post-deploy --execute",
     "debug:profiler": "node ./scripts/debug/run_profiler.ts",
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },

--- a/front/scripts/migrate.ts
+++ b/front/scripts/migrate.ts
@@ -15,12 +15,19 @@ makeScript(
         "check",
         "check-pre-deploy",
         "check-post-deploy",
+        "mark-pre-deploy",
+        "mark-post-deploy",
       ],
       demandOption: true,
       describe: "Migration command to run.",
     },
+    name: {
+      type: "string",
+      describe:
+        "Migration filename for mark commands (e.g. 20250101000000_my_migration or 20250101000000_my_migration.sql).",
+    },
   },
-  async ({ command, execute }) => {
+  async ({ command, name, execute }) => {
     if (!execute) {
       return;
     }
@@ -29,6 +36,7 @@ makeScript(
       getDatabaseURI: () => dbConfig.getRequiredFrontDatabaseURI(),
       logger,
       command,
+      name,
     });
     await frontSequelize.close();
   }

--- a/scripts/db/migration-runner.ts
+++ b/scripts/db/migration-runner.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "child_process";
+import { existsSync } from "fs";
 import { QueryTypes } from "sequelize";
 import type { Sequelize } from "sequelize";
 import type { MigrationParams } from "umzug";
@@ -11,7 +12,9 @@ type Command =
   | "status"
   | "check"
   | "check-pre-deploy"
-  | "check-post-deploy";
+  | "check-post-deploy"
+  | "mark-pre-deploy"
+  | "mark-post-deploy";
 
 export interface MigrationLogger {
   debug: (obj: Record<string, unknown>, msg?: string) => void;
@@ -180,6 +183,42 @@ async function runCheckPhase(
   logger.info({ phase }, "All migrations applied.");
 }
 
+async function runMark(
+  sequelize: Sequelize,
+  logger: MigrationLogger,
+  phase: Phase,
+  name: string
+): Promise<void> {
+  const filename = name.endsWith(".sql") ? name : `${name}.sql`;
+  const filePath = `migrations/${phase}/${filename}`;
+
+  if (!existsSync(filePath)) {
+    logger.error(
+      { phase, name: filename, filePath },
+      "Migration file not found."
+    );
+    process.exit(1);
+  }
+
+  const storage = new PhasedSequelizeStorage(sequelize, phase);
+  const storedName = `${phase}/${filename}`;
+
+  const executed = await storage.executed();
+  if (executed.includes(storedName)) {
+    logger.info(
+      { phase, name: storedName },
+      "Migration already marked as applied."
+    );
+    return;
+  }
+
+  await storage.logMigration({ name: storedName });
+  logger.info(
+    { phase, name: storedName },
+    "Migration marked as applied without running."
+  );
+}
+
 function assertNever(x: never): never {
   throw new Error(`Unexpected migration command: ${JSON.stringify(x)}`);
 }
@@ -189,11 +228,13 @@ export async function runMigrations({
   getDatabaseURI,
   logger,
   command,
+  name,
 }: {
   sequelize: Sequelize;
   getDatabaseURI: () => string;
   logger: MigrationLogger;
   command: string;
+  name?: string;
 }): Promise<void> {
   await ensureSchemaMigrationsTable(sequelize);
 
@@ -207,12 +248,28 @@ export async function runMigrations({
       await runStatus(sequelize, getDatabaseURI, logger);
       break;
     case "check":
+      await Promise.all([
+        runCheckPhase(sequelize, getDatabaseURI, logger, "pre-deploy"),
+        runCheckPhase(sequelize, getDatabaseURI, logger, "post-deploy"),
+      ]);
+      break;
     case "check-pre-deploy":
       await runCheckPhase(sequelize, getDatabaseURI, logger, "pre-deploy");
       break;
     case "check-post-deploy":
       await runCheckPhase(sequelize, getDatabaseURI, logger, "post-deploy");
       break;
+    case "mark-pre-deploy":
+    case "mark-post-deploy": {
+      if (!name) {
+        logger.error({}, "--name is required for mark commands.");
+        process.exit(1);
+      }
+      const markPhase =
+        typedCommand === "mark-pre-deploy" ? "pre-deploy" : "post-deploy";
+      await runMark(sequelize, logger, markPhase, name);
+      break;
+    }
     default:
       assertNever(typedCommand);
   }


### PR DESCRIPTION
## Description

Two changes to the shared migration runner (`scripts/db/migration-runner.ts`), wired up in `front`, `connectors`, and `front-api`:

**`migration:mark:pre-deploy` / `migration:mark:post-deploy`** — marks a migration as applied in `schema_migrations` without executing the SQL. Useful when the schema already exists by another means (e.g. `admin/db.ts` on a fresh DB for migration 0).

```bash
npm run -w front migration:mark:pre-deploy -- --name=00010101000000_migration_0
```

- Verifies the `.sql` file exists — fails if not found.
- Idempotent: already-marked migrations log a message and exit 0.
- `.sql` extension auto-appended if omitted.

**`migration:check` bug fix** — previously fell through to only check `pre-deploy`. Now runs both phases in parallel.
