### PR TITLE
[front] Fix members-usage pagination latency: cached billing period +…

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -171,17 +171,17 @@ export type MembersUsagePaginationInput = z.infer<
 >;
 
 async function fetchPerUserUsageCreditsForMembersTableUncached({
+  workspaceId,
   metronomeCustomerId,
-  metronomeContractId,
   userIds,
 }: {
+  workspaceId: string;
   metronomeCustomerId: string;
-  metronomeContractId: string;
   userIds: string[];
 }): Promise<Map<string, number>> {
   const result = await fetchPerUserAwuUsage({
+    workspaceId,
     metronomeCustomerId,
-    metronomeContractId,
     userIds,
   });
   if (result.isErr()) {
@@ -195,10 +195,12 @@ async function fetchPerUserUsageCreditsForMembersTableUncached({
 }
 
 async function fetchPerUserUsageCreditsForMembersTable({
+  workspaceId,
   metronomeCustomerId,
   metronomeContractId,
   userIds,
 }: {
+  workspaceId: string;
   metronomeCustomerId: string | null;
   metronomeContractId: string | null;
   userIds: string[];
@@ -208,6 +210,7 @@ async function fetchPerUserUsageCreditsForMembersTable({
   }
   try {
     return await getPerUserAwuUsage({
+      workspaceId,
       metronomeCustomerId,
       metronomeContractId,
       userIds,
@@ -218,8 +221,8 @@ async function fetchPerUserUsageCreditsForMembersTable({
       "[MembersUsage] Failed to read cached per-user usage, falling back to uncached fetch"
     );
     return fetchPerUserUsageCreditsForMembersTableUncached({
+      workspaceId,
       metronomeCustomerId,
-      metronomeContractId,
       userIds,
     });
   }
@@ -586,6 +589,7 @@ export async function fetchRemainingCapCreditsPercentageForUser({
     { defaultCapAwuCreditsBySeatType, seatAllowanceBySeatType },
   ] = await Promise.all([
     fetchPerUserUsageCreditsForMembersTable({
+      workspaceId,
       metronomeCustomerId,
       metronomeContractId,
       userIds: [metronomeUserId],
@@ -663,6 +667,7 @@ export async function getMemberUsage({
       users: [userResource],
     }),
     fetchPerUserUsageCreditsForMembersTable({
+      workspaceId: workspace.sId,
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
       // Include both forms; seat type is resolved from the membership fetched
@@ -864,6 +869,7 @@ export async function getMembersUsage({
   ] = await Promise.all([
     MembershipResource.getActiveMemberships({ workspace, users }),
     fetchPerUserUsageCreditsForMembersTable({
+      workspaceId: workspace.sId,
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
       // Include both the raw sId and the free-prefixed form: free-seat users'

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -496,8 +496,8 @@ export async function reconcileWorkspaceUserCreditStates({
     .map((m) => m.user?.sId)
     .filter((sId): sId is string => sId !== undefined);
   const usageResult = await fetchPerUserAwuUsage({
+    workspaceId,
     metronomeCustomerId,
-    metronomeContractId,
     userIds: memberUserIds,
   });
   if (usageResult.isErr()) {

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -263,8 +263,8 @@ export async function reconcileProgrammatic({
   }
 
   const spendResult = await fetchProgrammaticAwuSpend({
+    workspaceId: workspace.sId,
     metronomeCustomerId,
-    metronomeContractId,
   });
   if (spendResult.isErr()) {
     return new Err(

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -27,6 +27,10 @@ import {
   syncMauCount,
 } from "@app/lib/metronome/mau_sync";
 import {
+  type CachedContract,
+  getActiveContract,
+} from "@app/lib/metronome/plan_type";
+import {
   hasContractSeatSubscription,
   remapMembershipSeatTypesForContract,
   syncSeatCount,
@@ -1279,6 +1283,25 @@ export async function provisionShadowEnterpriseMetronomeContract({
   return new Ok({ metronomeCustomerId, metronomeContractId });
 }
 
+function billingPeriodFromContract(
+  contract: CachedContract
+): Result<BillingCycle, Error> {
+  const currentPeriod = contract.subscriptions
+    ?.map((s) => s.billing_periods?.current)
+    .find((bp) => bp !== undefined);
+
+  if (!currentPeriod) {
+    return new Err(
+      new Error("No current billing period found on Metronome contract")
+    );
+  }
+
+  return new Ok({
+    cycleStart: new Date(currentPeriod.starting_at),
+    cycleEnd: new Date(currentPeriod.ending_before),
+  });
+}
+
 /**
  * Retrieve the current billing period from the Metronome contract.
  *
@@ -1313,18 +1336,15 @@ export async function getMetronomeCurrentBillingPeriod({
     return new Err(contractResult.error);
   }
 
-  const currentPeriod = contractResult.value.subscriptions
-    ?.map((s) => s.billing_periods?.current)
-    .find((bp) => bp !== undefined);
+  return billingPeriodFromContract(contractResult.value);
+}
 
-  if (!currentPeriod) {
-    return new Err(
-      new Error("No current billing period found on Metronome contract")
-    );
+export async function getCachedMetronomeCurrentBillingPeriod(
+  workspaceId: string
+): Promise<Result<BillingCycle | null, Error>> {
+  const contract = await getActiveContract(workspaceId);
+  if (!contract) {
+    return new Ok(null);
   }
-
-  return new Ok({
-    cycleStart: new Date(currentPeriod.starting_at),
-    cycleEnd: new Date(currentPeriod.ending_before),
-  });
+  return billingPeriodFromContract(contract);
 }

--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -28,7 +28,7 @@ import {
 } from "@app/lib/metronome/mau_sync";
 import {
   type CachedContract,
-  getActiveContract,
+  resolveActiveMetronomeIds,
 } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
@@ -55,12 +55,14 @@ import {
 } from "@app/lib/plans/usage/types";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { cacheWithRedis } from "@app/lib/utils/cache";
 import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import { isSupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type Stripe from "stripe";
 import { metronomeAmount } from "./amounts";
@@ -1303,30 +1305,20 @@ function billingPeriodFromContract(
 }
 
 /**
- * Retrieve the current billing period from the Metronome contract.
+ * Retrieve the current billing period directly from Metronome (no caching).
  *
  * Returns:
  * - Ok(BillingCycle) when the period is found on the contract.
  * - Ok(null) when Metronome is not set up for this workspace (missing IDs).
  * - Err when the Metronome API call fails or no subscription has a billing period.
  */
-export async function getMetronomeCurrentBillingPeriod({
+async function fetchMetronomeCurrentBillingPeriod({
   metronomeContractId,
   metronomeCustomerId,
 }: {
-  metronomeContractId: string | null;
-  metronomeCustomerId: string | null;
+  metronomeContractId: string;
+  metronomeCustomerId: string;
 }): Promise<Result<BillingCycle | null, Error>> {
-  if (!metronomeContractId || !metronomeCustomerId) {
-    if (metronomeContractId !== null || metronomeCustomerId !== null) {
-      logger.warn(
-        { metronomeContractId, metronomeCustomerId },
-        "[Metronome] Partial Metronome configuration: one of metronomeContractId or metronomeCustomerId is missing"
-      );
-    }
-    return new Ok(null);
-  }
-
   const contractResult = await getMetronomeContractById({
     metronomeCustomerId,
     metronomeContractId,
@@ -1339,12 +1331,54 @@ export async function getMetronomeCurrentBillingPeriod({
   return billingPeriodFromContract(contractResult.value);
 }
 
+// Billing periods roll over independently of any contract lifecycle event
+// (contract.start/end/edit), so unlike the no-TTL active-contract cache, this
+// needs its own short TTL — otherwise a workspace whose contract hasn't been
+// edited in a while would keep reading a stale, expired period indefinitely.
+const BILLING_PERIOD_CACHE_TTL_MS = 60 * 1000;
+
+async function fetchBillingPeriodRecordForWorkspace(
+  workspaceId: string
+): Promise<{ cycleStartMs: number; cycleEndMs: number } | null> {
+  const ids = await resolveActiveMetronomeIds(workspaceId);
+  if (!ids) {
+    return null;
+  }
+  const periodResult = await fetchMetronomeCurrentBillingPeriod(ids);
+  if (periodResult.isErr()) {
+    throw periodResult.error;
+  }
+  if (!periodResult.value) {
+    return null;
+  }
+  return {
+    cycleStartMs: periodResult.value.cycleStart.getTime(),
+    cycleEndMs: periodResult.value.cycleEnd.getTime(),
+  };
+}
+
+const getCachedBillingPeriodRecordForWorkspace = cacheWithRedis(
+  fetchBillingPeriodRecordForWorkspace,
+  (workspaceId) => workspaceId,
+  { ttlMs: BILLING_PERIOD_CACHE_TTL_MS, cacheNullValues: false }
+);
+
+/**
+ * Retrieve the current billing period for a workspace's active Metronome contract.
+ */
 export async function getCachedMetronomeCurrentBillingPeriod(
   workspaceId: string
 ): Promise<Result<BillingCycle | null, Error>> {
-  const contract = await getActiveContract(workspaceId);
-  if (!contract) {
-    return new Ok(null);
+  try {
+    const record = await getCachedBillingPeriodRecordForWorkspace(workspaceId);
+    if (!record) {
+      return new Ok(null);
+    }
+    return new Ok({
+      cycleStart: new Date(record.cycleStartMs),
+      cycleEnd: new Date(record.cycleEndMs),
+    });
+  } catch (err) {
+    return new Err(normalizeError(err));
   }
-  return billingPeriodFromContract(contract);
 }

--- a/front/lib/metronome/live_user_credit_inputs.ts
+++ b/front/lib/metronome/live_user_credit_inputs.ts
@@ -158,8 +158,8 @@ export async function fetchLiveUserCreditInputs({
 
     if (metronomeContractId) {
       const usageResult = await fetchPerUserAwuUsage({
+        workspaceId,
         metronomeCustomerId,
-        metronomeContractId,
         userIds: [userId],
       });
       if (usageResult.isErr()) {

--- a/front/lib/metronome/per_user_usage.test.ts
+++ b/front/lib/metronome/per_user_usage.test.ts
@@ -1,0 +1,152 @@
+import { buildUsageQuerySegments } from "@app/lib/metronome/per_user_usage";
+import { describe, expect, it } from "vitest";
+
+describe("buildUsageQuerySegments", () => {
+  it("returns a single DAY segment when both boundaries are UTC midnight", () => {
+    const segments = buildUsageQuerySegments({
+      cycleStart: new Date("2026-06-01T00:00:00.000Z"),
+      requestEnd: new Date("2026-07-01T00:00:00.000Z"),
+    });
+    expect(segments).toEqual([
+      {
+        startingOn: "2026-06-01T00:00:00.000Z",
+        endingBefore: "2026-07-01T00:00:00.000Z",
+        windowSize: "DAY",
+      },
+    ]);
+  });
+
+  it("adds an HOUR segment for a non-midnight start, DAY for the interior", () => {
+    const segments = buildUsageQuerySegments({
+      cycleStart: new Date("2026-06-15T15:00:00.000Z"),
+      requestEnd: new Date("2026-07-01T00:00:00.000Z"),
+    });
+    expect(segments).toEqual([
+      {
+        startingOn: "2026-06-15T00:00:00.000Z",
+        endingBefore: "2026-06-16T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+      {
+        startingOn: "2026-06-16T00:00:00.000Z",
+        endingBefore: "2026-07-01T00:00:00.000Z",
+        windowSize: "DAY",
+      },
+    ]);
+  });
+
+  it("adds an HOUR segment for a non-midnight end, DAY for the interior", () => {
+    const segments = buildUsageQuerySegments({
+      cycleStart: new Date("2026-06-01T00:00:00.000Z"),
+      requestEnd: new Date("2026-06-20T09:30:00.000Z"),
+    });
+    expect(segments).toEqual([
+      {
+        startingOn: "2026-06-01T00:00:00.000Z",
+        endingBefore: "2026-06-20T00:00:00.000Z",
+        windowSize: "DAY",
+      },
+      {
+        startingOn: "2026-06-20T00:00:00.000Z",
+        endingBefore: "2026-06-21T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+    ]);
+  });
+
+  it("produces HOUR + DAY + HOUR for non-midnight start and end, multi-day", () => {
+    const segments = buildUsageQuerySegments({
+      cycleStart: new Date("2026-06-15T15:00:00.000Z"),
+      requestEnd: new Date("2026-06-20T09:30:00.000Z"),
+    });
+    expect(segments).toEqual([
+      {
+        startingOn: "2026-06-15T00:00:00.000Z",
+        endingBefore: "2026-06-16T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+      {
+        startingOn: "2026-06-16T00:00:00.000Z",
+        endingBefore: "2026-06-20T00:00:00.000Z",
+        windowSize: "DAY",
+      },
+      {
+        startingOn: "2026-06-20T00:00:00.000Z",
+        endingBefore: "2026-06-21T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+    ]);
+  });
+
+  it("collapses to a single HOUR segment when the range is confined to one day", () => {
+    const segments = buildUsageQuerySegments({
+      cycleStart: new Date("2026-06-15T12:00:00.000Z"),
+      requestEnd: new Date("2026-06-15T18:00:00.000Z"),
+    });
+    expect(segments).toEqual([
+      {
+        startingOn: "2026-06-15T00:00:00.000Z",
+        endingBefore: "2026-06-16T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+    ]);
+  });
+
+  it("collapses to a single HOUR segment when the range crosses exactly one midnight with no interior day", () => {
+    const segments = buildUsageQuerySegments({
+      cycleStart: new Date("2026-06-15T18:00:00.000Z"),
+      requestEnd: new Date("2026-06-16T06:00:00.000Z"),
+    });
+    expect(segments).toEqual([
+      {
+        startingOn: "2026-06-15T00:00:00.000Z",
+        endingBefore: "2026-06-17T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+    ]);
+  });
+
+  it("returns no segments when requestEnd does not come after cycleStart", () => {
+    const sameInstant = new Date("2026-06-15T12:00:00.000Z");
+    expect(
+      buildUsageQuerySegments({
+        cycleStart: sameInstant,
+        requestEnd: sameInstant,
+      })
+    ).toEqual([]);
+    expect(
+      buildUsageQuerySegments({
+        cycleStart: new Date("2026-06-15T12:00:00.000Z"),
+        requestEnd: new Date("2026-06-15T11:00:00.000Z"),
+      })
+    ).toEqual([]);
+  });
+
+  it("produces contiguous, non-overlapping segments covering the full range", () => {
+    const cycleStart = new Date("2026-06-15T15:00:00.000Z");
+    const requestEnd = new Date("2026-09-02T03:00:00.000Z");
+    const segments = buildUsageQuerySegments({ cycleStart, requestEnd });
+
+    expect(segments[0].startingOn).toBe(
+      new Date(
+        Date.UTC(
+          cycleStart.getUTCFullYear(),
+          cycleStart.getUTCMonth(),
+          cycleStart.getUTCDate()
+        )
+      ).toISOString()
+    );
+    expect(segments.at(-1)?.endingBefore).toBe(
+      new Date(
+        Date.UTC(
+          requestEnd.getUTCFullYear(),
+          requestEnd.getUTCMonth(),
+          requestEnd.getUTCDate() + 1
+        )
+      ).toISOString()
+    );
+    for (let i = 1; i < segments.length; i++) {
+      expect(segments[i].startingOn).toBe(segments[i - 1].endingBefore);
+    }
+  });
+});

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -112,8 +112,9 @@ function fetchSegmentedUsage({
   groupKey: string[];
   userIds: string[];
 }) {
-  return Promise.all(
-    segments.map((segment) =>
+  return concurrentExecutor(
+    segments,
+    (segment) =>
       listMetronomeUsageWithGroups({
         customerId: metronomeCustomerId,
         billableMetricId,
@@ -122,8 +123,8 @@ function fetchSegmentedUsage({
         windowSize: segment.windowSize,
         groupKey,
         groupFilters: { user_id: userIds },
-      })
-    )
+      }),
+    { concurrency: 3 }
   ).then(flattenUsageResults);
 }
 

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -10,7 +10,7 @@ import {
   USAGE_TYPE_FREE,
   USAGE_TYPE_GROUP_KEY,
 } from "@app/lib/metronome/constants";
-import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
   isToolCategory,
   TOOL_CATEGORY_AWU_WEIGHTS,
@@ -18,6 +18,114 @@ import {
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+type UsageWindowSize = "HOUR" | "DAY";
+
+interface UsageQuerySegment {
+  startingOn: string;
+  endingBefore: string;
+  windowSize: UsageWindowSize;
+}
+
+/**
+ * Partition `[cycleStart, requestEnd)` into the fewest midnight-aligned
+ * segments the usage endpoint can query directly: a single DAY-granularity
+ * segment for the interior days (the bulk of a typical month-long billing
+ * period), plus HOUR-granularity segments only for the partial first/last day
+ * when a boundary isn't already UTC midnight.
+ *
+ * Segments are contiguous and non-overlapping by construction, so summing
+ * their results is safe.
+ */
+export function buildUsageQuerySegments({
+  cycleStart,
+  requestEnd,
+}: {
+  cycleStart: Date;
+  requestEnd: Date;
+}): UsageQuerySegment[] {
+  if (requestEnd.getTime() <= cycleStart.getTime()) {
+    return [];
+  }
+
+  const dayStart = ceilToMidnightUTC(cycleStart);
+  const dayEnd = floorToMidnightUTC(requestEnd);
+
+  // No full day fits between the boundaries (period shorter than a day, or
+  // confined to a single partial day): one HOUR segment for the whole range.
+  if (dayEnd.getTime() <= dayStart.getTime()) {
+    return [
+      {
+        startingOn: floorToMidnightUTC(cycleStart).toISOString(),
+        endingBefore: ceilToMidnightUTC(requestEnd).toISOString(),
+        windowSize: "HOUR",
+      },
+    ];
+  }
+
+  const segments: UsageQuerySegment[] = [];
+  if (dayStart.getTime() > cycleStart.getTime()) {
+    segments.push({
+      startingOn: floorToMidnightUTC(cycleStart).toISOString(),
+      endingBefore: dayStart.toISOString(),
+      windowSize: "HOUR",
+    });
+  }
+  segments.push({
+    startingOn: dayStart.toISOString(),
+    endingBefore: dayEnd.toISOString(),
+    windowSize: "DAY",
+  });
+  if (requestEnd.getTime() > dayEnd.getTime()) {
+    segments.push({
+      startingOn: dayEnd.toISOString(),
+      endingBefore: ceilToMidnightUTC(requestEnd).toISOString(),
+      windowSize: "HOUR",
+    });
+  }
+  return segments;
+}
+
+function flattenUsageResults<T>(
+  results: Array<Result<T[], Error>>
+): Result<T[], Error> {
+  const merged: T[] = [];
+  for (const result of results) {
+    if (result.isErr()) {
+      return result;
+    }
+    merged.push(...result.value);
+  }
+  return new Ok(merged);
+}
+
+function fetchSegmentedUsage({
+  segments,
+  metronomeCustomerId,
+  billableMetricId,
+  groupKey,
+  userIds,
+}: {
+  segments: UsageQuerySegment[];
+  metronomeCustomerId: string;
+  billableMetricId: string;
+  groupKey: string[];
+  userIds: string[];
+}) {
+  return Promise.all(
+    segments.map((segment) =>
+      listMetronomeUsageWithGroups({
+        customerId: metronomeCustomerId,
+        billableMetricId,
+        startingOn: segment.startingOn,
+        endingBefore: segment.endingBefore,
+        windowSize: segment.windowSize,
+        groupKey,
+        groupFilters: { user_id: userIds },
+      })
+    )
+  ).then(flattenUsageResults);
+}
 
 /**
  * Per-user AWU consumption for the current billing period.
@@ -27,10 +135,10 @@ import { Err, Ok } from "@app/types/shared/result";
  *
  * Billing periods are anchored to the contract start date (e.g. June 15 15:00),
  * so bounds are non-midnight. The usage endpoint requires midnight-aligned
- * `starting_on`/`ending_before`, so we floor/ceil to midnight and use
- * `window_size: "HOUR"` to get per-hour buckets. Pre-period and post-period
- * buckets are filtered out in code so only usage within `[cycleStart, cycleEnd)`
- * is counted.
+ * `starting_on`/`ending_before`, so the query is split into per-day-granularity
+ * and per-hour-granularity segments by `buildUsageQuerySegments` (see there).
+ * Pre-period and post-period buckets are filtered out in code so only usage
+ * within `[cycleStart, cycleEnd)` is counted.
  *
  * `current_period: true` is rejected ("must have an active plan") — that flag
  * keys off Metronome's legacy v1 Plan entity, and we provision customers
@@ -51,14 +159,15 @@ import { Err, Ok } from "@app/types/shared/result";
  * so we must scope by `user_id`. Free usage is excluded by dropping
  * `usage_type === "free"` buckets in code (we still group by `usage_type` so
  * each bucket carries it).
+ *
  */
 export async function fetchPerUserAwuUsage({
+  workspaceId,
   metronomeCustomerId,
-  metronomeContractId,
   userIds,
 }: {
+  workspaceId: string;
   metronomeCustomerId: string;
-  metronomeContractId: string;
   // Users to scope the usage query to (the `user_id` group filter). Required:
   // an unfiltered query is capped and omits users. Empty → empty result.
   userIds: string[];
@@ -66,10 +175,8 @@ export async function fetchPerUserAwuUsage({
   if (userIds.length === 0) {
     return new Ok(new Map());
   }
-  const periodResult = await getMetronomeCurrentBillingPeriod({
-    metronomeCustomerId,
-    metronomeContractId,
-  });
+  const periodResult =
+    await getCachedMetronomeCurrentBillingPeriod(workspaceId);
   if (periodResult.isErr()) {
     return new Err(periodResult.error);
   }
@@ -80,35 +187,28 @@ export async function fetchPerUserAwuUsage({
   const cycleEndMs = cycleEnd.getTime();
   const cycleStartMs = cycleStart.getTime();
 
-  // The usage endpoint requires midnight-aligned bounds. Billing periods are
-  // anchored to the contract start date (e.g. June 15 15:00), so the period
-  // bounds are typically non-midnight. Floor/ceil to midnight for the query
-  // and use HOUR granularity so individual buckets can be trimmed: drop
-  // pre-start buckets (< cycleStart) and post-end buckets (>= cycleEnd) below.
-  const startingOn = floorToMidnightUTC(cycleStart).toISOString();
+  // The usage endpoint requires midnight-aligned bounds; buckets outside
+  // [cycleStart, cycleEnd) are trimmed below regardless of segment.
   const requestEnd = new Date(Math.min(cycleEndMs, Date.now()));
-  const endingBefore = ceilToMidnightUTC(requestEnd).toISOString();
-  const windowSize =
-    cycleStartMs === floorToMidnightUTC(cycleStart).getTime() ? "DAY" : "HOUR";
+  const segments = buildUsageQuerySegments({ cycleStart, requestEnd });
+  if (segments.length === 0) {
+    return new Ok(new Map());
+  }
 
   const [aiResult, toolResult] = await Promise.all([
-    listMetronomeUsageWithGroups({
-      customerId: metronomeCustomerId,
+    fetchSegmentedUsage({
+      segments,
+      metronomeCustomerId,
       billableMetricId: getMetricLlmProviderCostAwuId(),
-      startingOn,
-      endingBefore,
-      windowSize,
       groupKey: ["user_id", USAGE_TYPE_GROUP_KEY],
-      groupFilters: { user_id: userIds },
+      userIds,
     }),
-    listMetronomeUsageWithGroups({
-      customerId: metronomeCustomerId,
+    fetchSegmentedUsage({
+      segments,
+      metronomeCustomerId,
       billableMetricId: getMetricToolInvocationsId(),
-      startingOn,
-      endingBefore,
-      windowSize,
       groupKey: ["user_id", USAGE_TYPE_GROUP_KEY, "tool_category"],
-      groupFilters: { user_id: userIds },
+      userIds,
     }),
   ]);
   if (aiResult.isErr()) {
@@ -177,10 +277,12 @@ function perUserAwuUsageCacheKey(
  * reuse each other's entries. Throws if the batched fetch fails.
  */
 export async function getPerUserAwuUsage({
+  workspaceId,
   metronomeCustomerId,
   metronomeContractId,
   userIds,
 }: {
+  workspaceId: string;
   metronomeCustomerId: string;
   metronomeContractId: string;
   userIds: string[];
@@ -213,8 +315,8 @@ export async function getPerUserAwuUsage({
 
       if (misses.length > 0) {
         const fetched = await fetchPerUserAwuUsage({
+          workspaceId,
           metronomeCustomerId,
-          metronomeContractId,
           userIds: misses,
         });
         if (fetched.isErr()) {

--- a/front/lib/metronome/plan_type.ts
+++ b/front/lib/metronome/plan_type.ts
@@ -14,6 +14,35 @@ export type CachedContract = Omit<ContractV2, "commits" | "credits">;
 // Null values are NOT cached: when no contract is found we want a fresh fetch next time.
 
 /**
+ * Resolve a workspace's Metronome customer id and the contract id of its
+ * active subscription. Returns null when either is missing.
+ */
+export async function resolveActiveMetronomeIds(
+  workspaceId: string
+): Promise<{ metronomeCustomerId: string; metronomeContractId: string } | null> {
+  const workspace = await WorkspaceModel.findOne({
+    attributes: ["id", "metronomeCustomerId"],
+    where: { sId: workspaceId },
+  });
+  if (!workspace?.metronomeCustomerId) {
+    return null;
+  }
+
+  const subscription = await SubscriptionModel.findOne({
+    attributes: ["metronomeContractId"],
+    where: { workspaceId: workspace.id, status: "active" },
+  });
+  if (!subscription?.metronomeContractId) {
+    return null;
+  }
+
+  return {
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    metronomeContractId: subscription.metronomeContractId,
+  };
+}
+
+/**
  * Fetch the active Metronome contract for a workspace.
  * Resolves metronomeCustomerId from the workspace table and contractId from
  * the active subscription. Returns null when either is missing or on failure.
@@ -22,36 +51,22 @@ async function fetchActiveContract(
   workspaceId: string
 ): Promise<CachedContract | null> {
   try {
-    const workspace = await WorkspaceModel.findOne({
-      attributes: ["id", "metronomeCustomerId"],
-      where: { sId: workspaceId },
-    });
-    if (!workspace?.metronomeCustomerId) {
+    const ids = await resolveActiveMetronomeIds(workspaceId);
+    if (!ids) {
       return null;
     }
-
-    const subscription = await SubscriptionModel.findOne({
-      attributes: ["metronomeContractId"],
-      where: { workspaceId: workspace.id, status: "active" },
-    });
-    if (!subscription?.metronomeContractId) {
-      return null;
-    }
+    const { metronomeCustomerId, metronomeContractId } = ids;
 
     const result = await getMetronomeContractById({
-      metronomeCustomerId: workspace.metronomeCustomerId,
-      metronomeContractId: subscription.metronomeContractId,
+      metronomeCustomerId,
+      metronomeContractId,
     });
     if (result.isErr()) {
       throw result.error;
     }
 
     logger.info(
-      {
-        workspaceId,
-        metronomeCustomerId: workspace.metronomeCustomerId,
-        contractId: subscription.metronomeContractId,
-      },
+      { workspaceId, metronomeCustomerId, contractId: metronomeContractId },
       "[Metronome Contract] Contract fetched"
     );
 

--- a/front/lib/metronome/plan_type.ts
+++ b/front/lib/metronome/plan_type.ts
@@ -17,9 +17,10 @@ export type CachedContract = Omit<ContractV2, "commits" | "credits">;
  * Resolve a workspace's Metronome customer id and the contract id of its
  * active subscription. Returns null when either is missing.
  */
-export async function resolveActiveMetronomeIds(
-  workspaceId: string
-): Promise<{ metronomeCustomerId: string; metronomeContractId: string } | null> {
+export async function resolveActiveMetronomeIds(workspaceId: string): Promise<{
+  metronomeCustomerId: string;
+  metronomeContractId: string;
+} | null> {
   const workspace = await WorkspaceModel.findOne({
     attributes: ["id", "metronomeCustomerId"],
     where: { sId: workspaceId },

--- a/front/lib/metronome/programmatic_awu_usage.ts
+++ b/front/lib/metronome/programmatic_awu_usage.ts
@@ -10,7 +10,7 @@ import {
   USAGE_TYPE_GROUP_KEY,
   USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
-import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
   isToolCategory,
   TOOL_CATEGORY_AWU_WEIGHTS,
@@ -54,8 +54,8 @@ export async function getRemainingProgrammaticUsageFromMetronome(
   }
 
   const programmaticSpendRes = await fetchProgrammaticAwuSpend({
+    workspaceId: workspace.sId,
     metronomeCustomerId,
-    metronomeContractId,
   });
   if (programmaticSpendRes.isErr()) {
     logger.warn(
@@ -94,16 +94,15 @@ export async function getRemainingProgrammaticUsageFromMetronome(
  * risk of being capped server-side.
  */
 export async function fetchProgrammaticAwuSpend({
+  workspaceId,
   metronomeCustomerId,
-  metronomeContractId,
 }: {
+  workspaceId: string;
   metronomeCustomerId: string;
-  metronomeContractId: string;
 }): Promise<Result<number | null, Error>> {
-  const periodResult = await getMetronomeCurrentBillingPeriod({
-    metronomeCustomerId,
-    metronomeContractId,
-  });
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspaceId
+  );
   if (periodResult.isErr()) {
     return new Err(periodResult.error);
   }

--- a/front/lib/metronome/programmatic_awu_usage.ts
+++ b/front/lib/metronome/programmatic_awu_usage.ts
@@ -100,9 +100,8 @@ export async function fetchProgrammaticAwuSpend({
   workspaceId: string;
   metronomeCustomerId: string;
 }): Promise<Result<number | null, Error>> {
-  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
-    workspaceId
-  );
+  const periodResult =
+    await getCachedMetronomeCurrentBillingPeriod(workspaceId);
   if (periodResult.isErr()) {
     return new Err(periodResult.error);
   }

--- a/front/lib/reinforcement/billing.ts
+++ b/front/lib/reinforcement/billing.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
-import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import logger from "@app/logger/logger";
 
 function currentCalendarMonth(): BillingCycle {
@@ -22,13 +22,12 @@ function currentCalendarMonth(): BillingCycle {
 export async function getCurrentPeriod(
   auth: Authenticator
 ): Promise<BillingCycle> {
-  const subscription = auth.subscription();
   const workspace = auth.workspace();
+  if (!workspace) {
+    return currentCalendarMonth();
+  }
 
-  const result = await getMetronomeCurrentBillingPeriod({
-    metronomeContractId: subscription?.metronomeContractId ?? null,
-    metronomeCustomerId: workspace?.metronomeCustomerId ?? null,
-  });
+  const result = await getCachedMetronomeCurrentBillingPeriod(workspace.sId);
 
   if (result.isOk() && result.value !== null) {
     return result.value;

--- a/front/lib/reinforcement/consumption.test.ts
+++ b/front/lib/reinforcement/consumption.test.ts
@@ -18,17 +18,12 @@ import type { LightWorkspaceType } from "@app/types/user";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function makeAuth({
-  metronomeContractId = null,
-  metronomeCustomerId = null,
+  hasWorkspace = false,
 }: {
-  metronomeContractId?: string | null;
-  metronomeCustomerId?: string | null;
+  hasWorkspace?: boolean;
 } = {}): Authenticator {
   return {
-    subscription: () =>
-      metronomeContractId !== null ? { metronomeContractId } : null,
-    workspace: () =>
-      metronomeCustomerId !== null ? { metronomeCustomerId } : null,
+    workspace: () => (hasWorkspace ? { sId: "ws-1" } : null),
   } as unknown as Authenticator;
 }
 
@@ -180,7 +175,7 @@ describe("getWorkspaceDefaultSelfImprovementCapPerSkillAwuCredits", () => {
 describe("getCurrentPeriod", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.spyOn(metronomeContracts, "getMetronomeCurrentBillingPeriod");
+    vi.spyOn(metronomeContracts, "getCachedMetronomeCurrentBillingPeriod");
   });
 
   afterEach(() => {
@@ -189,7 +184,7 @@ describe("getCurrentPeriod", () => {
   });
 
   describe("fallback to current calendar month", () => {
-    it("falls back when auth has no metronome IDs", async () => {
+    it("falls back when auth has no workspace", async () => {
       vi.setSystemTime(new Date("2026-03-15T13:45:30.123Z"));
       const { cycleStart, cycleEnd } = await getCurrentPeriod(makeAuth());
       expect(cycleStart.toISOString()).toBe("2026-03-01T00:00:00.000Z");
@@ -199,13 +194,10 @@ describe("getCurrentPeriod", () => {
     it("falls back when the Metronome API returns an error", async () => {
       vi.setSystemTime(new Date("2026-03-15T13:45:30.123Z"));
       vi.mocked(
-        metronomeContracts.getMetronomeCurrentBillingPeriod
+        metronomeContracts.getCachedMetronomeCurrentBillingPeriod
       ).mockResolvedValue(new Err(new Error("Metronome unavailable")));
       const { cycleStart, cycleEnd } = await getCurrentPeriod(
-        makeAuth({
-          metronomeContractId: "contract-1",
-          metronomeCustomerId: "customer-1",
-        })
+        makeAuth({ hasWorkspace: true })
       );
       expect(cycleStart.toISOString()).toBe("2026-03-01T00:00:00.000Z");
       expect(cycleEnd.toISOString()).toBe("2026-04-01T00:00:00.000Z");
@@ -214,13 +206,10 @@ describe("getCurrentPeriod", () => {
     it("falls back when Metronome has no billing period (Ok(null))", async () => {
       vi.setSystemTime(new Date("2026-03-15T13:45:30.123Z"));
       vi.mocked(
-        metronomeContracts.getMetronomeCurrentBillingPeriod
+        metronomeContracts.getCachedMetronomeCurrentBillingPeriod
       ).mockResolvedValue(new Ok(null));
       const { cycleStart, cycleEnd } = await getCurrentPeriod(
-        makeAuth({
-          metronomeContractId: "contract-1",
-          metronomeCustomerId: "customer-1",
-        })
+        makeAuth({ hasWorkspace: true })
       );
       expect(cycleStart.toISOString()).toBe("2026-03-01T00:00:00.000Z");
       expect(cycleEnd.toISOString()).toBe("2026-04-01T00:00:00.000Z");
@@ -230,7 +219,7 @@ describe("getCurrentPeriod", () => {
   describe("using Metronome billing period", () => {
     it("returns the period from Metronome", async () => {
       vi.mocked(
-        metronomeContracts.getMetronomeCurrentBillingPeriod
+        metronomeContracts.getCachedMetronomeCurrentBillingPeriod
       ).mockResolvedValue(
         new Ok({
           cycleStart: new Date("2026-03-04T00:00:00.000Z"),
@@ -238,10 +227,7 @@ describe("getCurrentPeriod", () => {
         })
       );
       const { cycleStart, cycleEnd } = await getCurrentPeriod(
-        makeAuth({
-          metronomeContractId: "contract-1",
-          metronomeCustomerId: "customer-1",
-        })
+        makeAuth({ hasWorkspace: true })
       );
       expect(cycleStart.toISOString()).toBe("2026-03-04T00:00:00.000Z");
       expect(cycleEnd.toISOString()).toBe("2026-04-04T00:00:00.000Z");

--- a/front/scripts/debug_user_awu_spend.ts
+++ b/front/scripts/debug_user_awu_spend.ts
@@ -29,7 +29,7 @@ import {
   USAGE_TYPE_PROGRAMMATIC,
   USAGE_TYPE_USER,
 } from "@app/lib/metronome/constants";
-import { getMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import {
   isToolCategory,
   TOOL_CATEGORY_AWU_WEIGHTS,
@@ -77,10 +77,9 @@ makeScript(
       "[debug] Contract start"
     );
 
-    const periodResult = await getMetronomeCurrentBillingPeriod({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
+    const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+      workspace.sId
+    );
     if (periodResult.isErr() || !periodResult.value) {
       logger.error({ workspaceId }, "No current billing period");
       return;

--- a/front/scripts/debug_user_awu_spend.ts
+++ b/front/scripts/debug_user_awu_spend.ts
@@ -416,8 +416,8 @@ makeScript(
 
     // --- Canonical Consumed + reconciliation -------------------------------
     const consumedMap = await fetchPerUserAwuUsage({
+      workspaceId,
       metronomeCustomerId,
-      metronomeContractId,
       userIds: [userId],
     });
     const canonicalConsumed = consumedMap.isOk()


### PR DESCRIPTION
## Description

* The member-usage call is far too slow. I think it's due to the number of metronome calls. Two primary changes: (1) caching contract (2) decrease number of individual usage calls per member

## Tests

* Validated locally output remains the same. Seeing around ~25% decrease in latency (more optimizations we can make subsequently)

## Risk

* Low

## Deploy Plan

* Deploy front