### PR TITLE
refactor(front): move triggers DTOs into types/api and rename Codec->Schema

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -1,9 +1,9 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { GetTriggersResponseBody } from "@app/lib/api/assistant/configuration/triggers";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
+import type { GetTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
 import { TriggerSchema } from "@app/types/assistant/triggers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -1,10 +1,10 @@
-import type { PostTextAsCronRuleResponseBody } from "@app/lib/api/assistant/configuration/triggers";
 import {
   GENERIC_ERROR_MESSAGE,
   generateScheduleRule,
   INVALID_TIMEZONE_MESSAGE,
   TOO_FREQUENT_MESSAGE,
 } from "@app/lib/api/assistant/configuration/triggers";
+import type { PostTextAsCronRuleResponseBody } from "@app/types/api/assistant/configuration/triggers";
 import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/me/triggers.ts
+++ b/front-api/routes/w/[wId]/me/triggers.ts
@@ -1,6 +1,6 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import type { GetUserTriggersResponseBody } from "@app/lib/api/assistant/configuration/triggers";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { GetUserTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
 import { removeNulls } from "@app/types/shared/utils/general";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -8,10 +8,6 @@ import {
   getTableIdForContentNode,
 } from "@app/components/agent_builder/shared/tables";
 import type { AdditionalConfigurationInBuilderType } from "@app/components/shared/tools_picker/types";
-import type {
-  PatchTriggersRequestBody,
-  PostTriggersRequestBody,
-} from "@app/lib/api/assistant/configuration/triggers";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import type {
   GetContentNodesOrChildrenRequestBodyType,
@@ -31,6 +27,10 @@ import type {
   DataSourcesConfigurationsCodecType,
   PostOrPatchAgentConfigurationRequestBody,
 } from "@app/types/api/agent_configuration";
+import type {
+  PatchTriggersRequestBody,
+  PostTriggersRequestBody,
+} from "@app/types/api/assistant/configuration/triggers";
 import type {
   AgentConfigurationType,
   LightAgentConfigurationType,

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -1,80 +1,8 @@
 import { getCronTimezoneGeneration } from "@app/lib/api/assistant/configuration/triggers/cron_timezone";
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  ScheduleConfig,
-  TriggerType,
-} from "@app/types/assistant/triggers";
-import {
-  FullTriggerSchema,
-  TriggerSchema,
-} from "@app/types/assistant/triggers";
+import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { z } from "zod";
-
-export interface GetUserTriggersResponseBody {
-  triggers: (TriggerType & {
-    isEditor: boolean;
-    agentName: string;
-    agentPictureUrl: string;
-  })[];
-}
-
-export const GetTriggersResponseBodySchema = z.object({
-  triggers: z.array(
-    FullTriggerSchema.and(
-      z.object({
-        isEditor: z.boolean(),
-        editorName: z.string().optional(),
-      })
-    )
-  ),
-});
-export type GetTriggersResponseBody = z.infer<
-  typeof GetTriggersResponseBodySchema
->;
-
-export const DeleteTriggersRequestBodyCodec = z.object({
-  triggerIds: z.array(z.string()),
-});
-export type DeleteTriggersRequestBody = z.infer<
-  typeof DeleteTriggersRequestBodyCodec
->;
-
-export const PatchTriggersRequestBodyCodec = z.object({
-  triggers: z.array(z.object({ sId: z.string() }).and(TriggerSchema)),
-});
-export type PatchTriggersRequestBody = z.infer<
-  typeof PatchTriggersRequestBodyCodec
->;
-
-export const PostTriggersRequestBodyCodec = z.object({
-  triggers: z.array(TriggerSchema),
-});
-export type PostTriggersRequestBody = z.infer<
-  typeof PostTriggersRequestBodyCodec
->;
-
-// Backward-compatible: cron responses include cronRule, interval responses
-// include interval fields.
-export type PostTextAsCronRuleResponseBody =
-  | { type?: "cron"; cronRule: string; timezone: string }
-  | {
-      type: "interval";
-      intervalDays: number;
-      dayOfWeek: number | null;
-      hour: number;
-      minute: number;
-      timezone: string;
-    };
-
-export const PostTextAsCronRuleRequestBodySchema = z.object({
-  naturalDescription: z.string(),
-  defaultTimezone: z.string(),
-});
-export type PostTextAsCronRuleRequestBody = z.infer<
-  typeof PostTextAsCronRuleRequestBodySchema
->;
 
 function isValidIANATimezone(timezone: string): boolean {
   // Get the list of all supported IANA timezones

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -1,12 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type {
-  GetTriggersResponseBody,
-  GetUserTriggersResponseBody,
-  PatchTriggersRequestBody,
-  PostTextAsCronRuleRequestBody,
-  PostTextAsCronRuleResponseBody,
-  PostTriggersRequestBody,
-} from "@app/lib/api/assistant/configuration/triggers";
 import { clientFetch } from "@app/lib/egress/client";
 import { parseMatcherExpression } from "@app/lib/matcher";
 import {
@@ -16,6 +8,14 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger_usage_estimation";
+import type {
+  GetTriggersResponseBody,
+  GetUserTriggersResponseBody,
+  PatchTriggersRequestBody,
+  PostTextAsCronRuleRequestBody,
+  PostTextAsCronRuleResponseBody,
+  PostTriggersRequestBody,
+} from "@app/types/api/assistant/configuration/triggers";
 import type {
   PostWebhookFilterGeneratorRequestBody,
   PostWebhookFilterGeneratorResponseBody,

--- a/front/types/api/assistant/configuration/triggers.ts
+++ b/front/types/api/assistant/configuration/triggers.ts
@@ -1,0 +1,70 @@
+import type { TriggerType } from "@app/types/assistant/triggers";
+import {
+  FullTriggerSchema,
+  TriggerSchema,
+} from "@app/types/assistant/triggers";
+import { z } from "zod";
+
+export interface GetUserTriggersResponseBody {
+  triggers: (TriggerType & {
+    isEditor: boolean;
+    agentName: string;
+    agentPictureUrl: string;
+  })[];
+}
+
+export const GetTriggersResponseBodySchema = z.object({
+  triggers: z.array(
+    FullTriggerSchema.and(
+      z.object({
+        isEditor: z.boolean(),
+        editorName: z.string().optional(),
+      })
+    )
+  ),
+});
+export type GetTriggersResponseBody = z.infer<
+  typeof GetTriggersResponseBodySchema
+>;
+
+export const DeleteTriggersRequestBodySchema = z.object({
+  triggerIds: z.array(z.string()),
+});
+export type DeleteTriggersRequestBody = z.infer<
+  typeof DeleteTriggersRequestBodySchema
+>;
+
+export const PatchTriggersRequestBodySchema = z.object({
+  triggers: z.array(z.object({ sId: z.string() }).and(TriggerSchema)),
+});
+export type PatchTriggersRequestBody = z.infer<
+  typeof PatchTriggersRequestBodySchema
+>;
+
+export const PostTriggersRequestBodySchema = z.object({
+  triggers: z.array(TriggerSchema),
+});
+export type PostTriggersRequestBody = z.infer<
+  typeof PostTriggersRequestBodySchema
+>;
+
+// Backward-compatible: cron responses include cronRule, interval responses
+// include interval fields.
+export type PostTextAsCronRuleResponseBody =
+  | { type?: "cron"; cronRule: string; timezone: string }
+  | {
+      type: "interval";
+      intervalDays: number;
+      dayOfWeek: number | null;
+      hour: number;
+      minute: number;
+      timezone: string;
+    };
+
+export const PostTextAsCronRuleRequestBodySchema = z.object({
+  naturalDescription: z.string(),
+  defaultTimezone: z.string(),
+});
+export type PostTextAsCronRuleRequestBody = z.infer<
+  typeof PostTextAsCronRuleRequestBodySchema
+>;


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types and zod schemas out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

Stacked on #27842.

`configuration/triggers.ts` was **already zod** — the `*Codec` names were misnomers on `z.object(...)` schemas, so there was no io-ts to migrate. This renames the three `*RequestBodyCodec` schemas to `*RequestBodySchema` (GEN13) and moves all transport DTOs/schemas to `types/api/assistant/configuration/triggers.ts`.

- Moved: `GetUserTriggersResponseBody`, `GetTriggersResponseBody`(+`Schema`), `Delete`/`Patch`/`PostTriggersRequestBody`(+`Schema`), `PostTextAsCronRuleResponseBody`, `PostTextAsCronRuleRequestBody`(+`Schema`).
- Kept in lib: `generateScheduleRule`, `validateIntervalConfig`, IANA/cron helpers, `CRON_REGEXP`, error-message constants.
- The `Codec → Schema` rename had zero external consumers (pure internal rename).
- 6 consumers updated; the `text_as_cron_rule` route is split (DTO → types; constants + `generateScheduleRule` stay on lib).

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)