### PR TITLE
feat(llm): add Gemini-on-Vertex stream client and endpoints

### DIFF
--- a/front/lib/model_constructors/stream/clients/agent_platform_google.ts
+++ b/front/lib/model_constructors/stream/clients/agent_platform_google.ts
@@ -1,0 +1,76 @@
+import type { BaseEndpointConfiguration } from "@app/lib/model_constructors/configuration";
+import {
+  type GoogleAiStudioInputConfig,
+  googleAiStudioConfigSchema,
+} from "@app/lib/model_constructors/providers/google_ai_studio/inputConfig";
+import { WithGoogleGenAIInputConverter } from "@app/lib/model_constructors/sdk/google_genai/converters/input";
+import { WithGoogleGenAIOutputConverter } from "@app/lib/model_constructors/sdk/google_genai/converters/output";
+import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/google_genai/converters/output/utils";
+import { StreamEndpoint } from "@app/lib/model_constructors/stream/endpoint";
+import type { Credentials } from "@app/lib/model_constructors/types/credentials";
+import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
+import { AGENT_PLATFORM_API } from "@app/lib/model_constructors/types/provider_apis";
+import { GOOGLE_AI_STUDIO_PROVIDER_ID } from "@app/lib/model_constructors/types/provider_ids";
+import type {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from "@google/genai";
+import { GoogleGenAI } from "@google/genai";
+
+// Vertex AI `location` the endpoint targets. Only `global` today: Gemini 3.x
+// preview models are published solely to the global endpoint (they 404 on
+// `europe-west1`), and the native `generateContent` API does not serve the
+// `eu` multi-region alias that the Anthropic partner API uses. Legacy reaches
+// the same place — it passes no location, so `@google/genai` defaults to
+// `global`. Extend with a specific region (e.g. `europe-west1`) once these
+// models become available there.
+export type AgentPlatformGoogleLocation = "global";
+
+// Gemini-on-Vertex transport. Same @google/genai SDK and converters as the AI
+// Studio client; only the client construction differs (Vertex project +
+// location instead of an API key). Mirrors the legacy `useVertex` branch and is
+// the path non-BYOK plans depend on.
+export abstract class AgentPlatformGoogleStream extends WithGoogleGenAIInputConverter(
+  WithGoogleGenAIOutputConverter(
+    StreamEndpoint<
+      GenerateContentParameters,
+      GenerateContentResponse,
+      GoogleAiStudioInputConfig
+    >
+  )
+) {
+  // Narrow `this.constructor` so the per-endpoint static below is visible.
+  declare ["constructor"]: BaseEndpointConfiguration<GoogleAiStudioInputConfig> & {
+    regionalEndpoint: AgentPlatformGoogleLocation;
+  };
+
+  static readonly providerId = GOOGLE_AI_STUDIO_PROVIDER_ID;
+  static readonly api = AGENT_PLATFORM_API;
+
+  static readonly regionalEndpoint: AgentPlatformGoogleLocation;
+
+  static readonly configSchema = googleAiStudioConfigSchema;
+
+  private readonly client: GoogleGenAI;
+
+  constructor({ AGENT_PLATFORM_PROJECT_ID }: Credentials) {
+    super();
+    this.client = new GoogleGenAI({
+      vertexai: true,
+      project: AGENT_PLATFORM_PROJECT_ID,
+      location: this.constructor.regionalEndpoint,
+    });
+  }
+
+  async *streamRaw(
+    input: GenerateContentParameters
+  ): AsyncGenerator<GenerateContentResponse> {
+    yield* await this.client.models.generateContentStream(input);
+  }
+
+  async *rawStreamOutputToEvents(
+    stream: AsyncGenerator<GenerateContentResponse>
+  ): AsyncGenerator<ModelResponseEvent> {
+    yield* rawOutputToEvents(stream, this.metadata(), this);
+  }
+}

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
@@ -1,0 +1,23 @@
+import { WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { AgentPlatformGoogleStream } from "@app/lib/model_constructors/stream/clients/agent_platform_google";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream extends WithGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  AgentPlatformGoogleStream
+) {
+  // https://cloud.google.com/vertex-ai/generative-ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 1.0,
+    cacheHit: 0.025,
+    standardInput: 0.25,
+    standardOutput: 1.5,
+  };
+
+  static readonly region = EUROPE;
+  static readonly regionalEndpoint = "global";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_pro.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_pro.ts
@@ -1,0 +1,23 @@
+import { WithGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_1_pro";
+import { AgentPlatformGoogleStream } from "@app/lib/model_constructors/stream/clients/agent_platform_google";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class AgentPlatformEuropeGeminiThreeDotOneProStream extends WithGoogleAiStudioGeminiThreeDotOneProConfig(
+  AgentPlatformGoogleStream
+) {
+  // https://cloud.google.com/vertex-ai/generative-ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 4.5,
+    cacheHit: 0.4,
+    standardInput: 4.0,
+    standardOutput: 18.0,
+  };
+
+  static readonly region = EUROPE;
+  static readonly regionalEndpoint = "global";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeGeminiThreeDotOneProStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
+++ b/front/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
@@ -1,0 +1,23 @@
+import { WithGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/model_constructors/providers/google_ai_studio/models/gemini_3_5_flash";
+import { AgentPlatformGoogleStream } from "@app/lib/model_constructors/stream/clients/agent_platform_google";
+import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
+import { EUROPE } from "@app/lib/model_constructors/types/regions";
+
+export class AgentPlatformEuropeGeminiThreeDotFiveFlashStream extends WithGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  AgentPlatformGoogleStream
+) {
+  // https://cloud.google.com/vertex-ai/generative-ai/pricing (verify before launch).
+  static readonly tokenPricing = {
+    cacheCreated: 1.0,
+    cacheHit: 0.15,
+    standardInput: 1.5,
+    standardOutput: 9.0,
+  };
+
+  static readonly region = EUROPE;
+  static readonly regionalEndpoint = "global";
+
+  static readonly id = this.buildId();
+}
+
+AgentPlatformEuropeGeminiThreeDotFiveFlashStream satisfies StreamEndpointConstructor;

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
+import {
+  INPUT_CONFIGURATION_ERROR,
+  SUCCESS,
+} from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Flash-Lite supports none/minimal/low/medium/high. `maximal` is
+    // unsupported and rejected by the config schema. `none` maps to the minimum
+    // thinking budget with thoughts hidden (legacy parity).
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-none": null,
+    "simple/no-tools/t-0/r-none": null,
+    "simple/no-tools/t-0.1/r-none": null,
+    "simple/no-tools/t-1/r-none": null,
+    "calc/calc/t-default/r-none/force-tool": null,
+    "reasoning/no-tools/t-default/r-none": null,
+    "output-format/json-schema/t-default/r-none": null,
+
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-1/r-minimal": null,
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    // Unlike Pro/Flash, this lightweight model does not reliably surface thought
+    // content at `low` effort, so we only assert the stream completes.
+    "reasoning/no-tools/t-default/r-low": [SUCCESS],
+
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_flash_lite.test.ts
+runStreamEndpointTests(
+  AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
+  setup
+);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_pro.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_pro.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_pro";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeGeminiThreeDotOneProStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Pro supports low/medium/high only. `minimal`, `none`, and `maximal` are
+    // unsupported and rejected by the config schema.
+    "simple/no-tools/t-default/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-minimal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_1_pro.test.ts
+runStreamEndpointTests(AgentPlatformEuropeGeminiThreeDotOneProStream, setup);

--- a/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
+++ b/front/lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+import { INPUT_CONFIGURATION_ERROR } from "@app/lib/model_constructors/test/cases";
+import { runStreamEndpointTests } from "@app/lib/model_constructors/test/runner";
+import type { StreamSetup } from "@app/lib/model_constructors/test/setup";
+
+const setup: StreamSetup = {
+  createInstance: () =>
+    new AgentPlatformEuropeGeminiThreeDotFiveFlashStream({
+      AGENT_PLATFORM_PROJECT_ID: process.env.VERTEX_AI_PROJECT_ID ?? "",
+    }),
+  // `null` runs the case with its default checkers; a checker array overrides
+  // them. Every case always runs.
+  tests: {
+    // Flash supports minimal/low/medium/high. `none` and `maximal` are
+    // unsupported and rejected by the config schema.
+    "simple/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-default/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-0.1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-none": [INPUT_CONFIGURATION_ERROR],
+    "simple/no-tools/t-1/r-maximal": [INPUT_CONFIGURATION_ERROR],
+    "calc/calc/t-default/r-none/force-tool": [INPUT_CONFIGURATION_ERROR],
+    "reasoning/no-tools/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+    "output-format/json-schema/t-default/r-none": [INPUT_CONFIGURATION_ERROR],
+
+    "simple/no-tools/t-default/r-default": null,
+    "simple/no-tools/t-default/r-minimal": null,
+    "simple/no-tools/t-default/r-low": null,
+    "simple/no-tools/t-default/r-medium": null,
+    "simple/no-tools/t-default/r-high": null,
+    "simple/no-tools/t-0/r-default": null,
+    "simple/no-tools/t-0/r-minimal": null,
+    "simple/no-tools/t-0/r-low": null,
+    "simple/no-tools/t-0/r-medium": null,
+    "simple/no-tools/t-0/r-high": null,
+    "simple/no-tools/t-0.1/r-default": null,
+    "simple/no-tools/t-0.1/r-minimal": null,
+    "simple/no-tools/t-0.1/r-low": null,
+    "simple/no-tools/t-0.1/r-medium": null,
+    "simple/no-tools/t-0.1/r-high": null,
+    "simple/no-tools/t-1/r-default": null,
+    "simple/no-tools/t-1/r-minimal": null,
+    "simple/no-tools/t-1/r-low": null,
+    "simple/no-tools/t-1/r-medium": null,
+    "simple/no-tools/t-1/r-high": null,
+
+    // Gemini ignores the Anthropic-style cache markers (it uses implicit
+    // caching), so this behaves like a plain "say Hi" prompt.
+    "cache/no-tools/t-default/r-default": null,
+
+    "calc/calc/t-default/r-medium": null,
+    "calc/calc/t-0.1/r-default": null,
+    "calc/calc/t-0.1/r-medium": null,
+
+    "calc/calc/t-default/r-default/force-tool-default": null,
+    "calc/calc/t-default/r-default/force-tool": null,
+
+    "reasoning/no-tools/t-default/r-low": null,
+
+    "output-format/json-schema/t-default/r-high": null,
+
+    "following/no-tools/t-default/r-default": null,
+  },
+};
+
+// NODE_ENV=test RUN_LLM_TEST=true npm run test -- --config lib/model_constructors/test/vite.config.js --bail 1 lib/model_constructors/test/endpoints/agent_platform_eu_gemini_3_5_flash.test.ts
+runStreamEndpointTests(AgentPlatformEuropeGeminiThreeDotFiveFlashStream, setup);


### PR DESCRIPTION
## Description

Adds the Vertex AI (agent-platform) transport for Gemini to the new `model_constructors` router, for parity with the legacy `GoogleLLM` `useVertex` path.

- New client `stream/clients/agent_platform_google.ts` (`AgentPlatformGoogleStream`): constructs `new GoogleGenAI({ vertexai: true, project, location: "global" })`, `providerId = google_ai_studio`, `api = agent-platform`. Reuses the existing `google_genai` input/output converters and the `WithGoogleAiStudioGemini*Config` model mixins unchanged — the Vertex request contract is identical to AI Studio.
- Three endpoint classes `stream/endpoints/agent_platform_eu_gemini_{3_1_flash_lite,3_1_pro,3_5_flash}.ts` with per-endpoint pricing and `region: "eu"`.
- Three live integration tests mirroring the AI Studio sibling key sets.

**Why `location: "global"` and not `"eu"`/`"europe-west1"`:** the native `@google/genai` `:streamGenerateContent` API does not serve the `eu` multi-region alias (returns a generic 404), unlike Anthropic's `:rawPredict` partner API which does — that's why Anthropic-on-Vertex can use `region: "eu"` but Gemini can't. Gemini 3.x preview models are also not published to `europe-west1`. The legacy router passes no location, which `@google/genai` v1.43 defaults to `"global"` — so `"global"` is exact legacy parity. `region: "eu"` is kept as the Dust-facing residency label (matches legacy's hardcoded `inferenceRegion: "eu"`).

Stacked on #27835. **Not wired into the registries here** — registration lands in the follow-up so each PR typechecks independently (`DUST_STREAM_ENDPOINTS` is exhaustive over `StreamEndpointId`, so the two registrations must land atomically).

> ⚠️ **Review callout — pricing:** `tokenPricing` on the three endpoints currently mirrors the AI Studio sibling values. Vertex EU prices may differ; please confirm against the Vertex pricing page before launch.

## Tests

`dust-llm-class-tdd` live suite against Vertex (requires `gcloud` ADC + `VERTEX_AI_PROJECT_ID`):
- flash-lite 40/40, pro 40/40, 3.5-flash 40/40 (one transient 429 on a full flash-lite run, passes on retry — known project quota gap, not a code issue).
- `tsgo --noEmit` clean **in isolation** (verified on this branch tip without the follow-up's registrations); biome clean.

## Risk

Low and inert: the endpoints are not registered in this PR, so nothing routes to them yet. New client is additive.

## Deploy Plan

Standard. The endpoints become reachable only after the follow-up registration PR.