### PR TITLE
Add: endpoint and hook to write a text file using canonical path.

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].test.ts
@@ -24,6 +24,7 @@ function makeBucket(
     delete: ReturnType<typeof vi.fn>;
     fileDelete: ReturnType<typeof vi.fn>;
     getAllFilesByPrefix: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
   }> = {}
 ) {
   const existingFilePathSuffixes = overrides.existingFilePathSuffixes ?? [];
@@ -34,6 +35,7 @@ function makeBucket(
     overrides.createReadStream ?? vi.fn().mockReturnValue(makeReadStream());
   const fileDelete =
     overrides.fileDelete ?? vi.fn().mockResolvedValue(undefined);
+  const save = overrides.save ?? vi.fn().mockResolvedValue(undefined);
 
   return {
     file: vi.fn((filePath: string) => ({
@@ -45,6 +47,7 @@ function makeBucket(
       getMetadata,
       createReadStream,
       delete: fileDelete,
+      save,
     })),
     copyFile: overrides.copyFile ?? vi.fn().mockResolvedValue(undefined),
     delete: overrides.delete ?? vi.fn().mockResolvedValue(undefined),
@@ -361,6 +364,134 @@ describe("PATCH /api/w/:wId/files/path/:canonicalPath", () => {
     });
 
     expect(response.status).toBe(200);
+  });
+});
+
+describe("PUT /api/w/:wId/files/path/:canonicalPath", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a new file and returns 201", async () => {
+    const { workspace, conversation } = await setup();
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    const bucket = makeBucket({ save });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/notes.md`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "text/markdown" },
+        body: "# Hello",
+      }
+    );
+
+    expect(response.status).toBe(201);
+    expect(save).toHaveBeenCalledWith(Buffer.from("# Hello"), {
+      contentType: "text/markdown",
+    });
+  });
+
+  it("updates an existing file and returns 200", async () => {
+    const { workspace, conversation } = await setup();
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/notes.md"],
+      getMetadata: vi
+        .fn()
+        .mockResolvedValue([{ contentType: "text/markdown", size: "7" }]),
+      save,
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/notes.md`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "text/markdown" },
+        body: "# Updated",
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(save).toHaveBeenCalledWith(Buffer.from("# Updated"), {
+      contentType: "text/markdown",
+    });
+  });
+
+  it("returns 400 when updating a binary file type", async () => {
+    const { workspace, conversation } = await setup();
+
+    const save = vi.fn().mockResolvedValue(undefined);
+    const bucket = makeBucket({
+      existingFilePathSuffixes: ["/files/report.pdf"],
+      getMetadata: vi
+        .fn()
+        .mockResolvedValue([{ contentType: "application/pdf", size: "1024" }]),
+      save,
+    });
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/report.pdf`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/pdf" },
+        body: "not a real pdf",
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("returns 413 when content exceeds the size limit", async () => {
+    const { workspace, conversation } = await setup();
+
+    const bucket = makeBucket();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/large.txt`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "text/plain" },
+        body: "x".repeat(512 * 1024 + 1),
+      }
+    );
+
+    expect(response.status).toBe(413);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+  });
+
+  it("returns 413 when Content-Length exceeds the size limit", async () => {
+    const { workspace, conversation } = await setup();
+
+    const bucket = makeBucket();
+    vi.mocked(getPrivateUploadBucket).mockReturnValue(bucket as any);
+
+    const response = await request(
+      workspace,
+      `conversation-${conversation.sId}/large.txt`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "text/plain",
+          "Content-Length": String(512 * 1024 + 1),
+        },
+        body: "small",
+      }
+    );
+
+    expect(response.status).toBe(413);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
   });
 });
 

--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -7,9 +7,13 @@ import {
   moveCanonicalFile,
   renameCanonicalFile,
   streamThumbnail,
+  WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES,
+  WriteCanonicalFileContentError,
+  writeCanonicalFileContent,
 } from "@app/lib/api/files/file_system_ops";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
+import { bodyLimit } from "@front-api/middlewares/body_limit";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -32,6 +36,7 @@ const ParamsSchema = z.object({
  *   HEAD   /api/w/:wId/files/path/{...canonicalPath}                    metadata only
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"rename", fileName }
  *   PATCH  /api/w/:wId/files/path/{...canonicalPath}  { action:"move",   dest }
+ *   PUT    /api/w/:wId/files/path/{...canonicalPath}                    replace text content
  *   DELETE /api/w/:wId/files/path/{...canonicalPath}
  */
 const app = workspaceApp();
@@ -344,6 +349,101 @@ app.patch(
     }
 
     return new Response(null, { status: 200 });
+  }
+);
+
+/** @ignoreswagger */
+app.put(
+  "/:canonicalPath{.+}",
+  bodyLimit(WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES),
+  validate("param", ParamsSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { canonicalPath } = ctx.req.valid("param");
+    const { fs: dustFs, err } = await resolveFs(ctx, canonicalPath);
+    if (err) {
+      return err;
+    }
+
+    const contentLengthHeader = ctx.req.header("content-length");
+    if (contentLengthHeader) {
+      const contentLength = Number.parseInt(contentLengthHeader, 10);
+      if (
+        Number.isFinite(contentLength) &&
+        contentLength > WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES
+      ) {
+        return apiError(ctx, {
+          status_code: 413,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`,
+          },
+        });
+      }
+    }
+
+    let contentBuffer: ArrayBuffer;
+    try {
+      contentBuffer = await ctx.req.arrayBuffer();
+    } catch {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Failed to read request body.",
+        },
+      });
+    }
+
+    if (contentBuffer.byteLength > WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES) {
+      return apiError(ctx, {
+        status_code: 413,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`,
+        },
+      });
+    }
+
+    const writeResult = await writeCanonicalFileContent(
+      auth,
+      dustFs,
+      canonicalPath,
+      new Uint8Array(contentBuffer),
+      ctx.req.header("content-type") ?? undefined
+    );
+
+    if (writeResult.isErr()) {
+      const error = writeResult.error;
+      if (error instanceof WriteCanonicalFileContentError) {
+        const { code } = error;
+        switch (code) {
+          case "too_large":
+            return apiError(ctx, {
+              status_code: 413,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          case "unsupported_content_type":
+            return apiError(ctx, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: error.message,
+              },
+            });
+          default:
+            return assertNever(code);
+        }
+      }
+      return apiError(ctx, mapDustFsError(error));
+    }
+
+    return new Response(null, {
+      status: writeResult.value.created ? 201 : 200,
+    });
   }
 );
 

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -11,11 +11,18 @@ import {
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system/types";
+import { decodeBuffer } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
-import { isSupportedImageContentType } from "@app/types/files";
+import {
+  contentTypeFromFileName,
+  isSupportedFileContentType,
+  isSupportedImageContentType,
+  resolveFileContentType,
+  stripMimeParameters,
+} from "@app/types/files";
 import { DocumentRenderer } from "@app/types/shared/document_renderer";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -336,6 +343,112 @@ export async function moveCanonicalFile(
   }
 
   return moveResult;
+}
+
+// ---------------------------------------------------------------------------
+// Content write
+// ---------------------------------------------------------------------------
+
+export const WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES = 512 * 1024;
+
+export type WriteCanonicalFileContentErrorCode =
+  | "too_large"
+  | "unsupported_content_type";
+
+export class WriteCanonicalFileContentError extends Error {
+  constructor(
+    readonly code: WriteCanonicalFileContentErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "WriteCanonicalFileContentError";
+  }
+}
+
+function resolvePathWriteContentType(
+  scopedPath: string,
+  contentTypeFromRequest?: string
+): string {
+  const fileName = path.posix.basename(scopedPath);
+  const requested = contentTypeFromRequest
+    ? stripMimeParameters(contentTypeFromRequest)
+    : "text/plain";
+  const resolved = resolveFileContentType(requested, fileName);
+  if (isSupportedFileContentType(resolved)) {
+    return resolved;
+  }
+
+  return contentTypeFromFileName(fileName) ?? "text/plain";
+}
+
+function validatePathWritableContentType(
+  contentType: string
+): Result<void, WriteCanonicalFileContentError> {
+  if (!contentType.startsWith("text/")) {
+    return new Err(
+      new WriteCanonicalFileContentError(
+        "unsupported_content_type",
+        "Only text files can be updated through this endpoint."
+      )
+    );
+  }
+
+  return new Ok(undefined);
+}
+
+/**
+ * Create or replace the text content of a file at `scopedPath`.
+ * Only `text/*` content types are supported.
+ */
+export async function writeCanonicalFileContent(
+  _auth: Authenticator,
+  dustFs: DustFileSystem,
+  scopedPath: string,
+  content: Uint8Array,
+  contentTypeFromRequest?: string
+): Promise<
+  Result<
+    { created: boolean },
+    DustFileSystemError | WriteCanonicalFileContentError
+  >
+> {
+  if (content.byteLength > WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES) {
+    return new Err(
+      new WriteCanonicalFileContentError(
+        "too_large",
+        `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`
+      )
+    );
+  }
+
+  const contentBuffer = Buffer.from(decodeBuffer(content), "utf8");
+
+  const statResult = await dustFs.stat(scopedPath);
+  if (statResult.isErr()) {
+    return statResult;
+  }
+
+  const existingStat = statResult.value;
+  const exists = existingStat !== null;
+  const contentType = exists
+    ? stripMimeParameters(existingStat.contentType)
+    : resolvePathWriteContentType(scopedPath, contentTypeFromRequest);
+
+  const validationResult = validatePathWritableContentType(contentType);
+  if (validationResult.isErr()) {
+    return validationResult;
+  }
+
+  const writeResult = await dustFs.write(
+    scopedPath,
+    contentBuffer,
+    contentType
+  );
+  if (writeResult.isErr()) {
+    return writeResult;
+  }
+
+  return new Ok({ created: !exists });
 }
 
 // ---------------------------------------------------------------------------

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -20,9 +20,11 @@ import type {
   FileTypeWithMetadata,
   SharingGrantType,
 } from "@app/types/files";
+import { Err, Ok, type Result } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher, SWRConfiguration } from "swr";
+import { useSWRConfig } from "swr";
 
 export const getFileProcessedUrl = (
   owner: LightWorkspaceType,
@@ -100,6 +102,85 @@ export function useFileContentByUrl({
     isNotFound,
     isFileContentLoading: !error && data === undefined && !isDisabled,
     fileContentError: error ? normalizeError(error) : null,
+  };
+}
+
+export async function writeFileContentByPath({
+  owner,
+  canonicalPath,
+  content,
+  contentType = "text/plain",
+}: {
+  owner: LightWorkspaceType;
+  canonicalPath: string;
+  content: string;
+  contentType?: string;
+}): Promise<void> {
+  const url = getFilePathContentApiPath(owner, canonicalPath);
+  const response = await clientFetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: content,
+  });
+
+  if (!response.ok) {
+    const errorData = await getErrorFromResponse(response);
+    throw new Error(errorData.message);
+  }
+}
+
+export function useWriteFileContentByPath({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
+
+  return async ({
+    canonicalPath,
+    content,
+    contentType = "text/plain",
+    showSuccessNotification = false,
+  }: {
+    canonicalPath: string;
+    content: string;
+    contentType?: string;
+    showSuccessNotification?: boolean;
+  }): Promise<Result<void, Error>> => {
+    const url = getFilePathContentApiPath(owner, canonicalPath);
+
+    try {
+      await writeFileContentByPath({
+        owner,
+        canonicalPath,
+        content,
+        contentType,
+      });
+
+      await mutate<FileContentByUrlData>(
+        url,
+        { kind: "loaded", content },
+        { revalidate: false }
+      );
+
+      if (showSuccessNotification) {
+        sendNotification({
+          type: "success",
+          title: "File saved",
+        });
+      }
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to save file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
   };
 }
 


### PR DESCRIPTION
## Description

`PUT /api/w/:wId/files/path/{...canonicalPath}` creates or replaces text file content at a canonical path, returning 201 on creation and 200 on update. The core logic lives in `writeCanonicalFileContent` (`file_system_ops.ts`): on updates it preserves the existing file's content type; on creation it resolves the type from the request header and filename. Enforces `text/*`-only and a 512 KB size cap via `WriteCanonicalFileContentError` (`too_large` / `unsupported_content_type`).

`useWriteFileContentByPath` hook in `front/lib/swr/files.ts` wraps the PUT call, mutates the `useFileContentByUrl` SWR cache key on success (`revalidate: false`), and surfaces success/error notifications. `writeFileContentByPath` is also exported as a standalone async function for non-hook call sites.

## Tests

Added Vitest tests for the new `PUT` handler covering: create returns 201, update returns 200, binary content type rejected with 400, oversized content rejected with 413. `makeBucket` mock extended with `save`.

## Risk

Low. New endpoint only — no changes to existing GET/HEAD/PATCH/DELETE handlers. Binary files and oversized payloads are rejected server-side before any write. Safe to rollback by reverting.

## Deploy Plan

Deploy `front` only.
