### PR TITLE
fix: delete entries from authorizedFileAccessModel when deleting workspace

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -467,6 +467,11 @@ export class FileResource extends BaseResource<FileModel> {
       where: { workspaceId },
     });
 
+    // Delete authorized file accesses before shareable files (FK constraint).
+    await this.authorizedFileAccessModel.destroy({
+      where: { workspaceId },
+    });
+
     // Delete all shareable file records.
     await this.shareableFileModel.destroy({
       where: { workspaceId },


### PR DESCRIPTION
## Description

This PR fixes a missing cleanup step in the workspace deletion flow by deleting `authorizedFileAccess` entries before deleting shareable file records to satisfy the FK constraint.

## Tests

## Risks
Low.

## Deploy Plan
Standard deployment.
