### PR TITLE
refactor(front): finalize conversation/types DTO migration

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,11 +1,11 @@
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
-import type { PatchConversationResponseBody } from "@app/lib/api/assistant/conversation/types";
 import { addBackwardCompatibleConversationFields } from "@app/lib/api/v1/backward_compatibility";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import {
   type GetConversationResponseType,
   PatchConversationRequestSchema,
+  type PatchConversationResponseSchema,
 } from "@dust-tt/client";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -22,6 +22,10 @@ import files from "./files";
 import mentions from "./mentions";
 import messages from "./messages";
 import tools from "./tools";
+
+type PatchConversationResponseBody = z.infer<
+  typeof PatchConversationResponseSchema
+>;
 
 const ParamsSchema = z.object({
   cId: z.string(),

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,10 +1,6 @@
 import { deleteOrLeaveConversation } from "@app/lib/api/assistant/conversation";
 import { clearActionRequiredIfNoBlockedActions } from "@app/lib/api/assistant/conversation/blocked_actions";
 import { updateConversationTitle } from "@app/lib/api/assistant/conversation/title";
-import type {
-  GetConversationResponseBody,
-  PatchConversationResponseBody,
-} from "@app/lib/api/assistant/conversation/types";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
@@ -15,6 +11,10 @@ import {
   moveConversationToProject,
 } from "@app/lib/api/projects/conversations";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type {
+  GetConversationResponseBody,
+  PatchConversationResponseBody,
+} from "@app/types/api/assistant/conversation/types";
 import { ConversationError } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -5,10 +5,6 @@ import {
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type {
-  GetConversationsResponseBody,
-  PostConversationsResponseBody,
-} from "@app/lib/api/assistant/conversation/types";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -16,6 +12,10 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type {
+  GetConversationsResponseBody,
+  PostConversationsResponseBody,
+} from "@app/types/api/assistant/conversation/types";
 import { InternalPostConversationsRequestBodySchema } from "@app/types/api/internal/assistant";
 import type { UserMessageType } from "@app/types/assistant/conversation";
 import { ConversationError } from "@app/types/assistant/conversation";

--- a/front/hooks/conversations/useConversation.ts
+++ b/front/hooks/conversations/useConversation.ts
@@ -1,5 +1,5 @@
-import type { GetConversationResponseBody } from "@app/lib/api/assistant/conversation/types";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationResponseBody } from "@app/types/api/assistant/conversation/types";
 import type {
   ConversationError,
   ConversationWithoutContentType,

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -1,7 +1,7 @@
 import { usePodConversationsSummary } from "@app/hooks/conversations/usePodConversations";
-import type { PatchConversationsRequestBody } from "@app/lib/api/assistant/conversation/types";
 import { clientFetch } from "@app/lib/egress/client";
 import logger from "@app/logger/logger";
+import type { PatchConversationsRequestBody } from "@app/types/api/assistant/conversation/types";
 import type {
   ConversationListItemType,
   ConversationWithoutContentType,

--- a/front/hooks/conversations/useConversationUrlAccessMode.ts
+++ b/front/hooks/conversations/useConversationUrlAccessMode.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PatchConversationsRequestBody } from "@app/lib/api/assistant/conversation/types";
 import { clientFetch } from "@app/lib/egress/client";
+import type { PatchConversationsRequestBody } from "@app/types/api/assistant/conversation/types";
 import type { ConversationUrlAccessMode } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback, useState } from "react";

--- a/front/hooks/conversations/useConversations.ts
+++ b/front/hooks/conversations/useConversations.ts
@@ -1,9 +1,9 @@
-import type { GetConversationsResponseBody } from "@app/lib/api/assistant/conversation/types";
 import {
   emptyArray,
   useFetcher,
   useSWRInfiniteWithDefaults,
 } from "@app/lib/swr/swr";
+import type { GetConversationsResponseBody } from "@app/types/api/assistant/conversation/types";
 import type { ConversationListItemType } from "@app/types/assistant/conversation";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -1,11 +1,11 @@
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PostConversationsResponseBody } from "@app/lib/api/assistant/conversation/types";
 import { useClientType } from "@app/lib/context/clientType";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher } from "@app/lib/swr/swr";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { PostConversationsResponseBody } from "@app/types/api/assistant/conversation/types";
 import type {
   InternalPostConversationsRequestBodySchema,
   SupportedContentNodeContentType,

--- a/front/types/api/assistant/conversation/types.ts
+++ b/front/types/api/assistant/conversation/types.ts
@@ -49,6 +49,9 @@ export type GetConversationResponseBody = {
   conversation: ConversationWithoutContentType;
 };
 
+// Response body for the internal PATCH conversation endpoint. The public v1
+// endpoint uses the SDK's PatchConversationResponseSchema instead (the internal
+// API surface cannot import from @dust-tt/client).
 export type PatchConversationResponseBody = {
   success: boolean;
 };


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types and zod schemas out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

Stacked on #27830. Finalizes the `assistant/conversation` domain.

- 5 internal DTOs moved to `types/api/assistant/conversation/types.ts` (`Get`/`PostConversationsResponseBody`, `PatchConversationsRequestBody`(+`Schema`), `GetConversationResponseBody`). `lib/api/assistant/conversation/types.ts` deleted.
- `PatchConversationResponseBody` deduped: the public **v1** route derives its type from the SDK's existing `PatchConversationResponseSchema` (`@dust-tt/client` imports are lint-restricted to `/v1/`); the **internal** route uses a `types/api` copy. Correct split — public contract in the SDK, the internal endpoint's identical shape in `types/api`.
- 8 consumers updated.

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)