### PR TITLE
feat(llm): add TogetherAI provider plumbing to the new LLM router

### DIFF
--- a/front/lib/model_constructors/providers/togetherai/inputConfig.ts
+++ b/front/lib/model_constructors/providers/togetherai/inputConfig.ts
@@ -1,0 +1,18 @@
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import { z } from "zod";
+
+// Schema for the non-reasoning TogetherAI models we serve (Llama 3.3 70B Turbo,
+// Qwen2 72B Instruct): accept `none` but drop it so the request omits
+// `reasoning_effort` (the API rejects it on these models). Temperature passes
+// through unchanged. TogetherAI has no explicit prompt-cache key.
+export const togetheraiNonReasoningConfigSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({ effort: z.literal("none") })
+    .optional()
+    .transform(() => undefined),
+  cacheKey: z.undefined(),
+});
+
+export type TogetheraiInputConfig = z.infer<
+  typeof togetheraiNonReasoningConfigSchema
+>;

--- a/front/lib/model_constructors/sdk/openai_completions/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/input/index.ts
@@ -1,5 +1,4 @@
 import type { Client } from "@app/lib/model_constructors/client";
-import type { FireworksInputConfig } from "@app/lib/model_constructors/providers/fireworks/inputConfig";
 import {
   assistantReasoningMessageToMessage,
   assistantTextMessageToMessage,
@@ -15,6 +14,7 @@ import {
   userImageMessageToMessage,
   userTextMessageToMessage,
 } from "@app/lib/model_constructors/sdk/openai_completions/converters/input/utils";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import type { Payload } from "@app/lib/model_constructors/types/input/messages";
 import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat/completions";
 
@@ -25,7 +25,7 @@ type AbstractConstructor<T> = abstract new (...args: any[]) => T;
 // fields and the composite routes through `this`, so an endpoint can override a
 // single leaf.
 export function WithOpenAICompletionsInputConverter<
-  TBase extends AbstractConstructor<Client<FireworksInputConfig>>,
+  TBase extends AbstractConstructor<Client<InputConfig>>,
 >(Base: TBase) {
   abstract class WithOpenAICompletionsInputConverter
     extends Base
@@ -41,7 +41,7 @@ export function WithOpenAICompletionsInputConverter<
 
     buildRequestPayload(
       payload: Payload,
-      config: FireworksInputConfig
+      config: InputConfig
     ): ChatCompletionCreateParamsNonStreaming {
       const { conversation } = payload;
       const {
@@ -57,8 +57,8 @@ export function WithOpenAICompletionsInputConverter<
         : undefined;
 
       // `tool_choice` is always sent (matching the legacy client); `tools` is
-      // only sent when non-empty. Fireworks does not get an explicit max-output
-      // cap, matching the legacy client.
+      // only sent when non-empty. No explicit max-output cap is sent, matching
+      // the legacy client.
       return {
         model: this.constructor.modelId,
         messages: conversationToOpenAICompletionsMessages(conversation, this),

--- a/front/lib/model_constructors/stream/clients/togetherai.ts
+++ b/front/lib/model_constructors/stream/clients/togetherai.ts
@@ -1,0 +1,64 @@
+import {
+  type TogetheraiInputConfig,
+  togetheraiNonReasoningConfigSchema,
+} from "@app/lib/model_constructors/providers/togetherai/inputConfig";
+import { WithOpenAICompletionsInputConverter } from "@app/lib/model_constructors/sdk/openai_completions/converters/input";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_completions/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { TOGETHERAI_API } from "@app/lib/model_constructors/types/provider_apis";
+import { TOGETHERAI_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import OpenAI from "openai";
+import type {
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat/completions";
+
+const TOGETHERAI_BASE_URL = "https://api.together.xyz/v1";
+
+export abstract class TogetheraiStream extends WithOpenAICompletionsInputConverter(
+  StreamEndpoint<
+    ChatCompletionCreateParamsNonStreaming,
+    ChatCompletionChunk,
+    TogetheraiInputConfig
+  >
+) {
+  static readonly providerId = TOGETHERAI_PROVIDER_ID;
+  static readonly api = TOGETHERAI_API;
+
+  static readonly configSchema = togetheraiNonReasoningConfigSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ TOGETHERAI_API_KEY }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      apiKey: TOGETHERAI_API_KEY,
+      baseURL: TOGETHERAI_BASE_URL,
+    });
+  }
+
+  async *streamRaw(
+    input: ChatCompletionCreateParamsNonStreaming
+  ): AsyncGenerator<ChatCompletionChunk> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ChatCompletionCreateParamsStreaming = {
+      ...input,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    const stream = await this.client.chat.completions.create(streamingInput);
+
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ChatCompletionChunk>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata());
+  }
+}

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -6,4 +6,5 @@ export type Credentials = {
   AGENT_PLATFORM_PROJECT_ID?: string;
   MISTRAL_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
+  TOGETHERAI_API_KEY?: string;
 };

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -4,6 +4,7 @@ export const GOOGLE_AI_STUDIO_API = "google-ai-studio" as const;
 export const AGENT_PLATFORM_API = "agent-platform" as const;
 export const MISTRAL_API = "mistral" as const;
 export const FIREWORKS_API = "fireworks" as const;
+export const TOGETHERAI_API = "togetherai" as const;
 
 const PROVIDER_APIS = [
   OPENAI_RESPONSES_API,
@@ -12,5 +13,6 @@ const PROVIDER_APIS = [
   AGENT_PLATFORM_API,
   MISTRAL_API,
   FIREWORKS_API,
+  TOGETHERAI_API,
 ] as const;
 export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -5,6 +5,7 @@ export const ANTHROPIC_PROVIDER_ID = "anthropic" as const;
 export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
 export const MISTRAL_PROVIDER_ID = "mistral" as const;
 export const FIREWORKS_PROVIDER_ID = "fireworks" as const;
+export const TOGETHERAI_PROVIDER_ID = "togetherai" as const;
 
 // `satisfies readonly ModelProviderIdType[]` guarantees every new-system
 // provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
@@ -17,6 +18,7 @@ const PROVIDER_IDS = [
   GOOGLE_AI_STUDIO_PROVIDER_ID,
   MISTRAL_PROVIDER_ID,
   FIREWORKS_PROVIDER_ID,
+  TOGETHERAI_PROVIDER_ID,
 ] as const satisfies readonly ModelProviderIdType[];
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 


### PR DESCRIPTION
## Description

First step toward serving TogetherAI models through the new `model_constructors` LLM router. This PR adds only the shared provider plumbing — no model endpoint classes yet (those land in follow-ups). It mirrors the existing Fireworks provider layer, since TogetherAI exposes an OpenAI chat-completions–compatible API.

Changes:
- **Decouple the shared `openai_completions` input converter** from `FireworksInputConfig`, typing it against the base `InputConfig` instead. The converter only reads base config fields, so Fireworks is unaffected, and a second OpenAI-compatible provider can now reuse it without a dependency on Fireworks-specific types.
- **Register the provider**: `TOGETHERAI_PROVIDER_ID` / `TOGETHERAI_API` (`"togetherai"`, already present in the legacy `ModelProviderIdType` union, so the `satisfies` constraint holds) and the `TOGETHERAI_API_KEY` credential field.
- **Provider config + client**: `togetheraiNonReasoningConfigSchema` (mirrors the Mistral non-reasoning schema — accepts only `reasoning: none`, dropped before the request, temperature passes through) and the abstract `TogetheraiStream` client (base URL `https://api.together.xyz/v1`).

The two target models (`meta-llama/Llama-3.3-70B-Instruct-Turbo` and `Qwen/Qwen2-72B-Instruct`) will be added as endpoint classes in subsequent PRs.

## Tests

- `npx tsgo --noEmit` clean (no new errors outside `node_modules`); full project typecheck passes, so the Fireworks converter refactor is verified non-breaking.
- Biome clean on all changed files; pre-commit hooks (typecheck + biome) passed.
- No live API tests in this PR — there is no concrete endpoint to exercise yet. Endpoint PRs will run the integration harness against the live TogetherAI API.

## Risk

Low. This is additive plumbing with one shared-code touch: widening the `openai_completions` input converter's config type from `FireworksInputConfig` to `InputConfig`. The converter body only accesses base `InputConfig` fields, and the existing Fireworks endpoints continue to typecheck and behave identically. Nothing is wired into agent selection or the legacy registry yet. Trivial to roll back.

## Deploy Plan

Standard deploy. No migrations, no config, no env changes required (the `DUST_MANAGED_TOGETHERAI_API_KEY` credential is already configured in the legacy provider). No runtime behavior changes until endpoint classes are added.