### PR TITLE
Skip reconcile on non cp plan

### DIFF
--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -1428,14 +1428,15 @@ export async function processMetronomeWebhook({
       // onto a business plan) leaves users stuck in their previous state.
       // Mirrors the pool reconcile above; pass the new contract id directly
       // since the subscription swap below may not have happened yet.
+      const targetPlanCode =
+        contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
+
       await reconcileWorkspaceUserCreditStates({
         workspace: renderLightWorkspaceType({ workspace }),
         metronomeCustomerId: customerId,
         metronomeContractId: contractId,
+        planCode: targetPlanCode ?? "",
       });
-
-      const targetPlanCode =
-        contractResult.value.custom_fields?.[PLAN_CODE_CUSTOM_FIELD_KEY];
       if (!targetPlanCode) {
         logger.info(
           { contractId, workspaceId: workspace.sId },

--- a/front/lib/api/metronome/reconcile_credit_state.test.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.test.ts
@@ -90,6 +90,7 @@ describe("reconcileWorkspaceUserCreditStates", () => {
       workspace: renderLightWorkspaceType({ workspace }),
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       metronomeContractId: METRONOME_CONTRACT_ID,
+      planCode: "CP_BUSINESS_PLAN",
     });
 
     const refreshed =
@@ -120,6 +121,7 @@ describe("reconcileWorkspaceUserCreditStates", () => {
       workspace: renderLightWorkspaceType({ workspace }),
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       metronomeContractId: METRONOME_CONTRACT_ID,
+      planCode: "CP_BUSINESS_PLAN",
     });
 
     const refreshed =
@@ -147,6 +149,7 @@ describe("reconcileWorkspaceUserCreditStates", () => {
       workspace: renderLightWorkspaceType({ workspace }),
       metronomeCustomerId: METRONOME_CUSTOMER_ID,
       metronomeContractId: METRONOME_CONTRACT_ID,
+      planCode: "CP_BUSINESS_PLAN",
     });
 
     const refreshed =

--- a/front/lib/api/metronome/reconcile_credit_state.ts
+++ b/front/lib/api/metronome/reconcile_credit_state.ts
@@ -28,6 +28,7 @@ import {
   expectedPoolCreditStateFromBalance,
   setWorkspacePoolCreditStateReconciled,
 } from "@app/lib/metronome/workspace_credit_state_machine";
+import { isCreditPricedPlanPrefix } from "@app/lib/plans/plan_codes";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -423,11 +424,16 @@ export async function reconcileWorkspaceUserCreditStates({
   workspace,
   metronomeCustomerId,
   metronomeContractId,
+  planCode,
 }: {
   workspace: LightWorkspaceType;
   metronomeCustomerId: string;
   metronomeContractId: string;
+  planCode: string;
 }): Promise<void> {
+  if (!isCreditPricedPlanPrefix(planCode)) {
+    return;
+  }
   const workspaceId = workspace.sId;
 
   // These return our `Result` type: handle their errors with early returns

--- a/front/lib/api/metronome/seat_sync.ts
+++ b/front/lib/api/metronome/seat_sync.ts
@@ -92,6 +92,7 @@ export async function syncMetronomeSeatCountForWorkspace({
     workspace,
     metronomeCustomerId: workspace.metronomeCustomerId,
     metronomeContractId: subscription.metronomeContractId,
+    planCode: subscription.getPlan().code,
   });
 
   // Ensure per-seat-type cap alerts exist with the current default pool limit.

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -290,6 +290,7 @@ export async function setDefaultUserSpendLimit(
       workspace,
       metronomeCustomerId,
       metronomeContractId,
+      planCode: auth.subscription()?.plan.code ?? "",
     }).catch((err) => {
       logger.error(
         { workspaceId: workspace.sId, err: normalizeError(err) },

--- a/front/lib/metronome/user_credit_state_machine.ts
+++ b/front/lib/metronome/user_credit_state_machine.ts
@@ -266,15 +266,17 @@ export async function setUserCreditStateReconciled(
   invalidateCacheAfterCommit(transaction, () =>
     setUserCreditState(ctx.workspaceId, ctx.userId, targetState)
   );
-  logger.info(
-    {
-      workspaceId: ctx.workspaceId,
-      userId: ctx.userId,
-      fromState: rawState,
-      toState: targetState,
-      wasStateChanged: rawState !== targetState,
-    },
-    "[UserCreditStateMachine] State reconciled"
-  );
+  const wasStateChanged = rawState !== targetState;
+  if (wasStateChanged) {
+    logger.info(
+      {
+        workspaceId: ctx.workspaceId,
+        userId: ctx.userId,
+        fromState: rawState,
+        toState: targetState,
+      },
+      "[UserCreditStateMachine] State reconciled"
+    );
+  }
   return targetState;
 }

--- a/front/temporal/metronome_events_queue/activities.ts
+++ b/front/temporal/metronome_events_queue/activities.ts
@@ -94,5 +94,6 @@ export async function reconcileWorkspaceUserCreditStatesActivity({
     workspace: renderLightWorkspaceType({ workspace }),
     metronomeCustomerId: workspace.metronomeCustomerId,
     metronomeContractId: subscription.metronomeContractId,
+    planCode: subscription.getPlan().code,
   });
 }


### PR DESCRIPTION
## Description

Two optimizations for the `[UserCreditStateMachine] State reconciled` log noise:

**1. Skip reconcile entirely for non-CP plans**

`reconcileWorkspaceUserCreditStates` was being triggered for all Metronome workspaces (every workspace has a shadow contract), including those not on credit-priced plans where per-user credit state is meaningless. It now takes a `planCode` parameter and returns immediately if the plan isn't a `CP_*` plan — short-circuiting all Metronome API calls (seat balances, per-user usage) and the membership loop.

**2. Only log when state actually changes**

`setUserCreditStateReconciled` was logging at `info` level for every member on every reconcile, even when no-op (same state, only Redis cache refreshed). Now only logs when `fromState !== toState`.

Together these eliminate the log flood for non-CP workspaces entirely, and reduce it to meaningful state-change events for CP workspaces.

## Tests

Updated existing tests in `reconcile_credit_state.test.ts` to pass the new required `planCode` field (`CP_BUSINESS_PLAN`). No behavior changes for CP plans.

## Risk

Low. Non-CP workspaces are cleanly skipped before any Metronome API calls. The CP guard uses the same `isCreditPricedPlanPrefix` (`CP_` prefix check) used elsewhere. The log reduction for CP workspaces is purely observational — the Redis cache refresh still happens unconditionally.

## Deploy Plan

Standard deploy, no migration needed.