### PR TITLE
Fix free seat reconcile

### DIFF
--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -3,6 +3,7 @@ import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_POOL,
   type ContractCreditType,
+  fromFreeMetronomeUserId,
   PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY,
   PLAN_CODE_CUSTOM_FIELD_KEY,
   SEAT_TYPE_CUSTOM_FIELD_KEY,
@@ -2667,9 +2668,9 @@ export async function listCustomerPerUserCreditBalances({
       if (entry.contract) {
         continue;
       }
-      const userId =
+      const rawUserId =
         entry.custom_fields?.[PER_USER_CREDIT_USER_CUSTOM_FIELD_KEY];
-      if (!userId) {
+      if (!rawUserId) {
         continue;
       }
       if (
@@ -2678,6 +2679,11 @@ export async function listCustomerPerUserCreditBalances({
       ) {
         continue;
       }
+      // Strip the "free-" prefix so the map is keyed by plain sId, matching
+      // callers that look up by membership.user.sId. Falls back to the raw
+      // value for old-format credits that were granted before the prefix was
+      // introduced.
+      const userId = fromFreeMetronomeUserId(rawUserId) ?? rawUserId;
       const startingBalanceAwu = (
         entry.access_schedule?.schedule_items ?? []
       ).reduce((sum, item) => sum + item.amount, 0);


### PR DESCRIPTION
## Description

listCustomerPerUserCreditBalances returns a map keyed by the raw value of the DUST_PER_USER_CREDIT_USER custom field, which — since #27682 — is stored as free-<sId>. Both callers looked up by plain sId, so balance lookups always missed. With no balance found, expectedUserCreditState returns user_seat for any null balance, so reconciling a free user whose credits were exhausted wrongly reverted their state from capped back to user_seat.

Fix: strip the free- prefix in listCustomerPerUserCreditBalances before using it as the map key (falling back to the raw value for old-format credits). Map is now consistently keyed by plain sId as the docstring promised.

## Tests

Manually verified via the poke reconcile plugin on an exhausted free-seat user — state now stays capped after reconcile.

## Risk

Low. Change is scoped to the balance map key; callers and state machine logic are untouched. No deploy ordering needed.


## Deploy Plan

deploy front