### PR TITLE
Add: generic markdown editor component.

### DIFF
--- a/front/components/editor/MarkdownEditor.tsx
+++ b/front/components/editor/MarkdownEditor.tsx
@@ -1,0 +1,321 @@
+import { ToolBarContent } from "@app/components/assistant/conversation/input_bar/toolbar/ToolbarContent";
+import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
+import { buildMarkdownEditorExtensions } from "@app/lib/editor/build_markdown_editor_extensions";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
+import { cn, Toolbar } from "@dust-tt/sparkle";
+import type { Editor as CoreEditor, Extensions } from "@tiptap/core";
+import type { Editor, EditorOptions } from "@tiptap/react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
+import { cva } from "class-variance-authority";
+import debounce from "lodash/debounce";
+import type { ReactNode } from "react";
+import { useEffect, useMemo, useRef } from "react";
+
+export const DEFAULT_MARKDOWN_EDITOR_DEBOUNCE_MS = 250;
+
+const editorVariants = cva(
+  [
+    "overflow-auto p-2 resize-y min-h-60 max-h-[2048px]",
+    "rounded-xl border transition-all duration-200",
+    "bg-muted-background dark:bg-muted-background-night",
+    "focus-within:ring-highlight-300 dark:focus-within:ring-highlight-300-night",
+    "focus-within:outline-highlight-200 dark:focus-within:outline-highlight-200-night",
+    "focus-within:border-highlight-300 dark:focus-within:border-highlight-300-night",
+  ],
+  {
+    variants: {
+      error: {
+        true: [
+          "border-warning-500 dark:border-warning-500-night",
+          "focus-within:ring-warning-500 dark:focus-within:ring-warning-500-night",
+          "focus-within:outline-warning-500 dark:focus-within:outline-warning-500-night",
+          "focus-within:border-warning-500 dark:focus-within:border-warning-500-night",
+        ],
+        false: ["border-border dark:border-border-night"],
+      },
+    },
+    defaultVariants: {
+      error: false,
+    },
+  }
+);
+
+function useEditorService(editor: Editor | null) {
+  return useMemo(
+    () => ({
+      getMarkdown() {
+        return editor?.getMarkdown() ?? "";
+      },
+
+      setContent(content: string) {
+        if (editor && !editor.isDestroyed) {
+          editor.commands.setContent(content, {
+            emitUpdate: false,
+            contentType: "markdown",
+          });
+        }
+      },
+
+      focusEnd() {
+        editor?.commands.focus("end");
+      },
+
+      isFocused() {
+        return editor?.isFocused ?? false;
+      },
+
+      isDestroyed() {
+        return editor?.isDestroyed ?? true;
+      },
+    }),
+    [editor]
+  );
+}
+
+export type MarkdownEditorService = ReturnType<typeof useEditorService>;
+
+interface UseMarkdownEditorProps {
+  content: string;
+  debounceMs?: number;
+  editable?: boolean;
+  maxCharacterCount?: number;
+  onBlur?: EditorOptions["onBlur"];
+  onChange?: (markdown: string) => void;
+  placeholder?: string;
+}
+
+export function useMarkdownEditor({
+  content,
+  debounceMs = DEFAULT_MARKDOWN_EDITOR_DEBOUNCE_MS,
+  editable = true,
+  maxCharacterCount,
+  onBlur,
+  onChange,
+  placeholder,
+}: UseMarkdownEditorProps) {
+  const initialContentSetRef = useRef(false);
+  const editorRef = useRef<Editor | null>(null);
+  const contentRef = useRef(content);
+  contentRef.current = content;
+
+  const extensions = useMemo(
+    (): Extensions =>
+      buildMarkdownEditorExtensions({
+        placeholder,
+        maxCharacterCount,
+      }),
+    [maxCharacterCount, placeholder]
+  );
+
+  const debouncedUpdate = useMemo(
+    () =>
+      debounce((editorInstance: CoreEditor | Editor) => {
+        if (!editorInstance.isDestroyed) {
+          onChange?.(editorInstance.getMarkdown());
+        }
+      }, debounceMs),
+    [debounceMs, onChange]
+  );
+
+  const editor = useEditor(
+    {
+      extensions,
+      contentType: "markdown",
+      editable,
+      immediatelyRender: false,
+      onUpdate: ({ editor: editorInstance, transaction }) => {
+        if (transaction.docChanged) {
+          debouncedUpdate(editorInstance);
+        }
+      },
+      onBlur,
+      editorProps: {
+        transformPastedHTML(html: string) {
+          return cleanupPastedHTML(html);
+        },
+      },
+    },
+    [extensions, editable]
+  );
+
+  const editorService = useEditorService(editor);
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+
+    if (initialContentSetRef.current && editorRef.current === editor) {
+      return;
+    }
+
+    editorRef.current = editor;
+    initialContentSetRef.current = true;
+
+    requestAnimationFrame(() => {
+      if (!editor || editor.isDestroyed) {
+        return;
+      }
+
+      editor.commands.setContent(contentRef.current, {
+        emitUpdate: false,
+        contentType: "markdown",
+      });
+    });
+  }, [editor]);
+
+  useEffect(() => {
+    return () => {
+      debouncedUpdate.cancel();
+    };
+  }, [debouncedUpdate]);
+
+  useEffect(() => {
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      !initialContentSetRef.current ||
+      editor.isFocused
+    ) {
+      return;
+    }
+
+    const currentContent = editor.getMarkdown();
+    if (currentContent !== content) {
+      requestAnimationFrame(() => {
+        if (editor && !editor.isDestroyed) {
+          editor.commands.setContent(content, {
+            emitUpdate: false,
+            contentType: "markdown",
+          });
+        }
+      });
+    }
+  }, [editor, content]);
+
+  return { editor, editorService };
+}
+
+interface CharacterCountDisplayProps {
+  count: number;
+  maxCount: number;
+}
+
+function CharacterCountDisplay({
+  count,
+  maxCount,
+}: CharacterCountDisplayProps) {
+  if (count <= maxCount / 2) {
+    return null;
+  }
+
+  const isOverLimit = count >= maxCount;
+
+  return (
+    <span
+      className={cn(
+        "text-end text-xs",
+        isOverLimit
+          ? "text-warning"
+          : "text-muted-foreground dark:text-muted-foreground-night"
+      )}
+    >
+      {count} / {maxCount} characters
+    </span>
+  );
+}
+
+export interface MarkdownEditorProps {
+  value: string;
+  onChange?: (markdown: string) => void;
+  onBlur?: EditorOptions["onBlur"];
+  placeholder?: string;
+  readOnly?: boolean;
+  maxCharacterCount?: number;
+  /** When true, show the floating formatting toolbar on text selection. */
+  showFormattingMenu?: boolean;
+  showCharacterCount?: boolean;
+  debounceMs?: number;
+  toolbarExtra?: ReactNode;
+  className?: string;
+  editorClassName?: string;
+}
+
+export function MarkdownEditor({
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  readOnly = false,
+  maxCharacterCount,
+  showFormattingMenu,
+  showCharacterCount,
+  debounceMs,
+  toolbarExtra,
+  className,
+  editorClassName,
+}: MarkdownEditorProps) {
+  const isMobile = useIsMobile();
+  const { editor } = useMarkdownEditor({
+    content: value,
+    onChange,
+    onBlur,
+    placeholder,
+    editable: !readOnly,
+    maxCharacterCount,
+    debounceMs,
+  });
+
+  const shouldShowFormattingMenu = showFormattingMenu ?? !readOnly;
+  const currentCharacterCount =
+    editor?.storage.characterCount?.characters?.() ?? 0;
+  const displayError =
+    maxCharacterCount !== undefined &&
+    currentCharacterCount >= maxCharacterCount;
+  const shouldShowCharacterCount =
+    (showCharacterCount ?? maxCharacterCount !== undefined) &&
+    maxCharacterCount !== undefined;
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setOptions({
+      editorProps: {
+        attributes: {
+          class: cn(editorVariants({ error: displayError }), editorClassName),
+        },
+        transformPastedHTML(html: string) {
+          return cleanupPastedHTML(html);
+        },
+      },
+    });
+  }, [editor, displayError, editorClassName]);
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      <div className="relative">
+        <EditorContent editor={editor} />
+        {shouldShowFormattingMenu && editor ? (
+          <BubbleMenu
+            editor={editor}
+            className={cn("flex", isMobile && "hidden")}
+          >
+            <Toolbar className={cn("inline-flex", isMobile && "hidden")}>
+              <ToolBarContent editor={editor} />
+              {toolbarExtra}
+            </Toolbar>
+          </BubbleMenu>
+        ) : null}
+      </div>
+      {shouldShowCharacterCount && editor ? (
+        <CharacterCountDisplay
+          count={currentCharacterCount}
+          maxCount={maxCharacterCount}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/front/lib/editor/build_markdown_editor_extensions.test.ts
+++ b/front/lib/editor/build_markdown_editor_extensions.test.ts
@@ -1,0 +1,78 @@
+import { buildMarkdownEditorExtensions } from "@app/lib/editor/build_markdown_editor_extensions";
+import type { Editor } from "@tiptap/core";
+import { Editor as TiptapEditor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("buildMarkdownEditorExtensions", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = new TiptapEditor({
+      extensions: buildMarkdownEditorExtensions(),
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  function rawBlocks(e: Editor) {
+    return (
+      e
+        .getJSON()
+        .content?.filter((n: { type: string }) => n.type === "rawMarkdownBlock")
+        .map((n: { attrs?: { rawContent?: string } }) => n.attrs?.rawContent) ??
+      []
+    );
+  }
+
+  it("preserves markdown tables as raw blocks", () => {
+    const table = "| a | b |\n|---|---|\n| 1 | 2 |";
+    editor.commands.setContent(table, { contentType: "markdown" });
+
+    const blocks = rawBlocks(editor);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toContain("| a | b |");
+  });
+
+  it("preserves raw content through getMarkdown round-trip", () => {
+    const md = "paragraph\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\nafter";
+    editor.commands.setContent(md, { contentType: "markdown" });
+
+    const out = editor.getMarkdown();
+    expect(out).toContain("| a | b |");
+    expect(out).toContain("paragraph");
+    expect(out).toContain("after");
+  });
+
+  it("parses standard markdown links", () => {
+    editor.commands.setContent("[test](https://google.com)", {
+      contentType: "markdown",
+    });
+
+    expect(editor.getMarkdown()).toBe("[test](https://google.com)");
+    const linkMark = editor.getJSON().content?.[0]?.content?.[0]?.marks?.[0];
+    expect(linkMark?.type).toBe("link");
+    expect(linkMark?.attrs?.href).toBe("https://google.com");
+  });
+
+  it("renders blockquotes as native blockquote nodes", () => {
+    editor.commands.setContent("> quoted text", { contentType: "markdown" });
+
+    expect(rawBlocks(editor)).toHaveLength(0);
+    expect(editor.getJSON().content?.[0]?.type).toBe("blockquote");
+    expect(editor.getMarkdown()).toContain("> quoted text");
+  });
+
+  it("renders horizontal rules as native hr nodes", () => {
+    editor.commands.setContent("before\n\n---\n\nafter", {
+      contentType: "markdown",
+    });
+
+    expect(rawBlocks(editor)).toHaveLength(0);
+    expect(
+      editor.getJSON().content?.some((node) => node.type === "horizontalRule")
+    ).toBe(true);
+    expect(editor.getMarkdown()).toContain("---");
+  });
+});

--- a/front/lib/editor/build_markdown_editor_extensions.ts
+++ b/front/lib/editor/build_markdown_editor_extensions.ts
@@ -1,0 +1,133 @@
+import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
+import { EmojiExtension } from "@app/components/editor/extensions/EmojiExtension";
+import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
+import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
+import {
+  RawMarkdownBlock,
+  rawMarkdownBlockParsers,
+} from "@app/components/editor/extensions/skill_builder/RawMarkdownBlock";
+import { BlockquoteExtension } from "@app/components/editor/input_bar/BlockquoteExtension";
+import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
+import { markdownStyles } from "@dust-tt/sparkle";
+import type { Extensions } from "@tiptap/core";
+import { CharacterCount, Placeholder } from "@tiptap/extensions";
+import { Markdown } from "@tiptap/markdown";
+import { StarterKit } from "@tiptap/starter-kit";
+
+/** Markdown token types handled natively; the rest fall through to RawMarkdownBlock. */
+const NATIVE_MARKDOWN_TOKEN_TYPES = new Set(["hr", "blockquote"]);
+
+const rawMarkdownBlockParsersForUnhandledTokens =
+  rawMarkdownBlockParsers.filter(
+    (extension) =>
+      !NATIVE_MARKDOWN_TOKEN_TYPES.has(
+        extension.name.replace("rawMarkdownBlock_", "")
+      )
+  );
+
+export interface BuildMarkdownEditorExtensionsOptions {
+  placeholder?: string;
+  maxCharacterCount?: number;
+}
+
+/**
+ * TipTap extension list for the generic markdown editor.
+ * Supports standard markdown formatting (headings, lists, code, links, emoji,
+ * blockquotes, horizontal rules). Unhandled markdown tokens (tables, link
+ * definitions) are preserved as opaque raw blocks via RawMarkdownBlock.
+ */
+export function buildMarkdownEditorExtensions({
+  placeholder,
+  maxCharacterCount,
+}: BuildMarkdownEditorExtensionsOptions = {}): Extensions {
+  const extensions: Extensions = [
+    Markdown,
+    StarterKit.configure({
+      heading: false,
+      hardBreak: false,
+      paragraph: {
+        HTMLAttributes: {
+          class: markdownStyles.paragraph(),
+        },
+      },
+      orderedList: {
+        HTMLAttributes: {
+          class: markdownStyles.orderedList(),
+        },
+      },
+      listItem: false,
+      link: false,
+      bulletList: {
+        HTMLAttributes: {
+          class: markdownStyles.unorderedList(),
+        },
+      },
+      blockquote: false,
+      horizontalRule: {
+        HTMLAttributes: {
+          class:
+            "my-4 border-0 border-t border-border dark:border-border-night",
+        },
+      },
+      strike: false,
+      undoRedo: {
+        depth: 100,
+      },
+      code: false,
+      codeBlock: {
+        HTMLAttributes: {
+          class: markdownStyles.codeBlock(),
+        },
+      },
+    }),
+    CodeExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.codeInline(),
+      },
+    }),
+    ListItemExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.list(),
+      },
+    }),
+    HeadingExtension.configure({
+      levels: [1, 2, 3, 4, 5, 6],
+      HTMLAttributes: { class: "mt-4 mb-3" },
+    }),
+    BlockquoteExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.blockquote(),
+      },
+    }),
+    EmojiExtension,
+    LinkExtension.configure({
+      HTMLAttributes: {
+        class: "text-blue-600 hover:underline hover:text-blue-800",
+      },
+      autolink: false,
+      openOnClick: false,
+    }),
+    RawMarkdownBlock,
+    ...rawMarkdownBlockParsersForUnhandledTokens,
+  ];
+
+  if (placeholder) {
+    extensions.push(
+      Placeholder.configure({
+        placeholder,
+        emptyNodeClass:
+          "first:before:text-gray-400 dark:first:before:text-gray-500 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+      })
+    );
+  }
+
+  if (maxCharacterCount !== undefined) {
+    extensions.push(
+      CharacterCount.configure({
+        limit: maxCharacterCount,
+      })
+    );
+  }
+
+  return extensions;
+}


### PR DESCRIPTION
## Description

Introduces a generic `MarkdownEditor` TipTap component (`front/components/editor/MarkdownEditor.tsx`) reusable across the app — separate from the input bar and skill builder editors. The shared extension bundle is extracted into `buildMarkdownEditorExtensions` (`front/lib/editor/`), supporting headings, lists, code, links, emoji, blockquotes, and horizontal rules; unhandled tokens (tables, link definitions) fall through to `RawMarkdownBlock` for lossless round-trips.

Key surface:
- `MarkdownEditor` — controlled component with `value`/`onChange`, `readOnly`, `placeholder`, `maxCharacterCount`, `debounceMs`, optional `BubbleMenu` formatting toolbar (hidden on mobile), and `toolbarExtra` slot.
- `useMarkdownEditor` hook + `MarkdownEditorService` type for imperative control (`setContent`, `focusEnd`, `getMarkdown`).
- `CharacterCountDisplay` — shown after 50% of the limit is reached, turns warning-colored at the cap.

<img width="964" height="376" alt="image" src="https://github.com/user-attachments/assets/01c335d1-2173-4c56-ab16-91f664305f94" />


## Tests

Added Vitest unit tests for `buildMarkdownEditorExtensions` covering: markdown table preservation as raw blocks, full `getMarkdown` round-trip, link parsing, blockquote and horizontal rule rendering as native TipTap nodes.

## Risk

Low. Additive only — new files, no existing component modified. `RawMarkdownBlock` reuse is read-only (parsers are filtered, not mutated).

## Deploy Plan

Deploy front.
