### PR TITLE
feat(model_constructors): add DeepSeek V4 Pro Fireworks endpoint with parity coverage

### DIFF
--- a/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
@@ -1,0 +1,15 @@
+export function WithDustFireworksDeepSeekV4ProConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustFireworksDeepSeekV4Pro extends Base {
+    static readonly displayName = "DeepSeek V4 Pro (Fireworks)";
+    static readonly description =
+      "DeepSeek's V4 Pro Mixture-of-Experts model with frontier reasoning, advanced coding, and 1M context (served via Fireworks).";
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = false;
+  }
+
+  return DustFireworksDeepSeekV4Pro;
+}

--- a/front/lib/llms/stream/endpoints/fireworks_global_deepseek_v4_pro.ts
+++ b/front/lib/llms/stream/endpoints/fireworks_global_deepseek_v4_pro.ts
@@ -1,0 +1,11 @@
+import { WithDustFireworksDeepSeekV4ProConfig } from "@app/lib/llms/providers/fireworks/models/deepseek_v4_pro";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro";
+
+export class DustFireworksGlobalDeepSeekV4ProStream extends WithDustFireworksDeepSeekV4ProConfig(
+  FireworksGlobalDeepSeekV4ProStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustFireworksGlobalDeepSeekV4ProStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -5,6 +5,7 @@ import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/s
 import { DustAnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { DustAnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { DustFireworksGlobalDeepSeekV4ProStream } from "@app/lib/llms/stream/endpoints/fireworks_global_deepseek_v4_pro";
 import { DustFireworksGlobalGlmFiveDotTwoStream } from "@app/lib/llms/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
@@ -65,6 +66,8 @@ export const DUST_STREAM_ENDPOINTS = {
     DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
   [DustFireworksGlobalGlmFiveDotTwoStream.id]:
     DustFireworksGlobalGlmFiveDotTwoStream,
+  [DustFireworksGlobalDeepSeekV4ProStream.id]:
+    DustFireworksGlobalDeepSeekV4ProStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
@@ -1,0 +1,35 @@
+import { fireworksConfigSchema } from "@app/lib/model_constructors/providers/fireworks/inputConfig";
+import { FIREWORKS_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/fireworks/reasoning_efforts";
+import { FIREWORKS_DEEPSEEK_V4_PRO_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import { z } from "zod";
+
+const CONTEXT_SIZE = 1_000_000;
+const MAX_OUTPUT_TOKENS = 64_000;
+
+// Mirrors the legacy Fireworks reasoning mapping: none/light drop
+// reasoning_effort (default chain-of-thought), only medium/high reach the model.
+const configSchema = fireworksConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.enum(FIREWORKS_SUPPORTED_REASONING_EFFORTS) })
+    .optional()
+    .transform((r) =>
+      r && (r.effort === "medium" || r.effort === "high") ? r : undefined
+    ),
+});
+
+export function WithFireworksDeepSeekV4ProConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class FireworksDeepSeekV4Pro extends Base {
+    static readonly modelId = FIREWORKS_DEEPSEEK_V4_PRO_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return FireworksDeepSeekV4Pro;
+}

--- a/front/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro.ts
@@ -1,0 +1,18 @@
+import { WithFireworksDeepSeekV4ProConfig } from "@app/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro";
+import { FireworksStream } from "@app/lib/model_constructors/stream/clients/fireworks";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class FireworksGlobalDeepSeekV4ProStream extends WithFireworksDeepSeekV4ProConfig(
+  FireworksStream
+) {
+  // https://fireworks.ai/models/fireworks/deepseek-v4-pro
+  static readonly tokenPricing = {
+    cacheHit: 0.14,
+    standardInput: 1.74,
+    standardOutput: 3.48,
+  };
+  static readonly region = GLOBAL;
+  static readonly id = this.buildId();
+}
+FireworksGlobalDeepSeekV4ProStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -5,6 +5,7 @@ import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_cons
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
+import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro";
 import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
@@ -56,6 +57,7 @@ export const STREAM_ENDPOINTS = {
   [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
   [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
+  [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro";
+import {
+  HAS_REASONING,
+  INPUT_CONFIGURATION_ERROR,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new FireworksGlobalDeepSeekV4ProStream({
+      FIREWORKS_API_KEY: process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
+    }),
+  tests: {
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    // V4 Pro always reasons, so `none` still yields reasoning content.
+    "reasoning/no-tools/t-default/r-none": [HAS_REASONING],
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
+runStreamEndpointTests(FireworksGlobalDeepSeekV4ProStream, setup);


### PR DESCRIPTION
## Description

Adds the **DeepSeek V4 Pro** endpoint to the per-endpoint LLM router (the `model_constructors` framework layer plus the `lib/llms` Dust registration layer), served through the global Fireworks chat-completions client. Continues the Fireworks new-router migration after the GLM-5.2 pilot (#27717).

The config schema mirrors the legacy Fireworks reasoning mapping — `none`/`light` drop `reasoning_effort` (default chain-of-thought), only `medium`/`high` reach the model — so the new router dispatches byte-identical requests to the legacy `FireworksLLM`. Like GLM-5.2, V4 Pro always reasons, so the live suite expects reasoning content even when the effort is dropped.

Pricing/context/output statics come from the in-repo source of truth (`token_pricing/global.ts`, `types/assistant/models/fireworks.ts`).

## Tests

- **Live Fireworks API** (`model_constructors` integration suite): 40/40 cases pass against `deepseek-v4-pro`.
- **Router parity** (`router_parity.test.ts`): 14/14 V4 Pro cases dispatch a request identical to the legacy router.
- `tsgo --noEmit` clean; biome clean.

Run locally (not in CI, gated on `RUN_LLM_TEST`):
```
NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js lib/model_constructors/test/endpoints/fireworks_global_deepseek_v4_pro.test.ts
```

## Risk

Low. Purely additive — registers one new endpoint; no existing endpoint or shared code path changes. The endpoint is gated by `endpointFilter` like its siblings. Rollback is removing the registry entries.

## Deploy Plan

Standard. No migration or config change required.