### PR TITLE
fix(analytics): exclude unbilled message statuses from credit sums

### DIFF
--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -3,6 +3,7 @@ import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -13,7 +14,9 @@ type TopAgentExportBucket = {
   doc_count: number;
   unique_users?: estypes.AggregationsCardinalityAggregate;
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
-  credits?: estypes.AggregationsSumAggregate;
+  credits?: estypes.AggregationsFilterAggregate & {
+    total?: estypes.AggregationsSumAggregate;
+  };
 };
 
 type TopAgentsExportAggs = {
@@ -82,7 +85,13 @@ export async function fetchAgentExportRows(
             unique_conversations: {
               cardinality: { field: "conversation_id" },
             },
-            credits: { sum: { field: "cost.full_awu" } },
+            // Credits mirror the billed scope (failed messages carry a cost in
+            // the index but are never billed), while the count metrics above
+            // stay inclusive of all activity.
+            credits: {
+              filter: { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+              aggs: { total: { sum: { field: "cost.full_awu" } } },
+            },
           },
         },
       },
@@ -105,7 +114,7 @@ export async function fetchAgentExportRows(
         messages: b.doc_count,
         distinctUsersReached: Math.round(b.unique_users?.value ?? 0),
         distinctConversations: Math.round(b.unique_conversations?.value ?? 0),
-        credits: Math.round(b.credits?.value ?? 0),
+        credits: Math.round(b.credits?.total?.value ?? 0),
       },
     ])
   );

--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -2,6 +2,7 @@ import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getUserGroupMemberships } from "@app/lib/workspace_usage";
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -14,7 +15,9 @@ type TopUserExportBucket = {
   doc_count: number;
   last_message?: estypes.AggregationsMaxAggregate;
   active_days?: estypes.AggregationsDateHistogramAggregate;
-  credits?: estypes.AggregationsSumAggregate;
+  credits?: estypes.AggregationsFilterAggregate & {
+    total?: estypes.AggregationsSumAggregate;
+  };
 };
 
 type TopUsersExportAggs = {
@@ -75,7 +78,13 @@ export async function fetchUserExportRows({
                 time_zone: timezone,
               },
             },
-            credits: { sum: { field: "cost.full_awu" } },
+            // Credits mirror the billed scope (failed messages carry a cost in
+            // the index but are never billed), while the count metrics above
+            // stay inclusive of all activity.
+            credits: {
+              filter: { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+              aggs: { total: { sum: { field: "cost.full_awu" } } },
+            },
           },
         },
       },
@@ -106,7 +115,7 @@ export async function fetchUserExportRows({
           activeDaysCount: Array.isArray(activeDaysBuckets)
             ? activeDaysBuckets.filter((d) => d.doc_count > 0).length
             : 0,
-          credits: Math.round(b.credits?.value ?? 0),
+          credits: Math.round(b.credits?.total?.value ?? 0),
         },
       ] as const;
     })

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -2,6 +2,7 @@ import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observabili
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -137,7 +138,13 @@ export async function fetchAgentCostStats(
 
   const query: estypes.QueryDslQueryContainer = {
     bool: {
-      filter: [baseQuery, { range: { "cost.full_awu": { gt: 0 } } }],
+      filter: [
+        baseQuery,
+        // Mirror the billed scope: failed messages carry a non-zero
+        // `cost.full_awu` in the index but are never billed by Metronome.
+        { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+        { range: { "cost.full_awu": { gt: 0 } } },
+      ],
     },
   };
 

--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -1,6 +1,7 @@
 import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
 import type { Authenticator } from "@app/lib/auth";
 import { FREE_ORIGINS } from "@app/lib/metronome/events";
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
@@ -107,11 +108,16 @@ export function buildAgentAnalyticsBaseQuery({
   };
 }
 
-// Workspace query scoped to the window, with free origins excluded to mirror the
-// non-free billed scope. Shared by the credit fetchers (timeseries, breakdown,
-// per-user and per-agent tables) so the scope stays identical across them.
-// `extraFilters` / `extraMustNot` carry per-caller constraints (e.g. requiring
-// an agent_id, or excluding the programmatic "unknown" user).
+// Workspace query scoped to the window, with free origins excluded and only the
+// billed message statuses kept, to mirror the non-free billed scope. Metronome
+// only emits usage events and credits for AGENT_MESSAGE_STATUSES_TO_TRACK (see
+// usage_queue activities and credit_cost), so failed messages carry a non-zero
+// `cost.full_awu` in the index but are never billed; without the status filter
+// the credit totals over-count failed runs and diverge from Metronome. Shared by
+// the credit fetchers (timeseries, breakdown, per-user and per-agent tables) so
+// the scope stays identical across them. `extraFilters` / `extraMustNot` carry
+// per-caller constraints (e.g. requiring an agent_id, or excluding the
+// programmatic "unknown" user).
 export function buildCreditsScopeQuery(
   auth: Authenticator,
   {
@@ -142,7 +148,11 @@ export function buildCreditsScopeQuery(
   });
   return {
     bool: {
-      filter: [baseQuery, ...extraFilters],
+      filter: [
+        baseQuery,
+        { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+        ...extraFilters,
+      ],
       must_not: [
         { terms: { context_origin: [...FREE_ORIGINS] } },
         ...extraMustNot,


### PR DESCRIPTION
## Description

The analyst agent and analytics-page credit views summed cost.full_awu while excluding free origins to mirror the billed scope, but never filtered on billed message status. Failed messages carry a non-zero cost.full_awu in the index yet are never billed by Metronome (failed is not in AGENT_MESSAGE_STATUSES_TO_TRACK), so the displayed credits over-counted failed runs (e.g. failed triggers) and diverged from Metronome.

Add the status filter to buildCreditsScopeQuery (covers the analyst agent, the credit dashboard, and the per-agent/per-user credit tables) and to the overview agent cost stats. For the CSV exports, wrap only the credits sum in a status filter sub-aggregation so the count metrics stay inclusive of all activity while credits match the billed scope.
## Tests

Local

## Risk

Low
## Deploy Plan

Front