### PR TITLE
refactor(front): move reclassified-internal DTO types out of lib/api into types/api

### DIFF
--- a/extension/shared/tools/takeScreenshotOrAttachFileTool.ts
+++ b/extension/shared/tools/takeScreenshotOrAttachFileTool.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerResult } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { FileUploadRequestResponseBody } from "@app/lib/api/files/upload_metadata";
 import { clientFetch } from "@app/lib/egress/client";
+import type { FileUploadRequestResponseBody } from "@app/types/api/files/upload_metadata";
 import { Err, Ok } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { normalizeError } from "@extension/shared/lib/utils";

--- a/front-api/routes/user/index.ts
+++ b/front-api/routes/user/index.ts
@@ -1,13 +1,13 @@
-import type {
-  GetUserResponseBody,
-  PostUserMetadataResponseBody,
-} from "@app/lib/api/user";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { getSubscriberHash } from "@app/lib/notifications";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type {
+  GetUserResponseBody,
+  PostUserMetadataResponseBody,
+} from "@app/types/api/user";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import { isJobType } from "@app/types/job_type";
 import { sendUserOperationMessage } from "@app/types/shared/user_operation";

--- a/front-api/routes/user/metadata/[key]/index.ts
+++ b/front-api/routes/user/metadata/[key]/index.ts
@@ -1,9 +1,9 @@
+import { getUserFromSession } from "@app/lib/iam/session";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type {
   GetUserMetadataResponseBody,
   PostUserMetadataKeyResponseBody as PostUserMetadataResponseBody,
-} from "@app/lib/api/user";
-import { getUserFromSession } from "@app/lib/iam/session";
-import { UserResource } from "@app/lib/resources/user_resource";
+} from "@app/types/api/user";
 import type { APIErrorResponse } from "@app/types/error";
 import { sessionApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/data_source_views/index.ts
@@ -1,5 +1,5 @@
-import type { GetDataSourceViewsResponseBody } from "@app/lib/api/data_source_view";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import type { GetDataSourceViewsResponseBody } from "@app/types/api/data_source_view";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 

--- a/front-api/routes/w/[wId]/dust_app_secrets/index.ts
+++ b/front-api/routes/w/[wId]/dust_app_secrets/index.ts
@@ -1,7 +1,3 @@
-import type {
-  GetDustAppSecretsResponseBody,
-  PostDustAppSecretsResponseBody,
-} from "@app/lib/api/dust_app_secrets";
 import {
   getDustAppSecret,
   getDustAppSecrets,
@@ -9,6 +5,10 @@ import {
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
+import type {
+  GetDustAppSecretsResponseBody,
+  PostDustAppSecretsResponseBody,
+} from "@app/types/api/dust_app_secrets";
 import { encrypt } from "@app/types/shared/utils/encryption";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import {

--- a/front-api/routes/w/[wId]/members/[uId]/index.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/index.ts
@@ -7,15 +7,15 @@ import {
   revokeAndTrackMembership,
   updateMembershipRoleAndTrack,
 } from "@app/lib/api/membership";
-import type {
-  GetMemberResponseBody,
-  PostMemberResponseBody,
-} from "@app/lib/api/user";
 import { getUserForWorkspace } from "@app/lib/api/user";
 import { getFeatureFlags } from "@app/lib/auth";
 import { showDebugTools } from "@app/lib/development";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import logger from "@app/logger/logger";
+import type {
+  GetMemberResponseBody,
+  PostMemberResponseBody,
+} from "@app/types/api/user";
 import { isMembershipRoleType } from "@app/types/memberships";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/members/me/agent_favorite.ts
+++ b/front-api/routes/w/[wId]/members/me/agent_favorite.ts
@@ -1,9 +1,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { PostAgentUserFavoriteResponseBody } from "@app/lib/api/assistant/user_relation";
-import {
-  PostAgentUserFavoriteRequestBodySchema,
-  setAgentUserFavorite,
-} from "@app/lib/api/assistant/user_relation";
+import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
+import type { PostAgentUserFavoriteResponseBody } from "@app/types/api/assistant/user_relation";
+import { PostAgentUserFavoriteRequestBodySchema } from "@app/types/api/assistant/user_relation";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";

--- a/front-api/routes/w/[wId]/providers/[pId]/check.ts
+++ b/front-api/routes/w/[wId]/providers/[pId]/check.ts
@@ -1,4 +1,4 @@
-import type { GetProvidersCheckResponseBody } from "@app/lib/api/provider_credentials";
+import type { GetProvidersCheckResponseBody } from "@app/types/api/provider_credentials";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -1,6 +1,6 @@
-import type { GetOrPostAppResponseBody } from "@app/lib/api/apps";
 import { softDeleteApp } from "@app/lib/api/apps";
 import { AppResource } from "@app/lib/resources/app_resource";
+import type { GetOrPostAppResponseBody } from "@app/types/api/apps";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]/index.ts
@@ -1,7 +1,7 @@
-import type { GetRunBlockResponseBody } from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
+import type { GetRunBlockResponseBody } from "@app/types/api/apps";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { BlockType } from "@app/types/run";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel.ts
@@ -1,7 +1,7 @@
-import type { PostRunCancelResponseBody } from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
+import type { PostRunCancelResponseBody } from "@app/types/api/apps";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,5 +1,5 @@
-import type { GetRunResponseBody } from "@app/lib/api/apps";
 import { AppResource } from "@app/lib/resources/app_resource";
+import type { GetRunResponseBody } from "@app/types/api/apps";
 import type { AppType } from "@app/types/app";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status.ts
@@ -1,7 +1,7 @@
-import type { GetRunStatusResponseBody } from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import logger from "@app/logger/logger";
+import type { GetRunStatusResponseBody } from "@app/types/api/apps";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -1,7 +1,3 @@
-import type {
-  GetRunsResponseBody,
-  PostRunsResponseBody,
-} from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { getDustAppSecrets } from "@app/lib/api/dust_app_secrets";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
@@ -10,6 +6,10 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { ProviderModel } from "@app/lib/resources/storage/models/apps";
 import { dumpSpecification } from "@app/lib/specification";
 import logger from "@app/logger/logger";
+import type {
+  GetRunsResponseBody,
+  PostRunsResponseBody,
+} from "@app/types/api/apps";
 import { credentialsFromProviders } from "@app/types/api/credentials";
 import { CoreAPI } from "@app/types/core/core_api";
 import type { APIErrorResponse } from "@app/types/error";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -1,11 +1,11 @@
-import type {
-  GetAppsResponseBody,
-  PostAppResponseBody,
-} from "@app/lib/api/apps";
 import config from "@app/lib/api/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import logger from "@app/logger/logger";
+import type {
+  GetAppsResponseBody,
+  PostAppResponseBody,
+} from "@app/types/api/apps";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
-import type { GetDataSourceViewDocumentResponseBody } from "@app/lib/api/data_source_view";
 import logger from "@app/logger/logger";
+import type { GetDataSourceViewDocumentResponseBody } from "@app/types/api/data_source_view";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -1,11 +1,11 @@
 import config from "@app/lib/api/config";
-import type {
-  GetDataSourceViewResponseBody,
-  PatchDataSourceViewResponseBody,
-} from "@app/lib/api/data_source_view";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import logger from "@app/logger/logger";
+import type {
+  GetDataSourceViewResponseBody,
+  PatchDataSourceViewResponseBody,
+} from "@app/types/api/data_source_view";
 import { PatchDataSourceViewSchema } from "@app/types/api/public/spaces";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { ConnectorType } from "@app/types/data_source";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/[tableId]/index.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
-import type { GetDataSourceViewTableResponseBody } from "@app/lib/api/tables";
 import logger from "@app/logger/logger";
+import type { GetDataSourceViewTableResponseBody } from "@app/types/api/tables";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/index.ts
@@ -1,6 +1,6 @@
-import type { ListTablesResponseBody } from "@app/lib/api/data_source_view";
 import { getFlattenedContentNodesOfViewTypeForDataSourceView } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
+import type { ListTablesResponseBody } from "@app/types/api/data_source_view";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.ts
@@ -1,8 +1,8 @@
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
-import type { SearchTablesResponseBody } from "@app/lib/api/data_source_view";
 import { getCursorPaginationParams } from "@app/lib/api/pagination";
 import logger from "@app/logger/logger";
+import type { SearchTablesResponseBody } from "@app/types/api/data_source_view";
 import { CoreAPI } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -3,15 +3,15 @@ import {
   getDataSourcesUsageByCategory,
   getDataSourceViewsUsageByModelIds,
 } from "@app/lib/api/agent_data_sources";
-import type {
-  GetSpaceDataSourceViewsResponseBody,
-  PostSpaceDataSourceViewsResponseBody,
-} from "@app/lib/api/data_source_view";
 import { augmentDataSourceWithConnectorDetails } from "@app/lib/api/data_sources";
 import { isManaged, isWebsite } from "@app/lib/data_sources";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import type {
+  GetSpaceDataSourceViewsResponseBody,
+  PostSpaceDataSourceViewsResponseBody,
+} from "@app/types/api/data_source_view";
 import { ContentSchema } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type { DataSourceViewsWithDetails } from "@app/types/data_source_view";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/configuration.ts
@@ -1,10 +1,10 @@
 import config from "@app/lib/api/config";
+import { isWebsite } from "@app/lib/data_sources";
+import logger from "@app/logger/logger";
 import type {
   GetDataSourceConfigurationResponseBody,
   PatchDataSourceConfigurationResponseBody,
-} from "@app/lib/api/data_sources";
-import { isWebsite } from "@app/lib/data_sources";
-import logger from "@app/logger/logger";
+} from "@app/types/api/data_sources";
 import {
   ConnectorsAPI,
   UpdateConnectorConfigurationTypeSchema,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,8 +1,8 @@
 import apiConfig from "@app/lib/api/config";
-import type { PatchDocumentResponseBody } from "@app/lib/api/data_sources";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { isManaged, isWebsite } from "@app/lib/data_sources";
 import logger from "@app/logger/logger";
+import type { PatchDocumentResponseBody } from "@app/types/api/data_sources";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types/api/public/data_sources";
 import { CoreAPI } from "@app/types/core/core_api";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -1,5 +1,5 @@
-import type { PostDocumentResponseBody } from "@app/lib/api/data_sources";
 import { upsertDocument } from "@app/lib/api/data_sources";
+import type { PostDocumentResponseBody } from "@app/types/api/data_sources";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types/api/public/data_sources";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -1,7 +1,7 @@
 import { upsertTable } from "@app/lib/api/data_sources";
-import type { PatchTableResponseBody } from "@app/lib/api/tables";
 import { deleteTable } from "@app/lib/api/tables";
 import { PatchDataSourceTableRequestBodySchema } from "@app/types/api/public/data_sources";
+import type { PatchTableResponseBody } from "@app/types/api/tables";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/data_sources/index.ts
@@ -4,14 +4,8 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import config from "@app/lib/api/config";
-import type {
-  PostDataSourceRequestBody,
-  PostSpaceDataSourceResponseBody,
-} from "@app/lib/api/data_sources";
 import {
   createDataSourceWithoutProvider,
-  PostDataSourceRequestBodySchema,
-  PostDataSourceWithProviderRequestBodySchema,
   registerSlackWebhookRouterEntry,
 } from "@app/lib/api/data_sources";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
@@ -35,6 +29,14 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isDisposableEmailDomain } from "@app/lib/utils/disposable_email_domains";
 import logger from "@app/logger/logger";
+import type {
+  PostDataSourceRequestBody,
+  PostSpaceDataSourceResponseBody,
+} from "@app/types/api/data_sources";
+import {
+  PostDataSourceRequestBodySchema,
+  PostDataSourceWithProviderRequestBodySchema,
+} from "@app/types/api/data_sources";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { WebCrawlerConfigurationTypeSchema } from "@app/types/connectors/webcrawler";

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -3,7 +3,6 @@ import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_sour
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PostDataSourceRequestBody } from "@app/lib/api/data_sources";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import {
@@ -24,6 +23,7 @@ import {
   trackEvent,
   withTracking,
 } from "@app/lib/tracking";
+import type { PostDataSourceRequestBody } from "@app/types/api/data_sources";
 import type {
   ConnectorProvider,
   ConnectorType,

--- a/front/components/spaces/SpaceCreateAppModal.tsx
+++ b/front/components/spaces/SpaceCreateAppModal.tsx
@@ -1,9 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PostAppResponseBody } from "@app/lib/api/apps";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useApps } from "@app/lib/swr/apps";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
+import type { PostAppResponseBody } from "@app/types/api/apps";
 import { APP_NAME_REGEXP } from "@app/types/app";
 import type { APIError } from "@app/types/error";
 import type { SpaceType } from "@app/types/space";

--- a/front/components/workspace/settings/BotToggle.tsx
+++ b/front/components/workspace/settings/BotToggle.tsx
@@ -1,9 +1,9 @@
 import { updateConnectorConnectionId } from "@app/components/data_source/ConnectorPermissionsModal";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PostDataSourceRequestBody } from "@app/lib/api/data_sources";
 import { useRegionContext } from "@app/lib/auth/RegionContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useConnectorConfig, useToggleChatBot } from "@app/lib/swr/connectors";
+import type { PostDataSourceRequestBody } from "@app/types/api/data_sources";
 import type { ConnectorProvider, DataSourceType } from "@app/types/data_source";
 import { setupOAuthConnection } from "@app/types/oauth/client/setup";
 import type { OAuthProvider, OAuthUseCase } from "@app/types/oauth/lib";

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -1,9 +1,9 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { FileUploadRequestResponseBody } from "@app/lib/api/files/upload_metadata";
 import { clientFetch } from "@app/lib/egress/client";
 import type { FileUploadedRequestResponseBody } from "@app/lib/resources/file_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { FileUploadRequestResponseBody } from "@app/types/api/files/upload_metadata";
 import { isAPIErrorResponse } from "@app/types/error";
 import type {
   FileUseCase,

--- a/front/lib/api/apps.ts
+++ b/front/lib/api/apps.ts
@@ -5,9 +5,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
-import type { AppType, SpecificationType } from "@app/types/app";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { RunType } from "@app/types/run";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -15,44 +13,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 type AppDeploymentCheck = {
   appId: string;
   appHash: string;
-};
-
-export type GetAppsResponseBody = {
-  apps: AppType[];
-};
-
-export type PostAppResponseBody = {
-  app: AppType;
-};
-
-export type GetOrPostAppResponseBody = {
-  app: AppType;
-};
-
-export type GetRunsResponseBody = {
-  runs: RunType[];
-  total: number;
-};
-
-export type PostRunsResponseBody = {
-  run: RunType;
-};
-
-export type GetRunResponseBody = {
-  run: RunType;
-  spec: SpecificationType;
-};
-
-export type GetRunBlockResponseBody = {
-  run: RunType | null;
-};
-
-export type PostRunCancelResponseBody = {
-  success: boolean;
-};
-
-export type GetRunStatusResponseBody = {
-  run: RunType | null;
 };
 
 export async function softDeleteApp(

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -3,21 +3,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentUserRelationModel } from "@app/lib/models/agent/agent";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { z } from "zod";
-
-export type PostAgentUserFavoriteResponseBody = {
-  agentId: string;
-  userFavorite: boolean;
-};
-
-export const PostAgentUserFavoriteRequestBodySchema = z.object({
-  agentId: z.string(),
-  userFavorite: z.boolean(),
-});
-
-export type PostAgentUserFavoriteRequestBody = z.infer<
-  typeof PostAgentUserFavoriteRequestBodySchema
->;
 
 export async function setAgentUserFavorite({
   auth,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -18,16 +18,11 @@ import type { PatchDataSourceViewType } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import { ContentNodesViewTypeCodec } from "@app/types/connectors/content_nodes";
 import type { CoreAPIContentNode } from "@app/types/core/content_node";
-import type {
-  CoreAPIDatasourceViewFilter,
-  SearchWarningCode,
-} from "@app/types/core/core_api";
+import type { CoreAPIDatasourceViewFilter } from "@app/types/core/core_api";
 import { CoreAPI } from "@app/types/core/core_api";
-import type { CoreAPIDocument } from "@app/types/core/data_source";
-import type { AgentsUsageType, ConnectorType } from "@app/types/data_source";
+import type { AgentsUsageType } from "@app/types/data_source";
 import type {
   DataSourceViewContentNode,
-  DataSourceViewsWithDetails,
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import type { Result } from "@app/types/shared/result";
@@ -372,36 +367,8 @@ export async function listDataSourceViewsWithUsage(
   );
 }
 
-// Contract types for the data source view API endpoints. These are the
-// request/response body shapes used by the data source view API routes
-// under `front-api/routes/.../data_source_views/*`.
-
-export type GetDataSourceViewsResponseBody = {
-  dataSourceViews: DataSourceViewType[];
-};
-
-export type GetSpaceDataSourceViewsResponseBody<
-  IncludeDetails extends boolean = boolean,
-> = {
-  dataSourceViews: IncludeDetails extends true
-    ? DataSourceViewsWithDetails[]
-    : DataSourceViewType[];
-};
-
-export type PostSpaceDataSourceViewsResponseBody = {
-  dataSourceView: DataSourceViewType;
-};
-
-export type GetDataSourceViewResponseBody = {
-  dataSourceView: DataSourceViewType;
-  connector: ConnectorType | null;
-};
-
-export type PatchDataSourceViewResponseBody = {
-  dataSourceView: DataSourceViewType;
-  connector: ConnectorType | null;
-};
-
+// Request schema for the content-nodes endpoints. Kept in lib because it
+// references SortingParamsCodec from `@app/lib/api/pagination`.
 export const GetContentNodesOrChildrenRequestBody = z.object({
   internalIds: z.array(z.string().nullable()).optional(),
   parentId: z.string().optional(),
@@ -417,19 +384,4 @@ export type GetDataSourceViewContentNodes = {
   total: number;
   totalIsAccurate: boolean;
   nextPageCursor: string | null;
-};
-
-export type GetDataSourceViewDocumentResponseBody = {
-  document: CoreAPIDocument;
-};
-
-export type ListTablesResponseBody = {
-  tables: DataSourceViewContentNode[];
-  nextPageCursor: string | null;
-};
-
-export type SearchTablesResponseBody = {
-  tables: DataSourceViewContentNode[];
-  nextPageCursor: string | null;
-  warningCode: SearchWarningCode | null;
 };

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -38,11 +38,7 @@ import type { FrontDataSourceDocumentSectionType } from "@app/types/api/public/d
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
 import type { AdminCommandType } from "@app/types/connectors/admin/cli";
-import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
-import {
-  ConnectorConfigurationTypeSchema,
-  ConnectorsAPI,
-} from "@app/types/connectors/connectors_api";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { CoreAPIError, CoreAPITable } from "@app/types/core/core_api";
 import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
 import type {
@@ -61,12 +57,7 @@ import type {
   DataSourceWithConnectorDetailsType,
   WithConnector,
 } from "@app/types/data_source";
-import {
-  CONNECTOR_PROVIDERS,
-  isDataSourceNameValid,
-} from "@app/types/data_source";
-import type { DataSourceViewType } from "@app/types/data_source_view";
-import type { DocumentType } from "@app/types/document";
+import { isDataSourceNameValid } from "@app/types/data_source";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
 import type { PlanType } from "@app/types/plan";
 import type { LLMCredentialsType } from "@app/types/provider_credential";
@@ -84,53 +75,7 @@ import type {
 } from "@dust-tt/client";
 import assert from "assert";
 import type { Transaction } from "sequelize";
-import { z } from "zod";
 import { ConversationResource } from "../resources/conversation_resource";
-
-// Contract types for the spaces data source endpoints (Next + Hono).
-
-export const PostDataSourceWithProviderRequestBodySchema = z.object({
-  provider: z.enum(CONNECTOR_PROVIDERS),
-  name: z.string().optional(),
-  configuration: ConnectorConfigurationTypeSchema,
-  connectionId: z.string().optional(), // Required for some providers
-  relatedCredentialId: z.string().optional(), // Required for private integrations
-  extraConfig: z.record(z.string(), z.string()).optional(), // Used by slack private integrations
-});
-
-const PostDataSourceWithoutProviderRequestBodySchema = z.object({
-  name: z.string(),
-  description: z.string().nullable(),
-});
-
-export const PostDataSourceRequestBodySchema = z.union([
-  PostDataSourceWithoutProviderRequestBodySchema,
-  PostDataSourceWithProviderRequestBodySchema,
-]);
-
-export type PostDataSourceRequestBody = z.infer<
-  typeof PostDataSourceRequestBodySchema
->;
-
-export type PostSpaceDataSourceResponseBody = {
-  dataSource: DataSourceType;
-  dataSourceView: DataSourceViewType;
-};
-
-export type GetDataSourceConfigurationResponseBody = {
-  configuration: ConnectorConfiguration;
-};
-
-export type PatchDataSourceConfigurationResponseBody =
-  GetDataSourceConfigurationResponseBody;
-
-export type PostDocumentResponseBody = {
-  document: DocumentType | CoreAPILightDocument;
-};
-
-export type PatchDocumentResponseBody = {
-  document: DocumentType | CoreAPILightDocument;
-};
 
 const CORE_UNKNOWN_DATA_SOURCE_DELETE_ERROR_PREFIX =
   "Failed to delete data source (error: Unknown DataSource: ";

--- a/front/lib/api/dust_app_secrets.ts
+++ b/front/lib/api/dust_app_secrets.ts
@@ -4,14 +4,6 @@ import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import { decrypt } from "@app/types/shared/utils/encryption";
 import { redactString } from "@app/types/shared/utils/string_utils";
 
-export type GetDustAppSecretsResponseBody = {
-  secrets: DustAppSecretType[];
-};
-
-export type PostDustAppSecretsResponseBody = {
-  secret: DustAppSecretType;
-};
-
 export async function getDustAppSecrets(
   auth: Authenticator,
   clear = false

--- a/front/lib/api/files/upload_metadata.ts
+++ b/front/lib/api/files/upload_metadata.ts
@@ -2,14 +2,9 @@ import { shouldStampSandboxRawDelimited } from "@app/lib/api/files/sandbox_raw";
 import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
 import type {
   AllSupportedFileContentType,
-  FileTypeWithUploadUrl,
   FileUseCase,
   FileUseCaseMetadata,
 } from "@app/types/files";
-
-export interface FileUploadRequestResponseBody {
-  file: FileTypeWithUploadUrl;
-}
 
 export function buildEffectiveUseCaseMetadata({
   contentType,

--- a/front/lib/api/provider_credentials.ts
+++ b/front/lib/api/provider_credentials.ts
@@ -15,10 +15,6 @@ import { EnvironmentConfig } from "@app/types/shared/utils/config";
 import assert from "assert";
 import type { z } from "zod";
 
-export type GetProvidersCheckResponseBody =
-  | { ok: true }
-  | { ok: false; error: string };
-
 // Fraction of requests that use BYOK credentials during the transition period.
 const BYOK_TRANSITION_BYOK_KEYS_RATIO = 1; // 100%
 

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -28,7 +28,7 @@ export type {
   GetRunsResponseBody,
   PostRunCancelResponseBody,
   PostRunsResponseBody,
-} from "@app/lib/api/apps";
+} from "@app/types/api/apps";
 
 /**
  * Walks an app-run's `block_execution` traces and emits one `RunUsageType` per trace that carries

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -11,14 +11,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 
-export type PatchTableResponseBody = {
-  table?: { table_id: string };
-};
-
-export type GetDataSourceViewTableResponseBody = {
-  table: CoreAPITable;
-};
-
 type NotFoundError = {
   type: "table_not_found" | "file_not_found";
   message: string;

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -14,8 +14,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type {
   LightWorkspaceType,
-  RoleType,
-  UserMetadataType,
   UserType,
   UserTypeWithExtensionWorkspaces,
   UserTypeWithWorkspaces,
@@ -23,42 +21,6 @@ import type {
 
 import { MembershipResource } from "../resources/membership_resource";
 import { findWorkOSOrganizationsForUserId } from "./workos/organization_membership";
-
-export type GetMemberResponseBody = {
-  member: {
-    id: string;
-    username: string;
-    email: string;
-    firstName: string;
-    lastName: string | null;
-    fullName: string;
-    image: string | null;
-    revoked: boolean;
-    role: RoleType;
-    startAt: string | null;
-    endAt: string | null;
-  };
-};
-
-export type PostMemberResponseBody = {
-  member: UserTypeWithWorkspaces;
-};
-
-export type GetUserResponseBody = {
-  user: UserTypeWithWorkspaces & { subscriberHash: string | null };
-};
-
-export type PostUserMetadataResponseBody = {
-  success: boolean;
-};
-
-export type GetUserMetadataResponseBody = {
-  metadata: UserMetadataType | null;
-};
-
-export type PostUserMetadataKeyResponseBody = {
-  metadata: UserMetadataType;
-};
 
 /**
  * Returns the acting user for an authenticated request. Falls back to looking up the user by

--- a/front/lib/providers.ts
+++ b/front/lib/providers.ts
@@ -1,5 +1,5 @@
-import type { GetProvidersCheckResponseBody } from "@app/lib/api/provider_credentials";
 import { clientFetch } from "@app/lib/egress/client";
+import type { GetProvidersCheckResponseBody } from "@app/types/api/provider_credentials";
 import type { WorkspaceType } from "@app/types/user";
 
 import type { useProviders } from "./swr/apps";

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -1,9 +1,4 @@
 import type {
-  GetAppsResponseBody,
-  GetOrPostAppResponseBody,
-} from "@app/lib/api/apps";
-import type { GetDustAppSecretsResponseBody } from "@app/lib/api/dust_app_secrets";
-import type {
   GetRunBlockResponseBody,
   GetRunResponseBody,
   GetRunStatusResponseBody,
@@ -13,6 +8,11 @@ import type {
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
+import type {
+  GetAppsResponseBody,
+  GetOrPostAppResponseBody,
+} from "@app/types/api/apps";
+import type { GetDustAppSecretsResponseBody } from "@app/types/api/dust_app_secrets";
 import type { GetKeysResponseBody } from "@app/types/api/keys";
 import type { GetProvidersResponseBody } from "@app/types/api/providers";
 import type { AppType } from "@app/types/app";

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -23,8 +23,6 @@ import type {
 } from "@app/lib/api/assistant/observability/tool_latency";
 import type { GetToolStepIndexResponse } from "@app/lib/api/assistant/observability/tool_step_index";
 import type { GetVersionMarkersResponse } from "@app/lib/api/assistant/observability/version_markers";
-import type { PostAgentUserFavoriteRequestBody } from "@app/lib/api/assistant/user_relation";
-import type { GetMemberResponseBody } from "@app/lib/api/user";
 import { clientFetch } from "@app/lib/egress/client";
 import type {
   FetchAgentTemplateResponse,
@@ -43,6 +41,8 @@ import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api
 import type { GetAgentConfigurationsResponseBody } from "@app/types/api/assistant/configuration";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/types/api/assistant/mcp_configurations";
 import type { GetAgentSummaryResponseBody } from "@app/types/api/assistant/observability/summary";
+import type { PostAgentUserFavoriteRequestBody } from "@app/types/api/assistant/user_relation";
+import type { GetMemberResponseBody } from "@app/types/api/user";
 import type {
   AgentConfigurationType,
   AgentsGetViewType,

--- a/front/lib/swr/data_source_view_documents.ts
+++ b/front/lib/swr/data_source_view_documents.ts
@@ -1,9 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { GetDataSourceViewDocumentResponseBody } from "@app/lib/api/data_source_view";
-import type {
-  PatchDocumentResponseBody,
-  PostDocumentResponseBody,
-} from "@app/lib/api/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
@@ -11,6 +6,11 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type { GetDataSourceViewDocumentResponseBody } from "@app/types/api/data_source_view";
+import type {
+  PatchDocumentResponseBody,
+  PostDocumentResponseBody,
+} from "@app/types/api/data_sources";
 import type {
   PatchDataSourceDocumentRequestBody,
   PostDataSourceDocumentRequestBody,

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -1,12 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type {
-  ListTablesResponseBody,
-  SearchTablesResponseBody,
-} from "@app/lib/api/data_source_view";
-import type {
-  GetDataSourceViewTableResponseBody,
-  PatchTableResponseBody,
-} from "@app/lib/api/tables";
 import { clientFetch } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
@@ -15,7 +7,15 @@ import {
   useFetcher,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type {
+  ListTablesResponseBody,
+  SearchTablesResponseBody,
+} from "@app/types/api/data_source_view";
 import type { PatchDataSourceTableRequestBody } from "@app/types/api/public/data_sources";
+import type {
+  GetDataSourceViewTableResponseBody,
+  PatchTableResponseBody,
+} from "@app/types/api/tables";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -1,9 +1,7 @@
 import type {
   GetContentNodesOrChildrenRequestBodyType,
   GetDataSourceViewContentNodes,
-  GetDataSourceViewsResponseBody,
 } from "@app/lib/api/data_source_view";
-import type { GetDataSourceConfigurationResponseBody } from "@app/lib/api/data_sources";
 import type {
   CursorPaginationParams,
   SortingParams,
@@ -15,7 +13,9 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { GetDataSourceViewsResponseBody } from "@app/types/api/data_source_view";
 import type { PostTagSearchBody } from "@app/types/api/data_source_view_tags";
+import type { GetDataSourceConfigurationResponseBody } from "@app/types/api/data_sources";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -1,10 +1,5 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import type {
-  GetDataSourceViewResponseBody,
-  GetSpaceDataSourceViewsResponseBody,
-} from "@app/lib/api/data_source_view";
-import type { PostSpaceDataSourceResponseBody } from "@app/lib/api/data_sources";
-import type {
   CursorPaginationParams,
   SortingParams,
 } from "@app/lib/api/pagination";
@@ -30,6 +25,11 @@ import {
   useSWRInfiniteWithDefaults,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
+import type {
+  GetDataSourceViewResponseBody,
+  GetSpaceDataSourceViewsResponseBody,
+} from "@app/types/api/data_source_view";
+import type { PostSpaceDataSourceResponseBody } from "@app/types/api/data_sources";
 import type { SpacesLookupResponseBody } from "@app/types/api/projects/list";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,8 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type {
-  GetUserMetadataResponseBody,
-  GetUserResponseBody,
-} from "@app/lib/api/user";
 import { clientFetch } from "@app/lib/egress/client";
 import type { GetWorkspaceUsageStatusResponseBody } from "@app/lib/metronome/user_block";
 import type { GetUserApprovalsResponseBody } from "@app/lib/resources/user_resource";
@@ -16,6 +12,10 @@ import {
 import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
 import type { GetPendingInvitationsResponseBody } from "@app/types/api/invitation";
 import type { GetSlackNotificationResponseBody } from "@app/types/api/me/slack_notifications";
+import type {
+  GetUserMetadataResponseBody,
+  GetUserResponseBody,
+} from "@app/types/api/user";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/types/api/apps.ts
+++ b/front/types/api/apps.ts
@@ -1,0 +1,40 @@
+import type { AppType, SpecificationType } from "@app/types/app";
+import type { RunType } from "@app/types/run";
+
+export type GetAppsResponseBody = {
+  apps: AppType[];
+};
+
+export type PostAppResponseBody = {
+  app: AppType;
+};
+
+export type GetOrPostAppResponseBody = {
+  app: AppType;
+};
+
+export type GetRunsResponseBody = {
+  runs: RunType[];
+  total: number;
+};
+
+export type PostRunsResponseBody = {
+  run: RunType;
+};
+
+export type GetRunResponseBody = {
+  run: RunType;
+  spec: SpecificationType;
+};
+
+export type GetRunBlockResponseBody = {
+  run: RunType | null;
+};
+
+export type PostRunCancelResponseBody = {
+  success: boolean;
+};
+
+export type GetRunStatusResponseBody = {
+  run: RunType | null;
+};

--- a/front/types/api/assistant/user_relation.ts
+++ b/front/types/api/assistant/user_relation.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export type PostAgentUserFavoriteResponseBody = {
+  agentId: string;
+  userFavorite: boolean;
+};
+
+export const PostAgentUserFavoriteRequestBodySchema = z.object({
+  agentId: z.string(),
+  userFavorite: z.boolean(),
+});
+
+export type PostAgentUserFavoriteRequestBody = z.infer<
+  typeof PostAgentUserFavoriteRequestBodySchema
+>;

--- a/front/types/api/data_source_view.ts
+++ b/front/types/api/data_source_view.ts
@@ -1,0 +1,49 @@
+import type { SearchWarningCode } from "@app/types/core/core_api";
+import type { CoreAPIDocument } from "@app/types/core/data_source";
+import type { ConnectorType } from "@app/types/data_source";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewsWithDetails,
+  DataSourceViewType,
+} from "@app/types/data_source_view";
+
+export type GetDataSourceViewsResponseBody = {
+  dataSourceViews: DataSourceViewType[];
+};
+
+export type GetSpaceDataSourceViewsResponseBody<
+  IncludeDetails extends boolean = boolean,
+> = {
+  dataSourceViews: IncludeDetails extends true
+    ? DataSourceViewsWithDetails[]
+    : DataSourceViewType[];
+};
+
+export type PostSpaceDataSourceViewsResponseBody = {
+  dataSourceView: DataSourceViewType;
+};
+
+export type GetDataSourceViewResponseBody = {
+  dataSourceView: DataSourceViewType;
+  connector: ConnectorType | null;
+};
+
+export type PatchDataSourceViewResponseBody = {
+  dataSourceView: DataSourceViewType;
+  connector: ConnectorType | null;
+};
+
+export type GetDataSourceViewDocumentResponseBody = {
+  document: CoreAPIDocument;
+};
+
+export type ListTablesResponseBody = {
+  tables: DataSourceViewContentNode[];
+  nextPageCursor: string | null;
+};
+
+export type SearchTablesResponseBody = {
+  tables: DataSourceViewContentNode[];
+  nextPageCursor: string | null;
+  warningCode: SearchWarningCode | null;
+};

--- a/front/types/api/data_sources.ts
+++ b/front/types/api/data_sources.ts
@@ -1,0 +1,51 @@
+import type { ConnectorConfiguration } from "@app/types/connectors/configuration";
+import { ConnectorConfigurationTypeSchema } from "@app/types/connectors/connectors_api";
+import type { CoreAPILightDocument } from "@app/types/core/data_source";
+import type { DataSourceType } from "@app/types/data_source";
+import { CONNECTOR_PROVIDERS } from "@app/types/data_source";
+import type { DataSourceViewType } from "@app/types/data_source_view";
+import type { DocumentType } from "@app/types/document";
+import { z } from "zod";
+
+export const PostDataSourceWithProviderRequestBodySchema = z.object({
+  provider: z.enum(CONNECTOR_PROVIDERS),
+  name: z.string().optional(),
+  configuration: ConnectorConfigurationTypeSchema,
+  connectionId: z.string().optional(), // Required for some providers
+  relatedCredentialId: z.string().optional(), // Required for private integrations
+  extraConfig: z.record(z.string(), z.string()).optional(), // Used by slack private integrations
+});
+
+const PostDataSourceWithoutProviderRequestBodySchema = z.object({
+  name: z.string(),
+  description: z.string().nullable(),
+});
+
+export const PostDataSourceRequestBodySchema = z.union([
+  PostDataSourceWithoutProviderRequestBodySchema,
+  PostDataSourceWithProviderRequestBodySchema,
+]);
+
+export type PostDataSourceRequestBody = z.infer<
+  typeof PostDataSourceRequestBodySchema
+>;
+
+export type PostSpaceDataSourceResponseBody = {
+  dataSource: DataSourceType;
+  dataSourceView: DataSourceViewType;
+};
+
+export type GetDataSourceConfigurationResponseBody = {
+  configuration: ConnectorConfiguration;
+};
+
+export type PatchDataSourceConfigurationResponseBody =
+  GetDataSourceConfigurationResponseBody;
+
+export type PostDocumentResponseBody = {
+  document: DocumentType | CoreAPILightDocument;
+};
+
+export type PatchDocumentResponseBody = {
+  document: DocumentType | CoreAPILightDocument;
+};

--- a/front/types/api/dust_app_secrets.ts
+++ b/front/types/api/dust_app_secrets.ts
@@ -1,0 +1,9 @@
+import type { DustAppSecretType } from "@app/types/dust_app_secret";
+
+export type GetDustAppSecretsResponseBody = {
+  secrets: DustAppSecretType[];
+};
+
+export type PostDustAppSecretsResponseBody = {
+  secret: DustAppSecretType;
+};

--- a/front/types/api/files/upload_metadata.ts
+++ b/front/types/api/files/upload_metadata.ts
@@ -1,0 +1,5 @@
+import type { FileTypeWithUploadUrl } from "@app/types/files";
+
+export interface FileUploadRequestResponseBody {
+  file: FileTypeWithUploadUrl;
+}

--- a/front/types/api/provider_credentials.ts
+++ b/front/types/api/provider_credentials.ts
@@ -1,0 +1,3 @@
+export type GetProvidersCheckResponseBody =
+  | { ok: true }
+  | { ok: false; error: string };

--- a/front/types/api/tables.ts
+++ b/front/types/api/tables.ts
@@ -1,0 +1,9 @@
+import type { CoreAPITable } from "@app/types/core/core_api";
+
+export type PatchTableResponseBody = {
+  table?: { table_id: string };
+};
+
+export type GetDataSourceViewTableResponseBody = {
+  table: CoreAPITable;
+};

--- a/front/types/api/user.ts
+++ b/front/types/api/user.ts
@@ -1,0 +1,41 @@
+import type {
+  RoleType,
+  UserMetadataType,
+  UserTypeWithWorkspaces,
+} from "@app/types/user";
+
+export type GetMemberResponseBody = {
+  member: {
+    id: string;
+    username: string;
+    email: string;
+    firstName: string;
+    lastName: string | null;
+    fullName: string;
+    image: string | null;
+    revoked: boolean;
+    role: RoleType;
+    startAt: string | null;
+    endAt: string | null;
+  };
+};
+
+export type PostMemberResponseBody = {
+  member: UserTypeWithWorkspaces;
+};
+
+export type GetUserResponseBody = {
+  user: UserTypeWithWorkspaces & { subscriberHash: string | null };
+};
+
+export type PostUserMetadataResponseBody = {
+  success: boolean;
+};
+
+export type GetUserMetadataResponseBody = {
+  metadata: UserMetadataType | null;
+};
+
+export type PostUserMetadataKeyResponseBody = {
+  metadata: UserMetadataType;
+};


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types and zod schemas out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

These 9 files were initially deferred as "public" because v1 routes import from them — but symbol-level analysis showed the v1 routes import only their **functions** (which stay in lib/api), never their DTO *types*. The DTO types are internal (the public counterparts already live separately in `@dust-tt/client`), so they get the normal `types/api` treatment.

- Files: `apps`, `assistant/user_relation`, `dust_app_secrets`, `files/upload_metadata`, `provider_credentials`, `tables`, `user`, `data_sources`, `data_source_view`.
- All business functions stay in lib/api; v1 routes importing them are untouched.
- 38 consumers updated; `lib/api/run.ts` re-export shim repointed to `types/api/apps`.

**Partial:** `data_source_view.ts` keeps `GetContentNodesOrChildrenRequestBody` (references `SortingParamsCodec`, an io-ts codec in `lib/api/pagination` — a real `types → lib` gotcha) for a later pass.

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)