### PR TITLE
fix(llm): inline images as base64 for Vertex in the new LLM router

### DIFF
--- a/front/lib/model_constructors/batch/clients/anthropic.ts
+++ b/front/lib/model_constructors/batch/clients/anthropic.ts
@@ -14,6 +14,9 @@ import type { Credentials } from "@app/lib/model_constructors/types/credentials"
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { ANTHROPIC_API } from "@app/lib/model_constructors/types/provider_apis";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+
+const BUILD_PAYLOAD_CONCURRENCY = 8;
 
 /**
  * The batch sibling of `AnthropicStream`: same input/output converters (so batch
@@ -51,11 +54,13 @@ export abstract class AnthropicBatch extends WithAnthropicAIInputConverter(
   async sendBatch(
     requests: Map<string, BatchRequest<AnthropicInputConfig>>
   ): Promise<string> {
-    const batchRequests = Array.from(requests.entries()).map(
-      ([customId, { payload, config }]) => ({
+    const batchRequests = await concurrentExecutor(
+      Array.from(requests.entries()),
+      async ([customId, { payload, config }]) => ({
         custom_id: customId,
-        params: this.buildRequestPayload(payload, config),
-      })
+        params: await this.buildRequestPayload(payload, config),
+      }),
+      { concurrency: BUILD_PAYLOAD_CONCURRENCY }
     );
 
     const batch = await this.client.messages.batches.create({

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/index.ts
@@ -12,14 +12,13 @@ import {
   assistantToolCallRequestToToolUseBlock,
   conversationToMessages,
   forceToolNameToToolChoice,
+  imageUrlToImageBlock,
   type MessageBlockConverters,
   outputFormatToOutputConfig,
   reasoningToThinkingConfig,
   systemMessagesToSystemParam,
   systemMessageToTextBlock,
-  toolCallResultMessageToToolResultBlock,
   toolSpecsToAnthropicAITools,
-  userImageMessageToImageBlock,
   userTextMessageToTextBlock,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
 import type {
@@ -42,9 +41,8 @@ export function WithAnthropicAIInputConverter<
   {
     systemMessageToTextBlock = systemMessageToTextBlock;
     userTextMessageToTextBlock = userTextMessageToTextBlock;
-    userImageMessageToImageBlock = userImageMessageToImageBlock;
-    toolCallResultMessageToToolResultBlock =
-      toolCallResultMessageToToolResultBlock;
+    imageUrlToImageBlock: MessageBlockConverters["imageUrlToImageBlock"] =
+      imageUrlToImageBlock;
     assistantTextMessageToTextBlock = assistantTextMessageToTextBlock;
     assistantReasoningMessageToThinkingBlocks =
       assistantReasoningMessageToThinkingBlocks;
@@ -55,7 +53,7 @@ export function WithAnthropicAIInputConverter<
 
     conversationToMessages(
       conversation: Payload["conversation"]
-    ): MessageParam[] {
+    ): Promise<MessageParam[]> {
       return conversationToMessages(conversation, this);
     }
 
@@ -63,10 +61,10 @@ export function WithAnthropicAIInputConverter<
       return systemMessagesToSystemParam(system, this);
     }
 
-    buildRequestPayload(
+    async buildRequestPayload(
       payload: Payload,
       config: AnthropicInputConfig
-    ): MessageCreateParamsNonStreaming {
+    ): Promise<MessageCreateParamsNonStreaming> {
       const { conversation } = payload;
       const {
         tools = [],
@@ -87,7 +85,7 @@ export function WithAnthropicAIInputConverter<
       return {
         model: this.modelIdToApiModelId(this.constructor.modelId),
         max_tokens: this.constructor.maxOutputTokens,
-        messages: this.conversationToMessages(conversation),
+        messages: await this.conversationToMessages(conversation),
         system: this.systemMessagesToSystemParam(conversation.system),
         thinking: thinkingConfig.thinking,
         tools: toolSpecsToAnthropicAITools(tools, { forceTool }),

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
@@ -1,7 +1,6 @@
 import type {
   ImageBlockParam,
   TextBlockParam,
-  ToolResultBlockParam,
   ToolUseBlockParam,
 } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { MessageBlockConverters } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
@@ -13,6 +12,8 @@ import {
   cacheControlFor,
   conversationToMessages,
   forceToolNameToToolChoice,
+  imageUrlToBase64ImageBlock,
+  imageUrlToImageBlock,
   outputFormatToOutputConfig,
   parseToolArguments,
   reasoningToThinkingConfig,
@@ -38,15 +39,19 @@ import type {
   BaseUserTextMessage,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/types/shared/utils/image_utils", () => ({
+  trustedFetchImageBase64: vi.fn(),
+}));
 
 // The real leaf converters, bundled into the interface the composites consume.
 // Used wherever a test wants the genuine end-to-end conversion.
 const realConverters: MessageBlockConverters = {
   systemMessageToTextBlock,
   userTextMessageToTextBlock,
-  userImageMessageToImageBlock,
-  toolCallResultMessageToToolResultBlock,
+  imageUrlToImageBlock,
   assistantTextMessageToTextBlock,
   assistantReasoningMessageToThinkingBlocks,
   assistantToolCallRequestToToolUseBlock,
@@ -62,20 +67,11 @@ function makeStubConverters(): MessageBlockConverters {
     userTextMessageToTextBlock: vi.fn(
       () => ({ type: "text", text: "stub-user-text" }) as TextBlockParam
     ),
-    userImageMessageToImageBlock: vi.fn(
-      () =>
-        ({
-          type: "image",
-          source: { type: "url", url: "stub-url" },
-        }) as ImageBlockParam
-    ),
-    toolCallResultMessageToToolResultBlock: vi.fn(
-      () =>
-        ({
-          type: "tool_result",
-          tool_use_id: "stub-call",
-          content: [],
-        }) as ToolResultBlockParam
+    imageUrlToImageBlock: vi.fn(() =>
+      Promise.resolve({
+        type: "image",
+        source: { type: "url", url: "stub-url" },
+      } as ImageBlockParam)
     ),
     assistantTextMessageToTextBlock: vi.fn(
       () => ({ type: "text", text: "stub-assistant-text" }) as TextBlockParam
@@ -205,6 +201,54 @@ describe("userTextMessageToTextBlock", () => {
   });
 });
 
+describe("imageUrlToImageBlock", () => {
+  it("converts a url to a url image block", async () => {
+    expect(await imageUrlToImageBlock("https://example.com/cat.png")).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://example.com/cat.png" },
+    });
+  });
+});
+
+describe("imageUrlToBase64ImageBlock", () => {
+  const url = "https://example.com/cat.png";
+
+  it("fetches the image and inlines it as a base64 image block", async () => {
+    vi.mocked(trustedFetchImageBase64).mockResolvedValueOnce({
+      mediaType: "image/png",
+      data: "ZmFrZS1wbmctYnl0ZXM=",
+    });
+    expect(await imageUrlToBase64ImageBlock(url)).toEqual({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: "ZmFrZS1wbmctYnl0ZXM=",
+      },
+    });
+    expect(trustedFetchImageBase64).toHaveBeenCalledWith(url);
+  });
+
+  it("degrades to a text note when the fetch fails", async () => {
+    vi.mocked(trustedFetchImageBase64).mockRejectedValueOnce(new Error("boom"));
+    expect(await imageUrlToBase64ImageBlock(url)).toEqual({
+      type: "text",
+      text: "Attachment: image could not be loaded.",
+    });
+  });
+
+  it("degrades to a text note when the media type is unsupported", async () => {
+    vi.mocked(trustedFetchImageBase64).mockResolvedValueOnce({
+      mediaType: "image/tiff",
+      data: "ZmFrZQ==",
+    });
+    expect(await imageUrlToBase64ImageBlock(url)).toEqual({
+      type: "text",
+      text: "Attachment: an unsupported image media type was provided.",
+    });
+  });
+});
+
 describe("userImageMessageToImageBlock", () => {
   const base: BaseUserImageMessage = {
     role: "user",
@@ -212,24 +256,45 @@ describe("userImageMessageToImageBlock", () => {
     content: { url: "https://example.com/cat.png" },
   };
 
-  it("converts to a url image block", () => {
-    expect(userImageMessageToImageBlock(base)).toEqual({
+  it("delegates to the image leaf and emits a url block", async () => {
+    expect(await userImageMessageToImageBlock(base, realConverters)).toEqual({
       type: "image",
       source: { type: "url", url: "https://example.com/cat.png" },
     });
   });
 
-  it("includes cache control when set", () => {
-    expect(userImageMessageToImageBlock({ ...base, cache: "long" })).toEqual({
+  it("includes cache control when set", async () => {
+    expect(
+      await userImageMessageToImageBlock(
+        { ...base, cache: "long" },
+        realConverters
+      )
+    ).toEqual({
       type: "image",
       source: { type: "url", url: "https://example.com/cat.png" },
       cache_control: { type: "ephemeral", ttl: "1h" },
     });
   });
+
+  it("inlines base64 when the image leaf is the base64 variant", async () => {
+    vi.mocked(trustedFetchImageBase64).mockResolvedValueOnce({
+      mediaType: "image/png",
+      data: "ZmFrZQ==",
+    });
+    expect(
+      await userImageMessageToImageBlock(base, {
+        ...realConverters,
+        imageUrlToImageBlock: imageUrlToBase64ImageBlock,
+      })
+    ).toEqual({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "ZmFrZQ==" },
+    });
+  });
 });
 
 describe("toolCallResultMessageToToolResultBlock", () => {
-  it("converts text and image parts in order", () => {
+  it("converts text and image parts in order", async () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
@@ -243,7 +308,9 @@ describe("toolCallResultMessageToToolResultBlock", () => {
         isError: false,
       },
     };
-    expect(toolCallResultMessageToToolResultBlock(message)).toEqual({
+    expect(
+      await toolCallResultMessageToToolResultBlock(message, realConverters)
+    ).toEqual({
       type: "tool_result",
       tool_use_id: "call_1",
       content: [
@@ -256,7 +323,39 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     });
   });
 
-  it("sets is_error only when isError is true", () => {
+  it("inlines image parts as base64 when the image leaf is the base64 variant", async () => {
+    vi.mocked(trustedFetchImageBase64).mockResolvedValueOnce({
+      mediaType: "image/png",
+      data: "ZmFrZQ==",
+    });
+    const message: BaseToolCallResultMessage = {
+      role: "user",
+      type: "tool_call_result",
+      content: {
+        callId: "call_b64",
+        toolName: "tool_b64",
+        parts: [{ type: "image_url", url: "https://example.com/img.png" }],
+        isError: false,
+      },
+    };
+    expect(
+      await toolCallResultMessageToToolResultBlock(message, {
+        ...realConverters,
+        imageUrlToImageBlock: imageUrlToBase64ImageBlock,
+      })
+    ).toEqual({
+      type: "tool_result",
+      tool_use_id: "call_b64",
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "ZmFrZQ==" },
+        },
+      ],
+    });
+  });
+
+  it("sets is_error only when isError is true", async () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
@@ -267,7 +366,9 @@ describe("toolCallResultMessageToToolResultBlock", () => {
         isError: true,
       },
     };
-    expect(toolCallResultMessageToToolResultBlock(message)).toEqual({
+    expect(
+      await toolCallResultMessageToToolResultBlock(message, realConverters)
+    ).toEqual({
       type: "tool_result",
       tool_use_id: "call_err",
       content: [],
@@ -275,7 +376,7 @@ describe("toolCallResultMessageToToolResultBlock", () => {
     });
   });
 
-  it("omits is_error when isError is false", () => {
+  it("omits is_error when isError is false", async () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
@@ -286,12 +387,12 @@ describe("toolCallResultMessageToToolResultBlock", () => {
         isError: false,
       },
     };
-    expect(toolCallResultMessageToToolResultBlock(message)).not.toHaveProperty(
-      "is_error"
-    );
+    expect(
+      await toolCallResultMessageToToolResultBlock(message, realConverters)
+    ).not.toHaveProperty("is_error");
   });
 
-  it("includes cache control when set", () => {
+  it("includes cache control when set", async () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
@@ -303,12 +404,14 @@ describe("toolCallResultMessageToToolResultBlock", () => {
       },
       cache: "short",
     };
-    expect(toolCallResultMessageToToolResultBlock(message)).toMatchObject({
+    expect(
+      await toolCallResultMessageToToolResultBlock(message, realConverters)
+    ).toMatchObject({
       cache_control: { type: "ephemeral", ttl: "5m" },
     });
   });
 
-  it("produces empty content for no parts", () => {
+  it("produces empty content for no parts", async () => {
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
@@ -319,7 +422,10 @@ describe("toolCallResultMessageToToolResultBlock", () => {
         isError: false,
       },
     };
-    expect(toolCallResultMessageToToolResultBlock(message).content).toEqual([]);
+    expect(
+      (await toolCallResultMessageToToolResultBlock(message, realConverters))
+        .content
+    ).toEqual([]);
   });
 });
 
@@ -399,49 +505,62 @@ describe("assistantToolCallRequestToToolUseBlock", () => {
 });
 
 describe("userMessageToContentBlocks", () => {
-  it("delegates text messages to userTextMessageToTextBlock", () => {
+  it("delegates text messages to userTextMessageToTextBlock", async () => {
     const stub = makeStubConverters();
     const message: BaseUserTextMessage = {
       role: "user",
       type: "text",
       content: { value: "hello" },
     };
-    const result = userMessageToContentBlocks(message, stub);
+    const result = await userMessageToContentBlocks(message, stub);
     expect(stub.userTextMessageToTextBlock).toHaveBeenCalledWith(message);
     expect(result).toEqual([{ type: "text", text: "stub-user-text" }]);
   });
 
-  it("delegates image messages to userImageMessageToImageBlock", () => {
+  it("routes image messages through the image leaf", async () => {
     const stub = makeStubConverters();
     const message: BaseUserImageMessage = {
       role: "user",
       type: "image_url",
       content: { url: "u" },
     };
-    userMessageToContentBlocks(message, stub);
-    expect(stub.userImageMessageToImageBlock).toHaveBeenCalledWith(message);
+    const result = await userMessageToContentBlocks(message, stub);
+    expect(stub.imageUrlToImageBlock).toHaveBeenCalledWith("u");
+    expect(result).toEqual([
+      { type: "image", source: { type: "url", url: "stub-url" } },
+    ]);
   });
 
-  it("delegates tool_call_result messages to toolCallResultMessageToToolResultBlock", () => {
+  it("routes tool_call_result image parts through the image leaf", async () => {
     const stub = makeStubConverters();
     const message: BaseToolCallResultMessage = {
       role: "user",
       type: "tool_call_result",
-      content: { callId: "c", toolName: "t", parts: [], isError: false },
+      content: {
+        callId: "c",
+        toolName: "t",
+        parts: [{ type: "image_url", url: "u" }],
+        isError: false,
+      },
     };
-    userMessageToContentBlocks(message, stub);
-    expect(stub.toolCallResultMessageToToolResultBlock).toHaveBeenCalledWith(
-      message
-    );
+    const result = await userMessageToContentBlocks(message, stub);
+    expect(stub.imageUrlToImageBlock).toHaveBeenCalledWith("u");
+    expect(result).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "c",
+        content: [{ type: "image", source: { type: "url", url: "stub-url" } }],
+      },
+    ]);
   });
 
-  it("wraps the leaf result in a single-element array (real converters)", () => {
+  it("wraps the leaf result in a single-element array (real converters)", async () => {
     const message: BaseUserTextMessage = {
       role: "user",
       type: "text",
       content: { value: "hi" },
     };
-    expect(userMessageToContentBlocks(message, realConverters)).toEqual([
+    expect(await userMessageToContentBlocks(message, realConverters)).toEqual([
       { type: "text", text: "hi" },
     ]);
   });
@@ -509,7 +628,7 @@ describe("assistantMessageToContentBlocks", () => {
 });
 
 describe("conversationToMessages", () => {
-  it("maps user and assistant messages to role-tagged MessageParams in order", () => {
+  it("maps user and assistant messages to role-tagged MessageParams in order", async () => {
     const conversation: BaseConversation = {
       system: [],
       messages: [
@@ -517,18 +636,20 @@ describe("conversationToMessages", () => {
         { role: "assistant", type: "text", content: { value: "hi back" } },
       ],
     };
-    expect(conversationToMessages(conversation, realConverters)).toEqual([
+    expect(await conversationToMessages(conversation, realConverters)).toEqual([
       { role: "user", content: [{ type: "text", text: "hello" }] },
       { role: "assistant", content: [{ type: "text", text: "hi back" }] },
     ]);
   });
 
-  it("returns an empty array for an empty conversation", () => {
+  it("returns an empty array for an empty conversation", async () => {
     const conversation: BaseConversation = { system: [], messages: [] };
-    expect(conversationToMessages(conversation, realConverters)).toEqual([]);
+    expect(await conversationToMessages(conversation, realConverters)).toEqual(
+      []
+    );
   });
 
-  it("preserves message ordering across mixed roles", () => {
+  it("preserves message ordering across mixed roles", async () => {
     const conversation: BaseConversation = {
       system: [],
       messages: [
@@ -537,7 +658,7 @@ describe("conversationToMessages", () => {
         { role: "assistant", type: "text", content: { value: "c" } },
       ],
     };
-    const result = conversationToMessages(conversation, realConverters);
+    const result = await conversationToMessages(conversation, realConverters);
     expect(result.map((m) => m.role)).toEqual([
       "assistant",
       "user",

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.test.ts
@@ -244,7 +244,7 @@ describe("imageUrlToBase64ImageBlock", () => {
     });
     expect(await imageUrlToBase64ImageBlock(url)).toEqual({
       type: "text",
-      text: "Attachment: an unsupported image media type was provided.",
+      text: "Attachement: an unsupported media type was provided.",
     });
   });
 });

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -34,7 +34,9 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isRecord } from "@app/types/shared/utils/general";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
@@ -57,9 +59,11 @@ function isSupportedImageMediaType(
   );
 }
 
+// Kept byte-identical to the legacy AnthropicLLM client so the model-visible
+// fallback text is iso across the router migration (typo included).
 const IMAGE_LOAD_FAILED_TEXT = "Attachment: image could not be loaded.";
 const UNSUPPORTED_MEDIA_TYPE_TEXT =
-  "Attachment: an unsupported image media type was provided.";
+  "Attachement: an unsupported media type was provided.";
 
 // The per-message leaf converters. Composites below take an object satisfying
 // this interface (`this`), so overriding one leaf on an endpoint changes how
@@ -148,12 +152,21 @@ export async function imageUrlToBase64ImageBlock(
   let fetchResult: Awaited<ReturnType<typeof trustedFetchImageBase64>>;
   try {
     fetchResult = await trustedFetchImageBase64(url);
-  } catch {
+  } catch (err) {
+    // Don't log the URL: conversation image URLs are signed GCS URLs ([SEC1]).
+    logger.warn(
+      { err: normalizeError(err) },
+      "Failed to fetch image for base64 inlining; using text placeholder."
+    );
     return { type: "text", text: IMAGE_LOAD_FAILED_TEXT };
   }
 
   const { mediaType, data } = fetchResult;
   if (!isSupportedImageMediaType(mediaType)) {
+    logger.warn(
+      { mediaType },
+      "Unsupported image media type for base64 inlining; using text placeholder."
+    );
     return { type: "text", text: UNSUPPORTED_MEDIA_TYPE_TEXT };
   }
 

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -54,9 +54,7 @@ type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number];
 function isSupportedImageMediaType(
   mediaType: string
 ): mediaType is SupportedImageMediaType {
-  return SUPPORTED_IMAGE_MEDIA_TYPES.includes(
-    mediaType as SupportedImageMediaType
-  );
+  return SUPPORTED_IMAGE_MEDIA_TYPES.some((t) => t === mediaType);
 }
 
 // Kept byte-identical to the legacy AnthropicLLM client so the model-visible

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -33,9 +33,33 @@ import type {
   CacheOption,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { isRecord } from "@app/types/shared/utils/general";
+import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+const MESSAGE_CONVERSION_CONCURRENCY = 10;
+
+const SUPPORTED_IMAGE_MEDIA_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+type SupportedImageMediaType = (typeof SUPPORTED_IMAGE_MEDIA_TYPES)[number];
+
+function isSupportedImageMediaType(
+  mediaType: string
+): mediaType is SupportedImageMediaType {
+  return SUPPORTED_IMAGE_MEDIA_TYPES.includes(
+    mediaType as SupportedImageMediaType
+  );
+}
+
+const IMAGE_LOAD_FAILED_TEXT = "Attachment: image could not be loaded.";
+const UNSUPPORTED_MEDIA_TYPE_TEXT =
+  "Attachment: an unsupported image media type was provided.";
 
 // The per-message leaf converters. Composites below take an object satisfying
 // this interface (`this`), so overriding one leaf on an endpoint changes how
@@ -43,10 +67,10 @@ import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 export interface MessageBlockConverters {
   systemMessageToTextBlock(message: SystemTextMessage): TextBlockParam;
   userTextMessageToTextBlock(message: BaseUserTextMessage): TextBlockParam;
-  userImageMessageToImageBlock(message: BaseUserImageMessage): ImageBlockParam;
-  toolCallResultMessageToToolResultBlock(
-    message: BaseToolCallResultMessage
-  ): ToolResultBlockParam;
+  // The single provider-specific image conversion point, shared by user image
+  // messages and tool-result image parts (mirrors the legacy client). Direct
+  // Anthropic keeps the URL source; Vertex overrides it to inline base64.
+  imageUrlToImageBlock(url: string): Promise<ImageBlockParam | TextBlockParam>;
   assistantTextMessageToTextBlock(
     message: BaseAssistantTextMessage
   ): TextBlockParam;
@@ -110,36 +134,32 @@ export function userTextMessageToTextBlock(
   };
 }
 
-export function userImageMessageToImageBlock(
-  message: BaseUserImageMessage
-): ImageBlockParam {
-  return {
-    type: "image",
-    source: { type: "url", url: message.content.url },
-    ...cacheControlFor(message.cache),
-  };
+export async function imageUrlToImageBlock(
+  url: string
+): Promise<ImageBlockParam> {
+  return { type: "image", source: { type: "url", url } };
 }
 
-export function toolCallResultMessageToToolResultBlock(
-  message: BaseToolCallResultMessage
-): ToolResultBlockParam {
-  const content: Array<TextBlockParam | ImageBlockParam> =
-    message.content.parts.map((part) => {
-      switch (part.type) {
-        case "text":
-          return { type: "text", text: part.text };
-        case "image_url":
-          return { type: "image", source: { type: "url", url: part.url } };
-        default:
-          return assertNever(part);
-      }
-    });
+// Vertex AI rejects URL image sources, so fetch the bytes and inline them as
+// base64, degrading to a text note rather than failing the whole request.
+export async function imageUrlToBase64ImageBlock(
+  url: string
+): Promise<ImageBlockParam | TextBlockParam> {
+  let fetchResult: Awaited<ReturnType<typeof trustedFetchImageBase64>>;
+  try {
+    fetchResult = await trustedFetchImageBase64(url);
+  } catch {
+    return { type: "text", text: IMAGE_LOAD_FAILED_TEXT };
+  }
+
+  const { mediaType, data } = fetchResult;
+  if (!isSupportedImageMediaType(mediaType)) {
+    return { type: "text", text: UNSUPPORTED_MEDIA_TYPE_TEXT };
+  }
+
   return {
-    type: "tool_result",
-    tool_use_id: message.content.callId,
-    content,
-    ...(message.content.isError ? { is_error: true } : {}),
-    ...cacheControlFor(message.cache),
+    type: "image",
+    source: { type: "base64", media_type: mediaType, data },
   };
 }
 
@@ -178,17 +198,54 @@ export function assistantToolCallRequestToToolUseBlock(
 
 // -- Composite message converters (depend on the leaf converters) --
 
-export function userMessageToContentBlocks(
+export async function userImageMessageToImageBlock(
+  message: BaseUserImageMessage,
+  converters: MessageBlockConverters
+): Promise<ImageBlockParam | TextBlockParam> {
+  const block = await converters.imageUrlToImageBlock(message.content.url);
+  return { ...block, ...cacheControlFor(message.cache) };
+}
+
+export async function toolCallResultMessageToToolResultBlock(
+  message: BaseToolCallResultMessage,
+  converters: MessageBlockConverters
+): Promise<ToolResultBlockParam> {
+  const content = await concurrentExecutor(
+    message.content.parts,
+    (part): Promise<TextBlockParam | ImageBlockParam> => {
+      switch (part.type) {
+        case "text":
+          return Promise.resolve({ type: "text", text: part.text });
+        case "image_url":
+          return converters.imageUrlToImageBlock(part.url);
+        default:
+          return assertNever(part);
+      }
+    },
+    { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
+  );
+  return {
+    type: "tool_result",
+    tool_use_id: message.content.callId,
+    content,
+    ...(message.content.isError ? { is_error: true } : {}),
+    ...cacheControlFor(message.cache),
+  };
+}
+
+export async function userMessageToContentBlocks(
   message: BaseUserMessage,
   converters: MessageBlockConverters
-): MessageParam["content"] {
+): Promise<MessageParam["content"]> {
   switch (message.type) {
     case "text":
       return [converters.userTextMessageToTextBlock(message)];
     case "image_url":
-      return [converters.userImageMessageToImageBlock(message)];
+      return [await userImageMessageToImageBlock(message, converters)];
     case "tool_call_result":
-      return [converters.toolCallResultMessageToToolResultBlock(message)];
+      return [
+        await toolCallResultMessageToToolResultBlock(message, converters),
+      ];
     default:
       assertNever(message);
   }
@@ -213,23 +270,27 @@ export function assistantMessageToContentBlocks(
 export function conversationToMessages(
   conversation: BaseConversation,
   converters: MessageBlockConverters
-): MessageParam[] {
-  return conversation.messages.map((message) => {
-    switch (message.role) {
-      case "user":
-        return {
-          role: "user",
-          content: userMessageToContentBlocks(message, converters),
-        };
-      case "assistant":
-        return {
-          role: "assistant",
-          content: assistantMessageToContentBlocks(message, converters),
-        };
-      default:
-        assertNever(message);
-    }
-  });
+): Promise<MessageParam[]> {
+  return concurrentExecutor(
+    conversation.messages,
+    async (message): Promise<MessageParam> => {
+      switch (message.role) {
+        case "user":
+          return {
+            role: "user",
+            content: await userMessageToContentBlocks(message, converters),
+          };
+        case "assistant":
+          return {
+            role: "assistant",
+            content: assistantMessageToContentBlocks(message, converters),
+          };
+        default:
+          assertNever(message);
+      }
+    },
+    { concurrency: MESSAGE_CONVERSION_CONCURRENCY }
+  );
 }
 
 export function systemMessagesToSystemParam(

--- a/front/lib/model_constructors/stream/clients/agent_platform.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform.ts
@@ -9,6 +9,7 @@ import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/conf
 import type { AnthropicInputConfig } from "@app/lib/model_constructors/providers/anthropic/inputConfig";
 import { ANTHROPIC_SUPPORTED_NON_NULL_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/anthropic/reasoning_efforts";
 import { WithAnthropicAIInputConverter } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input";
+import { imageUrlToBase64ImageBlock } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/utils";
 import { WithAnthropicAIOutputConverter } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output";
 import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/output/utils";
 import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
@@ -76,6 +77,9 @@ export abstract class AgentPlatformStream extends WithAnthropicAIInputConverter(
 
   modelIdToApiModelId = (modelId: ModelId): Model =>
     MODEL_MAPPING[modelId] ?? modelId;
+
+  // Vertex AI rejects URL image sources, so inline images as base64.
+  imageUrlToImageBlock = imageUrlToBase64ImageBlock;
 
   async *streamRaw(
     input: MessageCreateParamsNonStreaming


### PR DESCRIPTION
## Description

PNG uploads broke for EU users when `use_new_llm_router` was active. The new-router Anthropic input converter always emitted image content blocks with a `source.type: "url"`. Vertex AI (used for EU Claude endpoints) does not support URL image sources — only inline base64 — so requests failed with:

```
400 invalid_request_error: messages.0.content.1.image.source.base64.data: URL sources are not supported
```

(The flag was rolled back in EU as a hotfix.)

This routes every image — both user-message images and tool-result image parts — through a single overridable leaf converter `imageUrlToImageBlock`, mirroring how the legacy `AnthropicLLM` client used one shared `userContentToParam(..., { convertToBase64 })` conversion point:

- **Direct Anthropic (US)**: keeps the URL source (no regression).
- **Vertex / agent platform (EU)**: overrides the single leaf to fetch the image, convert to base64, and emit `{ type: "base64", media_type, data }`. Falls back to a text note when the image can't be loaded or its media type is unsupported, rather than failing the whole request.

Because both user images and tool-result images delegate to the same leaf, one override fixes both — a tool that returns an image gets the same base64 treatment on Vertex.

The image conversion is now async, so `buildRequestPayload` / `conversationToMessages` are awaited (the stream path and test harness already awaited; the batch Anthropic client now builds payloads via `concurrentExecutor`). No change to the feature flag gating or rollout path — this is a pure correctness fix inside the converter.

## Tests

- Added unit tests covering both providers: Vertex leaf emits base64 (with fetch-failure and unsupported-media-type fallbacks); direct Anthropic leaf keeps the URL source; tool-result image parts go through the same leaf and become base64 when the Vertex leaf is active.
- Updated existing converter tests for the now-async signatures.
- `npx tsgo --noEmit` clean; `model_constructors` suite passes (63 converter tests).

## Risk

Low. Behavior for direct Anthropic endpoints is unchanged (still URL sources). The Vertex path mirrors the proven legacy logic. Safe to roll back by reverting the branch. The fix only changes converter internals; no schema, flag, or API contract changes.

## Deploy Plan

Standard deploy. After deploy, `use_new_llm_router` can be re-enabled in EU; verify a PNG upload to an EU Claude endpoint no longer 400s.