### PR TITLE
feat(llm): add xAI provider scaffolding to the new LLM router

### DIFF
--- a/front/lib/model_constructors/providers/xai/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/xai/reasoning_efforts.ts
@@ -1,0 +1,25 @@
+import type { ReasoningEffort } from "@app/lib/model_constructors/types/reasoning_efforts";
+
+// Reasoning efforts xAI's Grok models accept through the OpenAI Responses API.
+// ISO with the legacy router: `lib/api/llm/.../conversation_to_openai.ts` maps
+// none→none, light→low, medium→medium, high→high, so xAI only ever receives
+// `none | low | medium | high` (no "minimal"/"xhigh"). The strings match
+// OpenAI's, so the shared `reasoningToOpenAIResponsesReasoning` converter passes
+// a supported effort through verbatim.
+export const XAI_SUPPORTED_REASONING_EFFORTS = [
+  "none",
+  "low",
+  "medium",
+  "high",
+] as const satisfies readonly ReasoningEffort[];
+
+export type XaiSupportedReasoningEffort =
+  (typeof XAI_SUPPORTED_REASONING_EFFORTS)[number];
+
+export function isXaiSupportedReasoningEffort(
+  effort: string
+): effort is XaiSupportedReasoningEffort {
+  return XAI_SUPPORTED_REASONING_EFFORTS.some(
+    (supported) => supported === effort
+  );
+}

--- a/front/lib/model_constructors/stream/clients/xai.ts
+++ b/front/lib/model_constructors/stream/clients/xai.ts
@@ -1,0 +1,72 @@
+import { XAI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/xai/reasoning_efforts";
+import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/input";
+import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { XAI_API } from "@app/lib/model_constructors/types/provider_apis";
+import { XAI_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import OpenAI from "openai";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseCreateParamsStreaming,
+  ResponseStreamEvent,
+} from "openai/resources/responses/responses";
+import { z } from "zod";
+
+// xAI is OpenAI-Responses-compatible and reachable at this fixed base URL.
+const XAI_BASE_URL = "https://api.x.ai/v1";
+
+const configSchema = inputConfigSchema.extend({
+  reasoning: z
+    .object({
+      effort: z.enum(XAI_SUPPORTED_REASONING_EFFORTS),
+    })
+    .optional(),
+});
+
+type XaiInputConfig = z.infer<typeof configSchema>;
+
+export abstract class XaiStream extends WithOpenAIResponsesInputConverter(
+  WithOpenAIResponsesOutputConverter(
+    StreamEndpoint<ResponseCreateParamsNonStreaming, ResponseStreamEvent>
+  )
+) {
+  static readonly providerId = XAI_PROVIDER_ID;
+  static readonly api = XAI_API;
+
+  static readonly configSchema: z.ZodType<XaiInputConfig> = configSchema;
+
+  private readonly client: OpenAI;
+
+  constructor({ XAI_API_KEY }: Credentials) {
+    super();
+    this.client = new OpenAI({
+      apiKey: XAI_API_KEY,
+      baseURL: XAI_BASE_URL,
+    });
+  }
+
+  async *streamRaw(
+    input: ResponseCreateParamsNonStreaming
+  ): AsyncGenerator<ResponseStreamEvent> {
+    // `buildRequestPayload` is shared with batch and omits `stream`; opt in here.
+    const streamingInput: ResponseCreateParamsStreaming = {
+      ...input,
+      stream: true,
+    };
+    const stream = await this.client.responses.create(streamingInput);
+
+    for await (const event of stream) {
+      yield event;
+    }
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<ResponseStreamEvent>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/types/credentials.ts
+++ b/front/lib/model_constructors/types/credentials.ts
@@ -7,4 +7,5 @@ export type Credentials = {
   MISTRAL_API_KEY?: string;
   FIREWORKS_API_KEY?: string;
   TOGETHERAI_API_KEY?: string;
+  XAI_API_KEY?: string;
 };

--- a/front/lib/model_constructors/types/model_ids.ts
+++ b/front/lib/model_constructors/types/model_ids.ts
@@ -40,6 +40,12 @@ export const FIREWORKS_GLM_5P2_MODEL_ID =
   "accounts/fireworks/models/glm-5p2" as const;
 
 // TogetherAI-served models keep their full TogetherAI model path as the id.
+export const GROK_4_MODEL_ID = "grok-4-latest" as const;
+export const GROK_4_1_FAST_REASONING_MODEL_ID =
+  "grok-4-1-fast-reasoning-latest" as const;
+export const GROK_4_1_FAST_NON_REASONING_MODEL_ID =
+  "grok-4-1-fast-non-reasoning-latest" as const;
+
 export const TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID =
   "meta-llama/Llama-3.3-70B-Instruct-Turbo" as const;
 
@@ -74,6 +80,9 @@ export const MODEL_IDS = [
   FIREWORKS_GLM_5_MODEL_ID,
   FIREWORKS_GLM_5P2_MODEL_ID,
   TOGETHERAI_LLAMA_3_3_70B_INSTRUCT_TURBO_MODEL_ID,
+  GROK_4_MODEL_ID,
+  GROK_4_1_FAST_REASONING_MODEL_ID,
+  GROK_4_1_FAST_NON_REASONING_MODEL_ID,
 ] as const;
 
 export type ModelId = (typeof MODEL_IDS)[number];

--- a/front/lib/model_constructors/types/provider_apis.ts
+++ b/front/lib/model_constructors/types/provider_apis.ts
@@ -5,6 +5,7 @@ export const AGENT_PLATFORM_API = "agent-platform" as const;
 export const MISTRAL_API = "mistral" as const;
 export const FIREWORKS_API = "fireworks" as const;
 export const TOGETHERAI_API = "togetherai" as const;
+export const XAI_API = "xai" as const;
 
 const PROVIDER_APIS = [
   OPENAI_RESPONSES_API,
@@ -14,5 +15,6 @@ const PROVIDER_APIS = [
   MISTRAL_API,
   FIREWORKS_API,
   TOGETHERAI_API,
+  XAI_API,
 ] as const;
 export type ProviderApi = (typeof PROVIDER_APIS)[number];

--- a/front/lib/model_constructors/types/provider_ids.ts
+++ b/front/lib/model_constructors/types/provider_ids.ts
@@ -6,6 +6,7 @@ export const GOOGLE_AI_STUDIO_PROVIDER_ID = "google_ai_studio" as const;
 export const MISTRAL_PROVIDER_ID = "mistral" as const;
 export const FIREWORKS_PROVIDER_ID = "fireworks" as const;
 export const TOGETHERAI_PROVIDER_ID = "togetherai" as const;
+export const XAI_PROVIDER_ID = "xai" as const;
 
 // `satisfies readonly ModelProviderIdType[]` guarantees every new-system
 // provider id is also a legacy `ModelProviderIdType`. This keeps `ProviderId`
@@ -19,6 +20,7 @@ const PROVIDER_IDS = [
   MISTRAL_PROVIDER_ID,
   FIREWORKS_PROVIDER_ID,
   TOGETHERAI_PROVIDER_ID,
+  XAI_PROVIDER_ID,
 ] as const satisfies readonly ModelProviderIdType[];
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 


### PR DESCRIPTION
## Description

First of two PRs adding Grok support to the new `model_constructors` LLM router. This one lays the provider scaffolding only; model-config mixins, endpoint classes, tests, and registration follow in PR2.

xAI is OpenAI-Responses-compatible (`client.responses.create`, base URL `https://api.x.ai/v1`), so the new client is a thin clone of `OpenAIResponsesStream` that reuses the shared `sdk/openai_responses` converters — no new converter code.

What's included:
- **Type registrations** — `XAI_PROVIDER_ID` (`xai`), `XAI_API` (`xai`, mirroring the fireworks/togetherai pattern), `XAI_API_KEY` credential, and the three model ids: `grok-4-latest`, `grok-4-1-fast-reasoning-latest`, `grok-4-1-fast-non-reasoning-latest`.
- **`providers/xai/reasoning_efforts.ts`** — `XAI_SUPPORTED_REASONING_EFFORTS = none/low/medium/high`, kept ISO with the legacy router's effort mapping (`none→none, light→low, medium→medium, high→high`).
- **`stream/clients/xai.ts`** — `XaiStream` abstract client (apiKey + baseURL only, matching legacy — no extra OpenAI-client knobs).

Kept 100% ISO with the legacy `XaiLLM` on every constant: base URL, client options, credential name, provider id, Responses-API surface, reasoning-effort set, and model-id strings.

## Tests

No runtime behavior is wired yet (no endpoints registered), so there's nothing to exercise at the API level in this PR. `npx tsgo --noEmit` is clean and biome passes (both also enforced by the pre-commit hook). Live-API integration tests for each endpoint land in PR2 via the model_constructors test harness.

## Risk

Very low / inert. This PR only adds new type entries and an abstract client that nothing instantiates yet — no endpoint is added to `STREAM_ENDPOINTS`, so the router's behavior is unchanged. Trivially rollback-able.

## Deploy Plan

Standard deploy. No migrations, no config, no feature-flag changes. Safe to ship independently of PR2.