### PR TITLE
feat(analytics): add a credits column to the agents and users export

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -258,7 +258,7 @@
             "in": "query",
             "name": "table",
             "required": true,
-            "description": "The analytics table to export:\n- \"usage_metrics\": Messages, conversations, and active users over time.\n- \"active_users\": Daily, weekly, and monthly active user counts.\n- \"source\": Message volume by context origin (web, slack, etc.).\n- \"agents\": Top agents by message count.\n- \"users\": Top users by message count.\n- \"skills\": Skill metadata catalog.\n- \"skill_usage\": Skill executions and unique users over time.\n- \"tool_usage\": Tool executions and unique users over time.\n- \"messages\": Detailed message-level logs.\n- \"feedback\": Detailed message-level feedback (thumbs, content, conversation URL).\n",
+            "description": "The analytics table to export:\n- \"usage_metrics\": Messages, conversations, and active users over time.\n- \"active_users\": Daily, weekly, and monthly active user counts.\n- \"source\": Message volume by context origin (web, slack, etc.).\n- \"agents\": Top agents by message count, including credits.\n- \"users\": Top users by message count, including credits.\n- \"skills\": Skill metadata catalog.\n- \"skill_usage\": Skill executions and unique users over time.\n- \"tool_usage\": Tool executions and unique users over time.\n- \"messages\": Detailed message-level logs.\n- \"feedback\": Detailed message-level feedback (thumbs, content, conversation URL).\n",
             "schema": {
               "type": "string",
               "enum": [
@@ -10462,12 +10462,12 @@
           "costCredits": {
             "type": "integer",
             "nullable": true,
-            "description": "Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
+            "description": "Cost of producing this agent message, in credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
           },
           "subAgentCostCredits": {
             "type": "number",
             "nullable": true,
-            "description": "Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
+            "description": "Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
           }
         }
       },
@@ -10613,12 +10613,12 @@
           "costCredits": {
             "type": "integer",
             "nullable": true,
-            "description": "Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
+            "description": "Cost of producing this agent message, in credits (intelligence + tool credits). Null when no billable usage is attributed to the message."
           },
           "subAgentCostCredits": {
             "type": "number",
             "nullable": true,
-            "description": "Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
+            "description": "Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise."
           },
           "activitySteps": {
             "type": "array",

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -403,11 +403,11 @@
  *         costCredits:
  *           type: integer
  *           nullable: true
- *           description: Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
+ *           description: Cost of producing this agent message, in credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
  *         subAgentCostCredits:
  *           type: number
  *           nullable: true
- *           description: Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
+ *           description: Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
  *     PrivateLightAgentMessage:
  *       type: object
  *       description: A lighter agent message used in paginated message list responses.
@@ -503,11 +503,11 @@
  *         costCredits:
  *           type: integer
  *           nullable: true
- *           description: Cost of producing this agent message, in AWU credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
+ *           description: Cost of producing this agent message, in credits (intelligence + tool credits). Null when no billable usage is attributed to the message.
  *         subAgentCostCredits:
  *           type: number
  *           nullable: true
- *           description: Aggregated AWU credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
+ *           description: Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned recursively by this message. Computed only on single-message fetches; null otherwise.
  *         activitySteps:
  *           type: array
  *           items:

--- a/front-api/routes/v1/w/[wId]/analytics/export.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.ts
@@ -23,8 +23,8 @@
  *           - "usage_metrics": Messages, conversations, and active users over time.
  *           - "active_users": Daily, weekly, and monthly active user counts.
  *           - "source": Message volume by context origin (web, slack, etc.).
- *           - "agents": Top agents by message count.
- *           - "users": Top users by message count.
+ *           - "agents": Top agents by message count, including credits.
+ *           - "users": Top users by message count, including credits.
  *           - "skills": Skill metadata catalog.
  *           - "skill_usage": Skill executions and unique users over time.
  *           - "tool_usage": Tool executions and unique users over time.

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -13,6 +13,7 @@ type TopAgentExportBucket = {
   doc_count: number;
   unique_users?: estypes.AggregationsCardinalityAggregate;
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
+  credits?: estypes.AggregationsSumAggregate;
 };
 
 type TopAgentsExportAggs = {
@@ -42,6 +43,7 @@ export interface AgentExportRow {
   distinctUsersReached: number;
   distinctConversations: number;
   lastEdit: string;
+  credits: number;
 }
 
 export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [
@@ -56,6 +58,7 @@ export const AGENT_EXPORT_HEADERS: (keyof AgentExportRow)[] = [
   "distinctUsersReached",
   "distinctConversations",
   "lastEdit",
+  "credits",
 ];
 
 export async function fetchAgentExportRows(
@@ -79,6 +82,7 @@ export async function fetchAgentExportRows(
             unique_conversations: {
               cardinality: { field: "conversation_id" },
             },
+            credits: { sum: { field: "cost.full_awu" } },
           },
         },
       },
@@ -101,6 +105,7 @@ export async function fetchAgentExportRows(
         messages: b.doc_count,
         distinctUsersReached: Math.round(b.unique_users?.value ?? 0),
         distinctConversations: Math.round(b.unique_conversations?.value ?? 0),
+        credits: Math.round(b.credits?.value ?? 0),
       },
     ])
   );
@@ -153,6 +158,7 @@ export async function fetchAgentExportRows(
       distinctUsersReached: metrics?.distinctUsersReached ?? 0,
       distinctConversations: metrics?.distinctConversations ?? 0,
       lastEdit: agent.lastEdit,
+      credits: metrics?.credits ?? 0,
     };
   });
 
@@ -178,6 +184,7 @@ export async function fetchAgentExportRows(
         distinctUsersReached: metrics?.distinctUsersReached ?? 0,
         distinctConversations: metrics?.distinctConversations ?? 0,
         lastEdit: "",
+        credits: metrics?.credits ?? 0,
       });
     }
   }

--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -14,6 +14,7 @@ type TopUserExportBucket = {
   doc_count: number;
   last_message?: estypes.AggregationsMaxAggregate;
   active_days?: estypes.AggregationsDateHistogramAggregate;
+  credits?: estypes.AggregationsSumAggregate;
 };
 
 type TopUsersExportAggs = {
@@ -28,6 +29,7 @@ export interface UserExportRow {
   lastMessageSent: string;
   activeDaysCount: number;
   groups: string;
+  credits: number;
 }
 
 export const USER_EXPORT_HEADERS: (keyof UserExportRow)[] = [
@@ -38,6 +40,7 @@ export const USER_EXPORT_HEADERS: (keyof UserExportRow)[] = [
   "lastMessageSent",
   "activeDaysCount",
   "groups",
+  "credits",
 ];
 
 export async function fetchUserExportRows({
@@ -72,6 +75,7 @@ export async function fetchUserExportRows({
                 time_zone: timezone,
               },
             },
+            credits: { sum: { field: "cost.full_awu" } },
           },
         },
       },
@@ -102,6 +106,7 @@ export async function fetchUserExportRows({
           activeDaysCount: Array.isArray(activeDaysBuckets)
             ? activeDaysBuckets.filter((d) => d.doc_count > 0).length
             : 0,
+          credits: Math.round(b.credits?.value ?? 0),
         },
       ] as const;
     })
@@ -142,6 +147,7 @@ export async function fetchUserExportRows({
       lastMessageSent: metrics?.lastMessageSent ?? "",
       activeDaysCount: metrics?.activeDaysCount ?? 0,
       groups: groupsMap[userModelId] ?? "",
+      credits: metrics?.credits ?? 0,
     };
   });
 


### PR DESCRIPTION
## Description

Append a credits column (sum of cost.full_awu over the period) to the public analytics export's agents and users tables. The existing by_agent/by_user aggregations gain a credits sub-agg, and the column is appended last so the change stays backward-compatible (BACK12). Free origins carry 0 cost, so the plain sum already matches the non-free billed scope.

Exposed via GET /api/v1/w/:wId/analytics/export?table=agents|users (CSV/JSON).
## Tests

Local
## Risk

Low
## Deploy Plan

Front, OpenAPI docs