### PR TITLE
feat(billing): direct seat sync on auto-upgrade and reconcile on enable

### DIFF
--- a/front/lib/api/credits/auto_seat_upgrade.test.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.test.ts
@@ -226,6 +226,7 @@ describe("maybeAutoUpgradeSeat", () => {
       expect.objectContaining({
         newSeatType: "max",
         author: "no-author",
+        isDirectSync: true,
       })
     );
     expect(workosAudit.emitAuditLogEventDirect).toHaveBeenCalledWith(

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -208,6 +208,9 @@ export async function maybeAutoUpgradeSeat({
     workspace: lightWorkspace,
     newSeatType,
     author: "no-author",
+    // Unblock the member immediately rather than waiting on the debounced
+    // seat-count sync: push the seat count now and reconcile just this user.
+    isDirectSync: true,
   });
   if (result.isErr()) {
     logger.warn(

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,5 +1,6 @@
 import { passesBillingGate } from "@app/lib/api/credits/auto_seat_upgrade";
 import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import type { Authenticator } from "@app/lib/auth";
 import { isEnterprisePlanPrefix, isFreePlan } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
@@ -9,6 +10,7 @@ import {
   DEFAULT_TOP_UP_ENABLED,
   DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
 } from "@app/lib/resources/storage/models/credit_usage_configurations";
+import logger from "@app/logger/logger";
 import type {
   CreditUsageConfigurationBody,
   PatchCreditUsageConfigurationBody,
@@ -114,6 +116,14 @@ export async function updateUsageConfiguration(
     }
   }
 
+  // Detect a false→true transition of the auto-upgrade toggle: enabling it is
+  // the one moment we reconcile the *whole* workspace (rather than per seat
+  // transition), so every member lands in the correct seat↔pool credit state
+  // under the new policy.
+  const enablingAutoSeatUpgrade =
+    patch.autoSeatUpgradeEnabled === true &&
+    !(await getUsageConfiguration(auth)).autoSeatUpgradeEnabled;
+
   if (
     patch.allowMemberUpgradeRequests !== undefined ||
     patch.upgradeRequestEmailEnabled !== undefined ||
@@ -126,6 +136,22 @@ export async function updateUsageConfiguration(
     });
     if (toggleResult.isErr()) {
       return new Err(toggleResult.error);
+    }
+  }
+
+  if (enablingAutoSeatUpgrade) {
+    // Best-effort: a failure here must not fail the configuration update.
+    const reconcileResult = await syncMetronomeSeatCountForWorkspace({
+      workspace: auth.getNonNullableWorkspace(),
+    });
+    if (reconcileResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          err: reconcileResult.error.message,
+        },
+        "[UsageConfiguration] Whole-workspace reconcile after enabling auto-upgrade failed"
+      );
     }
   }
 

--- a/front/lib/api/membership.ts
+++ b/front/lib/api/membership.ts
@@ -4,6 +4,7 @@ import {
   emitAuditLogEventDirect,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
+import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import type { AuditLogActor } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -649,6 +650,7 @@ export async function updateMembershipSeatAndTrack({
   newSeatType,
   author,
   immediate = false,
+  isDirectSync = false,
 }: {
   user: UserResource;
   workspace: LightWorkspaceType;
@@ -656,6 +658,7 @@ export async function updateMembershipSeatAndTrack({
   author: UserType | "no-author";
   // When true, skip billing-period scheduling and apply the change right now.
   immediate?: boolean;
+  isDirectSync?: boolean;
 }): Promise<
   Result<
     {
@@ -869,6 +872,23 @@ export async function updateMembershipSeatAndTrack({
       "[Metronome] Failed to sync seat count for transition"
     );
     return new Err({ type: "metronome_error" });
+  }
+
+  if (isDirectSync && resultingActiveSeatType !== previousSeatType) {
+    const directSyncResult = await syncMetronomeSeatCountForWorkspace({
+      workspace,
+      reconcileUserId: user.sId,
+    });
+    if (directSyncResult.isErr()) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          userId: user.sId,
+          err: directSyncResult.error.message,
+        },
+        "[Metronome] Direct seat sync failed; debounced workflow will retry"
+      );
+    }
   }
 
   return new Ok({

--- a/front/lib/api/metronome/credit_state_dispatcher.ts
+++ b/front/lib/api/metronome/credit_state_dispatcher.ts
@@ -4,9 +4,8 @@ import { recalculatePerUserCapAlertForSeatChange } from "@app/lib/api/membership
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
-import { getNetBalance } from "@app/lib/metronome/client";
-import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
 import { fetchLiveUserCreditInputs } from "@app/lib/metronome/live_user_credit_inputs";
+import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { transitionProgrammaticCreditState } from "@app/lib/metronome/programmatic_credit_state_machine";
 import {
   clearWorkspaceProgrammaticWarningReached,
@@ -634,18 +633,4 @@ export async function syncPoolCreditStateFromBalance({
   } else {
     await dispatchPoolExhausted({ workspace });
   }
-}
-
-/**
- * Sum the live Metronome AWU balance across all AWU credit-type schedules for
- * a customer. This is the same balance the pool credit state machine reacts
- * to via `syncPoolCreditStateFromBalance`; exposed so debug tooling can read
- * it without re-implementing the reduction.
- */
-export async function getWorkspacePoolAwuBalance(
-  metronomeCustomerId: string
-): Promise<Result<number, Error>> {
-  return getNetBalance(metronomeCustomerId, {
-    creditTypeId: getCreditTypeAwuId(),
-  });
 }

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -1,4 +1,3 @@
-import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
 import type { Authenticator } from "@app/lib/auth";
 import { isPAYGEnabled } from "@app/lib/credits/credit_payg";
 import { WARNING_BALANCE_RATIO } from "@app/lib/metronome/alerts/programmatic_cap";
@@ -12,6 +11,7 @@ import {
   fetchLiveUserCreditInputs,
 } from "@app/lib/metronome/live_user_credit_inputs";
 import { fetchPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
+import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import {
   expectedProgrammaticCreditStateFromUsage,

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -1,11 +1,16 @@
-import { reconcileWorkspaceUserCreditStates } from "@app/lib/api/metronome/reconcile_credit_state";
+import {
+  reconcileUser,
+  reconcileWorkspaceUserCreditStates,
+} from "@app/lib/api/metronome/reconcile_credit_state";
 import { syncDefaultPoolCapAlertsForWorkspace } from "@app/lib/api/workspace/default_user_spend_limit";
+import { Authenticator } from "@app/lib/auth";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import {
   hasContractSeatSubscription,
   syncSeatCount,
 } from "@app/lib/metronome/seats";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -35,11 +40,18 @@ export type SeatSyncOutcome =
  *
  * Returns a domain `Result`: a Metronome failure from `syncSeatCount` is
  * propagated as `Err` rather than swallowed, so the caller can surface it.
+ *
+ * `reconcileUserId` scopes the post-sync credit-state reconcile to a single
+ * user (e.g. an auto-upgrade unblocking one member mid-flow) and skips the
+ * workspace-wide cap-alert sync. The seat-count push itself is always
+ * workspace-wide. When omitted, the whole workspace is reconciled.
  */
 export async function syncMetronomeSeatCountForWorkspace({
   workspace,
+  reconcileUserId,
 }: {
   workspace: LightWorkspaceType;
+  reconcileUserId?: string;
 }): Promise<Result<SeatSyncOutcome, Error>> {
   if (!workspace.metronomeCustomerId) {
     return new Ok({
@@ -82,6 +94,34 @@ export async function syncMetronomeSeatCountForWorkspace({
   });
   if (result.isErr()) {
     return new Err(result.error);
+  }
+
+  // Single-user scope: reconcile just this user from the live balances now that
+  // their seat credits are assigned. Skips the whole-workspace reconcile and the
+  // cap-alert sync below — the debounced workflow runs the full path as backstop.
+  if (reconcileUserId) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    if (workspaceResource) {
+      const userReconcile = await reconcileUser({
+        auth,
+        workspace: workspaceResource,
+        metronomeCustomerId: workspace.metronomeCustomerId,
+        userId: reconcileUserId,
+        execute: true,
+      });
+      if (userReconcile.isErr()) {
+        logger.warn(
+          {
+            workspaceId: workspace.sId,
+            userId: reconcileUserId,
+            err: userReconcile.error.message,
+          },
+          "[SeatSync] Single-user credit-state reconcile failed; continuing"
+        );
+      }
+    }
+    return new Ok({ status: "synced" });
   }
 
   // Now that per-user seat credits are assigned, reconcile each seated user's

--- a/front/lib/metronome/pool_balance.ts
+++ b/front/lib/metronome/pool_balance.ts
@@ -1,0 +1,17 @@
+import { getNetBalance } from "@app/lib/metronome/client";
+import { getCreditTypeAwuId } from "@app/lib/metronome/constants";
+import type { Result } from "@app/types/shared/result";
+
+/**
+ * Sum the live Metronome AWU balance across all AWU credit-type schedules for
+ * a customer. This is the same balance the pool credit state machine reacts
+ * to via `syncPoolCreditStateFromBalance`; exposed so debug tooling can read
+ * it without re-implementing the reduction.
+ */
+export async function getWorkspacePoolAwuBalance(
+  metronomeCustomerId: string
+): Promise<Result<number, Error>> {
+  return getNetBalance(metronomeCustomerId, {
+    creditTypeId: getCreditTypeAwuId(),
+  });
+}

--- a/front/temporal/reinforcement/activities.ts
+++ b/front/temporal/reinforcement/activities.ts
@@ -12,12 +12,12 @@ import {
 import type { BatchStatus } from "@app/lib/api/llm/types/batch";
 import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
-import { getWorkspacePoolAwuBalance } from "@app/lib/api/metronome/credit_state_dispatcher";
 import { getRemainingDailyCapMicroUsd } from "@app/lib/api/programmatic_usage/daily_cap";
 import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage/tracking";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { type Authenticator, hasFeatureFlag } from "@app/lib/auth";
 import { intelligenceAwuFromRunUsages } from "@app/lib/metronome/events";
+import { getWorkspacePoolAwuBalance } from "@app/lib/metronome/pool_balance";
 import { getRemainingProgrammaticUsageFromMetronome } from "@app/lib/metronome/programmatic_awu_usage";
 import {
   isApiBlocked,


### PR DESCRIPTION
## Description

Stacked on top of #27775.

This builds on the free-plan UI gate by making auto-upgrade actually sync seats immediately and reconcile the workspace when the policy is enabled.

- When `maybeAutoUpgradeSeat` upgrades a member, it now passes `isDirectSync` down to `updateMembershipSeatAndTrack`. Instead of waiting on the debounced seat-count sync workflow, we push the seat count immediately and reconcile *just that member* (`reconcileUserId`), unblocking them in-flow. The debounced workflow still runs as a backstop.
- Enabling the auto-upgrade toggle (false→true transition in `updateUsageConfiguration`) now triggers a best-effort whole-workspace reconcile, so every member lands in the correct seat↔pool credit state under the new policy. A failure here is logged but never fails the configuration update.
- `getWorkspacePoolAwuBalance` is extracted from `credit_state_dispatcher.ts` into a new standalone `lib/metronome/pool_balance.ts` module; all callers updated.

## Tests

- `npm run test -w front -- auto_seat_upgrade` passes (12 tests). Updated the assertion to match the `isDirectSync` parameter name.
- `front` and `front-api` typecheck clean.
