### PR TITLE
Migrate plan mode out of FileResource

### DIFF
--- a/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
+++ b/front-api/routes/sse/v1/w/[wId]/assistant/conversations/[cId]/events.test.ts
@@ -42,10 +42,8 @@ function planUpdatedEvent(): ConversationEvent {
       type: "plan_updated",
       created: 0,
       conversationId: "conv",
-      planFileId: "file",
       version: 1,
       isClosed: false,
-      hasApproval: false,
     },
   };
 }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -3,17 +3,19 @@ import {
   REQUEST_PLAN_APPROVAL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type {
-  GetConversationPlanModeResponseBody,
-  PlanApprovalState,
+import type { GetConversationPlanModeResponseBody } from "@app/lib/api/assistant/plan_mode";
+import {
+  derivePlanApprovalState,
+  findActivePlan,
+  getPlanContent,
+  isApprovalRequestStale,
 } from "@app/lib/api/assistant/plan_mode";
-import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
-import { getFileContent } from "@app/lib/api/files/utils";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
 
@@ -32,23 +34,39 @@ app.get(
     const auth = ctx.get("auth");
     const { cId } = ctx.req.valid("param");
 
-    // Ensure the caller has access to the conversation.
     const conversationRes = await getLightConversation(auth, cId);
     if (conversationRes.isErr()) {
       return apiErrorForConversation(ctx, conversationRes.error);
     }
+    const conversation = conversationRes.value;
 
-    const planFile = await findActivePlanFile(auth, cId);
-    if (!planFile) {
+    const plan = await findActivePlan(auth, conversation);
+    if (!plan) {
       return ctx.json({
-        planFile: null,
+        plan: null,
         content: null,
-        approvalState: "draft" as PlanApprovalState,
+        approvalState: "none",
       });
     }
 
     // Sequential fetches to avoid holding multiple DB connections from the pool simultaneously.
-    const content = await getFileContent(auth, planFile, "original");
+    const contentRes = await getPlanContent(auth, conversation, plan);
+    if (contentRes.isErr()) {
+      // A missing file is Ok(null); an Err here is a real read failure, surfaced not silenced.
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to read the plan content.",
+          },
+        },
+        contentRes.error
+      );
+    }
+    const content = contentRes.value;
+
     const conversationResource = await ConversationResource.fetchById(
       auth,
       cId
@@ -60,22 +78,19 @@ app.get(
         )
       : [];
 
+    // A stale request would be rejected by the handler, so it must not show as "pending". Mirrors
+    // the handler's staleness check (`action.created` === the action's `createdAt`).
     const hasPendingApproval = blockedActions.some(
       (a) =>
         a.metadata.mcpServerName === PLAN_MODE_SERVER_NAME &&
-        a.metadata.toolName === REQUEST_PLAN_APPROVAL_TOOL_NAME
+        a.metadata.toolName === REQUEST_PLAN_APPROVAL_TOOL_NAME &&
+        !isApprovalRequestStale(plan, { requestedAtMs: a.created })
     );
 
-    const approvalState: PlanApprovalState = hasPendingApproval
-      ? "pending"
-      : planFile.useCaseMetadata?.planModeLastApproval != null
-        ? "approved"
-        : "draft";
-
     return ctx.json({
-      planFile: planFile.toJSON(auth),
+      plan: { version: plan.version },
       content,
-      approvalState,
+      approvalState: derivePlanApprovalState(plan, { hasPendingApproval }),
     });
   }
 );

--- a/front-api/routes/w/[wId]/files/[fileId]/index.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/index.ts
@@ -248,20 +248,6 @@ app.delete("/", validate("param", ParamsSchema), async (ctx) => {
     return accessCheck;
   }
 
-  // Plan-mode files are agent-owned: the user interacts with them only through
-  // the agent (via messages and approval decisions), never by direct mutation.
-  // The agent can retire a plan via the `close_plan` tool.
-  if (file.useCaseMetadata?.isPlanFile) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "plan.md is managed by the agent and cannot be deleted directly. Ask the agent to close the plan.",
-      },
-    });
-  }
-
   const space = await getSpaceForFile(auth, file);
   const isFileAuthor = file.userId === auth.user()?.id;
   const isUploadUseCase =
@@ -319,18 +305,6 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
   const accessCheck = await checkFileAccess(ctx, file);
   if (accessCheck) {
     return accessCheck;
-  }
-
-  // Plan-mode files are agent-owned; users cannot upload over them.
-  if (file.useCaseMetadata?.isPlanFile) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "workspace_auth_error",
-        message:
-          "plan.md is managed by the agent and cannot be overwritten directly.",
-      },
-    });
   }
 
   const space = await getSpaceForFile(auth, file);

--- a/front-api/routes/w/[wId]/files/[fileId]/rename.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/rename.ts
@@ -39,18 +39,6 @@ app.patch(
       });
     }
 
-    // Plan-mode files are agent-owned; users cannot rename them.
-    if (file.useCaseMetadata?.isPlanFile) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message:
-            "plan.md is managed by the agent and cannot be renamed directly.",
-        },
-      });
-    }
-
     const space = file.useCaseMetadata?.spaceId
       ? await SpaceResource.fetchById(auth, file.useCaseMetadata.spaceId)
       : null;

--- a/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
+++ b/front/components/assistant/conversation/plan_mode/ConversationPlanModePanel.tsx
@@ -19,7 +19,7 @@ export function ConversationPlanModePanel({
   owner,
 }: ConversationPlanModePanelProps) {
   const { closePanel } = useConversationSidePanelContext();
-  const { planFile, content, approvalState, isPlanLoading } = usePlanFile({
+  const { plan, content, approvalState, isPlanLoading } = usePlanFile({
     conversationId: conversation.sId,
     workspaceId: owner.sId,
   });
@@ -49,15 +49,15 @@ export function ConversationPlanModePanel({
           <div className="flex h-full items-center justify-center">
             <Spinner />
           </div>
-        ) : !planFile ? (
+        ) : !plan ? (
           <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             No active plan for this conversation.
           </div>
         ) : (
-          // Key by planFile.version so React remounts on each edit. Sparkle's `Markdown`
+          // Key by plan.version so React remounts on each edit. Sparkle's `Markdown`
           // memoizes AST nodes for streaming reveal, which can hold stale child nodes when the
           // full content prop changes between edits. Remounting forces a clean render.
-          content && <Markdown key={planFile.version} content={content} />
+          content && <Markdown key={plan.version} content={content} />
         )}
       </div>
     </div>

--- a/front/components/assistant/conversation/plan_mode/PlanCard.tsx
+++ b/front/components/assistant/conversation/plan_mode/PlanCard.tsx
@@ -37,7 +37,7 @@ export const PlanCard = React.memo(function PlanCard({
 }: PlanCardProps) {
   const { hasFeature } = useFeatureFlags();
   const isPlanModeEnabled = hasFeature("plan_mode");
-  const { planFile, content, approvalState } = usePlanFile({
+  const { plan, content, approvalState } = usePlanFile({
     // Skip the fetch entirely for workspaces without the plan_mode feature flag.
     conversationId: isPlanModeEnabled ? conversationId : null,
     workspaceId,
@@ -50,9 +50,9 @@ export const PlanCard = React.memo(function PlanCard({
   // Hide the card until the plan has been edited at least once (version >= 2). The skeleton
   // upload from `create_plan` produces version 1; the first `edit_plan` bumps it to 2. This
   // matches the side-panel auto-open trigger so the card appears at the same moment the panel
-  // first opens. `findActivePlanFile` already filters closed plans server-side, so `!planFile`
+  // first opens. `findActivePlan` already filters closed plans server-side, so `!plan`
   // also covers the post-close_plan case.
-  if (!planFile || planFile.version < 2) {
+  if (!plan || plan.version < 2) {
     return null;
   }
 

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -18,7 +18,12 @@ export function ApprovalStateChip({ state }: { state: PlanApprovalState }) {
       return <Chip size="mini" color="success" label="Approved" />;
     case "pending":
       return <Chip size="mini" color="warning" label="Pending approval" />;
-    case "draft":
+    case "stale":
+      return (
+        <Chip size="mini" color="warning" label="Changed since approval" />
+      );
+    case "none":
+      // Approval is optional; show nothing when no approval is in play.
       return null;
     default:
       assertNeverAndIgnore(state);

--- a/front/hooks/conversations/usePlanFile.ts
+++ b/front/hooks/conversations/usePlanFile.ts
@@ -28,9 +28,9 @@ export function usePlanFile({
   );
 
   return {
-    planFile: data?.planFile ?? null,
+    plan: data?.plan ?? null,
     content: data?.content ?? null,
-    approvalState: data?.approvalState ?? "draft",
+    approvalState: data?.approvalState ?? "none",
     isPlanLoading: conversationId != null && !error && !data,
     isPlanError: error,
     mutatePlan: mutate,

--- a/front/lib/api/actions/servers/plan_mode/metadata.ts
+++ b/front/lib/api/actions/servers/plan_mode/metadata.ts
@@ -69,10 +69,14 @@ export const PLAN_MODE_TOOLS_METADATA = createToolsRecord({
   },
   request_plan_approval: {
     description:
+      "Approval is OPTIONAL. A plan can be created, edited, and executed without ever being " +
+      "approved. Only call this when the user must explicitly confirm the plan before you " +
+      "proceed (e.g. risky or irreversible work).\n\n" +
       "Surface the current plan.md to the user and pause execution pending their decision. " +
       "The user sees an approval card and either approves or rejects. On approve, the tool " +
       "returns success and execution resumes. On reject, the tool returns with `denied` status " +
-      "and the handler does not run.\n\n" +
+      "and the handler does not run. Approval is recorded for the current plan version only — " +
+      "if you edit the plan afterwards, the approval becomes stale and must be requested again.\n\n" +
       "Only call when plan.md is ready. Do not call with an incomplete plan.\n\n" +
       "See skill instructions for when to request approval and how to handle rejection.",
     schema: {

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -3,35 +3,33 @@ import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_de
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { PLAN_MODE_TOOLS_METADATA } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import {
-  createPlanFile,
-  findActivePlanFile,
+  createPlan,
+  findActivePlan,
+  getPlanContent,
+  isApprovalRequestStale,
   markPlanApproved,
   markPlanClosed,
   withPlanModeLock,
+  writePlanContent,
 } from "@app/lib/api/assistant/plan_mode";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
-import {
-  getFileContent,
-  getUpdatedContentAndOccurrences,
-} from "@app/lib/api/files/utils";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import { getUpdatedContentAndOccurrences } from "@app/lib/api/files/utils";
+import type { ConversationPlanResource } from "@app/lib/resources/conversation_plan_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 async function publishPlanUpdated(
   conversationId: string,
-  planFile: FileResource
+  plan: ConversationPlanResource
 ): Promise<void> {
   await publishConversationEvent(
     {
       type: "plan_updated",
       created: Date.now(),
       conversationId,
-      planFileId: planFile.sId,
-      version: planFile.version,
-      isClosed: planFile.useCaseMetadata?.isPlanClosed === true,
-      hasApproval: planFile.useCaseMetadata?.planModeLastApproval != null,
+      version: plan.version,
+      isClosed: plan.isClosed,
     },
     { conversationId }
   );
@@ -42,10 +40,10 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation, agentConfiguration } = agentLoopContext.runContext;
+    const { conversation } = agentLoopContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
-      const existing = await findActivePlanFile(auth, conversation.sId);
+      const existing = await findActivePlan(auth, conversation);
       if (existing) {
         return new Err(
           new MCPError(
@@ -55,17 +53,17 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      const planFile = await createPlanFile(auth, {
-        conversationId: conversation.sId,
-        agentConfigurationId: agentConfiguration.sId,
-      });
+      const planRes = await createPlan(auth, { conversation });
+      if (planRes.isErr()) {
+        return new Err(new MCPError(planRes.error.message));
+      }
 
-      await publishPlanUpdated(conversation.sId, planFile);
+      await publishPlanUpdated(conversation.sId, planRes.value);
 
       return new Ok([
         {
           type: "text",
-          text: `plan.md created (file id: ${planFile.sId}). Populate it via \`edit_plan\`.`,
+          text: `plan.md created. Populate it via \`edit_plan\`.`,
         },
       ]);
     });
@@ -75,12 +73,12 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation, agentConfiguration } = agentLoopContext.runContext;
+    const { conversation } = agentLoopContext.runContext;
 
     try {
       return await withPlanModeLock(conversation.sId, async () => {
-        const planFile = await findActivePlanFile(auth, conversation.sId);
-        if (!planFile) {
+        const plan = await findActivePlan(auth, conversation);
+        if (!plan) {
           return new Err(
             new MCPError(
               "No active plan.md for this conversation. Call `create_plan` first to start one."
@@ -88,9 +86,15 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
           );
         }
 
-        const currentContent = await getFileContent(auth, planFile, "original");
-        if (currentContent === null) {
+        const contentRes = await getPlanContent(auth, conversation, plan);
+        if (contentRes.isErr()) {
           return new Err(new MCPError("Failed to read plan.md."));
+        }
+        const currentContent = contentRes.value;
+        if (currentContent === null) {
+          return new Err(
+            new MCPError("plan.md content is missing and cannot be edited.")
+          );
         }
 
         const { updatedContent, occurrences } = getUpdatedContentAndOccurrences(
@@ -118,19 +122,19 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
           );
         }
 
-        await planFile.uploadContent(auth, updatedContent);
-
-        if (
-          planFile.useCaseMetadata?.lastEditedByAgentConfigurationId !==
-          agentConfiguration.sId
-        ) {
-          await planFile.setUseCaseMetadata(auth, {
-            ...planFile.useCaseMetadata,
-            lastEditedByAgentConfigurationId: agentConfiguration.sId,
-          });
+        const writeRes = await writePlanContent(
+          auth,
+          conversation,
+          plan,
+          updatedContent
+        );
+        if (writeRes.isErr()) {
+          return new Err(new MCPError(writeRes.error.message));
         }
 
-        await publishPlanUpdated(conversation.sId, planFile);
+        await plan.incrementVersion();
+
+        await publishPlanUpdated(conversation.sId, plan);
 
         return new Ok([
           {
@@ -152,18 +156,31 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("Agent loop context is required."));
     }
-    const { conversation } = agentLoopContext.runContext;
+    const { conversation, currentAction } = agentLoopContext.runContext;
 
-    // Handler only runs after user approval (tool stake is "high" → routes through the standard
-    // MCP tool-approval flow). On reject, this function is never called; the agent sees the
-    // action as denied.
+    // Runs only after the user approves (stake "high"); on reject it is never called.
     return withPlanModeLock(conversation.sId, async () => {
-      const planFile = await findActivePlanFile(auth, conversation.sId);
-      if (!planFile) {
+      const plan = await findActivePlan(auth, conversation);
+      if (!plan) {
         return new Err(
           new MCPError(
             "No active plan.md for this conversation. `request_plan_approval` requires an " +
               "existing plan — create one first with `create_plan` and populate it."
+          )
+        );
+      }
+
+      // The pending card isn't tied to a plan row/version, so reject it if the plan was edited or
+      // replaced since the request (`currentAction.createdAt` is when approval was requested).
+      if (
+        isApprovalRequestStale(plan, {
+          requestedAtMs: currentAction.createdAt,
+        })
+      ) {
+        return new Err(
+          new MCPError(
+            "The plan changed since approval was requested (it was edited or replaced), so this " +
+              "approval is no longer valid. Call `request_plan_approval` again for the current plan."
           )
         );
       }
@@ -175,14 +192,10 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      // Note: `user.sId` here is the author of the user message that triggered the agent loop,
-      // not necessarily the person who clicked Approve. The existing validate-action check
-      // requires those to be the same user, so in practice they match — but if validate-action
-      // is ever opened up, this needs to become the actual approver's sId from the approval
-      // callback.
-      const approval = await markPlanApproved(auth, planFile, user.sId);
+      // `user.sId` is the triggering user message's author. validate-action requires that to be
+      // the approver, so they match today; revisit if validate-action is opened up.
+      const approval = await markPlanApproved(plan, user.sId);
       if (!approval) {
-        // Plan was closed between approval request and approval decision (close_plan race).
         return new Err(
           new MCPError(
             "The plan was closed while approval was pending. It cannot be approved anymore."
@@ -190,14 +203,14 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      await publishPlanUpdated(conversation.sId, planFile);
+      await publishPlanUpdated(conversation.sId, plan);
 
       return new Ok([
         {
           type: "text",
           text:
-            `Plan approved by ${user.sId} at ${approval.approvedAt} ` +
-            `(plan.md version ${approval.fileVersion}). Proceed with execution: work ` +
+            `Plan approved by ${user.sId} at ${approval.approvedAt.toISOString()} ` +
+            `(plan.md version ${approval.approvedVersion}). Proceed with execution: work ` +
             `through the tasks in plan.md, using \`edit_plan\` to check them off as you ` +
             `go. Stay within the approved scope; if scope changes, surface it to the user ` +
             `before acting.` +
@@ -214,8 +227,8 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
     const { conversation } = agentLoopContext.runContext;
 
     return withPlanModeLock(conversation.sId, async () => {
-      const planFile = await findActivePlanFile(auth, conversation.sId);
-      if (!planFile) {
+      const plan = await findActivePlan(auth, conversation);
+      if (!plan) {
         return new Err(
           new MCPError(
             "No active plan.md for this conversation. Nothing to close."
@@ -223,19 +236,17 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      // Intentionally do not resolve any pending `request_plan_approval` blocked action here.
-      // The codebase only transitions blocked actions to terminal via user action on the
-      // approval card itself (UI or email). If a stale card remains after close, existing
-      // paths degrade gracefully: `markPlanApproved` already no-ops on closed plans, and a
-      // reject goes through the normal relaunch flow.
-      await markPlanClosed(auth, planFile);
-      await publishPlanUpdated(conversation.sId, planFile);
+      // Don't resolve any pending approval action here: the codebase only transitions blocked
+      // actions to terminal via user action on the card, and a stale card degrades gracefully
+      // (markPlanApproved no-ops on closed plans). Closing keeps the content; it only flips
+      // `isClosed`.
+      await markPlanClosed(plan);
+      await publishPlanUpdated(conversation.sId, plan);
 
       if (reason) {
         logger.info(
           {
             conversationId: conversation.sId,
-            planFileId: planFile.sId,
             reason,
           },
           "Plan closed by agent"

--- a/front/lib/api/actions/servers/plan_mode/tools/index.ts
+++ b/front/lib/api/actions/servers/plan_mode/tools/index.ts
@@ -192,9 +192,9 @@ const handlers: ToolHandlers<typeof PLAN_MODE_TOOLS_METADATA> = {
         );
       }
 
-      // `user.sId` is the triggering user message's author. validate-action requires that to be
-      // the approver, so they match today; revisit if validate-action is opened up.
-      const approval = await markPlanApproved(plan, user.sId);
+      // `user` is the triggering user message's author. validate-action requires that to be the
+      // approver, so they match today; revisit if validate-action is opened up.
+      const approval = await markPlanApproved(plan, user.id);
       if (!approval) {
         return new Err(
           new MCPError(

--- a/front/lib/api/assistant/plan_mode.test.ts
+++ b/front/lib/api/assistant/plan_mode.test.ts
@@ -137,7 +137,7 @@ describe("plan_mode lifecycle", () => {
     );
 
     const user = auth.getNonNullableUser();
-    const approval = await markPlanApproved(plan, user.sId);
+    const approval = await markPlanApproved(plan, user.id);
     expect(approval).not.toBeNull();
     expect(approval?.approvedVersion).toBe(2);
     expect(derivePlanApprovalState(plan, { hasPendingApproval: false })).toBe(
@@ -178,10 +178,7 @@ describe("plan_mode lifecycle", () => {
     const plan = created.value;
     await markPlanClosed(plan);
 
-    const approval = await markPlanApproved(
-      plan,
-      auth.getNonNullableUser().sId
-    );
+    const approval = await markPlanApproved(plan, auth.getNonNullableUser().id);
     expect(approval).toBeNull();
   });
 

--- a/front/lib/api/assistant/plan_mode.test.ts
+++ b/front/lib/api/assistant/plan_mode.test.ts
@@ -1,0 +1,288 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import {
+  createPlan,
+  derivePlanApprovalState,
+  findActivePlan,
+  getPlanContent,
+  isApprovalRequestStale,
+  markPlanApproved,
+  markPlanClosed,
+  planScopedPath,
+  writePlanContent,
+} from "@app/lib/api/assistant/plan_mode";
+import type { Authenticator } from "@app/lib/auth";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { beforeEach, describe, expect, it } from "vitest";
+
+async function setup(): Promise<{
+  auth: Authenticator;
+  conversation: ConversationWithoutContentType;
+}> {
+  const { authenticator: auth } = await createResourceTest({ role: "admin" });
+  const conversation = await createConversation(auth, {
+    title: "Plan mode test",
+    visibility: "unlisted",
+    spaceId: null,
+  });
+  return { auth, conversation };
+}
+
+// The GCS mock records every `file.save(...)` but cannot round-trip reads, so we assert on what
+// was written. `scopedPath` is `conversation-{cId}/.tool_outputs/...`; the recorded GCS path ends
+// with everything after the mount prefix, so we match on that tail.
+function lastWriteContentFor(scopedPath: string): string | null {
+  const tail = scopedPath.split("/").slice(1).join("/");
+  const calls = fileStorageMock.saveFileCalls.filter((c) =>
+    c.filePath.endsWith(tail)
+  );
+  const last = calls[calls.length - 1];
+  return last ? last.content.toString() : null;
+}
+
+describe("plan_mode lifecycle", () => {
+  beforeEach(() => {
+    fileStorageMock.reset();
+  });
+
+  it("create_plan creates an active plan at version 1 and writes the skeleton", async () => {
+    const { auth, conversation } = await setup();
+
+    const res = await createPlan(auth, { conversation });
+    expect(res.isOk()).toBe(true);
+    if (!res.isOk()) {
+      return;
+    }
+    const plan = res.value;
+
+    expect(plan.version).toBe(1);
+    expect(plan.isClosed).toBe(false);
+    expect(planScopedPath(conversation, plan)).toContain(
+      `conversation-${conversation.sId}/.tool_outputs/plans/`
+    );
+    expect(planScopedPath(conversation, plan).endsWith("/plan.md")).toBe(true);
+
+    const active = await findActivePlan(auth, conversation);
+    expect(active?.id).toBe(plan.id);
+
+    expect(lastWriteContentFor(planScopedPath(conversation, plan))).toContain(
+      "# Untitled plan"
+    );
+  });
+
+  it("create_plan refuses a second active plan via findActivePlan guard", async () => {
+    const { auth, conversation } = await setup();
+
+    const first = await createPlan(auth, { conversation });
+    expect(first.isOk()).toBe(true);
+
+    const active = await findActivePlan(auth, conversation);
+    expect(active).not.toBeNull();
+  });
+
+  it("create_plan rolls the row back when the content write fails", async () => {
+    const { auth, conversation } = await setup();
+
+    fileStorageMock.setFileSaveFails(() => true);
+    const res = await createPlan(auth, { conversation });
+    expect(res.isErr()).toBe(true);
+    expect(await findActivePlan(auth, conversation)).toBeNull();
+  });
+
+  it("edit_plan writes new content and bumps the version", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+    fileStorageMock.reset();
+
+    const writeRes = await writePlanContent(
+      auth,
+      conversation,
+      plan,
+      "# My plan\n\n- [ ] step one\n"
+    );
+    expect(writeRes.isOk()).toBe(true);
+    await plan.incrementVersion();
+
+    expect(plan.version).toBe(2);
+    const reloaded = await findActivePlan(auth, conversation);
+    expect(reloaded?.version).toBe(2);
+
+    expect(lastWriteContentFor(planScopedPath(conversation, plan))).toContain(
+      "# My plan"
+    );
+  });
+
+  it("approval state: none -> approved, and becomes stale after a later edit", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+
+    // Move to version 2 (an edit) before approving.
+    await plan.incrementVersion();
+    expect(derivePlanApprovalState(plan, { hasPendingApproval: false })).toBe(
+      "none"
+    );
+
+    // A pending approval action dominates.
+    expect(derivePlanApprovalState(plan, { hasPendingApproval: true })).toBe(
+      "pending"
+    );
+
+    const user = auth.getNonNullableUser();
+    const approval = await markPlanApproved(plan, user.sId);
+    expect(approval).not.toBeNull();
+    expect(approval?.approvedVersion).toBe(2);
+    expect(derivePlanApprovalState(plan, { hasPendingApproval: false })).toBe(
+      "approved"
+    );
+
+    // Editing past the approved version makes the approval stale.
+    await plan.incrementVersion();
+    expect(plan.version).toBe(3);
+    expect(derivePlanApprovalState(plan, { hasPendingApproval: false })).toBe(
+      "stale"
+    );
+  });
+
+  it("close_plan hides the plan without writing/overwriting content", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+    const scopedPathBefore = planScopedPath(conversation, plan);
+    fileStorageMock.reset();
+
+    await markPlanClosed(plan);
+    expect(plan.isClosed).toBe(true);
+    expect(await findActivePlan(auth, conversation)).toBeNull();
+    expect(planScopedPath(conversation, plan)).toBe(scopedPathBefore);
+    expect(lastWriteContentFor(scopedPathBefore)).toBeNull();
+  });
+
+  it("approving a closed plan no-ops", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+    await markPlanClosed(plan);
+
+    const approval = await markPlanApproved(
+      plan,
+      auth.getNonNullableUser().sId
+    );
+    expect(approval).toBeNull();
+  });
+
+  it("a new plan after close uses a fresh path and does not overwrite the old content", async () => {
+    const { auth, conversation } = await setup();
+
+    const first = await createPlan(auth, { conversation });
+    if (!first.isOk()) {
+      throw new Error("setup failed");
+    }
+    const firstPlan = first.value;
+    await markPlanClosed(firstPlan);
+    fileStorageMock.reset();
+
+    const second = await createPlan(auth, { conversation });
+    if (!second.isOk()) {
+      throw new Error("second create failed");
+    }
+    const secondPlan = second.value;
+
+    expect(planScopedPath(conversation, secondPlan)).not.toBe(
+      planScopedPath(conversation, firstPlan)
+    );
+
+    // The new plan wrote its own skeleton; nothing was written to the old plan's path.
+    expect(
+      lastWriteContentFor(planScopedPath(conversation, secondPlan))
+    ).toContain("# Untitled plan");
+    expect(
+      lastWriteContentFor(planScopedPath(conversation, firstPlan))
+    ).toBeNull();
+  });
+
+  it("isApprovalRequestStale: not stale when nothing changed after the request", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+
+    // Approval requested at/after the plan's current state, with no later change → valid.
+    expect(
+      isApprovalRequestStale(plan, {
+        requestedAtMs: plan.updatedAt.getTime() + 1,
+      })
+    ).toBe(false);
+  });
+
+  it("isApprovalRequestStale: stale when the plan was edited after the request", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+
+    await plan.incrementVersion();
+    const reloaded = await findActivePlan(auth, conversation);
+    // An approval requested before the latest edit is stale (updatedAt only moves forward).
+    expect(
+      isApprovalRequestStale(reloaded!, {
+        requestedAtMs: reloaded!.updatedAt.getTime() - 1,
+      })
+    ).toBe(true);
+  });
+
+  it("isApprovalRequestStale: stale when the plan was replaced (closed + recreated) after the request", async () => {
+    const { auth, conversation } = await setup();
+    const first = await createPlan(auth, { conversation });
+    if (!first.isOk()) {
+      throw new Error("setup failed");
+    }
+    await markPlanClosed(first.value);
+    const second = await createPlan(auth, { conversation });
+    if (!second.isOk()) {
+      throw new Error("second create failed");
+    }
+
+    // An approval requested before the replacement plan existed is stale (it targets a plan that
+    // was created after the request → a different plan).
+    expect(
+      isApprovalRequestStale(second.value, {
+        requestedAtMs: second.value.createdAt.getTime() - 1,
+      })
+    ).toBe(true);
+  });
+
+  it("getPlanContent returns Ok(null) when the file is missing", async () => {
+    const { auth, conversation } = await setup();
+    const created = await createPlan(auth, { conversation });
+    if (!created.isOk()) {
+      throw new Error("setup failed");
+    }
+    const plan = created.value;
+
+    fileStorageMock.setFileExists(() => false);
+    const contentRes = await getPlanContent(auth, conversation, plan);
+    expect(contentRes.isOk()).toBe(true);
+    if (contentRes.isOk()) {
+      expect(contentRes.value).toBeNull();
+    }
+  });
+});

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -6,6 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { ConversationPlanResource } from "@app/lib/resources/conversation_plan_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 
 // The plan markdown lives at a per-plan path derived from the conversation and the plan sId, so a
@@ -117,7 +118,7 @@ export async function createPlan(
 // No-ops (returns null) if the plan is already closed, covering the close_plan-during-approval race.
 export async function markPlanApproved(
   plan: ConversationPlanResource,
-  approvedByUserId: string
+  approvedByUserId: ModelId
 ): Promise<{ approvedAt: Date; approvedVersion: number } | null> {
   if (plan.isClosed) {
     return null;

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -1,20 +1,33 @@
 import { PLAN_MODE_SKELETON } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { SCOPED_PREFIX_CONVERSATION } from "@app/lib/api/file_system/types";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
-import { FileResource } from "@app/lib/resources/file_resource";
-import type { FileType, PlanModeApproval } from "@app/types/files";
+import { ConversationPlanResource } from "@app/lib/resources/conversation_plan_resource";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 
-export type PlanApprovalState = "draft" | "pending" | "approved";
+// The plan markdown lives at a per-plan path derived from the conversation and the plan sId, so a
+// new plan created after a close never overwrites a previous plan's content.
+export function planScopedPath(
+  conversation: ConversationWithoutContentType,
+  plan: ConversationPlanResource
+): string {
+  return `${SCOPED_PREFIX_CONVERSATION}${conversation.sId}/${TOOL_OUTPUTS_FOLDER_NAME}/plans/${plan.sId}/plan.md`;
+}
+
+// "none": no approval recorded. "pending": a blocked approval action is awaiting the user.
+// "approved": the current version is approved. "stale": the plan was edited after approval.
+export type PlanApprovalState = "none" | "pending" | "approved" | "stale";
 
 export type GetConversationPlanModeResponseBody = {
-  planFile: FileType | null;
+  plan: { version: number } | null;
   content: string | null;
   approvalState: PlanApprovalState;
 };
 
-// Conversation-scoped lock for all plan-mode operations. One plan per conversation, so a single
-// lock keyed on conversation sId serializes create/edit/approve/close and prevents races (e.g.
-// edit landing on a just-closed plan, two concurrent creates, approval stamping a closed plan).
+// Serializes all plan-mode operations for a conversation so create/edit/approve/close can't race.
 export async function withPlanModeLock<T>(
   conversationId: string,
   fn: () => Promise<T>
@@ -22,97 +35,136 @@ export async function withPlanModeLock<T>(
   return executeWithLock(`plan_mode:${conversationId}`, fn);
 }
 
-// Find the currently active plan file for a conversation. "Active" = attached to the conversation
-// with `isPlanFile: true` and NOT `isPlanClosed: true`. Returns null if no active plan exists.
-//
-// Plan counts per conversation are small (1-2), so the TS-side filter is cheap. If plan mode
-// sees heavy use, a partial expression index on
-// `(workspaceId, useCase, (useCaseMetadata ->> 'conversationId'))` would help.
-export async function findActivePlanFile(
+export async function findActivePlan(
   auth: Authenticator,
-  conversationId: string
-): Promise<FileResource | null> {
-  const files = await FileResource.listPlanFilesForConversation(auth, {
-    conversationId,
-  });
-  return files.find((f) => !f.useCaseMetadata?.isPlanClosed) ?? null;
+  conversation: ConversationWithoutContentType
+): Promise<ConversationPlanResource | null> {
+  return ConversationPlanResource.fetchActiveForConversation(
+    auth,
+    conversation
+  );
 }
 
-// Create a fresh plan.md file attached to the conversation, seeded with the skeleton. Does not
-// check for existing active plans — callers should guard against that.
-export async function createPlanFile(
+// Ok(null) when the file is missing; Err on a real read failure, so callers don't treat a read
+// failure as blank content.
+export async function getPlanContent(
   auth: Authenticator,
-  {
-    conversationId,
-    agentConfigurationId,
-  }: {
-    conversationId: string;
-    agentConfigurationId?: string;
+  conversation: ConversationWithoutContentType,
+  plan: ConversationPlanResource
+): Promise<Result<string | null, Error>> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new Error(fsResult.error.message));
   }
-): Promise<FileResource> {
-  const workspace = auth.getNonNullableWorkspace();
 
-  const file = await FileResource.makeNew({
-    workspaceId: workspace.id,
-    fileName: "plan.md",
-    contentType: "text/markdown",
-    fileSize: 0,
-    useCase: "conversation",
-    useCaseMetadata: {
-      conversationId,
-      isPlanFile: true,
-      planModeLastApproval: null,
-      lastEditedByAgentConfigurationId: agentConfigurationId,
-    },
-  });
+  const bufferResult = await fsResult.value.readBuffer(
+    planScopedPath(conversation, plan)
+  );
+  if (bufferResult.isErr()) {
+    return new Err(new Error(bufferResult.error.message));
+  }
 
-  await file.uploadContent(auth, PLAN_MODE_SKELETON);
-
-  return file;
+  return new Ok(
+    bufferResult.value ? bufferResult.value.toString("utf8") : null
+  );
 }
 
-// Stamp the plan file with approval metadata. Called by the request_plan_approval tool handler
-// after user approval. No-ops (returns null) if the plan is already closed — this covers the race
-// where close_plan runs between approval request and approval decision.
-export async function markPlanApproved(
+export async function writePlanContent(
   auth: Authenticator,
-  planFile: FileResource,
+  conversation: ConversationWithoutContentType,
+  plan: ConversationPlanResource,
+  content: string
+): Promise<Result<void, Error>> {
+  const fsResult = await DustFileSystem.forConversation(auth, conversation);
+  if (fsResult.isErr()) {
+    return new Err(new Error(fsResult.error.message));
+  }
+
+  const writeResult = await fsResult.value.write(
+    planScopedPath(conversation, plan),
+    content,
+    "text/markdown"
+  );
+  if (writeResult.isErr()) {
+    return new Err(new Error(writeResult.error.message));
+  }
+
+  return new Ok(undefined);
+}
+
+// Creates the state row then seeds plan.md. Rolls the row back if the write fails, so there is
+// never an active plan with no readable content.
+export async function createPlan(
+  auth: Authenticator,
+  { conversation }: { conversation: ConversationWithoutContentType }
+): Promise<Result<ConversationPlanResource, Error>> {
+  const plan = await ConversationPlanResource.makeNew(auth, { conversation });
+
+  const writeResult = await writePlanContent(
+    auth,
+    conversation,
+    plan,
+    PLAN_MODE_SKELETON
+  );
+  if (writeResult.isErr()) {
+    await plan.delete(auth);
+    return writeResult;
+  }
+
+  return new Ok(plan);
+}
+
+// No-ops (returns null) if the plan is already closed, covering the close_plan-during-approval race.
+export async function markPlanApproved(
+  plan: ConversationPlanResource,
   approvedByUserId: string
-): Promise<PlanModeApproval | null> {
-  if (planFile.useCaseMetadata?.isPlanClosed) {
+): Promise<{ approvedAt: Date; approvedVersion: number } | null> {
+  if (plan.isClosed) {
     return null;
   }
 
-  const approval: PlanModeApproval = {
-    approvedAt: new Date().toISOString(),
-    approvedByUserId,
-    fileVersion: planFile.version,
+  await plan.recordApproval({ approvedByUserId });
+
+  return {
+    approvedAt: plan.approvedAt ?? new Date(),
+    approvedVersion: plan.approvedVersion ?? plan.version,
   };
-
-  await planFile.setUseCaseMetadata(auth, {
-    ...planFile.useCaseMetadata,
-    planModeLastApproval: approval,
-  });
-
-  return approval;
 }
 
-// Retire the plan. Sets `isPlanClosed: true`. The file stays in DB for audit; the skill and UI
-// stop referencing it. Any pending approval on this plan should be resolved separately by the
-// caller (close_plan handler).
 export async function markPlanClosed(
-  auth: Authenticator,
-  planFile: FileResource
+  plan: ConversationPlanResource
 ): Promise<void> {
-  if (planFile.useCaseMetadata?.isPlanClosed) {
+  if (plan.isClosed) {
     return;
   }
-  await planFile.setUseCaseMetadata(auth, {
-    ...planFile.useCaseMetadata,
-    isPlanClosed: true,
-  });
+  await plan.markClosed();
 }
 
-export function isPlanApproved(file: FileResource): boolean {
-  return file.useCaseMetadata?.planModeLastApproval != null;
+// A pending approval (requested at `requestedAtMs`) is stale once the plan is edited (updatedAt
+// moves past it) or replaced by a newer plan (createdAt past it). Stops a stale card from
+// approving the wrong plan/version. Timestamps share the DB clock.
+export function isApprovalRequestStale(
+  plan: ConversationPlanResource,
+  { requestedAtMs }: { requestedAtMs: number }
+): boolean {
+  return (
+    plan.createdAt.getTime() > requestedAtMs ||
+    plan.updatedAt.getTime() > requestedAtMs
+  );
+}
+
+export function derivePlanApprovalState(
+  plan: ConversationPlanResource,
+  { hasPendingApproval }: { hasPendingApproval: boolean }
+): PlanApprovalState {
+  if (hasPendingApproval) {
+    return "pending";
+  }
+  if (plan.approvedVersion == null) {
+    return "none";
+  }
+  if (plan.version > plan.approvedVersion) {
+    return "stale";
+  }
+  return "approved";
 }

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -413,28 +413,6 @@ export class FileResource extends BaseResource<FileModel> {
     return files.map((f) => new this(this.model, f.get()));
   }
 
-  // List plan-mode files attached to a conversation. Callers filter active vs. closed via the
-  // returned `useCaseMetadata.isPlanClosed` flag (present only on closed plans). Ordered by
-  // createdAt DESC so the most recent plan is first.
-  static async listPlanFilesForConversation(
-    auth: Authenticator,
-    { conversationId }: { conversationId: string }
-  ): Promise<FileResource[]> {
-    const owner = auth.getNonNullableWorkspace();
-
-    const files = await this.model.findAll({
-      where: {
-        workspaceId: owner.id,
-        useCase: "conversation",
-        status: "ready",
-        useCaseMetadata: { conversationId, isPlanFile: true },
-      },
-      order: [["createdAt", "DESC"]],
-    });
-
-    return files.map((f) => new this(this.model, f.get()));
-  }
-
   static async fetchByMountFilePaths(
     auth: Authenticator,
     mountFilePaths: string[]

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -760,16 +760,14 @@ export type ConversationTitleEvent = {
 };
 
 // Event sent when the conversation's plan.md is created, edited, approved, or closed. Carries
-// only metadata (id, version, status flags) — the UI refetches the full file contents via the
-// plan_mode GET endpoint on receipt.
+// only metadata (version, closed flag) — the UI refetches the full content and approval state via
+// the plan_mode GET endpoint on receipt.
 export type PlanUpdatedEvent = {
   type: "plan_updated";
   created: number;
   conversationId: string;
-  planFileId: string;
   version: number;
   isClosed: boolean;
-  hasApproval: boolean;
 };
 
 // Event sent when a wake-up in the conversation is created or changes status. Thin payload: the

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -35,14 +35,6 @@ export type FileUseCase =
   // Workspace branding: logo/favicon uploaded by workspace admins.
   | "workspace_branding";
 
-// Audit trail for a plan-mode approval. Recorded on `plan.md.useCaseMetadata` when the user
-// approves a `request_plan_approval` call.
-export type PlanModeApproval = {
-  approvedAt: string; // ISO timestamp.
-  approvedByUserId: string; // sId of the approving user.
-  fileVersion: number; // FileModel.version at the moment of approval.
-};
-
 export type FileUseCaseMetadata = {
   conversationId?: string;
   skillId?: string;
@@ -59,13 +51,6 @@ export type FileUseCaseMetadata = {
   // only the original blob exists. Stamped together for sandbox-mounted raw delimited files.
   skipDataSourceIndexing?: boolean;
   skipFileProcessing?: boolean;
-  // Plan mode. `isPlanFile: true` marks a file as agent-owned (user can't directly mutate).
-  // `planModeLastApproval` is set when the agent's `request_plan_approval` is approved.
-  // `isPlanClosed: true` marks the plan as retired — hidden from UI and ignored by the skill.
-  // Active plans omit `isPlanClosed` (only closed plans have it set).
-  isPlanFile?: boolean;
-  planModeLastApproval?: PlanModeApproval | null;
-  isPlanClosed?: boolean;
   // Which branding asset this file was uploaded for (workspace_branding use case only).
   asset?: string;
 };


### PR DESCRIPTION
## Description

Second of two PRs migrating plan mode off `FileResource`. It depends on the storage layer added in the previous PR (the `conversation_plans` table, model, and resource). This PR switches the plan mode tools, the API route, and the UI onto that storage, and removes the old `FileResource` plumbing. After this, a `FileResource` is only ever created when a user uploads a file, never for an agent created plan.

A plan is now split in two. The markdown content lives in the conversation's `DustFileSystem` at a per plan path derived from the conversation sId and the plan sId, so a plan created after a close never overwrites a previous plan's content. The lifecycle state lives in `conversation_plans`. The plan mode tools (`create_plan`, `edit_plan`, `request_plan_approval`, `close_plan`) read and write content through `DustFileSystem` and update state through `ConversationPlanResource`. `create_plan` writes the skeleton and rolls the row back if that write fails, so there is never an active plan with no readable content. `close_plan` only flips the closed flag and never deletes or overwrites the content.

Approval is now optional and is recorded against a specific plan version. The API exposes an `approvalState` of `none`, `pending`, `approved`, or `stale`, derived from the approval columns and whether a blocked approval action is awaiting the user. Editing a plan past its approved version makes the approval stale. Two consistency guards close the stale approval gap: the `request_plan_approval` handler refuses to approve if the plan was edited or replaced since the approval was requested (bound through the approval action's creation time), and the GET route applies the same staleness check so a stale card never shows as pending in the UI.

This PR also removes the now dead plan mode code on the `FileResource` side: the `listPlanFilesForConversation` query, the `isPlanFile`, `isPlanClosed`, and `planModeLastApproval` fields on `FileUseCaseMetadata`, the `PlanModeApproval` type, and the three `isPlanFile` guards in the files endpoints (those guarded a surface that no longer exists, since plan content is not a `FileResource` anymore).

On the client, the API response field is renamed from `planFile` to `plan`, the approval chip no longer shows a Draft state, and a stale approval is surfaced as "Changed since approval". The plan updated event payload is slimmed to the version and closed flag, which is all the client uses before refetching.

## Tests

Adds `plan_mode.test.ts` covering the lifecycle end to end: create at version one with the skeleton written, the single active plan guard, rollback when the content write fails, edit writing new content and bumping the version, the approval state moving from none to approved and becoming stale after a later edit, close hiding the plan without overwriting content, approving a closed plan being a no op, a new plan after a close using a fresh path without touching the old content, the missing file path returning null, and the approval staleness checks for edited and replaced plans.

## Risk

It is gated behind the existing `plan_mode` feature flag. Any `plan.md` `FileResource` records created by the old code before this deploy become orphaned, since the new code reads from the new table. Given plan mode is experimental and feature flagged, we drop those rather than write a data migration. The renamed response field and slimmed event payload are internal to our own client and ship together with this change, so there is no external contract break.

## Deploy Plan

Deploy front, after https://github.com/dust-tt/dust/pull/27758