### PR TITLE
Render file previews as inline links

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -123,11 +123,21 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
         </FilePreviewProvider>
       );
 
-      expect(screen.getByText("booklet.pdf")).toBeInTheDocument();
+      const link = screen.getByRole("link", {
+        name: "Open preview for booklet.pdf",
+      });
+
+      expect(link).toHaveAttribute(
+        "href",
+        expect.stringContaining(
+          "/api/w/test-workspace/files/path/conversation-c1/booklet.pdf"
+        )
+      );
+      expect(link).toHaveTextContent("booklet.pdf");
       expect(screen.getByText("PDF")).toBeInTheDocument();
       expect(container.querySelector("a[href*='download=1']")).toBeNull();
 
-      fireEvent.click(screen.getByText("booklet.pdf"));
+      fireEvent.click(link);
 
       expect(await screen.findByText("Preview Data")).toBeInTheDocument();
       expect(
@@ -160,13 +170,19 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       });
 
       const { container } = render(
-        <AgentMessageMarkdown
-          owner={mockOwner}
-          content={`Download\n${directive}`}
-        />
+        <FilePreviewProvider owner={mockOwner}>
+          <AgentMessageMarkdown
+            owner={mockOwner}
+            content={`Download\n${directive}`}
+          />
+        </FilePreviewProvider>
       );
 
-      expect(container.textContent).toContain(title);
+      const link = screen.getByRole("link", {
+        name: `Open preview for ${title}`,
+      });
+
+      expect(link).toHaveTextContent(title);
       expect(container.textContent).toContain("PDF");
       expect(container.querySelector("a[href*='download=1']")).toBeNull();
     });

--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -24,10 +24,12 @@ interface PreviewableFile {
 }
 
 type FilePreviewContextType = {
+  getFilePreviewUrl: (file: PreviewableFile) => string | null;
   openFilePreview: (file: PreviewableFile) => void;
 };
 
 const FilePreviewContext = createContext<FilePreviewContextType>({
+  getFilePreviewUrl: () => null,
   openFilePreview: () => {},
 });
 
@@ -46,13 +48,19 @@ export function FilePreviewProvider({
     downloadUrl: string;
   } | null>(null);
 
-  const openFilePreview = useCallback(
-    (file: PreviewableFile) => {
-      const fileUrl = file.filePath
+  const getFilePreviewUrl = useCallback(
+    (file: PreviewableFile) =>
+      file.filePath
         ? getFilePathViewUrl(owner, file.filePath)
         : file.fileId
           ? getFileViewUrl(owner, file.fileId)
-          : null;
+          : null,
+    [owner]
+  );
+
+  const openFilePreview = useCallback(
+    (file: PreviewableFile) => {
+      const fileUrl = getFilePreviewUrl(file);
 
       const downloadUrl = file.filePath
         ? getFilePathDownloadUrl(owner, file.filePath)
@@ -80,7 +88,7 @@ export function FilePreviewProvider({
         downloadUrl,
       });
     },
-    [owner]
+    [getFilePreviewUrl, owner]
   );
 
   const handleDownload = useCallback(async () => {
@@ -89,7 +97,10 @@ export function FilePreviewProvider({
     }
   }, [previewState?.downloadUrl]);
 
-  const contextValue = useMemo(() => ({ openFilePreview }), [openFilePreview]);
+  const contextValue = useMemo(
+    () => ({ getFilePreviewUrl, openFilePreview }),
+    [getFilePreviewUrl, openFilePreview]
+  );
 
   return (
     <FilePreviewContext.Provider value={contextValue}>

--- a/front/components/markdown/FilePreviewBlock.tsx
+++ b/front/components/markdown/FilePreviewBlock.tsx
@@ -1,4 +1,4 @@
-import { PreviewableCitation } from "@app/components/assistant/conversation/attachment/PreviewableCitation";
+import { useFilePreviewContext } from "@app/components/assistant/conversation/FilePreviewContext";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import {
   FILE_PREVIEW_COMPONENT_NAME,
@@ -9,6 +9,7 @@ import {
 } from "@app/lib/markdown/file_preview";
 import { isString } from "@app/types/shared/utils/general";
 import { Icon } from "@dust-tt/sparkle";
+import type { MouseEvent } from "react";
 import { visit } from "unist-util-visit";
 
 interface FilePreviewBlockProps {
@@ -45,6 +46,8 @@ export function FilePreviewBlock({
   path,
   title,
 }: FilePreviewBlockProps) {
+  const { getFilePreviewUrl, openFilePreview } = useFilePreviewContext();
+
   if (!path) {
     return null;
   }
@@ -59,15 +62,43 @@ export function FilePreviewBlock({
     fileName,
   });
   const FileIcon = getFileTypeIcon(fileContentType, fileName);
+  const previewFile = {
+    filePath: path,
+    title: fileName,
+    contentType: fileContentType,
+  };
+  const href = getFilePreviewUrl(previewFile) ?? undefined;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    openFilePreview(previewFile);
+  };
 
   return (
-    <PreviewableCitation
-      filePath={path}
-      contentType={fileContentType}
-      title={fileName}
-      description={typeLabel}
-      icon={<Icon visual={FileIcon} size="xs" />}
-    />
+    <a
+      href={href}
+      title={`${fileName} (${typeLabel})`}
+      aria-label={`Open preview for ${fileName}`}
+      onClick={handleClick}
+      className="inline-flex max-w-full items-center gap-1 align-baseline font-semibold text-highlight transition-colors duration-200 hover:text-highlight-400 hover:underline hover:underline-offset-2 active:text-highlight-700 dark:text-highlight-night dark:hover:text-highlight-400-night dark:active:text-highlight-700-night"
+    >
+      <Icon visual={FileIcon} size="xs" className="shrink-0" />
+      <span className="min-w-0 truncate">{fileName}</span>
+      <span className="shrink-0 text-xs font-normal text-muted-foreground dark:text-muted-foreground-night">
+        {typeLabel}
+      </span>
+    </a>
   );
 }
 


### PR DESCRIPTION
## Description

Follow-up to #27531. The first renderer used the existing file citation card, which made an inline file reference look like a large attachment card instead of a hyperlink.

Render `:preview_file` as an inline link-style citation. Normal click still opens the existing preview dialog, and the link carries the preview URL so open-in-new-tab behavior has a real target.

This PR is intentionally between #27531 and #27542. #27542 should be rebased onto this branch.

## Tests

- `NODE_ENV=test npm run test -- components/assistant/AgentMessageMarkdown.integration.test.tsx`
- `npx biome check components/assistant/conversation/FilePreviewContext.tsx components/markdown/FilePreviewBlock.tsx components/assistant/AgentMessageMarkdown.integration.test.tsx`
- `npm --prefix front run tsgo`

## Risk

Low. This only changes the presentation of `:preview_file` citations and keeps the preview dialog path intact.

## Deploy Plan

Standard deploy.