### PR TITLE
Fix: do not completely ignore the AGENTS.md file if it's too big.

### DIFF
--- a/front/components/editor/MarkdownFileEditor.tsx
+++ b/front/components/editor/MarkdownFileEditor.tsx
@@ -2,6 +2,7 @@ import {
   MarkdownEditor,
   type MarkdownEditorProps,
 } from "@app/components/editor/MarkdownEditor";
+import { useSendNotification } from "@app/hooks/useNotification";
 import {
   getFilePathContentApiPath,
   useFileContentByUrl,
@@ -38,8 +39,10 @@ export function MarkdownFileEditor({
   onContentLoaded,
   onSaved,
   readOnly,
+  maxCharacterCount,
   ...markdownEditorProps
 }: MarkdownFileEditorProps) {
+  const sendNotification = useSendNotification();
   const resolvedUrl = useMemo(
     () => (filePath ? getFilePathContentApiPath(owner, filePath) : null),
     [filePath, owner]
@@ -114,6 +117,15 @@ export function MarkdownFileEditor({
       return;
     }
 
+    if (maxCharacterCount !== undefined && draft.length > maxCharacterCount) {
+      sendNotification({
+        type: "error",
+        title: "Content too long",
+        description: `Shorten the file to ${maxCharacterCount} characters or fewer before saving.`,
+      });
+      return;
+    }
+
     setIsSaving(true);
     const result = await writeFileContent({
       canonicalPath: filePath,
@@ -132,8 +144,10 @@ export function MarkdownFileEditor({
     filePath,
     isDirty,
     isSaving,
+    maxCharacterCount,
     onSaved,
     saveContentType,
+    sendNotification,
     writeFileContent,
   ]);
 
@@ -175,11 +189,22 @@ export function MarkdownFileEditor({
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-2">
+      {maxCharacterCount !== undefined && draft.length > maxCharacterCount ? (
+        <ContentMessage
+          title="Content exceeds the character limit"
+          variant="warning"
+          className="w-full"
+        >
+          This file is longer than {maxCharacterCount} characters. You can read
+          and edit it, but trim it down before saving.
+        </ContentMessage>
+      ) : null}
       <MarkdownEditor
         {...markdownEditorProps}
         value={draft}
         onChange={handleChange}
         readOnly={readOnly}
+        maxCharacterCount={maxCharacterCount}
       />
       {canPersist && isDirty && (
         <div className="flex gap-2">

--- a/front/lib/api/projects/constants.ts
+++ b/front/lib/api/projects/constants.ts
@@ -7,7 +7,7 @@ export const PROJECT_CONTEXT_FOLDER_NAME = "Context";
 export const POD_AGENTS_MD_FILENAME = "AGENTS.md";
 
 /** Matches the character limit enforced in Pod settings UI. */
-export const POD_AGENTS_MD_MAX_CHARACTER_COUNT = 4096;
+export const POD_AGENTS_MD_MAX_CHARACTER_COUNT = 8192;
 
 export function getPodAgentsMdScopedPath(podId: string): string {
   return podScopedPath(podId, POD_AGENTS_MD_FILENAME);

--- a/front/lib/editor/build_markdown_editor_extensions.ts
+++ b/front/lib/editor/build_markdown_editor_extensions.ts
@@ -122,11 +122,9 @@ export function buildMarkdownEditorExtensions({
   }
 
   if (maxCharacterCount !== undefined) {
-    extensions.push(
-      CharacterCount.configure({
-        limit: maxCharacterCount,
-      })
-    );
+    // Count only — do not set `limit`. TipTap trims initial content when `limit`
+    // is set, which hides oversized files instead of showing them for editing.
+    extensions.push(CharacterCount.configure({}));
   }
 
   return extensions;


### PR DESCRIPTION
## Description

Two bugs with oversized `AGENTS.md` files:

- **TipTap was silently trimming content** when `CharacterCount.configure({ limit })` was set — loading a file above the limit caused TipTap to cut the content at load time, so the editor appeared to show (and potentially save) a truncated version. Fixed by dropping the `limit` from `CharacterCount` so it counts only, and enforcing the cap explicitly in `MarkdownFileEditor`'s save handler instead. A warning banner (`ContentMessage`) now surfaces when content exceeds the limit, and saving is blocked until the file is trimmed.
- **`POD_AGENTS_MD_MAX_CHARACTER_COUNT` was too low** (4096 → 8192), causing valid AGENTS.md files to be ignored in prompt injection via `readPodAgentsMdContent`.

## Tests

Tested locally: opened an oversized AGENTS.md in Pod settings — warning banner appears, save is blocked with an error notification. Trimming below 8192 chars restores normal save behavior.

## Risk

Low. Changes are confined to the `MarkdownFileEditor` component and the shared `POD_AGENTS_MD_MAX_CHARACTER_COUNT` constant. No data is deleted or migrated; the limit increase only allows more content through, and the editor-side enforcement is additive (warning + blocked save).

## Deploy Plan

Deploy `front` only.
