### PR TITLE
feat(conversation): open presentations in resizable file preview panel

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -38,7 +38,7 @@ export default function ConversationSidePanelContent({
       );
 
     case FILE_PREVIEW_SIDE_PANEL_TYPE:
-      return <FilePreviewPanel owner={owner} />;
+      return <FilePreviewPanel conversation={conversation} owner={owner} />;
 
     case FILES_SIDE_PANEL_TYPE:
       return (

--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -1,11 +1,13 @@
 import { AgentActionsPanel } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
 import { ConversationFilesPanel } from "@app/components/assistant/conversation/files_panel/ConversationFilesPanel";
+import { FilePreviewPanel } from "@app/components/assistant/conversation/files_panel/FilePreviewPanel";
 import { InteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/InteractiveContentContainer";
 import { ConversationPlanModePanel } from "@app/components/assistant/conversation/plan_mode/ConversationPlanModePanel";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  FILE_PREVIEW_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
   PLAN_SIDE_PANEL_TYPE,
@@ -34,6 +36,9 @@ export default function ConversationSidePanelContent({
           owner={owner}
         />
       );
+
+    case FILE_PREVIEW_SIDE_PANEL_TYPE:
+      return <FilePreviewPanel owner={owner} />;
 
     case FILES_SIDE_PANEL_TYPE:
       return (

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -30,7 +30,7 @@ type OpenPanelParams =
     }
   | {
       type: "file_preview";
-      fileId: string;
+      filePath: string;
     }
   | {
       type: "files";
@@ -162,7 +162,7 @@ export function ConversationSidePanelProvider({
           break;
 
         case FILE_PREVIEW_SIDE_PANEL_TYPE:
-          setData(params.fileId);
+          setData(params.filePath);
           break;
 
         case FILES_SIDE_PANEL_TYPE:

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -5,6 +5,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  FILE_PREVIEW_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   FULL_SCREEN_HASH_PARAM,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
@@ -28,6 +29,10 @@ type OpenPanelParams =
       timestamp?: string;
     }
   | {
+      type: "file_preview";
+      fileId: string;
+    }
+  | {
       type: "files";
     }
   | {
@@ -39,6 +44,7 @@ const isSupportedPanelType = (
 ): type is ConversationSidePanelType =>
   type === "actions" ||
   type === "interactive_content" ||
+  type === "file_preview" ||
   type === "files" ||
   type === "plan";
 
@@ -153,6 +159,10 @@ export function ConversationSidePanelProvider({
           params.timestamp
             ? setData(`${params.fileId}@${params.timestamp}`)
             : setData(params.fileId);
+          break;
+
+        case FILE_PREVIEW_SIDE_PANEL_TYPE:
+          setData(params.fileId);
           break;
 
         case FILES_SIDE_PANEL_TYPE:

--- a/front/components/assistant/conversation/ConversationSidePanelHeader.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelHeader.tsx
@@ -2,15 +2,15 @@ import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { Button, XClose } from "@dust-tt/sparkle";
 import type React from "react";
 
-interface InteractiveContentHeaderProps {
+interface ConversationSidePanelHeaderProps {
   children?: React.ReactNode;
   onClose?: () => void;
 }
 
-export function InteractiveContentHeader({
+export function ConversationSidePanelHeader({
   children,
   onClose,
-}: InteractiveContentHeaderProps) {
+}: ConversationSidePanelHeaderProps) {
   return (
     <AppLayoutTitle className="bg-panel-background @container">
       <div className="flex h-full items-center">

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -4,10 +4,7 @@ import { PreviewableCitation } from "@app/components/assistant/conversation/atta
 import type { AttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
 import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import {
-  isInteractiveContentType,
-  isPresentationContentType,
-} from "@app/types/files";
+import { isInteractiveContentType, opensInSidePanel } from "@app/types/files";
 import { Icon, useTranscribingProgress } from "@dust-tt/sparkle";
 import { useContext } from "react";
 
@@ -99,13 +96,13 @@ export function AttachmentCitation({
     );
   }
 
-  // Presentations (PowerPoint): open the resizable side panel instead of the
-  // center preview dialog. Requires a file path (the PDF-preview conversion is
+  // Some formats (e.g. presentations) open the resizable side panel instead of
+  // the center preview dialog. Requires a file path (the preview conversion is
   // only served on the path-based route) and the side panel provider.
   if (
     filePath &&
     !isLoading &&
-    isPresentationContentType(contentType) &&
+    opensInSidePanel(contentType) &&
     sidePanel != null
   ) {
     return (

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -4,7 +4,10 @@ import { PreviewableCitation } from "@app/components/assistant/conversation/atta
 import type { AttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
 import { ConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { isInteractiveContentType } from "@app/types/files";
+import {
+  isInteractiveContentType,
+  isPresentationContentType,
+} from "@app/types/files";
 import { Icon, useTranscribingProgress } from "@dust-tt/sparkle";
 import { useContext } from "react";
 
@@ -90,6 +93,28 @@ export function AttachmentCitation({
         onClick={() =>
           sidePanel.openPanel({ type: "interactive_content", fileId })
         }
+        onRemove={attachmentCitation.onRemove}
+        tooltipLabel={title}
+      />
+    );
+  }
+
+  // Presentations (PowerPoint): open the resizable side panel instead of the
+  // center preview dialog. Requires a file path (the PDF-preview conversion is
+  // only served on the path-based route) and the side panel provider.
+  if (
+    filePath &&
+    !isLoading &&
+    isPresentationContentType(contentType) &&
+    sidePanel != null
+  ) {
+    return (
+      <FileCitationCard
+        icon={attachmentCitation.visual}
+        title={title}
+        description={attachmentCitation.description}
+        compact={compact}
+        onClick={() => sidePanel.openPanel({ type: "file_preview", filePath })}
         onRemove={attachmentCitation.onRemove}
         tooltipLabel={title}
       />

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -113,7 +113,7 @@ export function AttachmentCitation({
         icon={attachmentCitation.visual}
         title={title}
         description={attachmentCitation.description}
-        compact={compact}
+        size={size}
         onClick={() => sidePanel.openPanel({ type: "file_preview", filePath })}
         onRemove={attachmentCitation.onRemove}
         tooltipLabel={title}

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -1,6 +1,9 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { FileExplorer } from "@app/components/file_explorer/FileExplorer";
-import type { FileExplorerPathEntry } from "@app/components/file_explorer/types";
+import type {
+  FileEntry,
+  FileExplorerPathEntry,
+} from "@app/components/file_explorer/types";
 import { useFileDownload } from "@app/components/file_explorer/useFileDownload";
 import { withVirtualExplorerPath } from "@app/components/file_explorer/utils";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -11,11 +14,22 @@ import {
   type ConversationWithoutContentType,
   isPodConversation,
 } from "@app/types/assistant/conversation";
+import { isPresentationContentType } from "@app/types/files";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, XClose } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 
 const POD_CONVERSATION_SCOPE_ROOTS = ["conversation", "pod"] as const;
+
+type FilePanelTarget = "presentation";
+
+function getFilePanelTarget(entry: FileEntry): FilePanelTarget | null {
+  if (isPresentationContentType(entry.contentType)) {
+    return "presentation";
+  }
+  return null;
+}
 
 interface ConversationFileExplorerProps {
   conversation: ConversationWithoutContentType;
@@ -69,9 +83,20 @@ export function ConversationFileExplorer({
     [openPanel]
   );
 
-  const onOpenPresentation = useCallback(
-    (entry: { path: string }) =>
-      openPanel({ type: "file_preview", filePath: entry.path }),
+  const onOpenInPanel = useCallback(
+    (entry: FileEntry): boolean => {
+      const target = getFilePanelTarget(entry);
+      switch (target) {
+        case "presentation":
+          openPanel({ type: "file_preview", filePath: entry.path });
+          return true;
+        case null:
+          return false;
+        default:
+          assertNeverAndIgnore(target);
+          return false;
+      }
+    },
     [openPanel]
   );
 
@@ -104,7 +129,7 @@ export function ConversationFileExplorer({
           getFileUrl={getFileUrl}
           onFileDownload={onFileDownload}
           onOpenInteractive={onOpenInteractive}
-          onOpenPresentation={onOpenPresentation}
+          onOpenInPanel={onOpenInPanel}
           owner={owner}
           virtualScopeRoots={isPod ? POD_CONVERSATION_SCOPE_ROOTS : undefined}
         />

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -70,8 +70,8 @@ export function ConversationFileExplorer({
   );
 
   const onOpenPresentation = useCallback(
-    (entry: { fileId: string }) =>
-      openPanel({ type: "file_preview", fileId: entry.fileId }),
+    (entry: { path: string }) =>
+      openPanel({ type: "file_preview", filePath: entry.path }),
     [openPanel]
   );
 

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -69,6 +69,12 @@ export function ConversationFileExplorer({
     [openPanel]
   );
 
+  const onOpenPresentation = useCallback(
+    (entry: { fileId: string }) =>
+      openPanel({ type: "file_preview", fileId: entry.fileId }),
+    [openPanel]
+  );
+
   return (
     <div className="flex h-panel min-h-0 flex-col">
       <AppLayoutTitle>
@@ -98,6 +104,7 @@ export function ConversationFileExplorer({
           getFileUrl={getFileUrl}
           onFileDownload={onFileDownload}
           onOpenInteractive={onOpenInteractive}
+          onOpenPresentation={onOpenPresentation}
           owner={owner}
           virtualScopeRoots={isPod ? POD_CONVERSATION_SCOPE_ROOTS : undefined}
         />

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -14,22 +14,12 @@ import {
   type ConversationWithoutContentType,
   isPodConversation,
 } from "@app/types/assistant/conversation";
-import { isPresentationContentType } from "@app/types/files";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { opensInSidePanel } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, XClose } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 
 const POD_CONVERSATION_SCOPE_ROOTS = ["conversation", "pod"] as const;
-
-type FilePanelTarget = "presentation";
-
-function getFilePanelTarget(entry: FileEntry): FilePanelTarget | null {
-  if (isPresentationContentType(entry.contentType)) {
-    return "presentation";
-  }
-  return null;
-}
 
 interface ConversationFileExplorerProps {
   conversation: ConversationWithoutContentType;
@@ -85,17 +75,11 @@ export function ConversationFileExplorer({
 
   const onOpenInPanel = useCallback(
     (entry: FileEntry): boolean => {
-      const target = getFilePanelTarget(entry);
-      switch (target) {
-        case "presentation":
-          openPanel({ type: "file_preview", filePath: entry.path });
-          return true;
-        case null:
-          return false;
-        default:
-          assertNeverAndIgnore(target);
-          return false;
+      if (opensInSidePanel(entry.contentType)) {
+        openPanel({ type: "file_preview", filePath: entry.path });
+        return true;
       }
+      return false;
     },
     [openPanel]
   );

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -74,10 +74,11 @@ export function ConversationFilesPanel({
     }) => {
       if (isInteractiveContentType(contentType)) {
         openPanel({ type: "interactive_content", fileId });
-      } else if (isPresentationContentType(contentType)) {
+      } else if (isPresentationContentType(contentType) && filePath) {
         // Presentations (PowerPoint) open in the resizable right panel like
-        // frames, rather than the cramped file preview modal.
-        openPanel({ type: "file_preview", fileId });
+        // frames, rather than the cramped file preview modal. Preview relies on
+        // the path-based PDF conversion route, so a file path is required.
+        openPanel({ type: "file_preview", filePath });
       } else {
         openFilePreview({
           fileId,

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -14,7 +14,10 @@ import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attach
 import { downloadFile } from "@app/lib/swr/files";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import { isInteractiveContentType } from "@app/types/files";
+import {
+  isInteractiveContentType,
+  isPresentationContentType,
+} from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -71,6 +74,10 @@ export function ConversationFilesPanel({
     }) => {
       if (isInteractiveContentType(contentType)) {
         openPanel({ type: "interactive_content", fileId });
+      } else if (isPresentationContentType(contentType)) {
+        // Presentations (PowerPoint) open in the resizable right panel like
+        // frames, rather than the cramped file preview modal.
+        openPanel({ type: "file_preview", fileId });
       } else {
         openFilePreview({
           fileId,

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -14,10 +14,7 @@ import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attach
 import { downloadFile } from "@app/lib/swr/files";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import {
-  isInteractiveContentType,
-  isPresentationContentType,
-} from "@app/types/files";
+import { isInteractiveContentType, opensInSidePanel } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -74,10 +71,10 @@ export function ConversationFilesPanel({
     }) => {
       if (isInteractiveContentType(contentType)) {
         openPanel({ type: "interactive_content", fileId });
-      } else if (isPresentationContentType(contentType) && filePath) {
-        // Presentations (PowerPoint) open in the resizable right panel like
-        // frames, rather than the cramped file preview modal. Preview relies on
-        // the path-based PDF conversion route, so a file path is required.
+      } else if (opensInSidePanel(contentType) && filePath) {
+        // Some formats (e.g. presentations) open in the resizable right panel
+        // like frames, rather than the cramped file preview modal. Preview
+        // relies on the path-based conversion route, so a file path is required.
         openPanel({ type: "file_preview", filePath });
       } else {
         openFilePreview({

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -2,6 +2,7 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
+import type { FilePreviewCategory } from "@app/components/file_explorer/utils";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
@@ -9,7 +10,7 @@ import { getFilePathDownloadUrl, getFilePathViewUrl } from "@app/lib/swr/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { contentTypeFromFileName } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Download01, Icon, RefreshCw01 } from "@dust-tt/sparkle";
+import { Button, Download01, Icon } from "@dust-tt/sparkle";
 
 interface FilePreviewPanelProps {
   conversation: ConversationWithoutContentType;
@@ -26,7 +27,7 @@ export function FilePreviewPanel({
   // bust it with the file's lastModifiedMs. SWR revalidates this list on mount
   // and window focus, so the preview refreshes after the file is touched (and
   // the reload button forces an immediate revalidation).
-  const { sandboxFiles, mutateSandboxFiles } = useConversationSandboxFiles({
+  const { sandboxFiles } = useConversationSandboxFiles({
     conversationId: conversation.sId,
     owner,
     options: { disabled: !filePath },
@@ -46,28 +47,6 @@ export function FilePreviewPanel({
   const version = sandboxFiles.find((f) => f.path === filePath)?.lastModifiedMs;
   const baseUrl = getFilePathViewUrl(owner, filePath);
 
-  const renderContent = () => {
-    // Office documents (presentations, etc.) are rendered as a server-side PDF
-    // conversion (?preview=pdf); native PDFs are rendered directly. Both are
-    // only available through the path-based file route.
-    if (category === "viewer") {
-      const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
-      return <PDFViewer key={url} url={url} />;
-    }
-    if (category === "pdf") {
-      const url = baseUrl + (version ? `?v=${version}` : "");
-      return <PDFViewer key={url} url={url} />;
-    }
-
-    return (
-      <CenteredState>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Unable to preview this file. You can download it instead.
-        </p>
-      </CenteredState>
-    );
-  };
-
   return (
     <div className="flex h-panel min-h-0 flex-col">
       <InteractiveContentHeader onClose={closePanel}>
@@ -76,13 +55,6 @@ export function FilePreviewPanel({
           <span className="line-clamp-1 text-sm font-medium">{fileName}</span>
         </div>
         <div className="ml-2 flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            icon={RefreshCw01}
-            tooltip="Reload"
-            onClick={() => void mutateSandboxFiles()}
-          />
           <Button
             variant="ghost"
             size="sm"
@@ -95,8 +67,39 @@ export function FilePreviewPanel({
         </div>
       </InteractiveContentHeader>
       <div className="min-h-0 flex-1 overflow-hidden bg-gray-50 dark:bg-gray-900">
-        {renderContent()}
+        <FilePreviewContent
+          category={category}
+          baseUrl={baseUrl}
+          version={version}
+        />
       </div>
     </div>
+  );
+}
+
+interface FilePreviewContentProps {
+  category: FilePreviewCategory;
+  baseUrl: string;
+  version: number | undefined;
+}
+
+function FilePreviewContent({
+  category,
+  baseUrl,
+  version,
+}: FilePreviewContentProps) {
+  // Office documents (presentations, etc.) are rendered as a server-side PDF
+  // conversion (?preview=pdf), available only through the path-based file route.
+  if (category === "viewer") {
+    const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
+    return <PDFViewer key={url} url={url} />;
+  }
+
+  return (
+    <CenteredState>
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        Unable to preview this file. You can download it instead.
+      </p>
+    </CenteredState>
   );
 }

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -1,6 +1,6 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
-import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import type { FilePreviewCategory } from "@app/components/file_explorer/utils";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
@@ -50,7 +50,7 @@ export function FilePreviewPanel({
 
   return (
     <div className="flex h-panel min-h-0 flex-col">
-      <InteractiveContentHeader onClose={closePanel}>
+      <ConversationSidePanelHeader onClose={closePanel}>
         <div className="flex min-w-0 items-center gap-1.5">
           <Icon visual={FileIcon} size="sm" className="shrink-0" />
           <span className="line-clamp-1 text-sm font-medium">{fileName}</span>
@@ -66,7 +66,7 @@ export function FilePreviewPanel({
             rel="noopener noreferrer"
           />
         </div>
-      </InteractiveContentHeader>
+      </ConversationSidePanelHeader>
       <div className="min-h-0 flex-1 overflow-hidden bg-gray-50 dark:bg-gray-900">
         <FilePreviewContent
           category={category}

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -95,7 +95,9 @@ function FilePreviewContent({
       // PDF conversion (?preview=pdf), available only through the path-based
       // file route.
       const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
-      return <PDFViewer key={url} url={url} />;
+      // Slides are wide/landscape; render them smaller by default since the
+      // side panel is narrower than the full-screen preview dialog.
+      return <PDFViewer key={url} url={url} initialZoomIdx={1} />;
     }
 
     case "frame":

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -1,15 +1,17 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
-import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
-import type { FilePreviewCategory } from "@app/components/file_explorer/utils";
-import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
+import {
+  FilePreviewContent,
+  useFilePreviewContent,
+} from "@app/components/file_explorer/FilePreviewContent";
+import type { FileEntry } from "@app/components/file_explorer/types";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { getFilePathDownloadUrl, getFilePathViewUrl } from "@app/lib/swr/files";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { contentTypeFromFileName } from "@app/types/files";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, Download01, Icon } from "@dust-tt/sparkle";
 
@@ -35,19 +37,55 @@ export function FilePreviewPanel({
     options: { disabled: !filePath },
   });
 
-  if (!filePath) {
+  const fileName = filePath ? (filePath.split("/").pop() ?? filePath) : "";
+  const baseUrl = filePath ? getFilePathViewUrl(owner, filePath) : null;
+
+  // Reuse the file-explorer entry when the sandbox listing has loaded so we get
+  // the real content type, fileId, and version. Before it loads (or for files
+  // missing from the listing) fall back to a minimal entry derived from the
+  // file name — Office documents have no in-browser renderer, so the content
+  // type is needed to pick the right preview strategy and icon.
+  const sandboxFile = filePath
+    ? sandboxFiles.find(
+        (f): f is FileSystemFileEntry => !f.isDirectory && f.path === filePath
+      )
+    : undefined;
+  const contentType =
+    sandboxFile?.contentType ?? contentTypeFromFileName(fileName) ?? "";
+
+  const entry: FileEntry | null = !filePath
+    ? null
+    : sandboxFile
+      ? { ...sandboxFile, kind: "file" }
+      : {
+          kind: "file",
+          isDirectory: false,
+          fileName,
+          path: filePath,
+          contentType,
+          fileId: null,
+          thumbnailUrl: null,
+          sizeBytes: 0,
+          lastModifiedMs: 0,
+        };
+
+  const {
+    category,
+    truncatedContent,
+    processedContent,
+    hasError,
+    isContentLoading,
+  } = useFilePreviewContent({
+    entry,
+    fileUrl: baseUrl,
+    enabled: !!filePath,
+  });
+
+  if (!filePath || !entry || !baseUrl) {
     return null;
   }
 
-  const fileName = filePath.split("/").pop() ?? filePath;
-  // Office documents have no in-browser renderer; the file's content type is
-  // derived from its name to pick the right preview strategy and icon.
-  const contentType = contentTypeFromFileName(fileName) ?? "";
-  const { category } = getFilePreviewConfig(contentType);
   const FileIcon = getFileTypeIcon(contentType, fileName);
-
-  const version = sandboxFiles.find((f) => f.path === filePath)?.lastModifiedMs;
-  const baseUrl = getFilePathViewUrl(owner, filePath);
 
   return (
     <div className="flex h-panel min-h-0 flex-col">
@@ -68,58 +106,27 @@ export function FilePreviewPanel({
           />
         </div>
       </ConversationSidePanelHeader>
-      <div className="min-h-0 flex-1 overflow-hidden bg-muted-background">
-        <FilePreviewContent
-          category={category}
-          baseUrl={baseUrl}
-          version={version}
-        />
+      <div className="min-h-0 flex-1 overflow-y-auto bg-muted-background p-4">
+        {hasError ? (
+          <CenteredState>
+            <p className="text-sm text-muted-foreground">
+              Unable to preview this file. You can download it instead.
+            </p>
+          </CenteredState>
+        ) : (
+          <FilePreviewContent
+            category={category}
+            entry={entry}
+            fileContent={truncatedContent}
+            fileUrl={baseUrl}
+            isContentLoading={isContentLoading}
+            isFullWidth
+            markdownContent={processedContent?.text}
+            markdownViewMode="preview"
+            processedContent={processedContent}
+          />
+        )}
       </div>
     </div>
-  );
-}
-
-interface FilePreviewContentProps {
-  category: FilePreviewCategory;
-  baseUrl: string;
-  version: number | undefined;
-}
-
-function FilePreviewContent({
-  category,
-  baseUrl,
-  version,
-}: FilePreviewContentProps) {
-  switch (category) {
-    case "viewer": {
-      // Office documents (presentations, etc.) are rendered as a server-side
-      // PDF conversion (?preview=pdf), available only through the path-based
-      // file route.
-      const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
-      // Slides are wide/landscape; render them at the panel width so they fill
-      // the narrower side panel instead of overflowing or rendering oversized.
-      return <PDFViewer key={url} url={url} isFullWidth />;
-    }
-
-    case "frame":
-    case "code":
-    case "pdf":
-    case "audio":
-    case "markdown":
-    case "delimited":
-    case "text":
-    case "image":
-      break;
-
-    default:
-      assertNeverAndIgnore(category);
-  }
-
-  return (
-    <CenteredState>
-      <p className="text-sm text-muted-foreground">
-        Unable to preview this file. You can download it instead.
-      </p>
-    </CenteredState>
   );
 }

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -4,63 +4,39 @@ import { InteractiveContentHeader } from "@app/components/assistant/conversation
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import {
-  getFileDownloadUrl,
-  getFileViewUrl,
-  useFileMetadata,
-} from "@app/lib/swr/files";
-import { stripMimeParameters } from "@app/types/files";
+import { getFilePathDownloadUrl, getFilePathViewUrl } from "@app/lib/swr/files";
+import { contentTypeFromFileName } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Download01, Icon, Spinner } from "@dust-tt/sparkle";
+import { Button, Download01, Icon } from "@dust-tt/sparkle";
 
 interface FilePreviewPanelProps {
   owner: LightWorkspaceType;
 }
 
 export function FilePreviewPanel({ owner }: FilePreviewPanelProps) {
-  const { data: fileId, closePanel } = useConversationSidePanelContext();
+  const { data: filePath, closePanel } = useConversationSidePanelContext();
 
-  const { fileMetadata, isFileMetadataLoading, isFileMetadataError } =
-    useFileMetadata({
-      fileId: fileId ?? null,
-      owner,
-    });
-
-  if (!fileId) {
+  if (!filePath) {
     return null;
   }
 
+  const fileName = filePath.split("/").pop() ?? filePath;
+  // Office documents have no in-browser renderer; the file's content type is
+  // derived from its name to pick the right preview strategy and icon.
+  const contentType = contentTypeFromFileName(fileName) ?? "";
+  const { category } = getFilePreviewConfig(contentType);
+  const fileUrl = getFilePathViewUrl(owner, filePath);
+  const FileIcon = getFileTypeIcon(contentType, fileName);
+
   const renderContent = () => {
-    if (isFileMetadataLoading) {
-      return (
-        <CenteredState>
-          <Spinner size="sm" />
-          <span>Loading file...</span>
-        </CenteredState>
-      );
-    }
-
-    if (isFileMetadataError || !fileMetadata) {
-      return (
-        <CenteredState>
-          <p className="text-warning-500">Error loading file metadata</p>
-        </CenteredState>
-      );
-    }
-
-    const mimeType = stripMimeParameters(fileMetadata.contentType);
-    const { category } = getFilePreviewConfig(mimeType);
-    const fileUrl = getFileViewUrl(owner, fileId);
-
     // Office documents (presentations, etc.) are rendered as a server-side PDF
-    // conversion; PDFs are rendered directly.
-    if (category === "viewer" || category === "pdf") {
-      const sep = fileUrl.includes("?") ? "&" : "?";
-      const viewerUrl =
-        category === "viewer"
-          ? `${fileUrl}${sep}preview=pdf&v=${fileMetadata.version}`
-          : `${fileUrl}${sep}v=${fileMetadata.version}`;
-      return <PDFViewer key={viewerUrl} url={viewerUrl} />;
+    // conversion (?preview=pdf); native PDFs are rendered directly. Both are
+    // only available through the path-based file route.
+    if (category === "viewer") {
+      return <PDFViewer key={fileUrl} url={`${fileUrl}?preview=pdf`} />;
+    }
+    if (category === "pdf") {
+      return <PDFViewer key={fileUrl} url={fileUrl} />;
     }
 
     return (
@@ -72,33 +48,23 @@ export function FilePreviewPanel({ owner }: FilePreviewPanelProps) {
     );
   };
 
-  const FileIcon = fileMetadata
-    ? getFileTypeIcon(fileMetadata.contentType, fileMetadata.fileName)
-    : null;
-
   return (
     <div className="flex h-full flex-col">
       <InteractiveContentHeader onClose={closePanel}>
         <div className="flex min-w-0 items-center gap-1.5">
-          {FileIcon && (
-            <Icon visual={FileIcon} size="sm" className="shrink-0" />
-          )}
-          <span className="line-clamp-1 text-sm font-medium">
-            {fileMetadata?.fileName ?? "File"}
-          </span>
+          <Icon visual={FileIcon} size="sm" className="shrink-0" />
+          <span className="line-clamp-1 text-sm font-medium">{fileName}</span>
         </div>
-        {fileMetadata && (
-          <Button
-            variant="ghost"
-            size="sm"
-            icon={Download01}
-            tooltip="Download"
-            href={getFileDownloadUrl(owner, fileId)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-2"
-          />
-        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={Download01}
+          tooltip="Download"
+          href={getFilePathDownloadUrl(owner, filePath)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ml-2"
+        />
       </InteractiveContentHeader>
       <div className="min-h-0 flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900">
         {renderContent()}

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -68,7 +68,7 @@ export function FilePreviewPanel({
           />
         </div>
       </ConversationSidePanelHeader>
-      <div className="min-h-0 flex-1 overflow-hidden bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-0 flex-1 overflow-hidden bg-muted-background">
         <FilePreviewContent
           category={category}
           baseUrl={baseUrl}
@@ -117,7 +117,7 @@ function FilePreviewContent({
 
   return (
     <CenteredState>
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+      <p className="text-sm text-muted-foreground">
         Unable to preview this file. You can download it instead.
       </p>
     </CenteredState>

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -95,9 +95,9 @@ function FilePreviewContent({
       // PDF conversion (?preview=pdf), available only through the path-based
       // file route.
       const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
-      // Slides are wide/landscape; render them smaller by default since the
-      // side panel is narrower than the full-screen preview dialog.
-      return <PDFViewer key={url} url={url} initialZoomIdx={1} />;
+      // Slides are wide/landscape; render them at the panel width so they fill
+      // the narrower side panel instead of overflowing or rendering oversized.
+      return <PDFViewer key={url} url={url} isFullWidth />;
     }
 
     case "frame":

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -28,7 +28,7 @@ export function FilePreviewPanel({
   // bust it with the file's lastModifiedMs. SWR revalidates this list on mount
   // and window focus, so the preview refreshes after the file is touched (and
   // the reload button forces an immediate revalidation).
-  // TODO: use E2B events when files are updated when they are live
+  // TODO: use E2B events of "files are updated", when they are merged
   const { sandboxFiles } = useConversationSandboxFiles({
     conversationId: conversation.sId,
     owner,

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -9,6 +9,7 @@ import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { getFilePathDownloadUrl, getFilePathViewUrl } from "@app/lib/swr/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { contentTypeFromFileName } from "@app/types/files";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Button, Download01, Icon } from "@dust-tt/sparkle";
 
@@ -88,11 +89,27 @@ function FilePreviewContent({
   baseUrl,
   version,
 }: FilePreviewContentProps) {
-  // Office documents (presentations, etc.) are rendered as a server-side PDF
-  // conversion (?preview=pdf), available only through the path-based file route.
-  if (category === "viewer") {
-    const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
-    return <PDFViewer key={url} url={url} />;
+  switch (category) {
+    case "viewer": {
+      // Office documents (presentations, etc.) are rendered as a server-side
+      // PDF conversion (?preview=pdf), available only through the path-based
+      // file route.
+      const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
+      return <PDFViewer key={url} url={url} />;
+    }
+
+    case "frame":
+    case "code":
+    case "pdf":
+    case "audio":
+    case "markdown":
+    case "delimited":
+    case "text":
+    case "image":
+      break;
+
+    default:
+      assertNeverAndIgnore(category);
   }
 
   return (

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -3,18 +3,34 @@ import { CenteredState } from "@app/components/assistant/conversation/interactiv
 import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
+import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { getFilePathDownloadUrl, getFilePathViewUrl } from "@app/lib/swr/files";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { contentTypeFromFileName } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Download01, Icon } from "@dust-tt/sparkle";
+import { Button, Download01, Icon, RefreshCw01 } from "@dust-tt/sparkle";
 
 interface FilePreviewPanelProps {
+  conversation: ConversationWithoutContentType;
   owner: LightWorkspaceType;
 }
 
-export function FilePreviewPanel({ owner }: FilePreviewPanelProps) {
+export function FilePreviewPanel({
+  conversation,
+  owner,
+}: FilePreviewPanelProps) {
   const { data: filePath, closePanel } = useConversationSidePanelContext();
+
+  // The conversion preview is cached (Cache-Control: max-age) per URL, so we
+  // bust it with the file's lastModifiedMs. SWR revalidates this list on mount
+  // and window focus, so the preview refreshes after the file is touched (and
+  // the reload button forces an immediate revalidation).
+  const { sandboxFiles, mutateSandboxFiles } = useConversationSandboxFiles({
+    conversationId: conversation.sId,
+    owner,
+    options: { disabled: !filePath },
+  });
 
   if (!filePath) {
     return null;
@@ -25,18 +41,22 @@ export function FilePreviewPanel({ owner }: FilePreviewPanelProps) {
   // derived from its name to pick the right preview strategy and icon.
   const contentType = contentTypeFromFileName(fileName) ?? "";
   const { category } = getFilePreviewConfig(contentType);
-  const fileUrl = getFilePathViewUrl(owner, filePath);
   const FileIcon = getFileTypeIcon(contentType, fileName);
+
+  const version = sandboxFiles.find((f) => f.path === filePath)?.lastModifiedMs;
+  const baseUrl = getFilePathViewUrl(owner, filePath);
 
   const renderContent = () => {
     // Office documents (presentations, etc.) are rendered as a server-side PDF
     // conversion (?preview=pdf); native PDFs are rendered directly. Both are
     // only available through the path-based file route.
     if (category === "viewer") {
-      return <PDFViewer key={fileUrl} url={`${fileUrl}?preview=pdf`} />;
+      const url = `${baseUrl}?preview=pdf` + (version ? `&v=${version}` : "");
+      return <PDFViewer key={url} url={url} />;
     }
     if (category === "pdf") {
-      return <PDFViewer key={fileUrl} url={fileUrl} />;
+      const url = baseUrl + (version ? `?v=${version}` : "");
+      return <PDFViewer key={url} url={url} />;
     }
 
     return (
@@ -49,24 +69,32 @@ export function FilePreviewPanel({ owner }: FilePreviewPanelProps) {
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-panel min-h-0 flex-col">
       <InteractiveContentHeader onClose={closePanel}>
         <div className="flex min-w-0 items-center gap-1.5">
           <Icon visual={FileIcon} size="sm" className="shrink-0" />
           <span className="line-clamp-1 text-sm font-medium">{fileName}</span>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          icon={Download01}
-          tooltip="Download"
-          href={getFilePathDownloadUrl(owner, filePath)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="ml-2"
-        />
+        <div className="ml-2 flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={RefreshCw01}
+            tooltip="Reload"
+            onClick={() => void mutateSandboxFiles()}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={Download01}
+            tooltip="Download"
+            href={getFilePathDownloadUrl(owner, filePath)}
+            target="_blank"
+            rel="noopener noreferrer"
+          />
+        </div>
       </InteractiveContentHeader>
-      <div className="min-h-0 flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+      <div className="min-h-0 flex-1 overflow-hidden bg-gray-50 dark:bg-gray-900">
         {renderContent()}
       </div>
     </div>

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -28,6 +28,7 @@ export function FilePreviewPanel({
   // bust it with the file's lastModifiedMs. SWR revalidates this list on mount
   // and window focus, so the preview refreshes after the file is touched (and
   // the reload button forces an immediate revalidation).
+  // TODO: use E2B events when files are updated when they are live
   const { sandboxFiles } = useConversationSandboxFiles({
     conversationId: conversation.sId,
     owner,

--- a/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/FilePreviewPanel.tsx
@@ -1,0 +1,108 @@
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
+import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
+import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
+import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import {
+  getFileDownloadUrl,
+  getFileViewUrl,
+  useFileMetadata,
+} from "@app/lib/swr/files";
+import { stripMimeParameters } from "@app/types/files";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, Download01, Icon, Spinner } from "@dust-tt/sparkle";
+
+interface FilePreviewPanelProps {
+  owner: LightWorkspaceType;
+}
+
+export function FilePreviewPanel({ owner }: FilePreviewPanelProps) {
+  const { data: fileId, closePanel } = useConversationSidePanelContext();
+
+  const { fileMetadata, isFileMetadataLoading, isFileMetadataError } =
+    useFileMetadata({
+      fileId: fileId ?? null,
+      owner,
+    });
+
+  if (!fileId) {
+    return null;
+  }
+
+  const renderContent = () => {
+    if (isFileMetadataLoading) {
+      return (
+        <CenteredState>
+          <Spinner size="sm" />
+          <span>Loading file...</span>
+        </CenteredState>
+      );
+    }
+
+    if (isFileMetadataError || !fileMetadata) {
+      return (
+        <CenteredState>
+          <p className="text-warning-500">Error loading file metadata</p>
+        </CenteredState>
+      );
+    }
+
+    const mimeType = stripMimeParameters(fileMetadata.contentType);
+    const { category } = getFilePreviewConfig(mimeType);
+    const fileUrl = getFileViewUrl(owner, fileId);
+
+    // Office documents (presentations, etc.) are rendered as a server-side PDF
+    // conversion; PDFs are rendered directly.
+    if (category === "viewer" || category === "pdf") {
+      const sep = fileUrl.includes("?") ? "&" : "?";
+      const viewerUrl =
+        category === "viewer"
+          ? `${fileUrl}${sep}preview=pdf&v=${fileMetadata.version}`
+          : `${fileUrl}${sep}v=${fileMetadata.version}`;
+      return <PDFViewer key={viewerUrl} url={viewerUrl} />;
+    }
+
+    return (
+      <CenteredState>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Unable to preview this file. You can download it instead.
+        </p>
+      </CenteredState>
+    );
+  };
+
+  const FileIcon = fileMetadata
+    ? getFileTypeIcon(fileMetadata.contentType, fileMetadata.fileName)
+    : null;
+
+  return (
+    <div className="flex h-full flex-col">
+      <InteractiveContentHeader onClose={closePanel}>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {FileIcon && (
+            <Icon visual={FileIcon} size="sm" className="shrink-0" />
+          )}
+          <span className="line-clamp-1 text-sm font-medium">
+            {fileMetadata?.fileName ?? "File"}
+          </span>
+        </div>
+        {fileMetadata && (
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={Download01}
+            tooltip="Download"
+            href={getFileDownloadUrl(owner, fileId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-2"
+          />
+        )}
+      </InteractiveContentHeader>
+      <div className="min-h-0 flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+        {renderContent()}
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -1,10 +1,10 @@
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
-import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { ConfirmContext } from "@app/components/Confirm";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { PinPodBannerButton } from "@app/components/pod/files/PinPodBannerButton";
@@ -350,7 +350,7 @@ export function FrameRenderer({
   if (error) {
     return (
       <div className="flex h-panel flex-col">
-        <InteractiveContentHeader onClose={onClosePanel} />
+        <ConversationSidePanelHeader onClose={onClosePanel} />
         <CenteredState>
           <p className="text-warning-500">
             Error loading file: {error.message}
@@ -362,7 +362,7 @@ export function FrameRenderer({
 
   return (
     <div className="flex h-panel flex-col">
-      <InteractiveContentHeader onClose={onClosePanel}>
+      <ConversationSidePanelHeader onClose={onClosePanel}>
         <div className="flex w-full items-center justify-between">
           <Button
             icon={showCode ? Eye : Terminal}
@@ -416,7 +416,7 @@ export function FrameRenderer({
             )}
           </div>
         </div>
-      </InteractiveContentHeader>
+      </ConversationSidePanelHeader>
 
       <div className="flex-1 overflow-hidden">
         {isLoading ? (

--- a/front/components/assistant/conversation/interactive_content/InteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/interactive_content/InteractiveContentContainer.tsx
@@ -1,7 +1,7 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { FrameRenderer } from "@app/components/assistant/conversation/interactive_content/FrameRenderer";
-import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/interactive_content/UnsupportedContentRenderer";
 import { useFileMetadata } from "@app/lib/swr/files";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -44,7 +44,7 @@ export function InteractiveContentContainer({
     if (isFileMetadataLoading) {
       return (
         <div className="flex h-full flex-col">
-          <InteractiveContentHeader onClose={closePanel} />
+          <ConversationSidePanelHeader onClose={closePanel} />
           <CenteredState>
             <Spinner size="sm" />
             <span>Loading frame...</span>
@@ -56,7 +56,7 @@ export function InteractiveContentContainer({
     if (isFileMetadataError || !fileMetadata) {
       return (
         <div className="flex h-full flex-col">
-          <InteractiveContentHeader onClose={closePanel} />
+          <ConversationSidePanelHeader onClose={closePanel} />
           <CenteredState>
             <p className="text-warning-500">Error loading file metadata</p>
           </CenteredState>

--- a/front/components/assistant/conversation/interactive_content/UnsupportedContentRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/UnsupportedContentRenderer.tsx
@@ -1,6 +1,6 @@
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
-import { InteractiveContentHeader } from "@app/components/assistant/conversation/interactive_content/InteractiveContentHeader";
 import { AlertCircle, ContentMessage } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React from "react";
@@ -18,7 +18,7 @@ export function UnsupportedContentRenderer({
 
   return (
     <div className="flex h-full flex-col">
-      <InteractiveContentHeader onClose={closePanel} />
+      <ConversationSidePanelHeader onClose={closePanel} />
 
       <div className="flex-1 overflow-hidden">
         <CenteredState>

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -26,7 +26,6 @@ import {
   getScopedRelativePath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import {
   isInteractiveContentType,
   isPresentationContentType,

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -26,7 +26,11 @@ import {
   getScopedRelativePath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import { isInteractiveContentType } from "@app/types/files";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import {
+  isInteractiveContentType,
+  isPresentationContentType,
+} from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { cn, Edit04, FolderOpen, Trash01 } from "@dust-tt/sparkle";
@@ -52,6 +56,7 @@ interface FileExplorerProps {
     parentRelativePath: string
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
+  onOpenPresentation?: (entry: FileEntryWithId) => void;
   onRename?: (entry: FileEntry | FolderEntry) => void;
   owner?: LightWorkspaceType;
   getExtraFileMenuItems?: (
@@ -77,6 +82,7 @@ export function FileExplorer({
   onFileDownload,
   onMoveFile,
   onOpenInteractive,
+  onOpenPresentation,
   onRename,
   owner,
   getExtraFileMenuItems,
@@ -244,6 +250,14 @@ export function FileExplorer({
       entry.fileId
     ) {
       onOpenInteractive({ ...entry, fileId: entry.fileId });
+      return;
+    }
+    if (
+      onOpenPresentation &&
+      isPresentationContentType(entry.contentType) &&
+      entry.fileId
+    ) {
+      onOpenPresentation({ ...entry, fileId: entry.fileId });
       return;
     }
     setPreviewFile(entry);

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -26,10 +26,7 @@ import {
   getScopedRelativePath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import {
-  isInteractiveContentType,
-  isPresentationContentType,
-} from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { cn, Edit04, FolderOpen, Trash01 } from "@dust-tt/sparkle";
@@ -55,7 +52,7 @@ interface FileExplorerProps {
     parentRelativePath: string
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
-  onOpenPresentation?: (entry: FileEntry) => void;
+  onOpenInPanel?: (entry: FileEntry) => boolean;
   onRename?: (entry: FileEntry | FolderEntry) => void;
   owner?: LightWorkspaceType;
   getExtraFileMenuItems?: (
@@ -81,7 +78,7 @@ export function FileExplorer({
   onFileDownload,
   onMoveFile,
   onOpenInteractive,
-  onOpenPresentation,
+  onOpenInPanel,
   onRename,
   owner,
   getExtraFileMenuItems,
@@ -251,8 +248,7 @@ export function FileExplorer({
       onOpenInteractive({ ...entry, fileId: entry.fileId });
       return;
     }
-    if (onOpenPresentation && isPresentationContentType(entry.contentType)) {
-      onOpenPresentation(entry);
+    if (onOpenInPanel?.(entry)) {
       return;
     }
     setPreviewFile(entry);

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -56,7 +56,7 @@ interface FileExplorerProps {
     parentRelativePath: string
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
-  onOpenPresentation?: (entry: FileEntryWithId) => void;
+  onOpenPresentation?: (entry: FileEntry) => void;
   onRename?: (entry: FileEntry | FolderEntry) => void;
   owner?: LightWorkspaceType;
   getExtraFileMenuItems?: (
@@ -252,12 +252,8 @@ export function FileExplorer({
       onOpenInteractive({ ...entry, fileId: entry.fileId });
       return;
     }
-    if (
-      onOpenPresentation &&
-      isPresentationContentType(entry.contentType) &&
-      entry.fileId
-    ) {
-      onOpenPresentation({ ...entry, fileId: entry.fileId });
+    if (onOpenPresentation && isPresentationContentType(entry.contentType)) {
+      onOpenPresentation(entry);
       return;
     }
     setPreviewFile(entry);

--- a/front/components/file_explorer/FilePreviewContent.tsx
+++ b/front/components/file_explorer/FilePreviewContent.tsx
@@ -1,0 +1,385 @@
+import {
+  MarkdownFilePreview,
+  type MarkdownFilePreviewViewMode,
+} from "@app/components/file_explorer/MarkdownFilePreview";
+import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
+import type { FileEntry } from "@app/components/file_explorer/types";
+import type { FilePreviewCategory } from "@app/components/file_explorer/utils";
+import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
+import type { ProcessedContent } from "@app/lib/file_content_utils";
+import { processFileContent } from "@app/lib/file_content_utils";
+import { useFileContentByUrl } from "@app/lib/swr/files";
+import { stripMimeParameters } from "@app/types/files";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  CodeBlock,
+  cn,
+  DataTable,
+  Markdown,
+  ScrollableDataTable,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+
+export const MAX_CSV_ROWS = 200;
+export const MAX_TEXT_CHARS = 100_000;
+
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  py: "python",
+  js: "javascript",
+  jsx: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  json: "json",
+  sh: "bash",
+  bash: "bash",
+  html: "html",
+  css: "css",
+  sql: "sql",
+  yaml: "yaml",
+  yml: "yaml",
+  rs: "rust",
+  go: "go",
+  rb: "ruby",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  cpp: "cpp",
+  c: "c",
+  cs: "csharp",
+  php: "php",
+  r: "r",
+  md: "markdown",
+  xml: "xml",
+  toml: "toml",
+};
+
+function getCodeLanguage(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+
+  return EXTENSION_TO_LANGUAGE[ext] ?? "text";
+}
+
+export function getDelimitedRecordCount({
+  content,
+}: {
+  content: string;
+}): { displayed: number; total: number } | null {
+  const lines = content.split("\n").filter((l) => l.trim());
+  if (lines.length < 2) {
+    return null;
+  }
+
+  const [, ...dataLines] = lines;
+  const total = dataLines.length;
+
+  return { displayed: Math.min(total, MAX_CSV_ROWS), total };
+}
+
+interface DelimitedPreviewProps {
+  content: string;
+  mimeType: string;
+}
+
+type Row = Record<string, string>;
+
+function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
+  const isTsv =
+    mimeType === "text/tsv" || mimeType === "text/tab-separated-values";
+
+  const delimiter = isTsv ? "\t" : ",";
+  const lines = content.split("\n").filter((l) => l.trim());
+
+  if (lines.length < 2) {
+    return (
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        No data to preview.
+      </p>
+    );
+  }
+
+  const [headerLine, ...dataLines] = lines;
+  const headers = headerLine!
+    .split(delimiter)
+    .map((c) => c.trim().replace(/^"|"$/g, ""));
+  const allRows = dataLines.map((line) =>
+    line.split(delimiter).map((c) => c.trim().replace(/^"|"$/g, ""))
+  );
+  const displayed = allRows.slice(0, MAX_CSV_ROWS);
+
+  const baseRatio = Math.floor(100 / headers.length);
+  const columns: ColumnDef<Row>[] = headers.map((header, idx) => ({
+    id: header,
+    accessorFn: (row: Row) => row[header] ?? "",
+    header,
+    cell: (info: CellContext<Row, unknown>) => (
+      <DataTable.BasicCellContent label={String(info.getValue() ?? "")} />
+    ),
+    meta: {
+      // Last column absorbs rounding remainder so ratios always sum to 100.
+      sizeRatio:
+        idx < headers.length - 1
+          ? baseRatio
+          : 100 - baseRatio * (headers.length - 1),
+    },
+  }));
+
+  const data: Row[] = displayed.map((row) =>
+    Object.fromEntries(headers.map((h, i) => [h, row[i] ?? ""]))
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <ScrollableDataTable data={data} columns={columns} maxHeight={true} />
+    </div>
+  );
+}
+
+interface AudioPreviewProps {
+  fileUrl: string;
+  fileId: string | null;
+}
+
+function AudioPreview({ fileUrl, fileId }: AudioPreviewProps) {
+  const sep = fileUrl.includes("?") ? "&" : "?";
+  const transcriptUrl = fileId ? `${fileUrl}${sep}version=processed` : null;
+  const { fileContent: transcript } = useFileContentByUrl({
+    url: transcriptUrl,
+    disabled: !transcriptUrl,
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <audio controls className="w-full" src={fileUrl}>
+        Your browser does not support the audio element.
+      </audio>
+      {transcript ? (
+        <div className="flex flex-col gap-2">
+          <h4 className="text-sm font-semibold text-muted-foreground dark:text-muted-foreground-night">
+            Transcript
+          </h4>
+          <Markdown content={transcript} isStreaming={false} />
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No transcript available.
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface UseFilePreviewContentParams {
+  entry: FileEntry | null;
+  fileUrl: string | null;
+  // Visibility flag: the text content fetch is skipped while the preview is
+  // hidden (closed dialog, no file selected in the panel).
+  enabled: boolean;
+}
+
+export interface FilePreviewContentData {
+  category: FilePreviewCategory;
+  mimeType: string;
+  truncatedContent: string | null;
+  processedContent: ProcessedContent | null;
+  recordCounts: { displayed: number; total: number } | null;
+  hasError: boolean;
+  isContentLoading: boolean;
+}
+
+/**
+ * Shared data-fetching/processing for file previews, used by both the
+ * FilePreviewDialog (modal) and the FilePreviewPanel (conversation side panel).
+ * It fetches text content when the file category requires it and derives the
+ * processed/markdown/record-count views.
+ */
+export function useFilePreviewContent({
+  entry,
+  fileUrl,
+  enabled,
+}: UseFilePreviewContentParams): FilePreviewContentData {
+  const mimeType = stripMimeParameters(entry?.contentType ?? "");
+  const { category } = getFilePreviewConfig(mimeType);
+
+  const needsTextContent =
+    category === "code" ||
+    category === "markdown" ||
+    category === "text" ||
+    category === "delimited";
+
+  const { fileContent, isNotFound, isFileContentLoading, fileContentError } =
+    useFileContentByUrl({
+      url: fileUrl,
+      disabled: !enabled || !entry || !needsTextContent,
+    });
+
+  const hasError = needsTextContent && (!!fileContentError || isNotFound);
+  const isContentLoading =
+    enabled && !!entry && !hasError && needsTextContent && isFileContentLoading;
+
+  const truncatedContent = fileContent?.slice(0, MAX_TEXT_CHARS) ?? null;
+
+  const processedContent =
+    (category === "markdown" || category === "text") && truncatedContent
+      ? processFileContent(truncatedContent, mimeType)
+      : null;
+
+  const recordCounts =
+    category === "delimited" && truncatedContent
+      ? getDelimitedRecordCount({ content: truncatedContent })
+      : null;
+
+  return {
+    category,
+    mimeType,
+    truncatedContent,
+    processedContent,
+    recordCounts,
+    hasError,
+    isContentLoading,
+  };
+}
+
+interface FilePreviewContentProps {
+  category: FilePreviewCategory;
+  entry: FileEntry;
+  fileContent: string | null;
+  fileUrl: string;
+  isContentLoading: boolean;
+  // Render PDF/viewer previews at container width (used by the narrow side
+  // panel so slides/PDFs fill the available space).
+  isFullWidth?: boolean;
+  markdownCanEdit?: boolean;
+  markdownContent?: string;
+  markdownViewMode?: MarkdownFilePreviewViewMode;
+  onMarkdownContentChange?: (content: string) => void;
+  onMarkdownViewModeChange?: (mode: MarkdownFilePreviewViewMode) => void;
+  processedContent: ProcessedContent | null;
+}
+
+export function FilePreviewContent({
+  category,
+  entry,
+  fileContent,
+  fileUrl,
+  isContentLoading,
+  isFullWidth = false,
+  markdownCanEdit,
+  markdownContent,
+  markdownViewMode,
+  onMarkdownContentChange,
+  onMarkdownViewModeChange,
+  processedContent,
+}: FilePreviewContentProps) {
+  if (isContentLoading) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center",
+          category === "markdown" ? "min-h-0 flex-1" : "h-48"
+        )}
+      >
+        <Spinner />
+      </div>
+    );
+  }
+
+  switch (category) {
+    case "frame":
+      return null;
+
+    case "image":
+      return (
+        <img
+          src={entry.thumbnailUrl ?? fileUrl}
+          alt={entry.fileName}
+          className="w-full rounded-lg object-contain"
+        />
+      );
+
+    case "pdf": {
+      const sep = fileUrl.includes("?") ? "&" : "?";
+      const pdfUrl = entry.lastModifiedMs
+        ? `${fileUrl}${sep}v=${entry.lastModifiedMs}`
+        : fileUrl;
+      return <PDFViewer key={fileUrl} url={pdfUrl} isFullWidth={isFullWidth} />;
+    }
+
+    case "viewer": {
+      const sep = fileUrl.includes("?") ? "&" : "?";
+      const viewerUrl = entry.lastModifiedMs
+        ? `${fileUrl}${sep}preview=pdf&v=${entry.lastModifiedMs}`
+        : `${fileUrl}${sep}preview=pdf`;
+      return (
+        <PDFViewer key={fileUrl} url={viewerUrl} isFullWidth={isFullWidth} />
+      );
+    }
+
+    case "audio":
+      return <AudioPreview fileUrl={fileUrl} fileId={entry.fileId} />;
+
+    case "delimited":
+      if (fileContent) {
+        return (
+          <DelimitedPreview
+            content={fileContent.slice(0, MAX_TEXT_CHARS)}
+            mimeType={stripMimeParameters(entry.contentType)}
+          />
+        );
+      }
+      return null;
+
+    case "text":
+      if (processedContent) {
+        return (
+          <div className="rounded-lg bg-muted-background p-4 dark:bg-muted-background-night">
+            <Markdown content={processedContent.text} isStreaming={false} />
+          </div>
+        );
+      }
+      return null;
+
+    case "markdown":
+      if (
+        processedContent &&
+        markdownContent !== undefined &&
+        markdownViewMode
+      ) {
+        return (
+          <MarkdownFilePreview
+            content={markdownContent}
+            canEdit={markdownCanEdit}
+            showToolbar={false}
+            viewMode={markdownViewMode}
+            onContentChange={onMarkdownContentChange}
+            onViewModeChange={onMarkdownViewModeChange}
+          />
+        );
+      }
+      return null;
+
+    case "code": {
+      const lang = getCodeLanguage(entry.fileName);
+      const raw = fileContent?.slice(0, MAX_TEXT_CHARS) ?? "";
+      let displayContent = raw;
+      if (lang === "json") {
+        try {
+          displayContent = JSON.stringify(JSON.parse(raw), null, 2);
+        } catch {
+          // keep raw if not valid JSON
+        }
+      }
+      return (
+        <div className="rounded-lg bg-muted-background dark:bg-muted-background-night">
+          <CodeBlock className={`language-${lang}`} wrapLongLines={true}>
+            {displayContent}
+          </CodeBlock>
+        </div>
+      );
+    }
+
+    default:
+      assertNeverAndIgnore(category);
+      return null;
+  }
+}

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,30 +1,23 @@
 import {
-  MarkdownFilePreview,
+  FilePreviewContent,
+  MAX_CSV_ROWS,
+  useFilePreviewContent,
+} from "@app/components/file_explorer/FilePreviewContent";
+import {
   type MarkdownFilePreviewViewMode,
   MarkdownFilePreviewViewModeSwitch,
 } from "@app/components/file_explorer/MarkdownFilePreview";
-import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import type { FileEntry } from "@app/components/file_explorer/types";
-import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { parseCanonicalScopedPath } from "@app/lib/api/files/mount_path";
-import type { ProcessedContent } from "@app/lib/file_content_utils";
-import { processFileContent } from "@app/lib/file_content_utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import {
-  useFileContentByUrl,
-  writeFileContentByPath,
-} from "@app/lib/swr/files";
-import { stripMimeParameters } from "@app/types/files";
-import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { writeFileContentByPath } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   ChevronLeft,
   ChevronRight,
-  CodeBlock,
   cn,
-  DataTable,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -32,294 +25,9 @@ import {
   DialogTitle,
   Download01,
   Icon,
-  Markdown,
-  ScrollableDataTable,
-  Spinner,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
-
-const MAX_CSV_ROWS = 200;
-const MAX_TEXT_CHARS = 100_000;
-
-const EXTENSION_TO_LANGUAGE: Record<string, string> = {
-  py: "python",
-  js: "javascript",
-  jsx: "javascript",
-  ts: "typescript",
-  tsx: "typescript",
-  json: "json",
-  sh: "bash",
-  bash: "bash",
-  html: "html",
-  css: "css",
-  sql: "sql",
-  yaml: "yaml",
-  yml: "yaml",
-  rs: "rust",
-  go: "go",
-  rb: "ruby",
-  java: "java",
-  kt: "kotlin",
-  swift: "swift",
-  cpp: "cpp",
-  c: "c",
-  cs: "csharp",
-  php: "php",
-  r: "r",
-  md: "markdown",
-  xml: "xml",
-  toml: "toml",
-};
-
-function getCodeLanguage(fileName: string): string {
-  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-
-  return EXTENSION_TO_LANGUAGE[ext] ?? "text";
-}
-
-function getDelimitedRecordCount({
-  content,
-}: {
-  content: string;
-}): { displayed: number; total: number } | null {
-  const lines = content.split("\n").filter((l) => l.trim());
-  if (lines.length < 2) {
-    return null;
-  }
-
-  const [, ...dataLines] = lines;
-  const total = dataLines.length;
-
-  return { displayed: Math.min(total, MAX_CSV_ROWS), total };
-}
-
-interface DelimitedPreviewProps {
-  content: string;
-  mimeType: string;
-}
-
-type Row = Record<string, string>;
-
-function DelimitedPreview({ content, mimeType }: DelimitedPreviewProps) {
-  const isTsv =
-    mimeType === "text/tsv" || mimeType === "text/tab-separated-values";
-
-  const delimiter = isTsv ? "\t" : ",";
-  const lines = content.split("\n").filter((l) => l.trim());
-
-  if (lines.length < 2) {
-    return <p className="text-sm text-muted-foreground">No data to preview.</p>;
-  }
-
-  const [headerLine, ...dataLines] = lines;
-  const headers = headerLine!
-    .split(delimiter)
-    .map((c) => c.trim().replace(/^"|"$/g, ""));
-  const allRows = dataLines.map((line) =>
-    line.split(delimiter).map((c) => c.trim().replace(/^"|"$/g, ""))
-  );
-  const displayed = allRows.slice(0, MAX_CSV_ROWS);
-
-  const baseRatio = Math.floor(100 / headers.length);
-  const columns: ColumnDef<Row>[] = headers.map((header, idx) => ({
-    id: header,
-    accessorFn: (row: Row) => row[header] ?? "",
-    header,
-    cell: (info: CellContext<Row, unknown>) => (
-      <DataTable.BasicCellContent label={String(info.getValue() ?? "")} />
-    ),
-    meta: {
-      // Last column absorbs rounding remainder so ratios always sum to 100.
-      sizeRatio:
-        idx < headers.length - 1
-          ? baseRatio
-          : 100 - baseRatio * (headers.length - 1),
-    },
-  }));
-
-  const data: Row[] = displayed.map((row) =>
-    Object.fromEntries(headers.map((h, i) => [h, row[i] ?? ""]))
-  );
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <ScrollableDataTable data={data} columns={columns} maxHeight={true} />
-    </div>
-  );
-}
-
-interface AudioPreviewProps {
-  fileUrl: string;
-  fileId: string | null;
-}
-
-function AudioPreview({ fileUrl, fileId }: AudioPreviewProps) {
-  const transcriptUrl = fileId ? `${fileUrl}&version=processed` : null;
-  const { fileContent: transcript } = useFileContentByUrl({
-    url: transcriptUrl,
-    disabled: !transcriptUrl,
-  });
-
-  return (
-    <div className="flex flex-col gap-4">
-      <audio controls className="w-full" src={fileUrl}>
-        Your browser does not support the audio element.
-      </audio>
-      {transcript ? (
-        <div className="flex flex-col gap-2">
-          <h4 className="text-sm font-semibold text-muted-foreground">
-            Transcript
-          </h4>
-          <Markdown content={transcript} isStreaming={false} />
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">
-          No transcript available.
-        </p>
-      )}
-    </div>
-  );
-}
-
-interface FilePreviewDialogContentProps {
-  category: ReturnType<typeof getFilePreviewConfig>["category"];
-  entry: FileEntry;
-  fileContent: string | null;
-  fileUrl: string;
-  isContentLoading: boolean;
-  markdownCanEdit?: boolean;
-  markdownContent?: string;
-  markdownViewMode?: MarkdownFilePreviewViewMode;
-  onMarkdownContentChange?: (content: string) => void;
-  onMarkdownViewModeChange?: (mode: MarkdownFilePreviewViewMode) => void;
-  processedContent: ProcessedContent | null;
-}
-
-function FilePreviewDialogContent({
-  category,
-  entry,
-  fileContent,
-  fileUrl,
-  isContentLoading,
-  markdownCanEdit,
-  markdownContent,
-  markdownViewMode,
-  onMarkdownContentChange,
-  onMarkdownViewModeChange,
-  processedContent,
-}: FilePreviewDialogContentProps) {
-  if (isContentLoading) {
-    return (
-      <div
-        className={cn(
-          "flex items-center justify-center",
-          category === "markdown" ? "min-h-0 flex-1" : "h-48"
-        )}
-      >
-        <Spinner />
-      </div>
-    );
-  }
-
-  switch (category) {
-    case "frame":
-      return null;
-
-    case "image":
-      return (
-        <img
-          src={entry.thumbnailUrl ?? fileUrl}
-          alt={entry.fileName}
-          className="w-full rounded-lg object-contain"
-        />
-      );
-
-    case "pdf": {
-      const sep = fileUrl.includes("?") ? "&" : "?";
-      const pdfUrl = entry.lastModifiedMs
-        ? `${fileUrl}${sep}v=${entry.lastModifiedMs}`
-        : fileUrl;
-      return <PDFViewer key={fileUrl} url={pdfUrl} />;
-    }
-
-    case "viewer": {
-      const sep = fileUrl.includes("?") ? "&" : "?";
-      const viewerUrl = entry.lastModifiedMs
-        ? `${fileUrl}${sep}preview=pdf&v=${entry.lastModifiedMs}`
-        : `${fileUrl}${sep}preview=pdf`;
-      return <PDFViewer key={fileUrl} url={viewerUrl} />;
-    }
-
-    case "audio":
-      return <AudioPreview fileUrl={fileUrl} fileId={entry.fileId} />;
-
-    case "delimited":
-      if (fileContent) {
-        return (
-          <DelimitedPreview
-            content={fileContent.slice(0, MAX_TEXT_CHARS)}
-            mimeType={stripMimeParameters(entry.contentType)}
-          />
-        );
-      }
-      return null;
-
-    case "text":
-      if (processedContent) {
-        return (
-          <div className="rounded-lg bg-muted-background p-4">
-            <Markdown content={processedContent.text} isStreaming={false} />
-          </div>
-        );
-      }
-      return null;
-
-    case "markdown":
-      if (
-        processedContent &&
-        markdownContent !== undefined &&
-        markdownViewMode
-      ) {
-        return (
-          <MarkdownFilePreview
-            content={markdownContent}
-            canEdit={markdownCanEdit}
-            showToolbar={false}
-            viewMode={markdownViewMode}
-            onContentChange={onMarkdownContentChange}
-            onViewModeChange={onMarkdownViewModeChange}
-          />
-        );
-      }
-      return null;
-
-    case "code": {
-      const lang = getCodeLanguage(entry.fileName);
-      const raw = fileContent?.slice(0, MAX_TEXT_CHARS) ?? "";
-      let displayContent = raw;
-      if (lang === "json") {
-        try {
-          displayContent = JSON.stringify(JSON.parse(raw), null, 2);
-        } catch {
-          // keep raw if not valid JSON
-        }
-      }
-      return (
-        <div className="rounded-lg bg-muted-background">
-          <CodeBlock className={`language-${lang}`} wrapLongLines={true}>
-            {displayContent}
-          </CodeBlock>
-        </div>
-      );
-    }
-
-    default:
-      assertNeverAndIgnore(category);
-      return null;
-  }
-}
 
 interface FilePreviewDialogProps {
   entry: FileEntry | null;
@@ -397,40 +105,18 @@ export function FilePreviewDialog({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onPrev, onNext]);
 
-  const mimeType = stripMimeParameters(entry?.contentType ?? "");
-  const { category } = getFilePreviewConfig(mimeType);
-
-  const needsTextContent =
-    category === "code" ||
-    category === "markdown" ||
-    category === "text" ||
-    category === "delimited";
-
-  const { fileContent, isNotFound, isFileContentLoading, fileContentError } =
-    useFileContentByUrl({
-      url: fileUrl,
-      disabled: !isOpen || !entry || !needsTextContent,
-    });
-
-  const hasError = needsTextContent && (!!fileContentError || isNotFound);
-  const isContentLoading =
-    isOpen && !!entry && !hasError && needsTextContent && isFileContentLoading;
-
-  const truncatedContent = fileContent?.slice(0, MAX_TEXT_CHARS) ?? null;
-
-  const processedContent =
-    (category === "markdown" || category === "text") && truncatedContent
-      ? processFileContent(truncatedContent, mimeType)
-      : null;
+  const {
+    category,
+    truncatedContent,
+    processedContent,
+    recordCounts,
+    hasError,
+    isContentLoading,
+  } = useFilePreviewContent({ entry, fileUrl, enabled: isOpen });
 
   const FileIcon = entry
     ? getFileTypeIcon(entry.contentType, entry.fileName)
     : null;
-
-  const recordCounts =
-    category === "delimited" && truncatedContent
-      ? getDelimitedRecordCount({ content: truncatedContent })
-      : null;
 
   const editableMarkdownFilePath =
     entry && owner && parseCanonicalScopedPath(entry.path) ? entry.path : null;
@@ -580,7 +266,7 @@ export function FilePreviewDialog({
         ) : category === "delimited" ? (
           <div className="flex min-h-0 flex-1 flex-col px-4">
             {entry && (
-              <FilePreviewDialogContent
+              <FilePreviewContent
                 category={category}
                 entry={entry}
                 fileContent={truncatedContent}
@@ -617,7 +303,7 @@ export function FilePreviewDialog({
             )}
           >
             {entry && (
-              <FilePreviewDialogContent
+              <FilePreviewContent
                 category={category}
                 entry={entry}
                 fileContent={truncatedContent}

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -11,8 +11,8 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   import.meta.url
 ).toString();
 
-const ZOOM_LEVELS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
-const DEFAULT_ZOOM_IDX = 2;
+const ZOOM_LEVELS = [0.5, 0.66, 0.75, 1.0, 1.25, 1.5, 2.0];
+const DEFAULT_ZOOM_IDX = 3;
 const BASE_PAGE_WIDTH = 680;
 
 type State = {
@@ -33,14 +33,16 @@ type Action =
   | { type: "zoom_in" }
   | { type: "zoom_out" };
 
-const initialState: State = {
-  currentPage: 1,
-  hasError: false,
-  isFetching: true,
-  numPages: null,
-  objectUrl: null,
-  zoomIdx: DEFAULT_ZOOM_IDX,
-};
+function makeInitialState(zoomIdx: number): State {
+  return {
+    currentPage: 1,
+    hasError: false,
+    isFetching: true,
+    numPages: null,
+    objectUrl: null,
+    zoomIdx,
+  };
+}
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -76,11 +78,22 @@ function reducer(state: State, action: Action): State {
 
 interface PDFViewerProps {
   url: string;
+  // Initial zoom level index into ZOOM_LEVELS. Defaults to DEFAULT_ZOOM_IDX
+  // (100%). Callers with a narrower container (e.g. the side panel previewing
+  // wide slides) can pass a smaller index so pages don't render oversized.
+  initialZoomIdx?: number;
 }
 
-export function PDFViewer({ url }: PDFViewerProps) {
+export function PDFViewer({
+  url,
+  initialZoomIdx = DEFAULT_ZOOM_IDX,
+}: PDFViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const [state, dispatch] = useReducer(
+    reducer,
+    initialZoomIdx,
+    makeInitialState
+  );
   const { isFetching, hasError, objectUrl, numPages, currentPage, zoomIdx } =
     state;
 

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -1,7 +1,7 @@
 import { clientFetch } from "@app/lib/egress/client";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { Button, Spinner } from "@dust-tt/sparkle";
-import { useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -83,7 +83,9 @@ interface PDFViewerProps {
 }
 
 export function PDFViewer({ url, isFullWidth = false }: PDFViewerProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const resizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [containerWidth, setContainerWidth] = useState<number | null>(null);
   const [state, dispatch] = useReducer(reducer, initialState);
   const { isFetching, hasError, objectUrl, numPages, currentPage, zoomIdx } =
@@ -157,42 +159,57 @@ export function PDFViewer({ url, isFullWidth = false }: PDFViewerProps) {
     return () => observer.disconnect();
   }, [numPages]);
 
-  useEffect(() => {
-    // The scroll container only mounts once the fetch resolves, so re-run when
-    // those flags flip to pick up the now-available ref.
-    if (!isFullWidth || isFetching || hasError) {
-      return;
-    }
-    const container = scrollRef.current;
-    if (!container) {
-      return;
-    }
+  // Callback ref on the scroll container: keeps `scrollRef` in sync for the
+  // IntersectionObserver above and, when rendering full width, measures the
+  // container via a ResizeObserver. Measuring here (in response to the element
+  // mounting/resizing) instead of in an effect keyed on props avoids adjusting
+  // state on prop changes (react-doctor/no-adjust-state-on-prop-change).
+  const setScrollNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      scrollRef.current = node;
 
-    setContainerWidth(container.clientWidth);
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+      if (resizeDebounceRef.current) {
+        clearTimeout(resizeDebounceRef.current);
+        resizeDebounceRef.current = null;
+      }
 
-    // Re-rasterizing the PDF canvas on every resize tick flickers, so debounce
-    // and only commit the new width once the resize settles.
-    let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries.at(0);
-      if (!entry) {
+      if (!node || !isFullWidth) {
         return;
       }
-      const { width } = entry.contentRect;
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-      debounceTimeout = setTimeout(() => setContainerWidth(width), 20);
-    });
-    observer.observe(container);
 
-    return () => {
-      observer.disconnect();
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
+      // The container starts hidden (width 0) until the document loads; the
+      // observer picks up the real width once it becomes visible, so only
+      // commit positive widths and let `pageWidth` fall back until then.
+      if (node.clientWidth > 0) {
+        setContainerWidth(node.clientWidth);
       }
-    };
-  }, [isFullWidth, isFetching, hasError]);
+
+      // Re-rasterizing the PDF canvas on every resize tick flickers, so debounce
+      // and only commit the new width once the resize settles.
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries.at(0);
+        if (!entry) {
+          return;
+        }
+        const { width } = entry.contentRect;
+        if (width <= 0) {
+          return;
+        }
+        if (resizeDebounceRef.current) {
+          clearTimeout(resizeDebounceRef.current);
+        }
+        resizeDebounceRef.current = setTimeout(
+          () => setContainerWidth(width),
+          20
+        );
+      });
+      observer.observe(node);
+      resizeObserverRef.current = observer;
+    },
+    [isFullWidth]
+  );
 
   const zoom = ZOOM_LEVELS[zoomIdx] ?? 1.0;
   const pageWidth = isFullWidth
@@ -248,7 +265,7 @@ export function PDFViewer({ url, isFullWidth = false }: PDFViewerProps) {
             </div>
           )}
           <div
-            ref={scrollRef}
+            ref={setScrollNode}
             className={
               numPages !== null
                 ? "flex-1 min-h-0 overflow-auto rounded-lg"

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -1,7 +1,7 @@
 import { clientFetch } from "@app/lib/egress/client";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { Button, Spinner } from "@dust-tt/sparkle";
-import { useEffect, useReducer, useRef } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -11,8 +11,8 @@ pdfjs.GlobalWorkerOptions.workerSrc = new URL(
   import.meta.url
 ).toString();
 
-const ZOOM_LEVELS = [0.5, 0.66, 0.75, 1.0, 1.25, 1.5, 2.0];
-const DEFAULT_ZOOM_IDX = 3;
+const ZOOM_LEVELS = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
+const DEFAULT_ZOOM_IDX = 2;
 const BASE_PAGE_WIDTH = 680;
 
 type State = {
@@ -33,16 +33,14 @@ type Action =
   | { type: "zoom_in" }
   | { type: "zoom_out" };
 
-function makeInitialState(zoomIdx: number): State {
-  return {
-    currentPage: 1,
-    hasError: false,
-    isFetching: true,
-    numPages: null,
-    objectUrl: null,
-    zoomIdx,
-  };
-}
+const initialState: State = {
+  currentPage: 1,
+  hasError: false,
+  isFetching: true,
+  numPages: null,
+  objectUrl: null,
+  zoomIdx: DEFAULT_ZOOM_IDX,
+};
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -78,22 +76,16 @@ function reducer(state: State, action: Action): State {
 
 interface PDFViewerProps {
   url: string;
-  // Initial zoom level index into ZOOM_LEVELS. Defaults to DEFAULT_ZOOM_IDX
-  // (100%). Callers with a narrower container (e.g. the side panel previewing
-  // wide slides) can pass a smaller index so pages don't render oversized.
-  initialZoomIdx?: number;
+  // When true, pages render at the container width (no manual zoom controls).
+  // Useful in narrow containers like the side panel, where slides should fill
+  // the available space rather than render at a fixed zoom level.
+  isFullWidth?: boolean;
 }
 
-export function PDFViewer({
-  url,
-  initialZoomIdx = DEFAULT_ZOOM_IDX,
-}: PDFViewerProps) {
+export function PDFViewer({ url, isFullWidth = false }: PDFViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [state, dispatch] = useReducer(
-    reducer,
-    initialZoomIdx,
-    makeInitialState
-  );
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+  const [state, dispatch] = useReducer(reducer, initialState);
   const { isFetching, hasError, objectUrl, numPages, currentPage, zoomIdx } =
     state;
 
@@ -165,8 +157,47 @@ export function PDFViewer({
     return () => observer.disconnect();
   }, [numPages]);
 
+  useEffect(() => {
+    // The scroll container only mounts once the fetch resolves, so re-run when
+    // those flags flip to pick up the now-available ref.
+    if (!isFullWidth || isFetching || hasError) {
+      return;
+    }
+    const container = scrollRef.current;
+    if (!container) {
+      return;
+    }
+
+    setContainerWidth(container.clientWidth);
+
+    // Re-rasterizing the PDF canvas on every resize tick flickers, so debounce
+    // and only commit the new width once the resize settles.
+    let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries.at(0);
+      if (!entry) {
+        return;
+      }
+      const { width } = entry.contentRect;
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout);
+      }
+      debounceTimeout = setTimeout(() => setContainerWidth(width), 20);
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout);
+      }
+    };
+  }, [isFullWidth, isFetching, hasError]);
+
   const zoom = ZOOM_LEVELS[zoomIdx] ?? 1.0;
-  const pageWidth = Math.round(BASE_PAGE_WIDTH * zoom);
+  const pageWidth = isFullWidth
+    ? (containerWidth ?? BASE_PAGE_WIDTH)
+    : Math.round(BASE_PAGE_WIDTH * zoom);
 
   const isLoading = isFetching || (!hasError && numPages === null);
 
@@ -191,27 +222,29 @@ export function PDFViewer({
               <span className="text-xs text-muted-foreground">
                 Page {currentPage} of {numPages}
               </span>
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  label="-"
-                  disabled={zoomIdx <= 0}
-                  onClick={() => dispatch({ type: "zoom_out" })}
-                  tooltip="Zoom out"
-                />
-                <span className="w-10 text-center text-xs text-muted-foreground">
-                  {Math.round(zoom * 100)}%
-                </span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  label="+"
-                  disabled={zoomIdx >= ZOOM_LEVELS.length - 1}
-                  onClick={() => dispatch({ type: "zoom_in" })}
-                  tooltip="Zoom in"
-                />
-              </div>
+              {!isFullWidth && (
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    label="-"
+                    disabled={zoomIdx <= 0}
+                    onClick={() => dispatch({ type: "zoom_out" })}
+                    tooltip="Zoom out"
+                  />
+                  <span className="w-10 text-center text-xs text-muted-foreground">
+                    {Math.round(zoom * 100)}%
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    label="+"
+                    disabled={zoomIdx >= ZOOM_LEVELS.length - 1}
+                    onClick={() => dispatch({ type: "zoom_in" })}
+                    tooltip="Zoom in"
+                  />
+                </div>
+              )}
             </div>
           )}
           <div

--- a/front/components/file_explorer/PDFViewer.tsx
+++ b/front/components/file_explorer/PDFViewer.tsx
@@ -205,7 +205,7 @@ export function PDFViewer({ url }: PDFViewerProps) {
             ref={scrollRef}
             className={
               numPages !== null
-                ? "flex-1 min-h-0 overflow-y-auto rounded-lg"
+                ? "flex-1 min-h-0 overflow-auto rounded-lg"
                 : "hidden"
             }
           >
@@ -218,7 +218,10 @@ export function PDFViewer({ url }: PDFViewerProps) {
               loading={null}
               error={null}
             >
-              <div className="flex flex-col items-center gap-4 py-4">
+              {/* w-fit + min-w-full keeps pages centered when they fit, but
+                  anchors their left edge to the scroll origin when a page is
+                  wider than the viewport, so the left edge stays reachable. */}
+              <div className="flex w-fit min-w-full flex-col items-center gap-4 py-4">
                 {Array.from({ length: numPages ?? 0 }, (_, i) => (
                   <div key={i + 1} data-page-number={i + 1}>
                     <Page

--- a/front/types/conversation_side_panel.ts
+++ b/front/types/conversation_side_panel.ts
@@ -4,12 +4,14 @@ export const FULL_SCREEN_HASH_PARAM = "fullScreen";
 
 export const AGENT_ACTIONS_SIDE_PANEL_TYPE = "actions";
 export const INTERACTIVE_CONTENT_SIDE_PANEL_TYPE = "interactive_content";
+export const FILE_PREVIEW_SIDE_PANEL_TYPE = "file_preview";
 export const FILES_SIDE_PANEL_TYPE = "files";
 export const PLAN_SIDE_PANEL_TYPE = "plan";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SIDE_PANEL_TYPES = [
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
   INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
+  FILE_PREVIEW_SIDE_PANEL_TYPE,
   FILES_SIDE_PANEL_TYPE,
   PLAN_SIDE_PANEL_TYPE,
 ] as const;

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -444,6 +444,14 @@ type FileFormat = {
    * - Any file type that could contain executable code
    */
   isSafeToDisplay: boolean;
+  /**
+   * When true, this format opens in the resizable conversation side panel
+   * (like frames) rather than the cramped file preview modal. This is the
+   * source of truth for the open-in-side-panel behavior per content type.
+   * Note: the side panel preview relies on the path-based conversion route, so
+   * a file path is still required at the call site.
+   */
+  opensInSidePanel?: boolean;
   // When set, restricts which upload use cases expose this format in their file picker.
   // Possible values: conversation, avatar, tool_output, skill_attachment, upsert_document,
   // folders_document, upsert_table, project_context. Omit to allow in all contexts.
@@ -544,11 +552,13 @@ export const FILE_FORMATS = {
     cat: "data",
     exts: [".ppt", ".pptx"],
     isSafeToDisplay: true,
+    opensInSidePanel: true,
   },
   "application/vnd.openxmlformats-officedocument.presentationml.presentation": {
     cat: "data",
     exts: [".ppt", ".pptx"],
     isSafeToDisplay: true,
+    opensInSidePanel: true,
   },
   "application/pdf": { cat: "data", exts: [".pdf"], isSafeToDisplay: true },
   "application/vnd.google-apps.document": {
@@ -1036,12 +1046,8 @@ export function isMarkdownContentType(contentType: string): boolean {
   return contentType === "text/markdown";
 }
 
-export function isPresentationContentType(contentType: string): boolean {
-  return (
-    contentType === "application/vnd.ms-powerpoint" ||
-    contentType ===
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-  );
+export function opensInSidePanel(contentType: string): boolean {
+  return getFileFormat(contentType)?.opensInSidePanel ?? false;
 }
 
 /**

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -1036,6 +1036,14 @@ export function isMarkdownContentType(contentType: string): boolean {
   return contentType === "text/markdown";
 }
 
+export function isPresentationContentType(contentType: string): boolean {
+  return (
+    contentType === "application/vnd.ms-powerpoint" ||
+    contentType ===
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+  );
+}
+
 /**
  * Infers a supported content type from a file name's extension.
  * Returns null if the extension is not recognized.


### PR DESCRIPTION
## Description

Presentations (PowerPoint `.ppt`/`.pptx`) opened from the conversation file explorer now open in the resizable right side panel instead of the cramped file preview modal.

### Before
<img height="200" alt="Screenshot 2026-06-24 at 11 13 09" src="https://github.com/user-attachments/assets/93e9d8a6-26d1-4381-b154-0849ff02505a" />

### After
<img height="215" alt="Screenshot 2026-06-24 at 11 13 56" src="https://github.com/user-attachments/assets/4a752cbf-67c4-425e-8969-c60210fc7f04" />


### Why
See https://dust4ai.slack.com/archives/C050SM8NSPK/p1780913701212829

The previous view did not allow for live editing. While we want to push Frames as much as possible, some people in Consulting firms are not ready to move to it just yet
We need to have a clean UX to be able to progressively show them what we believe is the future.

### Tech details
A new `file_preview` side panel type renders the file as a server-side PDF conversion (`?preview=pdf`) via `PDFViewer`, with a header showing the file name, icon, and a download button. PDFs are rendered directly. The panel reuses the same layout chrome (`InteractiveContentHeader`) as the interactive content panel so it behaves like frames.

Changes:
- Add `isPresentationContentType` helper in `types/files.ts`.
- Add the `file_preview` side panel type and its open-panel params/handling in the conversation side panel context.
- Route presentation files to the new panel from both `ConversationFilesPanel` and the generic `FileExplorer` (via a new optional `onOpenPresentation` callback).
- Render slides at the panel width: `PDFViewer` gains an `isFullWidth` prop that sizes pages to the container (measured via a debounced `ResizeObserver`) and hides the manual zoom controls, so slides fill the narrower side panel instead of overflowing or rendering oversized.
