### PR TITLE
Fix: moving up and down in slash command results auto scroll.

### DIFF
--- a/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
@@ -214,6 +214,7 @@ export function ContextFileSlashSearch({
       fileItems.map((item, index) => (
         <DropdownMenuItem
           key={item.id}
+          itemId={item.id}
           icon={
             <Icon
               visual={getFileTypeIcon(item.file.contentType, item.label)}
@@ -238,6 +239,7 @@ export function ContextFileSlashSearch({
     <InlineSlashSearch
       deferDropdownUntilFocus
       dropdownContent={dropdownContent}
+      highlightedItemId={fileItems[selectedIndex]?.id}
       isDropdownOpen={fileItems.length > 0 || isLoading}
       itemCount={fileItems.length}
       onCancel={onCancel}

--- a/front/components/editor/extensions/shared/slash_suggestion/InlineSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/InlineSlashSearch.tsx
@@ -24,6 +24,7 @@ const INTERACT_OUTSIDE_GRACE_MS = 350;
 export interface InlineSlashSearchProps {
   deferDropdownUntilFocus?: boolean;
   dropdownContent: React.ReactNode;
+  highlightedItemId?: string;
   isDropdownOpen: boolean;
   itemCount: number;
   onCancel: () => void;
@@ -38,6 +39,7 @@ export interface InlineSlashSearchProps {
 export function InlineSlashSearch({
   deferDropdownUntilFocus = false,
   dropdownContent,
+  highlightedItemId,
   isDropdownOpen,
   itemCount,
   onCancel,
@@ -245,6 +247,8 @@ export function InlineSlashSearch({
             align="start"
             avoidCollisions
             collisionPadding={12}
+            highlightedItemId={highlightedItemId}
+            scrollHighlightedItemIntoView
             side="bottom"
             sideOffset={4}
             onInteractOutside={handleInteractOutside}

--- a/front/components/editor/extensions/shared/slash_suggestion/KnowledgeSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/KnowledgeSlashSearch.tsx
@@ -138,45 +138,55 @@ export function KnowledgeSlashSearch({
         : "No knowledge found"}
     </div>
   ) : (
-    knowledgeNodes.map((node, index) => (
-      <DropdownMenuItem
-        key={`${node.internalId}-${node.dataSourceView.sId}`}
-        icon={
-          isWebsite(node.dataSourceView.dataSource) ||
-          isFolder(node.dataSourceView.dataSource) ? (
-            <Icon
-              visual={getVisualForDataSourceViewContentNode(node)}
-              size="md"
-            />
-          ) : (
-            <DoubleIcon
-              size="md"
-              mainIcon={getVisualForDataSourceViewContentNode(node)}
-              secondaryIcon={getConnectorProviderLogoWithFallback({
-                provider: node.dataSourceView.dataSource.connectorProvider,
-              })}
-            />
-          )
-        }
-        label={node.title}
-        description={getLocationForDataSourceViewContentNodeWithSpace(
-          node,
-          spacesMap
-        )}
-        truncateText
-        onClick={() => handleItemSelect(index)}
-        onMouseEnter={() => setSelectedIndex(index)}
-        className={
-          index === selectedIndex ? "bg-gray-100 dark:bg-gray-800" : ""
-        }
-      />
-    ))
+    knowledgeNodes.map((node, index) => {
+      const itemId = `${node.internalId}-${node.dataSourceView.sId}`;
+
+      return (
+        <DropdownMenuItem
+          key={itemId}
+          itemId={itemId}
+          icon={
+            isWebsite(node.dataSourceView.dataSource) ||
+            isFolder(node.dataSourceView.dataSource) ? (
+              <Icon
+                visual={getVisualForDataSourceViewContentNode(node)}
+                size="md"
+              />
+            ) : (
+              <DoubleIcon
+                size="md"
+                mainIcon={getVisualForDataSourceViewContentNode(node)}
+                secondaryIcon={getConnectorProviderLogoWithFallback({
+                  provider: node.dataSourceView.dataSource.connectorProvider,
+                })}
+              />
+            )
+          }
+          label={node.title}
+          description={getLocationForDataSourceViewContentNodeWithSpace(
+            node,
+            spacesMap
+          )}
+          truncateText
+          onClick={() => handleItemSelect(index)}
+          onMouseEnter={() => setSelectedIndex(index)}
+          className={
+            index === selectedIndex ? "bg-gray-100 dark:bg-gray-800" : ""
+          }
+        />
+      );
+    })
   );
 
   return (
     <InlineSlashSearch
       deferDropdownUntilFocus
       dropdownContent={dropdownContent}
+      highlightedItemId={
+        knowledgeNodes[selectedIndex]
+          ? `${knowledgeNodes[selectedIndex].internalId}-${knowledgeNodes[selectedIndex].dataSourceView.sId}`
+          : undefined
+      }
       isDropdownOpen={isOpen}
       itemCount={knowledgeNodes.length}
       onCancel={onCancel}

--- a/front/components/editor/extensions/skill_builder/CapabilitySearchNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/CapabilitySearchNodeView.tsx
@@ -295,6 +295,7 @@ function CapabilitySearchNodeViewInner({
       <InlineSlashSearch
         deferDropdownUntilFocus
         dropdownContent={dropdownContent}
+        highlightedItemId={capabilityItems[selectedIndex]?.id}
         isDropdownOpen={capabilityItems.length > 0 || isLoading}
         itemCount={capabilityItems.length}
         onCancel={handleCancel}


### PR DESCRIPTION
## Description

Keyboard navigation (arrow up/down) in slash command dropdowns no longer goes offscreen when the highlighted item is outside the visible scroll area. Added `highlightedItemId` prop to `InlineSlashSearch` and enabled `scrollHighlightedItemIntoView` on the underlying dropdown. Each consumer (`ContextFileSlashSearch`, `KnowledgeSlashSearch`, `CapabilitySearchNodeView`) now passes `itemId` to `DropdownMenuItem` and forwards the currently selected item's id as `highlightedItemId`.

> 📎 Please attach a screenshot or GIF showing the scroll behavior in the slash command dropdown.

## Tests

Tested manually by opening a slash command dropdown with enough items to overflow, then navigating with arrow keys to confirm the highlighted item scrolls into view.

## Risk

Low. Additive change — new props with no behavioral impact unless explicitly passed. No logic changes to search, state, or selection handling.

## Deploy Plan

Deploy `front`.
