### PR TITLE
Reduce excel tool output size

### DIFF
--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -50,7 +50,7 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
   },
   read_worksheet: {
     description:
-      "Read data from a specific range in an Excel file stored in SharePoint. Returns the cell values as CSV.",
+      "Read data from an Excel file stored in SharePoint. Returns the cell values as CSV. Reads the used range by default; use the range parameter to read a specific subset.",
     schema: {
       itemId: z.string().describe("The ID of the Excel file to read from."),
       driveId: z
@@ -70,8 +70,9 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         .describe("Name of the worksheet to read from (e.g., 'Sheet1')"),
       range: z
         .string()
+        .optional()
         .describe(
-          "Cell range in A1 notation (e.g., 'A1:D10'). Must be a bounded range. Maximum 100,000 cells."
+          "Cell range in A1 notation (e.g., 'A1:D10'). If omitted, reads the entire used range. Maximum 100,000 cells — if the worksheet exceeds this limit, a range must be specified."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -50,7 +50,7 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
   },
   read_worksheet: {
     description:
-      "Read data from a specific range or entire worksheet in an Excel file stored in SharePoint.",
+      "Read data from a specific range in an Excel file stored in SharePoint. Returns the cell values as CSV.",
     schema: {
       itemId: z.string().describe("The ID of the Excel file to read from."),
       driveId: z
@@ -70,9 +70,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         .describe("Name of the worksheet to read from (e.g., 'Sheet1')"),
       range: z
         .string()
-        .optional()
         .describe(
-          "Optional cell range in A1 notation (e.g., 'A1:D10'). If not provided, reads the used range."
+          "Cell range in A1 notation (e.g., 'A1:D10'). Must be a bounded range. Maximum 100,000 cells."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
@@ -87,7 +87,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
     }
 
     try {
-      const MAX_CELLS = 100_000;
+      const MAX_CELLS = 25_000;
       const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
       const worksheetPath = `${endpoint}/workbook/worksheets/${encodeURIComponent(worksheetName)}`;
 

--- a/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
@@ -87,33 +87,55 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
     }
 
     try {
-      const rangeMatch = range.match(/^([A-Z]+\d+):([A-Z]+\d+)$/i);
-      if (!rangeMatch) {
-        return new Err(
-          new MCPError("Invalid range format. Use A1 notation like 'A1:D10'.")
-        );
-      }
-      const start = parseCellRef(rangeMatch[1].toUpperCase());
-      const end = parseCellRef(rangeMatch[2].toUpperCase());
-      const cellCount = (end.row - start.row + 1) * (end.col - start.col + 1);
       const MAX_CELLS = 100_000;
-      if (cellCount > MAX_CELLS) {
-        return new Err(
-          new MCPError(
-            `Range exceeds the ${MAX_CELLS.toLocaleString()} cell limit (requested ${cellCount.toLocaleString()}). Use a smaller range.`
-          )
-        );
-      }
-
       const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
-      const apiPath = `${endpoint}/workbook/worksheets/${encodeURIComponent(
-        worksheetName
-      )}/range(address='${encodeURIComponent(range)}')`;
+      const worksheetPath = `${endpoint}/workbook/worksheets/${encodeURIComponent(worksheetName)}`;
+
+      let apiPath: string;
+
+      if (range) {
+        const rangeMatch = range.match(/^([A-Z]+\d+):([A-Z]+\d+)$/i);
+        if (!rangeMatch) {
+          return new Err(
+            new MCPError("Invalid range format. Use A1 notation like 'A1:D10'.")
+          );
+        }
+        const start = parseCellRef(rangeMatch[1].toUpperCase());
+        const end = parseCellRef(rangeMatch[2].toUpperCase());
+        const cellCount = (end.row - start.row + 1) * (end.col - start.col + 1);
+        if (cellCount > MAX_CELLS) {
+          return new Err(
+            new MCPError(
+              `Range exceeds the ${MAX_CELLS.toLocaleString()} cell limit (requested ${cellCount.toLocaleString()}). Use a smaller range.`
+            )
+          );
+        }
+        apiPath = `${worksheetPath}/range(address='${encodeURIComponent(range)}')`;
+      } else {
+        const usedRangeInfo = await makeExcelRequest<{
+          address?: string;
+          rowCount?: number;
+          columnCount?: number;
+        }>(
+          client,
+          itemId,
+          authInfo?.clientId ?? "",
+          `${worksheetPath}/usedRange(valuesOnly=true)?$select=address,rowCount,columnCount`,
+          "get"
+        );
+        const cellCount =
+          (usedRangeInfo.rowCount ?? 0) * (usedRangeInfo.columnCount ?? 0);
+        if (cellCount > MAX_CELLS) {
+          return new Err(
+            new MCPError(
+              `The used range (${usedRangeInfo.address}) contains ${cellCount.toLocaleString()} cells, exceeding the ${MAX_CELLS.toLocaleString()} cell limit. Specify a range parameter to read a subset.`
+            )
+          );
+        }
+        apiPath = `${worksheetPath}/usedRange(valuesOnly=true)`;
+      }
 
       const response = await makeExcelRequest<{
-        address?: string;
-        rowCount?: number;
-        columnCount?: number;
         values?: (string | number | boolean | null)[][];
       }>(client, itemId, authInfo?.clientId ?? "", apiPath, "get");
 

--- a/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
@@ -87,28 +87,56 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
     }
 
     try {
-      const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
-      let apiPath = `${endpoint}/workbook/worksheets/${encodeURIComponent(
-        worksheetName
-      )}`;
-
-      if (range) {
-        apiPath += `/range(address='${encodeURIComponent(range)}')`;
-      } else {
-        apiPath += "/usedRange";
+      const rangeMatch = range.match(/^([A-Z]+\d+):([A-Z]+\d+)$/i);
+      if (!rangeMatch) {
+        return new Err(
+          new MCPError("Invalid range format. Use A1 notation like 'A1:D10'.")
+        );
+      }
+      const start = parseCellRef(rangeMatch[1].toUpperCase());
+      const end = parseCellRef(rangeMatch[2].toUpperCase());
+      const cellCount = (end.row - start.row + 1) * (end.col - start.col + 1);
+      const MAX_CELLS = 100_000;
+      if (cellCount > MAX_CELLS) {
+        return new Err(
+          new MCPError(
+            `Range exceeds the ${MAX_CELLS.toLocaleString()} cell limit (requested ${cellCount.toLocaleString()}). Use a smaller range.`
+          )
+        );
       }
 
-      const response = await makeExcelRequest(
-        client,
-        itemId,
-        authInfo?.clientId ?? "",
-        apiPath,
-        "get"
-      );
+      const endpoint = await getDriveItemEndpoint(itemId, driveId, siteId);
+      const apiPath = `${endpoint}/workbook/worksheets/${encodeURIComponent(
+        worksheetName
+      )}/range(address='${encodeURIComponent(range)}')`;
 
-      return new Ok([
-        { type: "text" as const, text: JSON.stringify(response, null, 2) },
-      ]);
+      const response = await makeExcelRequest<{
+        address?: string;
+        rowCount?: number;
+        columnCount?: number;
+        values?: (string | number | boolean | null)[][];
+      }>(client, itemId, authInfo?.clientId ?? "", apiPath, "get");
+
+      const values = response.values ?? [];
+      const csv = values
+        .map((row) =>
+          row
+            .map((cell) => {
+              if (cell === null || cell === undefined) {
+                return "";
+              }
+              const str = String(cell);
+              return str.includes(",") ||
+                str.includes('"') ||
+                str.includes("\n")
+                ? `"${str.replace(/"/g, '""')}"`
+                : str;
+            })
+            .join(",")
+        )
+        .join("\n");
+
+      return new Ok([{ type: "text" as const, text: csv }]);
     } catch (err) {
       return new Err(
         new MCPError(


### PR DESCRIPTION
## Description

Reduces the output size of the Microsoft Excel `read_worksheet` tool.

The tool now returns worksheet data as CSV instead of the full Microsoft Graph JSON response, which makes outputs much more compact and easier for agents to consume. It also adds a 25,000-cell safety limit to avoid overly large tool results.

When no range is provided, the tool first checks the worksheet used range size. If the used range is within the limit, it reads it; otherwise it returns an error asking the caller to provide a smaller range. 
When a range is provided, the tool validates that it is a bounded A1 range and rejects ranges above the same limit.

## Tests

Tested the tool manually.

## Risk

Low risk. The main behavior change is the response format for `read_worksheet`: callers now receive CSV text instead of the raw Graph API JSON payload. This should reduce context usage and improve agent usability, but any code relying on the previous JSON shape may need to be updated.

The 25,000-cell limit may also reject very large worksheets that were previously returned in full.

## Deploy Plan

Deploy front