### PR TITLE
fix(files): delete authorized_file_accesses before shareable_files on workspace cleanup

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -457,6 +457,10 @@ export class FileResource extends BaseResource<FileModel> {
   static async deleteAllForWorkspace(auth: Authenticator) {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
+    await AuthorizedFileAccessModel.destroy({
+      where: { workspaceId },
+    });
+
     // Delete external viewer sessions before shareable files (FK constraint).
     await ExternalViewerSessionModel.destroy({
       where: { workspaceId },


### PR DESCRIPTION
## Description

Fixes a foreign key constraint violation (`authorized_file_accesses_shareableFileId_fkey`) that crashed the `deleteWorkspaceActivity` Temporal activity. When scrubbing a workspace, `deleteAllForWorkspace` tried to delete `shareable_files` rows while `authorized_file_accesses` still held references to them.

Fix: delete `authorized_file_accesses` before `shareable_files`, consistent with the FK dependency order already established for `external_viewer_sessions` and `sharing_grants`.

Fixes that => https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows/poke-3f9EzEmqeL-delete-workspace/019ef446-3ded-7177-b351-ae6a3b8cb6c4/timeline

## Tests

Reproduced by the Temporal error log; the fix ensures the deletion order respects FK constraints.

## Risk

## Deploy Plan
