### PR TITLE
refactor(front): move credits DTO types out of lib/api into types/api

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/awu-pool-summary.ts
@@ -1,5 +1,5 @@
-import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
 import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
+++ b/front-api/routes/w/[wId]/credits/awu-pool-summary.ts
@@ -1,8 +1,6 @@
-import type {
-  AwuPoolSummaryError,
-  AwuPoolSummaryResponseBody,
-} from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolSummaryError } from "@app/lib/api/credits/awu_pool_summary";
 import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";

--- a/front-api/routes/w/[wId]/credits/members-seats.ts
+++ b/front-api/routes/w/[wId]/credits/members-seats.ts
@@ -1,7 +1,5 @@
-import {
-  type GetMembersSeatsResponseBody,
-  getMembersSeats,
-} from "@app/lib/api/credits/members_seats";
+import { getMembersSeats } from "@app/lib/api/credits/members_seats";
+import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/credits/upgrade-requests.ts
+++ b/front-api/routes/w/[wId]/credits/upgrade-requests.ts
@@ -1,15 +1,15 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
-import type {
-  GetUpgradeRequestsResponseBody,
-  PatchUpgradeRequestResponseBody,
-  PostUpgradeRequestResponseBody,
-  UpgradeRequestError,
-} from "@app/lib/api/credits/upgrade_requests";
+import type { UpgradeRequestError } from "@app/lib/api/credits/upgrade_requests";
 import {
   createUpgradeRequest,
   listPendingUpgradeRequests,
   resolveUpgradeRequest,
 } from "@app/lib/api/credits/upgrade_requests";
+import type {
+  GetUpgradeRequestsResponseBody,
+  PatchUpgradeRequestResponseBody,
+  PostUpgradeRequestResponseBody,
+} from "@app/types/api/credits/upgrade_requests";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/programmatic_usage_limit.ts
@@ -1,14 +1,14 @@
 /** @ignoreswagger */
 
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
-import type {
-  GetProgrammaticUsageLimitResponseBody,
-  PutProgrammaticUsageLimitResponseBody,
-} from "@app/lib/api/credits/programmatic_usage_limit";
 import {
   getProgrammaticUsageLimit,
   syncProgrammaticUsageLimit,
 } from "@app/lib/api/credits/programmatic_usage_limit";
+import type {
+  GetProgrammaticUsageLimitResponseBody,
+  PutProgrammaticUsageLimitResponseBody,
+} from "@app/types/api/credits/programmatic_usage_limit";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front/lib/api/credits/awu_pool_summary.ts
+++ b/front/lib/api/credits/awu_pool_summary.ts
@@ -14,6 +14,7 @@ import {
   getProductSeatTypes,
   getSeatTypesByProductIdFromContract,
 } from "@app/lib/metronome/seat_types";
+import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -30,21 +31,6 @@ function creditTypeIdToCurrency(
   }
   return null;
 }
-
-export type AwuPoolSummaryResponseBody = {
-  totalRemainingCredits: number;
-  totalActiveCredits: number;
-  /**
-   * PAYG overage consumed so far this billing period — credits charged on
-   * top of the workspace pool. `null` when the workspace is not on PAYG or
-   * no overage has been incurred this period.
-   */
-  overageCredits: number | null;
-  /** Fiat cost of `overageCredits`, in cents. `null` when `overageCredits` is null. */
-  overageAmountCents: number | null;
-  /** Invoice currency — needed to format `overageAmountCents`. */
-  overageCurrency: SupportedCurrency | null;
-};
 
 export class AwuPoolSummaryError extends Error {
   constructor(

--- a/front/lib/api/credits/members_seats.ts
+++ b/front/lib/api/credits/members_seats.ts
@@ -9,20 +9,10 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import type { MembershipSeatType } from "@app/types/memberships";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Subscription } from "@metronome/sdk/resources";
-
-export type GetMembersSeatsResponseBody = {
-  // Active members per seat type, from the DB ("assigned" seats).
-  seatTypes: Partial<Record<MembershipSeatType, number>>;
-  // Total seat quantity billed in Metronome per seat type (assigned +
-  // unassigned). Absent when the workspace isn't on a Metronome seat contract,
-  // or omitted for a seat type if Metronome couldn't be read. The UI derives
-  // the unassigned count as `metronomeSeats - seatTypes` per type.
-  metronomeSeats: Partial<Record<MembershipSeatType, number>>;
-  total: number;
-};
 
 /**
  * Read the current quantity from a subscription's `quantity_schedule` (used for

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -15,14 +15,6 @@ import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
-export type GetProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
-};
-
-export type PutProgrammaticUsageLimitResponseBody = {
-  monthlyCapCredits: number | null;
-};
-
 /**
  * Read the workspace's programmatic usage monthly cap.
  *

--- a/front/lib/api/credits/upgrade_requests.ts
+++ b/front/lib/api/credits/upgrade_requests.ts
@@ -89,18 +89,6 @@ async function notifyAdminsOfUpgradeRequest(
   }
 }
 
-export type GetUpgradeRequestsResponseBody = {
-  requests: MembershipUpgradeRequestType[];
-};
-
-export type PostUpgradeRequestResponseBody = {
-  request: MembershipUpgradeRequestType;
-};
-
-export type PatchUpgradeRequestResponseBody = {
-  request: MembershipUpgradeRequestType;
-};
-
 // Member-initiated: create (or return the already-pending) upgrade request for
 // the current user. Gated on the workspace being credit-priced and the member
 // actually being near/at their limit.

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -1,5 +1,3 @@
-import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
-import type { GetMembersSeatsResponseBody } from "@app/lib/api/credits/members_seats";
 import type { GetMemberUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { GetCreditPurchaseInfoResponseBody } from "@app/lib/api/credits/purchase";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
@@ -7,6 +5,8 @@ import type { GetAwuPurchaseInfoResponseBody } from "@app/lib/credits/awu_purcha
 import type { GetAwuPurchaseStatusResponseBody } from "@app/lib/credits/awu_purchase_status";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
+import type { GetMembersSeatsResponseBody } from "@app/types/api/credits/members_seats";
 import type {
   GetCreditsResponseBody,
   PendingCreditData,

--- a/front/lib/swr/upgrade_requests.ts
+++ b/front/lib/swr/upgrade_requests.ts
@@ -1,5 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { GetUpgradeRequestsResponseBody } from "@app/lib/api/credits/upgrade_requests";
 import { clientFetch } from "@app/lib/egress/client";
 import { invalidateMembersUsage } from "@app/lib/swr/memberships";
 import {
@@ -8,6 +7,7 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type { GetUpgradeRequestsResponseBody } from "@app/types/api/credits/upgrade_requests";
 import type { MembershipUpgradeRequestStatus } from "@app/types/memberships";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useCallback } from "react";

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -1,8 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type {
-  GetProgrammaticUsageLimitResponseBody,
-  PutProgrammaticUsageLimitResponseBody,
-} from "@app/lib/api/credits/programmatic_usage_limit";
 import type { GetCreditUsageConfigurationResponseBody } from "@app/lib/api/credits/usage_configuration";
 import type {
   GetDefaultUserSpendLimitResponseBody,
@@ -15,6 +11,10 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type {
+  GetProgrammaticUsageLimitResponseBody,
+  PutProgrammaticUsageLimitResponseBody,
+} from "@app/types/api/credits/programmatic_usage_limit";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -11,11 +11,11 @@ import type {
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
 import type { WindowSize } from "@app/lib/api/analytics/time_utils";
-import type { AwuPoolSummaryResponseBody } from "@app/lib/api/credits/awu_pool_summary";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import type { PokeListCreditsResponseBody } from "@app/lib/api/poke/credits";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { AwuPoolSummaryResponseBody } from "@app/types/api/credits/awu_pool_summary";
 import type { Fetcher } from "swr";
 
 export type PokeCreditsData = {

--- a/front/types/api/credits/awu_pool_summary.ts
+++ b/front/types/api/credits/awu_pool_summary.ts
@@ -1,0 +1,16 @@
+import type { SupportedCurrency } from "@app/types/currency";
+
+export type AwuPoolSummaryResponseBody = {
+  totalRemainingCredits: number;
+  totalActiveCredits: number;
+  /**
+   * PAYG overage consumed so far this billing period — credits charged on
+   * top of the workspace pool. `null` when the workspace is not on PAYG or
+   * no overage has been incurred this period.
+   */
+  overageCredits: number | null;
+  /** Fiat cost of `overageCredits`, in cents. `null` when `overageCredits` is null. */
+  overageAmountCents: number | null;
+  /** Invoice currency — needed to format `overageAmountCents`. */
+  overageCurrency: SupportedCurrency | null;
+};

--- a/front/types/api/credits/members_seats.ts
+++ b/front/types/api/credits/members_seats.ts
@@ -1,0 +1,12 @@
+import type { MembershipSeatType } from "@app/types/memberships";
+
+export type GetMembersSeatsResponseBody = {
+  // Active members per seat type, from the DB ("assigned" seats).
+  seatTypes: Partial<Record<MembershipSeatType, number>>;
+  // Total seat quantity billed in Metronome per seat type (assigned +
+  // unassigned). Absent when the workspace isn't on a Metronome seat contract,
+  // or omitted for a seat type if Metronome couldn't be read. The UI derives
+  // the unassigned count as `metronomeSeats - seatTypes` per type.
+  metronomeSeats: Partial<Record<MembershipSeatType, number>>;
+  total: number;
+};

--- a/front/types/api/credits/programmatic_usage_limit.ts
+++ b/front/types/api/credits/programmatic_usage_limit.ts
@@ -1,0 +1,7 @@
+export type GetProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};
+
+export type PutProgrammaticUsageLimitResponseBody = {
+  monthlyCapCredits: number | null;
+};

--- a/front/types/api/credits/upgrade_requests.ts
+++ b/front/types/api/credits/upgrade_requests.ts
@@ -1,0 +1,13 @@
+import type { MembershipUpgradeRequestType } from "@app/types/memberships";
+
+export type GetUpgradeRequestsResponseBody = {
+  requests: MembershipUpgradeRequestType[];
+};
+
+export type PostUpgradeRequestResponseBody = {
+  request: MembershipUpgradeRequestType;
+};
+
+export type PatchUpgradeRequestResponseBody = {
+  request: MembershipUpgradeRequestType;
+};


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types and zod schemas out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

**Batch 8 of a stack** — internal `credits` endpoints. Stacked on #27806.

All four files were partial (DTOs + business logic); the DTO response bodies move to `types/api/credits/*`, logic + domain error types stay.

- `awu_pool_summary`, `members_seats`: back-import their response body (used as a function return type).
- `programmatic_usage_limit`, `upgrade_requests`: no back-import (functions return domain types / `Result`, not the DTOs).
- 9 consumers updated; 5 front-api routes split (DTO → types, functions + domain error types → lib).

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)