### PR TITLE
feat(analytics): index is_free_seat to reset consumed credits on free to paid upgrade

### DIFF
--- a/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
+++ b/front/lib/analytics/indices/agent_message_analytics_2.mappings.json
@@ -30,6 +30,9 @@
     "status": {
       "type": "keyword"
     },
+    "is_free_seat": {
+      "type": "boolean"
+    },
     "latency_ms": {
       "type": "integer"
     },

--- a/front/lib/analytics/migrations/20260623_add_is_free_seat_to_agent_message_analytics_2.http
+++ b/front/lib/analytics/migrations/20260623_add_is_free_seat_to_agent_message_analytics_2.http
@@ -1,0 +1,8 @@
+PUT /front.agent_message_analytics_2/_mapping
+{
+  "properties": {
+    "is_free_seat": {
+      "type": "boolean"
+    }
+  }
+}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -184,25 +184,38 @@ type ConsumedCreditsBucket = {
   credits?: estypes.AggregationsSumAggregate;
 };
 
-type ConsumedCreditsAggs = {
+type ConsumedCreditsGroup = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumedCreditsBucket>;
+};
+
+type ConsumedCreditsAggs = {
+  paid_users?: ConsumedCreditsGroup;
+  free_users?: ConsumedCreditsGroup;
 };
 
 // Per-user consumed AWU credits for the current billing cycle, summed from the
 // analytics index (`cost.full_awu`, precomputed at index time) by Elasticsearch.
 // This replaces the per-user Metronome usage scan that previously dominated the
-// members-table load: one aggregation returns every requested user's
-// consumption. Keyed by user sId (the analytics `user_id`), so no Metronome
-// free-seat id mapping is needed. Filtered to the billed message statuses so
-// the consumed total matches Metronome (failed messages are indexed with a cost
-// but never billed). Returns an empty map on any failure so the table still
-// renders (the consumed column shows 0).
+// members-table load.
+//
+// Consumption is split on the `is_free_seat` dimension (the seat the author held
+// when each message was indexed), mirroring Metronome's free-seat user-id split
+// (`free-<sId>` vs `<sId>`): free-seat users see their free-seat usage, paid (and
+// seatless) users see only their paid-seat usage. A free→paid upgrade therefore
+// drops the user's pre-upgrade free usage (its docs stay `is_free_seat: true`),
+// while paid→paid changes (pro→max) keep counting (all `is_free_seat: false`).
+//
+// Filtered to the billed message statuses so the consumed total matches Metronome
+// (failed messages are indexed with a cost but never billed). Returns an empty
+// map on any failure so the table still renders (the consumed column shows 0).
 async function fetchConsumedAwuCreditsByUserId({
   workspace,
   userIds,
+  freeSeatUserIds,
 }: {
   workspace: LightWorkspaceType;
   userIds: string[];
+  freeSeatUserIds: string[];
 }): Promise<Map<string, number>> {
   if (userIds.length === 0) {
     return new Map();
@@ -223,12 +236,14 @@ async function fetchConsumedAwuCreditsByUserId({
   }
   const { cycleStart, cycleEnd } = periodResult.value;
 
+  const freeSeatUserIdSet = new Set(freeSeatUserIds);
+  const paidSeatUserIds = userIds.filter((id) => !freeSeatUserIdSet.has(id));
+
   const result = await searchAnalytics<never, ConsumedCreditsAggs>(
     {
       bool: {
         filter: [
           { term: { workspace_id: workspace.sId } },
-          { terms: { user_id: userIds } },
           // Mirror the billing-side filter: Metronome only emits usage events
           // and credits for these statuses (see usage_queue activities and
           // credit_cost), so failed messages carry a non-zero `cost.full_awu`
@@ -249,11 +264,46 @@ async function fetchConsumedAwuCreditsByUserId({
     },
     {
       aggregations: {
-        // Scoped to `userIds`, so `size` covers every distinct bucket and the
-        // per-bucket sums are exact (no cross-shard top-N approximation).
-        by_user: {
-          terms: { field: "user_id", size: userIds.length },
-          aggs: { credits: { sum: { field: "cost.full_awu" } } },
+        // Paid (and seatless) users: count only paid-seat usage, excluding any
+        // free-seat usage from before an upgrade. `must_not is_free_seat=true`
+        // (rather than `is_free_seat=false`) so historical docs indexed before
+        // this field existed — which can't be backfilled — count as paid.
+        paid_users: {
+          filter: {
+            bool: {
+              filter: [{ terms: { user_id: paidSeatUserIds } }],
+              must_not: [{ term: { is_free_seat: true } }],
+            },
+          },
+          aggs: {
+            by_user: {
+              terms: {
+                field: "user_id",
+                size: Math.max(1, paidSeatUserIds.length),
+              },
+              aggs: { credits: { sum: { field: "cost.full_awu" } } },
+            },
+          },
+        },
+        // Free-seat users: count their free-seat usage.
+        free_users: {
+          filter: {
+            bool: {
+              filter: [
+                { terms: { user_id: freeSeatUserIds } },
+                { term: { is_free_seat: true } },
+              ],
+            },
+          },
+          aggs: {
+            by_user: {
+              terms: {
+                field: "user_id",
+                size: Math.max(1, freeSeatUserIds.length),
+              },
+              aggs: { credits: { sum: { field: "cost.full_awu" } } },
+            },
+          },
         },
       },
       size: 0,
@@ -268,13 +318,18 @@ async function fetchConsumedAwuCreditsByUserId({
   }
 
   const consumedByUserId = new Map<string, number>();
-  for (const bucket of bucketsToArray<ConsumedCreditsBucket>(
-    result.value.aggregations?.by_user?.buckets
-  )) {
-    consumedByUserId.set(
-      String(bucket.key),
-      Math.round(bucket.credits?.value ?? 0)
-    );
+  for (const group of [
+    result.value.aggregations?.paid_users,
+    result.value.aggregations?.free_users,
+  ]) {
+    for (const bucket of bucketsToArray<ConsumedCreditsBucket>(
+      group?.by_user?.buckets
+    )) {
+      consumedByUserId.set(
+        String(bucket.key),
+        Math.round(bucket.credits?.value ?? 0)
+      );
+    }
   }
   return consumedByUserId;
 }
@@ -1039,20 +1094,32 @@ export async function getMembersUsage({
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-  // Fetch membership details and Metronome data in parallel for the
-  // current page of users.
+  // Memberships are needed up front to split consumed credits on seat type:
+  // free-seat users are counted from `is_free_seat: true` usage, everyone else
+  // from `is_free_seat: false`.
+  const membershipsResult = await MembershipResource.getActiveMemberships({
+    workspace,
+    users,
+  });
+  const membershipByUserId = new Map(
+    membershipsResult.memberships.map((m) => [m.userId, m])
+  );
+  const freeSeatUserIds = users.flatMap((u) =>
+    membershipByUserId.get(u.id)?.seatType === "free" ? [u.sId] : []
+  );
+
+  // Fetch Metronome data and consumed credits in parallel for the current page.
   const [
-    membershipsResult,
     perUserTotalConsumedCredits,
     seatDataByUserId,
     seatBalanceByUserId,
     perUserSpendLimits,
     freeCreditAlertIdsByUserId,
   ] = await Promise.all([
-    MembershipResource.getActiveMemberships({ workspace, users }),
     fetchConsumedAwuCreditsByUserId({
       workspace,
       userIds: users.map((u) => u.sId),
+      freeSeatUserIds,
     }),
     fetchSeatDataForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,
@@ -1099,8 +1166,6 @@ export async function getMembersUsage({
       workspace,
       userIds: memberships.map((m) => m.userId),
     });
-
-  const membershipByUserId = new Map(memberships.map((m) => [m.userId, m]));
 
   // Bulk-fetch near-limit flags from Redis (poke-only, gated on includeAlertLinks).
   const nearLimitByUserId = includeAlertLinks

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -179,18 +179,18 @@ export type MembersUsagePaginationInput = z.infer<
   typeof MembersUsagePaginationSchema
 >;
 
-type ConsumedCreditsBucket = {
-  key: string;
+type ConsumedCreditsSplit = {
   credits?: estypes.AggregationsSumAggregate;
 };
 
-type ConsumedCreditsGroup = {
-  by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumedCreditsBucket>;
+type ConsumedCreditsBucket = {
+  key: string;
+  paid_credits?: ConsumedCreditsSplit;
+  free_credits?: ConsumedCreditsSplit;
 };
 
 type ConsumedCreditsAggs = {
-  paid_users?: ConsumedCreditsGroup;
-  free_users?: ConsumedCreditsGroup;
+  by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumedCreditsBucket>;
 };
 
 // Per-user consumed AWU credits for the current billing cycle, summed from the
@@ -237,13 +237,13 @@ async function fetchConsumedAwuCreditsByUserId({
   const { cycleStart, cycleEnd } = periodResult.value;
 
   const freeSeatUserIdSet = new Set(freeSeatUserIds);
-  const paidSeatUserIds = userIds.filter((id) => !freeSeatUserIdSet.has(id));
 
   const result = await searchAnalytics<never, ConsumedCreditsAggs>(
     {
       bool: {
         filter: [
           { term: { workspace_id: workspace.sId } },
+          { terms: { user_id: userIds } },
           // Mirror the billing-side filter: Metronome only emits usage events
           // and credits for these statuses (see usage_queue activities and
           // credit_cost), so failed messages carry a non-zero `cost.full_awu`
@@ -264,43 +264,27 @@ async function fetchConsumedAwuCreditsByUserId({
     },
     {
       aggregations: {
-        // Paid (and seatless) users: count only paid-seat usage, excluding any
-        // free-seat usage from before an upgrade. `must_not is_free_seat=true`
-        // (rather than `is_free_seat=false`) so historical docs indexed before
-        // this field existed — which can't be backfilled — count as paid.
-        paid_users: {
-          filter: {
-            bool: {
-              filter: [{ terms: { user_id: paidSeatUserIds } }],
-              must_not: [{ term: { is_free_seat: true } }],
-            },
+        // One bucket per user, each splitting consumption on the `is_free_seat`
+        // dimension so we can pick the side matching the user's current seat:
+        //   - `paid_credits`: paid-seat usage. `must_not is_free_seat=true`
+        //     (rather than `is_free_seat=false`) so historical docs indexed
+        //     before this field existed — which can't be backfilled — count as
+        //     paid.
+        //   - `free_credits`: free-seat usage (from before an upgrade).
+        by_user: {
+          terms: {
+            field: "user_id",
+            size: Math.max(1, userIds.length),
           },
           aggs: {
-            by_user: {
-              terms: {
-                field: "user_id",
-                size: Math.max(1, paidSeatUserIds.length),
+            paid_credits: {
+              filter: {
+                bool: { must_not: [{ term: { is_free_seat: true } }] },
               },
               aggs: { credits: { sum: { field: "cost.full_awu" } } },
             },
-          },
-        },
-        // Free-seat users: count their free-seat usage.
-        free_users: {
-          filter: {
-            bool: {
-              filter: [
-                { terms: { user_id: freeSeatUserIds } },
-                { term: { is_free_seat: true } },
-              ],
-            },
-          },
-          aggs: {
-            by_user: {
-              terms: {
-                field: "user_id",
-                size: Math.max(1, freeSeatUserIds.length),
-              },
+            free_credits: {
+              filter: { term: { is_free_seat: true } },
               aggs: { credits: { sum: { field: "cost.full_awu" } } },
             },
           },
@@ -318,18 +302,16 @@ async function fetchConsumedAwuCreditsByUserId({
   }
 
   const consumedByUserId = new Map<string, number>();
-  for (const group of [
-    result.value.aggregations?.paid_users,
-    result.value.aggregations?.free_users,
-  ]) {
-    for (const bucket of bucketsToArray<ConsumedCreditsBucket>(
-      group?.by_user?.buckets
-    )) {
-      consumedByUserId.set(
-        String(bucket.key),
-        Math.round(bucket.credits?.value ?? 0)
-      );
-    }
+  for (const bucket of bucketsToArray<ConsumedCreditsBucket>(
+    result.value.aggregations?.by_user?.buckets
+  )) {
+    const userId = String(bucket.key);
+    // Free-seat users count their free-seat usage; paid (and seatless) users
+    // count only their paid-seat usage.
+    const split = freeSeatUserIdSet.has(userId)
+      ? bucket.free_credits
+      : bucket.paid_credits;
+    consumedByUserId.set(userId, Math.round(split?.credits?.value ?? 0));
   }
   return consumedByUserId;
 }
@@ -1008,9 +990,22 @@ async function resolveMembersUsagePageUsers({
   const sortKeyByUserId = new Map<string, number>();
   switch (orderColumn) {
     case "consumedAwuCredits": {
+      // Split consumed credits on seat type so free-seat users sort by their
+      // free-seat usage and everyone else by their paid-seat usage.
+      const { memberships } = await MembershipResource.getActiveMemberships({
+        workspace,
+        users: allUsers,
+      });
+      const seatTypeByUserModelId = new Map(
+        memberships.map((m) => [m.userId, m.seatType])
+      );
+      const freeSeatUserIds = allUsers.flatMap((u) =>
+        seatTypeByUserModelId.get(u.id) === "free" ? [u.sId] : []
+      );
       const creditsByUserId = await fetchConsumedAwuCreditsByUserId({
         workspace,
         userIds: allUsers.map((u) => u.sId),
+        freeSeatUserIds,
       });
       for (const u of allUsers) {
         sortKeyByUserId.set(u.sId, creditsByUserId.get(u.sId) ?? 0);

--- a/front/lib/resources/membership_resource.test.ts
+++ b/front/lib/resources/membership_resource.test.ts
@@ -228,6 +228,36 @@ describe("MembershipResource", () => {
         expect(inMemoryCache.has(cacheKey)).toBe(false);
       });
     });
+
+    describe("getActiveSeatTypeForUserModelId()", () => {
+      it("returns the active seat type", async () => {
+        const user = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, user, {
+          role: "user",
+          seatType: "free",
+        });
+
+        const seatType =
+          await MembershipResource.getActiveSeatTypeForUserModelId({
+            workspace,
+            userModelId: user.id,
+          });
+
+        expect(seatType).toBe("free");
+      });
+
+      it("returns null when the user has no active membership", async () => {
+        const user = await UserFactory.basic();
+
+        const seatType =
+          await MembershipResource.getActiveSeatTypeForUserModelId({
+            workspace,
+            userModelId: user.id,
+          });
+
+        expect(seatType).toBeNull();
+      });
+    });
   });
 
   describe("firstUsedAt behavior", () => {

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -659,6 +659,31 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     return memberships[0];
   }
 
+  // Returns the active seat type for a user (by model id) in a workspace, or
+  // null when the user has no active membership. Lightweight single-column read
+  // for hot paths (e.g. analytics indexing) that only need the seat type.
+  static async getActiveSeatTypeForUserModelId({
+    workspace,
+    userModelId,
+    transaction,
+  }: {
+    workspace: LightWorkspaceType;
+    userModelId: ModelId;
+    transaction?: Transaction;
+  }): Promise<MembershipSeatType | null> {
+    const row = await this.model.findOne({
+      attributes: ["seatType"],
+      where: {
+        workspaceId: workspace.id,
+        userId: userModelId,
+        startAt: { [Op.lte]: new Date() },
+        endAt: { [Op.or]: [{ [Op.eq]: null }, { [Op.gte]: new Date() }] },
+      },
+      transaction,
+    });
+    return row ? row.seatType : null;
+  }
+
   static async getMembersCountForWorkspace({
     workspace,
     activeOnly,

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -112,6 +112,7 @@ async function seedProgrammaticUsage(
       message_id: messageId,
       skills_used: [],
       status: "succeeded",
+      is_free_seat: false,
       timestamp: timestamp.toISOString(),
       tokens: {
         prompt: randomInt(TOKEN_PROMPT_RANGE.min, TOKEN_PROMPT_RANGE.max),

--- a/front/scripts/seed/factories/seedAnalytics.ts
+++ b/front/scripts/seed/factories/seedAnalytics.ts
@@ -132,6 +132,7 @@ export async function seedAnalytics(
       message_id: message.sId,
       skills_used: [],
       status: agentMessage.status,
+      is_free_seat: false,
       timestamp: new Date(message.createdAt).toISOString(),
       tokens: {
         prompt: 0,

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -39,6 +39,7 @@ import { AgentMCPServerConfigurationResource } from "@app/lib/resources/agent_mc
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
@@ -180,6 +181,18 @@ export async function storeAgentAnalytics(
 
   const isFreeUsage = contextOrigin !== null && isFreeOrigin(contextOrigin);
 
+  // Seat type at index time, to stamp `is_free_seat`. Mirrors Metronome's
+  // free-seat user-id split: free-seat usage is dropped from a user's consumed
+  // credits once they upgrade to a paid seat. Defaults to non-free when the
+  // message has no associated user (system/doNotAssociateUser messages).
+  const seatType = userModel
+    ? await MembershipResource.getActiveSeatTypeForUserModelId({
+        workspace: auth.getNonNullableWorkspace(),
+        userModelId: userModel.id,
+      })
+    : null;
+  const isFreeSeat = seatType === "free";
+
   const runUsages = await fetchRunUsagesForMessage(auth, agentAgentMessageRow);
 
   // Collect token usage from run data.
@@ -237,6 +250,7 @@ export async function storeAgentAnalytics(
     message_id: agentMessageRow.sId,
     skills_used: skillsUsed,
     status: agentAgentMessageRow.status,
+    is_free_seat: isFreeSeat,
     timestamp: new Date(agentMessageRow.createdAt).toISOString(),
     tokens,
     tools_used: toolsUsed,

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -61,6 +61,7 @@ export interface AgentMessageAnalyticsData extends ElasticsearchBaseDocument {
   message_id: string;
   skills_used: AgentMessageAnalyticsSkillUsed[];
   status: AgentMessageStatus;
+  is_free_seat: boolean;
   timestamp: string; // ISO date string.
   tokens: AgentMessageAnalyticsTokens;
   tools_used: AgentMessageAnalyticsToolUsed[];


### PR DESCRIPTION
## Description

The members usage table read per-user consumed AWU credits from Metronome at
page load, which required a usage scan that scaled with the number of members
and made the table slow to load. Source the consumed value from the analytics
Elasticsearch index instead (sum of cost.full_awu over the current billing
cycle), in a single aggregation per page. Seat data and spend limits stay on
their existing workspace-level cached Metronome calls.

## Tests

Unit + local

## Risk

Low
## Deploy Plan

Run ES migration (`npx tsx scripts/execute_elasticsearch_http.ts --file lib/analytics/migrations/20260623_add_is_free_seat_to_agent_message_analytics_2.http --execute
`), then deploy