### PR TITLE
feat(billing): block switching to a paid seat on a free plan in the backend

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/seat_type.ts
+++ b/front-api/routes/poke/workspaces/[wId]/seat_type.ts
@@ -63,6 +63,15 @@ app.post(
                 "Cannot assign a free seat to a member who did not start on a free seat.",
             },
           });
+        case "paid_seat_not_allowed_on_free_plan":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Cannot assign a paid seat while the workspace is on a free plan.",
+            },
+          });
         case "seat_limit_reached":
           return apiError(ctx, {
             status_code: 400,

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.test.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.test.ts
@@ -144,6 +144,33 @@ describe("PATCH /api/w/:wId/members/:uId/seat-type", () => {
       expect((await response.json()).seatType).toBe("max");
     });
 
+    it("returns 400 when assigning a paid seat while on a free plan", async () => {
+      const workspace = await WorkspaceFactory.creditPricedFree();
+      await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "admin",
+        workspace,
+      });
+
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+        seatType: "none",
+      });
+
+      const response = await honoApp.request(
+        seatTypeUrl(workspace.sId, targetUser.sId),
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ seatType: "pro" }),
+        }
+      );
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+
     it("returns 200 when downgrading from max to pro", async () => {
       const workspace = await WorkspaceFactory.metronome();
       const { workspace: w } = await createPrivateApiMockRequest({

--- a/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/seat-type.ts
@@ -93,6 +93,15 @@ app.patch(
                 "The free seat is reserved for first-time members and cannot be assigned again.",
             },
           });
+        case "paid_seat_not_allowed_on_free_plan":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "A paid seat cannot be assigned while the workspace is on a free plan. Upgrade the workspace first.",
+            },
+          });
         case "seat_limit_reached":
           return apiError(ctx, {
             status_code: 400,

--- a/front/lib/api/membership.test.ts
+++ b/front/lib/api/membership.test.ts
@@ -126,6 +126,22 @@ describe("createAndTrackMembership", () => {
     expect(membership.seatType).toBe("free");
   });
 
+  it("preserves an explicit none seat request on a free plan", async () => {
+    setupEntitledSeats(["free", "pro"]);
+
+    const workspace = await WorkspaceFactory.creditPricedFree();
+    const user = await UserFactory.basic();
+    const membership = await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+      requestedSeatType: "none",
+    });
+
+    expect(membership.seatType).toBe("none");
+  });
+
   it("still assigns a committed paid seat on a paid plan", async () => {
     setupEntitledSeats(["free", "pro"]);
 

--- a/front/lib/api/membership.test.ts
+++ b/front/lib/api/membership.test.ts
@@ -1,0 +1,151 @@
+import * as workosAudit from "@app/lib/api/audit/workos_audit";
+import { createAndTrackMembership } from "@app/lib/api/membership";
+import type { CachedContract } from "@app/lib/metronome/plan_type";
+import * as planType from "@app/lib/metronome/plan_type";
+import * as seatTypes from "@app/lib/metronome/seat_types";
+import { WorkspaceSeatLimitResource } from "@app/lib/resources/workspace_seat_limit_resource";
+import { ServerSideTracking } from "@app/lib/tracking/server";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { MembershipSeatType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/plan_type", async () => {
+  const actual = await vi.importActual<typeof planType>(
+    "@app/lib/metronome/plan_type"
+  );
+  return { ...actual, getActiveContract: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/seat_types", async () => {
+  const actual = await vi.importActual<typeof seatTypes>(
+    "@app/lib/metronome/seat_types"
+  );
+  return { ...actual, getProductSeatTypes: vi.fn() };
+});
+
+vi.mock("@app/lib/api/audit/workos_audit", async () => {
+  const actual = await vi.importActual<typeof workosAudit>(
+    "@app/lib/api/audit/workos_audit"
+  );
+  return { ...actual, emitAuditLogEventDirect: vi.fn() };
+});
+
+vi.mock("@app/temporal/usage_queue/client", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/temporal/usage_queue/client")
+  >("@app/temporal/usage_queue/client");
+  return {
+    ...actual,
+    launchMetronomeSeatCountSyncWorkflow: vi.fn(),
+    launchUpdateUsageWorkflow: vi.fn(),
+  };
+});
+
+import {
+  launchMetronomeSeatCountSyncWorkflow,
+  launchUpdateUsageWorkflow,
+} from "@app/temporal/usage_queue/client";
+
+const trackCreateMembershipSpy = vi.spyOn(
+  ServerSideTracking,
+  "trackCreateMembership"
+);
+
+function setupEntitledSeats(seatTypeList: MembershipSeatType[]): void {
+  const contract = {
+    subscriptions: seatTypeList.map((seatType) => ({
+      subscription_rate: {
+        product: { id: `${seatType}-product`, name: seatType },
+      },
+    })),
+    recurring_credits: [],
+    overrides: seatTypeList.map((seatType) => ({
+      entitled: true,
+      product: { id: `${seatType}-product` },
+    })),
+  } as unknown as CachedContract;
+
+  const catalog = new Map<string, MembershipSeatType>(
+    seatTypeList.map((seatType) => [`${seatType}-product`, seatType])
+  );
+
+  vi.mocked(planType.getActiveContract).mockResolvedValue(contract);
+  vi.mocked(seatTypes.getProductSeatTypes).mockResolvedValue(catalog);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  vi.mocked(workosAudit.emitAuditLogEventDirect).mockResolvedValue(undefined);
+  vi.mocked(launchUpdateUsageWorkflow).mockResolvedValue(new Ok(undefined));
+  vi.mocked(launchMetronomeSeatCountSyncWorkflow).mockResolvedValue(
+    new Ok(undefined)
+  );
+  trackCreateMembershipSpy.mockResolvedValue(undefined);
+});
+
+describe("createAndTrackMembership", () => {
+  it("assigns free instead of a committed paid seat on a free plan", async () => {
+    setupEntitledSeats(["free", "pro"]);
+
+    const workspace = await WorkspaceFactory.creditPricedFree();
+    const upsertResult = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 3,
+      maxSeats: null,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const user = await UserFactory.basic();
+    const membership = await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+    });
+
+    expect(membership.seatType).toBe("free");
+  });
+
+  it("drops a requested paid seat and still assigns free on a free plan", async () => {
+    setupEntitledSeats(["free", "pro"]);
+
+    const workspace = await WorkspaceFactory.creditPricedFree();
+    const user = await UserFactory.basic();
+    const membership = await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+      requestedSeatType: "pro",
+    });
+
+    expect(membership.seatType).toBe("free");
+  });
+
+  it("still assigns a committed paid seat on a paid plan", async () => {
+    setupEntitledSeats(["free", "pro"]);
+
+    const workspace = await WorkspaceFactory.creditPriced();
+    const upsertResult = await WorkspaceSeatLimitResource.upsert({
+      workspace,
+      seatType: "pro",
+      minSeats: 3,
+      maxSeats: null,
+    });
+    expect(upsertResult.isOk()).toBe(true);
+
+    const user = await UserFactory.basic();
+    const membership = await createAndTrackMembership({
+      user,
+      workspace,
+      role: "user",
+      origin: "invited",
+    });
+
+    expect(membership.seatType).toBe("pro");
+  });
+});

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -21,6 +21,7 @@ import {
   classifySeatChange,
   hasContractSeatSubscription,
 } from "@app/lib/metronome/seats";
+import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -41,7 +42,10 @@ import type {
   MembershipRoleType,
   MembershipSeatType,
 } from "@app/types/memberships";
-import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
+import {
+  isPaidSeatType,
+  normalizeToPoolLimitSeatType,
+} from "@app/types/memberships";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
@@ -53,7 +57,12 @@ import type { Transaction } from "sequelize";
 
 /**
  * Resolve the seat type for a brand-new membership on a Metronome-billed
- * workspace. The assignment follows three phases:
+ * workspace.
+ *
+ * On free plans, paid seats are never auto-assigned: the result is `free`
+ * when eligible, otherwise `none`.
+ *
+ * On non-free plans, the assignment follows three phases:
  *
  *  1. **Committed seats** — the cheapest seat tier whose committed allocation
  *     (`workspace_seat_limits.minSeats`) still has unassigned slots is picked.
@@ -92,6 +101,25 @@ async function resolveSeatTypeForNewMembership(
   if (!contract) {
     return "none";
   }
+
+  const isWorkspaceOnFreePlan = isFreePlan(subscription.getPlan().code);
+  let effectiveRequestedSeatType = requestedSeatType;
+  if (
+    requestedSeatType != null &&
+    isPaidSeatType(requestedSeatType) &&
+    isWorkspaceOnFreePlan
+  ) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        requestedSeatType,
+      },
+      "[Membership] Dropping requested paid seat on a free plan"
+    );
+    effectiveRequestedSeatType = null;
+  }
+
   const planLimits = subscription.toJSON().plan.limits.users;
   // `isReturningMember` is always queried — `free` is a one-shot starter tier
   // that cannot be assigned to any user who previously held any membership in
@@ -99,6 +127,31 @@ async function resolveSeatTypeForNewMembership(
   // when at least one of the two caps is set; skip the count queries otherwise.
   const limitsActive =
     planLimits.maxFreeUsers !== -1 || planLimits.maxLifetimeFreeUsers !== -1;
+
+  if (isWorkspaceOnFreePlan) {
+    const [productSeatTypes, isReturningMember, freeSeatCounts] =
+      await Promise.all([
+        getProductSeatTypes(),
+        MembershipResource.hasAnyMembershipOfUserInWorkspace({
+          user,
+          workspace,
+        }),
+        limitsActive
+          ? MembershipResource.getFreeSeatCounts({ workspace })
+          : Promise.resolve(undefined),
+      ]);
+
+    return resolveRequestedSeatTypeForContract(contract, productSeatTypes, {
+      requestedSeatType: "free",
+      isReturningMember,
+      freeSeatCounts,
+      freeSeatLimits: {
+        maxActiveFreeUsers: planLimits.maxFreeUsers,
+        maxLifetimeFreeUsers: planLimits.maxLifetimeFreeUsers,
+      },
+    });
+  }
+
   const [productSeatTypes, isReturningMember, freeSeatCounts, seatLimits] =
     await Promise.all([
       getProductSeatTypes(),
@@ -113,9 +166,9 @@ async function resolveSeatTypeForNewMembership(
   // still available, and to enforce the `maxSeats` cap when honoring an explicit
   // paid-seat request.
   const requestsPaidSeat =
-    requestedSeatType != null &&
-    requestedSeatType !== "free" &&
-    requestedSeatType !== "none";
+    effectiveRequestedSeatType != null &&
+    effectiveRequestedSeatType !== "free" &&
+    effectiveRequestedSeatType !== "none";
   const hasCommittedSeats = [...seatLimits.values()].some(
     (l) => l.minSeats > 0
   );
@@ -137,9 +190,9 @@ async function resolveSeatTypeForNewMembership(
     seatCounts,
   };
 
-  if (requestedSeatType != null) {
+  if (effectiveRequestedSeatType != null) {
     return resolveRequestedSeatTypeForContract(contract, productSeatTypes, {
-      requestedSeatType,
+      requestedSeatType: effectiveRequestedSeatType,
       ...commonSeatResolutionOptions,
     });
   }
@@ -155,8 +208,8 @@ async function resolveSeatTypeForNewMembership(
  * Create a membership with tracking, audit logging, and Metronome seat provisioning.
  *
  * For Metronome-billed workspaces with a seat-billed contract, the seat type
- * assigned follows the committed-seat → free → none priority order defined by
- * `resolveSeatTypeForNewMembership`.
+ * assigned follows `resolveSeatTypeForNewMembership`: free plans only allocate
+ * `free`/`none`, while paid plans use the committed-seat → free → none order.
  */
 export async function createAndTrackMembership({
   user,
@@ -611,6 +664,7 @@ export async function updateMembershipSeatAndTrack({
         | "not_found"
         | "metronome_error"
         | "free_seat_not_allowed"
+        | "paid_seat_not_allowed_on_free_plan"
         | "seat_limit_reached";
     }
   >
@@ -641,6 +695,14 @@ export async function updateMembershipSeatAndTrack({
     }
   } else if (newSeatType === "free" && previousSeatType !== "free") {
     return new Err({ type: "free_seat_not_allowed" });
+  }
+
+  if (isPaidSeatType(newSeatType) && newSeatType !== previousSeatType) {
+    const subscription =
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
+    if (subscription && isFreePlan(subscription.getPlan().code)) {
+      return new Err({ type: "paid_seat_not_allowed_on_free_plan" });
+    }
   }
 
   // Enforce the per-seat-type hard cap (`maxSeats`). Assigning to `none`

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -129,6 +129,10 @@ async function resolveSeatTypeForNewMembership(
     planLimits.maxFreeUsers !== -1 || planLimits.maxLifetimeFreeUsers !== -1;
 
   if (isWorkspaceOnFreePlan) {
+    if (requestedSeatType === "none") {
+      return "none";
+    }
+
     const [productSeatTypes, isReturningMember, freeSeatCounts] =
       await Promise.all([
         getProductSeatTypes(),

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -2,6 +2,7 @@ import { PlanModel } from "@app/lib/models/plan";
 import { upsertFreePlans } from "@app/lib/plans/free_plans";
 import {
   CREDIT_PRICED_BUSINESS_PLAN_CODE,
+  CREDIT_PRICED_FREE_PLAN_CODE,
   FREE_BYOK_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
   PRO_PLAN_SEAT_29_CODE,
@@ -56,6 +57,16 @@ export class WorkspaceFactory {
     return this.create(
       CREDIT_PRICED_BUSINESS_PLAN_CODE,
       { metronomeCustomerId: "cus_test_credit_priced", ...overrides },
+      { metronomeContractId: "test-metronome-contract-id" }
+    );
+  }
+
+  static async creditPricedFree(
+    overrides?: WorkspaceOverrides
+  ): Promise<WorkspaceType> {
+    return this.create(
+      CREDIT_PRICED_FREE_PLAN_CODE,
+      { metronomeCustomerId: "cus_test_credit_priced_free", ...overrides },
       { metronomeContractId: "test-metronome-contract-id" }
     );
   }

--- a/front/types/memberships.ts
+++ b/front/types/memberships.ts
@@ -171,6 +171,23 @@ export function isSeatBased(
   }
 }
 
+export function isPaidSeatType(seatType: MembershipSeatType): boolean {
+  switch (seatType) {
+    case "workspace":
+    case "workspace_yearly":
+    case "pro":
+    case "pro_yearly":
+    case "max":
+    case "max_yearly":
+      return true;
+    case "none":
+    case "free":
+      return false;
+    default:
+      return assertNever(seatType);
+  }
+}
+
 // Per-user credit state on a membership. Models where a user sits in the
 // personal-credits → workspace-pool → cap progression. Only the per-user
 // dimension lives here; the workspace-level pool state lives separately on


### PR DESCRIPTION
## Description

- Add isPaidSeatType helper to classify billable, non-free seat types
- Reject assigning a paid seat in updateMembershipSeatAndTrack when the
  workspace's active subscription is on a free plan, via a new
  paid_seat_not_allowed_on_free_plan domain error
- Map the new error to a 400 in the members seat-type and poke seat_type routes
- Drop a requested paid seat in resolveSeatTypeForNewMembership when the
  workspace is on a free plan, closing the invitation/signup bypass (the
  contract carries the full seat catalog for upgrades, so a paid request would
  otherwise be honored). Falls back to the default committed → free → none
  resolution
- Add WorkspaceFactory.creditPricedFree and a functional test covering the block

Ticket: https://github.com/dust-tt/tasks/issues/9069

## Tests

Unit + local

## Risk

Medium, could prevent correct paths if done wrong

## Deploy Plan

Front
