### PR TITLE
Fix Gong connectors on non-default regions hitting the wrong API host

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -265,12 +265,19 @@ export function clampRetryAfterSeconds(
 }
 
 export class GongClient {
-  private readonly baseUrl = "https://api.gong.io/v2";
+  private readonly baseUrl: string;
 
   constructor(
     private readonly authToken: string,
-    private readonly connectorId: ModelId
-  ) {}
+    private readonly connectorId: ModelId,
+    // Per-customer API host returned by Gong's OAuth token exchange
+    // (`api_base_url_for_customer`), e.g. "https://eu-2086.api.gong.io".
+    // Customers can be provisioned on different Gong cells, so we cannot
+    // hardcode "https://api.gong.io".
+    baseUrlForCustomer: string
+  ) {
+    this.baseUrl = `${baseUrlForCustomer}/v2`;
+  }
 
   /**
    * Handles response parsing and error handling for all API requests.

--- a/connectors/src/connectors/gong/lib/utils.ts
+++ b/connectors/src/connectors/gong/lib/utils.ts
@@ -40,5 +40,10 @@ export async function getGongClient(connector: ConnectorResource) {
     connectionId: connector.connectionId,
   });
 
-  return new GongClient(access_token, connector.id);
+  // The per-customer API host is captured at connector creation and stored on
+  // the configuration. Gong provisions customers on different cells, so this
+  // can differ from the default "https://api.gong.io".
+  const configuration = await fetchGongConfiguration(connector);
+
+  return new GongClient(access_token, connector.id, configuration.baseUrl);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/9123.

Some Gong customers are provisioned on a region-specific API host rather than the default one, and Gong returns that host during the OAuth token exchange. We were already capturing it at connector creation and storing it on the connector configuration, but the API client ignored it and always talked to the default host. For customers on another region this meant every request landed on the wrong host and came back as a forbidden response, which we interpret as a revoked token, so these connectors surfaced a misleading external OAuth token error even though their credentials were perfectly valid.

This change makes the API client use the per-customer host that we already store on the configuration instead of the hardcoded default. No migration is needed since that value has always been captured and stored as a required field, so every existing connector already has the correct host available and simply starts using it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
