### PR TITLE
feat(model_constructors): add Kimi K2.5 Fireworks endpoint with parity coverage

### DIFF
--- a/front/lib/llms/providers/fireworks/models/kimi_k2_dot_five.ts
+++ b/front/lib/llms/providers/fireworks/models/kimi_k2_dot_five.ts
@@ -1,0 +1,15 @@
+export function WithDustFireworksKimiK2Dot5Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustFireworksKimiK2Dot5 extends Base {
+    static readonly displayName = "Kimi K2.5 (Fireworks)";
+    static readonly description =
+      "Moonshot AI's flagship agentic model with 262k context and vision support (served via Fireworks).";
+    static readonly defaultReasoningEffort = "low";
+    static readonly byok = false;
+  }
+
+  return DustFireworksKimiK2Dot5;
+}

--- a/front/lib/llms/stream/endpoints/fireworks_global_kimi_k2_dot_five.ts
+++ b/front/lib/llms/stream/endpoints/fireworks_global_kimi_k2_dot_five.ts
@@ -1,0 +1,11 @@
+import { WithDustFireworksKimiK2Dot5Config } from "@app/lib/llms/providers/fireworks/models/kimi_k2_dot_five";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five";
+
+export class DustFireworksGlobalKimiK2Dot5Stream extends WithDustFireworksKimiK2Dot5Config(
+  FireworksGlobalKimiK2Dot5Stream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustFireworksGlobalKimiK2Dot5Stream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -7,6 +7,7 @@ import { DustAnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/llms/str
 import { DustAnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { DustFireworksGlobalDeepSeekV4ProStream } from "@app/lib/llms/stream/endpoints/fireworks_global_deepseek_v4_pro";
 import { DustFireworksGlobalGlmFiveDotTwoStream } from "@app/lib/llms/stream/endpoints/fireworks_global_glm_five_dot_two";
+import { DustFireworksGlobalKimiK2Dot5Stream } from "@app/lib/llms/stream/endpoints/fireworks_global_kimi_k2_dot_five";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
@@ -68,6 +69,7 @@ export const DUST_STREAM_ENDPOINTS = {
     DustFireworksGlobalGlmFiveDotTwoStream,
   [DustFireworksGlobalDeepSeekV4ProStream.id]:
     DustFireworksGlobalDeepSeekV4ProStream,
+  [DustFireworksGlobalKimiK2Dot5Stream.id]: DustFireworksGlobalKimiK2Dot5Stream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/providers/fireworks/models/kimi_k2_dot_five.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/kimi_k2_dot_five.ts
@@ -1,0 +1,35 @@
+import { fireworksConfigSchema } from "@app/lib/model_constructors/providers/fireworks/inputConfig";
+import { FIREWORKS_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/fireworks/reasoning_efforts";
+import { FIREWORKS_KIMI_K2P5_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+import { z } from "zod";
+
+const CONTEXT_SIZE = 262_100;
+const MAX_OUTPUT_TOKENS = 2_048;
+
+// Mirrors the legacy Fireworks reasoning mapping: none/light drop
+// reasoning_effort (default chain-of-thought), only medium/high reach the model.
+const configSchema = fireworksConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.enum(FIREWORKS_SUPPORTED_REASONING_EFFORTS) })
+    .optional()
+    .transform((r) =>
+      r && (r.effort === "medium" || r.effort === "high") ? r : undefined
+    ),
+});
+
+export function WithFireworksKimiK2Dot5Config<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class FireworksKimiK2Dot5 extends Base {
+    static readonly modelId = FIREWORKS_KIMI_K2P5_MODEL_ID;
+
+    static readonly configSchema = configSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return FireworksKimiK2Dot5;
+}

--- a/front/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five.ts
+++ b/front/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five.ts
@@ -1,0 +1,18 @@
+import { WithFireworksKimiK2Dot5Config } from "@app/lib/model_constructors/providers/fireworks/models/kimi_k2_dot_five";
+import { FireworksStream } from "@app/lib/model_constructors/stream/clients/fireworks";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class FireworksGlobalKimiK2Dot5Stream extends WithFireworksKimiK2Dot5Config(
+  FireworksStream
+) {
+  // https://fireworks.ai/models/fireworks/kimi-k2p5
+  static readonly tokenPricing = {
+    cacheHit: 0.1,
+    standardInput: 0.6,
+    standardOutput: 3.0,
+  };
+  static readonly region = GLOBAL;
+  static readonly id = this.buildId();
+}
+FireworksGlobalKimiK2Dot5Stream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -7,6 +7,7 @@ import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constr
 import { AnthropicGlobalClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_sonnet_four_dot_six";
 import { FireworksGlobalDeepSeekV4ProStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_deepseek_v4_pro";
 import { FireworksGlobalGlmFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_glm_five_dot_two";
+import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five";
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
@@ -58,6 +59,7 @@ export const STREAM_ENDPOINTS = {
     GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream,
   [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
   [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStream,
+  [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5Stream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
+++ b/front/lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/stream/endpoints/fireworks_global_kimi_k2_dot_five";
+import {
+  HAS_REASONING,
+  INPUT_CONFIGURATION_ERROR,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new FireworksGlobalKimiK2Dot5Stream({
+      FIREWORKS_API_KEY: process.env.DUST_MANAGED_FIREWORKS_API_KEY ?? "",
+    }),
+  tests: {
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    // Kimi K2.5 always reasons, so `none` still yields reasoning content.
+    "reasoning/no-tools/t-default/r-none": [HAS_REASONING],
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
+runStreamEndpointTests(FireworksGlobalKimiK2Dot5Stream, setup);


### PR DESCRIPTION
## Description

Adds the **Kimi K2.5** endpoint (Moonshot AI's flagship agentic model, 262k context, vision support) to the per-endpoint LLM router (`model_constructors` framework layer plus the `lib/llms` Dust registration layer), served through the global Fireworks chat-completions client. Continues the Fireworks new-router migration after GLM-5.2 (#27717) and DeepSeek V4 Pro (#27737).

The config schema mirrors the legacy Fireworks reasoning mapping — `none`/`light` drop `reasoning_effort` (default chain-of-thought), only `medium`/`high` reach the model — so the new router dispatches byte-identical requests to the legacy `FireworksLLM`. Kimi K2.5 always reasons, so the live suite expects reasoning content even when the effort is dropped. Vision flows through the shared chat-completions converter (no per-model code) and is exercised by the parity suite's image case.

Pricing/context/output statics come from the in-repo source of truth (`token_pricing/global.ts`, `types/assistant/models/fireworks.ts`).

## Tests

- **Live Fireworks API** (`model_constructors` integration suite): 40/40 cases pass against `kimi-k2p5`.
- **Router parity** (`router_parity.test.ts`): 14/14 cases — including the vision/image case — dispatch a request identical to the legacy router.
- `tsgo --noEmit` clean; biome clean.

Run locally (not in CI, gated on `RUN_LLM_TEST`):
```
NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js lib/model_constructors/test/endpoints/fireworks_global_kimi_k2_dot_five.test.ts
```

Note: the live suite occasionally hits the harness's 20s per-case timeout on random cases — Kimi K2.5's large-context responses are latency-heavy on Fireworks. These are transient (never the same case twice, never an API error); `--retry` clears them.

## Risk

Low. Purely additive — registers one new endpoint; no existing endpoint or shared code path changes. Gated by `endpointFilter` like its siblings. Rollback is removing the registry entries.

## Deploy Plan

Standard. No migration or config change required.