### PR TITLE
refactor(front): Pass A assistant gotchas — move DTOs + pure local types to types/api

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -1,12 +1,12 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { GetAgentOverviewResponseBody } from "@app/lib/api/assistant/observability/overview";
 import {
   fetchAgentCostStats,
   fetchAgentOverview,
   getAgentCostStats,
 } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/attachments.ts
@@ -1,6 +1,6 @@
-import type { GetConversationAttachmentsResponseBody } from "@app/lib/api/assistant/conversation/attachments";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
+import type { GetConversationAttachmentsResponseBody } from "@app/types/api/assistant/conversation/attachments";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -3,14 +3,14 @@ import {
   REQUEST_PLAN_APPROVAL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/plan_mode/metadata";
 import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
-import type {
-  GetConversationPlanModeResponseBody,
-  PlanApprovalState,
-} from "@app/lib/api/assistant/plan_mode";
 import { findActivePlanFile } from "@app/lib/api/assistant/plan_mode";
 import { getFileContent } from "@app/lib/api/files/utils";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type {
+  GetConversationPlanModeResponseBody,
+  PlanApprovalState,
+} from "@app/types/api/assistant/plan_mode";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front/components/assistant/conversation/files_panel/types.ts
+++ b/front/components/assistant/conversation/files_panel/types.ts
@@ -2,7 +2,7 @@ import type { FilePanelCategory } from "@app/components/file_explorer/types";
 import type {
   AttachmentCreator,
   GetConversationAttachmentsResponseBody,
-} from "@app/lib/api/assistant/conversation/attachments";
+} from "@app/types/api/assistant/conversation/attachments";
 
 export type ConversationAttachmentItem =
   GetConversationAttachmentsResponseBody["attachments"][number];

--- a/front/components/assistant/conversation/plan_mode/utils.tsx
+++ b/front/components/assistant/conversation/plan_mode/utils.tsx
@@ -1,4 +1,4 @@
-import type { PlanApprovalState } from "@app/lib/api/assistant/plan_mode";
+import type { PlanApprovalState } from "@app/types/api/assistant/plan_mode";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { Chip } from "@dust-tt/sparkle";
 

--- a/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
@@ -2,14 +2,12 @@ import { matchesSlashCommandCapabilityQuery } from "@app/components/editor/exten
 import { InlineSlashSearch } from "@app/components/editor/extensions/shared/slash_suggestion/InlineSlashSearch";
 import { getSingularFileCategoryLabelForContentType } from "@app/components/file_explorer/utils";
 import { useConversationAttachments } from "@app/hooks/conversations/useConversationAttachments";
-import {
-  type FileAttachmentType,
-  isFileAttachmentType,
-} from "@app/lib/api/assistant/conversation/attachments";
+import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
 import { usePodFiles } from "@app/lib/swr/pods";
 import type { ProjectFileSearchResult } from "@app/lib/swr/search";
 import { useSpaces } from "@app/lib/swr/spaces";
+import type { FileAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import { DropdownMenuItem, Icon, Spinner } from "@dust-tt/sparkle";

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -20,7 +20,6 @@ import { RenameFileDialog } from "@app/components/pod/files/RenameFileDialog";
 import SpaceManagedDatasourcesViewsModal from "@app/components/spaces/SpaceManagedDatasourcesViewsModal";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { usePinPodBanner } from "@app/hooks/usePinPodBanner";
-import type { ContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { useAppRouter } from "@app/lib/platform";
 import { downloadFile, getFilePathViewUrl } from "@app/lib/swr/files";
@@ -34,6 +33,7 @@ import {
 } from "@app/lib/swr/pods";
 import { useSpaceDataSourceViews, useSpaces } from "@app/lib/swr/spaces";
 import { isManualPodFilesManagementAllowed } from "@app/lib/workspace_policies";
+import type { ContentNodeAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type {
   DataSourceViewSelectionConfigurations,

--- a/front/hooks/conversations/useConversationAttachments.ts
+++ b/front/hooks/conversations/useConversationAttachments.ts
@@ -1,5 +1,5 @@
-import type { GetConversationAttachmentsResponseBody } from "@app/lib/api/assistant/conversation/attachments";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationAttachmentsResponseBody } from "@app/types/api/assistant/conversation/attachments";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";

--- a/front/hooks/conversations/usePlanFile.ts
+++ b/front/hooks/conversations/usePlanFile.ts
@@ -1,5 +1,5 @@
-import type { GetConversationPlanModeResponseBody } from "@app/lib/api/assistant/plan_mode";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetConversationPlanModeResponseBody } from "@app/types/api/assistant/plan_mode";
 import type { Fetcher } from "swr";
 
 export function planFileKey({

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,6 +1,5 @@
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { resolveFile } from "@app/lib/api/actions/servers/files/tools/utils";
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
@@ -16,6 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { streamToBuffer } from "@app/lib/utils/streams";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";
 import type { Result } from "@dust-tt/client";

--- a/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.test.ts
@@ -1,4 +1,4 @@
-import type { FileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import type { FileAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import { describe, expect, it } from "vitest";
 
 import { contentFromAttachments } from "./index";

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -17,8 +17,6 @@ import {
 import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import {
-  type ContentNodeAttachmentType,
-  type ConversationAttachmentType,
   conversationAttachmentId,
   isContentNodeAttachmentType,
   renderAttachmentXml,
@@ -31,6 +29,10 @@ import {
   CONTENT_OUTDATED_MSG,
   getContentFragmentFromAttachmentFile,
 } from "@app/lib/resources/content_fragment_resource";
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/types/api/assistant/conversation/attachments";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
   ImageContent,

--- a/front/lib/api/actions/servers/pod_manager/build_pod_search_data_sources.ts
+++ b/front/lib/api/actions/servers/pod_manager/build_pod_search_data_sources.ts
@@ -1,7 +1,6 @@
 import { getDataSourceURI } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
-import type { ContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   isContentFragmentDataSourceNode,
   isContentNodeAttachmentType,
@@ -16,6 +15,7 @@ import {
 } from "@app/lib/api/projects/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ContentNodeAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 export type PodSemanticSearchScope = "files" | "conversations" | "all";

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -8,8 +8,15 @@ import {
 import logger from "@app/logger/logger";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/assistant";
 import type {
+  AttachmentCreator,
+  BaseConversationAttachmentType,
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+  FileAttachmentType,
+  LargePasteType,
+} from "@app/types/api/assistant/conversation/attachments";
+import type {
   ContentFragmentType,
-  ContentFragmentVersion,
   ContentNodeContentFragmentType,
   FileContentFragmentType,
   SupportedContentFragmentType,
@@ -19,65 +26,12 @@ import {
   isExpiredContentFragment,
   isFileContentFragment,
 } from "@app/types/content_fragment";
-import type { ContentNodeType } from "@app/types/core/content_node";
 import { DATA_SOURCE_NODE_ID } from "@app/types/core/content_node";
 import type { AllSupportedFileContentType } from "@app/types/files";
 import { isSupportedDelimitedTextContentType } from "@app/types/files";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
-
-export type AttachmentCreator = {
-  type: "agent" | "user";
-  name: string;
-  pictureUrl: string;
-};
-
-export type BaseConversationAttachmentType = {
-  title: string;
-  contentType: SupportedContentFragmentType;
-  contentFragmentVersion: ContentFragmentVersion;
-  snippet: string | null;
-  generatedTables: string[];
-  isIncludable: boolean;
-  isSearchable: boolean;
-  isQueryable: boolean;
-  isInProjectContext: boolean;
-  creator: AttachmentCreator | null;
-  hidden: boolean; // Do not show this attachment to the user.
-};
-
-export type FileAttachmentType = BaseConversationAttachmentType & {
-  fileId: string;
-  path: string | null;
-  source: "agent" | "user" | null;
-  createdAt?: number;
-  updatedAt?: number;
-};
-
-export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
-  contentFragmentId: string;
-  nodeId: string;
-  nodeDataSourceViewId: string;
-  nodeType: ContentNodeType;
-  sourceUrl: string | null;
-  lastUpdatedAt?: number | null; //Last sync / update timestamp for the underlying data source node (Core node timestamp).
-};
-
-export type LargePasteType = {
-  title: string;
-};
-
-export type ConversationAttachmentType =
-  | FileAttachmentType
-  | ContentNodeAttachmentType;
-
-/** Same item shape as GET `/assistant/conversations/[cId]/attachments` and GET project context. */
-export type ContextAttachmentItem = ConversationAttachmentType;
-
-export type GetConversationAttachmentsResponseBody = {
-  attachments: ConversationAttachmentType[];
-};
 
 export function isFileAttachmentType(
   attachment: ConversationAttachmentType

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -1,7 +1,5 @@
 import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
 import {
-  type ContentNodeAttachmentType,
-  type FileAttachmentType,
   isContentNodeAttachmentType,
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
@@ -34,6 +32,10 @@ import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentInputWithFileIdType,
 } from "@app/types/api/assistant";
+import type {
+  ContentNodeAttachmentType,
+  FileAttachmentType,
+} from "@app/types/api/assistant/conversation/attachments";
 import type { CompactionAttachmentIdReplacements } from "@app/types/assistant/compaction";
 import type {
   ConversationType,

--- a/front/lib/api/assistant/jit/conversation.ts
+++ b/front/lib/api/assistant/jit/conversation.ts
@@ -1,11 +1,11 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { CONVERSATION_FILES_SERVER_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import assert from "assert";
 

--- a/front/lib/api/assistant/jit/folder.ts
+++ b/front/lib/api/assistant/jit/folder.ts
@@ -1,10 +1,6 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
-import type {
-  ContentNodeAttachmentType,
-  ConversationAttachmentType,
-} from "@app/lib/api/assistant/conversation/attachments";
 import {
   isContentFragmentDataSourceNode,
   isContentNodeAttachmentType,
@@ -13,6 +9,10 @@ import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/types/api/assistant/conversation/attachments";
 import assert from "assert";
 
 /**

--- a/front/lib/api/assistant/jit/query_tables_v2.ts
+++ b/front/lib/api/assistant/jit/query_tables_v2.ts
@@ -7,7 +7,6 @@ import {
   CONVERSATION_LIST_FILES_ACTION_NAME,
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   isContentNodeAttachmentType,
   isFileAttachmentType,
@@ -22,6 +21,7 @@ import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_r
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import assert from "assert";
 

--- a/front/lib/api/assistant/jit/utils.ts
+++ b/front/lib/api/assistant/jit/utils.ts
@@ -1,7 +1,3 @@
-import type {
-  ContentNodeAttachmentType,
-  ConversationAttachmentType,
-} from "@app/lib/api/assistant/conversation/attachments";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { isMultiSheetSpreadsheetContentType } from "@app/lib/api/assistant/conversation/content_types";
 import config from "@app/lib/api/config";
@@ -12,6 +8,10 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/types/api/assistant/conversation/attachments";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import { CoreAPI } from "@app/types/core/core_api";

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -3,7 +3,6 @@ import {
   CONVERSATION_FILES_SERVER_NAME,
   CONVERSATION_LIST_FILES_ACTION_NAME,
 } from "@app/lib/api/actions/servers/conversation_files/metadata";
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -18,6 +17,7 @@ import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { WorkspaceType } from "@app/types/user";

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,6 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import { getCommonUtilitiesServer } from "@app/lib/api/assistant/jit/common_utilities";
 import {
@@ -15,6 +14,7 @@ import { getSkillManagementServer } from "@app/lib/api/assistant/jit/skills";
 import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { removeNulls } from "@app/types/shared/utils/general";

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,15 +1,15 @@
 // Okay to use public API types because here front is talking to core API.
 
-import type {
-  ContentNodeAttachmentType,
-  ConversationAttachmentType,
-} from "@app/lib/api/assistant/conversation/attachments";
 import {
   getAttachmentFromContentFragment,
   makeFileAttachment,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { truncateLegacyPastedSnippet } from "@app/lib/api/files/snippet";
 import type { Authenticator } from "@app/lib/auth";
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/types/api/assistant/conversation/attachments";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import { isContentFragmentType } from "@app/types/content_fragment";

--- a/front/lib/api/assistant/observability/overview.ts
+++ b/front/lib/api/assistant/observability/overview.ts
@@ -2,16 +2,11 @@ import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observabili
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentCostStats } from "@app/types/api/assistant/observability/overview";
 import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
-
-export type AgentCostStats = {
-  totalCostCredits: number | null;
-  avgCostCredits: number | null;
-  medianCostCredits: number | null;
-};
 
 export type AgentOverview = {
   activeUsers: number;
@@ -192,18 +187,3 @@ export function getAgentCostStats(
 ): AgentCostStats {
   return map.get(agentId) ?? EMPTY_COST_STATS;
 }
-
-export type GetAgentOverviewResponseBody = {
-  activeUsers: number;
-  mentions: {
-    messageCount: number;
-    conversationCount: number;
-    timePeriodSec: number;
-  };
-  feedbacks: {
-    positiveFeedbacks: number;
-    negativeFeedbacks: number;
-    timePeriodSec: number;
-  };
-  costs: AgentCostStats;
-};

--- a/front/lib/api/assistant/plan_mode.ts
+++ b/front/lib/api/assistant/plan_mode.ts
@@ -2,15 +2,7 @@ import { PLAN_MODE_SKELETON } from "@app/lib/api/actions/servers/plan_mode/metad
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
-import type { FileType, PlanModeApproval } from "@app/types/files";
-
-export type PlanApprovalState = "draft" | "pending" | "approved";
-
-export type GetConversationPlanModeResponseBody = {
-  planFile: FileType | null;
-  content: string | null;
-  approvalState: PlanApprovalState;
-};
+import type { PlanModeApproval } from "@app/types/files";
 
 // Conversation-scoped lock for all plan-mode operations. One plan per conversation, so a single
 // lock keyed on conversation sId serializes create/edit/approve/close and prevents races (e.g.

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -1,4 +1,3 @@
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   getAttachmentFromContentFragment,
   isContentNodeAttachmentType,
@@ -37,6 +36,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/assistant";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -1,4 +1,3 @@
-import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
 import {
   conversationAttachmentId,
   getAttachmentFromContentFragment,
@@ -37,6 +36,7 @@ import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
 import type { ContentFragmentMessageTypeModel } from "@app/types/assistant/generation";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -13,7 +13,6 @@ import type {
   GetLatencyResponse,
   GetUsageMetricsResponse,
 } from "@app/lib/api/assistant/observability/messages_metrics";
-import type { GetAgentOverviewResponseBody } from "@app/lib/api/assistant/observability/overview";
 import type { GetSkillExecutionResponse } from "@app/lib/api/assistant/observability/skill_execution";
 import type { GetToolExecutionResponse } from "@app/lib/api/assistant/observability/tool_execution";
 import type {
@@ -40,6 +39,7 @@ import type { GetAgentUsageResponseBody } from "@app/types/api/assistant/agent_u
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
 import type { GetAgentConfigurationsResponseBody } from "@app/types/api/assistant/configuration";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/types/api/assistant/mcp_configurations";
+import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
 import type { GetAgentSummaryResponseBody } from "@app/types/api/assistant/observability/summary";
 import type { PostAgentUserFavoriteRequestBody } from "@app/types/api/assistant/user_relation";
 import type { GetMemberResponseBody } from "@app/types/api/user";

--- a/front/types/api/assistant/conversation/attachments.ts
+++ b/front/types/api/assistant/conversation/attachments.ts
@@ -1,0 +1,57 @@
+import type {
+  ContentFragmentVersion,
+  SupportedContentFragmentType,
+} from "@app/types/content_fragment";
+import type { ContentNodeType } from "@app/types/core/content_node";
+
+export type AttachmentCreator = {
+  type: "agent" | "user";
+  name: string;
+  pictureUrl: string;
+};
+
+export type BaseConversationAttachmentType = {
+  title: string;
+  contentType: SupportedContentFragmentType;
+  contentFragmentVersion: ContentFragmentVersion;
+  snippet: string | null;
+  generatedTables: string[];
+  isIncludable: boolean;
+  isSearchable: boolean;
+  isQueryable: boolean;
+  isInProjectContext: boolean;
+  creator: AttachmentCreator | null;
+  hidden: boolean; // Do not show this attachment to the user.
+};
+
+export type FileAttachmentType = BaseConversationAttachmentType & {
+  fileId: string;
+  path: string | null;
+  source: "agent" | "user" | null;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
+  contentFragmentId: string;
+  nodeId: string;
+  nodeDataSourceViewId: string;
+  nodeType: ContentNodeType;
+  sourceUrl: string | null;
+  lastUpdatedAt?: number | null; //Last sync / update timestamp for the underlying data source node (Core node timestamp).
+};
+
+export type LargePasteType = {
+  title: string;
+};
+
+export type ConversationAttachmentType =
+  | FileAttachmentType
+  | ContentNodeAttachmentType;
+
+/** Same item shape as GET `/assistant/conversations/[cId]/attachments` and GET project context. */
+export type ContextAttachmentItem = ConversationAttachmentType;
+
+export type GetConversationAttachmentsResponseBody = {
+  attachments: ConversationAttachmentType[];
+};

--- a/front/types/api/assistant/observability/overview.ts
+++ b/front/types/api/assistant/observability/overview.ts
@@ -1,0 +1,20 @@
+export type AgentCostStats = {
+  totalCostCredits: number | null;
+  avgCostCredits: number | null;
+  medianCostCredits: number | null;
+};
+
+export type GetAgentOverviewResponseBody = {
+  activeUsers: number;
+  mentions: {
+    messageCount: number;
+    conversationCount: number;
+    timePeriodSec: number;
+  };
+  feedbacks: {
+    positiveFeedbacks: number;
+    negativeFeedbacks: number;
+    timePeriodSec: number;
+  };
+  costs: AgentCostStats;
+};

--- a/front/types/api/assistant/plan_mode.ts
+++ b/front/types/api/assistant/plan_mode.ts
@@ -1,0 +1,9 @@
+import type { FileType } from "@app/types/files";
+
+export type PlanApprovalState = "draft" | "pending" | "approved";
+
+export type GetConversationPlanModeResponseBody = {
+  planFile: FileType | null;
+  content: string | null;
+  approvalState: PlanApprovalState;
+};


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

Stacked on #27855. **Pass A** (assistant). All 3 files' local domain types were pure, so each moves the DTO plus its local type(s) to `types/api`.

- `assistant/plan_mode` → `PlanApprovalState` + `GetConversationPlanModeResponseBody`.
- `assistant/observability/overview` → `AgentCostStats` + `GetAgentOverviewResponseBody` (lib back-imports `AgentCostStats`).
- `assistant/conversation/attachments` → the full attachment DTO tree (`ConversationAttachmentType` & friends); lib back-imports the 6 used by kept serializer/guard functions. Incidentally fixes the `ConversationAttachmentType` import in the deferred `projects/context.ts`.
- 31 consumers updated (split-aware). No deferrals.

Verified: `tsgo --noEmit` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)