### PR TITLE
Move back capabilities to the first layer of / command.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -18,12 +18,6 @@ import {
   type InputBarSlashCommand,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import {
-  ADD_CAPABILITY_SLASH_COMMAND_ACTION,
-  type AddCapabilitySlashCommand,
-  INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION,
-  type InsertKnowledgeSlashCommand,
-  isAddCapabilitySlashCommand,
-  isInsertKnowledgeSlashCommand,
   isRunCommandSlashCommand,
   isSkillSlashCommand,
   isToolSlashCommand,
@@ -118,9 +112,7 @@ import { InputBarContext } from "./InputBarContext";
 type KnownSlashCommand =
   | RunCommandSlashCommand<InputBarSlashCommand>
   | SkillSlashCommand
-  | ToolSlashCommand
-  | AddCapabilitySlashCommand
-  | InsertKnowledgeSlashCommand;
+  | ToolSlashCommand;
 
 function narrowToKnownSlashCommand(
   item: SlashCommand
@@ -132,12 +124,6 @@ function narrowToKnownSlashCommand(
     return item;
   }
   if (isToolSlashCommand(item)) {
-    return item;
-  }
-  if (isAddCapabilitySlashCommand(item)) {
-    return item;
-  }
-  if (isInsertKnowledgeSlashCommand(item)) {
     return item;
   }
   return null;
@@ -339,15 +325,6 @@ const InputBarContainer = ({
   const onDetailsRef = useRef<((item: SlashCommand) => void) | undefined>(
     undefined
   );
-  const onSelectToolRef = useRef<
-    ((tool: MCPServerViewType) => void) | undefined
-  >(undefined);
-  const onCapabilitySkillDetailsRef = useRef<
-    ((skill: { sId: string }) => void) | undefined
-  >(undefined);
-  const onCapabilityToolDetailsRef = useRef<
-    ((tool: MCPServerViewType) => void) | undefined
-  >(undefined);
   const onNodeSelectRef = useRef(onNodeSelect);
   onNodeSelectRef.current = onNodeSelect;
   const includeAttachKnowledgeRef = useRef(actions.includes("attachment"));
@@ -614,12 +591,6 @@ const InputBarContainer = ({
     }
   };
 
-  onSelectToolRef.current = onMCPServerViewSelect;
-  onCapabilitySkillDetailsRef.current = (skill) => {
-    setSelectedSkillIdForDetails(skill.sId);
-  };
-  onCapabilityToolDetailsRef.current = setSelectedServerViewForDetails;
-
   onSelectRef.current = (rawItem: SlashCommand) => {
     const item = narrowToKnownSlashCommand(rawItem);
     if (!item) {
@@ -635,9 +606,6 @@ const InputBarContainer = ({
         break;
       case SELECT_TOOL_SLASH_COMMAND_ACTION:
         onMCPServerViewSelect(item.data.tool.view);
-        break;
-      case ADD_CAPABILITY_SLASH_COMMAND_ACTION:
-      case INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION:
         break;
       default:
         assertNeverAndIgnore(item);
@@ -661,9 +629,6 @@ const InputBarContainer = ({
         break;
       case SELECT_TOOL_SLASH_COMMAND_ACTION:
         setSelectedServerViewForDetails(item.data.tool.view);
-        break;
-      case ADD_CAPABILITY_SLASH_COMMAND_ACTION:
-      case INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION:
         break;
       default:
         assertNeverAndIgnore(item);
@@ -691,9 +656,6 @@ const InputBarContainer = ({
       enabledRef: shouldEnableSlashSuggestionRef,
       onSelectRef,
       onDetailsRef,
-      onSelectToolRef,
-      onCapabilitySkillDetailsRef,
-      onCapabilityToolDetailsRef,
       onSkillDetails: setSelectedSkillIdForDetails,
       selectedMCPServerViewIdsRef,
       slashCommandsRef,

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -119,17 +119,33 @@ interface UseSkillInstructionsEditorProps {
 
 function buildSkillInstructionsEditableExtensions({
   capabilitySearchOptions,
+  currentSkillIdRef,
   onSelectRef,
+  onSkillDetailsRef,
+  onToolDetailsRef,
+  owner,
 }: {
   capabilitySearchOptions: CapabilitySearchNodeOptions;
+  currentSkillIdRef: React.RefObject<string | null>;
   onSelectRef: React.RefObject<
     ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
   >;
+  onSkillDetailsRef: React.RefObject<
+    ((skill: SlashCommandSkillSuggestion) => void) | undefined
+  >;
+  onToolDetailsRef: React.RefObject<
+    ((tool: MCPServerViewType) => void) | undefined
+  >;
+  owner?: LightWorkspaceType;
 }) {
   return [
     CapabilitySearchNodeWithView.configure(capabilitySearchOptions),
     SlashCommandExtension.configure({
+      currentSkillIdRef,
       onSelectRef,
+      onSkillDetailsRef,
+      onToolDetailsRef,
+      owner,
     }),
     AgentInstructionDiffExtension,
     Placeholder.configure({
@@ -162,6 +178,8 @@ export function useSkillInstructionsEditor({
   const onSelectRef = useRef<
     ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
   >(undefined);
+  const currentSkillIdRef = useRef<string | null>(currentSkillId);
+  currentSkillIdRef.current = currentSkillId;
   const onSelectSkillRef = useRef(onSelectSkill);
   const onSelectToolRef = useRef(onSelectTool);
   const onSkillDetailsRef = useRef(onSkillDetails);
@@ -181,9 +199,12 @@ export function useSkillInstructionsEditor({
           onSkillDetailsRef,
           onToolDetailsRef,
           owner,
-          variant: "skill-builder",
         },
+        currentSkillIdRef,
         onSelectRef,
+        onSkillDetailsRef,
+        onToolDetailsRef,
+        owner,
       }),
     [currentSkillId, owner]
   );

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.test.ts
@@ -1,5 +1,4 @@
 import {
-  ADD_CAPABILITY_SLASH_COMMAND_ACTION,
   INSERT_CONTEXT_FILE_SLASH_COMMAND_ACTION,
   INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION,
   isRunCommandSlashCommand,
@@ -48,7 +47,7 @@ describe("getAvailableInputBarSlashCommands", () => {
 });
 
 describe("buildInputBarSlashCommandItems", () => {
-  it("always includes the add capability command", () => {
+  it("returns no commands when none are available", () => {
     const result = buildInputBarSlashCommandItems({
       commands: [],
       includeAttachKnowledge: false,
@@ -56,9 +55,7 @@ describe("buildInputBarSlashCommandItems", () => {
       query: "",
     });
 
-    expect(result.map((item) => item.action)).toEqual([
-      ADD_CAPABILITY_SLASH_COMMAND_ACTION,
-    ]);
+    expect(result).toEqual([]);
   });
 
   it("lists commands in INPUT_BAR_SLASH_COMMAND_ORDER", () => {
@@ -71,7 +68,6 @@ describe("buildInputBarSlashCommandItems", () => {
 
     expect(result.map(getInputBarSlashCommandItemId)).toEqual([
       "compact",
-      "add-capability",
       "reference-file",
       "upload-file",
       "attach-knowledge",
@@ -86,7 +82,7 @@ describe("buildInputBarSlashCommandItems", () => {
         includeSelectContextFile: false,
         query: "",
       }).map(getInputBarSlashCommandItemId)
-    ).toEqual(["compact", "add-capability", "upload-file", "attach-knowledge"]);
+    ).toEqual(["compact", "upload-file", "attach-knowledge"]);
 
     expect(
       buildInputBarSlashCommandItems({
@@ -106,7 +102,7 @@ describe("buildInputBarSlashCommandItems", () => {
         includeSelectContextFile: true,
         query: "",
       }).map(getInputBarSlashCommandItemId)
-    ).toEqual(["compact", "add-capability", "reference-file", "upload-file"]);
+    ).toEqual(["compact", "reference-file", "upload-file"]);
 
     expect(
       buildInputBarSlashCommandItems({
@@ -160,26 +156,6 @@ describe("buildInputBarSlashCommandItems", () => {
         commands: ALL_COMMANDS,
         includeAttachKnowledge: true,
         includeSelectContextFile: true,
-        query: "zzz",
-      })
-    ).toEqual([]);
-  });
-
-  it("filters add capability by the query", () => {
-    expect(
-      buildInputBarSlashCommandItems({
-        commands: [],
-        includeAttachKnowledge: false,
-        includeSelectContextFile: false,
-        query: "cap",
-      }).map((item) => item.label)
-    ).toEqual(["Add capability"]);
-
-    expect(
-      buildInputBarSlashCommandItems({
-        commands: [],
-        includeAttachKnowledge: false,
-        includeSelectContextFile: false,
         query: "zzz",
       })
     ).toEqual([]);

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown.tsx
@@ -1,10 +1,12 @@
 import { buildInputBarSlashCommandItems } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionItems";
 import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
+import { buildSlashCommandSections } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandSections";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import { useInputBarSlashCommandCapabilities } from "@app/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import {
@@ -25,6 +27,7 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
     onClose: () => void;
     onDetailsRef?: RefObject<((item: SlashCommand) => void) | undefined>;
     owner: LightWorkspaceType;
+    selectedMCPServerViewIdsRef: RefObject<Set<string>>;
     slashCommandsRef: RefObject<InputBarSlashCommand[]>;
     includeAttachKnowledgeRef: RefObject<boolean>;
     includeSelectContextFileRef: RefObject<boolean>;
@@ -39,6 +42,8 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       range,
       onClose,
       onDetailsRef,
+      owner,
+      selectedMCPServerViewIdsRef,
       slashCommandsRef,
       includeAttachKnowledgeRef,
       includeSelectContextFileRef,
@@ -64,13 +69,33 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
       ]
     );
 
+    const { capabilityItems, isLoading } = useInputBarSlashCommandCapabilities({
+      owner,
+      query,
+      selectedMCPServerViewIdsRef,
+    });
+
+    const sections = useMemo(
+      () =>
+        buildSlashCommandSections({
+          commandItems,
+          capabilityItems,
+        }),
+      [capabilityItems, commandItems]
+    );
+
+    const flatItems = useMemo(
+      () => sections.flatMap((section) => section.items),
+      [sections]
+    );
+
     useImperativeHandle(
       ref,
       () => ({
         onKeyDown: ({ event }) => {
           if (
             (event.key === "Enter" || event.key === "Tab") &&
-            commandItems.length === 0
+            flatItems.length === 0
           ) {
             event.preventDefault();
             return true;
@@ -79,16 +104,17 @@ export const InputBarSlashSuggestionDropdown = forwardRef<
           return dropdownRef.current?.onKeyDown({ event }) ?? false;
         },
       }),
-      [commandItems.length]
+      [flatItems.length]
     );
 
     return (
       <SlashCommandDropdown
         ref={dropdownRef}
-        items={commandItems}
+        sections={sections}
         command={command}
         clientRect={clientRect}
         emptyMessage="No commands found"
+        isLoadingCapabilities={isLoading}
         onClose={onClose}
         onItemDetails={
           onDetailsRef

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -1,7 +1,6 @@
 import { InputBarSlashSuggestionDropdown } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionDropdown";
 import type { InputBarSlashCommand } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes";
 import {
-  isAddCapabilitySlashCommand,
   isInsertContextFileSlashCommand,
   isInsertKnowledgeSlashCommand,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
@@ -72,16 +71,6 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
   command: ({ editor, range, props, options, storage }) => {
     storage.dismissedTriggerStart = null;
 
-    if (isAddCapabilitySlashCommand(props)) {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertCapabilitySearchNode()
-        .run();
-      return;
-    }
-
     if (isInsertKnowledgeSlashCommand(props)) {
       editor
         .chain()
@@ -106,6 +95,7 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
     conversationIdRef: options.conversationIdRef,
     onDetailsRef: options.onDetailsRef,
     owner: options.owner,
+    selectedMCPServerViewIdsRef: options.selectedMCPServerViewIdsRef,
     slashCommandsRef: options.slashCommandsRef,
     includeAttachKnowledgeRef: options.includeAttachKnowledgeRef,
     includeSelectContextFileRef: options.includeSelectContextFileRef,

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionItems.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionItems.tsx
@@ -2,7 +2,6 @@ import { RUN_COMMAND_SLASH_COMMAND_ACTION } from "@app/components/editor/extensi
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getSlashCommandAvatarIcon } from "@app/components/editor/extensions/shared/slash_suggestion/slashCommandIcons";
 import {
-  createAddCapabilitySlashCommand,
   createAttachKnowledgeSlashCommand,
   createSelectContextFileSlashCommand,
 } from "@app/components/editor/extensions/shared/slash_suggestion/slashStaticCommands";
@@ -12,9 +11,6 @@ import type {
 } from "./InputBarSlashSuggestionTypes";
 import { INPUT_BAR_SLASH_COMMAND_ORDER } from "./InputBarSlashSuggestionTypes";
 
-const ADD_CAPABILITY_SLASH_COMMAND = createAddCapabilitySlashCommand(
-  "Add a skill or tool to your message"
-);
 const ATTACH_KNOWLEDGE_SLASH_COMMAND = createAttachKnowledgeSlashCommand();
 const SELECT_CONTEXT_FILE_SLASH_COMMAND = createSelectContextFileSlashCommand();
 
@@ -61,8 +57,6 @@ function getInputBarSlashCommandById({
   }
 
   switch (commandId) {
-    case "add-capability":
-      return ADD_CAPABILITY_SLASH_COMMAND;
     case "attach-knowledge":
       return includeAttachKnowledge ? ATTACH_KNOWLEDGE_SLASH_COMMAND : null;
     case "reference-file":

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionTypes.ts
@@ -3,7 +3,6 @@ import { Minimize01, UploadCloud02 } from "@dust-tt/sparkle";
 import type React from "react";
 
 export type InputBarSlashCommandId =
-  | "add-capability"
   | "attach-knowledge"
   | "compact"
   | "reference-file"
@@ -18,7 +17,6 @@ export type InputBarRunCommandId = Extract<
 /** Reorder this list to change display order in the `/` menu. */
 export const INPUT_BAR_SLASH_COMMAND_ORDER: InputBarSlashCommandId[] = [
   "compact",
-  "add-capability",
   "reference-file",
   "upload-file",
   "attach-knowledge",

--- a/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
+++ b/front/components/editor/extensions/shared/SlashCommandCapabilitiesItems.ts
@@ -15,7 +15,6 @@ export const RUN_COMMAND_SLASH_COMMAND_ACTION = "run-command";
 export const INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION = "insert-knowledge-node";
 export const INSERT_CONTEXT_FILE_SLASH_COMMAND_ACTION =
   "insert-context-file-search-node";
-export const ADD_CAPABILITY_SLASH_COMMAND_ACTION = "add-capability";
 
 export type SlashCommandSkillSuggestion = Pick<
   SkillWithoutInstructionsAndToolsType,
@@ -64,10 +63,6 @@ export interface InsertKnowledgeSlashCommand extends SlashCommand {
   action: typeof INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION;
 }
 
-export interface AddCapabilitySlashCommand extends SlashCommand {
-  action: typeof ADD_CAPABILITY_SLASH_COMMAND_ACTION;
-}
-
 export interface InsertContextFileSlashCommand extends SlashCommand {
   action: typeof INSERT_CONTEXT_FILE_SLASH_COMMAND_ACTION;
 }
@@ -94,12 +89,6 @@ export function isInsertKnowledgeSlashCommand(
   item: SlashCommand
 ): item is InsertKnowledgeSlashCommand {
   return item.action === INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION;
-}
-
-export function isAddCapabilitySlashCommand(
-  item: SlashCommand
-): item is AddCapabilitySlashCommand {
-  return item.action === ADD_CAPABILITY_SLASH_COMMAND_ACTION;
 }
 
 export function isInsertContextFileSlashCommand(

--- a/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown.tsx
@@ -1,3 +1,8 @@
+import {
+  flattenSlashCommandSections,
+  SLASH_COMMAND_CAPABILITIES_SECTION_LABEL,
+  type SlashCommandSection,
+} from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandSections";
 import { SLASH_COMMAND_DROPDOWN_LIST_CLASS_NAME } from "@app/components/editor/extensions/shared/slash_suggestion/slashSuggestionUtils";
 import {
   Button,
@@ -6,8 +11,10 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
   DropdownTooltipTrigger,
+  Spinner,
 } from "@dust-tt/sparkle";
 import type { SuggestionProps } from "@tiptap/suggestion";
 import type React from "react";
@@ -17,6 +24,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -46,15 +54,15 @@ export interface SlashCommand {
 }
 
 export interface SlashCommandDropdownProps
-  extends Pick<
-    SuggestionProps<SlashCommand>,
-    "clientRect" | "command" | "items"
-  > {
+  extends Pick<SuggestionProps<SlashCommand>, "clientRect" | "command"> {
   emptyMessage?: string;
   header?: string;
+  isLoadingCapabilities?: boolean;
+  items?: SlashCommand[];
   listMaxHeightClassName?: `max-h-${string}`;
   onClose?: () => void;
   onItemDetails?: (item: SlashCommand) => void;
+  sections?: SlashCommandSection[];
   size?: "default" | "wide";
 }
 
@@ -68,11 +76,13 @@ export const SlashCommandDropdown = forwardRef<
 >(
   (
     {
-      items,
+      items: itemsProp,
+      sections,
       command,
       clientRect,
       emptyMessage = DEFAULT_EMPTY_MESSAGE,
       header,
+      isLoadingCapabilities = false,
       listMaxHeightClassName = DEFAULT_LIST_MAX_HEIGHT_CLASS_NAME,
       onClose,
       onItemDetails,
@@ -80,6 +90,24 @@ export const SlashCommandDropdown = forwardRef<
     },
     ref
   ) => {
+    const items = useMemo(
+      () =>
+        sections ? flattenSlashCommandSections(sections) : (itemsProp ?? []),
+      [itemsProp, sections]
+    );
+    const itemIdsKey = useMemo(
+      () => items.map((item) => item.id).join("\0"),
+      [items]
+    );
+    const showCapabilitiesLoading =
+      isLoadingCapabilities &&
+      !sections?.some(
+        (section) =>
+          section.label === SLASH_COMMAND_CAPABILITIES_SECTION_LABEL &&
+          section.items.length > 0
+      );
+    const hasVisibleContent = items.length > 0 || showCapabilitiesLoading;
+
     const [selectedIndex, setSelectedIndex] = useState(0);
     const listRef = useRef<HTMLDivElement>(null);
     const [virtualTriggerStyle, setVirtualTriggerStyle] =
@@ -132,11 +160,11 @@ export const SlashCommandDropdown = forwardRef<
       [selectItem, selectedIndex, items.length]
     );
 
-    // Reset selected index when items change.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
+    // Reset selected index when the visible item list changes, not on every render.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: itemIdsKey is intentional trigger
     useEffect(() => {
       setSelectedIndex(0);
-    }, [items]);
+    }, [itemIdsKey]);
 
     // Update virtual trigger position.
     const updateTriggerPosition = useCallback(() => {
@@ -191,7 +219,7 @@ export const SlashCommandDropdown = forwardRef<
               {header}
             </div>
           ) : null}
-          {items.length === 0 ? (
+          {!hasVisibleContent ? (
             <div
               className={cn(
                 SLASH_COMMAND_DROPDOWN_LIST_CLASS_NAME,
@@ -202,67 +230,154 @@ export const SlashCommandDropdown = forwardRef<
             </div>
           ) : (
             <div ref={listRef} className={listMaxHeightClassName}>
-              {items.map((item, index) => {
-                const canShowDetails = !!onItemDetails && !!item.hasDetails;
-                const menuItem = (
-                  <DropdownMenuItem
-                    icon={item.icon}
-                    itemId={item.id}
-                    label={item.label}
-                    description={item.description}
-                    truncateText
-                    endComponent={
-                      canShowDetails ? (
-                        <Button
-                          icon={DotsHorizontal}
-                          variant="outline"
-                          size="mini"
-                          className={cn(
-                            "opacity-0 group-focus-within:opacity-100",
-                            index === selectedIndex && "opacity-100"
-                          )}
-                          onClick={(e) => {
-                            e.stopPropagation();
+              {sections
+                ? (() => {
+                    let flatIndex = 0;
+
+                    const renderItem = (item: SlashCommand, index: number) => {
+                      const canShowDetails =
+                        !!onItemDetails && !!item.hasDetails;
+                      const menuItem = (
+                        <DropdownMenuItem
+                          icon={item.icon}
+                          itemId={item.id}
+                          label={item.label}
+                          description={item.description}
+                          truncateText
+                          endComponent={
+                            canShowDetails ? (
+                              <Button
+                                icon={DotsHorizontal}
+                                variant="outline"
+                                size="mini"
+                                className={cn(
+                                  "opacity-0 group-focus-within:opacity-100",
+                                  index === selectedIndex && "opacity-100"
+                                )}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  e.preventDefault();
+                                  onItemDetails?.(item);
+                                }}
+                              />
+                            ) : undefined
+                          }
+                          onClick={() => selectItem(index)}
+                          onPointerMove={(e) => {
                             e.preventDefault();
-                            onItemDetails?.(item);
+                            setSelectedIndex(index);
                           }}
+                          onPointerLeave={(e) => e.preventDefault()}
+                          className={cn(
+                            "group",
+                            index === selectedIndex &&
+                              "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                          )}
                         />
-                      ) : undefined
-                    }
-                    onClick={() => selectItem(index)}
-                    // onPointerMove only fires on actual pointer movement
-                    // (not when items scroll under a stationary cursor).
-                    // preventDefault stops Radix from setting
-                    // data-highlighted, avoiding a double highlight.
-                    onPointerMove={(e) => {
-                      e.preventDefault();
-                      setSelectedIndex(index);
-                    }}
-                    onPointerLeave={(e) => e.preventDefault()}
-                    className={cn(
-                      "group",
-                      index === selectedIndex &&
-                        "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
-                    )}
-                  />
-                );
+                      );
 
-                // Wrap with DropdownTooltipTrigger if command has tooltip property.
-                const itemContent = item.tooltip ? (
-                  <DropdownTooltipTrigger
-                    description={item.tooltip.description}
-                    media={item.tooltip.media}
-                    side="right"
-                    sideOffset={8}
-                  >
-                    {menuItem}
-                  </DropdownTooltipTrigger>
-                ) : (
-                  menuItem
-                );
+                      const itemContent = item.tooltip ? (
+                        <DropdownTooltipTrigger
+                          description={item.tooltip.description}
+                          media={item.tooltip.media}
+                          side="right"
+                          sideOffset={8}
+                        >
+                          {menuItem}
+                        </DropdownTooltipTrigger>
+                      ) : (
+                        menuItem
+                      );
 
-                return <Fragment key={item.id}>{itemContent}</Fragment>;
-              })}
+                      return <Fragment key={item.id}>{itemContent}</Fragment>;
+                    };
+
+                    return (
+                      <>
+                        {sections.map((section) => (
+                          <Fragment key={section.label}>
+                            <DropdownMenuLabel>
+                              {section.label}
+                            </DropdownMenuLabel>
+                            {section.items.map((item) => {
+                              const index = flatIndex;
+                              flatIndex += 1;
+                              return renderItem(item, index);
+                            })}
+                          </Fragment>
+                        ))}
+                        {showCapabilitiesLoading ? (
+                          <>
+                            <DropdownMenuLabel>
+                              {SLASH_COMMAND_CAPABILITIES_SECTION_LABEL}
+                            </DropdownMenuLabel>
+                            <div className="flex h-14 items-center justify-center">
+                              <Spinner size="sm" />
+                              <span className="ml-2 text-sm text-gray-500 dark:text-gray-500-night">
+                                Loading capabilities…
+                              </span>
+                            </div>
+                          </>
+                        ) : null}
+                      </>
+                    );
+                  })()
+                : items.map((item, index) => {
+                    const canShowDetails = !!onItemDetails && !!item.hasDetails;
+                    const menuItem = (
+                      <DropdownMenuItem
+                        icon={item.icon}
+                        itemId={item.id}
+                        label={item.label}
+                        description={item.description}
+                        truncateText
+                        endComponent={
+                          canShowDetails ? (
+                            <Button
+                              icon={DotsHorizontal}
+                              variant="outline"
+                              size="mini"
+                              className={cn(
+                                "opacity-0 group-focus-within:opacity-100",
+                                index === selectedIndex && "opacity-100"
+                              )}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                e.preventDefault();
+                                onItemDetails?.(item);
+                              }}
+                            />
+                          ) : undefined
+                        }
+                        onClick={() => selectItem(index)}
+                        onPointerMove={(e) => {
+                          e.preventDefault();
+                          setSelectedIndex(index);
+                        }}
+                        onPointerLeave={(e) => e.preventDefault()}
+                        className={cn(
+                          "group",
+                          index === selectedIndex &&
+                            "bg-muted-background dark:bg-muted-night [transition-duration:0ms]"
+                        )}
+                      />
+                    );
+
+                    const itemContent = item.tooltip ? (
+                      <DropdownTooltipTrigger
+                        description={item.tooltip.description}
+                        media={item.tooltip.media}
+                        side="right"
+                        sideOffset={8}
+                      >
+                        {menuItem}
+                      </DropdownTooltipTrigger>
+                    ) : (
+                      menuItem
+                    );
+
+                    return <Fragment key={item.id}>{itemContent}</Fragment>;
+                  })}
             </div>
           )}
         </DropdownMenuContent>

--- a/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandSections.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildSlashCommandSections.ts
@@ -1,0 +1,41 @@
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+
+export const SLASH_COMMANDS_SECTION_LABEL = "Commands";
+export const SLASH_COMMAND_CAPABILITIES_SECTION_LABEL = "Capabilities";
+
+export interface SlashCommandSection {
+  label: string;
+  items: SlashCommand[];
+}
+
+export function buildSlashCommandSections({
+  commandItems,
+  capabilityItems,
+}: {
+  commandItems: SlashCommand[];
+  capabilityItems: SlashCommand[];
+}): SlashCommandSection[] {
+  const sections: SlashCommandSection[] = [];
+
+  if (commandItems.length > 0) {
+    sections.push({
+      label: SLASH_COMMANDS_SECTION_LABEL,
+      items: commandItems,
+    });
+  }
+
+  if (capabilityItems.length > 0) {
+    sections.push({
+      label: SLASH_COMMAND_CAPABILITIES_SECTION_LABEL,
+      items: capabilityItems,
+    });
+  }
+
+  return sections;
+}
+
+export function flattenSlashCommandSections(
+  sections: SlashCommandSection[]
+): SlashCommand[] {
+  return sections.flatMap((section) => section.items);
+}

--- a/front/components/editor/extensions/shared/slash_suggestion/slashStaticCommands.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/slashStaticCommands.tsx
@@ -1,11 +1,10 @@
 import {
-  ADD_CAPABILITY_SLASH_COMMAND_ACTION,
   INSERT_CONTEXT_FILE_SLASH_COMMAND_ACTION,
   INSERT_KNOWLEDGE_SLASH_COMMAND_ACTION,
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { getSlashCommandAvatarIcon } from "@app/components/editor/extensions/shared/slash_suggestion/slashCommandIcons";
-import { Attachment01, File02, ShapesPlus } from "@dust-tt/sparkle";
+import { Attachment01, File02 } from "@dust-tt/sparkle";
 
 export function createAttachKnowledgeSlashCommand(): SlashCommand {
   return {
@@ -35,17 +34,5 @@ export function createSelectContextFileSlashCommand(): SlashCommand {
     icon: getSlashCommandAvatarIcon(File02),
     id: "reference-file",
     label: "Reference file",
-  };
-}
-
-export function createAddCapabilitySlashCommand(
-  description: string
-): SlashCommand {
-  return {
-    action: ADD_CAPABILITY_SLASH_COMMAND_ACTION,
-    description,
-    icon: getSlashCommandAvatarIcon(ShapesPlus),
-    id: "add-capability",
-    label: "Add capability",
   };
 }

--- a/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities.ts
@@ -1,0 +1,144 @@
+import {
+  getMcpServerViewDisplayName,
+  isToolWithKnowledge,
+} from "@app/lib/actions/mcp_helper";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
+import { useSkills } from "@app/lib/swr/skill_configurations";
+import { useSpaces } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types/user";
+import { type RefObject, useMemo } from "react";
+
+import { buildCapabilitySlashCommandItems } from "./buildSlashCommandItems";
+
+function getSkillBuilderSlashCommandTools({
+  serverViews,
+  spaces,
+}: {
+  serverViews: MCPServerViewType[];
+  spaces: { sId: string; name: string }[];
+}): MCPServerViewType[] {
+  const serverIdToCount = serverViews.reduce(
+    (acc, view) => {
+      acc[view.server.sId] = (acc[view.server.sId] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  return serverViews
+    .filter((view) => !isToolWithKnowledge(view))
+    .filter((view) => getMCPServerRequirements(view).noRequirement)
+    .map((view) => {
+      const displayName = getMcpServerViewDisplayName(view);
+
+      if (serverIdToCount[view.server.sId] > 1) {
+        const spaceName = spaces.find(
+          (space) => space.sId === view.spaceId
+        )?.name;
+
+        if (spaceName) {
+          return {
+            ...view,
+            label: `${displayName} (${spaceName})`,
+          };
+        }
+      }
+
+      return {
+        ...view,
+        label: displayName,
+      };
+    });
+}
+
+export function useInputBarSlashCommandCapabilities({
+  excludeSkillId,
+  owner,
+  query,
+  selectedMCPServerViewIdsRef,
+}: {
+  excludeSkillId?: string | null;
+  owner: LightWorkspaceType;
+  query: string;
+  selectedMCPServerViewIdsRef?: RefObject<Set<string>>;
+}) {
+  const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["global"],
+  });
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+    globalSpaceOnly: true,
+  });
+  const { serverViews, isLoading: isServerViewsLoading } =
+    useMCPServerViewsFromSpaces(owner, globalSpaces);
+
+  const capabilityItems = useMemo(
+    () =>
+      buildCapabilitySlashCommandItems({
+        excludeSkillId,
+        query,
+        skills,
+        tools: serverViews,
+        toolFilter: (serverView) =>
+          isJITMCPServerView(serverView) &&
+          !(selectedMCPServerViewIdsRef?.current ?? new Set()).has(
+            serverView.sId
+          ),
+      }),
+    [excludeSkillId, query, selectedMCPServerViewIdsRef, serverViews, skills]
+  );
+
+  return {
+    capabilityItems,
+    isLoading: isSkillsLoading || isSpacesLoading || isServerViewsLoading,
+  };
+}
+
+export function useSkillBuilderSlashCommandCapabilities({
+  excludeSkillId,
+  owner,
+  query,
+}: {
+  excludeSkillId?: string | null;
+  owner: LightWorkspaceType;
+  query: string;
+}) {
+  const { spaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: "all",
+  });
+  const { skills, isSkillsLoading } = useSkills({
+    owner,
+    status: "active",
+  });
+  const { serverViews, isLoading: isServerViewsLoading } =
+    useMCPServerViewsFromSpaces(owner, spaces);
+
+  const tools = useMemo(
+    () => getSkillBuilderSlashCommandTools({ serverViews, spaces }),
+    [serverViews, spaces]
+  );
+
+  const capabilityItems = useMemo(
+    () =>
+      buildCapabilitySlashCommandItems({
+        excludeSkillId,
+        query,
+        skills,
+        tools,
+        toolFilter: (serverView) =>
+          getMCPServerRequirements(serverView).noRequirement,
+      }),
+    [excludeSkillId, query, skills, tools]
+  );
+
+  return {
+    capabilityItems,
+    isLoading: isSkillsLoading || isSpacesLoading || isServerViewsLoading,
+  };
+}

--- a/front/components/editor/extensions/skill_builder/CapabilitySearchNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/CapabilitySearchNodeView.tsx
@@ -9,12 +9,8 @@ import { InlineSlashSearch } from "@app/components/editor/extensions/shared/slas
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
-import { useSpaces } from "@app/lib/swr/spaces";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { isNumber } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -41,8 +37,6 @@ export interface CapabilitySearchNodeOptions {
   >;
   onToolDetailsRef?: RefObject<((tool: MCPServerViewType) => void) | undefined>;
   owner?: LightWorkspaceType;
-  selectedMCPServerViewIdsRef?: RefObject<Set<string>>;
-  variant?: "input-bar" | "skill-builder";
 }
 
 interface CapabilitySearchNodeViewProps extends NodeViewProps {
@@ -313,64 +307,13 @@ function CapabilitySearchNodeViewInner({
   );
 }
 
-function InputBarCapabilitySearchNodeView(
-  props: CapabilitySearchNodeViewProps & { owner: LightWorkspaceType }
-) {
-  const { deleteNode, editor, getPos, node, options, owner } = props;
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedIndex, setSelectedIndex] = useState(0);
+export function CapabilitySearchNodeView(props: CapabilitySearchNodeViewProps) {
+  const owner = props.options.owner;
+  if (!owner) {
+    return null;
+  }
 
-  const { spaces: globalSpaces, isSpacesLoading } = useSpaces({
-    workspaceId: owner.sId,
-    kinds: ["global"],
-  });
-  const { skills, isSkillsLoading } = useSkills({
-    owner,
-    status: "active",
-    globalSpaceOnly: true,
-  });
-  const { serverViews, isLoading: isServerViewsLoading } =
-    useMCPServerViewsFromSpaces(owner, globalSpaces);
-
-  const capabilityItems = useMemo(
-    () =>
-      buildCapabilitySlashCommandItems({
-        excludeSkillId: options.currentSkillId,
-        query: searchQuery,
-        skills,
-        tools: serverViews,
-        toolFilter: (serverView) =>
-          isJITMCPServerView(serverView) &&
-          !(options.selectedMCPServerViewIdsRef?.current ?? new Set()).has(
-            serverView.sId
-          ),
-      }),
-    [
-      options.currentSkillId,
-      options.selectedMCPServerViewIdsRef,
-      searchQuery,
-      serverViews,
-      skills,
-    ]
-  );
-
-  return (
-    <CapabilitySearchNodeViewInner
-      capabilityItems={capabilityItems}
-      deleteNode={deleteNode}
-      editor={editor}
-      getPos={getPos}
-      insertToolNode={false}
-      isLoading={isSkillsLoading || isSpacesLoading || isServerViewsLoading}
-      node={node}
-      onItemDetails={getCapabilityItemDetailsHandler(options)}
-      options={options}
-      searchQuery={searchQuery}
-      selectedIndex={selectedIndex}
-      onSearchQueryChange={setSearchQuery}
-      onSelectedIndexChange={setSelectedIndex}
-    />
-  );
+  return <SkillBuilderCapabilitySearchNodeView {...props} owner={owner} />;
 }
 
 function SkillBuilderCapabilitySearchNodeView(
@@ -428,22 +371,4 @@ function SkillBuilderCapabilitySearchNodeView(
       onSelectedIndexChange={setSelectedIndex}
     />
   );
-}
-
-export function CapabilitySearchNodeView(props: CapabilitySearchNodeViewProps) {
-  const owner = props.options.owner;
-  if (!owner) {
-    return null;
-  }
-
-  switch (props.options.variant) {
-    case "input-bar":
-      return <InputBarCapabilitySearchNodeView {...props} owner={owner} />;
-    case "skill-builder":
-    case undefined:
-      return <SkillBuilderCapabilitySearchNodeView {...props} owner={owner} />;
-    default:
-      assertNeverAndIgnore(props.options.variant);
-      return <SkillBuilderCapabilitySearchNodeView {...props} owner={owner} />;
-  }
 }

--- a/front/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView.tsx
+++ b/front/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView.tsx
@@ -18,19 +18,12 @@ const DEFAULT_CAPABILITY_SEARCH_NODE_OPTIONS: CapabilitySearchNodeOptions = {
   onSkillDetailsRef: { current: undefined },
   onToolDetailsRef: { current: undefined },
   owner: undefined,
-  selectedMCPServerViewIdsRef: { current: new Set<string>() },
-  variant: "skill-builder",
 };
 
-function createCapabilitySearchNodeExtension(
-  variant: NonNullable<CapabilitySearchNodeOptions["variant"]>
-) {
-  return CapabilitySearchNode.extend<CapabilitySearchNodeOptions>({
+export const CapabilitySearchNodeWithView =
+  CapabilitySearchNode.extend<CapabilitySearchNodeOptions>({
     addOptions() {
-      return {
-        ...DEFAULT_CAPABILITY_SEARCH_NODE_OPTIONS,
-        variant,
-      };
+      return DEFAULT_CAPABILITY_SEARCH_NODE_OPTIONS;
     },
 
     addNodeView() {
@@ -39,10 +32,3 @@ function createCapabilitySearchNodeExtension(
       ));
     },
   });
-}
-
-export const CapabilitySearchNodeWithView =
-  createCapabilitySearchNodeExtension("skill-builder");
-
-export const InputBarCapabilitySearchNode =
-  createCapabilitySearchNodeExtension("input-bar");

--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -1,67 +1,172 @@
-import { isAddCapabilitySlashCommand } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import {
+  isSkillSlashCommand,
+  isToolSlashCommand,
+  type SlashCommandSkillSuggestion,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import { filterSlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems";
+import { buildSlashCommandSections } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandSections";
 import type {
   SlashCommand,
   SlashCommandDropdownRef,
 } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { SlashCommandDropdown } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import { createSlashSuggestionExtension } from "@app/components/editor/extensions/shared/slash_suggestion/SlashSuggestionExtension";
-import {
-  createAddCapabilitySlashCommand,
-  createAttachKnowledgeSlashCommand,
-} from "@app/components/editor/extensions/shared/slash_suggestion/slashStaticCommands";
+import { createAttachKnowledgeSlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/slashStaticCommands";
+import { useSkillBuilderSlashCommandCapabilities } from "@app/components/editor/extensions/shared/slash_suggestion/useSlashCommandCapabilities";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { LightWorkspaceType } from "@app/types/user";
 import type { ChainedCommands, Editor, Range } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
-import { forwardRef, type RefObject, useImperativeHandle, useRef } from "react";
+import {
+  forwardRef,
+  type RefObject,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
 
 export const slashCommandPluginKey = new PluginKey("slashCommand");
 
-const SLASH_COMMANDS: SlashCommand[] = [
-  createAttachKnowledgeSlashCommand(),
-  createAddCapabilitySlashCommand("Add a skill or tool to these instructions"),
-];
+const SLASH_COMMANDS: SlashCommand[] = [createAttachKnowledgeSlashCommand()];
 
 interface SkillBuilderSlashSuggestionStorage {
   hasBeenFocused: boolean;
 }
 
+const SkillBuilderSlashCommandDropdownInner = forwardRef<
+  SlashCommandDropdownRef,
+  Pick<
+    SuggestionProps<SlashCommand>,
+    "clientRect" | "command" | "editor" | "query" | "range"
+  > & {
+    currentSkillIdRef?: RefObject<string | null>;
+    onClose: () => void;
+    onSkillDetailsRef?: RefObject<
+      ((skill: SlashCommandSkillSuggestion) => void) | undefined
+    >;
+    onToolDetailsRef?: RefObject<
+      ((tool: MCPServerViewType) => void) | undefined
+    >;
+    owner: LightWorkspaceType;
+  }
+>(
+  (
+    {
+      clientRect,
+      command,
+      editor,
+      query,
+      range,
+      currentSkillIdRef,
+      onClose,
+      onSkillDetailsRef,
+      onToolDetailsRef,
+      owner,
+    },
+    ref
+  ) => {
+    const dropdownRef = useRef<SlashCommandDropdownRef>(null);
+
+    const commandItems = useMemo(
+      () => filterSlashCommandItems(SLASH_COMMANDS, query),
+      [query]
+    );
+
+    const { capabilityItems, isLoading } =
+      useSkillBuilderSlashCommandCapabilities({
+        excludeSkillId: currentSkillIdRef?.current ?? null,
+        owner,
+        query,
+      });
+
+    const sections = useMemo(
+      () =>
+        buildSlashCommandSections({
+          commandItems,
+          capabilityItems,
+        }),
+      [capabilityItems, commandItems]
+    );
+
+    const flatItems = useMemo(
+      () => sections.flatMap((section) => section.items),
+      [sections]
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: ({ event }) => {
+          if (
+            (event.key === "Enter" || event.key === "Tab") &&
+            flatItems.length === 0
+          ) {
+            event.preventDefault();
+            return true;
+          }
+
+          return dropdownRef.current?.onKeyDown({ event }) ?? false;
+        },
+      }),
+      [flatItems.length]
+    );
+
+    const handleItemDetails =
+      onSkillDetailsRef || onToolDetailsRef
+        ? (item: SlashCommand) => {
+            editor.chain().focus().deleteRange(range).run();
+            if (isSkillSlashCommand(item)) {
+              onSkillDetailsRef?.current?.(item.data.skill);
+            } else if (isToolSlashCommand(item)) {
+              onToolDetailsRef?.current?.(item.data.tool.view);
+            }
+            onClose();
+          }
+        : undefined;
+
+    return (
+      <SlashCommandDropdown
+        ref={dropdownRef}
+        sections={sections}
+        command={command}
+        clientRect={clientRect}
+        emptyMessage="No commands found"
+        isLoadingCapabilities={isLoading}
+        onClose={onClose}
+        onItemDetails={handleItemDetails}
+        size="wide"
+      />
+    );
+  }
+);
+
+SkillBuilderSlashCommandDropdownInner.displayName =
+  "SkillBuilderSlashCommandDropdownInner";
+
 const SkillBuilderSlashCommandDropdown = forwardRef<
   SlashCommandDropdownRef,
-  Pick<SuggestionProps<SlashCommand>, "clientRect" | "command" | "items"> & {
+  Pick<
+    SuggestionProps<SlashCommand>,
+    "clientRect" | "command" | "editor" | "query" | "range"
+  > & {
+    currentSkillIdRef?: RefObject<string | null>;
     onClose: () => void;
+    onSkillDetailsRef?: RefObject<
+      ((skill: SlashCommandSkillSuggestion) => void) | undefined
+    >;
+    onToolDetailsRef?: RefObject<
+      ((tool: MCPServerViewType) => void) | undefined
+    >;
+    owner?: LightWorkspaceType;
   }
->(({ clientRect, command, items, onClose }, ref) => {
-  const dropdownRef = useRef<SlashCommandDropdownRef>(null);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      onKeyDown: ({ event }) => {
-        if (
-          (event.key === "Enter" || event.key === "Tab") &&
-          items.length === 0
-        ) {
-          event.preventDefault();
-          return true;
-        }
-
-        return dropdownRef.current?.onKeyDown({ event }) ?? false;
-      },
-    }),
-    [items.length]
-  );
+>(({ owner, ...props }, ref) => {
+  if (!owner) {
+    return null;
+  }
 
   return (
-    <SlashCommandDropdown
-      ref={dropdownRef}
-      items={items}
-      command={command}
-      clientRect={clientRect}
-      emptyMessage="No commands found"
-      onClose={onClose}
-      size="wide"
-    />
+    <SkillBuilderSlashCommandDropdownInner ref={ref} owner={owner} {...props} />
   );
 });
 
@@ -69,9 +174,15 @@ SkillBuilderSlashCommandDropdown.displayName =
   "SkillBuilderSlashCommandDropdown";
 
 export interface SlashCommandExtensionOptions {
+  currentSkillIdRef?: RefObject<string | null>;
   onSelectRef: RefObject<
     ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
   >;
+  onSkillDetailsRef?: RefObject<
+    ((skill: SlashCommandSkillSuggestion) => void) | undefined
+  >;
+  onToolDetailsRef?: RefObject<((tool: MCPServerViewType) => void) | undefined>;
+  owner?: LightWorkspaceType;
   suggestion: Partial<SuggestionOptions>;
 }
 
@@ -96,7 +207,11 @@ export const SlashCommandExtension = createSlashSuggestionExtension<
     hasBeenFocused: false,
   }),
   defaultOptions: {
+    currentSkillIdRef: { current: null },
     onSelectRef: { current: undefined },
+    onSkillDetailsRef: { current: undefined },
+    onToolDetailsRef: { current: undefined },
+    owner: undefined,
     suggestion: {
       char: "/",
       pluginKey: slashCommandPluginKey,
@@ -115,18 +230,13 @@ export const SlashCommandExtension = createSlashSuggestionExtension<
   allow: ({ storage }) => storage.hasBeenFocused,
   items: ({ query }) => filterSlashCommandItems(SLASH_COMMANDS, query),
   command: ({ editor, range, props, options }) => {
-    if (isAddCapabilitySlashCommand(props)) {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertCapabilitySearchNode()
-        .run();
-      return;
-    }
-
     options.onSelectRef.current?.(props, editor, range);
   },
-  mapDropdownProps: () => ({}),
+  mapDropdownProps: ({ options }) => ({
+    currentSkillIdRef: options.currentSkillIdRef,
+    onSkillDetailsRef: options.onSkillDetailsRef,
+    onToolDetailsRef: options.onToolDetailsRef,
+    owner: options.owner,
+  }),
   shouldAppendDropdown: ({ props }) => Boolean(props.clientRect),
 });

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -14,9 +14,7 @@ import { SkillNode } from "@app/components/editor/extensions/input_bar/SkillNode
 import { URLDetectionExtension } from "@app/components/editor/extensions/input_bar/URLDetectionExtension";
 import { URLStorageExtension } from "@app/components/editor/extensions/input_bar/URLStorageExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
-import type { SlashCommandSkillSuggestion } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
-import { InputBarCapabilitySearchNode } from "@app/components/editor/extensions/skill_builder/CapabilitySearchNodeWithView";
 import { VoicePartialNode } from "@app/components/editor/extensions/VoicePartialExtension";
 import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
 import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
@@ -26,7 +24,6 @@ import {
   createMentionSuggestion,
   mentionPluginKey,
 } from "@app/components/editor/input_bar/mentionSuggestion";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { extractFromEditorJSON } from "@app/lib/mentions/format";
@@ -313,16 +310,7 @@ export interface CustomEditorProps {
     enabledRef: React.RefObject<boolean>;
     onSelectRef: React.RefObject<((item: SlashCommand) => void) | undefined>;
     onDetailsRef?: React.RefObject<((item: SlashCommand) => void) | undefined>;
-    onSelectToolRef?: React.RefObject<
-      ((tool: MCPServerViewType) => void) | undefined
-    >;
     onSkillDetails?: (skillId: string) => void;
-    onCapabilitySkillDetailsRef?: React.RefObject<
-      ((skill: SlashCommandSkillSuggestion) => void) | undefined
-    >;
-    onCapabilityToolDetailsRef?: React.RefObject<
-      ((tool: MCPServerViewType) => void) | undefined
-    >;
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
     slashCommandsRef: React.RefObject<InputBarSlashCommand[]>;
     includeAttachKnowledgeRef: React.RefObject<boolean>;
@@ -483,21 +471,6 @@ export const buildEditorExtensions = ({
         onNodeSelectRef: slashSuggestion.onNodeSelectRef,
         owner,
         spaceIdRef: slashSuggestion.spaceIdRef,
-      }),
-      InputBarCapabilitySearchNode.configure({
-        onSelectToolRef: slashSuggestion.onSelectToolRef ?? {
-          current: undefined,
-        },
-        onSkillDetailsRef: slashSuggestion.onCapabilitySkillDetailsRef ?? {
-          current: undefined,
-        },
-        onToolDetailsRef: slashSuggestion.onCapabilityToolDetailsRef ?? {
-          current: undefined,
-        },
-        owner,
-        selectedMCPServerViewIdsRef:
-          slashSuggestion.selectedMCPServerViewIdsRef,
-        variant: "input-bar",
       }),
       InputBarSlashSuggestionExtension.configure({
         owner,


### PR DESCRIPTION
## Description

Removes the two-step "Add capability" flow from the input-bar `/` menu and surfaces skills and JIT MCP server views directly in the first level of the dropdown, grouped under a **Capabilities** section.

Previously, typing `/` showed an "Add capability" item that inserted a `CapabilitySearchNode` TipTap atom for inline searching. Now `useInputBarSlashCommandCapabilities` fetches active skills and `serverViews` from global spaces and feeds them into `buildSlashCommandSections`, which splits the dropdown into a **Commands** section and an async-loaded **Capabilities** section with a spinner while loading. `CapabilitySearchNodeView` and `InputBarCapabilitySearchNodeView` are removed from the input-bar path; the node view now only serves the skill-builder. `InputBarContainer` drops `onSelectToolRef`, `onCapabilitySkillDetailsRef`, and `onCapabilityToolDetailsRef` refs. `SkillInstructionsEditor` absorbs those refs directly via `buildSkillInstructionsEditableExtensions`.


https://github.com/user-attachments/assets/9260c7cf-b3c1-429e-aa05-46e0aaa5db47



## Tests

- Updated unit tests in `InputBarSlashSuggestionDropdown.test.ts` to reflect the removal of `add-capability` from the command list and the new empty-state behavior.
- Tested locally: `/` dropdown shows capabilities inline with section labels and loading spinner.

## Risk

Low. Frontend-only change with no API or data model impact. The `CapabilitySearchNode` insertion path is removed from the input bar but remains intact for the skill builder. Rollback is a straightforward front redeploy.

## Deploy Plan

Deploy `front`.
