### PR TITLE
Use markdownfileeditor in pod's settings.

### DIFF
--- a/front/components/editor/MarkdownFileEditor.tsx
+++ b/front/components/editor/MarkdownFileEditor.tsx
@@ -5,51 +5,45 @@ import {
 import {
   getFilePathContentApiPath,
   useFileContentByUrl,
+  useWriteFileContentByPath,
 } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types/user";
-import { ContentMessage, Spinner } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Button, ContentMessage, Spinner } from "@dust-tt/sparkle";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface MarkdownFileEditorProps
   extends Omit<MarkdownEditorProps, "value" | "onChange"> {
   owner: LightWorkspaceType;
   /**
    * Canonical scoped file path, e.g. `pod-{podId}/AGENTS.md`.
-   * Ignored when `fileUrl` is provided.
    */
   filePath?: string | null;
-  /**
-   * Full relative API URL for fetching file content.
-   * Takes precedence over `filePath` when set.
-   */
-  fileUrl?: string | null;
   disabled?: boolean;
   /** When true, show an empty editor if the file does not exist (404). */
   emptyWhenNotFound?: boolean;
+  /** Content-Type sent on save. Defaults to `text/markdown`. */
+  saveContentType?: string;
   onChange?: (content: string) => void;
   onContentLoaded?: (content: string) => void;
+  onSaved?: (content: string) => void;
 }
 
 export function MarkdownFileEditor({
   owner,
   filePath = null,
-  fileUrl = null,
   disabled = false,
   emptyWhenNotFound = false,
+  saveContentType = "text/markdown",
   onChange,
   onContentLoaded,
+  onSaved,
   readOnly,
   ...markdownEditorProps
 }: MarkdownFileEditorProps) {
-  const resolvedUrl = useMemo(() => {
-    if (fileUrl) {
-      return fileUrl;
-    }
-    if (filePath) {
-      return getFilePathContentApiPath(owner, filePath);
-    }
-    return null;
-  }, [filePath, fileUrl, owner]);
+  const resolvedUrl = useMemo(
+    () => (filePath ? getFilePathContentApiPath(owner, filePath) : null),
+    [filePath, owner]
+  );
 
   const { fileContent, isNotFound, isFileContentLoading, fileContentError } =
     useFileContentByUrl({
@@ -57,9 +51,16 @@ export function MarkdownFileEditor({
       disabled: disabled || !resolvedUrl,
     });
 
+  const writeFileContent = useWriteFileContentByPath({ owner });
+
   const [draft, setDraft] = useState("");
+  const [savedContent, setSavedContent] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
   const hasInitializedFromServerRef = useRef(false);
   const sourceKeyRef = useRef(resolvedUrl);
+
+  const canPersist = !!filePath && !readOnly && !disabled;
+  const isDirty = draft !== savedContent;
 
   useEffect(() => {
     if (sourceKeyRef.current === resolvedUrl) {
@@ -68,6 +69,7 @@ export function MarkdownFileEditor({
     sourceKeyRef.current = resolvedUrl;
     hasInitializedFromServerRef.current = false;
     setDraft("");
+    setSavedContent("");
   }, [resolvedUrl]);
 
   useEffect(() => {
@@ -86,6 +88,7 @@ export function MarkdownFileEditor({
 
     const content = isNotFound ? "" : (fileContent ?? "");
     setDraft(content);
+    setSavedContent(content);
     hasInitializedFromServerRef.current = true;
     onContentLoaded?.(content);
   }, [
@@ -101,6 +104,38 @@ export function MarkdownFileEditor({
     setDraft(content);
     onChange?.(content);
   };
+
+  const handleCancel = useCallback(() => {
+    setDraft(savedContent);
+  }, [savedContent]);
+
+  const handleSave = useCallback(async () => {
+    if (!filePath || isSaving || !isDirty) {
+      return;
+    }
+
+    setIsSaving(true);
+    const result = await writeFileContent({
+      canonicalPath: filePath,
+      content: draft,
+      contentType: saveContentType,
+      showSuccessNotification: true,
+    });
+    setIsSaving(false);
+
+    if (result.isOk()) {
+      setSavedContent(draft);
+      onSaved?.(draft);
+    }
+  }, [
+    draft,
+    filePath,
+    isDirty,
+    isSaving,
+    onSaved,
+    saveContentType,
+    writeFileContent,
+  ]);
 
   if (!resolvedUrl || disabled) {
     return null;
@@ -139,11 +174,29 @@ export function MarkdownFileEditor({
   }
 
   return (
-    <MarkdownEditor
-      {...markdownEditorProps}
-      value={draft}
-      onChange={handleChange}
-      readOnly={readOnly}
-    />
+    <div className="flex w-full min-w-0 flex-col gap-2">
+      <MarkdownEditor
+        {...markdownEditorProps}
+        value={draft}
+        onChange={handleChange}
+        readOnly={readOnly}
+      />
+      {canPersist && isDirty && (
+        <div className="flex gap-2">
+          <Button
+            label="Save"
+            variant="highlight"
+            isLoading={isSaving}
+            onClick={() => void handleSave()}
+          />
+          <Button
+            label="Cancel"
+            variant="outline"
+            disabled={isSaving}
+            onClick={handleCancel}
+          />
+        </div>
+      )}
+    </div>
   );
 }

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -1,5 +1,6 @@
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
 import { ConfirmContext } from "@app/components/Confirm";
+import { MarkdownFileEditor } from "@app/components/editor/MarkdownFileEditor";
 import { DeletePodDialog } from "@app/components/pod/settings/DeletePodDialog";
 import { PodMembersTable } from "@app/components/pod/settings/PodMembersTable";
 import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettingsOptionLabel";
@@ -48,6 +49,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
+// Note: this does not use the right format for the path (missing -{podId}) but that how the api expects it.
+// TODO(2026-06-23 FILE SYSTEM): Fix this.
+const AGENTS_MD_CANONICAL_PATH = "AGENTS.md";
 interface PodSettingsTabProps {
   owner: LightWorkspaceType;
   pod: RichSpaceType;
@@ -218,6 +222,7 @@ export function PodSettingsTab({
     podMetadata?.description ?? ""
   );
   const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [isSavingDescription, setIsSavingDescription] = useState(false);
 
   const form = useForm<PatchPodMetadataBodyType>({
     resolver: zodResolver(PatchPodMetadataBodySchema),
@@ -281,8 +286,13 @@ export function PodSettingsTab({
   };
 
   const onSaveDescription = async () => {
-    await doUpdateMetadata({ description: podDescription });
-    setIsEditingDescription(false);
+    setIsSavingDescription(true);
+    try {
+      await doUpdateMetadata({ description: podDescription });
+      setIsEditingDescription(false);
+    } finally {
+      setIsSavingDescription(false);
+    }
   };
 
   const { archivePod, unarchivePod } = useArchivePod({
@@ -409,11 +419,13 @@ export function PodSettingsTab({
                 <Button
                   label="Save"
                   variant="highlight"
-                  onClick={onSaveDescription}
+                  isLoading={isSavingDescription}
+                  onClick={() => void onSaveDescription()}
                 />
                 <Button
                   label="Cancel"
                   variant="outline"
+                  disabled={isSavingDescription}
                   onClick={() => {
                     setPodDescription(podMetadata?.description ?? "");
                     setIsEditingDescription(false);
@@ -421,6 +433,24 @@ export function PodSettingsTab({
                 />
               </div>
             )}
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col gap-2">
+          <div className="heading-lg">Instructions for Agents</div>
+          <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Seen by all agents in this Pod, stored as{" "}
+            <span className="font-medium">AGENTS.md</span> in the Pod's files.
+          </div>
+          <div className="flex w-full min-w-0 flex-col gap-2">
+            <MarkdownFileEditor
+              owner={owner}
+              filePath={`pod-${pod.sId}/${AGENTS_MD_CANONICAL_PATH}`}
+              emptyWhenNotFound
+              readOnly={!isPodEditor}
+              placeholder="Enter instructions for agents"
+              maxCharacterCount={4096}
+            />
           </div>
         </div>
 


### PR DESCRIPTION
## Description

Adds an `AGENTS.md` editor to `PodSettingsTab` using `MarkdownFileEditor`, allowing pod editors to write agent instructions directly from the pod settings page. The editor is read-only for non-editors and creates the file if it doesn't exist (`emptyWhenNotFound`), with a 4096-character limit.

To support self-contained save/cancel UX, `MarkdownFileEditor` now integrates `useWriteFileContentByPath` directly: it tracks `savedContent` alongside `draft`, computes `isDirty`, and renders Save/Cancel buttons when `canPersist && isDirty`. The `fileUrl` prop is removed — `filePath` is the only fetch/write path. `onSaved` and `saveContentType` props are added.

Also fixes `onSaveDescription` in `PodSettingsTab` to properly gate the Save/Cancel buttons with `isSavingDescription`.

<img width="926" height="328" alt="image" src="https://github.com/user-attachments/assets/bfe2752f-d1c6-45d6-b1c6-2abf76091a47" />

## Tests

Tested locally by navigating to pod settings and verifying the AGENTS.md editor loads, shows Save/Cancel on edit, persists on save, and is read-only for non-editors.

## Risk

Low. Front-only changes. `fileUrl` prop removal is a breaking interface change on `MarkdownFileEditor` — verify no other callers relied on it. The AGENTS.md path has a known TODO but is functional as-is per the current API expectation.

## Deploy Plan

Deploy `front` only.
