### PR TITLE
Add: leverage new file directive when referencing files.

### DIFF
--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -95,7 +95,7 @@ export function ToolGeneratedFileDetails({
 
   return (
     <PreviewableCitation
-      compact
+      size="sm"
       fileId={resource.fileId ?? null}
       filePath={"filePath" in resource ? resource.filePath : undefined}
       contentType={resource.contentType}

--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -124,12 +124,11 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       );
 
       expect(screen.getByText("booklet.pdf")).toBeInTheDocument();
-      expect(screen.getByText("PDF")).toBeInTheDocument();
       expect(container.querySelector("a[href*='download=1']")).toBeNull();
 
       fireEvent.click(screen.getByText("booklet.pdf"));
 
-      expect(await screen.findByText("Preview Data")).toBeInTheDocument();
+      expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Download" })
       ).toBeInTheDocument();
@@ -167,7 +166,6 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       );
 
       expect(container.textContent).toContain(title);
-      expect(container.textContent).toContain("PDF");
       expect(container.querySelector("a[href*='download=1']")).toBeNull();
     });
 

--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -1,4 +1,6 @@
-import { render } from "@testing-library/react";
+import { FilePreviewProvider } from "@app/components/assistant/conversation/FilePreviewContext";
+import { getFilePreviewMarkdownDirective } from "@app/lib/markdown/file_preview";
+import { render, screen } from "@testing-library/react";
 import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -296,6 +298,26 @@ Quote text
       );
       // The component should render with pasted attachment directive processed
       expect(container).toBeInTheDocument();
+    });
+
+    it("renders scoped file preview directives as previewable files", () => {
+      const directive = getFilePreviewMarkdownDirective({
+        contentType: "application/pdf",
+        path: "conversation-c1/booklet.pdf",
+        title: "booklet.pdf",
+      });
+      const message = { ...mockMessage, content: directive };
+      render(
+        <FilePreviewProvider owner={mockOwner}>
+          <UserMessageMarkdown
+            owner={mockOwner}
+            message={message}
+            isLastMessage={false}
+          />
+        </FilePreviewProvider>
+      );
+
+      expect(screen.getByText("booklet.pdf")).toBeInTheDocument();
     });
 
     it("handles multiple custom directives in one message", () => {

--- a/front/components/assistant/UserMessageMarkdown.tsx
+++ b/front/components/assistant/UserMessageMarkdown.tsx
@@ -7,6 +7,10 @@ import {
   contentNodeMentionDirective,
 } from "@app/components/markdown/ContentNodeMentionBlock";
 import {
+  filePreviewDirective,
+  getFilePreviewPlugin,
+} from "@app/components/markdown/FilePreviewBlock";
+import {
   PastedAttachmentBlock,
   pastedAttachmentDirective,
 } from "@app/components/markdown/PastedAttachmentBlock";
@@ -52,6 +56,7 @@ export const UserMessageMarkdown = ({
       mention_user: getUserMentionPlugin(owner),
       content_node_mention: ContentNodeMentionBlock,
       pasted_attachment: PastedAttachmentBlock,
+      file_preview: getFilePreviewPlugin(),
       skill: ({ skillIcon, skillId, skillName }: SkillDirectiveProps) => (
         <SkillBlock
           owner={owner}
@@ -73,6 +78,7 @@ export const UserMessageMarkdown = ({
       taskDirective,
       contentNodeMentionDirective,
       pastedAttachmentDirective,
+      filePreviewDirective,
       skillDirective,
     ],
     []

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1475,7 +1475,7 @@ function getCitations({
       <AttachmentCitation
         key={index}
         attachmentCitation={attachmentCitation}
-        compact
+        size="sm"
       />
     );
   });

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -173,7 +173,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               <AttachmentCitation
                 key={index}
                 attachmentCitation={attachmentCitation}
-                compact={!hasImageCitation}
+                size={hasImageCitation ? "md" : "sm"}
               />
             );
           })

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -1,3 +1,4 @@
+import type { FileCitationCardSize } from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { FileCitationCard } from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { PreviewableCitation } from "@app/components/assistant/conversation/attachment/PreviewableCitation";
 import type { AttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
@@ -9,12 +10,12 @@ import { useContext } from "react";
 
 interface AttachmentCitationProps {
   attachmentCitation: AttachmentCitation;
-  compact?: boolean;
+  size?: FileCitationCardSize;
 }
 
 export function AttachmentCitation({
   attachmentCitation,
-  compact,
+  size = "md",
 }: AttachmentCitationProps) {
   const sidePanel = useContext(ConversationSidePanelContext);
 
@@ -58,7 +59,7 @@ export function AttachmentCitation({
       title: attachmentCitation.title,
       description: attachmentCitation.path ?? attachmentCitation.spaceName,
       onRemove: attachmentCitation.onRemove,
-      compact,
+      size,
       tooltipLabel: tooltipContent,
     };
     return nodeUrl ? (
@@ -85,7 +86,7 @@ export function AttachmentCitation({
         icon={attachmentCitation.visual}
         title={title}
         description={attachmentCitation.description}
-        compact={compact}
+        size={size}
         onClick={() =>
           sidePanel.openPanel({ type: "interactive_content", fileId })
         }
@@ -107,7 +108,7 @@ export function AttachmentCitation({
         downloadUrl={sourceUrl ?? undefined}
         icon={attachmentCitation.visual}
         description={attachmentCitation.description}
-        compact={compact}
+        size={size}
         isLoading={isLoading}
         loadingLabel={loadingLabel}
         onRemove={attachmentCitation.onRemove}
@@ -121,7 +122,7 @@ export function AttachmentCitation({
     icon: attachmentCitation.visual,
     title,
     description: attachmentCitation.description,
-    compact,
+    size,
     isLoading,
     loadingLabel,
     onRemove: attachmentCitation.onRemove,

--- a/front/components/assistant/conversation/attachment/FileCitationCard.tsx
+++ b/front/components/assistant/conversation/attachment/FileCitationCard.tsx
@@ -1,20 +1,26 @@
 import {
+  Chip,
   Citation,
   CitationClose,
   CitationDescription,
   CitationIcons,
   CitationTitle,
+  Icon,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type React from "react";
+import { type ComponentType, isValidElement } from "react";
+
+export type FileCitationCardSize = "md" | "sm" | "xs";
+export type FileCitationCardIcon = ComponentType | React.ReactNode;
 
 interface FileCitationCardPropsBase {
-  compact?: boolean;
   description?: React.ReactNode;
-  icon: React.ReactNode;
+  icon: FileCitationCardIcon;
   isLoading?: boolean;
   loadingLabel?: string;
   onRemove?: () => void;
+  size?: FileCitationCardSize;
   title: string;
   tooltipLabel: React.ReactNode;
 }
@@ -27,18 +33,139 @@ type FileCitationCardProps = FileCitationCardPropsBase &
     | { onClick?: never; href?: never }
   );
 
-export function FileCitationCard({
-  compact,
+function getFileCitationCardLayout(size: Exclude<FileCitationCardSize, "xs">) {
+  switch (size) {
+    case "sm":
+      return {
+        citationClassName: "h-full",
+        citationCompact: true,
+        showDescription: true,
+      };
+    case "md":
+    default:
+      return {
+        citationClassName: "h-full",
+        citationCompact: false,
+        showDescription: true,
+      };
+  }
+}
+
+function getFileCitationCardTooltipLabel({
   description,
-  href,
-  icon,
-  isLoading,
-  loadingLabel,
-  onClick,
-  onRemove,
-  title,
+  size,
   tooltipLabel,
-}: FileCitationCardProps) {
+}: {
+  description?: React.ReactNode;
+  size: FileCitationCardSize;
+  tooltipLabel: React.ReactNode;
+}) {
+  if (size !== "xs" || !description) {
+    return tooltipLabel;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div>{tooltipLabel}</div>
+      <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+        {description}
+      </div>
+    </div>
+  );
+}
+
+function getIconSizeForCitationCard(size: FileCitationCardSize): "xs" | "sm" {
+  return size === "xs" ? "xs" : "sm";
+}
+
+function renderFileCitationIcon(
+  icon: FileCitationCardIcon,
+  size: FileCitationCardSize
+): React.ReactNode {
+  if (isValidElement(icon)) {
+    return icon;
+  }
+
+  if (typeof icon === "function") {
+    return <Icon visual={icon} size={getIconSizeForCitationCard(size)} />;
+  }
+
+  if (typeof icon === "object" && icon !== null) {
+    return (
+      <Icon
+        visual={icon as unknown as ComponentType}
+        size={getIconSizeForCitationCard(size)}
+      />
+    );
+  }
+
+  return icon;
+}
+
+export function FileCitationCard(props: FileCitationCardProps) {
+  const {
+    description,
+    icon,
+    isLoading,
+    loadingLabel,
+    onRemove,
+    size = "md",
+    title,
+    tooltipLabel,
+  } = props;
+
+  const renderedIcon = renderFileCitationIcon(icon, size);
+
+  if (size === "xs") {
+    const chipContent = (
+      <span className="flex min-w-0 items-center gap-1">
+        {renderedIcon}
+        <span className="truncate">{title}</span>
+      </span>
+    );
+
+    const chipProps = {
+      children: chipContent,
+      className: "inline-flex max-w-48 align-middle",
+      color: "white" as const,
+      isBusy: isLoading,
+      onRemove,
+      size: "xs" as const,
+    };
+
+    const chip =
+      "href" in props && props.href ? (
+        <Chip {...chipProps} href={props.href} />
+      ) : (
+        <Chip
+          {...chipProps}
+          onClick={
+            "onClick" in props && props.onClick
+              ? () =>
+                  props.onClick({
+                    stopPropagation: () => {},
+                  } as React.MouseEvent<HTMLDivElement>)
+              : undefined
+          }
+        />
+      );
+
+    return (
+      <Tooltip
+        trigger={chip}
+        label={getFileCitationCardTooltipLabel({
+          description,
+          size: "xs",
+          tooltipLabel,
+        })}
+      />
+    );
+  }
+
+  const href = "href" in props ? props.href : undefined;
+  const onClick = "onClick" in props ? props.onClick : undefined;
+
+  const layout = getFileCitationCardLayout(size);
   const action = onRemove ? (
     <CitationClose
       onClick={(e) => {
@@ -50,9 +177,9 @@ export function FileCitationCard({
 
   const interior = (
     <>
-      <CitationIcons>{icon}</CitationIcons>
+      <CitationIcons>{renderedIcon}</CitationIcons>
       <CitationTitle className="truncate text-ellipsis">{title}</CitationTitle>
-      {description && (
+      {layout.showDescription && description && (
         <CitationDescription className="truncate text-ellipsis">
           {description}
         </CitationDescription>
@@ -62,27 +189,36 @@ export function FileCitationCard({
 
   const citation = href ? (
     <Citation
-      compact={compact}
+      className={layout.citationClassName}
+      compact={layout.citationCompact}
       isLoading={isLoading}
       loadingLabel={loadingLabel}
       href={href}
-      containerClassName="h-full"
       action={action}
     >
       {interior}
     </Citation>
   ) : (
     <Citation
-      compact={compact}
+      className={layout.citationClassName}
+      compact={layout.citationCompact}
       isLoading={isLoading}
       loadingLabel={loadingLabel}
       onClick={onClick}
-      containerClassName="h-full"
       action={action}
     >
       {interior}
     </Citation>
   );
 
-  return <Tooltip trigger={citation} label={tooltipLabel} />;
+  return (
+    <Tooltip
+      trigger={citation}
+      label={getFileCitationCardTooltipLabel({
+        description,
+        size,
+        tooltipLabel,
+      })}
+    />
+  );
 }

--- a/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
+++ b/front/components/assistant/conversation/attachment/PreviewableCitation.tsx
@@ -1,12 +1,15 @@
+import type {
+  FileCitationCardIcon,
+  FileCitationCardSize,
+} from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { FileCitationCard } from "@app/components/assistant/conversation/attachment/FileCitationCard";
 import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { isSupportedImageContentType } from "@app/types/files";
-import { Citation, CitationImage, Icon, Tooltip } from "@dust-tt/sparkle";
+import { Citation, CitationImage, Tooltip } from "@dust-tt/sparkle";
 import type React from "react";
 
 interface PreviewableCitationProps {
-  compact?: boolean;
   containerClassName?: string;
   contentType: string;
   description?: React.ReactNode;
@@ -14,10 +17,11 @@ interface PreviewableCitationProps {
   fileId?: string | null;
   filePath?: string;
   // Icon for non-image citations, auto-computed from contentType and title if omitted.
-  icon?: React.ReactNode;
+  icon?: FileCitationCardIcon;
   isLoading?: boolean;
   loadingLabel?: string;
   onRemove?: () => void;
+  size?: FileCitationCardSize;
   // Thumbnail shown inside CitationImage, required for image citations.
   thumbnailUrl?: string;
   title: string;
@@ -25,7 +29,6 @@ interface PreviewableCitationProps {
 }
 
 export function PreviewableCitation({
-  compact,
   containerClassName,
   contentType,
   description,
@@ -36,6 +39,7 @@ export function PreviewableCitation({
   isLoading,
   loadingLabel,
   onRemove,
+  size = "md",
   thumbnailUrl,
   title,
   tooltipLabel,
@@ -45,13 +49,13 @@ export function PreviewableCitation({
   const handleClick = () =>
     openFilePreview({ fileId, filePath, title, contentType });
 
-  if (isSupportedImageContentType(contentType)) {
+  if (isSupportedImageContentType(contentType) && thumbnailUrl) {
     return (
       <Tooltip
         trigger={
           <Citation
             isLoading={isLoading}
-            compact={compact}
+            compact={size !== "md"}
             containerClassName={containerClassName ?? "h-full min-h-24"}
           >
             <CitationImage
@@ -72,10 +76,10 @@ export function PreviewableCitation({
   const FileIcon = getFileTypeIcon(contentType, title);
   return (
     <FileCitationCard
-      icon={icon ?? <Icon visual={FileIcon} size="xs" />}
+      icon={icon ?? FileIcon}
       title={title}
       description={description}
-      compact={compact}
+      size={size}
       isLoading={isLoading}
       loadingLabel={loadingLabel}
       onClick={handleClick}

--- a/front/components/editor/extensions/input_bar/FilePreviewExtension.test.ts
+++ b/front/components/editor/extensions/input_bar/FilePreviewExtension.test.ts
@@ -1,0 +1,62 @@
+import { FilePreviewExtension } from "@app/components/editor/extensions/input_bar/FilePreviewExtension";
+import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+import { getFilePreviewMarkdownDirective } from "@app/lib/markdown/file_preview";
+import type { Editor } from "@tiptap/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("FilePreviewExtension", () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = EditorFactory([FilePreviewExtension]);
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  it("parses scoped file preview directives from markdown", () => {
+    const directive = getFilePreviewMarkdownDirective({
+      contentType: "application/pdf",
+      path: "conversation-c1/booklet.pdf",
+      title: "booklet.pdf",
+    });
+
+    editor.commands.setContent(directive, {
+      contentType: "markdown",
+    });
+
+    expect(editor.getJSON()).toEqual({
+      content: [
+        {
+          content: [
+            {
+              attrs: {
+                contentType: "application/pdf",
+                path: "conversation-c1/booklet.pdf",
+                title: "booklet.pdf",
+              },
+              type: "filePreview",
+            },
+          ],
+          type: "paragraph",
+        },
+      ],
+      type: "doc",
+    });
+  });
+
+  it("round-trips file preview directives to markdown", () => {
+    const directive = getFilePreviewMarkdownDirective({
+      contentType: "application/pdf",
+      path: "conversation-c1/booklet.pdf",
+      title: "booklet.pdf",
+    });
+
+    editor.commands.setContent(directive, {
+      contentType: "markdown",
+    });
+
+    expect(editor.getMarkdown()).toBe(directive);
+  });
+});

--- a/front/components/editor/extensions/input_bar/FilePreviewExtension.ts
+++ b/front/components/editor/extensions/input_bar/FilePreviewExtension.ts
@@ -1,0 +1,83 @@
+import { FilePreviewComponent } from "@app/components/editor/input_bar/FilePreviewComponent";
+import {
+  FILE_PREVIEW_DIRECTIVE_NAME,
+  FILE_PREVIEW_NODE_TYPE,
+  getFilePreviewMarkdownDirective,
+  parseFilePreviewMarkdownDirective,
+} from "@app/lib/markdown/file_preview";
+import { mergeAttributes, Node } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+export { FILE_PREVIEW_NODE_TYPE };
+
+export const FilePreviewExtension = Node.create({
+  name: FILE_PREVIEW_NODE_TYPE,
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      contentType: { default: null },
+      path: { default: null },
+      title: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="file-preview"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes({ "data-type": "file-preview" }, HTMLAttributes),
+    ];
+  },
+
+  renderText({ node }) {
+    return node.attrs.title ?? node.attrs.path ?? "[file]";
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FilePreviewComponent);
+  },
+
+  markdownTokenizer: {
+    name: FILE_PREVIEW_NODE_TYPE,
+    level: "inline",
+    start: (src) => src.indexOf(`:${FILE_PREVIEW_DIRECTIVE_NAME}`),
+    tokenize: (src) => {
+      const parsed = parseFilePreviewMarkdownDirective(src);
+      if (!parsed) {
+        return undefined;
+      }
+
+      return {
+        type: FILE_PREVIEW_NODE_TYPE,
+        raw: parsed.raw,
+        attrs: {
+          contentType: parsed.contentType ?? null,
+          path: parsed.path,
+          title: parsed.title ?? null,
+        },
+      };
+    },
+  },
+
+  parseMarkdown: (token) => ({
+    type: FILE_PREVIEW_NODE_TYPE,
+    attrs: {
+      contentType: token.attrs.contentType,
+      path: token.attrs.path,
+      title: token.attrs.title,
+    },
+  }),
+
+  renderMarkdown: (node) =>
+    getFilePreviewMarkdownDirective({
+      contentType: node.attrs?.contentType ?? undefined,
+      path: node.attrs?.path ?? "",
+      title: node.attrs?.title ?? undefined,
+    }),
+});

--- a/front/components/editor/extensions/input_bar/FileSearchNodeView.tsx
+++ b/front/components/editor/extensions/input_bar/FileSearchNodeView.tsx
@@ -1,3 +1,4 @@
+import { FILE_PREVIEW_NODE_TYPE } from "@app/components/editor/extensions/input_bar/FilePreviewExtension";
 import {
   ContextFileSlashSearch,
   type ContextFileSlashSearchSelection,
@@ -18,19 +19,17 @@ interface FileSearchNodeViewProps extends NodeViewProps {
   options: FileSearchNodeOptions;
 }
 
-function getContextFileReferenceText(
+function getContextFileReferenceContent(
   selection: ContextFileSlashSearchSelection
-): string {
-  // TODO: Replace with the right markdown directive when available.
-  return selection.path ?? selection.fileId;
-}
-
-function getContextFileReferenceContent(reference: string) {
+) {
   return [
     {
-      type: "text" as const,
-      marks: [{ type: "code" as const }],
-      text: reference,
+      type: FILE_PREVIEW_NODE_TYPE,
+      attrs: {
+        contentType: selection.contentType,
+        path: selection.path,
+        title: selection.label,
+      },
     },
     { type: "text" as const, text: " " },
   ];
@@ -66,9 +65,7 @@ export function FileSearchNodeView({
         .chain()
         .focus()
         .deleteRange({ from: pos, to: pos + node.nodeSize })
-        .insertContent(
-          getContextFileReferenceContent(getContextFileReferenceText(selection))
-        )
+        .insertContent(getContextFileReferenceContent(selection))
         .run();
     },
     [editor, getPos, node.nodeSize]

--- a/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
@@ -16,9 +16,10 @@ import { DropdownMenuItem, Icon, Spinner } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 export type ContextFileSlashSearchSelection = {
+  contentType: string;
   fileId: string;
   label: string;
-  path: string | null;
+  path: string;
 };
 
 export type ContextFileSlashSearchItem =
@@ -29,7 +30,7 @@ export type ContextFileSlashSearchItem =
       id: string;
       kind: "conversation";
       label: string;
-      path: string | null;
+      path: string;
     }
   | {
       description: string;
@@ -53,6 +54,7 @@ function toSelection(
   item: ContextFileSlashSearchItem
 ): ContextFileSlashSearchSelection {
   return {
+    contentType: item.file.contentType,
     fileId: item.fileId,
     label: item.label,
     path: item.path,
@@ -120,6 +122,10 @@ export function ContextFileSlashSearch({
       .filter(isFileAttachmentType)
       .filter((attachment) => !attachment.hidden)
       .filter((attachment) => !attachment.isInProjectContext)
+      .filter(
+        (attachment): attachment is typeof attachment & { path: string } =>
+          attachment.path !== null
+      )
       .filter((attachment) =>
         matchesQuery(attachment.title, "Conversation file")
       )

--- a/front/components/editor/input_bar/FilePreviewComponent.tsx
+++ b/front/components/editor/input_bar/FilePreviewComponent.tsx
@@ -1,0 +1,48 @@
+import { FileCitationCard } from "@app/components/assistant/conversation/attachment/FileCitationCard";
+import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import {
+  getFileNameFromScopedPath,
+  getFilePreviewContentType,
+  getFilePreviewTypeLabel,
+} from "@app/lib/markdown/file_preview";
+import { NodeViewWrapper } from "@tiptap/react";
+
+interface FilePreviewComponentProps {
+  node: {
+    attrs: {
+      contentType?: string | null;
+      path?: string | null;
+      title?: string | null;
+    };
+  };
+}
+
+export function FilePreviewComponent({ node }: FilePreviewComponentProps) {
+  const { contentType, path, title } = node.attrs;
+  if (!path) {
+    return null;
+  }
+
+  const fileName = title || getFileNameFromScopedPath(path);
+  const fileContentType = getFilePreviewContentType({
+    contentType: contentType ?? undefined,
+    fileName,
+  });
+  const typeLabel = getFilePreviewTypeLabel({
+    contentType: fileContentType,
+    fileName,
+  });
+  const FileIcon = getFileTypeIcon(fileContentType, fileName);
+
+  return (
+    <NodeViewWrapper className="inline-flex align-middle">
+      <FileCitationCard
+        size="xs"
+        description={typeLabel}
+        icon={FileIcon}
+        title={fileName}
+        tooltipLabel={fileName}
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -1,6 +1,7 @@
 import { CodeExtension } from "@app/components/editor/extensions/CodeExtension";
 import { createEmojiExtension } from "@app/components/editor/extensions/EmojiExtension";
 import { DataSourceLinkExtension } from "@app/components/editor/extensions/input_bar/DataSourceLinkExtension";
+import { FilePreviewExtension } from "@app/components/editor/extensions/input_bar/FilePreviewExtension";
 import { InputBarFileSearchNode } from "@app/components/editor/extensions/input_bar/FileSearchNodeWithView";
 import {
   InputBarSlashSuggestionExtension,
@@ -456,6 +457,7 @@ export const buildEditorExtensions = ({
     PastedAttachmentExtension.configure({
       onInlineText,
     }),
+    FilePreviewExtension,
     URLStorageExtension,
   ];
 

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -377,25 +377,26 @@ export function FilePreviewDialog({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent size="2xl" height="2xl" className="gap-4 px-4">
         <DialogHeader className="flex gap-4">
-          <DialogTitle>Preview Data</DialogTitle>
-          <div className="flex items-center justify-between">
+          <DialogTitle>
             <div className="flex items-center gap-1.5 overflow-hidden">
               {FileIcon && (
                 <Icon
                   visual={FileIcon}
-                  size="xs"
+                  size="sm"
                   className="shrink-0 text-foreground dark:text-foreground-night"
                 />
               )}
               <span
                 className={cn(
-                  "line-clamp-1 text-sm leading-5",
+                  "line-clamp-1 leading-5",
                   "text-foreground dark:text-foreground-night"
                 )}
               >
-                {entry?.fileName ?? ""}
+                {entry?.fileName ?? "Preview Data"}
               </span>
             </div>
+          </DialogTitle>
+          <div className="flex items-center justify-between">
             {recordCounts && (
               <span
                 className={cn(

--- a/front/components/markdown/FilePreviewBlock.tsx
+++ b/front/components/markdown/FilePreviewBlock.tsx
@@ -1,5 +1,4 @@
 import { PreviewableCitation } from "@app/components/assistant/conversation/attachment/PreviewableCitation";
-import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   FILE_PREVIEW_COMPONENT_NAME,
   FILE_PREVIEW_DIRECTIVE_NAME,
@@ -8,7 +7,6 @@ import {
   getFilePreviewTypeLabel,
 } from "@app/lib/markdown/file_preview";
 import { isString } from "@app/types/shared/utils/general";
-import { Icon } from "@dust-tt/sparkle";
 import { visit } from "unist-util-visit";
 
 interface FilePreviewBlockProps {
@@ -58,7 +56,6 @@ export function FilePreviewBlock({
     contentType: fileContentType,
     fileName,
   });
-  const FileIcon = getFileTypeIcon(fileContentType, fileName);
 
   return (
     <PreviewableCitation
@@ -66,7 +63,7 @@ export function FilePreviewBlock({
       contentType={fileContentType}
       title={fileName}
       description={typeLabel}
-      icon={<Icon visual={FileIcon} size="xs" />}
+      size="xs"
     />
   );
 }

--- a/front/lib/markdown/file_preview.test.ts
+++ b/front/lib/markdown/file_preview.test.ts
@@ -4,6 +4,7 @@ import {
   getFilePreviewContentType,
   getFilePreviewMarkdownDirective,
   getFilePreviewTypeLabel,
+  parseFilePreviewMarkdownDirective,
 } from "./file_preview";
 
 describe("getFilePreviewMarkdownDirective", () => {
@@ -27,6 +28,21 @@ describe("getFilePreviewMarkdownDirective", () => {
     ).toBe(
       ':preview_file{path="conversation-c1/reports/report &quot;Q2&quot; final.pdf" title="report &quot;Q2&quot; final.pdf" contentType="application/pdf"}'
     );
+  });
+
+  it("round-trips through parseFilePreviewMarkdownDirective", () => {
+    const directive = getFilePreviewMarkdownDirective({
+      contentType: "application/pdf",
+      path: "conversation-c1/booklet.pdf",
+      title: "booklet.pdf",
+    });
+
+    expect(parseFilePreviewMarkdownDirective(directive)).toEqual({
+      contentType: "application/pdf",
+      path: "conversation-c1/booklet.pdf",
+      raw: directive,
+      title: "booklet.pdf",
+    });
   });
 });
 

--- a/front/lib/markdown/file_preview.ts
+++ b/front/lib/markdown/file_preview.ts
@@ -4,12 +4,20 @@ import {
   isAllSupportedFileContentType,
   stripMimeParameters,
 } from "@app/types/files";
-import { escape } from "html-escaper";
+import { escape, unescape } from "html-escaper";
 
 export const FILE_PREVIEW_DIRECTIVE_NAME = "preview_file";
 export const FILE_PREVIEW_COMPONENT_NAME = "file_preview";
+export const FILE_PREVIEW_NODE_TYPE = "filePreview";
 export const FILE_PREVIEW_DIRECTIVE_EXAMPLE =
   ':preview_file{path="conversation-<id>/report.pdf" title="report.pdf" contentType="application/pdf"}';
+
+export type ParsedFilePreviewDirective = {
+  contentType?: string;
+  path: string;
+  raw: string;
+  title?: string;
+};
 
 function fileExtensionLabel(fileName: string): string | null {
   const lastDot = fileName.lastIndexOf(".");
@@ -35,6 +43,80 @@ function contentTypeExtensionLabel(contentType: string | null): string | null {
 
 function quoteDirectiveAttribute(value: string): string {
   return `"${escape(value.replaceAll("\r", " ").replaceAll("\n", " "))}"`;
+}
+
+function parseQuotedDirectiveAttributeValue(
+  src: string,
+  startIndex: number
+): { endIndex: number; value: string } | null {
+  if (src[startIndex] !== '"') {
+    return null;
+  }
+
+  let value = "";
+  for (let index = startIndex + 1; index < src.length; index += 1) {
+    if (src[index] === '"') {
+      return {
+        endIndex: index + 1,
+        value: unescape(value),
+      };
+    }
+
+    value += src[index];
+  }
+
+  return null;
+}
+
+export function parseFilePreviewMarkdownDirective(
+  src: string
+): ParsedFilePreviewDirective | null {
+  const prefix = `:${FILE_PREVIEW_DIRECTIVE_NAME}{`;
+  if (!src.startsWith(prefix)) {
+    return null;
+  }
+
+  let index = prefix.length;
+  const attributes: Record<string, string> = {};
+
+  while (index < src.length && src[index] !== "}") {
+    while (index < src.length && src[index] === " ") {
+      index += 1;
+    }
+
+    const equalsIndex = src.indexOf("=", index);
+    if (equalsIndex === -1) {
+      return null;
+    }
+
+    const key = src.slice(index, equalsIndex);
+    const parsedValue = parseQuotedDirectiveAttributeValue(
+      src,
+      equalsIndex + 1
+    );
+    if (!parsedValue) {
+      return null;
+    }
+
+    attributes[key] = parsedValue.value;
+    index = parsedValue.endIndex;
+  }
+
+  if (src[index] !== "}") {
+    return null;
+  }
+
+  const path = attributes.path;
+  if (!path) {
+    return null;
+  }
+
+  return {
+    contentType: attributes.contentType,
+    path,
+    raw: src.slice(0, index + 1),
+    title: attributes.title,
+  };
 }
 
 export function getFileNameFromScopedPath(filePath: string): string {


### PR DESCRIPTION
## Description

Wires up the `:preview_file` markdown directive end-to-end in the input bar and user message renderer.

- `FilePreviewExtension`: new inline TipTap atom that parses `:preview_file{path=… title=… contentType=…}` directives and renders them as `FilePreviewComponent` (a `PreviewableCitation` chip with file icon + type label).
- `FileSearchNodeView` now inserts a `filePreview` node instead of the temporary backtick-wrapped path placeholder (removes the `// TODO` comment).
- `parseFilePreviewMarkdownDirective` added to `file_preview.ts` to handle round-trip parsing, including HTML attribute unescaping.
- `UserMessageMarkdown` registers `filePreviewDirective` so received messages containing `:preview_file` render the preview chip.
- `ContextFileSlashSearch` now filters out attachments with a null `path` and propagates `contentType` in selections.

https://github.com/user-attachments/assets/ab930126-3e4b-46da-9cc6-1d06739dda24

<img width="570" height="979" alt="file-1d013dc347033a416fd1d27314024cce" src="https://github.com/user-attachments/assets/b1054809-d715-41bc-916e-1cac3fd7319b" />


## Tests

- Added `FilePreviewExtension.test.ts`: parse-from-markdown and round-trip to markdown.
- Extended `file_preview.test.ts`: round-trip through `parseFilePreviewMarkdownDirective`.
- Extended `UserMessageMarkdown.integration.test.tsx`: directive renders as a previewable file chip.
- Tested locally in the input bar slash-command file selection flow.

~~@fontanierh couple of notes, wdyt:~~
~~- the component is quite big when used in the user message / input bar (shall i make a small variant ?)~~
~~- it seems that the inline preview for image do not work, but clicking on it works (shall I investigate ?)~~

FIXED

## Risk

Low. Front-only change. The `filePreview` node degrades gracefully — `renderText` falls back to title/path/`[file]` in plain-text contexts. The old code-text fallback is removed but was already a temporary placeholder.

## Deploy Plan

Deploy `front`.
