### PR TITLE
fix(llm): default reasoning effort to the model default instead of "none"

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -64,7 +64,7 @@ export abstract class LLM<TPayload = unknown> {
       context,
       getTraceOutput,
       modelId,
-      reasoningEffort = "none",
+      reasoningEffort,
       responseFormat = null,
       temperature = AGENT_CREATIVITY_LEVEL_TEMPERATURES.balanced,
     }: LLMParameters
@@ -79,7 +79,8 @@ export abstract class LLM<TPayload = unknown> {
     }
     this.modelConfig = modelConfig;
     this.temperature = temperature;
-    this.reasoningEffort = reasoningEffort;
+    this.reasoningEffort =
+      reasoningEffort ?? modelConfig.defaultReasoningEffort;
     this.responseFormat = responseFormat;
     this.bypassFeatureFlag = bypassFeatureFlag;
     this.metadata = {


### PR DESCRIPTION
## Description

The base LLM constructor hardcoded `reasoningEffort = "none"` when callers omitted it, conflating "unspecified" with "explicitly none". Some models — e.g. `gpt-5-mini` — do not support `"none"` (their config has `supportedReasoningEfforts.none = false` and the provider API rejects it), so the request failed with a `ZodError` against the model's config schema:

```
ZodError: reasoning.effort received "none", expected 'minimal' | 'low' | 'medium' | 'high'
```

Every utility caller that goes through `runMultiActionsAgent` / `getStreamLLM` (title, name, description, tag and emoji suggestions, candidate deduplication, web summarization, etc.) and the batch reinforcement caller via `getBatchLLM` omits `reasoningEffort`, so all of them crashed whenever the selected model didn't accept `"none"` (notably `getSmallWhitelistedModel`, which returns `gpt-5-mini` first).

Fix: fall back to the model's own `defaultReasoningEffort` when the caller doesn't specify one, instead of a global `"none"`. Callers that explicitly pass an effort (including `"none"` on models that support it) are unaffected.

## Tests

Type-checked (`tsgo --noEmit`) and validated through the pre-commit typecheck/biome hooks. Manually traced the failing path (`merge_into_project` → `deduplicateCandidates` → `runMultiActionsAgent` → `getStreamLLM`) to confirm `gpt-5-mini` now resolves to its `"medium"` default and passes the config schema.

## Risk

Low. The change only affects callers that omit `reasoningEffort` (previously `"none"`). Those callers now run at each model's intended `defaultReasoningEffort` — a small cost/latency increase for utility calls on reasoning models, in exchange for not crashing. The main agent runner passes an explicit effort and is unchanged. Safe to roll back by reverting the single commit.

## Deploy Plan

Standard `front` deploy. No migration, no config change.