### PR TITLE
Allow to assign seat on enterprise plan

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -392,21 +392,8 @@ const actionsColumn: ColumnDef<RowData, string> = {
   },
 };
 
-function buildColumns({
-  isSeatBased,
-}: {
-  isSeatBased: boolean;
-}): ColumnDef<RowData, string>[] {
-  const optionalColumns = [];
-  if (isSeatBased) {
-    optionalColumns.push(seatTypeColumn);
-  }
-  return [
-    nameColumn,
-    ...optionalColumns,
-    consumedAwuCreditsColumn,
-    actionsColumn,
-  ];
+function buildColumns(): ColumnDef<RowData, string>[] {
+  return [nameColumn, seatTypeColumn, consumedAwuCreditsColumn, actionsColumn];
 }
 
 interface MembersUsageTableProps {
@@ -464,11 +451,21 @@ export function MembersUsageTable({
         ),
         isSeatChangePending: seatChangePendingMemberIds.has(m.sId),
         menuItems: [
-          ...(isSeatBased
+          ...(!m.seatType || m.seatType === "none"
             ? [
                 {
                   kind: "item" as const,
-                  label: m.seatType ? "Change seat type" : "Assign seat",
+                  label: "Assign seat",
+                  disabled: readOnly,
+                  onClick: () => onChangeSeat(m),
+                },
+              ]
+            : []),
+          ...(isSeatBased && m.seatType && m.seatType !== "none"
+            ? [
+                {
+                  kind: "item" as const,
+                  label: "Change seat type",
                   disabled: readOnly,
                   onClick: () => onChangeSeat(m),
                 },
@@ -511,7 +508,7 @@ export function MembersUsageTable({
     ]
   );
 
-  const columns = useMemo(() => buildColumns({ isSeatBased }), [isSeatBased]);
+  const columns = useMemo(() => buildColumns(), []);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Description

On enterprise plans with a single seat type (e.g. Platform/Yearly), the members usage table had two issues:

- The **seat column** was hidden because it was gated on having more than one seat type — but it's useful to see at a glance who has a seat and who doesn't.
- The **\"Assign seat\"** action was missing for members without a seat (`seatType = null` or `"none"`), making it impossible to assign them a seat from the table.

Changes:
- Seat column is now always visible (unconditional).
- **\"Assign seat\"** appears for any member with no billable seat, regardless of how many seat types the plan has.
- **\"Change seat type\"** only appears when there are 2+ seat types available and the member already holds a billable seat (existing behaviour preserved).

## Tests

Tested manually on an enterprise workspace with a single seat type (`workspace_yearly`): seat column visible, \"Assign seat\" appears for unseated members, \"Change seat type\" hidden (nothing to change to).

## Risk

Low — display-only change, no backend or data model changes.

## Deploy Plan

Frontend only, no deploy coordination needed.