### PR TITLE
feat(billing): block seat auto-upgrade in the UI on free plans

### DIFF
--- a/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.test.ts
@@ -36,6 +36,9 @@ describe("/api/w/[wId]/credits/usage-configuration", () => {
     expect(configuration.allowMemberUpgradeRequests).toBe(true);
     expect(configuration.upgradeRequestEmailEnabled).toBe(true);
     expect(configuration.autoSeatUpgradeEnabled).toBe(false);
+    // The default mock workspace is on a free (non-Metronome) plan, so
+    // auto-upgrade is not available — the UI disables the toggle.
+    expect(configuration.autoSeatUpgradeAvailable).toBe(false);
   });
 
   it("PATCH persists the upgrade-request toggles and GET reflects them", async () => {

--- a/front/components/workspace/usage/UsageSettingsCard.tsx
+++ b/front/components/workspace/usage/UsageSettingsCard.tsx
@@ -146,12 +146,32 @@ export function UsageSettingsCard({
         />
         <SettingsList.Row
           title="Auto-upgrade seats"
-          description="When a member reaches their credit limit, automatically move them to the next seat tier available in your plan (free → pro, pro → max) instead of blocking them. This may increase your subscription cost."
+          description={
+            usageSettings.autoSeatUpgradeAvailable ? (
+              "When a member reaches their credit limit, automatically move them to the next seat tier available in your plan (free → pro, pro → max) instead of blocking them. This may increase your subscription cost."
+            ) : (
+              <>
+                When a member reaches their credit limit, automatically move
+                them to the next seat tier available in your plan (free → pro,
+                pro → max) instead of blocking them.{" "}
+                <strong>
+                  Auto-upgrade isn't available on your current plan. Upgrade to
+                  a paid plan to enable it.
+                </strong>
+              </>
+            )
+          }
           action={
             <SliderToggle
-              selected={usageSettings.autoSeatUpgradeEnabled}
+              selected={
+                usageSettings.autoSeatUpgradeAvailable &&
+                usageSettings.autoSeatUpgradeEnabled
+              }
               disabled={
-                readOnly || isSavingAutoSeatUpgrade || isUsageSettingsLoading
+                readOnly ||
+                isSavingAutoSeatUpgrade ||
+                isUsageSettingsLoading ||
+                !usageSettings.autoSeatUpgradeAvailable
               }
               onClick={() => void handleToggleAutoSeatUpgrade()}
             />

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -44,7 +44,7 @@ const AUTO_UPGRADE_TARGET_BASE_TIER: Partial<
  * Metronome-billed on a non-free credit-priced plan. (The same gate the member
  * upgrade-request flow uses, plus the explicit non-free check.)
  */
-function passesBillingGate(subscription: SubscriptionResource): boolean {
+export function passesBillingGate(subscription: SubscriptionResource): boolean {
   if (!subscription.isMetronomeOnlyBilled) {
     return false;
   }

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,3 +1,4 @@
+import { passesBillingGate } from "@app/lib/api/credits/auto_seat_upgrade";
 import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
 import type { Authenticator } from "@app/lib/auth";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
@@ -21,6 +22,7 @@ export type CreditUsageConfigurationBody = {
   // Whether members who hit their per-user credit limit are automatically bumped
   // to the next entitled seat tier instead of being blocked.
   autoSeatUpgradeEnabled: boolean;
+  autoSeatUpgradeAvailable: boolean;
 };
 
 export type GetCreditUsageConfigurationResponseBody = {
@@ -58,6 +60,8 @@ export async function getUsageConfiguration(
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
+  const subscription = auth.subscriptionResource();
+
   return {
     balanceThresholdCredits: config?.balanceThresholdAwuCredits ?? null,
     allowMemberUpgradeRequests:
@@ -68,6 +72,9 @@ export async function getUsageConfiguration(
       DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
     autoSeatUpgradeEnabled:
       config?.autoSeatUpgradeEnabled ?? DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
+    autoSeatUpgradeAvailable: subscription
+      ? passesBillingGate(subscription)
+      : false,
   };
 }
 

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -32,6 +32,7 @@ const PutDefaultUserSpendLimitResponseSchema = z.object({
 export interface UsageSettings {
   allowUpgradeRequest: boolean;
   autoSeatUpgradeEnabled: boolean;
+  autoSeatUpgradeAvailable: boolean;
 }
 
 export interface UsageNotifications {
@@ -43,6 +44,7 @@ export interface UsageNotifications {
 const DEFAULT_USAGE_SETTINGS: UsageSettings = {
   allowUpgradeRequest: true,
   autoSeatUpgradeEnabled: false,
+  autoSeatUpgradeAvailable: false,
 };
 
 const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
@@ -96,6 +98,7 @@ export function useUsageSettings({ workspaceId }: { workspaceId: string }) {
       ? {
           allowUpgradeRequest: data.configuration.allowMemberUpgradeRequests,
           autoSeatUpgradeEnabled: data.configuration.autoSeatUpgradeEnabled,
+          autoSeatUpgradeAvailable: data.configuration.autoSeatUpgradeAvailable,
         }
       : {}),
   };


### PR DESCRIPTION
## Description

The "Auto-upgrade seats" toggle on the workspace Usage → Settings page could be flipped on even when the workspace's plan can't actually act on it. Auto-upgrade only takes effect for Metronome-billed, credit-priced, **non-free** plans (the backend `passesBillingGate`), so on a free plan the toggle was a no-op with no explanation.

This surfaces that gate to the front end and blocks the toggle when auto-upgrade is unavailable:

- `passesBillingGate` is exported and reused as the single source of truth.
- The usage-configuration response now includes `autoSeatUpgradeAvailable`, computed from the workspace subscription.
- The SWR hook exposes the flag, and `UsageSettingsCard` disables (and unselects) the toggle when unavailable, showing: *"Auto-upgrade isn't available on your current plan. Upgrade to a paid plan to enable it."*

No backend behavior changes — the gate already no-oped auto-upgrade on free plans; this only makes the UI honest about it.

## Tests

- Added an assertion in the `front-api` usage-configuration route test that `autoSeatUpgradeAvailable` is `false` for the default (free-plan) mock workspace.
- `front` and `front-api` typecheck clean.
