### PR TITLE
End Metronome contract on payment failure

### DIFF
--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -1534,10 +1534,21 @@ export async function processStripeWebhookEvent({
             matchingSubscription.metronomeContractId &&
             workspace.metronomeCustomerId
           ) {
-            void scheduleMetronomeContractEnd({
+            const metronomeRes = await scheduleMetronomeContractEnd({
               metronomeCustomerId: workspace.metronomeCustomerId,
               contractId: matchingSubscription.metronomeContractId,
             });
+            if (metronomeRes.isErr()) {
+              logger.error(
+                {
+                  stripeError: true,
+                  workspaceId: workspace.sId,
+                  metronomeContractId: matchingSubscription.metronomeContractId,
+                  error: metronomeRes.error,
+                },
+                "[Stripe Webhook] Failed to end active Metronome contract on subscription deletion."
+              );
+            }
           }
 
           const scheduleScrubRes = await launchScheduleWorkspaceScrubWorkflow({

--- a/front/lib/api/stripe/webhook_handler.ts
+++ b/front/lib/api/stripe/webhook_handler.ts
@@ -1530,6 +1530,16 @@ export async function processStripeWebhookEvent({
           );
           assert(workspace, "Workspace not found for trialing subscription.");
 
+          if (
+            matchingSubscription.metronomeContractId &&
+            workspace.metronomeCustomerId
+          ) {
+            void scheduleMetronomeContractEnd({
+              metronomeCustomerId: workspace.metronomeCustomerId,
+              contractId: matchingSubscription.metronomeContractId,
+            });
+          }
+
           const scheduleScrubRes = await launchScheduleWorkspaceScrubWorkflow({
             workspaceId: workspace.sId,
           });


### PR DESCRIPTION
## Description

When a subscription's payment fails, the Stripe webhook handler now also schedules the associated Metronome contract to end immediately (defaulting to "now"). Previously, the workspace scrub workflow was triggered but the Metronome contract was left open-ended, potentially allowing continued usage billing on Metronome's side despite the failed payment. This PR also adds an error log when the Metronome contract termination fails.

## Risk

Low. On failure, the error is logged but does not block the rest of the payment failure flow (workspace scrub, etc.).

## Deploy Plan

Deploy front.