### PR TITLE
feat(analytics): make seat and credits usage columns sortable on the Usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -186,7 +186,10 @@ export function UsagePage() {
   }, []);
 
   const sort = sorting[0];
-  const membersOrderColumn = sort?.id === "email" ? "email" : "name";
+  const membersOrderColumn =
+    sort?.id === "email" || sort?.id === "consumedAwuCredits"
+      ? sort.id
+      : "name";
   const membersOrderDirection = sort?.desc ? "desc" : "asc";
 
   const { myUsage } = useMyUsage({ workspaceId: owner.sId });

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -401,9 +401,7 @@ const consumedAwuCreditsColumn: ColumnDef<RowData, string> = {
   meta: {
     className: "w-64",
   },
-  // Consumed is computed per-page from Metronome usage, not a server-sortable
-  // field, so it can't participate in server-side sorting.
-  enableSorting: false,
+  enableSorting: true,
 };
 
 const actionsColumn: ColumnDef<RowData, string> = {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -60,6 +60,9 @@ import {
   normalizeToPoolLimitSeatType,
   toBaseSeatType,
 } from "@app/types/memberships";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { estypes } from "@elastic/elasticsearch";
@@ -162,8 +165,10 @@ export const MembersUsagePaginationSchema = z.object({
   offset: z.coerce.number().int().min(0).catch(0),
   search: z.string().optional().catch(undefined),
   // Members are ordered by name (ascending) by default, giving a stable order
-  // for pagination instead of relevance ranking.
-  orderColumn: z.enum(["name", "email"]).catch("name"),
+  // for pagination instead of relevance ranking. "name"/"email" are sorted by
+  // the search index; "consumedAwuCredits" is sorted in-app over the full
+  // matching set (see resolveMembersUsagePageUsers).
+  orderColumn: z.enum(["name", "email", "consumedAwuCredits"]).catch("name"),
   orderDirection: z.enum(["asc", "desc"]).catch("asc"),
   // Optional seat-type filter. A base seat type (e.g. "pro") matches its
   // monthly and yearly variants; "none" matches members with no seat.
@@ -903,6 +908,80 @@ async function resolveSeatTypeFilterUserIds({
   );
 }
 
+// "name"/"email" live in the user search index, which owns sort + pagination
+// for those columns. "consumedAwuCredits" is not indexed, so to sort by it we
+// fetch the full matching set with Elasticsearch `search_after`, rank it by
+// consumed AWU (the same analytics-index signal the table displays, see
+// fetchConsumedAwuCreditsByUserId), sort in-app, then slice the requested page.
+async function resolveMembersUsagePageUsers({
+  auth,
+  workspace,
+  paginationParams,
+  restrictToUserIds,
+}: {
+  auth: Authenticator;
+  workspace: LightWorkspaceType;
+  paginationParams: MembersUsagePaginationInput;
+  restrictToUserIds: string[] | undefined;
+}): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
+  const { orderColumn, orderDirection, offset, limit } = paginationParams;
+  const searchTerm = paginationParams.search ?? "";
+
+  // "name"/"email" are indexed: let Elasticsearch own sort and pagination.
+  if (orderColumn === "name" || orderColumn === "email") {
+    return UserResource.searchUsers(auth, {
+      searchTerm,
+      offset,
+      limit,
+      orderBy: { field: orderColumn, direction: orderDirection },
+      restrictToUserIds,
+    });
+  }
+
+  const allUsersResult = await UserResource.searchAllUsers(auth, {
+    searchTerm,
+    restrictToUserIds,
+  });
+  if (allUsersResult.isErr()) {
+    return allUsersResult;
+  }
+  const { users: allUsers, total } = allUsersResult.value;
+
+  const sortKeyByUserId = new Map<string, number>();
+  switch (orderColumn) {
+    case "consumedAwuCredits": {
+      const creditsByUserId = await fetchConsumedAwuCreditsByUserId({
+        workspace,
+        userIds: allUsers.map((u) => u.sId),
+      });
+      for (const u of allUsers) {
+        sortKeyByUserId.set(u.sId, creditsByUserId.get(u.sId) ?? 0);
+      }
+      break;
+    }
+    default:
+      assertNever(orderColumn);
+  }
+
+  const directionFactor = orderDirection === "asc" ? 1 : -1;
+  const sortedUsers = [...allUsers].sort((a, b) => {
+    const keyA = sortKeyByUserId.get(a.sId) ?? 0;
+    const keyB = sortKeyByUserId.get(b.sId) ?? 0;
+    if (keyA !== keyB) {
+      return (keyA - keyB) * directionFactor;
+    }
+    // Stable, direction-independent tiebreaker so pages don't reshuffle.
+    const nameA = (a.fullName() || a.name).toLowerCase();
+    const nameB = (b.fullName() || b.name).toLowerCase();
+    if (nameA !== nameB) {
+      return nameA < nameB ? -1 : 1;
+    }
+    return a.sId < b.sId ? -1 : a.sId > b.sId ? 1 : 0;
+  });
+
+  return new Ok({ users: sortedUsers.slice(offset, offset + limit), total });
+}
+
 export async function getMembersUsage({
   auth,
   paginationParams,
@@ -935,14 +1014,10 @@ export async function getMembersUsage({
     }
   }
 
-  const usersResult = await UserResource.searchUsers(auth, {
-    searchTerm: paginationParams.search ?? "",
-    offset: paginationParams.offset,
-    limit: paginationParams.limit,
-    orderBy: {
-      field: paginationParams.orderColumn,
-      direction: paginationParams.orderDirection,
-    },
+  const usersResult = await resolveMembersUsagePageUsers({
+    auth,
+    workspace,
+    paginationParams,
     restrictToUserIds,
   });
 

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
 const deletedKeys = vi.hoisted(() => [] as string[]);
 const mockEsSearchUsers = vi.hoisted(() => vi.fn());
+const mockEsSearchAllUsers = vi.hoisted(() => vi.fn());
 
 // Elasticsearch isn't available in unit tests; mock the search layer so we can
-// control the returned order and capture the arguments `searchUsers` forwards.
+// control the returned order and capture the arguments the resource forwards.
 vi.mock("@app/lib/user_search/search", () => ({
   searchUsers: mockEsSearchUsers,
+  searchAllUsers: mockEsSearchAllUsers,
 }));
 
 vi.mock("@app/lib/utils/cache", () => ({
@@ -112,6 +114,7 @@ describe("UserResource", () => {
   describe("searchUsers", () => {
     beforeEach(() => {
       mockEsSearchUsers.mockReset();
+      mockEsSearchAllUsers.mockReset();
     });
 
     it("forwards orderBy and returns users in the order Elasticsearch returned", async () => {
@@ -143,6 +146,65 @@ describe("UserResource", () => {
       expect(mockEsSearchUsers).toHaveBeenCalledWith(
         expect.objectContaining({
           orderBy: { field: "name", direction: "desc" },
+        })
+      );
+      expect(result.isOk()).toBe(true);
+      const users = result.isOk() ? result.value.users : [];
+      expect(users.map((u) => u.sId)).toEqual([bob.sId, alice.sId]);
+    });
+
+    it("preserves the Elasticsearch total when the current page is empty", async () => {
+      mockEsSearchUsers.mockResolvedValue(
+        new Ok({
+          users: [],
+          total: 2,
+        })
+      );
+
+      const result = await UserResource.searchUsers(auth, {
+        searchTerm: "",
+        offset: 10,
+        limit: 10,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        return;
+      }
+
+      expect(result.value.users).toEqual([]);
+      expect(result.value.total).toBe(2);
+    });
+  });
+
+  describe("searchAllUsers", () => {
+    beforeEach(() => {
+      mockEsSearchAllUsers.mockReset();
+    });
+
+    it("returns all users in the order Elasticsearch returned", async () => {
+      const alice = await UserFactory.basic();
+      const bob = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, alice, { role: "user" });
+      await MembershipFactory.associate(workspace, bob, { role: "user" });
+
+      mockEsSearchAllUsers.mockResolvedValue(
+        new Ok({
+          users: [
+            { user_id: bob.sId, email: "b@example.com", full_name: "Bob" },
+            { user_id: alice.sId, email: "a@example.com", full_name: "Alice" },
+          ],
+          total: 2,
+        })
+      );
+
+      const result = await UserResource.searchAllUsers(auth, {
+        searchTerm: "",
+      });
+
+      expect(mockEsSearchAllUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchTerm: "",
         })
       );
       expect(result.isOk()).toBe(true);

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -10,7 +10,10 @@ import {
 } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { SearchUsersOrderBy } from "@app/lib/user_search/search";
-import { searchUsers } from "@app/lib/user_search/search";
+import {
+  searchAllUsers as searchAllUserDocuments,
+  searchUsers as searchUserDocuments,
+} from "@app/lib/user_search/search";
 import {
   cacheWithRedis,
   invalidateCacheAfterCommit,
@@ -32,6 +35,7 @@ import type {
 } from "@app/types/user";
 import type { UserSearchDocument } from "@app/types/user_search/user_search";
 import { escape } from "html-escaper";
+import chunk from "lodash/chunk";
 import fromPairs from "lodash/fromPairs";
 import sortBy from "lodash/sortBy";
 import type {
@@ -62,6 +66,7 @@ export interface DeleteUserApprovalsResponseBody {
 const USER_METADATA_COMMA_SEPARATOR = ",";
 const USER_METADATA_COMMA_REPLACEMENT = "DUST_COMMA";
 const TOOLS_VALIDATION_WILDCARD = "*";
+const USER_SEARCH_DB_BATCH_SIZE = 1000;
 
 type CachedUserData = {
   id: ModelId;
@@ -362,62 +367,44 @@ export class UserResource extends BaseResource<UserModel> {
     return users.map((user) => new UserResource(UserModel, user.get()));
   }
 
-  static async searchUsers(
-    auth: Authenticator,
-    {
-      searchTerm,
-      offset,
-      limit,
-      orderBy,
-      restrictToUserIds,
-    }: {
-      searchTerm: string;
-      offset: number;
-      limit: number;
-      orderBy?: SearchUsersOrderBy;
-      restrictToUserIds?: string[];
-    }
-  ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
-    const owner = auth.getNonNullableWorkspace();
-
-    // Search users in Elasticsearch
-    const searchResult = await searchUsers({
-      owner,
-      searchTerm,
-      offset,
-      limit,
-      orderBy,
-      userIds: restrictToUserIds,
-    });
-    if (searchResult.isErr()) {
-      return searchResult;
-    }
-
-    const { users: userDocs, total } = searchResult.value;
+  private static async hydrateSearchUsers({
+    owner,
+    userDocs,
+    total,
+  }: {
+    owner: LightWorkspaceType;
+    userDocs: UserSearchDocument[];
+    total: number;
+  }): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
     const userIds = userDocs.map((doc) => doc.user_id);
 
     if (userIds.length === 0) {
-      return new Ok({ users: [], total: 0 });
+      return new Ok({ users: [], total });
     }
 
-    // Note that UserResource has stored sIds, not generated ones.
-    const users = await UserModel.findAll({
-      where: {
-        sId: { [Op.in]: userIds },
-      },
-      include: [
-        {
-          model: MembershipModel,
-          as: "memberships",
-          required: true, // INNER JOIN
-          where: {
-            workspaceId: owner.id,
-            startAt: { [Op.lte]: new Date() },
-            endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }] },
-          },
+    const now = new Date();
+    const users: UserModel[] = [];
+    for (const userIdBatch of chunk(userIds, USER_SEARCH_DB_BATCH_SIZE)) {
+      // Note that UserResource has stored sIds, not generated ones.
+      const batchUsers = await UserModel.findAll({
+        where: {
+          sId: { [Op.in]: userIdBatch },
         },
-      ],
-    });
+        include: [
+          {
+            model: MembershipModel,
+            as: "memberships",
+            required: true, // INNER JOIN
+            where: {
+              workspaceId: owner.id,
+              startAt: { [Op.lte]: now },
+              endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: now }] },
+            },
+          },
+        ],
+      });
+      users.push(...batchUsers);
+    }
 
     // Check if we found fewer users than expected (means some were revoked)
     if (users.length < userIds.length) {
@@ -442,19 +429,84 @@ export class UserResource extends BaseResource<UserModel> {
       );
     }
 
-    // Create a map to maintain the order from Elasticsearch results
+    // Create a map to maintain the order from Elasticsearch results.
     const userResourceMap = new Map<string, UserResource>();
     users.forEach((u) => {
       const userBlob = u.get();
       userResourceMap.set(u.sId, new UserResource(UserModel, userBlob));
     });
 
-    // Return users in the order from Elasticsearch results
+    // Return users in the order from Elasticsearch results.
     const orderedUsers = userIds
       .map((sId) => userResourceMap.get(sId))
       .filter((user): user is UserResource => user !== undefined);
 
     return new Ok({ users: orderedUsers, total });
+  }
+
+  static async searchUsers(
+    auth: Authenticator,
+    {
+      searchTerm,
+      offset,
+      limit,
+      orderBy,
+      restrictToUserIds,
+    }: {
+      searchTerm: string;
+      offset: number;
+      limit: number;
+      orderBy?: SearchUsersOrderBy;
+      restrictToUserIds?: string[];
+    }
+  ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const searchResult = await searchUserDocuments({
+      owner,
+      searchTerm,
+      offset,
+      limit,
+      orderBy,
+      userIds: restrictToUserIds,
+    });
+    if (searchResult.isErr()) {
+      return searchResult;
+    }
+
+    return this.hydrateSearchUsers({
+      owner,
+      userDocs: searchResult.value.users,
+      total: searchResult.value.total,
+    });
+  }
+
+  static async searchAllUsers(
+    auth: Authenticator,
+    {
+      searchTerm,
+      restrictToUserIds,
+    }: {
+      searchTerm: string;
+      restrictToUserIds?: string[];
+    }
+  ): Promise<Result<{ users: UserResource[]; total: number }, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const searchResult = await searchAllUserDocuments({
+      owner,
+      searchTerm,
+      userIds: restrictToUserIds,
+    });
+    if (searchResult.isErr()) {
+      return searchResult;
+    }
+
+    return this.hydrateSearchUsers({
+      owner,
+      userDocs: searchResult.value.users,
+      total: searchResult.value.total,
+    });
   }
 
   async updateName(firstName: string, lastName: string | null) {

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -246,7 +246,7 @@ export function useMembersUsage({
   searchTerm?: string;
   pageIndex: number;
   pageSize: number;
-  orderColumn?: "name" | "email";
+  orderColumn?: "name" | "email" | "consumedAwuCredits";
   orderDirection?: "asc" | "desc";
   seatType?: MembershipSeatType | "none";
   disabled?: boolean;

--- a/front/lib/user_search/search.test.ts
+++ b/front/lib/user_search/search.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClientSearch = vi.hoisted(() => vi.fn());
+
+vi.mock("@app/lib/api/elasticsearch", async () => {
+  const { Ok } = await import("@app/types/shared/result");
+
+  return {
+    USER_SEARCH_ALIAS_NAME: "front.user_search",
+    withEs: async (
+      fn: (client: { search: typeof mockClientSearch }) => Promise<unknown>
+    ) => new Ok(await fn({ search: mockClientSearch })),
+  };
+});
+
+import { searchAllUsers, searchUsers } from "@app/lib/user_search/search";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+describe("user_search/search", () => {
+  beforeEach(() => {
+    mockClientSearch.mockReset();
+  });
+
+  it("requests exact totals for paginated user searches", async () => {
+    const workspace = await WorkspaceFactory.basic();
+
+    mockClientSearch.mockResolvedValue({
+      hits: {
+        total: { value: 12345, relation: "eq" },
+        hits: [],
+      },
+    });
+
+    const result = await searchUsers({
+      owner: workspace,
+      searchTerm: "",
+      offset: 0,
+      limit: 25,
+      orderBy: { field: "name", direction: "asc" },
+    });
+
+    expect(mockClientSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        track_total_hits: true,
+      })
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.total).toBe(12345);
+  });
+
+  it("pages through all matching users with search_after", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const updatedAt = new Date("2026-01-01T00:00:00.000Z");
+    const firstPageHits = Array.from({ length: 1000 }, (_, index) => {
+      const userNumber = index + 1;
+      const fullName = `User ${userNumber.toString().padStart(4, "0")}`;
+      const userId = `user-${userNumber}`;
+
+      return {
+        _source: {
+          workspace_id: workspace.sId,
+          user_id: userId,
+          email: `${userId}@example.com`,
+          full_name: fullName,
+          updated_at: updatedAt,
+        },
+        sort: [fullName, userId],
+      };
+    });
+
+    mockClientSearch
+      .mockResolvedValueOnce({
+        hits: {
+          total: { value: 1002, relation: "eq" },
+          hits: firstPageHits,
+        },
+      })
+      .mockResolvedValueOnce({
+        hits: {
+          total: { value: 1002, relation: "eq" },
+          hits: [
+            {
+              _source: {
+                workspace_id: workspace.sId,
+                user_id: "user-1001",
+                email: "user-1001@example.com",
+                full_name: "User 1001",
+                updated_at: updatedAt,
+              },
+              sort: ["User 1001", "user-1001"],
+            },
+            {
+              _source: {
+                workspace_id: workspace.sId,
+                user_id: "user-1002",
+                email: "user-1002@example.com",
+                full_name: "User 1002",
+                updated_at: updatedAt,
+              },
+              sort: ["User 1002", "user-1002"],
+            },
+          ],
+        },
+      });
+
+    const result = await searchAllUsers({
+      owner: workspace,
+      searchTerm: "user",
+    });
+
+    expect(mockClientSearch).toHaveBeenCalledTimes(2);
+    expect(mockClientSearch.mock.calls[0][0]).toMatchObject({
+      index: "front.user_search",
+      size: 1000,
+      sort: [
+        { "full_name.keyword": { order: "asc" } },
+        { user_id: { order: "asc" } },
+      ],
+      track_total_hits: true,
+    });
+    expect(mockClientSearch.mock.calls[1][0]).toMatchObject({
+      search_after: ["User 1000", "user-1000"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.total).toBe(1002);
+    expect(result.value.users).toHaveLength(1002);
+    expect(result.value.users[0]?.user_id).toBe("user-1");
+    expect(result.value.users[1001]?.user_id).toBe("user-1002");
+  });
+});

--- a/front/lib/user_search/search.ts
+++ b/front/lib/user_search/search.ts
@@ -5,6 +5,8 @@ import type { LightWorkspaceType } from "@app/types/user";
 import type { UserSearchDocument } from "@app/types/user_search/user_search";
 import type { estypes } from "@elastic/elasticsearch";
 
+const USER_SEARCH_SCAN_PAGE_SIZE = 1000;
+
 export interface SearchUsersResult {
   users: UserSearchDocument[];
   total: number;
@@ -16,6 +18,77 @@ export type SearchUsersOrderBy = {
   field: "name" | "email";
   direction: "asc" | "desc";
 };
+
+function buildUserSearchQuery({
+  owner,
+  searchTerm,
+  userIds,
+}: {
+  owner: LightWorkspaceType;
+  searchTerm: string;
+  userIds?: string[];
+}): estypes.QueryDslQueryContainer {
+  const hasSearchTerm = searchTerm.trim().length > 0;
+
+  return {
+    bool: {
+      filter: [
+        { term: { workspace_id: owner.sId } },
+        ...(userIds ? [{ terms: { user_id: userIds } }] : []),
+      ],
+      ...(hasSearchTerm && {
+        should: [
+          // Prefix matching on full_name using edge n-grams
+          {
+            match_phrase_prefix: {
+              "full_name.edge": {
+                query: searchTerm,
+              },
+            },
+          },
+          // Token matching on email (works with email tokenizer)
+          {
+            match_phrase_prefix: {
+              email: {
+                query: searchTerm,
+              },
+            },
+          },
+        ],
+        minimum_should_match: 1,
+      }),
+    },
+  };
+}
+
+function buildUserSearchSort(orderBy?: SearchUsersOrderBy): estypes.Sort {
+  // When an explicit order is requested, sort on the keyword sub-field (with
+  // `user_id` as a stable tiebreaker for consistent pagination); otherwise
+  // rank by relevance. `full_name.keyword` / `email.keyword` exist in the
+  // index mapping.
+  return orderBy
+    ? [
+        {
+          [orderBy.field === "name" ? "full_name.keyword" : "email.keyword"]: {
+            order: orderBy.direction,
+          },
+        },
+        { user_id: { order: "asc" } },
+      ]
+    : [{ _score: { order: "desc" } }];
+}
+
+function getTotalHits(
+  total: estypes.SearchTotalHits | number | undefined
+): number {
+  return typeof total === "number" ? total : (total?.value ?? 0);
+}
+
+function getUserSearchHitSources(
+  hits: estypes.SearchHit<UserSearchDocument>[]
+): UserSearchDocument[] {
+  return hits.flatMap((hit) => (hit._source ? [hit._source] : []));
+}
 
 /**
  * Search users by email and full name.
@@ -38,70 +111,72 @@ export async function searchUsers({
   userIds?: string[];
 }): Promise<Result<SearchUsersResult, ElasticsearchError>> {
   return withEs(async (client) => {
-    // If searchTerm is empty or only whitespace, return all users from the workspace.
-    const hasSearchTerm = searchTerm && searchTerm.trim().length > 0;
-
-    const query: estypes.QueryDslQueryContainer = {
-      bool: {
-        filter: [
-          { term: { workspace_id: owner.sId } },
-          ...(userIds ? [{ terms: { user_id: userIds } }] : []),
-        ],
-        ...(hasSearchTerm && {
-          should: [
-            // Prefix matching on full_name using edge n-grams
-            {
-              match_phrase_prefix: {
-                "full_name.edge": {
-                  query: searchTerm,
-                },
-              },
-            },
-            // Token matching on email (works with email tokenizer)
-            {
-              match_phrase_prefix: {
-                email: {
-                  query: searchTerm,
-                },
-              },
-            },
-          ],
-          minimum_should_match: 1,
-        }),
-      },
-    };
-
-    // When an explicit order is requested, sort on the keyword sub-field (with
-    // `user_id` as a stable tiebreaker for consistent pagination); otherwise
-    // rank by relevance. `full_name.keyword` / `email.keyword` exist in the
-    // index mapping.
-    const sort: estypes.Sort = orderBy
-      ? [
-          {
-            [orderBy.field === "name" ? "full_name.keyword" : "email.keyword"]:
-              { order: orderBy.direction },
-          },
-          { user_id: { order: "asc" } },
-        ]
-      : [{ _score: { order: "desc" } }];
-
     const response = await client.search<UserSearchDocument>({
       index: USER_SEARCH_ALIAS_NAME,
-      query,
+      query: buildUserSearchQuery({ owner, searchTerm, userIds }),
       size: limit,
       from: offset,
-      sort,
+      sort: buildUserSearchSort(orderBy),
+      track_total_hits: true,
     });
 
-    const users = response.hits.hits.map((hit) => hit._source!);
-    const total =
-      typeof response.hits.total === "number"
-        ? response.hits.total
-        : (response.hits.total?.value ?? 0);
-
     return {
-      users,
-      total,
+      users: getUserSearchHitSources(response.hits.hits),
+      total: getTotalHits(response.hits.total),
     };
+  });
+}
+
+export async function searchAllUsers({
+  owner,
+  searchTerm,
+  userIds,
+}: {
+  owner: LightWorkspaceType;
+  searchTerm: string;
+  userIds?: string[];
+}): Promise<Result<SearchUsersResult, ElasticsearchError>> {
+  return withEs(async (client) => {
+    const query = buildUserSearchQuery({ owner, searchTerm, userIds });
+    const sort: estypes.Sort = [
+      { "full_name.keyword": { order: "asc" } },
+      { user_id: { order: "asc" } },
+    ];
+
+    let total = 0;
+    let fetchedHitCount = 0;
+    let searchAfter: estypes.SortResults | undefined;
+    const users: UserSearchDocument[] = [];
+
+    while (true) {
+      const response = await client.search<UserSearchDocument>({
+        index: USER_SEARCH_ALIAS_NAME,
+        query,
+        size: USER_SEARCH_SCAN_PAGE_SIZE,
+        sort,
+        track_total_hits: true,
+        ...(searchAfter ? { search_after: searchAfter } : {}),
+      });
+
+      const hits = response.hits.hits;
+      total = getTotalHits(response.hits.total);
+      fetchedHitCount += hits.length;
+      users.push(...getUserSearchHitSources(hits));
+
+      if (
+        hits.length < USER_SEARCH_SCAN_PAGE_SIZE ||
+        fetchedHitCount >= total
+      ) {
+        break;
+      }
+
+      const lastSort = hits[hits.length - 1]?.sort;
+      if (!lastSort) {
+        break;
+      }
+      searchAfter = lastSort;
+    }
+
+    return { users, total };
   });
 }


### PR DESCRIPTION
## Description

Ticket: https://github.com/dust-tt/tasks/issues/9094

Sort seatType/consumedAwuCredits over the full member set: neither is in the user search index, so fetch all matching members, compute the sort key in-app (seat tier or cached Metronome usage), sort, then paginate.

## Tests

Local + unit

## Risk

Low

## Deploy Plan

front