### PR TITLE
Fixed cancel pending contract

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/index.ts
@@ -11,6 +11,7 @@ import analytics from "./analytics";
 import apps from "./apps";
 import assistants from "./assistants";
 import authContext from "./auth-context";
+import cancelPendingContract from "./cancel_pending_contract";
 import conversations from "./conversations";
 import credits from "./credits";
 import dataRetention from "./data_retention";
@@ -81,6 +82,7 @@ app.patch(
 
 app.route("/agent_configurations", agentConfigurations);
 app.route("/analytics", analytics);
+app.route("/cancel_pending_contract", cancelPendingContract);
 app.route("/apps", apps);
 app.route("/assistants", assistants);
 app.route("/conversations", conversations);

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -1,5 +1,9 @@
 import { Authenticator } from "@app/lib/auth";
-import { listMetronomePackages } from "@app/lib/metronome/client";
+import {
+  archiveMetronomeContract,
+  listMetronomePackages,
+  reactivateMetronomeContract,
+} from "@app/lib/metronome/client";
 import {
   ensureMetronomeCustomerForWorkspace,
   provisionMetronomeContract,
@@ -32,7 +36,9 @@ vi.mock("@app/lib/metronome/client", async () => {
   >("@app/lib/metronome/client");
   return {
     ...actual,
+    archiveMetronomeContract: vi.fn(),
     listMetronomePackages: vi.fn(),
+    reactivateMetronomeContract: vi.fn(),
   };
 });
 
@@ -200,6 +206,8 @@ function postSwitchContract(workspaceId: string, body: unknown) {
 }
 
 beforeEach(() => {
+  vi.mocked(archiveMetronomeContract).mockResolvedValue(new Ok(undefined));
+  vi.mocked(reactivateMetronomeContract).mockResolvedValue(new Ok(undefined));
   vi.mocked(ensureMetronomeCustomerForWorkspace).mockResolvedValue(
     new Ok({ metronomeCustomerId: METRONOME_CUSTOMER_ID })
   );

--- a/front/lib/api/poke/cancel_pending_contract.ts
+++ b/front/lib/api/poke/cancel_pending_contract.ts
@@ -95,46 +95,12 @@ export async function cancelPendingContract({
     }
   }
 
-  // 1. Restore the current Metronome contract: remove the scheduled end that
-  //    switch_contract set up so it no longer lapses at the swap time.
-  if (currentSubscription?.metronomeContractId && metronomeCustomerId) {
-    const reactivateResult = await reactivateMetronomeContract({
-      metronomeCustomerId,
-      contractId: currentSubscription.metronomeContractId,
-    });
-    if (reactivateResult.isErr()) {
-      return new Err(
-        new CancelPendingContractError(
-          "restore_failed",
-          "Failed to restore the current Metronome contract " +
-            `${currentSubscription.metronomeContractId}: ` +
-            `${reactivateResult.error.message}. No changes were applied.`
-        )
-      );
-    }
-  }
-
-  // 2. Restore the current Stripe subscription: clear the scheduled
-  //    cancellation so it keeps running.
-  if (currentSubscription?.stripeSubscriptionId) {
-    const clearResult = await clearScheduledSubscriptionCancellation({
-      stripeSubscriptionId: currentSubscription.stripeSubscriptionId,
-    });
-    if (clearResult.isErr()) {
-      return new Err(
-        new CancelPendingContractError(
-          "restore_failed",
-          "Restored the current Metronome contract but failed to clear the " +
-            `scheduled cancellation on Stripe subscription ` +
-            `${currentSubscription.stripeSubscriptionId}: ` +
-            `${clearResult.error.message}. ` +
-            "URGENT: clear cancel_at on the Stripe subscription manually."
-        )
-      );
-    }
-  }
-
-  // 3. Archive the pending Metronome contract (it has not started yet).
+  // 1. Archive the pending Metronome contract first. Metronome rejects clearing
+  //    the end date on the current contract (step 2) while its RENEWAL successor
+  //    has finalized invoices (e.g. prepaid commit invoices created at switch
+  //    time). Archiving with voidInvoices:true removes those invoices, lifting
+  //    the restriction on the current contract. Done before step 2 so that
+  //    step 2 can succeed.
   const pendingContractId = pending.metronomeContractId;
   if (pendingContractId && metronomeCustomerId) {
     const archiveResult = await archiveMetronomeContract({
@@ -144,11 +110,49 @@ export async function cancelPendingContract({
     if (archiveResult.isErr()) {
       return new Err(
         new CancelPendingContractError(
+          "restore_failed",
+          `Failed to archive the pending Metronome contract ${pendingContractId}: ` +
+            `${archiveResult.error.message}. No changes were applied.`
+        )
+      );
+    }
+  }
+
+  // 2. Restore the current Metronome contract: remove the scheduled end that
+  //    switch_contract set up so it no longer lapses at the swap time.
+  if (currentSubscription?.metronomeContractId && metronomeCustomerId) {
+    const reactivateResult = await reactivateMetronomeContract({
+      metronomeCustomerId,
+      contractId: currentSubscription.metronomeContractId,
+    });
+    if (reactivateResult.isErr()) {
+      return new Err(
+        new CancelPendingContractError(
           "cleanup_inconsistent",
-          "Restored the current contract/subscription but failed to archive " +
-            `the pending Metronome contract ${pendingContractId}: ` +
-            `${archiveResult.error.message}. Archive it manually, then delete ` +
-            "the pending subscription."
+          "Archived the pending Metronome contract but failed to restore the " +
+            `current contract ${currentSubscription.metronomeContractId}: ` +
+            `${reactivateResult.error.message}. ` +
+            "URGENT: manually remove the end date from the current contract."
+        )
+      );
+    }
+  }
+
+  // 3. Restore the current Stripe subscription: clear the scheduled
+  //    cancellation so it keeps running.
+  if (currentSubscription?.stripeSubscriptionId) {
+    const clearResult = await clearScheduledSubscriptionCancellation({
+      stripeSubscriptionId: currentSubscription.stripeSubscriptionId,
+    });
+    if (clearResult.isErr()) {
+      return new Err(
+        new CancelPendingContractError(
+          "cleanup_inconsistent",
+          "Archived the pending contract and restored the current Metronome " +
+            "contract, but failed to clear the scheduled cancellation on " +
+            `Stripe subscription ${currentSubscription.stripeSubscriptionId}: ` +
+            `${clearResult.error.message}. ` +
+            "URGENT: clear cancel_at on the Stripe subscription manually."
         )
       );
     }

--- a/front/lib/api/poke/switch_contract.ts
+++ b/front/lib/api/poke/switch_contract.ts
@@ -2,6 +2,7 @@ import {
   dispatchPaygDisabled,
   dispatchPaygEnabled,
 } from "@app/lib/api/metronome/credit_state_dispatcher";
+import { cancelPendingContract } from "@app/lib/api/poke/cancel_pending_contract";
 import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
@@ -589,6 +590,25 @@ export async function switchContract({
         workspace: owner,
         seatType: seat.seatType,
       });
+    }
+  }
+
+  // If there's already a pending contract, cancel it before creating a new one.
+  // Metronome rejects a second transition from a contract that already has a
+  // RENEWAL successor, so we must archive the pending contract and restore the
+  // current one first.
+  const existingPending =
+    await SubscriptionResource.fetchPendingByWorkspaceModelId(owner.id);
+  if (existingPending) {
+    const cancelResult = await cancelPendingContract({ auth });
+    if (cancelResult.isErr()) {
+      return new Err(
+        new SwitchContractError(
+          "metronome_api_error",
+          `A pending contract already exists and could not be cancelled before ` +
+            `switching: ${cancelResult.error.message}`
+        )
+      );
     }
   }
 

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -1261,6 +1261,7 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
     await this.model.destroy({
       where: {
         id: this.id,
+        workspaceId: this.workspaceId,
       },
       transaction,
     });


### PR DESCRIPTION
## Description

Three fixes for the poke contract-switching flow:

**1. "Cancel pending" button returning 404**

The `cancel_pending_contract` route handler existed in `front-api/routes/poke/workspaces/[wId]/` but was never imported or mounted in the workspace router index. Added the missing import and `app.route()` call.

**2. `switchContract` failing when a pending contract already exists**

Metronome rejects creating a new RENEWAL transition from a contract that already has a pending successor (`"Cannot transition from X because it was already transitioned to active contract Y"`). `switchContract` now checks for an existing pending subscription before provisioning, and cancels it first (restoring the current contract) so Metronome sees a clean "from" state.

**3. `cancelPendingContract` failing when the pending contract has finalized invoices**

The cancellation steps were in the wrong order. Metronome refuses to clear the end date on the current contract (`updateEndDate`) while its RENEWAL successor has finalized invoices (e.g. prepaid commit invoices created at switch time). The fix is to **archive the pending contract first** (with `voidInvoices: true`, which voids those commitment invoices), and only then remove the scheduled end from the current contract. The old order (reactivate → archive) was the root cause of the 502 errors.

As a side effect, the error classifications were updated to match the new sequence: a failure before the archive is now `restore_failed` (nothing changed); a failure after the archive is `cleanup_inconsistent` (partial state requiring manual intervention).

**4. `workspace_isolation_violation` warning on subscription delete**

`SubscriptionResource.delete` was issuing `DELETE WHERE id = ?` without a workspace constraint, tripping the isolation hook. Added `workspaceId` to the where clause.

## Tests

Tested end-to-end in the dev hive:
- Cancel pending button now works (no 404)
- Switch contract with an existing pending correctly auto-cancels the pending before creating the new contract (no 502)
- No `workspace_isolation_violation` warnings on delete