### PR TITLE
Fix usage bars for free seats

### DIFF
--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -40,6 +40,7 @@ type RowData = {
   image: string | null;
   seatType: MembershipSeatType | null;
   memberUsageLimit: number | null;
+  seatBalanceAwu: number | null;
   consumedAwuCredits: number;
   consumedFromAllowanceAwuCredits: number;
   consumedFromPoolAwuCredits: number;
@@ -109,6 +110,10 @@ export interface AwuUsageBarProps {
   consumedFromAllowance: number;
   consumedFromPool: number;
   memberUsageLimit: number | null;
+  // Live remaining Metronome balance for the per-user credit (free seats only).
+  // When provided for a free seat, the bar shows lifetime consumed/remaining
+  // instead of period spend.
+  seatBalanceAwu?: number | null;
   // The fully-resolved spend cap from `spendLimitAwuCredits` (member override or
   // workspace default, both including seat allowance). Always non-null for seated
   // users — workspace default pool cap treats null as 0 (seat-only). Pass `?? 0`
@@ -123,12 +128,20 @@ export function AwuUsageBar({
   consumedFromAllowance,
   consumedFromPool,
   memberUsageLimit,
+  seatBalanceAwu,
   effectiveLimit,
   seatType,
   isTotalAllowedUsagePending: isPending,
 }: AwuUsageBarProps) {
   const seatColors = getSeatBarClasses(seatType);
   const allowance = memberUsageLimit ?? 0;
+  // For free seats: use lifetime consumed (derived from the live Metronome
+  // balance) instead of period spend, so the bar reflects remaining credit.
+  const isFreeWithBalance =
+    seatType === "free" && seatBalanceAwu !== null && memberUsageLimit !== null;
+  const lifetimeConsumed = isFreeWithBalance
+    ? Math.max(0, memberUsageLimit - seatBalanceAwu!)
+    : null;
   // Uncapped is not a real product state: fall back to seat allowance when no
   // explicit spend limit is configured (no pool access).
   // The bar splits consumption into seat → pool → overage:
@@ -137,8 +150,12 @@ export function AwuUsageBar({
   // A seat with no pool (poolLimit === 0) shows no pool section —
   // any spend beyond the seat allowance is overage. Zero-width sections are
   // skipped. `pool remaining` is omitted when uncapped (no finite headroom).
-  const seatConsumed = consumedFromAllowance;
-  const seatRemaining = Math.max(0, allowance - seatConsumed);
+  const seatConsumed = isFreeWithBalance
+    ? lifetimeConsumed!
+    : consumedFromAllowance;
+  const seatRemaining = isFreeWithBalance
+    ? seatBalanceAwu!
+    : Math.max(0, allowance - seatConsumed);
   const poolLimit =
     effectiveLimit !== null ? Math.max(0, effectiveLimit - allowance) : null;
   // Of the pool consumption, the part within the pool limit vs. the overage
@@ -158,12 +175,13 @@ export function AwuUsageBar({
     className: string;
     label: string;
   }> = [];
+  const creditLabel = isFreeWithBalance ? "lifetime credits" : "seat allowance";
   if (seatConsumed > 0) {
     sections.push({
       key: "seat-consumed",
       value: seatConsumed,
       className: seatColors.fill,
-      label: `${formatCredits(seatConsumed)} of ${formatCredits(allowance)} seat allowance used`,
+      label: `${formatCredits(seatConsumed)} of ${formatCredits(allowance)} ${creditLabel} used`,
     });
   }
   if (seatRemaining > 0) {
@@ -171,7 +189,7 @@ export function AwuUsageBar({
       key: "seat-remaining",
       value: seatRemaining,
       className: seatColors.track,
-      label: `${formatCredits(seatRemaining)} of ${formatCredits(allowance)} seat allowance remaining`,
+      label: `${formatCredits(seatRemaining)} of ${formatCredits(allowance)} ${creditLabel} remaining`,
     });
   }
   if (poolConsumed > 0) {
@@ -211,7 +229,7 @@ export function AwuUsageBar({
     tooltipLines.push({
       track: seatColors.track,
       fill: seatColors.fill,
-      legend: "Seat usage",
+      legend: isFreeWithBalance ? "Lifetime credits" : "Seat usage",
       usage: `${formatCredits(seatConsumed)} credits used out of ${formatCredits(allowance)}`,
     });
   }
@@ -285,12 +303,20 @@ export function AwuUsageBar({
   return (
     <div className="flex w-full flex-col gap-1">
       <div className="flex justify-between text-xs tabular-nums text-foreground dark:text-foreground-night">
-        <span>{formatCredits(consumed)}</span>
+        <span>
+          {isFreeWithBalance
+            ? formatCredits(lifetimeConsumed! + overage)
+            : formatCredits(consumed)}
+        </span>
         {isPending ? (
           <Spinner size="xs" />
         ) : (
           <span>
-            {effectiveLimit !== null ? formatCredits(effectiveLimit) : "—"}
+            {isFreeWithBalance
+              ? formatCredits(allowance)
+              : effectiveLimit !== null
+                ? formatCredits(effectiveLimit)
+                : "—"}
           </span>
         )}
       </div>
@@ -363,6 +389,7 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
         }
         consumedFromPool={info.row.original.consumedFromPoolAwuCredits}
         memberUsageLimit={info.row.original.memberUsageLimit}
+        seatBalanceAwu={info.row.original.seatBalanceAwu}
         effectiveLimit={info.row.original.spendLimitAwuCredits ?? 0}
         seatType={info.row.original.seatType}
         isTotalAllowedUsagePending={
@@ -440,6 +467,7 @@ export function MembersUsageTable({
         image: m.image,
         seatType: m.seatType,
         memberUsageLimit: m.memberUsageLimit,
+        seatBalanceAwu: m.seatBalanceAwu,
         consumedAwuCredits: m.consumedAwuCredits,
         consumedFromAllowanceAwuCredits: m.consumedFromAllowanceAwuCredits,
         consumedFromPoolAwuCredits: m.consumedFromPoolAwuCredits,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1017,7 +1017,8 @@ export async function getMembersUsage({
         memberUsageLimit: awuAllocation > 0 ? awuAllocation : null,
         seatBalanceAwu:
           awuAllocation > 0
-            ? (seatBalanceByUserId.get(metronomeUserId) ?? null)
+            ? (seatBalanceByUserId.get(userId) ??
+              (membership.seatType === "free" ? 0 : null))
             : null,
         consumedAwuCredits: totalConsumedCredits,
         consumedFromAllowanceAwuCredits,

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -2664,6 +2664,9 @@ export async function listCustomerPerUserCreditBalances({
     for await (const entry of client.v1.customers.credits.list({
       customer_id: metronomeCustomerId,
       include_balance: true,
+      // Include archived (exhausted) credits so fully-consumed free-seat
+      // credits appear with balance 0 rather than being absent from the map.
+      include_archived: true,
     })) {
       if (entry.contract) {
         continue;
@@ -2679,10 +2682,9 @@ export async function listCustomerPerUserCreditBalances({
       ) {
         continue;
       }
-      // Strip the "free-" prefix so the map is keyed by plain sId, matching
-      // callers that look up by membership.user.sId. Falls back to the raw
-      // value for old-format credits that were granted before the prefix was
-      // introduced.
+      // Strip the "free-" prefix so the map is keyed by plain sId. All
+      // callers look up by membership.user.sId; old-format credits without
+      // the prefix keep their raw value as the key.
       const userId = fromFreeMetronomeUserId(rawUserId) ?? rawUserId;
       const startingBalanceAwu = (
         entry.access_schedule?.schedule_items ?? []


### PR DESCRIPTION
## Description

Three related bugs in how free-seat credit balances were read and displayed.

**1. `listCustomerPerUserCreditBalances` returned wrong map keys**

Since #27682 introduced the `free-<sId>` Metronome user ID prefix, the `DUST_PER_USER_CREDIT_USER` custom field is stored as `free-<sId>`. `listCustomerPerUserCreditBalances` used that raw field value as the map key, but all callers (`reconcile_credit_state`, `live_user_credit_inputs`, `members_usage`) looked up by plain `sId` → every lookup missed. Added prefix-stripping at map build time so the map is consistently keyed by `sId`. Also added `include_archived: true` so exhausted (archived) credits come back with `balance: 0` — without it, the reconcile path sees `null` and incorrectly reverts `capped` users back to `user_seat`.

**2. `members_usage` looked up balance with wrong key**

The `seatBalanceAwu` field in the members-usage response was computed with `seatBalanceByUserId.get(metronomeUserId)` (using the `free-<sId>` form) against the fixed map (now keyed by plain `sId`). Changed to use `userId`. Added a `?? 0` fallback for free seats: if the credit is still absent (e.g. archived before the fix), the remaining balance is correctly 0, not `null`.

**3. Members usage table showed period spend instead of lifetime credit usage**

For free seats the bar was showing period AWU consumption against the 500-credit lifetime grant — meaningless because the grant is lifetime, not per-period. Now uses `seatBalanceAwu` to derive **lifetime consumed** (`grant - remaining`) and displays it as `consumed / 500`, matching the consumed/total framing of other seat types but using lifetime data.

## Tests

Manually verified on an exhausted free-seat user (balance 0) and a partially-used one. Reconcile no longer reverts `capped` state, and the usage bar shows the correct lifetime consumed/total.

## Risk

Low — changes are scoped to the balance map key normalization and display logic. No schema or API contract changes.

## Deploy Plan

Standard deploy, no ordering required.