### PR TITLE
chore(tools): add gotenberg dev process for document preview

### DIFF
--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -157,6 +157,13 @@ procs:
     shell: "docker-compose up --build"
     autostart: false
 
+  # Gotenberg: Office/PDF document preview conversion (LibreOffice route).
+  # front-api reads its URL from DOCUMENT_RENDERER_URL (set to http://localhost:3100).
+  gotenberg:
+    cwd: "<CONFIG_DIR>/.."
+    shell: "docker compose --profile gotenberg up gotenberg"
+    autostart: false
+
   novu:
     # Doc: https://docs.novu.co/framework/studio
     shell: "npx novu@latest dev --port 3000"

--- a/tools/process-compose.yaml
+++ b/tools/process-compose.yaml
@@ -206,6 +206,14 @@ processes:
     namespace: optional
     disabled: true
 
+  # Gotenberg: Office/PDF document preview conversion (LibreOffice route).
+  # front-api reads its URL from DOCUMENT_RENDERER_URL (set to http://localhost:3100).
+  gotenberg:
+    command: "docker compose --profile gotenberg up gotenberg"
+    working_dir: "${DUST_DEV_ROOT}"
+    namespace: optional
+    disabled: true
+
   novu:
     # Doc: https://docs.novu.co/framework/studio
     command: "npx novu@latest dev --port 3000"


### PR DESCRIPTION
## Description

Adds a `gotenberg` process to the local dev tooling (`mprocs.yaml` and `process-compose.yaml`) so developers can run the Office/PDF document preview conversion service (LibreOffice route) locally. The process runs `docker compose --profile gotenberg up gotenberg` and is opt-in (not autostarted / disabled by default).

`front-api` reads the service URL from `DOCUMENT_RENDERER_URL` (set to `http://localhost:3100`).

## Tests

Dev-tooling only. Start the process via `mprocs`/`process-compose` and confirm the Gotenberg container comes up and is reachable at `http://localhost:3100`.
