### PR TITLE
chore(ci): remove explicit node-version pins from workflow setup-node-deps calls

### DIFF
--- a/.github/workflows/build-spa.yaml
+++ b/.github/workflows/build-spa.yaml
@@ -23,6 +23,5 @@ jobs:
         with:
           build-sdks: "true"
           build-sparkle: "true"
-          node-version: '22.22.0'
       - name: Typecheck
         run: npm -w front-spa run tsgo -- --version && npm -w front-spa run tsgo

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,26 +34,16 @@ jobs:
         with:
           fetch-depth: 0 # Full depth for better git operations
 
-      # Setup Node.js for JS/TS projects
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
         with:
-          node-version: 24.16.0
+          build-sdks: "true"
 
       # Setup Rust for core project
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@aad518f59d88bae90133242f9ddac7f8bbc5dddf # 1.94.1
         with:
           components: rustfmt
-
-      # Pre-build SDK only as it's a dependency for other projects
-      - name: Build SDK
-        run: |
-          # Install global tools
-          npm install -g tsx
-
-          # Pre-build SDK as it's a dependency for front and connectors
-          cd sdks/js && npm install && npm run build && cd ../..
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/deploy-spa-production.yaml
+++ b/.github/workflows/deploy-spa-production.yaml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
-        with:
-          node-version: "22.22.0"
 
       - name: Resolve version ID
         id: version

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -122,7 +122,6 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
-          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
 

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -29,11 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 24.16.0
-          cache: "npm"
-          cache-dependency-path: ./package-lock.json
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
       - name: Install Biome
         run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Install Grit CLI

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -19,12 +19,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22.22.0"
-          cache: "npm"
-          cache-dependency-path: ./package-lock.json
-          registry-url: "https://registry.npmjs.org"
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
 
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest

--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -19,12 +19,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "22.22.0"
-          cache: "npm"
-          cache-dependency-path: ./package-lock.json
-          registry-url: "https://registry.npmjs.org"
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
 
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest

--- a/.github/workflows/run-dangerjs.yml
+++ b/.github/workflows/run-dangerjs.yml
@@ -56,7 +56,6 @@ jobs:
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}
         uses: ./.github/actions/setup-node-deps
         with:
-          node-version: "22.22.0"
           build-sdks: "true"
           build-sparkle: "true"
 
@@ -96,8 +95,6 @@ jobs:
       - name: Setup Node Dependencies
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}
         uses: ./.github/actions/setup-node-deps
-        with:
-          node-version: "22.22.0"
 
       - name: Run Danger for connectors
         if: ${{ steps.file_changes.outputs.run_danger == 'true' }}

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Setup Node Dependencies
         uses: ./.github/actions/setup-node-deps
         with:
-          node-version: "22.22.0"
           build-sdks: "true"
 
       - name: Check sandbox images


### PR DESCRIPTION
## Description

Standardizes Node.js setup across all CI workflows by removing hardcoded `node-version` parameters from `setup-node-deps` composite action calls, letting the action manage the Node version centrally. Also migrates `claude.yml` from a direct `actions/setup-node` + manual SDK build step to the shared `setup-node-deps` composite action with `build-sdks: "true"`.

Affected workflows: `build-spa`, `claude`, `deploy-spa`, `deploy-spa-production`, `format-check`, `publish-cli`, `publish-sdk-client`, `run-dangerjs`, `sandbox-img-registry`.

## Tests

CI workflows will be validated on merge.

## Risk

Low — the `setup-node-deps` composite action already handles Node version resolution; removing the explicit override just lets the default kick in.

## Deploy Plan

No deploy steps required.
