### PR TITLE
[marketing] fix: update sonnet model ID in academy chat

### DIFF
--- a/front-api/routes/marketing/academy/chat.ts
+++ b/front-api/routes/marketing/academy/chat.ts
@@ -1,6 +1,7 @@
 /** @ignoreswagger */
 import Anthropic from "@anthropic-ai/sdk";
 import config from "@app/lib/api/config";
+import { CLAUDE_SONNET_4_6_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { streamEvents } from "@front-api/lib/api/sse/stream_events";
@@ -259,7 +260,7 @@ app.post("/", async (ctx) => {
       try {
         const stream = await client.messages.create(
           {
-            model: "claude-4-sonnet-20250514",
+            model: CLAUDE_SONNET_4_6_MODEL_ID,
             max_tokens: 1024,
             system: systemPrompt,
             messages: apiMessages,

--- a/marketing/hooks/useAcademyQuiz.ts
+++ b/marketing/hooks/useAcademyQuiz.ts
@@ -139,24 +139,31 @@ export function useAcademyQuiz({
                 continue;
               }
 
+              let parsed;
               try {
-                const parsed = JSON.parse(data);
-                if (parsed.text) {
-                  assistantMessage += parsed.text;
-                  setMessages((prev) => {
-                    const newMessages = [...prev];
-                    newMessages[newMessages.length - 1] = {
-                      role: "assistant",
-                      content: assistantMessage,
-                    };
-                    return newMessages;
-                  });
-                }
-                if (parsed.error) {
-                  throw new Error(parsed.error);
-                }
+                parsed = JSON.parse(data);
               } catch {
-                // Ignore parse errors for incomplete chunks
+                // Ignore parse errors for incomplete chunks.
+                continue;
+              }
+
+              // Surface server-sent errors to the outer catch (which sets the
+              // error state and removes the placeholder message). This must be
+              // outside the JSON.parse try above, otherwise the throw would be
+              // swallowed by the incomplete-chunk catch.
+              if (parsed.error) {
+                throw new Error(parsed.error);
+              }
+              if (parsed.text) {
+                assistantMessage += parsed.text;
+                setMessages((prev) => {
+                  const newMessages = [...prev];
+                  newMessages[newMessages.length - 1] = {
+                    role: "assistant",
+                    content: assistantMessage,
+                  };
+                  return newMessages;
+                });
               }
             }
           }


### PR DESCRIPTION
## Description

A bug prior to marketing code migration what that we hardcoded the model-id in academy/chat endpoint.
When that model-id stopped to work, so did the endpoint.
Now we use a constant from llm-router's that will make typing catch any regression (what we should have done in the first place tbh)

Also we were swallowing errors, we now throw them, 🫶 oncall eng.


## Tests

- Tested locally

## Risk

Low

## Deploy Plan

- Deploy front & marketing