### PR TITLE
feat(credits): revoke Free seat downgrades to None immediately

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -211,9 +211,16 @@ export function UsagePage() {
   );
   const onRemoveSeat = useCallback(
     async (member: MemberUsageType) => {
+      // Free seats carry no renewing allowance to preserve, so removing one is
+      // immediate; paid seats keep access until the end of the current billing
+      // period.
+      const message =
+        member.seatType === "free"
+          ? `Are you sure you want to remove ${member.name}'s seat? They will immediately lose the ability to send messages, and the Free seat cannot be re-granted.`
+          : `Are you sure you want to remove ${member.name}'s seat? They will keep access until the end of the current billing period, then lose the ability to send messages.`;
       const confirmed = await confirm({
         title: "Remove seat",
-        message: `Are you sure you want to remove ${member.name}'s seat? They will keep access until the end of the current billing period, then lose the ability to send messages.`,
+        message,
         validateLabel: "Remove seat",
         validateVariant: "warning",
       });

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -441,8 +441,8 @@ describe("classifySeatChange", () => {
     ).toEqual({ kind: "deferred", at: new Date("2026-07-01T00:00:00Z") });
   });
 
-  it("treats free → none as a no-op (free is a one-shot tier)", () => {
-    expect(classify("free", "none")).toEqual({ kind: "noop" });
+  it("removes a free seat (free → none) immediately (no renewing allowance to preserve)", () => {
+    expect(classify("free", "none")).toEqual({ kind: "immediate" });
   });
 
   it("returns undefined for a deferral when no anchor date exists", () => {

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -156,8 +156,8 @@ export type SeatChangeOutcome =
  * Branches:
  * - Same seat as current: `cancelled` if a pending future change exists,
  *   else `noop`.
- * - `free` → `none`: `noop`. A `free` seat is a one-shot tier that cannot be
- *   downgraded to no seat.
+ * - `free` → `none`: `immediate`. A `free` seat carries no renewing, already-paid
+ *   allowance to preserve, so removing it takes effect right away.
  * - New allocation ≥ previous: `immediate` (the user gains/keeps access
  *   right away).
  * - New allocation < previous: `deferred` to the next time the previous
@@ -184,11 +184,13 @@ export function classifySeatChange({
     return pendingScheduledChange ? { kind: "cancelled" } : { kind: "noop" };
   }
 
-  // `free` is a one-shot tier that can't be given back: downgrading a free
-  // seat to no seat is not allowed, so treat it as a no-op (the caller leaves
-  // the membership untouched).
+  // `free` → `none`: remove the seat immediately. A free seat carries a
+  // one-shot allocation with no renewing, already-paid allowance to preserve,
+  // so there's nothing to defer to — the member drops to no seat right away.
+  // (The `free` tier is one-shot: once removed it can't be re-granted, which
+  // `updateMembershipSeatAndTrack` enforces separately.)
   if (previousSeatType === "free" && newSeatType === "none") {
-    return { kind: "noop" };
+    return { kind: "immediate" };
   }
 
   const previousAllocation = getAwuAllocationForSeatType(


### PR DESCRIPTION
## Description

Revoking a member's **Free** seat from the Usage page used to be a silent no-op: `classifySeatChange` classified `free → none` as `noop`, so the confirmation dialog fired but the membership was left untouched. 
It was strange.

This makes the downgrade take effect **immediately**. A Free seat carries a one-shot allocation with no renewing, already-paid allowance to preserve, so there is nothing to defer to — consistent with how zero-allowance seats (e.g. `workspace → none`) are already removed immediately.

- `classifySeatChange`: `free → none` now returns `{ kind: "immediate" }` instead of `{ kind: "noop" }`.
- Usage page `onRemoveSeat`: shows Free-specific confirmation copy ("They will immediately lose the ability to send messages, and the Free seat cannot be re-granted.") instead of the "until the end of the current billing period" wording, which only applies to paid seats.

The other callers of `updateMembershipSeatAndTrack` (subscription activation, business activation, auto-upgrade) only perform upgrades/paid assignments, never `free → none`, so they are unaffected.

## Tests

- Updated `seats.test.ts` to assert `free → none` is now classified `immediate`; full classifier suite (39 tests) passes.
- Manual: from the Usage page, remove a Free member's seat and confirm the member drops to `none` right away.
