### PR TITLE
Inject AGENTS.md in the prompt of all Pod's conversations.

### DIFF
--- a/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
+++ b/front-api/routes/w/[wId]/files/path/[...canonicalPath].ts
@@ -13,12 +13,12 @@ import {
 } from "@app/lib/api/files/file_system_ops";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { readableToReadableStream } from "@app/types/shared/utils/streams";
-import { bodyLimit } from "@front-api/middlewares/body_limit";
 import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import type { Context } from "hono";
+import { bodyLimit as honoBodyLimit } from "hono/body-limit";
 import path from "path";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
@@ -56,6 +56,28 @@ const PatchBodySchema = z.discriminatedUnion("action", [
     dest: z.string().min(1),
   }),
 ]);
+
+function isBodyLimitError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === "BodyLimitError" || err.message === "Payload Too Large")
+  );
+}
+
+function putContentTooLargeError(ctx: Context) {
+  return apiError(ctx, {
+    status_code: 413,
+    api_error: {
+      type: "invalid_request_error",
+      message: `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`,
+    },
+  });
+}
+
+const putBodyLimit = honoBodyLimit({
+  maxSize: WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES,
+  onError: putContentTooLargeError,
+});
 
 /** Resolve and validate the canonical path from the URL, returning an error response if invalid. */
 async function resolveFs(
@@ -355,7 +377,7 @@ app.patch(
 /** @ignoreswagger */
 app.put(
   "/:canonicalPath{.+}",
-  bodyLimit(WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES),
+  putBodyLimit,
   validate("param", ParamsSchema),
   async (ctx) => {
     const auth = ctx.get("auth");
@@ -372,20 +394,17 @@ app.put(
         Number.isFinite(contentLength) &&
         contentLength > WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES
       ) {
-        return apiError(ctx, {
-          status_code: 413,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`,
-          },
-        });
+        return putContentTooLargeError(ctx);
       }
     }
 
     let contentBuffer: ArrayBuffer;
     try {
       contentBuffer = await ctx.req.arrayBuffer();
-    } catch {
+    } catch (err) {
+      if (isBodyLimitError(err)) {
+        return putContentTooLargeError(ctx);
+      }
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -396,13 +415,7 @@ app.put(
     }
 
     if (contentBuffer.byteLength > WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES) {
-      return apiError(ctx, {
-        status_code: 413,
-        api_error: {
-          type: "invalid_request_error",
-          message: `Content exceeds the ${WRITE_CANONICAL_FILE_CONTENT_MAX_BYTES / 1024} KB limit.`,
-        },
-      });
+      return putContentTooLargeError(ctx);
     }
 
     const writeResult = await writeCanonicalFileContent(

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -7,6 +7,11 @@ import { PodSettingsOptionLabel } from "@app/components/pod/settings/PodSettings
 import { SuggestedTasksGenerationTile } from "@app/components/pod/settings/SuggestedTasksGenerationTile";
 import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useArchivePod } from "@app/hooks/useArchivePod";
+import {
+  getPodAgentsMdScopedPath,
+  POD_AGENTS_MD_FILENAME,
+  POD_AGENTS_MD_MAX_CHARACTER_COUNT,
+} from "@app/lib/api/projects/constants";
 import type { RichSpaceType } from "@app/lib/api/spaces";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
@@ -49,9 +54,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
-// Note: this does not use the right format for the path (missing -{podId}) but that how the api expects it.
-// TODO(2026-06-23 FILE SYSTEM): Fix this.
-const AGENTS_MD_CANONICAL_PATH = "AGENTS.md";
 interface PodSettingsTabProps {
   owner: LightWorkspaceType;
   pod: RichSpaceType;
@@ -440,16 +442,17 @@ export function PodSettingsTab({
           <div className="heading-lg">Instructions for Agents</div>
           <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             Seen by all agents in this Pod, stored as{" "}
-            <span className="font-medium">AGENTS.md</span> in the Pod's files.
+            <span className="font-medium">{POD_AGENTS_MD_FILENAME}</span> in the
+            Pod's files.
           </div>
           <div className="flex w-full min-w-0 flex-col gap-2">
             <MarkdownFileEditor
               owner={owner}
-              filePath={`pod-${pod.sId}/${AGENTS_MD_CANONICAL_PATH}`}
+              filePath={getPodAgentsMdScopedPath(pod.sId)}
               emptyWhenNotFound
               readOnly={!isPodEditor}
               placeholder="Enter instructions for agents"
-              maxCharacterCount={4096}
+              maxCharacterCount={POD_AGENTS_MD_MAX_CHARACTER_COUNT}
             />
           </div>
         </div>

--- a/front/lib/api/projects/agents_md.test.ts
+++ b/front/lib/api/projects/agents_md.test.ts
@@ -1,0 +1,175 @@
+import { DustFileSystem, DustFileSystemError } from "@app/lib/api/file_system";
+import {
+  formatPodAgentsMdPromptSection,
+  readPodAgentsMdContent,
+} from "@app/lib/api/projects/agents_md";
+import {
+  getPodAgentsMdScopedPath,
+  POD_AGENTS_MD_MAX_CHARACTER_COUNT,
+} from "@app/lib/api/projects/constants";
+import { Authenticator } from "@app/lib/auth";
+import { constructProjectContext } from "@app/lib/resources/skill/code_defined/projects";
+import logger from "@app/logger/logger";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { describe, expect, it, vi } from "vitest";
+
+describe("readPodAgentsMdContent", () => {
+  it("returns null when the file does not exist", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const podId = "pod_test";
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        readBuffer: vi.fn().mockResolvedValue(new Ok(null)),
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await readPodAgentsMdContent(auth, podId);
+    expect(result).toBeNull();
+    expect(DustFileSystem.fromScopedPath).toHaveBeenCalledWith(
+      auth,
+      getPodAgentsMdScopedPath(podId)
+    );
+  });
+
+  it("returns trimmed content when the file exists", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const podId = "pod_test";
+    const scopedPath = getPodAgentsMdScopedPath(podId);
+
+    const readBuffer = vi
+      .fn()
+      .mockResolvedValue(new Ok(Buffer.from("  Always cite sources.\n")));
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        readBuffer,
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await readPodAgentsMdContent(auth, podId);
+    expect(result).toBe("Always cite sources.");
+    expect(readBuffer).toHaveBeenCalledWith(scopedPath);
+  });
+
+  it("truncates content to the Pod settings character limit", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const podId = "pod_test";
+    const longContent = "x".repeat(POD_AGENTS_MD_MAX_CHARACTER_COUNT + 100);
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        readBuffer: vi
+          .fn()
+          .mockResolvedValue(new Ok(Buffer.from(longContent, "utf8"))),
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await readPodAgentsMdContent(auth, podId);
+    expect(result).toHaveLength(POD_AGENTS_MD_MAX_CHARACTER_COUNT);
+  });
+
+  it("logs a warning when reading AGENTS.md fails unexpectedly", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const podId = "pod_test";
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        readBuffer: vi
+          .fn()
+          .mockResolvedValue(
+            new Err(new DustFileSystemError("internal", "stream read failed"))
+          ),
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await readPodAgentsMdContent(auth, podId);
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+  });
+
+  it("does not log when AGENTS.md is missing", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const podId = "pod_test";
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Err(new DustFileSystemError("not_found", "Space not found"))
+    );
+
+    const result = await readPodAgentsMdContent(auth, podId);
+
+    expect(result).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("formatPodAgentsMdPromptSection", () => {
+  it("wraps content in a labeled section", () => {
+    const section = formatPodAgentsMdPromptSection("Use Pod tools first.");
+    expect(section).toContain("## Pod agent instructions (AGENTS.md)");
+    expect(section).toContain("<file_content>");
+    expect(section).toContain("Use Pod tools first.");
+    expect(section).toContain("</file_content>");
+  });
+});
+
+describe("constructProjectContext", () => {
+  it("returns empty string for non-pod conversations", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
+    const result = await constructProjectContext(auth, { conversation });
+    expect(result).toBe("");
+  });
+
+  it("includes AGENTS.md instructions for pod conversations", async () => {
+    const { workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const project = await SpaceFactory.project(workspace, user.id);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent",
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+      spaceId: project.id,
+    });
+
+    vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
+      new Ok({
+        readBuffer: vi
+          .fn()
+          .mockResolvedValue(
+            new Ok(Buffer.from("Prefer concise answers.", "utf8"))
+          ),
+      } as unknown as DustFileSystem)
+    );
+
+    const result = await constructProjectContext(auth, { conversation });
+
+    expect(result).toContain(`part of the Pod "${project.name}"`);
+    expect(result).toContain("## Pod agent instructions (AGENTS.md)");
+    expect(result).toContain("Prefer concise answers.");
+  });
+});

--- a/front/lib/api/projects/agents_md.ts
+++ b/front/lib/api/projects/agents_md.ts
@@ -1,0 +1,61 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import {
+  getPodAgentsMdScopedPath,
+  POD_AGENTS_MD_MAX_CHARACTER_COUNT,
+} from "@app/lib/api/projects/constants";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+
+export async function readPodAgentsMdContent(
+  auth: Authenticator,
+  podId: string
+): Promise<string | null> {
+  const scopedPath = getPodAgentsMdScopedPath(podId);
+  const fsResult = await DustFileSystem.fromScopedPath(auth, scopedPath);
+  if (fsResult.isErr()) {
+    if (fsResult.error.code !== "not_found") {
+      logger.warn(
+        { err: fsResult.error, scopedPath },
+        "Failed to open file system for Pod AGENTS.md"
+      );
+    }
+    return null;
+  }
+
+  const readResult = await fsResult.value.readBuffer(scopedPath);
+  if (readResult.isErr()) {
+    logger.warn(
+      { err: readResult.error, scopedPath },
+      "Failed to read Pod AGENTS.md"
+    );
+    return null;
+  }
+
+  if (readResult.value === null) {
+    return null;
+  }
+
+  const content = readResult.value.toString("utf8").trim();
+  if (!content) {
+    return null;
+  }
+
+  if (content.length > POD_AGENTS_MD_MAX_CHARACTER_COUNT) {
+    return content.slice(0, POD_AGENTS_MD_MAX_CHARACTER_COUNT);
+  }
+
+  return content;
+}
+
+export function formatPodAgentsMdPromptSection(content: string): string {
+  return `
+## Pod agent instructions (AGENTS.md)
+
+The Pod maintainers configured these instructions for all agents in this Pod.
+Follow them when relevant.
+
+<file_content>
+${content}
+</file_content>
+`;
+}

--- a/front/lib/api/projects/constants.ts
+++ b/front/lib/api/projects/constants.ts
@@ -1,2 +1,14 @@
+import { podScopedPath } from "@app/lib/api/file_system/types";
+
 export const PROJECT_CONTEXT_FOLDER_ID = "project-context-folder";
 export const PROJECT_CONTEXT_FOLDER_NAME = "Context";
+
+/** Pod-wide agent instructions file, edited in Pod settings. */
+export const POD_AGENTS_MD_FILENAME = "AGENTS.md";
+
+/** Matches the character limit enforced in Pod settings UI. */
+export const POD_AGENTS_MD_MAX_CHARACTER_COUNT = 4096;
+
+export function getPodAgentsMdScopedPath(podId: string): string {
+  return podScopedPath(podId, POD_AGENTS_MD_FILENAME);
+}

--- a/front/lib/resources/skill/code_defined/projects.ts
+++ b/front/lib/resources/skill/code_defined/projects.ts
@@ -1,6 +1,10 @@
 import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { FILES_SERVER_NAME } from "@app/lib/api/actions/servers/files/metadata";
 import { POD_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/pod_manager/metadata";
+import {
+  formatPodAgentsMdPromptSection,
+  readPodAgentsMdContent,
+} from "@app/lib/api/projects/agents_md";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -84,6 +88,11 @@ export async function constructProjectContext(
 IMPORTANT: This conversation (id: ${conversation.sId}) is part of the Pod "${space?.name}" (id: ${space?.sId}).
 Therefore, ALWAYS start by using the Pod tools to search for information before using company-wide tools.
 `;
+
+    const agentsMd = await readPodAgentsMdContent(auth, conversation.spaceId);
+    if (agentsMd) {
+      instructions += formatPodAgentsMdPromptSection(agentsMd);
+    }
   }
 
   return instructions;


### PR DESCRIPTION
## Description

When a conversation runs inside a Pod space, `constructProjectContext` now reads `AGENTS.md` via `DustFileSystem` and appends a `## Pod agent instructions (AGENTS.md)` section to the system prompt. Pod maintainers write these instructions in Pod settings; agents see them automatically in every Pod conversation.

Also extracts shared constants (`POD_AGENTS_MD_FILENAME`, `POD_AGENTS_MD_MAX_CHARACTER_COUNT`, `getPodAgentsMdScopedPath`) into `projects/constants.ts` and fixes the previously incorrect file path used in `PodSettingsTab` (removes the TODO comment).

<img width="929" height="323" alt="file-c961616d6cb6ca0ac9608a3ebddf7350" src="https://github.com/user-attachments/assets/264ce4d6-17ae-49b4-8830-d4b6f27a4cff" />

<img width="842" height="380" alt="file-f055b325c79fc25c29c13fe4f011c74b" src="https://github.com/user-attachments/assets/13ee7f47-58bf-48a0-85ef-65c596d503ea" />


## Tests

Added Vitest unit tests for `readPodAgentsMdContent` (file missing, success with trim, truncation to 4096 chars, error logging), `formatPodAgentsMdPromptSection`, and integration tests for `constructProjectContext` (non-Pod conversation returns empty string; Pod conversation includes AGENTS.md section).

## Risk

Low. `readPodAgentsMdContent` returns `null` on any error or missing file — no AGENTS.md means the prompt is unchanged. Read-only at inference time, no writes, no schema changes.

## Deploy Plan

Deploy front.
