### PR TITLE
fix(mcp): raise REMOTE_MAX_RESOURCE_SIZE_BYTES to 20MB

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -12,7 +12,9 @@ export const FILE_OFFLOAD_SNIPPET_LENGTH = 8_000; // Approximately 2K tokens.
 // When any content block exceeds these sizes, the entire tool result is rejected.
 export const REMOTE_MAX_TEXT_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
 export const REMOTE_MAX_IMAGE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB.
-export const REMOTE_MAX_RESOURCE_SIZE_BYTES = FILE_OFFLOAD_TEXT_SIZE_BYTES;
+// Resource-with-text blocks above FILE_OFFLOAD_TEXT_SIZE_BYTES are offloaded to a file in
+// processToolResults, so this hard limit only needs to guard against absurd payloads.
+export const REMOTE_MAX_RESOURCE_SIZE_BYTES = 20 * 1024 * 1024; // 20MB.
 // Hard limit on the entire array of tool outputs.
 export const REMOTE_MAX_TOOL_RESULT_SIZE_BYTES = 50 * 1024 * 1024; // 50MB.
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR raises `REMOTE_MAX_RESOURCE_SIZE_BYTES` from 20KB (`= FILE_OFFLOAD_TEXT_SIZE_BYTES`) to 20MB.

I introduced a regression in https://github.com/dust-tt/dust/pull/27178 overseeing the whole plumbing. This PR restores previous hard limit on remote MCP servers, all results above 20kb will be offloaded to a file. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
