### PR TITLE
feat(llm): add TogetherAI Llama 3.3 70B Instruct Turbo to the new LLM router

### DIFF
--- a/front/lib/api/llm/clients/togetherai/index.ts
+++ b/front/lib/api/llm/clients/togetherai/index.ts
@@ -1,0 +1,89 @@
+import type { TogetheraiWhitelistedModelId } from "@app/lib/api/llm/clients/togetherai/types";
+import {
+  overwriteLLMParameters,
+  TOGETHERAI_PROVIDER_ID,
+} from "@app/lib/api/llm/clients/togetherai/types";
+import { LLM } from "@app/lib/api/llm/llm";
+import { handleGenericError } from "@app/lib/api/llm/types/errors";
+import type { LLMEvent } from "@app/lib/api/llm/types/events";
+import type {
+  LLMParameters,
+  LLMStreamParameters,
+} from "@app/lib/api/llm/types/options";
+import { systemPromptToText } from "@app/lib/api/llm/types/options";
+import {
+  toMessages,
+  toOutputFormatParam,
+  toReasoningParam,
+  toToolChoiceParam,
+  toTools,
+} from "@app/lib/api/llm/utils/openai_like/chat/conversation_to_openai";
+import { streamLLMEvents } from "@app/lib/api/llm/utils/openai_like/chat/openai_to_events";
+import { handleError } from "@app/lib/api/llm/utils/openai_like/errors";
+import type { Authenticator } from "@app/lib/auth";
+import assert from "assert";
+import { APIError, OpenAI } from "openai";
+import type { ChatCompletionCreateParamsStreaming } from "openai/resources/chat/completions";
+
+export class TogetheraiLLM extends LLM<ChatCompletionCreateParamsStreaming> {
+  private client: OpenAI;
+
+  constructor(
+    auth: Authenticator,
+    llmParameters: LLMParameters & {
+      modelId: TogetheraiWhitelistedModelId;
+    }
+  ) {
+    const params = overwriteLLMParameters(llmParameters);
+    super(auth, TOGETHERAI_PROVIDER_ID, params);
+
+    const { TOGETHERAI_API_KEY } = llmParameters.credentials;
+    assert(TOGETHERAI_API_KEY, "TOGETHERAI_API_KEY credential is required");
+    this.client = new OpenAI({
+      apiKey: TOGETHERAI_API_KEY,
+      baseURL: "https://api.together.xyz/v1",
+    });
+  }
+
+  protected buildStreamRequestPayload({
+    conversation,
+    prompt,
+    specifications,
+    forceToolCall,
+  }: LLMStreamParameters): ChatCompletionCreateParamsStreaming {
+    const tools =
+      specifications.length > 0 ? toTools(specifications) : undefined;
+
+    return {
+      model: this.modelId,
+      messages: toMessages(systemPromptToText(prompt), conversation),
+      stream: true,
+      stream_options: {
+        include_usage: true,
+      },
+      temperature: this.temperature ?? undefined,
+      reasoning_effort: toReasoningParam(
+        this.reasoningEffort,
+        this.modelConfig.useNativeLightReasoning
+      ),
+      tool_choice: toToolChoiceParam(specifications, forceToolCall),
+      ...(tools ? { tools } : {}),
+      response_format: toOutputFormatParam(this.responseFormat),
+    };
+  }
+
+  protected async *sendRequest(
+    payload: ChatCompletionCreateParamsStreaming
+  ): AsyncGenerator<LLMEvent> {
+    try {
+      const events = await this.client.chat.completions.create(payload);
+      yield* streamLLMEvents(events, this.metadata);
+    } catch (err) {
+      if (err instanceof APIError) {
+        yield handleError(err, this.metadata);
+      } else {
+        yield handleGenericError(err, this.metadata);
+      }
+    }
+  }
+}

--- a/front/lib/api/llm/clients/togetherai/types.ts
+++ b/front/lib/api/llm/clients/togetherai/types.ts
@@ -1,0 +1,45 @@
+import type {
+  LLMParameterOverwrites,
+  LLMParameters,
+} from "@app/lib/api/llm/types/options";
+import { TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID } from "@app/types/assistant/models/togetherai";
+import type { ModelIdType } from "@app/types/assistant/models/types";
+
+export const TOGETHERAI_PROVIDER_ID = "togetherai";
+
+export const TOGETHERAI_WHITELISTED_MODEL_IDS = [
+  TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID,
+] as const;
+export type TogetheraiWhitelistedModelId =
+  (typeof TOGETHERAI_WHITELISTED_MODEL_IDS)[number];
+
+export const TOGETHERAI_MODEL_CONFIGS: Record<
+  TogetheraiWhitelistedModelId,
+  {
+    overwrites: LLMParameterOverwrites;
+  }
+> = {
+  // Non-reasoning model: never send a reasoning effort.
+  [TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID]: {
+    overwrites: { reasoningEffort: "none" },
+  },
+};
+
+export function overwriteLLMParameters(
+  llmParameters: LLMParameters & {
+    modelId: TogetheraiWhitelistedModelId;
+  }
+): LLMParameters & { modelId: TogetheraiWhitelistedModelId } {
+  return {
+    ...llmParameters,
+    ...TOGETHERAI_MODEL_CONFIGS[llmParameters.modelId].overwrites,
+  };
+}
+
+export const isTogetheraiWhitelistedModelId = (
+  modelId: ModelIdType
+): modelId is TogetheraiWhitelistedModelId => {
+  return (TOGETHERAI_WHITELISTED_MODEL_IDS as readonly string[]).includes(
+    modelId
+  );
+};

--- a/front/lib/api/llm/tests/parity/providers.ts
+++ b/front/lib/api/llm/tests/parity/providers.ts
@@ -6,6 +6,8 @@ import { GoogleLLM } from "@app/lib/api/llm/clients/google";
 import { isGoogleAIStudioWhitelistedModelId } from "@app/lib/api/llm/clients/google/types";
 import { OpenAIResponsesLLM } from "@app/lib/api/llm/clients/openai";
 import { isOpenAIResponsesWhitelistedModelId } from "@app/lib/api/llm/clients/openai/types";
+import { TogetheraiLLM } from "@app/lib/api/llm/clients/togetherai";
+import { isTogetheraiWhitelistedModelId } from "@app/lib/api/llm/clients/togetherai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
@@ -25,6 +27,7 @@ export const PARITY_CREDENTIALS: LLMCredentialsType = {
   GOOGLE_AI_STUDIO_API_KEY: "test-google-key",
   OPENAI_API_KEY: "test-openai-key",
   FIREWORKS_API_KEY: "test-fireworks-key",
+  TOGETHERAI_API_KEY: "test-togetherai-key",
 };
 
 /** Per-call parameters shared by both routers for one parity case. */
@@ -246,11 +249,48 @@ const fireworksProvider: ParityProvider = {
   },
 };
 
+const togetheraiProvider: ParityProvider = {
+  toModelId(raw) {
+    if (!isModelId(raw) || !isTogetheraiWhitelistedModelId(raw)) {
+      throw new Error(`${raw} is not a whitelisted TogetherAI model.`);
+    }
+    return raw;
+  },
+  buildLegacyLLM(auth, _endpoint, params) {
+    if (
+      !isModelId(params.modelId) ||
+      !isTogetheraiWhitelistedModelId(params.modelId)
+    ) {
+      throw new Error(
+        `${params.modelId} is not a whitelisted TogetherAI model.`
+      );
+    }
+    return new TogetheraiLLM(auth, {
+      credentials: PARITY_CREDENTIALS,
+      modelId: params.modelId,
+      temperature: params.temperature,
+      reasoningEffort: params.reasoningEffort,
+      responseFormat: params.responseFormat,
+      bypassFeatureFlag: true,
+    });
+  },
+  // Like Fireworks, both routers hit the same `chat.completions.create`; the
+  // test drains the legacy stream before the new one, so the first capture is
+  // legacy, the last new.
+  selectOldRequest(_endpoint, captures) {
+    return first(captures.openai_chat);
+  },
+  selectNewRequest(_endpoint, captures) {
+    return last(captures.openai_chat);
+  },
+};
+
 const PARITY_PROVIDERS: Partial<Record<ProviderId, ParityProvider>> = {
   anthropic: anthropicProvider,
   google_ai_studio: googleProvider,
   openai: openaiProvider,
   fireworks: fireworksProvider,
+  togetherai: togetheraiProvider,
 };
 
 export function getParityProvider(providerId: ProviderId): ParityProvider {

--- a/front/lib/llms/providers/togetherai/models/llama_3_3_70b_instruct_turbo.ts
+++ b/front/lib/llms/providers/togetherai/models/llama_3_3_70b_instruct_turbo.ts
@@ -1,0 +1,15 @@
+export function WithDustTogetheraiLlama3370BInstructTurboConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class DustTogetheraiLlama3370BInstructTurbo extends Base {
+    static readonly displayName = "Llama 3.3 70B Instruct Turbo";
+    static readonly description =
+      "Meta's fast, powerful and open source model (128k context, served via TogetherAI).";
+    static readonly defaultReasoningEffort = "none";
+    static readonly byok = false;
+  }
+
+  return DustTogetheraiLlama3370BInstructTurbo;
+}

--- a/front/lib/llms/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.ts
+++ b/front/lib/llms/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.ts
@@ -1,0 +1,11 @@
+import { WithDustTogetheraiLlama3370BInstructTurboConfig } from "@app/lib/llms/providers/togetherai/models/llama_3_3_70b_instruct_turbo";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
+
+export class DustTogetheraiGlobalLlama3370BInstructTurboStream extends WithDustTogetheraiLlama3370BInstructTurboConfig(
+  TogetheraiGlobalLlama3370BInstructTurboStream
+) {
+  static readonly endpointFilter = {};
+}
+
+defineDustStreamEndpoint(DustTogetheraiGlobalLlama3370BInstructTurboStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -20,6 +20,7 @@ import { DustOpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/llms/stre
 import { DustOpenAIResponsesGlobalGptFiveDotTwoStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_two";
 import { DustOpenAIResponsesGlobalGptFiveMiniStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_mini";
 import { DustOpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_nano";
+import { DustTogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/llms/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
 import type {
   EndpointConfig,
@@ -70,6 +71,8 @@ export const DUST_STREAM_ENDPOINTS = {
   [DustFireworksGlobalDeepSeekV4ProStream.id]:
     DustFireworksGlobalDeepSeekV4ProStream,
   [DustFireworksGlobalKimiK2Dot5Stream.id]: DustFireworksGlobalKimiK2Dot5Stream,
+  [DustTogetheraiGlobalLlama3370BInstructTurboStream.id]:
+    DustTogetheraiGlobalLlama3370BInstructTurboStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/providers/togetherai/inputConfig.ts
+++ b/front/lib/model_constructors/providers/togetherai/inputConfig.ts
@@ -1,14 +1,21 @@
-import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import {
+  inputConfigSchema,
+  reasoningSchema,
+} from "@app/lib/model_constructors/types/input/configuration";
 import { z } from "zod";
 
 // Schema for the non-reasoning TogetherAI models we serve (Llama 3.3 70B Turbo,
-// Qwen2 72B Instruct): accept only `none`, so every other effort is rejected.
-// The converter maps `none` to no `reasoning_effort`, so the request never
-// carries one. `none` is kept (not transformed away) so the Dust layer can
-// still read it as `defaultReasoningEffort`. Temperature passes through
-// unchanged. TogetherAI has no explicit prompt-cache key.
+// Qwen2 72B Instruct): accept any reasoning effort but always drop it, so the
+// request never carries a `reasoning_effort` — matching the legacy client, which
+// forces the effort to `none`. The parsed output keeps `none` so the Dust layer
+// can read it as `defaultReasoningEffort`. Temperature passes through unchanged.
+// TogetherAI has no explicit prompt-cache key.
 export const togetheraiNonReasoningConfigSchema = inputConfigSchema.extend({
-  reasoning: z.object({ effort: z.literal("none") }).optional(),
+  reasoning: reasoningSchema
+    .optional()
+    .transform((r): { effort: "none" } | undefined =>
+      r ? { effort: "none" } : undefined
+    ),
   cacheKey: z.undefined(),
 });
 

--- a/front/lib/model_constructors/providers/togetherai/inputConfig.ts
+++ b/front/lib/model_constructors/providers/togetherai/inputConfig.ts
@@ -2,14 +2,13 @@ import { inputConfigSchema } from "@app/lib/model_constructors/types/input/confi
 import { z } from "zod";
 
 // Schema for the non-reasoning TogetherAI models we serve (Llama 3.3 70B Turbo,
-// Qwen2 72B Instruct): accept `none` but drop it so the request omits
-// `reasoning_effort` (the API rejects it on these models). Temperature passes
-// through unchanged. TogetherAI has no explicit prompt-cache key.
+// Qwen2 72B Instruct): accept only `none`, so every other effort is rejected.
+// The converter maps `none` to no `reasoning_effort`, so the request never
+// carries one. `none` is kept (not transformed away) so the Dust layer can
+// still read it as `defaultReasoningEffort`. Temperature passes through
+// unchanged. TogetherAI has no explicit prompt-cache key.
 export const togetheraiNonReasoningConfigSchema = inputConfigSchema.extend({
-  reasoning: z
-    .object({ effort: z.literal("none") })
-    .optional()
-    .transform(() => undefined),
+  reasoning: z.object({ effort: z.literal("none") }).optional(),
   cacheKey: z.undefined(),
 });
 

--- a/front/lib/model_constructors/providers/togetherai/models/llama_3_3_70b_instruct_turbo.ts
+++ b/front/lib/model_constructors/providers/togetherai/models/llama_3_3_70b_instruct_turbo.ts
@@ -1,0 +1,28 @@
+import { togetheraiNonReasoningConfigSchema } from "@app/lib/model_constructors/providers/togetherai/inputConfig";
+import { TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
+
+// Verified against https://docs.together.ai/docs/serverless-models (2026-06-23):
+// Llama 3.3 70B Instruct Turbo (FP8) has a 131,072-token context window.
+const CONTEXT_SIZE = 131_072;
+// Capability metadata only — the request does not send an explicit max (the
+// openai-completions converter doesn't either), so TogetherAI uses its default.
+const MAX_OUTPUT_TOKENS = 2_048;
+
+// Mixin carrying shared config; runtime base differs per surface.
+export function WithTogetheraiLlama3370BInstructTurboConfig<
+  TBase extends abstract new (
+    ...args: any[]
+  ) => object,
+>(Base: TBase) {
+  abstract class TogetheraiLlama3370BInstructTurbo extends Base {
+    static readonly modelId = TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID;
+
+    // Non-reasoning model: the API rejects `reasoning_effort`.
+    static readonly configSchema = togetheraiNonReasoningConfigSchema;
+
+    static readonly contextSize = CONTEXT_SIZE;
+    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+  }
+
+  return TogetheraiLlama3370BInstructTurbo;
+}

--- a/front/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.ts
+++ b/front/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.ts
@@ -1,0 +1,20 @@
+import { WithTogetheraiLlama3370BInstructTurboConfig } from "@app/lib/model_constructors/providers/togetherai/models/llama_3_3_70b_instruct_turbo";
+import { TogetheraiStream } from "@app/lib/model_constructors/stream/clients/togetherai";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { GLOBAL } from "@app/lib/model_constructors/types/regions";
+
+export class TogetheraiGlobalLlama3370BInstructTurboStream extends WithTogetheraiLlama3370BInstructTurboConfig(
+  TogetheraiStream
+) {
+  // https://www.together.ai/models/llama-3-3-70b ($1.04 / 1M tokens, in & out)
+  static readonly tokenPricing = {
+    standardInput: 1.04,
+    standardOutput: 1.04,
+  };
+
+  static readonly region = GLOBAL;
+
+  static readonly id = this.buildId();
+}
+
+TogetheraiGlobalLlama3370BInstructTurboStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -20,6 +20,7 @@ import { OpenAIResponsesGlobalGptFiveDotOneStream } from "@app/lib/model_constru
 import { OpenAIResponsesGlobalGptFiveDotTwoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_two";
 import { OpenAIResponsesGlobalGptFiveMiniStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_mini";
 import { OpenAIResponsesGlobalGptFiveNanoStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_nano";
+import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
 
 export const STREAM_ENDPOINTS = {
   [AnthropicGlobalClaudeSonnetFourDotSixStream.id]:
@@ -60,6 +61,8 @@ export const STREAM_ENDPOINTS = {
   [FireworksGlobalGlmFiveDotTwoStream.id]: FireworksGlobalGlmFiveDotTwoStream,
   [FireworksGlobalDeepSeekV4ProStream.id]: FireworksGlobalDeepSeekV4ProStream,
   [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5Stream,
+  [TogetheraiGlobalLlama3370BInstructTurboStream.id]:
+    TogetheraiGlobalLlama3370BInstructTurboStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;

--- a/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
+++ b/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new TogetheraiGlobalLlama3370BInstructTurboStream({
+      TOGETHERAI_API_KEY: process.env.DUST_MANAGED_TOGETHERAI_API_KEY ?? "",
+    }),
+  // Llama 3.3 70B Instruct Turbo is a non-reasoning model: only `none` is
+  // accepted, so every other reasoning effort is rejected by the config schema.
+  tests: {
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
+
+    // Supported (`none`/default) cases run with their default checkers.
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-none": null,
+
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-none": null,
+
+    "output-format/json-schema/t-default/r-none": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
+runStreamEndpointTests(TogetheraiGlobalLlama3370BInstructTurboStream, setup);

--- a/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
+++ b/front/lib/model_constructors/test/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { TogetheraiGlobalLlama3370BInstructTurboStream } from "@app/lib/model_constructors/stream/endpoints/togetherai_global_llama_3_3_70b_instruct_turbo";
-import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { HAS_NO_REASONING } from "@app/lib/model_constructors/test/cases";
 import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
 import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
 
@@ -10,56 +10,58 @@ const setup: StreamSetup = {
     new TogetheraiGlobalLlama3370BInstructTurboStream({
       TOGETHERAI_API_KEY: process.env.DUST_MANAGED_TOGETHERAI_API_KEY ?? "",
     }),
-  // Llama 3.3 70B Instruct Turbo is a non-reasoning model: only `none` is
-  // accepted, so every other reasoning effort is rejected by the config schema.
+  // Llama 3.3 70B Instruct Turbo is a non-reasoning model: the config schema
+  // accepts any reasoning effort but drops it, so the request never carries a
+  // `reasoning_effort` and every effort behaves like `none` (no error). All
+  // cases therefore run with their default checkers.
   tests: {
-    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-low": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-medium": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-high": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-low": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-high": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-low": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-medium": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-high": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
-    "calc/calc/t-default/r-medium": [INPUT_CONFIGURATION_ERROR],
-    "calc/calc/t-0.1/r-medium": [INPUT_CONFIGURATION_ERROR],
-    "reasoning/no-tools/t-default/r-low": [INPUT_CONFIGURATION_ERROR],
-    "output-format/json-schema/t-default/r-high": [INPUT_CONFIGURATION_ERROR],
-
-    // Supported (`none`/default) cases run with their default checkers.
     "simple/no-tools/t-default/r-default": null,
     "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-default/r-maximal": null,
     "simple/no-tools/t-0/r-default": null,
     "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0/r-maximal": null,
     "simple/no-tools/t-0.1/r-default": null,
     "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-0.1/r-maximal": null,
     "simple/no-tools/t-1/r-default": null,
     "simple/no-tools/t-1/r-none": null,
+    "simple/no-tools/t-1/r-minimal": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+    "simple/no-tools/t-1/r-maximal": null,
 
-    "cache/no-tools/t-default/r-default": null,
-
+    "calc/calc/t-default/r-medium": null,
     "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
     "calc/calc/t-default/r-default/force-tool-default": null,
     "calc/calc/t-default/r-default/force-tool": null,
     "calc/calc/t-default/r-none/force-tool": null,
 
     "reasoning/no-tools/t-default/r-none": null,
+    // r-low degrades to no reasoning on this non-reasoning model, so override
+    // the default HAS_REASONING checker.
+    "reasoning/no-tools/t-default/r-low": [HAS_NO_REASONING],
 
     "output-format/json-schema/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-high": null,
 
     "following/no-tools/t-default/r-default": null,
+
+    "cache/no-tools/t-default/r-default": null,
   },
 };
 

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -39,6 +39,10 @@ export const FIREWORKS_GLM_5_MODEL_ID =
 export const FIREWORKS_GLM_5P2_MODEL_ID =
   "accounts/fireworks/models/glm-5p2" as const;
 
+// TogetherAI-served models keep their full TogetherAI model path as the id.
+export const TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID =
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo" as const;
+
 // Include a few examples for now
 export const MODEL_IDS = [
   GPT_5_5_MODEL_ID,
@@ -69,6 +73,7 @@ export const MODEL_IDS = [
   FIREWORKS_MINIMAX_M2P5_MODEL_ID,
   FIREWORKS_GLM_5_MODEL_ID,
   FIREWORKS_GLM_5P2_MODEL_ID,
+  TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];


### PR DESCRIPTION
## Description

Adds the first TogetherAI endpoint to the new `model_constructors` LLM router, building on the provider plumbing from #27776. TogetherAI serves an OpenAI chat-completions–compatible API, so this reuses the shared `openai_completions` converters and mirrors the Fireworks endpoint shape.

What's added for `meta-llama/Llama-3.3-70B-Instruct-Turbo`:
- model id (`TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID`) registered in `MODEL_IDS`
- model-config mixin: 131,072-token context (verified against TogetherAI docs), non-reasoning
- stream endpoint class `TogetheraiGlobalLlama3370BInstructTurboStream` — `global` region, pricing $1.04 / 1M tokens for both input and output (per the [Together AI model page](https://www.together.ai/models/llama-3-3-70b))
- the `lib/llms` Dust wrapper (`DustTogetherai...Stream`) + model config (display name, description, `defaultReasoningEffort: "none"`, `byok: false`)
- registered in both the `model_constructors` `STREAM_ENDPOINTS` and the `lib/llms` `DUST_STREAM_ENDPOINTS` registries

### Router parity coverage

The router parity regression test (`lib/api/llm/tests/router_parity.test.ts`) drives every registered stream endpoint through both the legacy and the new router and compares the dispatched SDK request, so a new endpoint needs a legacy counterpart + a parity adapter:
- added the legacy `TogetheraiLLM` client (OpenAI chat-completions to `api.together.xyz`, mirroring the Fireworks client) and its whitelist, with the non-reasoning Llama model forcing reasoning effort to `none`
- registered the `togetherai` parity adapter (reusing the existing `openai_chat` capture bucket) and a test credential

### Non-reasoning schema: degrade instead of reject

The config schema now **degrades** any reasoning effort to no reasoning rather than rejecting unsupported efforts. The parity matrix feeds `light`/`medium`/`high` to every endpoint; rejecting them made the new router emit no request and broke parity. Degrading matches the legacy client (which forces the effort to `none`), so both routers dispatch an identical request with no `reasoning_effort`. `none` is preserved in the parsed output so the Dust layer can read it as `defaultReasoningEffort`.

## Tests

- **Router parity** (`router_parity.test.ts`, togetherai endpoint): all 14 cases pass — the legacy and new requests match exactly across the temperature/reasoning matrix, no normalizer needed.
- **Endpoint integration** (live TogetherAI API, 40 cases): all pass. Every reasoning effort is accepted and degraded to no reasoning; tool calls, forced tools, JSON-schema structured output, instruction-following, and cache all succeed. (Note: running all 40 cases live can occasionally hit TogetherAI rate limits and time out a case; re-run or run targeted subsets — the suite is local-only and gated on `NODE_ENV=test RUN_LLM_TEST=true`, never in CI.)
- `npx tsgo --noEmit` and biome clean.

## Risk

Low. Additive — a new endpoint plus its legacy parity counterpart, registered alongside existing ones. The behavioral choice (degrade reasoning to none for this non-reasoning model) matches the legacy client exactly. Trivial to roll back by removing the registry entries.

## Deploy Plan

Standard deploy. No migrations or config changes. The `DUST_MANAGED_TOGETHERAI_API_KEY` credential is already configured. Qwen2-72B-Instruct follows in a separate PR.