### PR TITLE
Backport tool search defer_loading to the new LLM router

### DIFF
--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -18,7 +18,7 @@ import {
   systemMessagesToSystemParam,
   systemMessageToTextBlock,
   toolCallResultMessageToToolResultBlock,
-  toolSpecToAnthropicAITool,
+  toolSpecsToAnthropicAITools,
   userImageMessageToImageBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
@@ -90,7 +90,7 @@ export function WithAnthropicAIInputConverter<
         messages: this.conversationToMessages(conversation),
         system: this.systemMessagesToSystemParam(conversation.system),
         thinking: thinkingConfig.thinking,
-        tools: tools.map((tool) => toolSpecToAnthropicAITool(tool)),
+        tools: toolSpecsToAnthropicAITools(tools, { forceTool }),
         tool_choice: forceToolNameToToolChoice(tools, forceTool),
         temperature,
         ...(Object.keys(outputConfig).length > 0

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -261,7 +261,34 @@ export function toolSpecToAnthropicAITool(tool: ToolSpecification): Tool {
     // https://platform.claude.com/docs/en/agents-and-tools/tool-use/fine-grained-tool-streaming
     eager_input_streaming: true,
     input_schema: { type: "object", ...tool.inputSchema },
+    // Only set when true so non-deferred tools serialize identically (stable prefix bytes).
+    ...(tool.deferLoading ? { defer_loading: true } : {}),
   };
+}
+
+// Search tool that lets the model discover deferred tools on demand. Prepended
+// to the tools array whenever at least one tool is deferred.
+const TOOL_SEARCH_TOOL = {
+  type: "tool_search_tool_bm25_20251119",
+  name: "tool_search_tool_bm25",
+} as const;
+
+export function toolSpecsToAnthropicAITools(
+  tools: ToolSpecification[],
+  { forceTool }: { forceTool: string | undefined }
+): Array<Tool | typeof TOOL_SEARCH_TOOL> {
+  const converted = tools.map((tool) =>
+    // A forced tool cannot be deferred: the API requires the tool_choice target
+    // to be loaded, so treat it as non-deferred.
+    toolSpecToAnthropicAITool(
+      tool.name === forceTool ? { ...tool, deferLoading: false } : tool
+    )
+  );
+
+  // The tool search tool is only needed when at least one tool is actually deferred.
+  return converted.some((tool) => tool.defer_loading)
+    ? [TOOL_SEARCH_TOOL, ...converted]
+    : converted;
 }
 
 export function forceToolNameToToolChoice(

--- a/front/lib/model_constructors/types/input/configuration.ts
+++ b/front/lib/model_constructors/types/input/configuration.ts
@@ -31,6 +31,10 @@ export const toolSpecificationSchema = z.object({
   name: z.string(),
   description: z.string(),
   inputSchema: z.record(z.unknown()),
+  // When true, providers that support tool search (Anthropic) keep this tool's
+  // schema out of the cached prefix and load it on demand. Ignored by providers
+  // without tool-search support.
+  deferLoading: z.boolean().optional(),
 });
 export type ToolSpecification = z.infer<typeof toolSpecificationSchema>;
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/pull/27655.

The new LLM router (`use_new_llm_router`) dropped the §deferLoading§ signal: its tool spec schema had no `deferLoading` field, so the field was stripped during config parsing and the Anthropic converter never emitted `defer_loading` or prepended the tool search tool.

This PR plumbs `deferLoading` through the tool spec schema and realize it in the Anthropic input converter, mirroring the legacy client: emit `defer_loading` only when true (stable prefix bytes), un-defer a forced tool, and prepend the bm25 tool search tool when any tool is deferred.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
