### PR TITLE
refactor(front): move sandbox DTO types out of lib/api into types/api

### DIFF
--- a/front-api/routes/poke/sandbox_kill/images.ts
+++ b/front-api/routes/poke/sandbox_kill/images.ts
@@ -1,7 +1,5 @@
-import {
-  getRegisteredImages,
-  type SandboxKillImagesResponseBody,
-} from "@app/lib/api/sandbox/image";
+import { getRegisteredImages } from "@app/lib/api/sandbox/image";
+import type { SandboxKillImagesResponseBody } from "@app/types/api/sandbox/image";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 

--- a/front-api/routes/w/[wId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy.ts
@@ -3,14 +3,14 @@ import {
   emitAuditLogEvent,
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
-import type {
-  GetWorkspaceEgressPolicyResponseBody,
-  PutWorkspaceEgressPolicyResponseBody,
-} from "@app/lib/api/sandbox/egress_policy";
 import {
   readWorkspacePolicy,
   writeWorkspacePolicy,
 } from "@app/lib/api/sandbox/egress_policy";
+import type {
+  GetWorkspaceEgressPolicyResponseBody,
+  PutWorkspaceEgressPolicyResponseBody,
+} from "@app/types/api/sandbox/egress_policy";
 import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/sandbox/env-vars/index.ts
@@ -1,13 +1,13 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
-import type {
-  GetWorkspaceSandboxEnvVarsResponseBody,
-  PostWorkspaceSandboxEnvVarsResponseBody,
-} from "@app/lib/api/sandbox/env_vars";
 import {
   parseWorkspaceSandboxEnvVarNameForKind,
   validateEnvVarValueForKind,
 } from "@app/lib/api/sandbox/env_vars";
 import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_sandbox_env_var_resource";
+import type {
+  GetWorkspaceSandboxEnvVarsResponseBody,
+  PostWorkspaceSandboxEnvVarsResponseBody,
+} from "@app/types/api/sandbox/env_vars";
 import { WORKSPACE_SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -17,14 +17,6 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const INVALIDATION_TIMEOUT_MS = 5_000;
 const SANDBOX_POLICY_MAX_DOMAINS = 100;
 
-export type GetWorkspaceEgressPolicyResponseBody = {
-  policy: EgressPolicy;
-};
-
-export type PutWorkspaceEgressPolicyResponseBody = {
-  policy: EgressPolicy;
-};
-
 function getWorkspacePolicyPath(auth: Authenticator): string {
   return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
 }

--- a/front/lib/api/sandbox/env_vars.ts
+++ b/front/lib/api/sandbox/env_vars.ts
@@ -1,18 +1,6 @@
-import type {
-  WorkspaceSandboxEnvVarKind,
-  WorkspaceSandboxEnvVarType,
-} from "@app/types/sandbox/env_var";
+import type { WorkspaceSandboxEnvVarKind } from "@app/types/sandbox/env_var";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-
-export type GetWorkspaceSandboxEnvVarsResponseBody = {
-  envVars: WorkspaceSandboxEnvVarType[];
-};
-
-export type PostWorkspaceSandboxEnvVarsResponseBody = {
-  envVar: WorkspaceSandboxEnvVarType;
-  created: boolean;
-};
 
 export const SANDBOX_ENV_VAR_PREFIX = "DST_";
 export const SANDBOX_HTTPS_SECRET_ENV_VAR_PREFIX = "DSEC_";

--- a/front/lib/api/sandbox/image/index.ts
+++ b/front/lib/api/sandbox/image/index.ts
@@ -114,7 +114,3 @@ export type {
 } from "@app/lib/api/sandbox/image/types";
 export { formatSandboxImageId } from "@app/lib/api/sandbox/image/types";
 export { getRegisteredImages, getSandboxImageFromRegistry };
-
-export interface SandboxKillImagesResponseBody {
-  images: Array<{ baseImage: string; version: string }>;
-}

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -1,12 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type {
-  GetWorkspaceEgressPolicyResponseBody,
-  PutWorkspaceEgressPolicyResponseBody,
-} from "@app/lib/api/sandbox/egress_policy";
-import type {
-  GetWorkspaceSandboxEnvVarsResponseBody,
-  PostWorkspaceSandboxEnvVarsResponseBody,
-} from "@app/lib/api/sandbox/env_vars";
 import { clientFetch } from "@app/lib/egress/client";
 import type { PatchWorkspaceSandboxEnvVarResponseBody } from "@app/lib/resources/workspace_sandbox_env_var_resource";
 import {
@@ -15,6 +7,14 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type {
+  GetWorkspaceEgressPolicyResponseBody,
+  PutWorkspaceEgressPolicyResponseBody,
+} from "@app/types/api/sandbox/egress_policy";
+import type {
+  GetWorkspaceSandboxEnvVarsResponseBody,
+  PostWorkspaceSandboxEnvVarsResponseBody,
+} from "@app/types/api/sandbox/env_vars";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import { EMPTY_EGRESS_POLICY } from "@app/types/sandbox/egress_policy";
 import type {

--- a/front/poke/swr/sandbox_kill.ts
+++ b/front/poke/swr/sandbox_kill.ts
@@ -1,8 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { SandboxKillImagesResponseBody } from "@app/lib/api/sandbox/image";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher } from "@app/lib/swr/swr";
 import type { SandboxKillRequestResponseBody } from "@app/types/api/poke/types";
+import type { SandboxKillImagesResponseBody } from "@app/types/api/sandbox/image";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -1,0 +1,9 @@
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+
+export type GetWorkspaceEgressPolicyResponseBody = {
+  policy: EgressPolicy;
+};
+
+export type PutWorkspaceEgressPolicyResponseBody = {
+  policy: EgressPolicy;
+};

--- a/front/types/api/sandbox/env_vars.ts
+++ b/front/types/api/sandbox/env_vars.ts
@@ -1,0 +1,10 @@
+import type { WorkspaceSandboxEnvVarType } from "@app/types/sandbox/env_var";
+
+export type GetWorkspaceSandboxEnvVarsResponseBody = {
+  envVars: WorkspaceSandboxEnvVarType[];
+};
+
+export type PostWorkspaceSandboxEnvVarsResponseBody = {
+  envVar: WorkspaceSandboxEnvVarType;
+  created: boolean;
+};

--- a/front/types/api/sandbox/image/index.ts
+++ b/front/types/api/sandbox/image/index.ts
@@ -1,0 +1,3 @@
+export interface SandboxKillImagesResponseBody {
+  images: Array<{ baseImage: string; version: string }>;
+}


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types and zod schemas out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

**Batch 9 of a stack** — internal `sandbox` endpoints. Stacked on #27808.

All three files were partial (DTOs + business logic); the body types move to `types/api/sandbox/*`, logic stays.

- `egress_policy`: moved `Get`/`PutWorkspaceEgressPolicyResponseBody`; kept all policy read/write/invalidate logic.
- `env_vars`: moved `Get`/`PostWorkspaceSandboxEnvVarsResponseBody`; dropped the now-unused `WorkspaceSandboxEnvVarType` import; kept constants/validation.
- `image/index.ts`: moved `SandboxKillImagesResponseBody`; kept the barrel re-exports + image functions.
- 5 consumers updated; 3 front-api routes split (DTO → types, functions → lib).

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)