### PR TITLE
Reverse feature-flag

### DIFF
--- a/front-api/routes/w/[wId]/subscriptions/index.test.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.test.ts
@@ -124,28 +124,20 @@ describe("POST /api/w/:wId/subscriptions", () => {
     expect(response.status).toBe(400);
   });
 
-  it("returns embedded clientSecret when metronome_billing flag overrides the kill switch", async () => {
-    const { workspace, user, auth } = await createPrivateApiMockRequest({
+  it("returns hosted checkoutUrl when legacy_billing flag is set even without the kill switch", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
 
-    await KillSwitchResource.enableKillSwitch(
-      "global_disable_metronome_billing"
-    );
-    await FeatureFlagFactory.basic(auth, "metronome_billing");
+    await FeatureFlagFactory.basic(auth, "legacy_billing");
 
-    const response = await post(workspace, {
-      billingPeriod: "monthly",
-      seatType: "pro",
-      targetUserId: user.sId,
-    });
+    const response = await post(workspace, { billingPeriod: "monthly" });
 
     expect(response.status).toBe(200);
     const data = await response.json();
-    expect(data.mode).toEqual("embedded");
-    expect(data.clientSecret).toEqual(TEST_CLIENT_SECRET);
-    expect(data.sessionId).toEqual(TEST_SESSION_ID);
+    expect(data.mode).toEqual("hosted");
+    expect(data.checkoutUrl).toEqual(TEST_CHECKOUT_URL);
   });
 
   it("returns 403 when user is not admin", async () => {

--- a/front/components/pages/onboarding/TrialPage.tsx
+++ b/front/components/pages/onboarding/TrialPage.tsx
@@ -12,7 +12,7 @@ export function TrialPage() {
   const { killSwitches } = useKillSwitches();
 
   const isMetronome =
-    hasFeature("metronome_billing") ||
+    !hasFeature("legacy_billing") &&
     !killSwitches?.includes("global_disable_metronome_billing");
 
   const skip = async () => {

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -72,7 +72,7 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
     title: "Metronome Billing",
     description:
       "Disable Metronome billing globally and fall back to legacy Stripe subscriptions.",
-    note: "Workspaces with the `metronome_billing` feature flag bypass this kill switch.",
+    note: "Workspaces with the `legacy_billing` feature flag are always on legacy billing regardless of this switch.",
     icon: CreditCard01,
   },
 };

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -50,15 +50,15 @@ export type GetSubscriptionTrialInfoResponseBody = {
 
 // Metronome billing is enabled by default for all workspaces. The
 // `global_disable_metronome_billing` kill switch turns it off globally; the
-// `metronome_billing` feature flag re-enables it for individual workspaces.
+// `legacy_billing` feature flag forces it off for individual workspaces.
 export async function isMetronomeBillingEnabled(
   auth: Authenticator
 ): Promise<boolean> {
-  const [hasFlag, killed] = await Promise.all([
-    hasFeatureFlag(auth, "metronome_billing"),
+  const [hasLegacyFlag, killed] = await Promise.all([
+    hasFeatureFlag(auth, "legacy_billing"),
     KillSwitchResource.isKillSwitchEnabled("global_disable_metronome_billing"),
   ]);
-  return hasFlag || !killed;
+  return !hasLegacyFlag && !killed;
 }
 
 /**

--- a/front/lib/client/subscription.ts
+++ b/front/lib/client/subscription.ts
@@ -25,8 +25,8 @@ export const CP_MAX_SEAT_COST_YEARLY = 120;
  * Client-side mirror of the server-side `isMetronomeBillingEnabled` gate: the
  * credit-priced checkout flow follows Metronome billing, which is enabled by
  * default for all workspaces. The `global_disable_metronome_billing` kill
- * switch turns it off globally; the `metronome_billing` feature flag
- * re-enables it for individual workspaces.
+ * switch turns it off globally; the `legacy_billing` feature flag forces it
+ * off for individual workspaces.
  *
  * Prefer the `useIsMetronomeCheckout` hook; this helper is for components that
  * render outside the auth context provider (e.g. the SPA workspace layout).
@@ -39,7 +39,7 @@ export function computeIsMetronomeCheckout({
   killSwitches: KillSwitchType[] | null | undefined;
 }): boolean {
   return (
-    featureFlags.includes("metronome_billing") ||
+    !featureFlags.includes("legacy_billing") &&
     !killSwitches?.includes("global_disable_metronome_billing")
   );
 }
@@ -60,9 +60,9 @@ export function formatPriceWithCurrency(
 /**
  * Hook that resolves the user's billing currency from IP geolocation.
  *
- * When the workspace has the metronome_billing feature flag:
+ * When Metronome billing is enabled:
  *   EU/EEA/CH → EUR, rest of world → USD.
- * Without the flag (Stripe billing, or no workspace):
+ * With legacy billing (Stripe billing, or no workspace):
  *   US → USD, rest of world → EUR (matches Stripe adaptive pricing).
  *
  * Falls back to Stripe behaviour while loading or on error.
@@ -72,7 +72,7 @@ export function useUserBillingCurrency(): SupportedCurrency {
   const { hasFeature } = useFeatureFlags();
   const { killSwitches } = useKillSwitches();
   const isMetronomeBillingEnabled =
-    hasFeature("metronome_billing") ||
+    !hasFeature("legacy_billing") &&
     !killSwitches?.includes("global_disable_metronome_billing");
 
   if (geoData?.countryCode) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -266,9 +266,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable the Poke MCP server for cross-workspace data access.",
     stage: "dust_only",
   },
-  metronome_billing: {
+  legacy_billing: {
     description:
-      "Enable Metronome usage event emission (llm_usage, tool_use) for this workspace.",
+      "Force this workspace to use legacy Stripe billing, bypassing Metronome credit-priced plans regardless of the global kill switch.",
     stage: "dust_only",
   },
   plan_mode: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -743,7 +743,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "power_bi_mcp"
   | "reinforced_agents"
   | "self_improvement_beta_tester"
-  | "metronome_billing"
+  | "legacy_billing"
   | "plan_mode"
   | "pod_default_agent"
   | "poke_mcp"


### PR DESCRIPTION
## Description

Drops the `metronome_billing` feature flag (which re-enabled Metronome for individual workspaces) and replaces it with the opposite `legacy_billing` flag, which forces a workspace onto legacy Stripe billing regardless of the global kill switch.

## Tests

## Risks

## Deploy plan

deploy front