### PR TITLE
fix: update pod group name when updating pod name

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -23,6 +23,8 @@ import type { GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
   PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+  SPACE_GROUP_PREFIX,
 } from "@app/types/groups";
 import type {
   CombinedResourcePermissions,
@@ -651,17 +653,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // For regular spaces that only have a single group, update
     // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
     const regularGroup = this.getSpaceManualMemberGroup();
-    if (this.isRegular()) {
+    if (this.isRegular() || this.isProject()) {
       await regularGroup.updateName(
         auth,
-        `Group for ${this.isProject() ? "project" : "space"} ${trimmedName}`
+        `${this.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${this.name}`
       );
     }
     const spaceEditorGroup = this.getSpaceManualEditorGroup();
-    if (spaceEditorGroup && this.isRegular()) {
+    if (spaceEditorGroup && this.isProject()) {
       await spaceEditorGroup.updateName(
         auth,
-        `Editors for ${this.isProject() ? "project" : "space"} ${trimmedName}`
+        `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`
       );
     }
 

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -3,51 +3,86 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
 } from "@app/types/groups";
 
-makeScript({}, async ({ execute }) => {
-  await runOnAllWorkspaces(async (w) => {
-    const auth = await Authenticator.internalAdminForWorkspace(w.sId);
-    const allSpaces = await SpaceResource.listWorkspaceSpaces(auth);
-    const regularSpaces = allSpaces.filter((s) => s.kind === "regular");
-    logger.info(
-      `Found ${regularSpaces.length} regular spaces for workspace ${w.name}`
-    );
-    for (const space of regularSpaces) {
-      const regularGroups = space.groups.filter((g) => g.isRegular());
-      if (regularGroups.length === 1) {
-        const group = regularGroups[0];
-        if (execute) {
-          await group.updateName(
-            auth,
-            `${space.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${space.name}`
-          );
-        }
-        logger.info(
-          `[Execute: ${execute}] Updating group ${group.id} to "${space.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${space.name}"`
-        );
-      }
+const LOG_EVERY_N_WORKSPACES = 500;
 
-      const spaceEditorsGroups = space.groups.filter(
-        (g) => g.kind === "space_editors"
-      );
-      if (spaceEditorsGroups.length === 1) {
-        const group = spaceEditorsGroups[0];
-        if (execute) {
-          await group.updateName(
-            auth,
-            `${PROJECT_EDITOR_GROUP_PREFIX} ${space.name}`
+makeScript(
+  {
+    fromModelId: {
+      type: "number",
+      describe: "Only process workspaces with a model id >= this value",
+    },
+  },
+  async ({ execute, fromModelId }) => {
+    const erroredWorkspaceIds: number[] = [];
+    let processedCount = 0;
+
+    await runOnAllWorkspaces(
+      async (w) => {
+        try {
+          const auth = await Authenticator.internalAdminForWorkspace(w.sId);
+          const pods = await SpaceResource.listProjectSpaces(auth);
+          for (const pod of pods) {
+            const regularGroups = pod.groups.filter((g) => g.isRegular());
+            if (regularGroups.length === 1) {
+              const group = regularGroups[0];
+              const newName = `${pod.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${pod.name}`;
+              if (execute) {
+                await group.updateName(auth, newName);
+              } else {
+                logger.info(
+                  `[Execute: ${execute}] Updating group ${group.id} to "${newName}"`
+                );
+              }
+            }
+
+            const spaceEditorsGroups = pod.groups.filter(
+              (g) => g.kind === "space_editors"
+            );
+            if (spaceEditorsGroups.length === 1) {
+              const group = spaceEditorsGroups[0];
+              const newName = `${PROJECT_EDITOR_GROUP_PREFIX} ${pod.name}`;
+              if (execute) {
+                await group.updateName(auth, newName);
+              } else {
+                logger.info(
+                  `[Execute: ${execute}] Updating group ${group.id} to "${newName}"`
+                );
+              }
+            }
+          }
+        } catch (err) {
+          erroredWorkspaceIds.push(w.id);
+          logger.error(
+            { workspaceId: w.id, err: normalizeError(err) },
+            `Failed to process workspace ${w.name}, continuing`
           );
+        } finally {
+          processedCount += 1;
+          if (processedCount % LOG_EVERY_N_WORKSPACES === 0) {
+            logger.info(
+              {
+                processedCount,
+                lastProcessedWorkspaceId: w.id,
+                erroredWorkspaceIds,
+              },
+              `Processed ${processedCount} workspaces (last id: ${w.id}, ${erroredWorkspaceIds.length} errored)`
+            );
+          }
         }
-        logger.info(
-          `[Execute: ${execute}] Updating group ${group.id} to "${PROJECT_EDITOR_GROUP_PREFIX} ${space.name}"`
-        );
-      }
-    }
-    logger.info(`Done for workspace ${w.name}`);
-  });
-});
+      },
+      { fromWorkspaceId: fromModelId }
+    );
+
+    logger.info(
+      { processedCount, erroredWorkspaceIds },
+      `Done. Processed ${processedCount} workspaces, ${erroredWorkspaceIds.length} errored`
+    );
+  }
+);


### PR DESCRIPTION
## Description

This PR fixes pod group names not being updated when a pod's name is updated. This caused an unhandled api error when creating a new pod or space.

- Extends the group name update logic in `SpaceResource.update` to cover project spaces (`isProject()`) in addition to regular spaces, using the proper `PROJECT_GROUP_PREFIX` and `PROJECT_EDITOR_GROUP_PREFIX` constants.
- Updates the existing migration script to also rename groups for project spaces.

## Tests

Manually.

## Risk
Low. It only changes the group names.

## Deploy Plan
Deploy and run migration script.