### PR TITLE
[front] Extend advanced model access to credit-priced plans

### DIFF
--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -27,7 +27,6 @@ import {
   config as multiRegionsConfig,
   config as regionConfig,
 } from "@app/lib/api/regions/config";
-import { isEnterpriseOrDust } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { getBatchEndpoints } from "@app/lib/llms/batch";
@@ -50,7 +49,10 @@ import {
   GLOBAL,
   type Region,
 } from "@app/lib/model_constructors/types/regions";
-import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
+import {
+  isCreditPricedPlanPrefix,
+  isEnterpriseOrDust,
+} from "@app/lib/plans/plan_codes";
 import logger from "@app/logger/logger";
 import { BYOK_MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import type { ModelIdType } from "@app/types/assistant/models/types";

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -165,7 +165,7 @@ describe("isModelAvailable", () => {
   it("should return false for large model without upgraded plan", () => {
     const model = createMockModel({
       largeModel: true,
-      availableIfOneOf: { enterprise: true },
+      availableIfOneOf: { plansWithAdvancedModels: true },
     });
     const plan = createMockPlan(FREE_NO_PLAN_CODE);
 
@@ -182,7 +182,7 @@ describe("isModelAvailable", () => {
   it("should return false for large model with null plan", () => {
     const model = createMockModel({
       largeModel: true,
-      availableIfOneOf: { enterprise: true },
+      availableIfOneOf: { plansWithAdvancedModels: true },
     });
 
     expect(
@@ -212,9 +212,9 @@ describe("isModelAvailable", () => {
     ).toBe(false);
   });
 
-  it("should return true when enterprise is set and plan is an enterprise plan", () => {
+  it("should return true when plansWithAdvancedModels is set and plan is an enterprise plan", () => {
     const model = createMockModel({
-      availableIfOneOf: { enterprise: true },
+      availableIfOneOf: { plansWithAdvancedModels: true },
       largeModel: false,
     });
     const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
@@ -229,9 +229,9 @@ describe("isModelAvailable", () => {
     ).toBe(true);
   });
 
-  it("should return true when enterprise is set and plan has ENT_ prefix", () => {
+  it("should return true when plansWithAdvancedModels is set and plan has ENT_ prefix", () => {
     const model = createMockModel({
-      availableIfOneOf: { enterprise: true },
+      availableIfOneOf: { plansWithAdvancedModels: true },
       largeModel: false,
     });
     const plan = createMockPlan("ENT_CUSTOM_PLAN");
@@ -246,9 +246,12 @@ describe("isModelAvailable", () => {
     ).toBe(true);
   });
 
-  it("should return true when both enterprise and featureFlag are set, with enterprise plan", () => {
+  it("should return true when both plansWithAdvancedModels and featureFlag are set, with enterprise plan", () => {
     const model = createMockModel({
-      availableIfOneOf: { enterprise: true, featureFlag: "deepseek_feature" },
+      availableIfOneOf: {
+        plansWithAdvancedModels: true,
+        featureFlag: "deepseek_feature",
+      },
       largeModel: false,
     });
     const plan = createMockPlan(DUST_COMPANY_PLAN_CODE);
@@ -263,9 +266,12 @@ describe("isModelAvailable", () => {
     ).toBe(true);
   });
 
-  it("should return true when both enterprise and featureFlag are set, with featureFlag enabled", () => {
+  it("should return true when both plansWithAdvancedModels and featureFlag are set, with featureFlag enabled", () => {
     const model = createMockModel({
-      availableIfOneOf: { enterprise: true, featureFlag: "deepseek_feature" },
+      availableIfOneOf: {
+        plansWithAdvancedModels: true,
+        featureFlag: "deepseek_feature",
+      },
       largeModel: false,
     });
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);
@@ -280,9 +286,12 @@ describe("isModelAvailable", () => {
     ).toBe(true);
   });
 
-  it("should return false when both enterprise and featureFlag are set but neither condition is met", () => {
+  it("should return false when both plansWithAdvancedModels and featureFlag are set but neither condition is met", () => {
     const model = createMockModel({
-      availableIfOneOf: { enterprise: true, featureFlag: "deepseek_feature" },
+      availableIfOneOf: {
+        plansWithAdvancedModels: true,
+        featureFlag: "deepseek_feature",
+      },
       largeModel: false,
     });
     const plan = createMockPlan(PRO_PLAN_SEAT_29_CODE);

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,4 +1,5 @@
 import {
+  isCreditPricedPlanPrefix,
   isDustCompanyPlan,
   isEnterprisePlanPrefix,
   isUpgraded,
@@ -12,10 +13,12 @@ import type { PlanType } from "@app/types/plan";
 import type { RegionType } from "@app/types/region";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 
-export function isEnterpriseOrDust(plan: PlanType | null): boolean {
+export function isPlanForAdvancedModels(plan: PlanType | null): boolean {
   return (
     plan !== null &&
-    (isEnterprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
+    (isEnterprisePlanPrefix(plan.code) ||
+      isCreditPricedPlanPrefix(plan.code) ||
+      isDustCompanyPlan(plan.code))
   );
 }
 
@@ -50,9 +53,9 @@ export function isModelAvailable(
     return true;
   }
 
-  const { enterprise, featureFlag } = m.availableIfOneOf;
+  const { plansWithAdvancedModels, featureFlag } = m.availableIfOneOf;
 
-  if (enterprise === true && isEnterpriseOrDust(plan)) {
+  if (plansWithAdvancedModels === true && isPlanForAdvancedModels(plan)) {
     return true;
   }
 

--- a/front/lib/plans/plan_codes.ts
+++ b/front/lib/plans/plan_codes.ts
@@ -133,6 +133,13 @@ export const isUpgraded = (plan: PlanType | null): boolean => {
   return ![FREE_TEST_PLAN_CODE, FREE_NO_PLAN_CODE].includes(plan.code);
 };
 
+export function isEnterpriseOrDust(plan: PlanType | null): boolean {
+  return (
+    plan !== null &&
+    (isEnterprisePlanPrefix(plan.code) || isDustCompanyPlan(plan.code))
+  );
+}
+
 export const isWhitelistedBusinessPlan = (owner?: WorkspaceType) => {
   if (!owner) {
     return false;

--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -276,7 +276,7 @@ export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
-    enterprise: true,
+    plansWithAdvancedModels: true,
     featureFlag: "claude_4_5_opus_feature",
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
@@ -317,7 +317,7 @@ export const CLAUDE_OPUS_4_7_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
-    enterprise: true,
+    plansWithAdvancedModels: true,
     featureFlag: "claude_4_5_opus_feature",
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],
@@ -359,7 +359,7 @@ export const CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   tokenizer: { type: "tiktoken", base: "anthropic_base" },
   customThinkingType: "auto",
   availableIfOneOf: {
-    enterprise: true,
+    plansWithAdvancedModels: true,
     featureFlag: "claude_4_5_opus_feature",
   },
   customBetas: ["auto-thinking-2026-01-12", "max-effort-2026-01-24"],

--- a/front/types/assistant/models/types.ts
+++ b/front/types/assistant/models/types.ts
@@ -35,7 +35,7 @@ const WhitelistableFeatureSchema = z.custom<WhitelistableFeature>(
 );
 
 const AvailabilityConditionSchema = z.object({
-  enterprise: z.boolean().optional(),
+  plansWithAdvancedModels: z.boolean().optional(),
   featureFlag: WhitelistableFeatureSchema.optional(),
 });
 
@@ -115,8 +115,8 @@ export type ModelConfigurationType = Omit<
   // If object is empty, model is not available.
   // If defined, model must satisfy one of the conditions to be available.
   availableIfOneOf?: {
-    // If set to true and workspace is enterprise, model is available.
-    enterprise?: boolean;
+    // If set to true, model is available for plans with advanced models access.
+    plansWithAdvancedModels?: boolean;
     // If set, model is available if feature flag is enabled.
     featureFlag?: WhitelistableFeature;
   };


### PR DESCRIPTION
## Description

Until now, access to some advanced models was based on feature flags or if the plan was enterprise (based on availableIfOneOf in model declaration that could define "enterprise" or "featureFlag")
=> turn "enterprise" into "plansWithAvancedModels" and check this against a function isPlanForAvancedModels that would include CP plans

* Renames the enterprise field in availableIfOneOf to plansWithAvancedModels for clarity — it now reflects that access is tied to plan type, not just enterprise status.
* Introduces isPlanForAvancedModels in assistant.ts, which extends the previous isEnterpriseOrDust check to also include credit-priced plans (CP_*), giving those workspaces access to Opus models.
*  Moves isEnterpriseOrDust (the narrower enterprise+dust check, still used by the LLM router) to plan_codes.ts alongside the other plan predicates.

## Tests

Tested locally

## Risk

Low, should be only additive for CP plans

## Deploy Plan

Deploy front
