### PR TITLE
feat(llm): add OpenAI batch mode to the new LLM router

### DIFF
--- a/front/lib/llms/batch/endpoints/openai_responses_global_gpt_five_dot_five.ts
+++ b/front/lib/llms/batch/endpoints/openai_responses_global_gpt_five_dot_five.ts
@@ -1,0 +1,8 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { OpenAIResponsesGlobalGptFiveDotFiveBatch } from "@app/lib/model_constructors/batch/endpoints/openai_responses_global_gpt_five_dot_five";
+
+export class DustOpenAIResponsesGlobalGptFiveDotFiveBatch extends OpenAIResponsesGlobalGptFiveDotFiveBatch {
+  static readonly endpointFilter = {};
+}
+
+defineDustBatchEndpoint(DustOpenAIResponsesGlobalGptFiveDotFiveBatch);

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -3,6 +3,7 @@ import { DustAnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/llms/ba
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { DustOpenAIResponsesGlobalGptFiveDotFiveBatch } from "@app/lib/llms/batch/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -20,6 +21,8 @@ export const DUST_BATCH_ENDPOINTS = {
     DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch,
   [DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch.id]:
     DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch,
+  [DustOpenAIResponsesGlobalGptFiveDotFiveBatch.id]:
+    DustOpenAIResponsesGlobalGptFiveDotFiveBatch,
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;
 
 export function getBatchEndpoints(

--- a/front/lib/model_constructors/batch/clients/google_ai_studio.ts
+++ b/front/lib/model_constructors/batch/clients/google_ai_studio.ts
@@ -27,10 +27,14 @@ const CUSTOM_ID_METADATA_KEY = "custom_id";
 // How many request payloads to build concurrently (each may fetch image parts).
 const BUILD_PAYLOAD_CONCURRENCY = 8;
 
-// Terminal job states: the batch has finished and results can be read.
-const TERMINAL_JOB_STATES: ReadonlySet<JobState> = new Set([
+// Job states where results are available.
+const READY_JOB_STATES: ReadonlySet<JobState> = new Set([
   JobState.JOB_STATE_SUCCEEDED,
   JobState.JOB_STATE_PARTIALLY_SUCCEEDED,
+]);
+
+// Job states that are permanently terminal but produce no results.
+const ABORTED_JOB_STATES: ReadonlySet<JobState> = new Set([
   JobState.JOB_STATE_FAILED,
   JobState.JOB_STATE_CANCELLED,
   JobState.JOB_STATE_EXPIRED,
@@ -118,9 +122,13 @@ export abstract class GoogleAiStudioBatch extends WithGoogleGenAIInputConverter(
 
   async getBatchStatus(batchId: string): Promise<BatchStatus> {
     const batch = await this.client.batches.get({ name: batchId });
-    return batch.state && TERMINAL_JOB_STATES.has(batch.state)
-      ? "ready"
-      : "computing";
+    if (batch.state && READY_JOB_STATES.has(batch.state)) {
+      return "ready";
+    }
+    if (batch.state && ABORTED_JOB_STATES.has(batch.state)) {
+      return "aborted";
+    }
+    return "computing";
   }
 
   async getBatchResult(

--- a/front/lib/model_constructors/batch/clients/openai_responses.ts
+++ b/front/lib/model_constructors/batch/clients/openai_responses.ts
@@ -12,7 +12,7 @@ import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/ou
 import { OPENAI_RESPONSES_API } from "@app/lib/model_constructors/types/provider_apis";
 import { OPENAI_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { OpenAI, toFile } from "openai";
 import type {
   Response as OpenAIResponse,
@@ -109,17 +109,21 @@ export abstract class OpenAIResponsesBatch extends WithOpenAIResponsesInputConve
     const batch = await this.client.batches.retrieve(batchId);
     switch (batch.status) {
       case "completed":
-      case "failed":
-      case "expired":
-      case "cancelled":
         return "ready";
       case "validating":
       case "in_progress":
       case "finalizing":
       case "cancelling":
         return "computing";
+      case "failed":
+      case "expired":
+      case "cancelled":
+        return "aborted";
+      // `status` comes from the OpenAI API; tolerate unknown future values
+      // instead of crashing — treat them as still in progress.
       default:
-        return assertNever(batch.status);
+        assertNeverAndIgnore(batch.status);
+        return "computing";
     }
   }
 

--- a/front/lib/model_constructors/batch/clients/openai_responses.ts
+++ b/front/lib/model_constructors/batch/clients/openai_responses.ts
@@ -1,0 +1,181 @@
+import {
+  BatchEndpoint,
+  type BatchRequest,
+  type BatchStatus,
+} from "@app/lib/model_constructors/batch/endpoint";
+import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/input";
+import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/output";
+import { responseToEvents } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { OPENAI_RESPONSES_API } from "@app/lib/model_constructors/types/provider_apis";
+import { OPENAI_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { OpenAI, toFile } from "openai";
+import type {
+  Response as OpenAIResponse,
+  ResponseCreateParamsNonStreaming,
+} from "openai/resources/responses/responses";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+// The Responses endpoint and completion window for batch jobs.
+const BATCH_ENDPOINT_URL = "/v1/responses";
+const BATCH_COMPLETION_WINDOW = "24h";
+
+// One line of the JSONL output file the Batch API produces.
+const openAIBatchOutputLineSchema = z.object({
+  custom_id: z.string(),
+  response: z.object({ status_code: z.number(), body: z.unknown() }).nullable(),
+  error: z.object({ code: z.string(), message: z.string() }).nullable(),
+});
+
+function isOpenAIResponse(value: unknown): value is OpenAIResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "output" in value &&
+    Array.isArray(value.output)
+  );
+}
+
+/**
+ * The batch sibling of `OpenAIResponsesStream`: same input/output converters,
+ * but it talks to the OpenAI Batch API. Unlike Anthropic/Gemini (inlined
+ * requests), OpenAI batches are file-based: upload a JSONL of requests, create
+ * the job, then download a JSONL of responses.
+ */
+export abstract class OpenAIResponsesBatch extends WithOpenAIResponsesInputConverter(
+  WithOpenAIResponsesOutputConverter(
+    BatchEndpoint<ResponseCreateParamsNonStreaming, OpenAIResponse>
+  )
+) {
+  static readonly providerId = OPENAI_PROVIDER_ID;
+  static readonly api = OPENAI_RESPONSES_API;
+
+  private readonly client: OpenAI;
+
+  constructor({ OPENAI_API_KEY, OPENAI_BASE_URL }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      apiKey: OPENAI_API_KEY,
+      baseURL: OPENAI_BASE_URL,
+    });
+  }
+
+  rawBatchOutputToEvents(result: OpenAIResponse): NonDeltaResponseEvent[] {
+    return responseToEvents(result, this.metadata(), this);
+  }
+
+  async sendBatch(
+    requests: Map<string, BatchRequest<InputConfig>>
+  ): Promise<string> {
+    const lines = Array.from(requests.entries()).map(
+      ([customId, { payload, config }]) => {
+        // `buildRequestPayload` omits `stream`; force it off for the batch body.
+        const body: ResponseCreateParamsNonStreaming = {
+          ...this.buildRequestPayload(payload, config),
+          stream: false,
+        };
+        return JSON.stringify({
+          custom_id: customId,
+          method: "POST",
+          url: BATCH_ENDPOINT_URL,
+          body,
+        });
+      }
+    );
+
+    const file = await toFile(Buffer.from(lines.join("\n")), "batch.jsonl", {
+      type: "application/jsonl",
+    });
+    const uploadedFile = await this.client.files.create(
+      { file, purpose: "batch" },
+      // Clear the default JSON Content-Type so the SDK sends multipart/form-data.
+      { headers: { "Content-Type": null } }
+    );
+
+    const batch = await this.client.batches.create({
+      input_file_id: uploadedFile.id,
+      endpoint: BATCH_ENDPOINT_URL,
+      completion_window: BATCH_COMPLETION_WINDOW,
+    });
+    return batch.id;
+  }
+
+  async getBatchStatus(batchId: string): Promise<BatchStatus> {
+    const batch = await this.client.batches.retrieve(batchId);
+    switch (batch.status) {
+      case "completed":
+      case "failed":
+      case "expired":
+      case "cancelled":
+        return "ready";
+      case "validating":
+      case "in_progress":
+      case "finalizing":
+      case "cancelling":
+        return "computing";
+      default:
+        return assertNever(batch.status);
+    }
+  }
+
+  async getBatchResult(
+    batchId: string
+  ): Promise<Map<string, NonDeltaResponseEvent[]>> {
+    const batch = await this.client.batches.retrieve(batchId);
+    if (!batch.output_file_id) {
+      throw new Error(`OpenAI batch ${batchId} has no output file.`);
+    }
+
+    const fileContent = await this.client.files.content(batch.output_file_id);
+    const text = await fileContent.text();
+
+    const batchResult = new Map<string, NonDeltaResponseEvent[]>();
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const parsed = openAIBatchOutputLineSchema.safeParse(JSON.parse(trimmed));
+      if (!parsed.success) {
+        throw new Error(
+          `Failed to parse OpenAI batch output line: ${fromError(parsed.error)}`
+        );
+      }
+
+      const { custom_id, response, error } = parsed.data;
+      if (error || !response) {
+        batchResult.set(custom_id, [
+          buildErrorEvent({
+            metadata: this.metadata(),
+            type: "server_error",
+            message:
+              error?.message ?? `No response for custom_id ${custom_id}.`,
+          }),
+        ]);
+        continue;
+      }
+      if (!isOpenAIResponse(response.body)) {
+        throw new Error(`Unexpected response body for custom_id ${custom_id}.`);
+      }
+      batchResult.set(custom_id, this.rawBatchOutputToEvents(response.body));
+    }
+    return batchResult;
+  }
+
+  async deleteBatch(batchId: string): Promise<boolean> {
+    const batch = await this.client.batches.retrieve(batchId);
+    const fileIds = [batch.input_file_id, batch.output_file_id].filter(
+      (id): id is string => !!id
+    );
+    // At most 2 files (input + output).
+    const results = await Promise.all(
+      fileIds.map((fileId) => this.client.files.delete(fileId))
+    );
+    return results.every((result) => result.deleted);
+  }
+}

--- a/front/lib/model_constructors/batch/endpoint.ts
+++ b/front/lib/model_constructors/batch/endpoint.ts
@@ -3,7 +3,11 @@ import type { InputConfig } from "@app/lib/model_constructors/types/input/config
 import type { Payload } from "@app/lib/model_constructors/types/input/messages";
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
 
-export type BatchStatus = "ready" | "computing";
+// - "computing": the batch is still in progress; keep polling.
+// - "ready": the batch has finished and results can be retrieved.
+// - "aborted": the batch failed, expired, or was cancelled and will never
+//   produce results; callers should stop polling and surface an error.
+export type BatchStatus = "computing" | "ready" | "aborted";
 
 export type BatchRequest<C extends InputConfig = InputConfig> = {
   payload: Payload;

--- a/front/lib/model_constructors/batch/endpoints/openai_responses_global_gpt_five_dot_five.ts
+++ b/front/lib/model_constructors/batch/endpoints/openai_responses_global_gpt_five_dot_five.ts
@@ -1,0 +1,20 @@
+import { OpenAIResponsesBatch } from "@app/lib/model_constructors/batch/clients/openai_responses";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { WithOpenAIGptFiveDotFiveConfig } from "@app/lib/model_constructors/providers/openai/models/gpt_five_dot_five";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class OpenAIResponsesGlobalGptFiveDotFiveBatch extends WithOpenAIGptFiveDotFiveConfig(
+  OpenAIResponsesBatch
+) {
+  // Batch pricing is half the standard OpenAI rate.
+  static readonly tokenPricing = {
+    standardInput: 2.5,
+    standardOutput: 15.0,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+OpenAIResponsesGlobalGptFiveDotFiveBatch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/index.ts
+++ b/front/lib/model_constructors/batch/index.ts
@@ -3,6 +3,7 @@ import { AnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/model_const
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { OpenAIResponsesGlobalGptFiveDotFiveBatch } from "@app/lib/model_constructors/batch/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const BATCH_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixBatch.id]:
@@ -13,6 +14,8 @@ export const BATCH_ENDPOINTS = {
     GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch,
   [GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch,
+  [OpenAIResponsesGlobalGptFiveDotFiveBatch.id]:
+    OpenAIResponsesGlobalGptFiveDotFiveBatch,
 } as const satisfies Record<string, BatchEndpointConstructor>;
 
 export type BatchEndpointId = keyof typeof BATCH_ENDPOINTS;

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -2,6 +2,7 @@ import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoin
 import type {
   ErrorEvent,
   ModelResponseEvent,
+  NonDeltaResponseEvent,
   ReasoningDeltaEvent,
   ReasoningEvent,
   ResponseIdEvent,
@@ -21,6 +22,7 @@ import { isRecord } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { APIConnectionError, APIError } from "openai";
 import type {
+  Response as OpenAIResponse,
   ResponseCreatedEvent,
   ResponseOutputItem,
   ResponseStreamEvent,
@@ -570,4 +572,73 @@ export async function* rawOutputToEvents(
   }
 
   yield { type: "success", content: { aggregated }, metadata };
+}
+
+// -- Non-streaming entry point: a complete batch response → events --
+
+function isNonDeltaEvent(
+  event: ModelResponseEvent
+): event is NonDeltaResponseEvent {
+  return (
+    event.type !== "text_delta" &&
+    event.type !== "reasoning_delta" &&
+    event.type !== "tool_call_delta"
+  );
+}
+
+// Turns a complete `Response` (as returned by the Batch API) into the unified
+// event array, mirroring `rawOutputToEvents` minus the streaming-only delta
+// events. Reuses `outputItemToEvents` so output-item semantics stay
+// single-sourced.
+export function responseToEvents(
+  response: OpenAIResponse,
+  metadata: EndpointMetadata,
+  converters: OutputEventConverters
+): NonDeltaResponseEvent[] {
+  // Terminal failure states surface as a single error event.
+  if (response.status === "failed") {
+    return [converters.streamErrorToErrorEvent(metadata, response.error)];
+  }
+  if (response.status === "incomplete") {
+    return [
+      buildErrorEvent({
+        metadata,
+        type: "stop_error",
+        message:
+          response.incomplete_details?.reason ?? "The response was incomplete.",
+      }),
+    ];
+  }
+
+  const events: NonDeltaResponseEvent[] = [];
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+
+  events.push({
+    type: "response_id",
+    content: { responseId: response.id },
+    metadata,
+  });
+
+  for (const item of response.output) {
+    for (const event of outputItemToEvents(item, metadata, converters)) {
+      if (
+        event.type === "text" ||
+        event.type === "reasoning" ||
+        event.type === "tool_call"
+      ) {
+        aggregated.push(event);
+      }
+      if (isNonDeltaEvent(event)) {
+        events.push(event);
+      }
+    }
+  }
+
+  if (response.usage) {
+    events.push(converters.usageToTokenUsageEvent(metadata, response.usage));
+  }
+
+  events.push({ type: "success", content: { aggregated }, metadata });
+
+  return events;
 }


### PR DESCRIPTION
  ## What

  Adds **batch-mode** support for OpenAI in the new `model_constructors` / `lib/llms` router,
  starting with **GPT-5.5** (the model reinforcement picks as its large batch model). Until now
  only Anthropic (Sonnet 4.6) and Gemini had batch endpoints in the new router — OpenAI batch
  existed in the legacy router but had not been ported.

  ## Changes

  **Non-streaming converter**
  - `sdk/openai_responses/converters/output/utils.ts`: added `responseToEvents(response, ...)`
    (+ an `isNonDeltaEvent` guard). It reuses `outputItemToEvents` so output-item semantics stay
    single-sourced — effectively `rawOutputToEvents` minus the streaming-only delta events — and
    maps `failed` / `incomplete` Response statuses to error events.

  **Batch client** — `batch/clients/openai_responses.ts` (`OpenAIResponsesBatch`)
  - Same input/output converters as `OpenAIResponsesStream`, but file-based: the OpenAI Batch API
    doesn't accept inlined requests like Anthropic/Gemini.
  - `sendBatch`: builds a JSONL of `{ custom_id, method, url: "/v1/responses", body }`, uploads
    via `files.create` (clearing the default JSON Content-Type for multipart), then
    `batches.create`.
  - `getBatchStatus`: maps the 8 OpenAI batch statuses → `ready` / `computing` (exhaustive
    `switch` + `assertNever`).
  - `getBatchResult`: downloads `output_file_id`, parses each JSONL line with a zod schema,
    correlates by `custom_id`, converts the body via `responseToEvents`; per-line errors and
    missing bodies become error events.
  - `deleteBatch`: removes the input + output files.

  **Endpoint**
  - `batch/endpoints/openai_responses_global_gpt_five_dot_five.ts`: reuses the GPT-5.5 config
    mixin with batch pricing at 50% of the standard rate.
  - Dust wrapper under `lib/llms/batch/endpoints/` (just `endpointFilter`).
  - Registered in `BATCH_ENDPOINTS` and `DUST_BATCH_ENDPOINTS`.

  ## Testing

  - `npx tsgo --noEmit`: clean.
  - `biome check`: clean.
  - Runtime check: the endpoint registers in both registries as
    `openai/openai-responses/global/gpt-5.5`.

  No batch test was added — consistent with the existing Anthropic/Gemini batch endpoints, which
  have none (the live test harness covers stream endpoints only).

  ## Notes

  - Scoped to GPT-5.5 for now (the reinforcement batch workhorse), matching the Anthropic
    precedent of one batch model. Adding the other GPT-5.x models is one endpoint file + wrapper
    each, reusing this client.
  - Unlike Gemini, the provider filter does not strip `openai` for non-BYOK workspaces, so this is
    reachable through the normal `getBatchLLM` path (with `use_new_llm_router` enabled).