### PR TITLE
feat: remove conversationId unique constraint from dust project conversations

### DIFF
--- a/connectors/migrations/pre-deploy/20260623150755_remove_conversation_uniqueness_dust_project_datasource.sql
+++ b/connectors/migrations/pre-deploy/20260623150755_remove_conversation_uniqueness_dust_project_datasource.sql
@@ -1,0 +1,8 @@
+/*
+Statement 0
+  - ACQUIRES_ACCESS_EXCLUSIVE_LOCK: Index drops will lock out all accesses to the table. They should be fast.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."dust_project_conversations" DROP CONSTRAINT "dust_project_conversations_conversationId_key";

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -70,7 +70,6 @@ DustProjectConversationModel.init(
     conversationId: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: true,
     },
     projectId: {
       type: DataTypes.STRING,


### PR DESCRIPTION
## Description

This PR removes the unique constraint on `conversationId` in the `dust_project_conversations` table to allow multiple entries with the same conversation ID.

Followup of https://github.com/dust-tt/dust/pull/27434

## Tests

Manually.

## Risks
Low risk.

## Deploy Plan
Run the migration on the connector db.