### PR TITLE
fix(input-bar): maintain button row height in record mode

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1499,7 +1499,7 @@ const InputBarContainer = ({
                 </React.Fragment>
               ))}
             </div>
-            <div className="relative flex w-full items-center justify-between">
+            <div className="relative flex min-h-8 w-full items-center justify-between">
               {!isRecording && editor && (
                 <Toolbar
                   variant="overlay"


### PR DESCRIPTION
## Description

In recording mode, the left-side buttons are hidden via `{!isRecording && ...}`, which collapses the bottom button row to zero height. This made the `InputBarContainer` shorter, causing the `absolute bottom-2 right-2` send/voice buttons to overlap the editor text.

Added `min-h-8` to the button row so it always reserves enough vertical space, keeping the absolute-positioned buttons in the safe zone below the editor regardless of recording state.

## Tests

Manually tested: start a voice recording in the input bar and verify buttons stay fixed at the bottom while text remains visible without overlap.

## Risk

Low — single Tailwind class addition on an inner layout div; no logic change.
