### PR TITLE
feat(scripts): add eu/us cluster and prodbox connect helpers

### DIFF
--- a/scripts/connect-cluster.sh
+++ b/scripts/connect-cluster.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Point kubectl at a Dust production cluster (eu or us).
+#
+# Updates your default kubeconfig (KUBECONFIG, or ~/.kube/config) and switches
+# the current context to the chosen cluster, so subsequent `kubectl` commands
+# target it. Handles gcloud auth automatically.
+#
+# Usage: connect-cluster.sh <eu|us>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gcp.sh
+source "${SCRIPT_DIR}/lib/gcp.sh"
+
+ALIAS="${1:?Usage: connect-cluster.sh <eu|us>}"
+
+require_commands gcloud kubectl
+
+REGION="$(gcp_region_for_alias "$ALIAS")"
+
+ensure_gcloud_auth
+connect_cluster "$REGION" "${KUBECONFIG:-$HOME/.kube/config}"
+
+echo "✅ kubectl is now pointed at ${REGION} (dust-kube)."

--- a/scripts/connect-prodbox.sh
+++ b/scripts/connect-prodbox.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Open a shell (or run a one-off command) in the prodbox pod of a Dust
+# production cluster (eu or us).
+#
+# Uses an isolated kubeconfig so your local kubectl context is left untouched.
+# Handles gcloud auth automatically.
+#
+# Usage:
+#   connect-prodbox.sh <eu|us>                  # interactive shell
+#   connect-prodbox.sh <eu|us> -- <command...>  # run a command, then exit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gcp.sh
+source "${SCRIPT_DIR}/lib/gcp.sh"
+
+ALIAS="${1:?Usage: connect-prodbox.sh <eu|us> [-- <command...>]}"
+shift
+
+# Drop the optional "--" separator before the command, if present.
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+require_commands gcloud kubectl
+
+REGION="$(gcp_region_for_alias "$ALIAS")"
+
+# Isolated kubeconfig so we never mutate the caller's active kubectl context.
+TMPKUBECONFIG="$(mktemp)"
+cleanup() { rm -f "$TMPKUBECONFIG"; }
+trap cleanup EXIT
+
+ensure_gcloud_auth
+connect_cluster "$REGION" "$TMPKUBECONFIG"
+
+POD_NAME="$(get_prodbox_pod "$TMPKUBECONFIG")"
+echo "   Pod: ${POD_NAME}" >&2
+
+if [[ "$#" -gt 0 ]]; then
+  KUBECONFIG="$TMPKUBECONFIG" kubectl exec "$POD_NAME" -- "$@"
+else
+  echo "   Opening interactive shell (exit to disconnect)..." >&2
+  KUBECONFIG="$TMPKUBECONFIG" kubectl exec -it "$POD_NAME" -- bash
+fi

--- a/scripts/lib/gcp.sh
+++ b/scripts/lib/gcp.sh
@@ -1,0 +1,88 @@
+# shellcheck shell=bash
+#
+# Shared helpers for connecting to Dust production GKE clusters.
+#
+# Source this file from a script; do not execute it directly. All log/status
+# output goes to stderr so that helpers which "return" a value via stdout
+# (e.g. gcp_region_for_alias, get_prodbox_pod) stay safe inside $(...).
+
+# Map the short region alias used on the command line to the GCP region, which
+# is also the name of the gcloud configuration to use. Keep in sync with the
+# REGIONS list in run-migrations.sh as new regions are added.
+gcp_region_for_alias() {
+  local alias="$1"
+  case "$alias" in
+    us | us-central1) echo "us-central1" ;;
+    eu | europe-west1) echo "europe-west1" ;;
+    *)
+      echo "❌ Unknown region '${alias}'. Use 'eu' or 'us'." >&2
+      return 1
+      ;;
+  esac
+}
+
+# Verify required CLI tools are available before doing anything.
+require_commands() {
+  local missing=()
+  local cmd
+  for cmd in "$@"; do
+    if ! command -v "$cmd" &>/dev/null; then
+      missing+=("$cmd")
+    fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "❌ Missing required command(s): ${missing[*]}" >&2
+    return 1
+  fi
+}
+
+# Ensure the caller has a valid gcloud access token, triggering an interactive
+# login only when needed.
+ensure_gcloud_auth() {
+  echo "🔐 Checking gcloud authentication..." >&2
+  if ! gcloud auth print-access-token &>/dev/null; then
+    echo "   Not authenticated — running gcloud auth login..." >&2
+    gcloud auth login
+  fi
+}
+
+# Fetch cluster credentials for a region into the given KUBECONFIG path.
+# --configuration uses the region-named gcloud config without activating it
+# globally, keeping the caller's active configuration intact.
+connect_cluster() {
+  local region="$1"
+  local kubeconfig="$2"
+
+  echo "🌍 ${region} — fetching cluster credentials..." >&2
+  if ! KUBECONFIG="$kubeconfig" \
+    gcloud --configuration="${region}" \
+    container clusters get-credentials dust-kube \
+    --region "${region}" \
+    --quiet; then
+    echo "❌ Failed to get credentials for ${region}." >&2
+    return 1
+  fi
+}
+
+# Print the name of the prodbox pod in the cluster referenced by the given
+# KUBECONFIG path. Fails if the cluster is unreachable or no pod is found.
+get_prodbox_pod() {
+  local kubeconfig="$1"
+  local pod_name
+
+  pod_name=$(
+    KUBECONFIG="$kubeconfig" kubectl get pods \
+      -lapp.kubernetes.io/instance=prodbox \
+      --output jsonpath='{.items[0].metadata.name}'
+  ) || {
+    echo "❌ Failed to list prodbox pods." >&2
+    return 1
+  }
+
+  if [[ -z "$pod_name" ]]; then
+    echo "❌ No prodbox pod found." >&2
+    return 1
+  fi
+
+  echo "$pod_name"
+}

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 # post-deploy — apply migrations that must run after new code is deployed
 # status      — show pending migrations in every region (continues on failure)
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/gcp.sh
+source "${SCRIPT_DIR}/lib/gcp.sh"
+
 COMMAND="${1:?Usage: run-migrations.sh <pre-deploy|post-deploy|status> [front|connectors]}"
 COMPONENT="${2:?Usage: run-migrations.sh <pre-deploy|post-deploy|status> [front|connectors]}"
 
@@ -45,11 +49,8 @@ esac
 # GCP authentication
 # ---------------------------------------------------------------------------
 
-echo "🔐 Checking gcloud authentication..."
-if ! gcloud auth print-access-token &>/dev/null; then
-  echo "   Not authenticated — running gcloud auth login..."
-  gcloud auth login
-fi
+require_commands gcloud kubectl
+ensure_gcloud_auth
 
 # ---------------------------------------------------------------------------
 # Temp kubeconfig cleanup
@@ -77,36 +78,12 @@ run_in_region() {
   TMPFILES+=("$tmpkubeconfig")
 
   echo ""
-  echo "🌍 ${region} — fetching cluster credentials..."
+  connect_cluster "${region}" "$tmpkubeconfig" || return 1
 
-  # --configuration uses the named gcloud config without activating it globally,
-  # keeping the caller's active configuration intact.
-  if ! KUBECONFIG="$tmpkubeconfig" \
-    gcloud --configuration="${region}" \
-    container clusters get-credentials dust-kube \
-    --region "${region}" \
-    --quiet; then
-    echo "❌ Failed to get credentials for ${region}." >&2
-    return 1
-  fi
-
-  pod_name=$(
-    KUBECONFIG="$tmpkubeconfig" kubectl get pods \
-      -lapp.kubernetes.io/instance=prodbox \
-      --output jsonpath='{.items[0].metadata.name}'
-  ) || {
-    echo "❌ Failed to list pods in ${region}." >&2
-    return 1
-  }
-
-  if [[ -z "$pod_name" ]]; then
-    echo "❌ No prodbox pod found in ${region}." >&2
-    return 1
-  fi
+  pod_name=$(get_prodbox_pod "$tmpkubeconfig") || return 1
 
   echo "   Pod: ${pod_name}"
 
-  local pod_branch
   local pod_branch
   pod_branch=$(KUBECONFIG="$tmpkubeconfig" kubectl exec "${pod_name}" -- git -C /dust branch --show-current) || {
     echo "❌ Failed to check /dust branch in ${region}." >&2

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -38,6 +38,25 @@ case "$COMPONENT" in
     ;;
 esac
 
+# ---------------------------------------------------------------------------
+# Post-deploy confirmation
+# ---------------------------------------------------------------------------
+
+if [[ "$COMMAND" == "post-deploy" ]]; then
+  echo ""
+  echo "⚠️  Post-deploy migrations share DB models with front services."
+  echo "   Make sure the following are deployed with the latest code before continuing:"
+  echo "     • front"
+  echo "     • front-sse"
+  echo ""
+  read -r -p "   Have you deployed front and front-sse? [y/N] " confirm
+  if [[ "${confirm,,}" != "y" ]]; then
+    echo "❌ Aborted. Deploy front and front-sse first." >&2
+    exit 1
+  fi
+  echo ""
+fi
+
 # Map command to the npm script defined in package.json.
 case "$COMMAND" in
   pre-deploy) NPM_SCRIPT="migration:apply:pre-deploy" ;;


### PR DESCRIPTION
## Description

Two improvements to the migration and cluster tooling:

1. **Post-deploy confirmation gate** (`scripts/run-migrations.sh`): when running `post-deploy` migrations, the script now pauses and asks the operator to confirm that `front` and `front-sse` are deployed with the latest code before proceeding. Post-deploy migrations can reference DB models that the new code depends on, so running them against old pods is unsafe.

2. **Cluster/prodbox connect helpers** (`scripts/connect-cluster.sh`, `scripts/connect-prodbox.sh`, `scripts/lib/gcp.sh`): shared GCP helpers extracted into `lib/gcp.sh` and two convenience scripts for pointing `kubectl` at a Dust production cluster (`eu`/`us`) or dropping into a prodbox shell — without mutating the caller's active kubectl context.

## Tests

Manually verified the confirmation prompt blocks when answering `N` and proceeds when answering `y`.
