### PR TITLE
feat(llm): add Mistral batch mode to the new LLM router

### DIFF
--- a/front/lib/llms/batch/endpoints/mistral_eu_mistral_medium_3_5.ts
+++ b/front/lib/llms/batch/endpoints/mistral_eu_mistral_medium_3_5.ts
@@ -1,0 +1,8 @@
+import { defineDustBatchEndpoint } from "@app/lib/llms/batch/dust_batch_endpoint";
+import { MistralEuropeMistralMedium35Batch } from "@app/lib/model_constructors/batch/endpoints/mistral_eu_mistral_medium_3_5";
+
+export class DustMistralEuropeMistralMedium35Batch extends MistralEuropeMistralMedium35Batch {
+  static readonly endpointFilter = {};
+}
+
+defineDustBatchEndpoint(DustMistralEuropeMistralMedium35Batch);

--- a/front/lib/llms/batch/index.ts
+++ b/front/lib/llms/batch/index.ts
@@ -3,6 +3,7 @@ import { DustAnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/llms/ba
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/llms/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { DustMistralEuropeMistralMedium35Batch } from "@app/lib/llms/batch/endpoints/mistral_eu_mistral_medium_3_5";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveBatch } from "@app/lib/llms/batch/endpoints/openai_responses_global_gpt_five_dot_five";
 import { isEndpointAvailable } from "@app/lib/llms/batch/utils/is_endpoint_available";
 import type {
@@ -23,6 +24,8 @@ export const DUST_BATCH_ENDPOINTS = {
     DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch,
   [DustOpenAIResponsesGlobalGptFiveDotFiveBatch.id]:
     DustOpenAIResponsesGlobalGptFiveDotFiveBatch,
+  [DustMistralEuropeMistralMedium35Batch.id]:
+    DustMistralEuropeMistralMedium35Batch,
 } as const satisfies Record<BatchEndpointId, DustBatchEndpointConstructor>;
 
 export function getBatchEndpoints(

--- a/front/lib/model_constructors/batch/clients/mistral.ts
+++ b/front/lib/model_constructors/batch/clients/mistral.ts
@@ -14,6 +14,7 @@ import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/ou
 import { MISTRAL_API } from "@app/lib/model_constructors/types/provider_apis";
 import { MISTRAL_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Mistral } from "@mistralai/mistralai";
 import {
   ApiEndpoint,
@@ -24,6 +25,9 @@ import {
 } from "@mistralai/mistralai/models/components";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
+
+// A batch job references at most its input + output files.
+const FILE_DELETE_CONCURRENCY = 2;
 
 // One line of the JSONL output file the Batch API produces.
 const mistralBatchOutputLineSchema = z.object({
@@ -165,9 +169,10 @@ export abstract class MistralBatch extends WithMistralAIInputConverter(
     const fileIds = [job.inputFiles, job.outputFile]
       .flat()
       .filter((id): id is string => !!id);
-    // At most 2 files (input + output).
-    const results = await Promise.all(
-      fileIds.map((fileId) => this.client.files.delete({ fileId }))
+    const results = await concurrentExecutor(
+      fileIds,
+      (fileId) => this.client.files.delete({ fileId }),
+      { concurrency: FILE_DELETE_CONCURRENCY }
     );
     return results.every((result) => result.deleted);
   }

--- a/front/lib/model_constructors/batch/clients/mistral.ts
+++ b/front/lib/model_constructors/batch/clients/mistral.ts
@@ -21,6 +21,7 @@ import {
   BatchJobStatus,
   type ChatCompletionResponse,
   type ChatCompletionStreamRequest,
+  ChatCompletionStreamRequest$outboundSchema,
   chatCompletionResponseFromJSON,
 } from "@mistralai/mistralai/models/components";
 import { z } from "zod";
@@ -78,8 +79,13 @@ export abstract class MistralBatch extends WithMistralAIInputConverter(
     const batchRequests = Array.from(requests.entries()).map(
       ([customId, { payload, config }]) => ({
         customId,
-        // `buildRequestPayload` omits `stream`; force it off for the batch body.
-        body: { ...this.buildRequestPayload(payload, config), stream: false },
+        // The batch `body` is a passthrough record sent verbatim, so serialize
+        // the request to its wire (snake_case) shape — the SDK only does that
+        // for the streaming/non-batch paths. `stream` is forced off.
+        body: ChatCompletionStreamRequest$outboundSchema.parse({
+          ...this.buildRequestPayload(payload, config),
+          stream: false,
+        }),
       })
     );
 

--- a/front/lib/model_constructors/batch/clients/mistral.ts
+++ b/front/lib/model_constructors/batch/clients/mistral.ts
@@ -1,0 +1,174 @@
+import {
+  BatchEndpoint,
+  type BatchRequest,
+  type BatchStatus,
+} from "@app/lib/model_constructors/batch/endpoint";
+import {
+  type MistralInputConfig,
+  mistralConfigSchema,
+} from "@app/lib/model_constructors/providers/mistral/inputConfig";
+import { WithMistralAIInputConverter } from "@app/lib/model_constructors/sdk/mistralai/converters/input";
+import { responseToEvents } from "@app/lib/model_constructors/sdk/mistralai/converters/output/utils";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { MISTRAL_API } from "@app/lib/model_constructors/types/provider_apis";
+import { MISTRAL_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { Mistral } from "@mistralai/mistralai";
+import {
+  ApiEndpoint,
+  BatchJobStatus,
+  type ChatCompletionResponse,
+  type ChatCompletionStreamRequest,
+  chatCompletionResponseFromJSON,
+} from "@mistralai/mistralai/models/components";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+// One line of the JSONL output file the Batch API produces.
+const mistralBatchOutputLineSchema = z.object({
+  custom_id: z.string(),
+  response: z
+    .object({ status_code: z.number(), body: z.unknown() })
+    .nullable()
+    .optional(),
+  error: z
+    .object({ code: z.string().optional(), message: z.string() })
+    .nullable()
+    .optional(),
+});
+
+/**
+ * The batch sibling of `MistralStream`: same input converter, but it talks to
+ * the Mistral Batch API. The SDK accepts inlined requests (it uploads the input
+ * file internally) and exposes the results as a downloadable JSONL file.
+ */
+export abstract class MistralBatch extends WithMistralAIInputConverter(
+  BatchEndpoint<
+    ChatCompletionStreamRequest,
+    ChatCompletionResponse,
+    MistralInputConfig
+  >
+) {
+  static readonly providerId = MISTRAL_PROVIDER_ID;
+  static readonly api = MISTRAL_API;
+
+  static readonly configSchema = mistralConfigSchema;
+
+  private readonly client: Mistral;
+
+  constructor({ MISTRAL_API_KEY }: Credentials) {
+    super();
+    this.client = new Mistral({ apiKey: MISTRAL_API_KEY });
+  }
+
+  rawBatchOutputToEvents(
+    result: ChatCompletionResponse
+  ): NonDeltaResponseEvent[] {
+    return responseToEvents(result, this.metadata());
+  }
+
+  async sendBatch(
+    requests: Map<string, BatchRequest<MistralInputConfig>>
+  ): Promise<string> {
+    const batchRequests = Array.from(requests.entries()).map(
+      ([customId, { payload, config }]) => ({
+        customId,
+        // `buildRequestPayload` omits `stream`; force it off for the batch body.
+        body: { ...this.buildRequestPayload(payload, config), stream: false },
+      })
+    );
+
+    const job = await this.client.batch.jobs.create({
+      model: this.constructor.modelId,
+      endpoint: ApiEndpoint.RootV1ChatCompletions,
+      requests: batchRequests,
+    });
+    return job.id;
+  }
+
+  async getBatchStatus(batchId: string): Promise<BatchStatus> {
+    const job = await this.client.batch.jobs.get({ jobId: batchId });
+    switch (job.status) {
+      case BatchJobStatus.Success:
+      case BatchJobStatus.Failed:
+      case BatchJobStatus.TimeoutExceeded:
+      case BatchJobStatus.Cancelled:
+        return "ready";
+      case BatchJobStatus.Queued:
+      case BatchJobStatus.Running:
+      case BatchJobStatus.CancellationRequested:
+        return "computing";
+      // `status` is an open enum; treat any unknown future value as in progress.
+      default:
+        return "computing";
+    }
+  }
+
+  async getBatchResult(
+    batchId: string
+  ): Promise<Map<string, NonDeltaResponseEvent[]>> {
+    const job = await this.client.batch.jobs.get({ jobId: batchId });
+    if (!job.outputFile) {
+      throw new Error(`Mistral batch ${batchId} has no output file.`);
+    }
+
+    const stream = await this.client.files.download({ fileId: job.outputFile });
+    const text = await new Response(stream).text();
+
+    const batchResult = new Map<string, NonDeltaResponseEvent[]>();
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const parsed = mistralBatchOutputLineSchema.safeParse(
+        JSON.parse(trimmed)
+      );
+      if (!parsed.success) {
+        throw new Error(
+          `Failed to parse Mistral batch output line: ${fromError(parsed.error)}`
+        );
+      }
+
+      const { custom_id, response, error } = parsed.data;
+      if (error || !response) {
+        batchResult.set(custom_id, [
+          buildErrorEvent({
+            metadata: this.metadata(),
+            type: "server_error",
+            message:
+              error?.message ?? `No response for custom_id ${custom_id}.`,
+          }),
+        ]);
+        continue;
+      }
+
+      const parsedResponse = chatCompletionResponseFromJSON(
+        JSON.stringify(response.body)
+      );
+      if (!parsedResponse.ok) {
+        throw new Error(
+          `Failed to parse Mistral batch response for custom_id ${custom_id}: ${parsedResponse.error.message}`
+        );
+      }
+      batchResult.set(
+        custom_id,
+        this.rawBatchOutputToEvents(parsedResponse.value)
+      );
+    }
+    return batchResult;
+  }
+
+  async deleteBatch(batchId: string): Promise<boolean> {
+    const job = await this.client.batch.jobs.get({ jobId: batchId });
+    const fileIds = [job.inputFiles, job.outputFile]
+      .flat()
+      .filter((id): id is string => !!id);
+    // At most 2 files (input + output).
+    const results = await Promise.all(
+      fileIds.map((fileId) => this.client.files.delete({ fileId }))
+    );
+    return results.every((result) => result.deleted);
+  }
+}

--- a/front/lib/model_constructors/batch/clients/mistral.ts
+++ b/front/lib/model_constructors/batch/clients/mistral.ts
@@ -101,10 +101,11 @@ export abstract class MistralBatch extends WithMistralAIInputConverter(
     const job = await this.client.batch.jobs.get({ jobId: batchId });
     switch (job.status) {
       case BatchJobStatus.Success:
+        return "ready";
       case BatchJobStatus.Failed:
       case BatchJobStatus.TimeoutExceeded:
       case BatchJobStatus.Cancelled:
-        return "ready";
+        return "aborted";
       case BatchJobStatus.Queued:
       case BatchJobStatus.Running:
       case BatchJobStatus.CancellationRequested:

--- a/front/lib/model_constructors/batch/endpoints/mistral_eu_mistral_medium_3_5.ts
+++ b/front/lib/model_constructors/batch/endpoints/mistral_eu_mistral_medium_3_5.ts
@@ -1,0 +1,21 @@
+import { MistralBatch } from "@app/lib/model_constructors/batch/clients/mistral";
+import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
+import { WithMistralMedium35Config } from "@app/lib/model_constructors/providers/mistral/models/mistral_medium_3_5";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class MistralEuropeMistralMedium35Batch extends WithMistralMedium35Config(
+  MistralBatch
+) {
+  // Batch pricing is half the standard Mistral rate.
+  static readonly tokenPricing = {
+    standardInput: 0.2,
+    standardOutput: 1.0,
+  };
+
+  // Inference runs in the EU; the endpoint remains usable from both US and EU.
+  static readonly region = EUROPE;
+
+  static readonly id = this.buildId();
+}
+
+MistralEuropeMistralMedium35Batch satisfies BatchEndpointConstructor;

--- a/front/lib/model_constructors/batch/index.ts
+++ b/front/lib/model_constructors/batch/index.ts
@@ -3,6 +3,7 @@ import { AnthropicGlobalClaudeSonnetFourDotSixBatch } from "@app/lib/model_const
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashBatch } from "@app/lib/model_constructors/batch/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { MistralEuropeMistralMedium35Batch } from "@app/lib/model_constructors/batch/endpoints/mistral_eu_mistral_medium_3_5";
 import { OpenAIResponsesGlobalGptFiveDotFiveBatch } from "@app/lib/model_constructors/batch/endpoints/openai_responses_global_gpt_five_dot_five";
 
 export const BATCH_ENDPOINTS = {
@@ -16,6 +17,7 @@ export const BATCH_ENDPOINTS = {
     GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteBatch,
   [OpenAIResponsesGlobalGptFiveDotFiveBatch.id]:
     OpenAIResponsesGlobalGptFiveDotFiveBatch,
+  [MistralEuropeMistralMedium35Batch.id]: MistralEuropeMistralMedium35Batch,
 } as const satisfies Record<string, BatchEndpointConstructor>;
 
 export type BatchEndpointId = keyof typeof BATCH_ENDPOINTS;

--- a/front/lib/model_constructors/sdk/mistralai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/mistralai/converters/output/utils.ts
@@ -2,8 +2,10 @@ import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoin
 import type {
   ErrorEvent,
   ModelResponseEvent,
+  NonDeltaResponseEvent,
   ReasoningEvent,
   TextEvent,
+  TokenUsageEvent,
   ToolCallEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
@@ -11,13 +13,17 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isRecord, isString } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import type {
+  ChatCompletionResponse,
   CompletionEvent,
   ContentChunk,
   ThinkChunk,
   ToolCall,
   UsageInfo,
 } from "@mistralai/mistralai/models/components";
-import { CompletionResponseStreamChoiceFinishReason } from "@mistralai/mistralai/models/components";
+import {
+  ChatCompletionChoiceFinishReason,
+  CompletionResponseStreamChoiceFinishReason,
+} from "@mistralai/mistralai/models/components";
 import { MistralError } from "@mistralai/mistralai/models/errors/mistralerror";
 
 // Parses tool-call arguments into an object, falling back to `{}` for malformed
@@ -39,7 +45,7 @@ function thinkingChunkToText(thinking: ThinkChunk["thinking"]): string {
 function usageToTokenUsageEvent(
   metadata: EndpointMetadata,
   usage: UsageInfo | undefined
-): ModelResponseEvent {
+): TokenUsageEvent {
   return {
     type: "token_usage",
     content: {
@@ -332,4 +338,107 @@ export async function* rawOutputToEvents(
 
   yield usageToTokenUsageEvent(metadata, usage);
   yield { type: "success", content: { aggregated }, metadata };
+}
+
+// -- Non-streaming entry point: a complete batch response → events --
+
+function isNonDeltaEvent(
+  event: ModelResponseEvent
+): event is NonDeltaResponseEvent {
+  return (
+    event.type !== "text_delta" &&
+    event.type !== "reasoning_delta" &&
+    event.type !== "tool_call_delta"
+  );
+}
+
+function finishReasonToErrorEvent(
+  finishReason: ChatCompletionChoiceFinishReason | undefined,
+  metadata: EndpointMetadata
+): ErrorEvent | null {
+  switch (finishReason) {
+    case ChatCompletionChoiceFinishReason.Length:
+    case ChatCompletionChoiceFinishReason.ModelLength:
+      return buildErrorEvent({
+        metadata,
+        type: "stop_error",
+        message: "The maximum response length was reached.",
+      });
+    case ChatCompletionChoiceFinishReason.Error:
+      return buildErrorEvent({
+        metadata,
+        type: "server_error",
+        message: "Mistral reported an error during completion.",
+      });
+    // Stop / ToolCalls (and any future open-enum value) are not errors.
+    default:
+      return null;
+  }
+}
+
+// Turns a complete `ChatCompletionResponse` (as returned by the Batch API) into
+// the unified event array, mirroring `rawOutputToEvents` minus the
+// streaming-only delta events. Reuses the leaf converters so message semantics
+// stay single-sourced.
+export function responseToEvents(
+  response: ChatCompletionResponse,
+  metadata: EndpointMetadata
+): NonDeltaResponseEvent[] {
+  const events: NonDeltaResponseEvent[] = [];
+  const aggregated: (TextEvent | ReasoningEvent | ToolCallEvent)[] = [];
+  const acc: Accumulator = {
+    textParts: "",
+    reasoningParts: "",
+    toolCallIndex: 0,
+  };
+
+  if (response.id) {
+    events.push({
+      type: "response_id",
+      content: { responseId: response.id },
+      metadata,
+    });
+  }
+
+  const choice = response.choices[0];
+  const message = choice?.message;
+
+  // Accumulate text/reasoning from the message content, then flush it.
+  if (message?.content) {
+    for (const event of contentToEvents(message.content, acc, metadata)) {
+      if (isNonDeltaEvent(event)) {
+        events.push(event);
+      }
+    }
+  }
+  for (const event of flushAccumulated(acc, metadata, aggregated)) {
+    if (isNonDeltaEvent(event)) {
+      events.push(event);
+    }
+  }
+
+  if (message?.toolCalls) {
+    for (const toolCall of message.toolCalls) {
+      for (const event of toolCallToEvents(
+        toolCall,
+        acc,
+        metadata,
+        aggregated
+      )) {
+        if (isNonDeltaEvent(event)) {
+          events.push(event);
+        }
+      }
+    }
+  }
+
+  const errorEvent = finishReasonToErrorEvent(choice?.finishReason, metadata);
+  if (errorEvent) {
+    events.push(errorEvent);
+  }
+
+  events.push(usageToTokenUsageEvent(metadata, response.usage));
+  events.push({ type: "success", content: { aggregated }, metadata });
+
+  return events;
 }


### PR DESCRIPTION
  ## What

  Adds **batch-mode** support for Mistral in the new `model_constructors` / `lib/llms` router,
  starting with **Mistral Medium 3.5** (the model reinforcement picks as its large batch model).
  Mistral batch existed in the legacy router (all configs are `supportsBatchProcessing: true`,
  with a real `client.batch.jobs` implementation) but had not been ported — this fills the gap,
  bringing the new router's batch providers to Anthropic + Gemini + OpenAI + Mistral.

  ## Changes

  **Non-streaming converter**
  - `sdk/mistralai/converters/output/utils.ts`: added `responseToEvents(response, ...)` (+ an
    `isNonDeltaEvent` guard and a `finishReasonToErrorEvent` helper). It reuses the existing
    `contentToEvents` / `toolCallToEvents` / `flushAccumulated` leaf functions so message
    semantics stay single-sourced — effectively `rawOutputToEvents` minus the streaming-only
    delta events. Also narrowed `usageToTokenUsageEvent`'s return type to `TokenUsageEvent` so it
    composes into a `NonDeltaResponseEvent[]` (the streaming `yield` is unaffected).

  **Batch client** — `batch/clients/mistral.ts` (`MistralBatch`)
  - Same input converter as `MistralStream`. Unlike OpenAI's file upload, the Mistral SDK accepts
    inlined requests (`batch.jobs.create({ model, endpoint, requests })`) and uploads the input
    file internally.
  - `sendBatch`: builds `{ customId, body }` requests (body = the request payload with
    `stream: false`) and creates the job.
  - `getBatchStatus`: maps `BatchJobStatus` → `ready` / `computing` (open-enum-safe default for
    unknown future values).
  - `getBatchResult`: `batch.jobs.get` → `files.download` the output JSONL → parse each line with
    a zod schema → `chatCompletionResponseFromJSON` → `responseToEvents`; per-line errors and
    missing bodies become error events.
  - `deleteBatch`: removes the input + output files.

  **Endpoint**
  - `batch/endpoints/mistral_eu_mistral_medium_3_5.ts`: reuses the Mistral Medium 3.5 config mixin
    with `region = EUROPE` (matching the stream endpoint — inference runs in the EU but the
    endpoint is usable from both regions) and batch pricing at 50% of the standard rate.
  - Dust wrapper under `lib/llms/batch/endpoints/` (just `endpointFilter`).
  - Registered in `BATCH_ENDPOINTS` and `DUST_BATCH_ENDPOINTS`.

  ## Testing

  - `npx tsgo --noEmit`: clean.
  - `biome check`: clean.
  - Runtime check: the endpoint registers in both registries as
    `mistral/mistral/eu/mistral-medium-3-5`.

  No batch test was added — consistent with the existing Anthropic/Gemini/OpenAI batch endpoints,
  which have none (the live test harness covers stream endpoints only).

  ## Notes

  - Scoped to Mistral Medium 3.5 for now (the reinforcement batch workhorse), matching the
    Anthropic/OpenAI precedent of one batch model. Adding the other Mistral models is one endpoint
    file + wrapper each, reusing this client.