### PR TITLE
feat(llm): restore flash-lite `none` reasoning effort in the new router

### DIFF
--- a/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/inputConfig.ts
@@ -1,4 +1,4 @@
-import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import { GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import {
   inputConfigSchema,
   temperatureSchema,
@@ -6,12 +6,12 @@ import {
 import { z } from "zod";
 
 // Provider-wide input config: the widest reasoning contract any Gemini model
-// accepts (all four native thinking levels). Per-model schemas narrow this
-// further (e.g. Pro drops `minimal`).
+// accepts (`none` + all four native thinking levels). Per-model schemas narrow
+// this further (e.g. Pro drops `none`/`minimal`).
 export const googleAiStudioConfigSchema = inputConfigSchema.extend({
   reasoning: z
     .object({
-      effort: z.enum(GEMINI_SUPPORTED_REASONING_EFFORTS),
+      effort: z.enum(GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS),
     })
     .optional(),
   cacheKey: z.undefined(),

--- a/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite.ts
@@ -1,5 +1,5 @@
 import { googleAiStudioConfigSchema } from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
-import { GEMINI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
+import { GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/google_ai_studio/reasoning_efforts";
 import { GEMINI_3_1_FLASH_LITE_MODEL_ID } from "@app/lib/model_constructors/types/model_ids";
 import { z } from "zod";
 
@@ -8,10 +8,11 @@ export const MAX_OUTPUT_TOKENS = 65_536;
 
 const DEFAULT_REASONING_EFFORT = "minimal";
 
+// Flash-Lite is the only Gemini model that exposes `none` (legacy parity).
 export const configSchema = googleAiStudioConfigSchema.extend({
   reasoning: z
     .object({
-      effort: z.enum(GEMINI_SUPPORTED_REASONING_EFFORTS),
+      effort: z.enum(GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS),
     })
     .default({ effort: DEFAULT_REASONING_EFFORT }),
 });

--- a/front/lib/model_constructors/providers/google_ai_studio/reasoning_efforts.ts
+++ b/front/lib/model_constructors/providers/google_ai_studio/reasoning_efforts.ts
@@ -1,6 +1,8 @@
 // Native Gemini 3.x thinking levels exposed as reasoning efforts. Every Gemini
 // model supports low/medium/high; Flash and Flash-Lite additionally support
-// `minimal`. Gemini always thinks, so there is no `none` effort.
+// `minimal`. Flash-Lite additionally supports `none` — Gemini 3 has no "off"
+// thinking level, so (matching the legacy router) `none` maps to the minimum
+// thinking budget with thoughts hidden.
 export const GEMINI_PRO_SUPPORTED_REASONING_EFFORTS = [
   "low",
   "medium",
@@ -12,5 +14,11 @@ export const GEMINI_SUPPORTED_REASONING_EFFORTS = [
   ...GEMINI_PRO_SUPPORTED_REASONING_EFFORTS,
 ] as const;
 
+// Widest Gemini reasoning contract (Flash-Lite). Other models narrow it.
+export const GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS = [
+  "none",
+  ...GEMINI_SUPPORTED_REASONING_EFFORTS,
+] as const;
+
 export type GeminiSupportedReasoningEffort =
-  (typeof GEMINI_SUPPORTED_REASONING_EFFORTS)[number];
+  (typeof GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS)[number];

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/index.ts
@@ -6,7 +6,7 @@ import {
   assistantToolCallRequestToPart,
   type ContentBlockConverters,
   conversationToContents,
-  effortToThinkingLevel,
+  effortToThinkingConfig,
   forceToolNameToToolConfig,
   outputFormatToResponseSchema,
   systemMessagesToSystemInstruction,
@@ -83,12 +83,9 @@ export function WithGoogleGenAIInputConverter<
               ? [{ functionDeclarations: tools.map(toFunctionDeclaration) }]
               : undefined,
           toolConfig: forceToolNameToToolConfig(tools, forceTool),
-          thinkingConfig: {
-            includeThoughts: true,
-            thinkingLevel: reasoning
-              ? effortToThinkingLevel(reasoning.effort)
-              : undefined,
-          },
+          thinkingConfig: reasoning
+            ? effortToThinkingConfig(reasoning.effort)
+            : { includeThoughts: true },
           maxOutputTokens: this.constructor.maxOutputTokens,
           ...(outputFormat
             ? {

--- a/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/input/utils.ts
@@ -25,6 +25,7 @@ import type {
   FunctionDeclaration,
   Part,
   SchemaUnion,
+  ThinkingConfig,
   ToolConfig,
 } from "@google/genai";
 import { FunctionCallingConfigMode, ThinkingLevel } from "@google/genai";
@@ -323,18 +324,22 @@ export function forceToolNameToToolConfig(
     : undefined;
 }
 
-export function effortToThinkingLevel(
+export function effortToThinkingConfig(
   effort: GeminiSupportedReasoningEffort
-): ThinkingLevel {
+): ThinkingConfig {
   switch (effort) {
+    case "none":
+      // Gemini 3 has no "off" thinking level; matching the legacy router, the
+      // minimum budget with thoughts hidden is the closest to disabling it.
+      return { thinkingBudget: 128, includeThoughts: false };
     case "minimal":
-      return ThinkingLevel.MINIMAL;
+      return { thinkingLevel: ThinkingLevel.MINIMAL, includeThoughts: true };
     case "low":
-      return ThinkingLevel.LOW;
+      return { thinkingLevel: ThinkingLevel.LOW, includeThoughts: true };
     case "medium":
-      return ThinkingLevel.MEDIUM;
+      return { thinkingLevel: ThinkingLevel.MEDIUM, includeThoughts: true };
     case "high":
-      return ThinkingLevel.HIGH;
+      return { thinkingLevel: ThinkingLevel.HIGH, includeThoughts: true };
     default:
       assertNever(effort);
   }

--- a/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/google_ai_studio_global_gemini_3_1_flash_lite.test.ts
@@ -17,19 +17,21 @@ const setup: StreamSetup = {
   // `null` runs the case with its default checkers; a checker array overrides
   // them. Every case always runs.
   tests: {
-    // Gemini 3 supports none/low/medium/high (+ maximal → high). The `none`
-    // effort is unsupported and rejected by the config schema.
-    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
-    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
-    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
-    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
-    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    // Flash-Lite supports none/minimal/low/medium/high. `maximal` is
+    // unsupported and rejected by the config schema. `none` maps to the minimum
+    // thinking budget with thoughts hidden (legacy parity).
     "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
     "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-none": null,
 
     "simple/no-tools/t-default/r-minimal": null,
     "simple/no-tools/t-0/r-minimal": null,


### PR DESCRIPTION
## Description

Gemini 3 has no `ThinkingLevel.NONE`/`OFF` member, so the new `google_genai` converter had no way to express the legacy "minimal thinking, hidden thoughts" floor that the old router applied for the `none` reasoning effort.

This change:
- Maps `none` → `{ thinkingBudget: 128, includeThoughts: false }` in `effortToThinkingConfig` (replacing the previous `effortToThinkingLevel`, which could only return a level). This matches the legacy `POST_GEMINI_3_THINKING_CONFIG_MAPPING.none` exactly.
- Re-adds `none` as a supported reasoning effort for Gemini 3.1 Flash-Lite (`GEMINI_FLASH_LITE_SUPPORTED_REASONING_EFFORTS` = none/minimal/low/medium/high). Flash-3.5 and Pro are unchanged.

Net effect: the existing `google_ai_studio/global/gemini-3.1-flash-lite` endpoint reaches parity with the legacy router on the `none` effort. Behaviour for every other effort is byte-identical to before.

This is the first of a 3-PR stack adding Gemini-on-Vertex to the new router; it is independent and shippable on its own.

## Tests

`dust-llm-class-tdd` live integration suite against the real API:
- Flash-Lite `r-none` cases now run with default checkers (previously asserted `INPUT_CONFIGURATION_ERROR`); `reasoning/.../r-none` → `HAS_NO_REASONING` confirms `includeThoughts: false` surfaces no thoughts. 7/7 green.
- Full `google_ai_studio_global_gemini_3_1_flash_lite` suite green.
- `tsgo --noEmit` clean; biome clean (pre-commit).

## Risk

Low. Converter change is behaviour-preserving for all non-`none` efforts (same `ThinkingConfig` object). `none` is additive for flash-lite. Easy to roll back.

## Deploy Plan

Standard. No migration, no flag.