### PR TITLE
fix: warn about sse deployment when changing feature flags table

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -657,6 +657,7 @@ async function checkDiffFiles() {
     "front/lib/models/agent/conversation_branch.ts",
     "front/lib/models/agent/conversation_fork.ts",
     "front/lib/models/agent/conversation.ts",
+    "front/lib/models/feature_flag.ts",
     "front/lib/models/plan.ts",
     "front/lib/models/provider_credential.ts",
     "front/lib/resources/storage/models/group_memberships.ts",


### PR DESCRIPTION
## Description

This PR adds `front/lib/models/feature_flag.ts` to the list of files in `dangerfile.ts` that trigger a warning about SSE deployment when modified.

## Tests

Manually.

## Risks

None — this is a purely additive change to the Dangerfile configuration with no impact on runtime behavior.

## Deploy Plan

No specific deploy steps required.