### PR TITLE
feat(llm): register Mistral stream endpoints in the new LLM router

### DIFF
--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -11,6 +11,10 @@ import { DustFireworksGlobalKimiK2Dot5Stream } from "@app/lib/llms/stream/endpoi
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { DustGoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { DustMistralEuropeCodestralStream } from "@app/lib/llms/stream/endpoints/mistral_eu_codestral";
+import { DustMistralEuropeMistralLargeStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_large";
+import { DustMistralEuropeMistralMedium35Stream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_medium_3_5";
+import { DustMistralEuropeMistralSmallStream } from "@app/lib/llms/stream/endpoints/mistral_eu_mistral_small";
 import { DustOpenAIResponsesGlobalGptFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five";
 import { DustOpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { DustOpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/llms/stream/endpoints/openai_responses_global_gpt_five_dot_four";
@@ -73,6 +77,11 @@ export const DUST_STREAM_ENDPOINTS = {
   [DustFireworksGlobalKimiK2Dot5Stream.id]: DustFireworksGlobalKimiK2Dot5Stream,
   [DustTogetheraiGlobalLlama3370BInstructTurboStream.id]:
     DustTogetheraiGlobalLlama3370BInstructTurboStream,
+  [DustMistralEuropeMistralLargeStream.id]: DustMistralEuropeMistralLargeStream,
+  [DustMistralEuropeMistralMedium35Stream.id]:
+    DustMistralEuropeMistralMedium35Stream,
+  [DustMistralEuropeMistralSmallStream.id]: DustMistralEuropeMistralSmallStream,
+  [DustMistralEuropeCodestralStream.id]: DustMistralEuropeCodestralStream,
 } as const satisfies Record<StreamEndpointId, DustStreamEndpointConstructor>;
 
 export function getStreamEndpoints(

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -11,6 +11,10 @@ import { FireworksGlobalKimiK2Dot5Stream } from "@app/lib/model_constructors/str
 import { GoogleAiStudioGlobalGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_flash_lite";
 import { GoogleAiStudioGlobalGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_1_pro";
 import { GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/google_ai_studio_global_gemini_3_5_flash";
+import { MistralEuropeCodestralStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_codestral";
+import { MistralEuropeMistralLargeStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_large";
+import { MistralEuropeMistralMedium35Stream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_medium_3_5";
+import { MistralEuropeMistralSmallStream } from "@app/lib/model_constructors/stream/endpoints/mistral_eu_mistral_small";
 import { OpenAIResponsesGlobalGptFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five";
 import { OpenAIResponsesGlobalGptFiveDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_five";
 import { OpenAIResponsesGlobalGptFiveDotFourStream } from "@app/lib/model_constructors/stream/endpoints/openai_responses_global_gpt_five_dot_four";
@@ -63,6 +67,10 @@ export const STREAM_ENDPOINTS = {
   [FireworksGlobalKimiK2Dot5Stream.id]: FireworksGlobalKimiK2Dot5Stream,
   [TogetheraiGlobalLlama3370BInstructTurboStream.id]:
     TogetheraiGlobalLlama3370BInstructTurboStream,
+  [MistralEuropeMistralLargeStream.id]: MistralEuropeMistralLargeStream,
+  [MistralEuropeMistralMedium35Stream.id]: MistralEuropeMistralMedium35Stream,
+  [MistralEuropeMistralSmallStream.id]: MistralEuropeMistralSmallStream,
+  [MistralEuropeCodestralStream.id]: MistralEuropeCodestralStream,
 } as const satisfies Record<string, StreamEndpointConstructor>;
 
 export type StreamEndpointId = keyof typeof STREAM_ENDPOINTS;


### PR DESCRIPTION
## Description

The Mistral stream endpoint classes — Mistral Large, Mistral Medium 3.5, Mistral Small, and Codestral — along with their model-config mixins, the Mistral client, and their characterized integration tests, already existed in `model_constructors` but were never imported into the stream registries. As a result they were unreachable through the new LLM router.

This wires all four into both registries:

- `front/lib/model_constructors/stream/index.ts` → `STREAM_ENDPOINTS`
- `front/lib/llms/stream/index.ts` → `DUST_STREAM_ENDPOINTS`

The two must stay in sync: `DUST_STREAM_ENDPOINTS` is typed `satisfies Record<StreamEndpointId, …>`, where `StreamEndpointId` is derived from `STREAM_ENDPOINTS`, so registering in one alone fails type-checking.

`mistral-medium-3-5` was already live for batch; it now also has its stream path.

## Tests

The endpoint classes ship with already-characterized integration test files under `model_constructors/test/endpoints/`. `tsgo` is clean — the project error count is identical with and without this change (pre-existing baseline), confirming the wiring type-checks against both registries.

## Risk

Low. Additive only — four new entries in two endpoint maps, no existing entries touched. Rollback is a straight revert.

## Deploy Plan

Standard deploy. No migrations or config changes required.