### PR TITLE
Plan mode model & resource

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -78,6 +78,7 @@ import {
   ProviderModel,
 } from "@app/lib/resources/storage/models/apps";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { ConversationPlanModel } from "@app/lib/resources/storage/models/conversation_plan";
 import { CouponRedemptionModel } from "@app/lib/resources/storage/models/coupon_redemptions";
 import { CouponModel } from "@app/lib/resources/storage/models/coupons";
 import { CreditUsageConfigurationModel } from "@app/lib/resources/storage/models/credit_usage_configurations";
@@ -179,6 +180,7 @@ export function loadAllModels() {
     ConversationParticipantModel,
     UserConversationReadsModel,
     WakeUpModel,
+    ConversationPlanModel,
     DataSourceModel,
     DataSourceViewModel,
     RunModel,

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -19,6 +19,7 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationForkResource } from "@app/lib/resources/conversation_fork_resource";
+import { ConversationPlanResource } from "@app/lib/resources/conversation_plan_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -300,6 +301,11 @@ export async function destroyConversation(
   });
 
   await WakeUpResource.deleteByConversation(auth, conversation.toJSON());
+
+  await ConversationPlanResource.deleteByConversation(
+    auth,
+    conversation.toJSON()
+  );
 
   await ProjectTaskConversationModel.destroy({
     where: { workspaceId: owner.id, conversationId: conversation.id },

--- a/front/lib/resources/conversation_plan_resource.ts
+++ b/front/lib/resources/conversation_plan_resource.ts
@@ -75,7 +75,7 @@ export class ConversationPlanResource extends BaseResource<ConversationPlanModel
   async recordApproval({
     approvedByUserId,
   }: {
-    approvedByUserId: string;
+    approvedByUserId: ModelId;
   }): Promise<void> {
     await this.update({
       approvedAt: new Date(),

--- a/front/lib/resources/conversation_plan_resource.ts
+++ b/front/lib/resources/conversation_plan_resource.ts
@@ -1,0 +1,124 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { ConversationPlanModel } from "@app/lib/resources/storage/models/conversation_plan";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import { Err, Ok, type Result } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ConversationPlanResource
+  extends ReadonlyAttributesType<ConversationPlanModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ConversationPlanResource extends BaseResource<ConversationPlanModel> {
+  static model: ModelStaticWorkspaceAware<ConversationPlanModel> =
+    ConversationPlanModel;
+
+  get sId(): string {
+    return ConversationPlanResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("conversation_plan", { id, workspaceId });
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    { conversation }: { conversation: ConversationWithoutContentType }
+  ): Promise<ConversationPlanResource> {
+    const row = await this.model.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversation.id,
+      version: 1,
+      isClosed: false,
+      approvedAt: null,
+      approvedByUserId: null,
+      approvedVersion: null,
+    });
+
+    return new this(this.model, row.get());
+  }
+
+  static async fetchActiveForConversation(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType
+  ): Promise<ConversationPlanResource | null> {
+    const row = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+        isClosed: false,
+      },
+    });
+
+    return row ? new this(this.model, row.get()) : null;
+  }
+
+  async incrementVersion(): Promise<void> {
+    await this.update({ version: this.version + 1 });
+  }
+
+  async recordApproval({
+    approvedByUserId,
+  }: {
+    approvedByUserId: string;
+  }): Promise<void> {
+    await this.update({
+      approvedAt: new Date(),
+      approvedByUserId,
+      approvedVersion: this.version,
+    });
+  }
+
+  async markClosed(): Promise<void> {
+    await this.update({ isClosed: true });
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      });
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  // FK is RESTRICT, so the conversation destroy path must delete plans before the conversation row
+  // (mirrors WakeUp/Sandbox).
+  static async deleteByConversation(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+      },
+      transaction,
+    });
+  }
+}

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -6795,6 +6795,7 @@ const KNOWN_CONVERSATION_RELATED_MODELS = [
   "conversation_fork",
   "conversation_mcp_server_view",
   "conversation_participant",
+  "conversation_plan",
   "conversation_skills",
   "data_source",
   "message",

--- a/front/lib/resources/storage/models/conversation_plan.ts
+++ b/front/lib/resources/storage/models/conversation_plan.ts
@@ -1,6 +1,7 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
@@ -16,7 +17,9 @@ export class ConversationPlanModel extends WorkspaceAwareModel<ConversationPlanM
   declare version: CreationOptional<number>;
   declare isClosed: CreationOptional<boolean>;
   declare approvedAt: CreationOptional<Date | null>;
-  declare approvedByUserId: CreationOptional<string | null>;
+  declare approvedByUserId: CreationOptional<ForeignKey<
+    UserModel["id"]
+  > | null>;
   declare approvedVersion: CreationOptional<number | null>;
 }
 
@@ -56,9 +59,12 @@ ConversationPlanModel.init(
       defaultValue: null,
     },
     approvedByUserId: {
-      type: DataTypes.STRING,
+      type: DataTypes.BIGINT,
       allowNull: true,
-      defaultValue: null,
+      references: {
+        model: UserModel,
+        key: "id",
+      },
     },
     approvedVersion: {
       type: DataTypes.INTEGER,
@@ -83,6 +89,11 @@ ConversationPlanModel.init(
         name: "conversation_plans_active_unique",
         concurrently: true,
       },
+      {
+        fields: ["approvedByUserId"],
+        name: "conversation_plans_approved_by_user_id",
+        concurrently: true,
+      },
     ],
   }
 );
@@ -94,4 +105,15 @@ ConversationModel.hasMany(ConversationPlanModel, {
 
 ConversationPlanModel.belongsTo(ConversationModel, {
   foreignKey: { name: "conversationId", allowNull: false },
+});
+
+// Nullable: approval is optional, and the approver may later be scrubbed (SET NULL keeps the
+// approval record).
+UserModel.hasMany(ConversationPlanModel, {
+  foreignKey: { name: "approvedByUserId", allowNull: true },
+  onDelete: "SET NULL",
+});
+
+ConversationPlanModel.belongsTo(UserModel, {
+  foreignKey: { name: "approvedByUserId", allowNull: true },
 });

--- a/front/lib/resources/storage/models/conversation_plan.ts
+++ b/front/lib/resources/storage/models/conversation_plan.ts
@@ -1,0 +1,97 @@
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+// State for the agent-maintained plan. The markdown content lives in the conversation's
+// DustFileSystem (its path is derived from the conversation and the plan sId); this model holds
+// only the state that has no home on the file system. Approval is optional and captured against
+// `approvedVersion`, so an edit past that version makes the approval stale.
+export class ConversationPlanModel extends WorkspaceAwareModel<ConversationPlanModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare conversationId: ForeignKey<ConversationModel["id"]>;
+  declare version: CreationOptional<number>;
+  declare isClosed: CreationOptional<boolean>;
+  declare approvedAt: CreationOptional<Date | null>;
+  declare approvedByUserId: CreationOptional<string | null>;
+  declare approvedVersion: CreationOptional<number | null>;
+}
+
+ConversationPlanModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conversationId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      references: {
+        model: ConversationModel,
+        key: "id",
+      },
+    },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    },
+    isClosed: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    approvedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+    approvedByUserId: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
+    approvedVersion: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  {
+    modelName: "conversation_plan",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["conversationId"],
+        name: "conversation_plans_conversation_id",
+        concurrently: true,
+      },
+      // Enforce at most one active (non-closed) plan per conversation.
+      {
+        fields: ["workspaceId", "conversationId"],
+        unique: true,
+        where: { isClosed: false },
+        name: "conversation_plans_active_unique",
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+ConversationModel.hasMany(ConversationPlanModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+ConversationPlanModel.belongsTo(ConversationModel, {
+  foreignKey: { name: "conversationId", allowNull: false },
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -95,6 +95,9 @@ export const RESOURCES_PREFIX = {
   conversation_branch: "cbr",
   conversation_fork: "cfk",
 
+  // Conversation plan (plan mode).
+  conversation_plan: "cpl",
+
   // Provider credentials (BYOK).
   provider_credential: "pcr",
 

--- a/front/migrations/pre-deploy/20260622204424_create_conversation_plans_table.sql
+++ b/front/migrations/pre-deploy/20260622204424_create_conversation_plans_table.sql
@@ -1,0 +1,92 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE SEQUENCE "public"."conversation_plans_id_seq"
+	AS bigint
+	INCREMENT BY 1
+	MINVALUE 1 MAXVALUE 9223372036854775807
+	START WITH 1 CACHE 1 NO CYCLE
+;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+CREATE TABLE "public"."conversation_plans" (
+	"createdAt" timestamp with time zone NOT NULL,
+	"updatedAt" timestamp with time zone NOT NULL,
+	"conversationId" bigint NOT NULL,
+	"approvedAt" timestamp with time zone,
+	"workspaceId" bigint NOT NULL,
+	"id" bigint DEFAULT nextval('conversation_plans_id_seq'::regclass) NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"approvedVersion" integer,
+	"isClosed" boolean DEFAULT false NOT NULL,
+	"approvedByUserId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying
+);
+
+/*
+Statement 2
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY conversation_plans_pkey ON public.conversation_plans USING btree (id);
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_pkey" PRIMARY KEY USING INDEX "conversation_plans_pkey";
+
+/*
+Statement 4
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY conversation_plans_active_unique ON public.conversation_plans USING btree ("workspaceId", "conversationId") WHERE ("isClosed" = false);
+
+/*
+Statement 5
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY conversation_plans_conversation_id ON public.conversation_plans USING btree ("conversationId");
+
+/*
+Statement 6
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER SEQUENCE "public"."conversation_plans_id_seq" OWNED BY "public"."conversation_plans"."id";
+
+/*
+Statement 7
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 8
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" VALIDATE CONSTRAINT "conversation_plans_conversationId_fkey";
+
+/*
+Statement 9
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" VALIDATE CONSTRAINT "conversation_plans_workspaceId_fkey";

--- a/front/migrations/pre-deploy/20260623130707_create_conversation_plans_table.sql
+++ b/front/migrations/pre-deploy/20260623130707_create_conversation_plans_table.sql
@@ -20,12 +20,12 @@ CREATE TABLE "public"."conversation_plans" (
 	"updatedAt" timestamp with time zone NOT NULL,
 	"conversationId" bigint NOT NULL,
 	"approvedAt" timestamp with time zone,
+	"approvedByUserId" bigint,
 	"workspaceId" bigint NOT NULL,
 	"id" bigint DEFAULT nextval('conversation_plans_id_seq'::regclass) NOT NULL,
 	"version" integer DEFAULT 1 NOT NULL,
 	"approvedVersion" integer,
-	"isClosed" boolean DEFAULT false NOT NULL,
-	"approvedByUserId" character varying(255) COLLATE "pg_catalog"."default" DEFAULT NULL::character varying
+	"isClosed" boolean DEFAULT false NOT NULL
 );
 
 /*
@@ -54,38 +54,59 @@ Statement 5
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY conversation_plans_conversation_id ON public.conversation_plans USING btree ("conversationId");
+CREATE INDEX CONCURRENTLY conversation_plans_approved_by_user_id ON public.conversation_plans USING btree ("approvedByUserId");
 
 /*
 Statement 6
 */
-SET SESSION statement_timeout = 3000;
+SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-ALTER SEQUENCE "public"."conversation_plans_id_seq" OWNED BY "public"."conversation_plans"."id";
+CREATE INDEX CONCURRENTLY conversation_plans_conversation_id ON public.conversation_plans USING btree ("conversationId");
 
 /*
 Statement 7
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+ALTER SEQUENCE "public"."conversation_plans_id_seq" OWNED BY "public"."conversation_plans"."id";
 
 /*
 Statement 8
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."conversation_plans" VALIDATE CONSTRAINT "conversation_plans_conversationId_fkey";
+ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES conversations(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
 
 /*
 Statement 9
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
-ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+ALTER TABLE "public"."conversation_plans" VALIDATE CONSTRAINT "conversation_plans_conversationId_fkey";
 
 /*
 Statement 10
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_approvedByUserId_fkey" FOREIGN KEY ("approvedByUserId") REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL NOT VALID;
+
+/*
+Statement 11
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" VALIDATE CONSTRAINT "conversation_plans_approvedByUserId_fkey";
+
+/*
+Statement 12
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversation_plans" ADD CONSTRAINT "conversation_plans_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES workspaces(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 13
 */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;


### PR DESCRIPTION
## Description

First of two PRs migrating plan mode off `FileResource`. This PR adds the storage layer only and does not wire it into the plan mode tools, so there is no behavior change. The follow up PR switches the plan mode tools, API route, and UI onto this storage and removes the old `FileResource` plumbing.

It introduces a `conversation_plans` table with its model (`ConversationPlanModel`) and resource (`ConversationPlanResource`), registers the model, and adds conversation deletion cleanup. The resource follows the same conventions as `WakeUpResource`: it derives its `sId` from the row id via `makeSId` rather than storing it, and it is scoped and looked up by conversation.

The design splits a plan into two parts. The markdown content will live in the conversation's `DustFileSystem`, at a path derived from the conversation sId and the plan sId, so this table stores none of the content and no path. It holds only the state that has no home on the file system, which is the version counter, the closed flag, and an optional approval recorded against a specific version so that an edit past the approved version makes the approval stale.

The schema enforces at most one active plan per conversation through a partial unique index on `(workspaceId, conversationId) WHERE isClosed = false`, plus a standalone index on `conversationId` for the foreign key. The foreign key to conversations is `ON DELETE RESTRICT`, matching the other conversation scoped resources, and `destroyConversation` deletes plan rows before the conversation row.

## Tests

No behavior change in this PR, so it adds no functional tests. The plan lifecycle tests (create, edit, approve, stale, close, new plan after close) land in the follow up PR alongside the code that uses the table. The conversation relationship detection test in `conversation_resource.test.ts` now recognizes `conversation_plan` and confirms it is cleaned up on conversation deletion.

## Risk

/ 

## Deploy Plan

This PR carries a pre-deploy migration that creates the table before the code runs. There is no post-deploy step. Deploy this first, confirm the table exists, then ship the follow up refactor PR.