### PR TITLE
Restore pasted content snippets

### DIFF
--- a/front/components/assistant/conversation/input_bar/pasted_utils.ts
+++ b/front/components/assistant/conversation/input_bar/pasted_utils.ts
@@ -1,5 +1,7 @@
 import dayjs from "dayjs";
 
+export { isPastedFile } from "@app/lib/files";
+
 export const getDisplayNameFromPastedFileId = (id: string): string => {
   const match = id.match(/^pasted-text-(\d+)_/);
   if (match) {
@@ -29,8 +31,4 @@ export const getDisplayDateFromPastedFileId = (
 
 export const getPastedFileName = (count: number): string => {
   return `pasted-text-${count}_${dayjs().format("YYYY-MM-DD_HH-mm-ss")}.txt`;
-};
-
-export const isPastedFile = (contentType: string | undefined): boolean => {
-  return contentType === "text/vnd.dust.attachment.pasted";
 };

--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -1,5 +1,6 @@
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
+import { generateSnippet } from "@app/lib/api/files/snippet";
 import {
   CSV_UNSUPPORTED_ENCODING_ERROR_MESSAGE,
   processAndUpsertToDataSource,
@@ -30,6 +31,14 @@ vi.mock(import("@app/lib/api/files/upsert"), async (importOriginal) => {
   };
 });
 
+vi.mock(import("@app/lib/api/files/snippet"), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    generateSnippet: vi.fn(),
+  };
+});
+
 describe("maybeUpsertFileAttachment", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
@@ -51,6 +60,7 @@ describe("maybeUpsertFileAttachment", () => {
     vi.mocked(processAndUpsertToDataSource).mockResolvedValue(
       new Ok({} as any)
     );
+    vi.mocked(generateSnippet).mockResolvedValue(new Ok("pasted content"));
   });
 
   it("stamps conversationId on files without useCaseMetadata and attempts upsert", async () => {
@@ -101,6 +111,35 @@ describe("maybeUpsertFileAttachment", () => {
       skipDataSourceIndexing: true,
       conversationId: conversation.sId,
     });
+  });
+
+  it("generates snippets for pasted files without indexing them", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/vnd.dust.attachment.pasted",
+      fileName: "pasted-text-1_2026-06-22_10-00-00.txt",
+      fileSize: 500,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { skipDataSourceIndexing: true },
+    });
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(generateSnippet).toHaveBeenCalledOnce();
+    expect(vi.mocked(generateSnippet).mock.calls[0][1].file.sId).toBe(file.sId);
+    expect(getOrCreateConversationDataSourceFromFile).not.toHaveBeenCalled();
+    expect(processAndUpsertToDataSource).not.toHaveBeenCalled();
+
+    const reloaded = await FileResource.fetchById(auth, file.sId);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      skipDataSourceIndexing: true,
+      conversationId: conversation.sId,
+    });
+    expect(reloaded?.snippet).toBe("pasted content");
   });
 
   it("propagates upsert failures instead of swallowing them", async () => {

--- a/front/lib/api/files/attachments.test.ts
+++ b/front/lib/api/files/attachments.test.ts
@@ -142,6 +142,39 @@ describe("maybeUpsertFileAttachment", () => {
     expect(reloaded?.snippet).toBe("pasted content");
   });
 
+  it("generates missing snippets for pasted files already attached to a conversation", async () => {
+    const file = await FileFactory.create(auth, null, {
+      contentType: "text/vnd.dust.attachment.pasted",
+      fileName: "pasted-text-2_2026-06-22_10-00-00.txt",
+      fileSize: 500,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        skipDataSourceIndexing: true,
+        conversationId: conversation.sId,
+      },
+      snippet: null,
+    });
+
+    const result = await maybeUpsertFileAttachment(auth, {
+      contentFragments: [{ fileId: file.sId }],
+      conversation,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(generateSnippet).toHaveBeenCalledOnce();
+    expect(vi.mocked(generateSnippet).mock.calls[0][1].file.sId).toBe(file.sId);
+    expect(getOrCreateConversationDataSourceFromFile).not.toHaveBeenCalled();
+    expect(processAndUpsertToDataSource).not.toHaveBeenCalled();
+
+    const reloaded = await FileResource.fetchById(auth, file.sId);
+    expect(reloaded?.useCaseMetadata).toEqual({
+      skipDataSourceIndexing: true,
+      conversationId: conversation.sId,
+    });
+    expect(reloaded?.snippet).toBe("pasted content");
+  });
+
   it("propagates upsert failures instead of swallowing them", async () => {
     const file = await FileFactory.create(auth, null, {
       contentType: "text/csv",

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -1,10 +1,12 @@
 import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
+import { generateSnippet } from "@app/lib/api/files/snippet";
 import {
   isFileTypeUpsertableForUseCase,
   processAndUpsertToDataSource,
 } from "@app/lib/api/files/upsert";
 import type { Authenticator } from "@app/lib/auth";
+import { isPastedFile } from "@app/lib/files";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -52,6 +54,26 @@ export async function maybeUpsertFileAttachment(
             ...(fileResource.useCaseMetadata ?? {}),
             conversationId: conversation.sId,
           });
+
+          if (isPastedFile(fileResource.contentType)) {
+            const snippetRes = await generateSnippet(auth, {
+              file: fileResource,
+            });
+            if (snippetRes.isErr()) {
+              logger.error(
+                {
+                  fileModelId: fileResource.id,
+                  workspaceId: auth.getNonNullableWorkspace().sId,
+                  error: snippetRes.error,
+                },
+                "Failed to generate pasted file snippet."
+              );
+              return new Ok(undefined);
+            }
+
+            await fileResource.setSnippet(snippetRes.value);
+            return new Ok(undefined);
+          }
 
           // Only upsert if the file is upsertable.
           if (

--- a/front/lib/api/files/attachments.ts
+++ b/front/lib/api/files/attachments.ts
@@ -46,35 +46,42 @@ export async function maybeUpsertFileAttachment(
     const results = await concurrentExecutor(
       fileResources,
       async (fileResource): Promise<Result<undefined, Error>> => {
-        if (
-          fileResource.useCase === "conversation" &&
-          !fileResource.useCaseMetadata?.conversationId
-        ) {
+        const isConversationFile = fileResource.useCase === "conversation";
+        const isMissingConversationId =
+          isConversationFile && !fileResource.useCaseMetadata?.conversationId;
+
+        if (isMissingConversationId) {
           await fileResource.setUseCaseMetadata(auth, {
             ...(fileResource.useCaseMetadata ?? {}),
             conversationId: conversation.sId,
           });
+        }
 
-          if (isPastedFile(fileResource.contentType)) {
-            const snippetRes = await generateSnippet(auth, {
-              file: fileResource,
-            });
-            if (snippetRes.isErr()) {
-              logger.error(
-                {
-                  fileModelId: fileResource.id,
-                  workspaceId: auth.getNonNullableWorkspace().sId,
-                  error: snippetRes.error,
-                },
-                "Failed to generate pasted file snippet."
-              );
-              return new Ok(undefined);
-            }
-
-            await fileResource.setSnippet(snippetRes.value);
+        if (
+          isConversationFile &&
+          isPastedFile(fileResource.contentType) &&
+          fileResource.snippet === null
+        ) {
+          const snippetRes = await generateSnippet(auth, {
+            file: fileResource,
+          });
+          if (snippetRes.isErr()) {
+            logger.error(
+              {
+                fileModelId: fileResource.id,
+                workspaceId: auth.getNonNullableWorkspace().sId,
+                error: snippetRes.error,
+              },
+              "Failed to generate pasted file snippet."
+            );
             return new Ok(undefined);
           }
 
+          await fileResource.setSnippet(snippetRes.value);
+          return new Ok(undefined);
+        }
+
+        if (isMissingConversationId) {
           // Only upsert if the file is upsertable.
           if (
             !isSandboxRawDelimitedConversationFile(fileResource) &&

--- a/front/lib/api/files/should_skip_indexing.ts
+++ b/front/lib/api/files/should_skip_indexing.ts
@@ -1,4 +1,4 @@
-import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
+import { isPastedFile } from "@app/lib/files";
 
 const SLACK_THREAD_CONTENT_TYPE = "text/vnd.dust.attachment.slack.thread";
 const AUDIO_WEBM_CONTENT_TYPE = "audio/webm";

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -1,8 +1,8 @@
-import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { FILE_OFFLOAD_TEXT_SIZE_BYTES } from "@app/lib/actions/action_output_limits";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
+import { isPastedFile } from "@app/lib/files";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
@@ -57,7 +57,7 @@ export async function generateSnippet(
     dataSource,
   }: {
     file: FileResource;
-    dataSource: DataSourceResource;
+    dataSource?: DataSourceResource;
   }
 ): Promise<Result<string, Error>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -69,6 +69,12 @@ export async function generateSnippet(
   }
 
   if (isSupportedDelimitedTextContentType(file.contentType)) {
+    if (!dataSource) {
+      return new Err(
+        new Error("Data source is required to generate a delimited text snippet.")
+      );
+    }
+
     const { bucket, path } = file.getContentBucketAndPath(auth);
     const schemaRes = await coreAPI.tableValidateCSVContent({
       projectId: dataSource.dustAPIProjectId,

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -60,8 +60,6 @@ export async function generateSnippet(
     dataSource?: DataSourceResource;
   }
 ): Promise<Result<string, Error>> {
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-
   if (isSupportedImageContentType(file.contentType)) {
     return new Err(
       new Error("Image files are not supported for file snippets.")
@@ -75,6 +73,7 @@ export async function generateSnippet(
       );
     }
 
+    const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const { bucket, path } = file.getContentBucketAndPath(auth);
     const schemaRes = await coreAPI.tableValidateCSVContent({
       projectId: dataSource.dustAPIProjectId,

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -69,7 +69,9 @@ export async function generateSnippet(
   if (isSupportedDelimitedTextContentType(file.contentType)) {
     if (!dataSource) {
       return new Err(
-        new Error("Data source is required to generate a delimited text snippet.")
+        new Error(
+          "Data source is required to generate a delimited text snippet."
+        )
       );
     }
 

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -1,9 +1,12 @@
 import capitalize from "lodash/capitalize";
 import words from "lodash/words";
 
+import type { AllSupportedFileContentType } from "@app/types/files";
+
 export const FILE_ID_PATTERN = "fil_[A-Za-z0-9]{10,}";
 export const FILE_ID_REGEX = new RegExp(`\\b${FILE_ID_PATTERN}\\b`, "g");
-export const PASTED_FILE_CONTENT_TYPE = "text/vnd.dust.attachment.pasted";
+export const PASTED_FILE_CONTENT_TYPE =
+  "text/vnd.dust.attachment.pasted" satisfies AllSupportedFileContentType;
 
 export const isPastedFile = (contentType: string | undefined): boolean => {
   return contentType === PASTED_FILE_CONTENT_TYPE;

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -3,6 +3,11 @@ import words from "lodash/words";
 
 export const FILE_ID_PATTERN = "fil_[A-Za-z0-9]{10,}";
 export const FILE_ID_REGEX = new RegExp(`\\b${FILE_ID_PATTERN}\\b`, "g");
+export const PASTED_FILE_CONTENT_TYPE = "text/vnd.dust.attachment.pasted";
+
+export const isPastedFile = (contentType: string | undefined): boolean => {
+  return contentType === PASTED_FILE_CONTENT_TYPE;
+};
 
 // We use this to detect if a Interactive Content file uses conversation files.
 // In which case, we don't want to display it publicly. Our proxy here is to look for usage of the

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -1,7 +1,7 @@
+import type { AllSupportedFileContentType } from "@app/types/files";
+
 import capitalize from "lodash/capitalize";
 import words from "lodash/words";
-
-import type { AllSupportedFileContentType } from "@app/types/files";
 
 export const FILE_ID_PATTERN = "fil_[A-Za-z0-9]{10,}";
 export const FILE_ID_REGEX = new RegExp(`\\b${FILE_ID_PATTERN}\\b`, "g");

--- a/front/lib/resources/content_fragment_resource.test.ts
+++ b/front/lib/resources/content_fragment_resource.test.ts
@@ -199,6 +199,21 @@ describe("renderLightContentFragmentForModel", () => {
       expect(text).toContain('path="conversation-conv123/pasted-text-1.txt"');
     });
 
+    it("guides the model to read pasted files when the stored snippet is missing", async () => {
+      const result = await renderLightContentFragmentForModel(
+        authenticator,
+        makeFileFragment("text/vnd.dust.attachment.pasted", {
+          snippet: null,
+          path: "conversation-conv123/pasted-text-1.txt",
+        }),
+        visionModel,
+        { excludeImages: false, useFileSystem: false }
+      );
+      const text = getTextContent(result);
+      expect(text).toContain('truncated="true"');
+      expect(text).toContain('path="conversation-conv123/pasted-text-1.txt"');
+    });
+
     it("re-truncates a legacy oversized stored snippet so the full paste is not inlined", async () => {
       const fullPaste = "b".repeat(FILE_OFFLOAD_TEXT_SIZE_BYTES + 1);
       const result = await renderLightContentFragmentForModel(

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1,4 +1,3 @@
-import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
@@ -22,6 +21,7 @@ import {
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { isPastedFile } from "@app/lib/files";
 import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -1275,9 +1275,11 @@ export async function renderLightContentFragmentForModel(
   // Pasted content is always inlined regardless of feature flags.
   if (fileStringId && isPastedFile(contentType)) {
     const snippet = attachment.snippet ?? "";
+    const hasMissingSnippet = attachment.snippet === null;
     const truncated =
-      snippet.length === TRUNCATED_SNIPPET_SIZE &&
-      snippet.endsWith(TRUNCATED_SUFFIX);
+      hasMissingSnippet ||
+      (snippet.length === TRUNCATED_SNIPPET_SIZE &&
+        snippet.endsWith(TRUNCATED_SUFFIX));
     return {
       role: "content_fragment",
       name: `attach_pasted_content`,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9107.

Root cause: regression from PR #27433, which stopped non-tabular conversation files from going through the data-source upsert path that used to generate snippets as a side effect. The model renderer still expects pasted content on `FileResource.snippet`, so new pasted chips could render as empty `<pastedContent>` tags with no path guidance.

This keeps pasted files out of indexing, but generates their snippet when they are attached to a conversation, including files that are already linked to an active conversation. It also treats pasted files with missing stored snippets as truncated so already-affected messages still point the model at the conversation file path.

## Tests

- `NODE_ENV=test FRONT_DATABASE_URI="$TEST_FRONT_DATABASE_URI" REDIS_URI="$TEST_REDIS_URI" REDIS_CACHE_URI="$TEST_REDIS_URI" npx vitest --run components/assistant/conversation/input_bar/pasted_utils.test.ts lib/api/files/should_skip_indexing.test.ts lib/api/files/attachments.test.ts lib/resources/content_fragment_resource.test.ts`
- `source "$HOME/.nvm/nvm.sh" && nvm use && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit`
- `npx biome ci front/lib/files.ts front/lib/api/files/snippet.ts`

## Risk

Low. Worst case, pasted attachments fall back to the file path rendering. Safe to rollback.

## Deploy Plan

Standard deploy.
