### PR TITLE
feat(marketing): promo banner for June Product Update - Pods event

### DIFF
--- a/marketing/components/home/PromoBanner.tsx
+++ b/marketing/components/home/PromoBanner.tsx
@@ -1,4 +1,4 @@
-import { Button, Clock, User01, XClose } from "@dust-tt/sparkle";
+import { Clock, User01, XClose } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 // =============================================================================
@@ -6,16 +6,15 @@ import { useEffect, useState } from "react";
 // Set to null when there's nothing to promote.
 // =============================================================================
 const CURRENT_PROMO: PromoConfig | null = {
-  id: "dust-for-customer-success",
+  id: "june-product-update-pods",
   image: "/static/landing/SEO_Marketing_Webinar_Banner.png",
-  link: "https://watch.getcontrast.io/register/dust-dust-for-customer-success?utm_source=website",
+  link: "https://watch.getcontrast.io/register/dust-pods-hot-off-the-grill?utm_source=website",
   badge: "Online Event",
-  title: "Dust for Customer Success",
-  time: "June 11",
-  host: "Gianna Gard · AI Deployment",
+  title: "June Product Update - Pods",
+  time: "June 24 · 5:30pm CEST / 8:30am PDT",
   linkLabel: "Register Now",
-  // Banner auto-hides after this date (June 11th 7:00 PM Paris / CEST).
-  expiresAt: new Date("2026-06-11T19:00:00+02:00"),
+  // Banner auto-hides after this date (June 24th 7:00 PM Paris / CEST).
+  expiresAt: new Date("2026-06-24T19:00:00+02:00"),
 };
 // =============================================================================
 
@@ -64,42 +63,54 @@ export function PromoBanner() {
   const { link, badge, title, time, host, linkLabel, id } = CURRENT_PROMO;
 
   return (
-    <div className="fixed bottom-4 right-4 z-40 max-w-[180px] overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg sm:max-w-[210px]">
-      <Button
-        variant="outline"
-        icon={XClose}
-        size="icon-xs"
-        className="absolute right-1 top-1 z-10"
+    <div className="fixed bottom-4 right-4 z-40 w-[264px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-xl ring-1 ring-black/5">
+      <button
+        type="button"
+        aria-label="Dismiss"
+        className="absolute right-1.5 top-1.5 z-10 flex h-8 w-8 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
         onClick={() => {
           sessionStorage.setItem(storageKey(id), "true");
           setIsVisible(false);
         }}
-      />
+      >
+        <XClose className="h-4 w-4" />
+      </button>
       <a
         href={link}
         target="_blank"
         rel="noopener noreferrer"
-        className="block px-2.5 py-2 pr-7 sm:px-3 sm:py-2.5 sm:pr-3"
+        className="group block p-4"
       >
-        <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold text-slate-700">
-          <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
+        <div className="mb-2.5 flex items-center gap-2 pr-6 text-[11px] font-semibold uppercase tracking-wide text-blue-600">
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+          </span>
           {badge}
         </div>
-        <div className="text-xs font-semibold text-slate-900">{title}</div>
-        <div className="mt-1 space-y-0.5 text-[11px] text-slate-600">
-          <div className="flex items-center gap-1.5">
-            <Clock className="h-3 w-3 shrink-0 text-slate-400" />
+        <div className="text-sm font-semibold leading-snug text-slate-900">
+          {title}
+        </div>
+        <div className="mt-2 space-y-1 text-[11px] leading-relaxed text-slate-500">
+          <div className="flex items-start gap-1.5">
+            <Clock className="mt-px h-3.5 w-3.5 shrink-0 text-slate-400" />
             <span>{time}</span>
           </div>
           {host && (
-            <div className="flex items-center gap-1.5">
-              <User01 className="h-3 w-3 shrink-0 text-slate-400" />
+            <div className="flex items-start gap-1.5">
+              <User01 className="mt-px h-3.5 w-3.5 shrink-0 text-slate-400" />
               <span>{host}</span>
             </div>
           )}
         </div>
-        <div className="mt-1.5 text-[11px] font-medium text-blue-600 hover:underline">
-          {linkLabel} →
+        <div className="mt-3 flex items-center gap-1 text-[11px] font-medium text-blue-600 group-hover:underline">
+          {linkLabel}
+          <span
+            aria-hidden
+            className="transition-transform group-hover:translate-x-0.5"
+          >
+            →
+          </span>
         </div>
       </a>
     </div>


### PR DESCRIPTION
## Description

Updates the `PromoBanner` component to promote the **June 24 "June Product Update - Pods" online event**, replacing the previous "Dust for Customer Success" webinar. Also refines the banner design: wider card layout, pulsing live dot indicator, cleaner close button, and a larger close hit target for mobile.

## Tests

Visual check on marketing site — banner should appear, display the new event details, and dismiss correctly (stored in `sessionStorage`). Auto-hide kicks in after June 24 at 7:00 PM CEST.

## Risk

Low — marketing-only component with no backend changes.

## Deploy Plan

Deploy marketing.