### PR TITLE
chore: update anthropic API

### DIFF
--- a/front-api/package.json
+++ b/front-api/package.json
@@ -25,7 +25,7 @@
     "tsgo": "tsgo"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.100.1",
+    "@anthropic-ai/sdk": "^0.104.2",
     "@novu/framework": "^2.11.1",
     "umzug": "3.8.3",
     "@hono/mcp": "^0.3.0",

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -262,6 +262,7 @@ function* handleContentBlockStart(
     case "container_upload":
     case "compaction":
     case "advisor_tool_result":
+    case "fallback":
       // We don't use these Anthropic tools
       return;
     default:

--- a/front/package.json
+++ b/front/package.json
@@ -39,8 +39,8 @@
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.100.1",
-    "@anthropic-ai/vertex-sdk": "^0.16.1",
+    "@anthropic-ai/sdk": "^0.104.2",
+    "@anthropic-ai/vertex-sdk": "^0.17.1",
     "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,8 +494,8 @@
       "name": "@dust-tt/front",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.100.1",
-        "@anthropic-ai/vertex-sdk": "^0.16.1",
+        "@anthropic-ai/sdk": "^0.104.2",
+        "@anthropic-ai/vertex-sdk": "^0.17.1",
         "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
@@ -741,7 +741,7 @@
       "name": "@dust-tt/front-api",
       "version": "0.1.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.100.1",
+        "@anthropic-ai/sdk": "^0.104.2",
         "@hono/mcp": "^0.3.0",
         "@hono/node-server": "^1.19.10",
         "@hono/zod-validator": "^0.7.6",
@@ -1725,9 +1725,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.100.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
-      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "version": "0.104.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
+      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@anthropic-ai/vertex-sdk": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.16.1.tgz",
-      "integrity": "sha512-NQSJTmHFqJP32W4I+UyZ42ioUkd8avdye259Cs+P9yhi+XdI4wk7sDVnmVNNTiMtN08WXyELnAQPG2gcLQFXdQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.17.1.tgz",
+      "integrity": "sha512-+am1LjqEpb7Qq/fKDdu0PTE2U9+XSPXSSr9Fa5dvJ8FtJ5L9XOroNBnr7iecT+6iGlbiV6BYgMIGkAwPuly/jA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.50.3 <1",


### PR DESCRIPTION
## Description

Bumps `@anthropic-ai/sdk` from `0.100.1` → `0.104.2` and `@anthropic-ai/vertex-sdk` from `0.16.1` → `0.17.1` in `front` and `front-api`.

### What changed in `@anthropic-ai/sdk` (0.100.1 → 0.104.2)

**0.101.0**
- **feat:** New client-side [middleware](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/MIDDLEWARE.md) API — allows plugging into the request/response lifecycle.
- **fix:** Request timeout now applies to the inner fetch only, not the full middleware chain.
- **fix (streaming):** `stop_details` now correctly carried through `beta message_delta` accumulation — relevant for our streaming pipelines.
- **fix (streaming):** JSON numbers in scientific notation are now parsed correctly in the SSE stream.

**0.102.0**
- **feat:** Small type updates to Managed Agents API.
- **fix:** Middleware now runs before request signing (ordering correction).

**0.103.0**
- **feat:** Adds `claude-mythos-5` and `claude-fable-5` model constants + server-side fallbacks on refusal.
- **feat:** Client-side fallbacks middleware for providers that don't support server-side fallbacks.
- **feat:** `ctx.logger` available in middleware.
- **fix:** Third-party middleware ordering.

**0.104.0**
- **feat:** Support for Managed Agents deployments and environment variable credentials.

**0.104.1**
- **fix:** Adds `frontier_llm` as a new refusal category type.

**0.104.2**
- **chore:** Removes retired model identifiers from SDK types.

### What changed in `@anthropic-ai/vertex-sdk` (0.16.1 → 0.17.1)

**0.17.0**
- **feat:** Middleware support (mirrors the SDK).
- **feat:** Marks Claude Opus 4.1 as deprecated in type definitions.

**0.17.1**
- **fix:** Third-party middleware ordering.

### Impact on Dust

- **No breaking changes.** All changes are additive or bug fixes.
- **Streaming fixes** (0.101.0) are directly relevant to our streaming pipelines — the `stop_details` accumulation fix and scientific-notation JSON parsing fix could silently resolve edge-case issues.
- **Retired models** (0.104.2): Some older model identifiers are removed from SDK types. We define our own model identifiers so this has no impact, but any direct use of SDK-provided model type enums should be checked.
- **New model constants** (`claude-mythos-5`, `claude-fable-5`) and middleware features are available but not yet used.
- **Opus 4.1 deprecated** in vertex-sdk types — aligns with Anthropic's deprecation timeline; no runtime impact.
