### PR TITLE
refactor(front): Pass A billing/credits/spend gotchas — move DTOs + pure local types

### DIFF
--- a/front-api/routes/w/[wId]/billing/info.ts
+++ b/front-api/routes/w/[wId]/billing/info.ts
@@ -1,7 +1,5 @@
-import {
-  type GetBillingInfoResponseBody,
-  getWorkspaceBillingInfo,
-} from "@app/lib/api/billing/info";
+import { getWorkspaceBillingInfo } from "@app/lib/api/billing/info";
+import type { GetBillingInfoResponseBody } from "@app/types/api/billing/info";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/billing/invoices.ts
+++ b/front-api/routes/w/[wId]/billing/invoices.ts
@@ -1,7 +1,5 @@
-import {
-  type GetBillingInvoicesResponseBody,
-  listRecentBillingInvoices,
-} from "@app/lib/api/billing/invoices";
+import { listRecentBillingInvoices } from "@app/lib/api/billing/invoices";
+import type { GetBillingInvoicesResponseBody } from "@app/types/api/billing/invoices";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/credits/usage-configuration.ts
+++ b/front-api/routes/w/[wId]/credits/usage-configuration.ts
@@ -1,12 +1,12 @@
+import {
+  getUsageConfiguration,
+  updateUsageConfiguration,
+} from "@app/lib/api/credits/usage_configuration";
 import type {
   GetCreditUsageConfigurationResponseBody,
   PatchCreditUsageConfigurationResponseBody,
-} from "@app/lib/api/credits/usage_configuration";
-import {
-  getUsageConfiguration,
-  PatchCreditUsageConfigurationRequestBody,
-  updateUsageConfiguration,
-} from "@app/lib/api/credits/usage_configuration";
+} from "@app/types/api/credits/usage_configuration";
+import { PatchCreditUsageConfigurationRequestBody } from "@app/types/api/credits/usage_configuration";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
+++ b/front-api/routes/w/[wId]/members/[uId]/spend_limit.ts
@@ -1,13 +1,15 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
-  type GetUserSpendLimitResponseBody,
   getUserSpendLimit,
   MAX_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_USER_SPEND_LIMIT_AWU_CREDITS,
-  type PutUserSpendLimitResponseBody,
   setUserSpendLimit,
   type UserSpendLimitError,
 } from "@app/lib/api/users/spend_limit";
+import type {
+  GetUserSpendLimitResponseBody,
+  PutUserSpendLimitResponseBody,
+} from "@app/types/api/users/spend_limit";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/metronome/contract.ts
+++ b/front-api/routes/w/[wId]/metronome/contract.ts
@@ -1,10 +1,10 @@
-import type { GetMetronomeContractResponseBody } from "@app/lib/api/credits/metronome_contract";
 import {
   applyContractLifecycleAction,
   getMetronomeContractSummary,
-  PatchMetronomeContractRequestBody,
 } from "@app/lib/api/credits/metronome_contract";
 import type { ContractLifecycleError } from "@app/lib/metronome/contract_lifecycle";
+import type { GetMetronomeContractResponseBody } from "@app/types/api/credits/metronome_contract";
+import { PatchMetronomeContractRequestBody } from "@app/types/api/credits/metronome_contract";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
+++ b/front-api/routes/w/[wId]/subscriptions/checkout-status.ts
@@ -1,4 +1,4 @@
-import type { GetCheckoutStatusResponseBody } from "@app/lib/api/subscription";
+import type { GetCheckoutStatusResponseBody } from "@app/types/api/subscription";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/subscriptions/index.ts
+++ b/front-api/routes/w/[wId]/subscriptions/index.ts
@@ -1,11 +1,4 @@
-import type {
-  GetSubscriptionsResponseBody,
-  PostSubscriptionResponseBody,
-} from "@app/lib/api/subscription";
-import {
-  isMetronomeBillingEnabled,
-  PatchSubscriptionRequestBody,
-} from "@app/lib/api/subscription";
+import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import {
   createCheckoutUrl,
   PostSubscriptionRequestBody,
@@ -17,6 +10,11 @@ import {
 } from "@app/lib/plans/stripe";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import logger from "@app/logger/logger";
+import type {
+  GetSubscriptionsResponseBody,
+  PostSubscriptionResponseBody,
+} from "@app/types/api/subscription";
+import { PatchSubscriptionRequestBody } from "@app/types/api/subscription";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import {

--- a/front-api/routes/w/[wId]/subscriptions/trial-info.ts
+++ b/front-api/routes/w/[wId]/subscriptions/trial-info.ts
@@ -1,5 +1,5 @@
-import type { GetSubscriptionTrialInfoResponseBody } from "@app/lib/api/subscription";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
+import type { GetSubscriptionTrialInfoResponseBody } from "@app/types/api/subscription";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
+++ b/front-api/routes/w/[wId]/usage_settings/default_user_spend_limit.ts
@@ -3,11 +3,13 @@
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
   type DefaultUserSpendLimitError,
-  type GetDefaultUserSpendLimitResponseBody,
   getDefaultUserSpendLimit,
-  type PutDefaultUserSpendLimitResponseBody,
   setDefaultUserSpendLimit,
 } from "@app/lib/api/workspace/default_user_spend_limit";
+import type {
+  GetDefaultUserSpendLimitResponseBody,
+  PutDefaultUserSpendLimitResponseBody,
+} from "@app/types/api/workspace/default_user_spend_limit";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,

--- a/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
+++ b/front/components/pages/workspace/subscription/MetronomeSubscriptionPanel.tsx
@@ -3,7 +3,6 @@ import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCar
 import { useSubscriptionContext } from "@app/components/workspace/billing/SubscriptionContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
-import type { PatchSubscriptionRequestBody } from "@app/lib/api/subscription";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -20,6 +19,7 @@ import {
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import type { PatchSubscriptionRequestBody } from "@app/types/api/subscription";
 import type { BillingPeriod } from "@app/types/plan";
 import { isSubscriptionMetronomeBilled } from "@app/types/plan";
 import {

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -7,7 +7,6 @@ import { MetronomeSubscriptionPanel } from "@app/components/pages/workspace/subs
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { SubscriptionProvider } from "@app/components/workspace/billing/SubscriptionContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PatchSubscriptionRequestBody } from "@app/lib/api/subscription";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   getPriceAsString,
@@ -28,6 +27,7 @@ import {
   useWorkspaceSeatsCount,
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import type { PatchSubscriptionRequestBody } from "@app/types/api/subscription";
 import type {
   BillingPeriod,
   SubscriptionPerSeatPricing,

--- a/front/components/workspace/billing/BillingInformation.tsx
+++ b/front/components/workspace/billing/BillingInformation.tsx
@@ -2,11 +2,11 @@ import {
   CardBrandIcon,
   formatBrandName,
 } from "@app/components/checkout/PaymentMethodRow";
+import { useBillingInfo } from "@app/lib/swr/workspaces";
 import type {
   BillingAddress,
   BillingPaymentMethod,
-} from "@app/lib/api/billing/info";
-import { useBillingInfo } from "@app/lib/swr/workspaces";
+} from "@app/types/api/billing/info";
 import {
   Button,
   Hash01,

--- a/front/components/workspace/billing/RecentInvoices.tsx
+++ b/front/components/workspace/billing/RecentInvoices.tsx
@@ -1,7 +1,7 @@
-import type { BillingInvoice } from "@app/lib/api/billing/invoices";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useRecentBillingInvoices } from "@app/lib/swr/workspaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { BillingInvoice } from "@app/types/api/billing/invoices";
 import { Button, Spinner } from "@dust-tt/sparkle";
 import { useSubscriptionContext } from "./SubscriptionContext";
 

--- a/front/hooks/useMetronomeContractLifecycleAction.ts
+++ b/front/hooks/useMetronomeContractLifecycleAction.ts
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { PatchMetronomeContractRequestBody } from "@app/lib/api/credits/metronome_contract";
 import { clientFetch } from "@app/lib/egress/client";
+import type { PatchMetronomeContractRequestBody } from "@app/types/api/credits/metronome_contract";
 import { useCallback, useState } from "react";
 import type { z } from "zod";
 

--- a/front/lib/api/billing/info.ts
+++ b/front/lib/api/billing/info.ts
@@ -3,46 +3,16 @@ import {
   getBillingStripeCustomerId,
   getStripeClient,
 } from "@app/lib/plans/stripe";
+import type {
+  BillingAddress,
+  BillingInfo,
+  BillingPaymentMethod,
+} from "@app/types/api/billing/info";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { errorToString } from "@app/types/shared/utils/error_utils";
 import type Stripe from "stripe";
-
-export type BillingAddress = {
-  line1: string | null;
-  line2: string | null;
-  city: string | null;
-  state: string | null;
-  postalCode: string | null;
-  country: string | null;
-};
-
-export type BillingProfile = {
-  name: string | null;
-  email: string | null;
-  phone: string | null;
-  address: BillingAddress | null;
-};
-
-export type BillingPaymentMethod = {
-  type: string;
-  brand: string | null;
-  last4: string | null;
-  expMonth: number | null;
-  expYear: number | null;
-  bankName: string | null;
-  country: string | null;
-};
-
-export type BillingInfo = {
-  profile: BillingProfile;
-  paymentMethod: BillingPaymentMethod | null;
-};
-
-export type GetBillingInfoResponseBody = {
-  billingInfo: BillingInfo | null;
-};
 
 function serializeAddress(
   address: Stripe.Address | null | undefined

--- a/front/lib/api/billing/invoices.ts
+++ b/front/lib/api/billing/invoices.ts
@@ -3,6 +3,7 @@ import {
   getBillingStripeCustomerId,
   getStripeClient,
 } from "@app/lib/plans/stripe";
+import type { BillingInvoice } from "@app/types/api/billing/invoices";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -10,26 +11,6 @@ import { errorToString } from "@app/types/shared/utils/error_utils";
 import type Stripe from "stripe";
 
 const BILLING_INVOICES_PAGE_SIZE = 12;
-
-export type BillingInvoice = {
-  id: string;
-  number: string | null;
-  status: Stripe.Invoice.Status | null;
-  description: string | null;
-  currency: string;
-  totalCents: number;
-  amountPaidCents: number;
-  createdAtMs: number;
-  dueDateMs: number | null;
-  periodStartMs: number;
-  periodEndMs: number;
-  hostedInvoiceUrl: string | null;
-  invoicePdf: string | null;
-};
-
-export type GetBillingInvoicesResponseBody = {
-  billingInvoices: BillingInvoice[];
-};
 
 function serializeInvoice(invoice: Stripe.Invoice): BillingInvoice {
   return {

--- a/front/lib/api/credits/metronome_contract.ts
+++ b/front/lib/api/credits/metronome_contract.ts
@@ -12,41 +12,11 @@ import {
 } from "@app/lib/metronome/seat_types";
 import { hasContractSeatSubscription } from "@app/lib/metronome/seats";
 import { isEnterprisePlanPrefix } from "@app/lib/plans/plan_codes";
+import type { MetronomeContractSummary } from "@app/types/api/credits/metronome_contract";
 import { isSeatBased } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import { z } from "zod";
-
-export type GetMetronomeContractResponseBody = {
-  contract: MetronomeContractSummary | null;
-};
-
-export const PatchMetronomeContractRequestBody = z.object({
-  action: z.enum(["cancel", "reactivate"]),
-});
-
-export type MetronomeContractSummary = {
-  planFamily: "pro" | "enterprise";
-  /**
-   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
-   * `null` for simple MAU (no tiering) or non-enterprise.
-   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
-   */
-  mauTiers: Array<{ start: number; end: number | null }> | null;
-  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
-  contractEndingAtMs: number | null;
-  /** True if the contract has at least one seat-billed subscription */
-  hasSeatSubscription: boolean;
-  /**
-   * True if the contract sells at least one seat type that carries a personal
-   * (per-user) credit allocation — pro/max/free seats. Such users spend their
-   * personal credits before falling back to the shared workspace pool, so they
-   * keep working even when the pool is depleted/in overage. False for
-   * pool-based contracts (workspace seats only) and MAU contracts.
-   */
-  hasPersonalCreditSeats: boolean;
-};
 
 /**
  * Fetch the workspace's Metronome contract summary.

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -9,50 +9,12 @@ import {
   DEFAULT_TOP_UP_ENABLED,
   DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
 } from "@app/lib/resources/storage/models/credit_usage_configurations";
+import type {
+  CreditUsageConfigurationBody,
+  PatchCreditUsageConfigurationBody,
+} from "@app/types/api/credits/usage_configuration";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { z } from "zod";
-
-// Combined workspace-level usage configuration surfaced to admins on the Usage
-// page. All fields are stored on the `credit_usage_configurations` row:
-// `balanceThresholdCredits` is the source of truth from which the Metronome
-// balance-threshold alert is derived (see `balance_threshold_alert.ts`).
-export type CreditUsageConfigurationBody = {
-  // Credit balance (in AWU credits) below which workspace admins are emailed.
-  // `null` means no threshold is configured (the warning is off).
-  balanceThresholdCredits: number | null;
-  // Whether non-admin members who reach their per-user spend limit can request a
-  // spend-limit upgrade from the product.
-  allowMemberUpgradeRequests: boolean;
-  // Whether workspace admins are emailed when a member requests an upgrade.
-  upgradeRequestEmailEnabled: boolean;
-  // Whether members who hit their per-user credit limit are automatically bumped
-  // to the next entitled seat tier instead of being blocked.
-  autoSeatUpgradeEnabled: boolean;
-  autoSeatUpgradeAvailable: boolean;
-  // Whether enterprise-plan workspaces show the "Top up" button on the Usage page.
-  topUpEnabled: boolean;
-};
-
-export type GetCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export type PatchCreditUsageConfigurationResponseBody = {
-  configuration: CreditUsageConfigurationBody;
-};
-
-export const PatchCreditUsageConfigurationRequestBody = z.object({
-  // 0 (or null) clears the threshold; a positive value enables the alert.
-  balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
-  allowMemberUpgradeRequests: z.boolean().optional(),
-  upgradeRequestEmailEnabled: z.boolean().optional(),
-  autoSeatUpgradeEnabled: z.boolean().optional(),
-});
-
-export type PatchCreditUsageConfigurationBody = z.infer<
-  typeof PatchCreditUsageConfigurationRequestBody
->;
 
 /**
  * Read the full usage configuration for a workspace: the balance threshold plus

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -23,30 +23,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import type { CheckoutUrlResult, SubscriptionType } from "@app/types/plan";
 import { removeNulls } from "@app/types/shared/utils/general";
-import { z } from "zod";
-
-export const PatchSubscriptionRequestBody = z.object({
-  action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
-});
-
-type CheckoutStatus =
-  | { status: "success" }
-  | { status: "error"; message: string }
-  | { status: "pending" };
-
-export type GetCheckoutStatusResponseBody = CheckoutStatus;
-
-export type PostSubscriptionResponseBody = CheckoutUrlResult;
-
-export type GetSubscriptionsResponseBody = {
-  subscriptions: SubscriptionType[];
-};
-
-export type GetSubscriptionTrialInfoResponseBody = {
-  trialDaysRemaining: number | null;
-};
 
 // Metronome billing is enabled by default for all workspaces. The
 // `global_disable_metronome_billing` kill switch turns it off globally; the

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -16,6 +16,11 @@ import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_t
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import logger from "@app/logger/logger";
+import type {
+  GetUserSpendLimitResponse,
+  SetUserSpendLimitResponse,
+  UserSpendLimit,
+} from "@app/types/api/users/spend_limit";
 import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -23,20 +28,6 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 1;
 export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 1_000_000;
-
-export type UserSpendLimit =
-  | { kind: "unlimited" }
-  | { kind: "limited"; awuCredits: number };
-
-export type GetUserSpendLimitResponse = UserSpendLimit;
-
-export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
-
-export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
-
-export type SetUserSpendLimitResponse = {
-  limit: UserSpendLimit;
-};
 
 export type UserSpendLimitErrorType =
   | "user_not_found"

--- a/front/lib/api/workspace/default_user_spend_limit.ts
+++ b/front/lib/api/workspace/default_user_spend_limit.ts
@@ -17,6 +17,10 @@ import {
 } from "@app/lib/metronome/seat_types";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import logger from "@app/logger/logger";
+import type {
+  DefaultUserSpendLimit,
+  GetDefaultUserSpendLimitResponseBody,
+} from "@app/types/api/workspace/default_user_spend_limit";
 import {
   MAX_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
   MIN_DEFAULT_USER_SPEND_LIMIT_AWU_CREDITS,
@@ -29,16 +33,6 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-
-export type DefaultUserSpendLimit = {
-  awuCredits: number;
-};
-
-export type GetDefaultUserSpendLimitResponseBody = {
-  awuCredits: number | null;
-};
-
-export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;
 
 export type DefaultUserSpendLimitErrorType =
   | "workspace_not_metronome_billed"

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -4,15 +4,15 @@ import type {
   GetFreeSeatCountsResponseBody,
   MembersLookupResponseBody,
 } from "@app/lib/api/members";
-import type {
-  GetUserSpendLimitResponseBody,
-  PutUserSpendLimitResponseBody,
-} from "@app/lib/api/users/spend_limit";
 import type { GetMembersResponseBody } from "@app/lib/api/workspace";
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { debounce } from "@app/lib/utils/debounce";
 import type { GetWorkspaceInvitationsResponseBody } from "@app/types/api/invitation";
+import type {
+  GetUserSpendLimitResponseBody,
+  PutUserSpendLimitResponseBody,
+} from "@app/types/api/users/spend_limit";
 import type { GroupKind } from "@app/types/groups";
 import { isGroupKind } from "@app/types/groups";
 import type { MembershipSeatType } from "@app/types/memberships";

--- a/front/lib/swr/usage_settings.ts
+++ b/front/lib/swr/usage_settings.ts
@@ -1,9 +1,4 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { GetCreditUsageConfigurationResponseBody } from "@app/lib/api/credits/usage_configuration";
-import type {
-  GetDefaultUserSpendLimitResponseBody,
-  PutDefaultUserSpendLimitResponseBody,
-} from "@app/lib/api/workspace/default_user_spend_limit";
 import { clientFetch } from "@app/lib/egress/client";
 import { invalidateMembersUsage } from "@app/lib/swr/memberships";
 import {
@@ -15,6 +10,11 @@ import type {
   GetProgrammaticUsageLimitResponseBody,
   PutProgrammaticUsageLimitResponseBody,
 } from "@app/types/api/credits/programmatic_usage_limit";
+import type { GetCreditUsageConfigurationResponseBody } from "@app/types/api/credits/usage_configuration";
+import type {
+  GetDefaultUserSpendLimitResponseBody,
+  PutDefaultUserSpendLimitResponseBody,
+} from "@app/types/api/workspace/default_user_spend_limit";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { useCallback } from "react";
 import type { Fetcher } from "swr";

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -24,19 +24,10 @@ import type {
   GetWorkspaceToolUsageResponse,
 } from "@app/lib/api/assistant/observability/tool_usage";
 import type { GetUserCreditsResponse } from "@app/lib/api/assistant/observability/user_credits";
-import type { GetBillingInfoResponseBody } from "@app/lib/api/billing/info";
-import type { GetBillingInvoicesResponseBody } from "@app/lib/api/billing/invoices";
 import type {
   GetBusinessActivationResponseBody,
   PostBusinessActivationResponseBody,
 } from "@app/lib/api/checkout/business_activation";
-import type { GetMetronomeContractResponseBody } from "@app/lib/api/credits/metronome_contract";
-import type {
-  GetCheckoutStatusResponseBody,
-  GetSubscriptionsResponseBody,
-  GetSubscriptionTrialInfoResponseBody,
-  PostSubscriptionResponseBody,
-} from "@app/lib/api/subscription";
 import type {
   GetSeatAvailabilityResponseBody,
   GetWelcomeResponseBody,
@@ -65,8 +56,17 @@ import type {
   GetNoWorkspaceAuthContextResponseType,
   GetWorkspaceAuthContextResponseType,
 } from "@app/types/api/auth_context";
+import type { GetBillingInfoResponseBody } from "@app/types/api/billing/info";
+import type { GetBillingInvoicesResponseBody } from "@app/types/api/billing/invoices";
 import type { GetPreparePaymentResponseBody } from "@app/types/api/checkout/prepare_payment";
+import type { GetMetronomeContractResponseBody } from "@app/types/api/credits/metronome_contract";
 import type { GetPendingInvitationsLookupResponseBody } from "@app/types/api/invitation";
+import type {
+  GetCheckoutStatusResponseBody,
+  GetSubscriptionsResponseBody,
+  GetSubscriptionTrialInfoResponseBody,
+  PostSubscriptionResponseBody,
+} from "@app/types/api/subscription";
 import type { APIErrorResponse, RegionRedirectError } from "@app/types/error";
 import type { BillingPeriod } from "@app/types/plan";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";

--- a/front/types/api/billing/info.ts
+++ b/front/types/api/billing/info.ts
@@ -1,0 +1,34 @@
+export type BillingAddress = {
+  line1: string | null;
+  line2: string | null;
+  city: string | null;
+  state: string | null;
+  postalCode: string | null;
+  country: string | null;
+};
+
+export type BillingProfile = {
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: BillingAddress | null;
+};
+
+export type BillingPaymentMethod = {
+  type: string;
+  brand: string | null;
+  last4: string | null;
+  expMonth: number | null;
+  expYear: number | null;
+  bankName: string | null;
+  country: string | null;
+};
+
+export type BillingInfo = {
+  profile: BillingProfile;
+  paymentMethod: BillingPaymentMethod | null;
+};
+
+export type GetBillingInfoResponseBody = {
+  billingInfo: BillingInfo | null;
+};

--- a/front/types/api/billing/invoices.ts
+++ b/front/types/api/billing/invoices.ts
@@ -1,0 +1,21 @@
+import type Stripe from "stripe";
+
+export type BillingInvoice = {
+  id: string;
+  number: string | null;
+  status: Stripe.Invoice.Status | null;
+  description: string | null;
+  currency: string;
+  totalCents: number;
+  amountPaidCents: number;
+  createdAtMs: number;
+  dueDateMs: number | null;
+  periodStartMs: number;
+  periodEndMs: number;
+  hostedInvoiceUrl: string | null;
+  invoicePdf: string | null;
+};
+
+export type GetBillingInvoicesResponseBody = {
+  billingInvoices: BillingInvoice[];
+};

--- a/front/types/api/credits/metronome_contract.ts
+++ b/front/types/api/credits/metronome_contract.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export type GetMetronomeContractResponseBody = {
+  contract: MetronomeContractSummary | null;
+};
+
+export const PatchMetronomeContractRequestBody = z.object({
+  action: z.enum(["cancel", "reactivate"]),
+});
+
+export type MetronomeContractSummary = {
+  planFamily: "pro" | "enterprise";
+  /**
+   * MAU tier boundaries parsed from the MAU_TIERS contract custom field.
+   * `null` for simple MAU (no tiering) or non-enterprise.
+   * Each tier has `start` (inclusive, 1-indexed) and `end` (exclusive, null = unlimited).
+   */
+  mauTiers: Array<{ start: number; end: number | null }> | null;
+  /** ms epoch — set when the contract is scheduled to end (cancellation or fixed term). */
+  contractEndingAtMs: number | null;
+  /** True if the contract has at least one seat-billed subscription */
+  hasSeatSubscription: boolean;
+  /**
+   * True if the contract sells at least one seat type that carries a personal
+   * (per-user) credit allocation — pro/max/free seats. Such users spend their
+   * personal credits before falling back to the shared workspace pool, so they
+   * keep working even when the pool is depleted/in overage. False for
+   * pool-based contracts (workspace seats only) and MAU contracts.
+   */
+  hasPersonalCreditSeats: boolean;
+};

--- a/front/types/api/credits/usage_configuration.ts
+++ b/front/types/api/credits/usage_configuration.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export type CreditUsageConfigurationBody = {
+  // Credit balance (in AWU credits) below which workspace admins are emailed.
+  // `null` means no threshold is configured (the warning is off).
+  balanceThresholdCredits: number | null;
+  // Whether non-admin members who reach their per-user spend limit can request a
+  // spend-limit upgrade from the product.
+  allowMemberUpgradeRequests: boolean;
+  // Whether workspace admins are emailed when a member requests an upgrade.
+  upgradeRequestEmailEnabled: boolean;
+  // Whether members who hit their per-user credit limit are automatically bumped
+  // to the next entitled seat tier instead of being blocked.
+  autoSeatUpgradeEnabled: boolean;
+  autoSeatUpgradeAvailable: boolean;
+  // Whether enterprise-plan workspaces show the "Top up" button on the Usage page.
+  topUpEnabled: boolean;
+};
+
+export type GetCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export type PatchCreditUsageConfigurationResponseBody = {
+  configuration: CreditUsageConfigurationBody;
+};
+
+export const PatchCreditUsageConfigurationRequestBody = z.object({
+  // 0 (or null) clears the threshold; a positive value enables the alert.
+  balanceThresholdCredits: z.number().int().min(0).nullable().optional(),
+  allowMemberUpgradeRequests: z.boolean().optional(),
+  upgradeRequestEmailEnabled: z.boolean().optional(),
+  autoSeatUpgradeEnabled: z.boolean().optional(),
+});
+
+export type PatchCreditUsageConfigurationBody = z.infer<
+  typeof PatchCreditUsageConfigurationRequestBody
+>;

--- a/front/types/api/subscription.ts
+++ b/front/types/api/subscription.ts
@@ -1,0 +1,23 @@
+import type { CheckoutUrlResult, SubscriptionType } from "@app/types/plan";
+import { z } from "zod";
+
+export const PatchSubscriptionRequestBody = z.object({
+  action: z.enum(["cancel_free_trial", "pay_now", "upgrade_to_business"]),
+});
+
+type CheckoutStatus =
+  | { status: "success" }
+  | { status: "error"; message: string }
+  | { status: "pending" };
+
+export type GetCheckoutStatusResponseBody = CheckoutStatus;
+
+export type PostSubscriptionResponseBody = CheckoutUrlResult;
+
+export type GetSubscriptionsResponseBody = {
+  subscriptions: SubscriptionType[];
+};
+
+export type GetSubscriptionTrialInfoResponseBody = {
+  trialDaysRemaining: number | null;
+};

--- a/front/types/api/users/spend_limit.ts
+++ b/front/types/api/users/spend_limit.ts
@@ -1,0 +1,13 @@
+export type UserSpendLimit =
+  | { kind: "unlimited" }
+  | { kind: "limited"; awuCredits: number };
+
+export type GetUserSpendLimitResponse = UserSpendLimit;
+
+export type GetUserSpendLimitResponseBody = GetUserSpendLimitResponse;
+
+export type PutUserSpendLimitResponseBody = SetUserSpendLimitResponse;
+
+export type SetUserSpendLimitResponse = {
+  limit: UserSpendLimit;
+};

--- a/front/types/api/workspace/default_user_spend_limit.ts
+++ b/front/types/api/workspace/default_user_spend_limit.ts
@@ -1,0 +1,9 @@
+export type DefaultUserSpendLimit = {
+  awuCredits: number;
+};
+
+export type GetDefaultUserSpendLimitResponseBody = {
+  awuCredits: number | null;
+};
+
+export type PutDefaultUserSpendLimitResponseBody = DefaultUserSpendLimit;


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

Stacked on #27854. **Pass A** (billing/credits/spend): for gotcha files where a DTO references a same-file domain type, move the DTO + the *pure* local type to `types/api`; defer files whose local type transitively couples to `@app/lib`.

**Migrated (7):** `billing/info`, `billing/invoices`, `credits/metronome_contract`, `credits/usage_configuration`, `subscription`, `users/spend_limit`, `workspace/default_user_spend_limit`. The pure domain types (`BillingInfo`, `BillingInvoice`, `MetronomeContractSummary`, `CreditUsageConfigurationBody`, `CheckoutStatus`, `UserSpendLimit`, `DefaultUserSpendLimit`, …) moved alongside their DTOs; lib back-imports the ones returned by kept functions.

**Deferred to Pass B** (transitive `@app/lib` couplings): `credits/members_usage` (`BillingFrequency`/`EffectiveSpendLimitSource`/`MetronomeAlertRef`), `credits/purchase` (`CreditPurchaseLimits`), `credits/seat_plan` (`SeatAwuCreditsPeriod`).

21 consumers updated (split-aware).

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)