### PR TITLE
feat(llm): register Gemini-on-Vertex endpoints in the LLM routers

### DIFF
--- a/front/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite.ts
@@ -1,0 +1,20 @@
+import { WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_flash_lite";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
+
+export class DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream extends WithDustGoogleAiStudioGeminiThreeDotOneFlashLiteConfig(
+  AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(
+  DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream
+);

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_pro.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_pro.ts
@@ -1,0 +1,18 @@
+import { WithDustGoogleAiStudioGeminiThreeDotOneProConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_1_pro";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_pro";
+
+export class DustAgentPlatformEuropeGeminiThreeDotOneProStream extends WithDustGoogleAiStudioGeminiThreeDotOneProConfig(
+  AgentPlatformEuropeGeminiThreeDotOneProStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeGeminiThreeDotOneProStream);

--- a/front/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
+++ b/front/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash.ts
@@ -1,0 +1,18 @@
+import { WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig } from "@app/lib/llms/providers/google_ai_studio/models/gemini_3_5_flash";
+import { defineDustStreamEndpoint } from "@app/lib/llms/stream/dust_stream_endpoint";
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
+
+export class DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream extends WithDustGoogleAiStudioGeminiThreeDotFiveFlashConfig(
+  AgentPlatformEuropeGeminiThreeDotFiveFlashStream
+) {
+  static readonly endpointFilter = {
+    or: [
+      {
+        featureFlags: { contains: "use_vertex_for_supported_models" as const },
+      },
+      { isCreditPriced: { eq: true } },
+    ],
+  };
+}
+
+defineDustStreamEndpoint(DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream);

--- a/front/lib/llms/stream/index.ts
+++ b/front/lib/llms/stream/index.ts
@@ -1,6 +1,9 @@
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustAgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { DustAgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
+import { DustAgentPlatformEuropeGeminiThreeDotOneProStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_1_pro";
+import { DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/llms/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
 import { DustAnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { DustAnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { DustAnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/llms/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
@@ -44,6 +47,12 @@ export const DUST_STREAM_ENDPOINTS = {
     DustAnthropicGlobalClaudeOpusFourDotSixStream,
   [DustAgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     DustAgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [DustAgentPlatformEuropeGeminiThreeDotOneProStream.id]:
+    DustAgentPlatformEuropeGeminiThreeDotOneProStream,
+  [DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
+    DustAgentPlatformEuropeGeminiThreeDotFiveFlashStream,
+  [DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
+    DustAgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
   [DustGoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
     DustGoogleAiStudioGlobalGeminiThreeDotOneProStream,
   [DustGoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:

--- a/front/lib/model_constructors/stream/index.ts
+++ b/front/lib/model_constructors/stream/index.ts
@@ -1,6 +1,9 @@
 import type { StreamEndpointConstructor } from "@app/lib/model_constructors/stream/configuration";
 import { AgentPlatformEuropeClaudeHaikuFourDotFiveStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_haiku_four_dot_five";
 import { AgentPlatformEuropeClaudeSonnetFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_claude_sonnet_four_dot_six";
+import { AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_flash_lite";
+import { AgentPlatformEuropeGeminiThreeDotOneProStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_1_pro";
+import { AgentPlatformEuropeGeminiThreeDotFiveFlashStream } from "@app/lib/model_constructors/stream/endpoints/agent_platform_eu_gemini_3_5_flash";
 import { AnthropicGlobalClaudeOpusFourDotEightStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_eight";
 import { AnthropicGlobalClaudeOpusFourDotSevenStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_seven";
 import { AnthropicGlobalClaudeOpusFourDotSixStream } from "@app/lib/model_constructors/stream/endpoints/anthropic_global_claude_opus_four_dot_six";
@@ -37,6 +40,12 @@ export const STREAM_ENDPOINTS = {
     AnthropicGlobalClaudeOpusFourDotSixStream,
   [AgentPlatformEuropeClaudeSonnetFourDotSixStream.id]:
     AgentPlatformEuropeClaudeSonnetFourDotSixStream,
+  [AgentPlatformEuropeGeminiThreeDotOneProStream.id]:
+    AgentPlatformEuropeGeminiThreeDotOneProStream,
+  [AgentPlatformEuropeGeminiThreeDotFiveFlashStream.id]:
+    AgentPlatformEuropeGeminiThreeDotFiveFlashStream,
+  [AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream.id]:
+    AgentPlatformEuropeGeminiThreeDotOneFlashLiteStream,
   [GoogleAiStudioGlobalGeminiThreeDotOneProStream.id]:
     GoogleAiStudioGlobalGeminiThreeDotOneProStream,
   [GoogleAiStudioGlobalGeminiThreeDotFiveFlashStream.id]:


### PR DESCRIPTION
## Description

Activates the Gemini-on-Vertex endpoints added in #27836 by wiring them into both routers:
- Registers the three `agent-platform/eu` Gemini endpoints in `STREAM_ENDPOINTS` (`model_constructors`).
- Adds the three Dust routing wrappers `llms/stream/endpoints/agent_platform_eu_gemini_*.ts` and registers them in `DUST_STREAM_ENDPOINTS`.

Both registrations land together by necessity: `DUST_STREAM_ENDPOINTS satisfies Record<StreamEndpointId, ...>` is exhaustive, so adding a `STREAM_ENDPOINTS` key without its Dust wrapper would fail to typecheck.

Stacked on #27836 (← #27835).

## Tests

- Full live suites green via the endpoint classes (see #27836).
- `tsgo --noEmit` clean on this tip (full state, both registries populated); biome clean.

## Risk

Medium — this is the change that makes traffic actually route to Vertex for matching workspaces. Mitigated by the `endpointFilter` gate (flag / credit-priced only) and easy rollback (revert the registration). Validate the gate audience (callout above) before merge.

## Deploy Plan

Merge after #27835 and #27836. Roll out by enabling `use_vertex_for_supported_models` for the target workspaces; monitor Vertex EU error/latency before broadening.