### PR TITLE
[front] Remove beta UI for self-improving skills

### DIFF
--- a/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
@@ -1,11 +1,7 @@
 import { SelfImprovingSkillsConsumptionSection } from "@app/components/pages/workspace/developers/SelfImprovingSkillsConsumptionSection";
 import { SelfImprovingSkillsListSection } from "@app/components/workspace/settings/SelfImprovingSkillsListSection";
 import { SelfImprovingSkillsSettingsSection } from "@app/components/workspace/settings/SelfImprovingSkillsSettingsSection";
-import {
-  useAuth,
-  useFeatureFlags,
-  useWorkspace,
-} from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useIsSelfImprovementAvailable } from "@app/lib/client/self_improvement";
 import {
   getReinforcementMonthlyCapAwuCredits,
@@ -14,21 +10,13 @@ import {
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { useReinforcementBillingUnit } from "@app/lib/swr/useSelfImprovingSkillsSettings";
-import {
-  ContentMessage,
-  InfoCircle,
-  LinkWrapper,
-  Page,
-  Stars02,
-} from "@dust-tt/sparkle";
+import { ContentMessage, InfoCircle, Page, Stars02 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 export function SelfImprovingSkillsPage() {
   const owner = useWorkspace();
   const { isAdmin } = useAuth();
-  const { hasFeature } = useFeatureFlags();
   const hasSelfImprovement = useIsSelfImprovementAvailable();
-  const isBetaTester = hasFeature("self_improvement_beta_tester");
 
   const unit = useReinforcementBillingUnit({ owner });
 
@@ -63,24 +51,6 @@ export function SelfImprovingSkillsPage() {
     }
     return (
       <>
-        {isBetaTester && (
-          <ContentMessage variant="info" size="lg">
-            This feature is currently in <strong>beta</strong>, and only
-            available to a select group of customers.
-            <br />
-            Note that the feature is currently free during beta testing but will
-            generate additional costs upon release.
-            <br />
-            Contact{" "}
-            <LinkWrapper
-              href="mailto:self-improving-skills@dust.tt"
-              className="underline"
-            >
-              self-improving-skills@dust.tt
-            </LinkWrapper>{" "}
-            to share some feedback about this feature.
-          </ContentMessage>
-        )}
         <SelfImprovingSkillsSettingsSection
           owner={owner}
           onCapSaved={setCap}

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -4,10 +4,8 @@ import { SkillBuilderIsDefaultSection } from "@app/components/skill_builder/Skil
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 import {
-  Chip,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -23,9 +21,6 @@ export function SkillBuilderSettingsSection({
   skill,
   hasSelfImprovingSkills,
 }: SkillBuilderSettingsSectionProps) {
-  const { hasFeature } = useFeatureFlags();
-  const isBetaTester = hasFeature("self_improvement_beta_tester");
-
   return (
     <div className="space-y-5">
       <h2 className="heading-lg text-foreground dark:text-foreground-night">
@@ -48,12 +43,9 @@ export function SkillBuilderSettingsSection({
       </div>
       {hasSelfImprovingSkills && (
         <div className="space-y-3">
-          <div className="flex items-center gap-2">
-            <Label className="text-base font-semibold text-foreground dark:text-foreground-night">
-              Self Improvement
-            </Label>
-            {isBetaTester && <Chip size="xs" color="golden" label="Beta" />}
-          </div>
+          <Label className="text-base font-semibold text-foreground dark:text-foreground-night">
+            Self Improvement
+          </Label>
           <SkillBuilderEnableSuggestionsSection
             selfImprovementLock={skill?.selfImprovementLock ?? false}
           />

--- a/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
+++ b/front/components/skill_builder/SkillBuilderSuggestionsPanel.tsx
@@ -7,15 +7,8 @@ import {
   usePatchSkillSuggestions,
   useSkillSuggestions,
 } from "@app/hooks/useSkillSuggestions";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
-import {
-  Chip,
-  ContentMessage,
-  Lightbulb04,
-  ScrollArea,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { Lightbulb04, ScrollArea, Spinner } from "@dust-tt/sparkle";
 import { useCallback } from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -33,8 +26,6 @@ export function SkillBuilderSuggestionsPanel({
     setSelectedSuggestionId,
     acceptInstructionEdits,
   } = useSkillBuilderContext();
-  const { hasFeature } = useFeatureFlags();
-  const isBetaTester = hasFeature("self_improvement_beta_tester");
   const { getValues, setValue } = useFormContext<SkillBuilderFormData>();
 
   const getSkillInstructionsHtml = useCallback(
@@ -159,18 +150,9 @@ export function SkillBuilderSuggestionsPanel({
   return (
     <div className="flex h-full flex-col">
       <div className="flex flex-col gap-1 px-4 pb-3 pt-4">
-        <div className="flex items-center gap-2">
-          <h2 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-            Suggestions
-          </h2>
-          {isBetaTester && <Chip size="xs" color="golden" label="Beta" />}
-        </div>
-        {isBetaTester && (
-          <ContentMessage variant="info" size="lg">
-            Skill suggestions are currently in beta testing. We are very
-            interested in your feedback to improve the feature.
-          </ContentMessage>
-        )}
+        <h2 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+          Suggestions
+        </h2>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           Dust continuously analyses conversations using this skill to suggest
           improvements.


### PR DESCRIPTION
## Description

Remove beta UI elements (Beta chips, info banners) from the self-improving skills pages.

The `self_improvement_beta_tester` feature flag and the free usage bypass for beta testers in `activities.ts` are intentionally **kept intact** — current beta testers can continue using the feature for free.

This is a subset of #27338 (UI-only part).

## Tests

Manual — UI-only change removing conditional renders.

## Risk

Low

## Deploy Plan

Deploy front