### PR TITLE
UsagePage: change color for free seat CTA

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -611,13 +611,13 @@ export function UsagePage() {
             <ContentMessage
               title={noOrFreeSeatTitle(myUsage.seatType)}
               icon={AlertCircle}
-              variant="warning"
+              variant="blue"
             >
               <div className="flex items-center justify-between gap-4">
                 <span>{noOrFreeSeatBody(myUsage.seatType)}</span>
                 <Button
                   label="Change my seat"
-                  variant="warning"
+                  variant="primary"
                   size="xs"
                   onClick={() => setChangeSeatMember(myUsage)}
                 />


### PR DESCRIPTION
## Description

Change free seat CTA (on UsagePage when admin has a free seat) color to be a bit more nuanced (blue instead of read)
<img width="1492" height="494" alt="image" src="https://github.com/user-attachments/assets/4ac2ef25-95cf-4070-9f6b-0e7b0969b744" />


## Tests

Tested locally

## Risk

Low, UI

## Deploy Plan

Deploy front
