### PR TITLE
Added invoice+topup setting

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
+++ b/front-api/routes/w/[wId]/subscriptions/awu-purchase.ts
@@ -44,7 +44,7 @@ app.get(
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: "Failed to get AWU purchase info.",
+          message: "Failed to get credit purchase info.",
         },
       });
     }
@@ -71,7 +71,7 @@ app.post(
             api_error: {
               type: "invalid_request_error",
               message:
-                "AWU credit purchases are only available for Metronome-billed workspaces.",
+                "Credit purchases are not available for this workspace. Please contact support.",
             },
           });
         case "legacy_plan":
@@ -80,7 +80,7 @@ app.post(
             api_error: {
               type: "invalid_request_error",
               message:
-                "AWU credit purchases are not available for legacy plan workspaces.",
+                "Credit purchases are not available for your current plan. Please contact support.",
             },
           });
         case "enterprise_plan":
@@ -89,7 +89,7 @@ app.post(
             api_error: {
               type: "invalid_request_error",
               message:
-                "AWU credit purchases are not available for Enterprise workspaces. Please contact your Dust sales representative.",
+                "Credit purchases are not available for Enterprise workspaces. Please contact your Dust sales representative.",
             },
           });
         case "no_stripe_customer":
@@ -107,7 +107,7 @@ app.post(
             api_error: {
               type: "invalid_request_error",
               message:
-                "A pending AWU credit purchase already exists for this workspace. Please wait for it to complete.",
+                "A pending credit purchase already exists for this workspace. Please wait for it to complete.",
             },
           });
         case "invalid_amount":

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -39,6 +39,7 @@ import {
   useResolveUpgradeRequest,
   useUpgradeRequests,
 } from "@app/lib/swr/upgrade_requests";
+import { useUsageSettings } from "@app/lib/swr/usage_settings";
 import {
   useAwuUsage,
   usePerSeatPricing,
@@ -471,6 +472,8 @@ export function UsagePage() {
     );
   }, [seatPlans]);
 
+  const { usageSettings } = useUsageSettings({ workspaceId: owner.sId });
+
   const plan = subscription.plan;
   const isEnterprise = isEnterprisePlanPrefix(plan.code);
   const isFreePlanWorkspace = isFreePlan(plan.code);
@@ -602,7 +605,7 @@ export function UsagePage() {
       <div className="flex flex-col items-stretch gap-10 pb-20">
         <div className="flex items-center justify-between">
           <Page.Header title="Usage" icon={PieChart01} />
-          {!isReadOnly && !isFreePlanWorkspace && !isEnterprise && (
+          {!isReadOnly && usageSettings.topUpEnabled && (
             <Button
               label="Top up"
               icon={ArrowUp}

--- a/front/components/workspace/settings/SelfImprovingSkillsSettingsSection.tsx
+++ b/front/components/workspace/settings/SelfImprovingSkillsSettingsSection.tsx
@@ -176,7 +176,7 @@ function SelfImprovementCapPerSkillItem({
       }
     >
       <ContextItem.Description
-        description={`Maximum cost per skill per self-improvement run (in ${unit === "awu_credits" ? "AWU credits" : "USD"}). Once reached, no further self-improvement runs are started for that skill.`}
+        description={`Maximum cost per skill per self-improvement run (in ${unit === "awu_credits" ? "credits" : "USD"}). Once reached, no further self-improvement runs are started for that skill.`}
       />
     </ContextItem>
   );
@@ -234,7 +234,7 @@ function SelfImprovingCapItem({
       }
     >
       <ContextItem.Description
-        description={`Self-improving skills is priced as programmatic usage. This is the maximum cost per month (in ${unit === "awu_credits" ? "AWU credits" : "USD"}) for the feature across all skills. Once reached, no new self-improving runs are started until the next billing month.`}
+        description={`Self-improving skills is priced as programmatic usage. This is the maximum cost per month (in ${unit === "awu_credits" ? "credits" : "USD"}) for the feature across all skills. Once reached, no new self-improving runs are started until the next billing month.`}
       />
     </ContextItem>
   );

--- a/front/hooks/useAwuPurchase.ts
+++ b/front/hooks/useAwuPurchase.ts
@@ -4,6 +4,7 @@ import {
   useAwuPoolSummary,
   useAwuPurchaseInfo,
 } from "@app/lib/swr/credits";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback, useSyncExternalStore } from "react";
 
 const awuPurchaseLoadingState = new Map<string, boolean>();
@@ -67,7 +68,7 @@ export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
         if (!response.ok) {
           const errorData = await response.json().catch(() => null);
           const message =
-            errorData?.error?.message ?? "Failed to purchase AWU credits";
+            errorData?.error?.message ?? "Failed to purchase credits";
           return { status: "error", message };
         }
 
@@ -79,9 +80,7 @@ export function useAwuPurchase({ workspaceId }: { workspaceId: string }) {
 
         return { status: "success" };
       } catch (err) {
-        const message =
-          err instanceof Error ? err.message : "Failed to purchase AWU credits";
-        return { status: "error", message };
+        return { status: "error", message: normalizeError(err).message };
       } finally {
         setAwuPurchaseLoading(workspaceId, false);
       }

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,7 +1,14 @@
 import { passesBillingGate } from "@app/lib/api/credits/auto_seat_upgrade";
 import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
 import type { Authenticator } from "@app/lib/auth";
+import { isEnterprisePlanPrefix, isFreePlan } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import {
+  DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS,
+  DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
+  DEFAULT_TOP_UP_ENABLED,
+  DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
+} from "@app/lib/resources/storage/models/credit_usage_configurations";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
@@ -23,6 +30,8 @@ export type CreditUsageConfigurationBody = {
   // to the next entitled seat tier instead of being blocked.
   autoSeatUpgradeEnabled: boolean;
   autoSeatUpgradeAvailable: boolean;
+  // Whether enterprise-plan workspaces show the "Top up" button on the Usage page.
+  topUpEnabled: boolean;
 };
 
 export type GetCreditUsageConfigurationResponseBody = {
@@ -44,10 +53,6 @@ export const PatchCreditUsageConfigurationRequestBody = z.object({
 export type PatchCreditUsageConfigurationBody = z.infer<
   typeof PatchCreditUsageConfigurationRequestBody
 >;
-
-const DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS = true;
-const DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED = true;
-const DEFAULT_AUTO_SEAT_UPGRADE_ENABLED = false;
 
 /**
  * Read the full usage configuration for a workspace: the balance threshold plus
@@ -75,6 +80,14 @@ export async function getUsageConfiguration(
     autoSeatUpgradeAvailable: subscription
       ? passesBillingGate(subscription)
       : false,
+    // Free plan workspaces cannot top up. Enterprise workspaces can only top up
+    // when the poke-managed flag is explicitly enabled. All other plans can
+    // always top up.
+    topUpEnabled:
+      !isFreePlan(auth.plan()?.code ?? "") &&
+      (isEnterprisePlanPrefix(auth.plan()?.code ?? "")
+        ? (config?.topUpEnabled ?? DEFAULT_TOP_UP_ENABLED)
+        : true),
   };
 }
 

--- a/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_credit_usage_configuration.ts
@@ -4,10 +4,7 @@ import {
   getProgrammaticUsageLimit,
   syncProgrammaticUsageLimit,
 } from "@app/lib/api/credits/programmatic_usage_limit";
-import {
-  getUsageConfiguration,
-  updateUsageConfiguration,
-} from "@app/lib/api/credits/usage_configuration";
+import { updateUsageConfiguration } from "@app/lib/api/credits/usage_configuration";
 import { createPlugin } from "@app/lib/api/poke/types";
 import {
   getDefaultUserSpendLimit,
@@ -15,6 +12,11 @@ import {
 } from "@app/lib/api/workspace/default_user_spend_limit";
 import { MAX_AWU_DISCOUNT_PERCENT } from "@app/lib/credits/awu_purchase_constants";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
+import {
+  DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED,
+  DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
+  DEFAULT_TOP_UP_ENABLED,
+} from "@app/lib/resources/storage/models/credit_usage_configurations";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
@@ -57,6 +59,8 @@ const CreditUsageConfigurationSchema = z.object({
     .min(0, "Programmatic monthly cap must be non-negative")
     .default(0),
   autoSeatUpgradeEnabled: z.boolean().default(false),
+  topUpEnabled: z.boolean().default(false),
+  autoInvoiceFinalizationEnabled: z.boolean().default(true),
 });
 
 export const manageCreditUsageConfigurationPlugin = createPlugin({
@@ -123,6 +127,22 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
           "Automatically upgrade members to the next seat tier when they hit their credit limit.",
         async: true,
       },
+      topUpEnabled: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Top-Up Enabled (Enterprise)",
+        description:
+          "Show the 'Top up' button on the Usage page for enterprise-plan workspaces.",
+        async: true,
+      },
+      autoInvoiceFinalizationEnabled: {
+        type: "boolean",
+        variant: "toggle",
+        label: "Auto Invoice Finalization",
+        description:
+          "Automatically finalize Metronome-pushed Stripe draft invoices. Disable to leave invoices as cleaned drafts for manual review.",
+        async: true,
+      },
     },
     requiredRoles: ["billing"],
   },
@@ -136,12 +156,10 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
     const config =
       await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-    const [defaultPoolLimit, programmaticLimit, usageConfig] =
-      await Promise.all([
-        getDefaultUserSpendLimit(auth),
-        getProgrammaticUsageLimit(auth),
-        getUsageConfiguration(auth),
-      ]);
+    const [defaultPoolLimit, programmaticLimit] = await Promise.all([
+      getDefaultUserSpendLimit(auth),
+      getProgrammaticUsageLimit(auth),
+    ]);
 
     return new Ok({
       defaultDiscountPercent: config?.defaultDiscountPercent ?? 0,
@@ -154,7 +172,12 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       programmaticMonthlyCapCredits: programmaticLimit.isOk()
         ? (programmaticLimit.value ?? 0)
         : 0,
-      autoSeatUpgradeEnabled: usageConfig.autoSeatUpgradeEnabled,
+      autoSeatUpgradeEnabled:
+        config?.autoSeatUpgradeEnabled ?? DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
+      topUpEnabled: config?.topUpEnabled ?? DEFAULT_TOP_UP_ENABLED,
+      autoInvoiceFinalizationEnabled:
+        config?.autoInvoiceFinalizationEnabled ??
+        DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED,
     });
   },
 
@@ -187,19 +210,42 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       defaultPoolCapCredits,
       programmaticMonthlyCapCredits,
       autoSeatUpgradeEnabled,
+      topUpEnabled,
+      autoInvoiceFinalizationEnabled,
     } = parseResult.data;
 
     const resolvedUsageCapCredits =
       usageCapCredits > 0 ? usageCapCredits : null;
+    const resolvedBalanceThresholdCredits =
+      balanceThresholdCredits > 0 ? balanceThresholdCredits : null;
+    const resolvedProgrammaticMonthlyCapCredits =
+      programmaticMonthlyCapCredits > 0 ? programmaticMonthlyCapCredits : null;
 
-    // 1. Core config (discount, PAYG, workspace usage cap).
-    const existingConfig =
-      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    // Fetch current state upfront so each sync step can be skipped when its
+    // inputs haven't changed (avoids triggering seat reconciliation for every
+    // save regardless of what actually changed).
+    const [existingConfig, currentPoolLimit, currentProgrammaticLimit] =
+      await Promise.all([
+        CreditUsageConfigurationResource.fetchByWorkspaceId(auth),
+        getDefaultUserSpendLimit(auth),
+        getProgrammaticUsageLimit(auth),
+      ]);
+
+    const currentPoolCapCredits = currentPoolLimit.isOk()
+      ? (currentPoolLimit.value.awuCredits ?? 0)
+      : 0;
+    const currentProgrammaticCapCredits = currentProgrammaticLimit.isOk()
+      ? (currentProgrammaticLimit.value ?? 0)
+      : 0;
+
+    // 1. Core config (discount, PAYG, workspace usage cap, static flags).
     if (existingConfig) {
       const updateResult = await existingConfig.updateConfiguration(auth, {
         defaultDiscountPercent,
         paygEnabled,
         usageCapCredits: resolvedUsageCapCredits,
+        topUpEnabled,
+        autoInvoiceFinalizationEnabled,
       });
       if (updateResult.isErr()) {
         return updateResult;
@@ -211,6 +257,8 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
           defaultDiscountPercent,
           paygEnabled,
           usageCapCredits: resolvedUsageCapCredits,
+          topUpEnabled,
+          autoInvoiceFinalizationEnabled,
         }
       );
       if (createResult.isErr()) {
@@ -218,53 +266,72 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
       }
     }
 
-    const paygResult = await syncCreditBasedPayg({
-      auth,
-      paygEnabled,
-      usageCapCredits: resolvedUsageCapCredits,
-    });
-    if (paygResult.isErr()) {
-      return paygResult;
+    // Only sync PAYG when paygEnabled or usageCapCredits changed.
+    const paygChanged =
+      paygEnabled !== (existingConfig?.paygEnabled ?? false) ||
+      resolvedUsageCapCredits !== (existingConfig?.usageCapCredits ?? null);
+    if (paygChanged) {
+      const paygResult = await syncCreditBasedPayg({
+        auth,
+        paygEnabled,
+        usageCapCredits: resolvedUsageCapCredits,
+      });
+      if (paygResult.isErr()) {
+        return paygResult;
+      }
     }
 
-    // 2. Balance threshold alert.
-    const balanceResult = await syncMetronomeBalanceThresholdAlert({
-      auth,
-      balanceThresholdCredits:
-        balanceThresholdCredits > 0 ? balanceThresholdCredits : null,
-    });
-    if (balanceResult.isErr()) {
-      return new Err(balanceResult.error);
+    // 2. Balance threshold alert — only sync when the threshold changed.
+    const balanceChanged =
+      resolvedBalanceThresholdCredits !==
+      (existingConfig?.balanceThresholdAwuCredits ?? null);
+    if (balanceChanged) {
+      const balanceResult = await syncMetronomeBalanceThresholdAlert({
+        auth,
+        balanceThresholdCredits: resolvedBalanceThresholdCredits,
+      });
+      if (balanceResult.isErr()) {
+        return new Err(balanceResult.error);
+      }
     }
 
-    // 3. Default per-user pool limit.
-    const poolResult = await setDefaultUserSpendLimit(auth, {
-      awuCredits: defaultPoolCapCredits,
-      auditContext: POKE_AUDIT_CONTEXT,
-    });
-    if (poolResult.isErr()) {
-      return new Err(poolResult.error);
+    // 3. Default per-user pool limit — only sync when the cap changed.
+    if (defaultPoolCapCredits !== currentPoolCapCredits) {
+      const poolResult = await setDefaultUserSpendLimit(auth, {
+        awuCredits: defaultPoolCapCredits,
+        auditContext: POKE_AUDIT_CONTEXT,
+      });
+      if (poolResult.isErr()) {
+        return new Err(poolResult.error);
+      }
     }
 
-    // 4. Programmatic monthly cap.
-    const programmaticResult = await syncProgrammaticUsageLimit({
-      auth,
-      monthlyCapCredits:
-        programmaticMonthlyCapCredits > 0
-          ? programmaticMonthlyCapCredits
-          : null,
-      auditContext: POKE_AUDIT_CONTEXT,
-    });
-    if (programmaticResult.isErr()) {
-      return new Err(programmaticResult.error);
+    // 4. Programmatic monthly cap — only sync when the cap changed.
+    if (
+      resolvedProgrammaticMonthlyCapCredits !== currentProgrammaticCapCredits
+    ) {
+      const programmaticResult = await syncProgrammaticUsageLimit({
+        auth,
+        monthlyCapCredits: resolvedProgrammaticMonthlyCapCredits,
+        auditContext: POKE_AUDIT_CONTEXT,
+      });
+      if (programmaticResult.isErr()) {
+        return new Err(programmaticResult.error);
+      }
     }
 
-    // 5. Auto-upgrade seats toggle.
-    const toggleResult = await updateUsageConfiguration(auth, {
-      autoSeatUpgradeEnabled,
-    });
-    if (toggleResult.isErr()) {
-      return new Err(toggleResult.error);
+    // 5. Auto-upgrade seats toggle — only update when changed.
+    const autoSeatUpgradeChanged =
+      autoSeatUpgradeEnabled !==
+      (existingConfig?.autoSeatUpgradeEnabled ??
+        DEFAULT_AUTO_SEAT_UPGRADE_ENABLED);
+    if (autoSeatUpgradeChanged) {
+      const toggleResult = await updateUsageConfiguration(auth, {
+        autoSeatUpgradeEnabled,
+      });
+      if (toggleResult.isErr()) {
+        return new Err(toggleResult.error);
+      }
     }
 
     return new Ok({
@@ -278,6 +345,8 @@ export const manageCreditUsageConfigurationPlugin = createPlugin({
         `Pool limit: ${defaultPoolCapCredits.toLocaleString()} credits`,
         `Programmatic cap: ${programmaticMonthlyCapCredits > 0 ? `${programmaticMonthlyCapCredits.toLocaleString()} credits/month` : "disabled"}`,
         `Auto-upgrade: ${autoSeatUpgradeEnabled ? "on" : "off"}`,
+        `Top-up (enterprise): ${topUpEnabled ? "on" : "off"}`,
+        `Auto invoice finalization: ${autoInvoiceFinalizationEnabled ? "on" : "off"}`,
       ].join(". "),
     });
   },

--- a/front/lib/credits/awu_purchase.ts
+++ b/front/lib/credits/awu_purchase.ts
@@ -25,6 +25,7 @@ import {
 import { USAGE_TAG } from "@app/lib/metronome/setup_common";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { getStripeClient } from "@app/lib/plans/stripe";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import {
@@ -129,7 +130,11 @@ async function checkAwuPurchaseEligibility(
   }
 
   if (isEnterprisePlanPrefix(subscription.plan.code)) {
-    return new Err({ code: "enterprise_plan" });
+    const config =
+      await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+    if (!config?.topUpEnabled) {
+      return new Err({ code: "enterprise_plan" });
+    }
   }
 
   const stripeCustomerResult =

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -10,7 +10,10 @@ import {
   isSupportedReportUsage,
   SUPPORTED_REPORT_USAGE,
 } from "@app/lib/plans/usage/types";
+import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED } from "@app/lib/resources/storage/models/credit_usage_configurations";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
@@ -1469,6 +1472,16 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
     // Freeze the draft so Stripe's auto-advance can't finalize it while we edit.
     await stripe.invoices.update(invoiceId, { auto_advance: false });
 
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    const creditConfig = workspace
+      ? await CreditUsageConfigurationResource.fetchByWorkspaceModelId(
+          workspace.id
+        )
+      : null;
+    const autoInvoiceFinalizationEnabled =
+      creditConfig?.autoInvoiceFinalizationEnabled ??
+      DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED;
+
     await cleanMetronomeInvoiceLines(stripe, invoice);
 
     await stripe.invoices.update(invoiceId, {
@@ -1478,10 +1491,14 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
       },
     });
 
-    // Finalization is intentionally disabled for now: while we are still
-    // inspecting line shapes and designing the transform, leave the invoice as a
-    // draft so it can be reviewed manually rather than charged. Re-enable once
-    // the line transform is in place.
+    if (!autoInvoiceFinalizationEnabled) {
+      logger.info(
+        { stripeInvoiceId: invoiceId, workspaceId },
+        "[Stripe] Cleaned Metronome draft invoice (finalization disabled for workspace)"
+      );
+      return new Ok({ outcome: "cleaned" });
+    }
+
     const finalizeResult = await finalizeInvoice(invoice);
     if (finalizeResult.isErr()) {
       return finalizeResult;
@@ -1489,7 +1506,7 @@ export async function cleanAndFinalizeMetronomeDraftInvoice({
 
     logger.info(
       { stripeInvoiceId: invoiceId, workspaceId },
-      "[Stripe] Cleaned Metronome draft invoice (finalization disabled)"
+      "[Stripe] Cleaned and finalized Metronome draft invoice"
     );
     return new Ok({ outcome: "cleaned" });
   } catch (error) {

--- a/front/lib/resources/credit_usage_configuration_resource.ts
+++ b/front/lib/resources/credit_usage_configuration_resource.ts
@@ -128,6 +128,8 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       programmaticMonthlyCapAwuCredits: number | null;
       autoSeatUpgradeEnabled: boolean;
       balanceThresholdAwuCredits: number | null;
+      topUpEnabled: boolean;
+      autoInvoiceFinalizationEnabled: boolean;
     }>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
@@ -192,6 +194,7 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
       programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
       balanceThresholdAwuCredits: this.balanceThresholdAwuCredits,
+      topUpEnabled: this.topUpEnabled,
     };
   }
 
@@ -207,6 +210,10 @@ export class CreditUsageConfigurationResource extends BaseResource<CreditUsageCo
       defaultPoolCapAwuCredits: this.defaultPoolCapAwuCredits,
       programmaticMonthlyCapAwuCredits: this.programmaticMonthlyCapAwuCredits,
       balanceThresholdAwuCredits: this.balanceThresholdAwuCredits,
+      topUpEnabled: String(this.topUpEnabled),
+      autoInvoiceFinalizationEnabled: String(
+        this.autoInvoiceFinalizationEnabled
+      ),
     };
   }
 }

--- a/front/lib/resources/storage/models/credit_usage_configurations.ts
+++ b/front/lib/resources/storage/models/credit_usage_configurations.ts
@@ -1,3 +1,9 @@
+export const DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS = true;
+export const DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED = true;
+export const DEFAULT_AUTO_SEAT_UPGRADE_ENABLED = false;
+export const DEFAULT_TOP_UP_ENABLED = false;
+export const DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED = true;
+
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -42,6 +48,12 @@ import type { CreationOptional } from "sequelize";
  *   Metronome balance-threshold alert (see
  *   `lib/metronome/alerts/balance_threshold.ts`) is derived from it. NULL means
  *   no threshold is configured (the warning is off); 0 is normalized to NULL.
+ * - topUpEnabled: When true, enterprise-plan workspaces show the "Top up"
+ *   button on the Usage page. Defaults to false (enterprise workspaces are
+ *   directed to sales by default).
+ * - autoInvoiceFinalizationEnabled: When false, `cleanAndFinalizeMetronomeDraftInvoice`
+ *   skips the Stripe finalization step and leaves the invoice as a cleaned draft
+ *   for manual review. Defaults to true (finalization is automatic).
  *
  * The Metronome balance-threshold alert id (used by the webhook to match the
  * firing alert) is NOT stored here: it is a Metronome-generated value resolved
@@ -59,6 +71,8 @@ export class CreditUsageConfigurationModel extends WorkspaceAwareModel<CreditUsa
   declare programmaticMonthlyCapAwuCredits: number | null;
   declare autoSeatUpgradeEnabled: CreationOptional<boolean>;
   declare balanceThresholdAwuCredits: number | null;
+  declare topUpEnabled: CreationOptional<boolean>;
+  declare autoInvoiceFinalizationEnabled: CreationOptional<boolean>;
 }
 
 CreditUsageConfigurationModel.init(
@@ -104,12 +118,12 @@ CreditUsageConfigurationModel.init(
     allowMemberUpgradeRequests: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
-      defaultValue: true,
+      defaultValue: DEFAULT_ALLOW_MEMBER_UPGRADE_REQUESTS,
     },
     upgradeRequestEmailEnabled: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
-      defaultValue: true,
+      defaultValue: DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
     },
     defaultPoolCapAwuCredits: {
       type: DataTypes.INTEGER,
@@ -124,12 +138,22 @@ CreditUsageConfigurationModel.init(
     autoSeatUpgradeEnabled: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
-      defaultValue: false,
+      defaultValue: DEFAULT_AUTO_SEAT_UPGRADE_ENABLED,
     },
     balanceThresholdAwuCredits: {
       type: DataTypes.INTEGER,
       allowNull: true,
       defaultValue: null,
+    },
+    topUpEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: DEFAULT_TOP_UP_ENABLED,
+    },
+    autoInvoiceFinalizationEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: DEFAULT_AUTO_INVOICE_FINALIZATION_ENABLED,
     },
   },
   {

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -33,6 +33,7 @@ export interface UsageSettings {
   allowUpgradeRequest: boolean;
   autoSeatUpgradeEnabled: boolean;
   autoSeatUpgradeAvailable: boolean;
+  topUpEnabled: boolean;
 }
 
 export interface UsageNotifications {
@@ -45,6 +46,7 @@ const DEFAULT_USAGE_SETTINGS: UsageSettings = {
   allowUpgradeRequest: true,
   autoSeatUpgradeEnabled: false,
   autoSeatUpgradeAvailable: false,
+  topUpEnabled: false,
 };
 
 const DEFAULT_USAGE_NOTIFICATIONS: UsageNotifications = {
@@ -99,6 +101,7 @@ export function useUsageSettings({ workspaceId }: { workspaceId: string }) {
           allowUpgradeRequest: data.configuration.allowMemberUpgradeRequests,
           autoSeatUpgradeEnabled: data.configuration.autoSeatUpgradeEnabled,
           autoSeatUpgradeAvailable: data.configuration.autoSeatUpgradeAvailable,
+          topUpEnabled: data.configuration.topUpEnabled,
         }
       : {}),
   };

--- a/front/migrations/pre-deploy/20260623113341_add_topup_and_invoice_finalization_flags.sql
+++ b/front/migrations/pre-deploy/20260623113341_add_topup_and_invoice_finalization_flags.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "topUpEnabled" boolean NOT NULL DEFAULT false;
+ALTER TABLE "public"."credit_usage_configurations" ADD COLUMN "autoInvoiceFinalizationEnabled" boolean NOT NULL DEFAULT true;


### PR DESCRIPTION
## Description

Adds two flags to the `credit_usage_configurations` table:

**`topUpEnabled`** (default: `false`)
Allows enterprise-plan workspaces to show the \"Top up\" button on the Usage page. By default, enterprise workspaces are directed to their sales representative; enabling this flag lets them self-serve credit purchases.

**`autoInvoiceFinalizationEnabled`** (default: `true`)
Controls whether `cleanAndFinalizeMetronomeDraftInvoice` automatically finalizes the cleaned Stripe draft invoice. When disabled, the invoice is left as a cleaned draft for manual review (useful for inspecting line shapes or pausing billing for a specific workspace without changing the global flow).

Both flags are managed via the existing **Manage Credit Usage Configuration** poke plugin (billing role required).

### Changes

- SQL migration: adds both columns with safe defaults (`false` / `true`)
- Sequelize model + Resource: exposes both fields, wires `updateConfiguration`, `toJSON`, `toLogJSON`
- API layer (`usage_configuration.ts`): surfaces `topUpEnabled` in `CreditUsageConfigurationBody` so the frontend can read it; `autoInvoiceFinalizationEnabled` stays server-side only
- SWR hook (`useUsageSettings`): maps `topUpEnabled` through to the UI
- `UsagePage`: top-up button now shows for enterprise workspaces when `topUpEnabled` is on (`!isEnterprise || usageSettings.topUpEnabled`)
- `cleanAndFinalizeMetronomeDraftInvoice`: fetches the workspace config and skips `finalizeInvoice` when `autoInvoiceFinalizationEnabled === false`
- Poke plugin: both flags added as async toggle args with current-value population

## Tests

Manually tested via type-check (`npx tsgo --noEmit` passes clean). Existing tests for the credit usage configuration resource and auto-seat-upgrade logic are unaffected (no behavioral change to existing fields).

## Risk

Low. Both flags default to the current behavior (`topUpEnabled: false` preserves the existing enterprise top-up block; `autoInvoiceFinalizationEnabled: true` preserves automatic finalization). The migration adds nullable-equivalent boolean columns with DB-level defaults, so no backfill is needed.

## Deploy Plan

- Run pre-deploy migration (`20260623000000_add_topup_and_invoice_finalization_flags.sql`) — adds two columns with safe defaults, no locking risk.
- Deploy front — new flags are read-only until set via poke.
- Use the **Manage Credit Usage Configuration** poke plugin to enable flags per workspace as needed.