### PR TITLE
fix(members): reset consumed credits on free to paid seat upgrade

### DIFF
--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -183,25 +183,50 @@ type ConsumedCreditsAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumedCreditsBucket>;
 };
 
+type ConsumedCreditsFilterBucket = {
+  credits?: estypes.AggregationsSumAggregate;
+};
+
+type CustomStartConsumedCreditsAggs = {
+  by_custom_user?: {
+    buckets: Record<string, ConsumedCreditsFilterBucket>;
+  };
+};
+
+function consumedCreditsBaseFilters(
+  workspace: LightWorkspaceType
+): estypes.QueryDslQueryContainer[] {
+  return [
+    { term: { workspace_id: workspace.sId } },
+    { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+  ];
+}
+
 // Per-user consumed AWU credits for the current billing cycle, summed from the
 // analytics index (`cost.full_awu`, precomputed at index time) by Elasticsearch.
 // This replaces the per-user Metronome usage scan that previously dominated the
-// members-table load: one aggregation returns every requested user's
-// consumption. Keyed by user sId (the analytics `user_id`), so no Metronome
-// free-seat id mapping is needed. Filtered to the billed message statuses so
-// the consumed total matches Metronome (failed messages are indexed with a cost
-// but never billed). Returns an empty map on any failure so the table still
-// renders (the consumed column shows 0).
+// members-table load. Keyed by user sId (the analytics `user_id`).
+//
+// Free-seat usage lives under a separate Metronome user id (`free-<sId>`), so a
+// free→paid upgrade resets a user's billed consumption to 0. The analytics index
+// is keyed only by sId and can't make that distinction, so `freeSeatExitedAtBy`
+// carries the upgrade timestamp for users who left a free seat: those users are
+// counted only from their upgrade (clamped into the cycle) instead of from
+// `cycleStart`, excluding pre-upgrade free usage. Paid→paid changes never set
+// the timestamp, so they don't reset. Returns an empty map on any failure so the
+// table still renders (the consumed column shows 0).
 async function fetchConsumedAwuCreditsByUserId({
   workspace,
   metronomeCustomerId,
   metronomeContractId,
   userIds,
+  freeSeatExitedAtByUserId,
 }: {
   workspace: LightWorkspaceType;
   metronomeCustomerId: string | null;
   metronomeContractId: string | null;
   userIds: string[];
+  freeSeatExitedAtByUserId: Map<string, Date>;
 }): Promise<Map<string, number>> {
   if (userIds.length === 0) {
     return new Map();
@@ -223,25 +248,58 @@ async function fetchConsumedAwuCreditsByUserId({
   }
   const { cycleStart, cycleEnd } = periodResult.value;
 
+  const defaultStartUserIds: string[] = [];
+  const customStartByUserId = new Map<string, Date>();
+  for (const userId of userIds) {
+    const exitedAt = freeSeatExitedAtByUserId.get(userId);
+    if (exitedAt && exitedAt.getTime() > cycleStart.getTime()) {
+      customStartByUserId.set(userId, exitedAt);
+    } else {
+      defaultStartUserIds.push(userId);
+    }
+  }
+
+  const [defaultResult, customResult] = await Promise.all([
+    fetchConsumedCreditsWithSharedStart({
+      workspace,
+      userIds: defaultStartUserIds,
+      start: cycleStart,
+      end: cycleEnd,
+    }),
+    fetchConsumedCreditsWithPerUserStart({
+      workspace,
+      startByUserId: customStartByUserId,
+      end: cycleEnd,
+    }),
+  ]);
+
+  return new Map([...defaultResult, ...customResult]);
+}
+
+async function fetchConsumedCreditsWithSharedStart({
+  workspace,
+  userIds,
+  start,
+  end,
+}: {
+  workspace: LightWorkspaceType;
+  userIds: string[];
+  start: Date;
+  end: Date;
+}): Promise<Map<string, number>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+
   const result = await searchAnalytics<never, ConsumedCreditsAggs>(
     {
       bool: {
         filter: [
-          { term: { workspace_id: workspace.sId } },
+          ...consumedCreditsBaseFilters(workspace),
           { terms: { user_id: userIds } },
-          // Mirror the billing-side filter: Metronome only emits usage events
-          // and credits for these statuses (see usage_queue activities and
-          // credit_cost), so failed messages carry a non-zero `cost.full_awu`
-          // in the index but are never billed. Without this filter the consumed
-          // total over-counts failed runs (e.g. failed triggers) and diverges
-          // from Metronome.
-          { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
           {
             range: {
-              timestamp: {
-                gte: cycleStart.toISOString(),
-                lte: cycleEnd.toISOString(),
-              },
+              timestamp: { gte: start.toISOString(), lte: end.toISOString() },
             },
           },
         ],
@@ -249,8 +307,6 @@ async function fetchConsumedAwuCreditsByUserId({
     },
     {
       aggregations: {
-        // Scoped to `userIds`, so `size` covers every distinct bucket and the
-        // per-bucket sums are exact (no cross-shard top-N approximation).
         by_user: {
           terms: { field: "user_id", size: userIds.length },
           aggs: { credits: { sum: { field: "cost.full_awu" } } },
@@ -275,6 +331,65 @@ async function fetchConsumedAwuCreditsByUserId({
       String(bucket.key),
       Math.round(bucket.credits?.value ?? 0)
     );
+  }
+  return consumedByUserId;
+}
+
+async function fetchConsumedCreditsWithPerUserStart({
+  workspace,
+  startByUserId,
+  end,
+}: {
+  workspace: LightWorkspaceType;
+  startByUserId: Map<string, Date>;
+  end: Date;
+}): Promise<Map<string, number>> {
+  if (startByUserId.size === 0) {
+    return new Map();
+  }
+
+  const filters: Record<string, estypes.QueryDslQueryContainer> = {};
+  for (const [userId, start] of startByUserId) {
+    filters[userId] = {
+      bool: {
+        filter: [
+          { term: { user_id: userId } },
+          {
+            range: {
+              timestamp: { gte: start.toISOString(), lte: end.toISOString() },
+            },
+          },
+        ],
+      },
+    };
+  }
+
+  const result = await searchAnalytics<never, CustomStartConsumedCreditsAggs>(
+    {
+      bool: { filter: consumedCreditsBaseFilters(workspace) },
+    },
+    {
+      aggregations: {
+        by_custom_user: {
+          filters: { filters },
+          aggs: { credits: { sum: { field: "cost.full_awu" } } },
+        },
+      },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to read consumed credits (per-user start) from analytics index"
+    );
+    return new Map();
+  }
+
+  const consumedByUserId = new Map<string, number>();
+  const buckets = result.value.aggregations?.by_custom_user?.buckets ?? {};
+  for (const [userId, bucket] of Object.entries(buckets)) {
+    consumedByUserId.set(userId, Math.round(bucket.credits?.value ?? 0));
   }
   return consumedByUserId;
 }
@@ -961,22 +1076,36 @@ export async function getMembersUsage({
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-  // Fetch membership details and Metronome data in parallel for the
-  // current page of users.
+  // Memberships are needed up front to resolve per-user consumed-credit start
+  // bounds (free→paid upgraders are counted from their upgrade, not cycle
+  // start). Keyed by user model id, matching the rest of the flow.
+  const membershipsResult = await MembershipResource.getActiveMemberships({
+    workspace,
+    users,
+  });
+  const userSIdByModelId = new Map(users.map((u) => [u.id, u.sId]));
+  const freeSeatExitedAtByUserId = new Map<string, Date>();
+  for (const membership of membershipsResult.memberships) {
+    const sId = userSIdByModelId.get(membership.userId);
+    if (sId && membership.freeSeatExitedAt) {
+      freeSeatExitedAtByUserId.set(sId, membership.freeSeatExitedAt);
+    }
+  }
+
+  // Fetch Metronome data and consumed credits in parallel for the current page.
   const [
-    membershipsResult,
     perUserTotalConsumedCredits,
     seatDataByUserId,
     seatBalanceByUserId,
     perUserSpendLimits,
     freeCreditAlertIdsByUserId,
   ] = await Promise.all([
-    MembershipResource.getActiveMemberships({ workspace, users }),
     fetchConsumedAwuCreditsByUserId({
       workspace,
       metronomeCustomerId: metronomeCustomerId ?? null,
       metronomeContractId,
       userIds: users.map((u) => u.sId),
+      freeSeatExitedAtByUserId,
     }),
     fetchSeatDataForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -228,6 +228,43 @@ describe("MembershipResource", () => {
         expect(inMemoryCache.has(cacheKey)).toBe(false);
       });
     });
+
+    describe("updateMembershipSeat() - freeSeatExitedAt", () => {
+      it("stamps freeSeatExitedAt when leaving a free seat for a paid seat", async () => {
+        const user = await UserFactory.basic();
+        const membership = await MembershipFactory.associate(workspace, user, {
+          role: "user",
+          seatType: "free",
+        });
+        expect(membership.freeSeatExitedAt).toBeNull();
+
+        await membership.updateMembershipSeat({
+          user,
+          workspace,
+          newSeatType: "pro",
+          author: "no-author",
+        });
+
+        expect(membership.freeSeatExitedAt).toBeInstanceOf(Date);
+      });
+
+      it("does not stamp freeSeatExitedAt on a paid→paid change", async () => {
+        const user = await UserFactory.basic();
+        const membership = await MembershipFactory.associate(workspace, user, {
+          role: "user",
+          seatType: "pro",
+        });
+
+        await membership.updateMembershipSeat({
+          user,
+          workspace,
+          newSeatType: "max",
+          author: "no-author",
+        });
+
+        expect(membership.freeSeatExitedAt).toBeNull();
+      });
+    });
   });
 
   describe("firstUsedAt behavior", () => {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -1527,6 +1527,13 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       return { previousSeatType, newSeatType };
     }
 
+    // Stamp when the user leaves the one-shot `free` seat. `free` can never be
+    // re-granted, so this fires at most once and is never cleared. The members
+    // table uses it to start counting a paid user's consumed credits after the
+    // upgrade, excluding pre-upgrade free usage (which the analytics index,
+    // keyed by sId, can't otherwise distinguish).
+    const leftFreeSeat = previousSeatType === "free" && newSeatType !== "free";
+
     await this.update(
       {
         seatType: newSeatType,
@@ -1534,6 +1541,7 @@ export class MembershipResource extends BaseResource<MembershipModel> {
         // type (same logic as createMembership) so the member isn't stuck in
         // the wrong state during the seat sync's debounce window.
         creditState: initialCreditStateForSeatType(newSeatType),
+        ...(leftFreeSeat ? { freeSeatExitedAt: new Date() } : {}),
       },
       transaction
     );

--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -21,6 +21,7 @@ export class MembershipModel extends WorkspaceAwareModel<MembershipModel> {
   declare firstUsedAt: Date | null;
   declare seatType: CreationOptional<MembershipSeatType>;
   declare creditState: CreationOptional<UserCreditState>;
+  declare freeSeatExitedAt: CreationOptional<Date | null>;
   // Admin-set per-user cap on workspace-pool AWU consumption, in AWU credits,
   // excluding the seat allowance (i.e. exactly what the admin entered). NULL
   // means no override — the seat-type default applies. The Metronome
@@ -73,6 +74,11 @@ MembershipModel.init(
       type: DataTypes.STRING,
       allowNull: false,
       defaultValue: "on_pool",
+    },
+    freeSeatExitedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
     },
     poolCapOverrideAwuCredits: {
       type: DataTypes.INTEGER,

--- a/front/migrations/pre-deploy/20260623155240_add_free_seat_exited_at_to_membership.sql
+++ b/front/migrations/pre-deploy/20260623155240_add_free_seat_exited_at_to_membership.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."memberships" ADD COLUMN "freeSeatExitedAt" timestamp with time zone;


### PR DESCRIPTION
## Description

The members table sourced consumed credits from the analytics index keyed by sId for everyone. Metronome instead records free-seat usage under a separate user id (free-<sId>), so a free→paid upgrade resets the user's billed consumption to 0 — behavior the ES-backed table lost. Paid→paid changes (e.g. pro→max) keep the same id and must not reset.

Add a freeSeatExitedAt timestamp stamped once when a user leaves the one-shot free seat (centralized in updateMembershipSeat, so all upgrade paths are covered; never set on paid→paid). The members table counts a free→paid upgrader's consumed credits only from that timestamp (clamped into the cycle) via a keyed filters aggregation, while everyone else is summed from cycle start in the existing terms aggregation. Prior-cycle free usage is already outside the window, so no backfill is needed.
## Tests

local

## Risk

low
## Deploy Plan

merge, pre-deploy mig, deploy