### PR TITLE
refactor(front): move skills-import request DTOs out of lib/api into types/api

### DIFF
--- a/front-api/routes/w/[wId]/skills/import/index.ts
+++ b/front-api/routes/w/[wId]/skills/import/index.ts
@@ -1,12 +1,8 @@
-import type {
-  ImportSkillsRequestBody,
-  ImportSkillsResponseBody,
-} from "@app/lib/api/skills/detection/github/import_skills";
-import {
-  ImportSkillsRequestBodySchema,
-  importSkillsFromGitHub,
-} from "@app/lib/api/skills/detection/github/import_skills";
+import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
+import { importSkillsFromGitHub } from "@app/lib/api/skills/detection/github/import_skills";
 import logger from "@app/logger/logger";
+import type { ImportSkillsRequestBody } from "@app/types/api/skills/detection/github/import_skills";
+import { ImportSkillsRequestBodySchema } from "@app/types/api/skills/detection/github/import_skills";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsBuilder } from "@front-api/middlewares/ensure_role";

--- a/front/lib/api/skills/detection/github/import_skills.ts
+++ b/front/lib/api/skills/detection/github/import_skills.ts
@@ -27,16 +27,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { Octokit } from "@octokit/core";
 import path from "path";
-import { z } from "zod";
-
-export const ImportSkillsRequestBodySchema = z.object({
-  repoUrl: z.string(),
-  names: z.array(z.string()),
-});
-
-export type ImportSkillsRequestBody = z.infer<
-  typeof ImportSkillsRequestBodySchema
->;
 
 export type ImportSkillsResponseBody = {
   imported: SkillType[];

--- a/front/types/api/skills/detection/github/import_skills.ts
+++ b/front/types/api/skills/detection/github/import_skills.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ImportSkillsRequestBodySchema = z.object({
+  repoUrl: z.string(),
+  names: z.array(z.string()),
+});
+
+export type ImportSkillsRequestBody = z.infer<
+  typeof ImportSkillsRequestBodySchema
+>;


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types and zod schemas out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

Stacked on #27831.

- Moved `ImportSkillsRequestBodySchema` + `ImportSkillsRequestBody` to `types/api/skills/detection/github/import_skills.ts`; dropped the now-unused zod import from the lib file.
- `ImportSkillsResponseBody` intentionally **stays in lib/api (deferred)**: a full move requires porting `SkillType` → `SkillSchema` → the divergent `MCPServerViewSchema` into the published SDK plus a build/publish — its own project, tracked separately.
- 1 consumer (internal skills/import route) split: response body + function from `@app/lib`, request body + schema from `@app/types`.

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)