### PR TITLE
Merge skill and input bar attach knowledge slash command.

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -329,12 +329,6 @@ const InputBarContainer = ({
   onNodeSelectRef.current = onNodeSelect;
   const includeAttachKnowledgeRef = useRef(actions.includes("attachment"));
   includeAttachKnowledgeRef.current = actions.includes("attachment");
-  const contextSpaceId = conversation?.spaceId ?? space?.sId ?? null;
-  const includeContextFilesRef = useRef(
-    Boolean(conversation?.sId) || Boolean(contextSpaceId)
-  );
-  includeContextFilesRef.current =
-    Boolean(conversation?.sId) || Boolean(contextSpaceId);
   const [selectedSkillIdForDetails, setSelectedSkillIdForDetails] = useState<
     string | null
   >(null);
@@ -658,7 +652,6 @@ const InputBarContainer = ({
       selectedMCPServerViewIdsRef,
       slashCommandsRef,
       includeAttachKnowledgeRef,
-      includeContextFilesRef,
       attachedNodesRef,
       onNodeSelectRef,
       spaceIdRef,

--- a/front/components/editor/extensions/input_bar/ContextSearchNodeView.tsx
+++ b/front/components/editor/extensions/input_bar/ContextSearchNodeView.tsx
@@ -13,7 +13,6 @@ import { useCallback } from "react";
 export interface ContextSearchNodeOptions {
   attachedNodesRef?: RefObject<DataSourceViewContentNode[]>;
   conversationIdRef?: RefObject<string | null>;
-  includeFilesRef?: RefObject<boolean>;
   onNodeSelectRef?: RefObject<
     ((node: DataSourceViewContentNode) => void) | undefined
   >;
@@ -50,7 +49,6 @@ export function ContextSearchNodeView({
 }: ContextSearchNodeViewProps) {
   const owner = options.owner;
   const conversationId = options.conversationIdRef?.current ?? null;
-  const includeFiles = options.includeFilesRef?.current ?? false;
 
   const handleCancel = useCallback(() => {
     deleteNode();
@@ -111,11 +109,11 @@ export function ContextSearchNodeView({
     <NodeViewWrapper className="inline">
       <ContextSlashSearch
         conversationId={conversationId}
-        includeFiles={includeFiles}
         isNodeAttached={isNodeAttached}
         onCancel={handleCancel}
         onSelect={handleSelect}
         owner={owner}
+        useCase="conversation-input"
         spaceId={options.spaceIdRef?.current ?? null}
       />
     </NodeViewWrapper>

--- a/front/components/editor/extensions/input_bar/ContextSearchNodeWithView.tsx
+++ b/front/components/editor/extensions/input_bar/ContextSearchNodeWithView.tsx
@@ -14,7 +14,6 @@ export { CONTEXT_SEARCH_NODE_TYPE };
 const DEFAULT_CONTEXT_SEARCH_NODE_OPTIONS: ContextSearchNodeOptions = {
   attachedNodesRef: { current: [] },
   conversationIdRef: { current: null },
-  includeFilesRef: { current: false },
   onNodeSelectRef: { current: undefined },
   owner: undefined,
   spaceIdRef: { current: null },

--- a/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
+++ b/front/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension.tsx
@@ -20,7 +20,6 @@ interface InputBarSlashSuggestionStorage {
 export interface InputBarSlashSuggestionExtensionOptions {
   conversationIdRef?: RefObject<string | null>;
   enabledRef: RefObject<boolean>;
-  includeContextFilesRef: RefObject<boolean>;
   includeAttachKnowledgeRef: RefObject<boolean>;
   onActiveChangeRef?: RefObject<((active: boolean) => void) | undefined>;
   onDetailsRef?: RefObject<((item: SlashCommand) => void) | undefined>;
@@ -49,7 +48,6 @@ export const InputBarSlashSuggestionExtension = createSlashSuggestionExtension<
     conversationIdRef: { current: null },
     enabledRef: { current: false },
     includeAttachKnowledgeRef: { current: false },
-    includeContextFilesRef: { current: false },
     onSelectRef: { current: undefined },
     onDetailsRef: { current: undefined },
     selectedMCPServerViewIdsRef: { current: new Set<string>() },

--- a/front/components/editor/extensions/shared/slash_suggestion/ContextSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/ContextSlashSearch.tsx
@@ -63,25 +63,43 @@ function contextFileItemToSearchItem(
   };
 }
 
+export type ContextSlashSearchUseCase = "conversation-input" | "skill-builder";
+
+const CONTEXT_SLASH_SEARCH_USE_CASES = {
+  "conversation-input": {
+    excludeNonRemoteDatabaseTables: false,
+    includeDataSources: true,
+  },
+  "skill-builder": {
+    excludeNonRemoteDatabaseTables: true,
+    includeDataSources: false,
+  },
+} as const;
+
 export interface ContextSlashSearchProps {
-  conversationId: string | null;
-  includeFiles: boolean;
+  conversationId?: string | null;
   isNodeAttached?: (node: DataSourceViewContentNode) => boolean;
   onCancel: () => void;
   onSelect: (selection: ContextSlashSearchSelection) => void;
   owner: LightWorkspaceType;
+  useCase: ContextSlashSearchUseCase;
   spaceId?: string | null;
 }
 
 export function ContextSlashSearch({
-  conversationId,
-  includeFiles,
+  conversationId = null,
   isNodeAttached,
   onCancel,
   onSelect,
   owner,
-  spaceId,
+  useCase,
+  spaceId = null,
 }: ContextSlashSearchProps) {
+  const { excludeNonRemoteDatabaseTables, includeDataSources } =
+    CONTEXT_SLASH_SEARCH_USE_CASES[useCase];
+  const includeFiles =
+    useCase === "conversation-input" &&
+    (Boolean(conversationId) || Boolean(spaceId));
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -129,7 +147,8 @@ export function ContextSlashSearch({
       spaceIds,
       projectId,
       viewType: "all",
-      includeDataSources: true,
+      excludeNonRemoteDatabaseTables,
+      includeDataSources,
       searchSourceUrls: true,
       includeTools: false,
       prioritizeSpaceAccess: true,
@@ -204,21 +223,30 @@ export function ContextSlashSearch({
     isFileItemsLoading ||
     (shouldSearchKnowledge && isSearchLoading);
 
+  const isDropdownOpen =
+    searchQuery.trim().length > 0 || items.length > 0 || isLoading;
+
+  const emptyMessage = !shouldSearchKnowledge
+    ? "Type at least 2 characters to search"
+    : "No results found";
+
+  const loadingMessage = includeFiles
+    ? "Searching..."
+    : "Searching knowledge...";
+
   const dropdownContent =
     isLoading && items.length === 0 ? (
       <div className="flex h-14 items-center justify-center">
         <Spinner size="sm" />
         <span className="ml-2 text-sm text-gray-500 dark:text-gray-500-night">
-          Searching...
+          {loadingMessage}
         </span>
       </div>
     ) : items.length === 0 ? (
       <div className="flex h-14 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-500-night">
-        {!shouldSearchKnowledge && !includeFiles
-          ? "Type at least 2 characters to search"
-          : !shouldSearchKnowledge && includeFiles
-            ? "No files found"
-            : "No results found"}
+        {!shouldSearchKnowledge && includeFiles && fileItems.length === 0
+          ? "No files found"
+          : emptyMessage}
       </div>
     ) : (
       items.map((item, index) => (
@@ -271,7 +299,7 @@ export function ContextSlashSearch({
       deferDropdownUntilFocus
       dropdownContent={dropdownContent}
       highlightedItemId={items[selectedIndex]?.id}
-      isDropdownOpen={items.length > 0 || isLoading}
+      isDropdownOpen={isDropdownOpen}
       itemCount={items.length}
       onCancel={onCancel}
       onSearchQueryChange={(text) => {

--- a/front/components/editor/extensions/shared/slash_suggestion/KnowledgeSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/KnowledgeSlashSearch.tsx
@@ -1,23 +1,10 @@
-import { InlineSlashSearch } from "@app/components/editor/extensions/shared/slash_suggestion/InlineSlashSearch";
+import type { ContextSlashSearchSelection } from "@app/components/editor/extensions/shared/slash_suggestion/ContextSlashSearch";
+import { ContextSlashSearch } from "@app/components/editor/extensions/shared/slash_suggestion/ContextSlashSearch";
 import { computeHasChildren } from "@app/components/editor/extensions/skill_builder/KnowledgeNodeTypes";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
-import {
-  getLocationForDataSourceViewContentNodeWithSpace,
-  getVisualForDataSourceViewContentNode,
-} from "@app/lib/content_nodes";
-import { isFolder, isWebsite } from "@app/lib/data_sources";
-import { useUnifiedSearch } from "@app/lib/swr/search";
-import { useSpaces } from "@app/lib/swr/spaces";
-import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewContentNode } from "@app/types/data_source_view";
-import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
-import { DoubleIcon, DropdownMenuItem, Icon, Spinner } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useMemo, useState } from "react";
 
 export interface KnowledgeSlashSearchProps {
-  excludeNonRemoteDatabaseTables?: boolean;
-  includeDataSources?: boolean;
   isNodeAttached?: (node: DataSourceViewContentNode) => boolean;
   onCancel: () => void;
   onSelect: (node: DataSourceViewContentNode) => void;
@@ -26,180 +13,26 @@ export interface KnowledgeSlashSearchProps {
 }
 
 export function KnowledgeSlashSearch({
-  excludeNonRemoteDatabaseTables = false,
-  includeDataSources = false,
   isNodeAttached,
   onCancel,
   onSelect,
   owner,
   spaceId,
 }: KnowledgeSlashSearchProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [searchQuery, setSearchQuery] = useState("");
-
-  const { spaces, isSpacesLoading } = useSpaces({
-    workspaceId: owner.sId,
-    kinds: ["global", "regular", "project"],
-    disabled: false,
-  });
-
-  const spacesMap = useMemo(
-    () => Object.fromEntries(spaces.map((space) => [space.sId, space])),
-    [spaces]
-  );
-
-  const spaceIds = useMemo(() => {
-    if (spaceId) {
-      return spaces
-        .filter((space) => space.sId === spaceId || space.kind === "global")
-        .map((space) => space.sId);
+  const handleSelect = (selection: ContextSlashSearchSelection) => {
+    if (selection.kind === "knowledge") {
+      onSelect(selection.node);
     }
-
-    return spaces.map((space) => space.sId);
-  }, [spaceId, spaces]);
-
-  const projectId =
-    spaceId && spacesMap[spaceId]?.kind === "project" ? spaceId : undefined;
-
-  const { knowledgeResults: searchResults, isSearchLoading } = useUnifiedSearch(
-    {
-      owner,
-      query: searchQuery,
-      pageSize: 10,
-      disabled: isSpacesLoading || searchQuery.length < MIN_SEARCH_QUERY_SIZE,
-      spaceIds,
-      projectId,
-      viewType: "all",
-      excludeNonRemoteDatabaseTables,
-      includeDataSources,
-      searchSourceUrls: true,
-      includeTools: false,
-      prioritizeSpaceAccess: true,
-    }
-  );
-
-  const knowledgeNodes = useMemo(
-    () =>
-      removeNulls(
-        searchResults.map((node) => {
-          const { dataSourceViews, ...rest } = node;
-          const dataSourceView = dataSourceViews.find(
-            (view) => spacesMap[view.spaceId]
-          );
-
-          if (!dataSourceView) {
-            return null;
-          }
-
-          const knowledgeNode = { ...rest, dataSourceView };
-
-          if (isNodeAttached?.(knowledgeNode)) {
-            return null;
-          }
-
-          return knowledgeNode;
-        })
-      ),
-    [isNodeAttached, searchResults, spacesMap]
-  );
-
-  useEffect(() => {
-    setSelectedIndex(0);
-    if (knowledgeNodes.length > 0) {
-      setIsOpen(true);
-    }
-  }, [knowledgeNodes.length]);
-
-  const handleItemSelect = useCallback(
-    (index: number) => {
-      const node = knowledgeNodes[index];
-      if (node) {
-        onSelect(node);
-        setIsOpen(false);
-        setSelectedIndex(0);
-        setSearchQuery("");
-      }
-    },
-    [knowledgeNodes, onSelect]
-  );
-
-  const dropdownContent = isSearchLoading ? (
-    <div className="flex h-14 items-center justify-center">
-      <Spinner size="sm" />
-      <span className="ml-2 text-sm text-gray-500 dark:text-gray-500-night">
-        Searching knowledge...
-      </span>
-    </div>
-  ) : knowledgeNodes.length === 0 ? (
-    <div className="flex h-14 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-500-night">
-      {searchQuery.length < MIN_SEARCH_QUERY_SIZE
-        ? "Type at least 2 characters to search"
-        : "No knowledge found"}
-    </div>
-  ) : (
-    knowledgeNodes.map((node, index) => {
-      const itemId = `${node.internalId}-${node.dataSourceView.sId}`;
-
-      return (
-        <DropdownMenuItem
-          key={itemId}
-          itemId={itemId}
-          icon={
-            isWebsite(node.dataSourceView.dataSource) ||
-            isFolder(node.dataSourceView.dataSource) ? (
-              <Icon
-                visual={getVisualForDataSourceViewContentNode(node)}
-                size="md"
-              />
-            ) : (
-              <DoubleIcon
-                size="md"
-                mainIcon={getVisualForDataSourceViewContentNode(node)}
-                secondaryIcon={getConnectorProviderLogoWithFallback({
-                  provider: node.dataSourceView.dataSource.connectorProvider,
-                })}
-              />
-            )
-          }
-          label={node.title}
-          description={getLocationForDataSourceViewContentNodeWithSpace(
-            node,
-            spacesMap
-          )}
-          truncateText
-          onClick={() => handleItemSelect(index)}
-          onMouseEnter={() => setSelectedIndex(index)}
-          className={
-            index === selectedIndex ? "bg-gray-100 dark:bg-gray-800" : ""
-          }
-        />
-      );
-    })
-  );
+  };
 
   return (
-    <InlineSlashSearch
-      deferDropdownUntilFocus
-      dropdownContent={dropdownContent}
-      highlightedItemId={
-        knowledgeNodes[selectedIndex]
-          ? `${knowledgeNodes[selectedIndex].internalId}-${knowledgeNodes[selectedIndex].dataSourceView.sId}`
-          : undefined
-      }
-      isDropdownOpen={isOpen}
-      itemCount={knowledgeNodes.length}
+    <ContextSlashSearch
+      isNodeAttached={isNodeAttached}
       onCancel={onCancel}
-      onSearchQueryChange={(text) => {
-        setSearchQuery(text);
-        setSelectedIndex(0);
-        setIsOpen(text.trim().length > 0);
-      }}
-      onSelectIndex={handleItemSelect}
-      onSelectedIndexChange={setSelectedIndex}
-      placeholder="Search for knowledge..."
-      searchQuery={searchQuery}
-      selectedIndex={selectedIndex}
+      onSelect={handleSelect}
+      owner={owner}
+      useCase="skill-builder"
+      spaceId={spaceId}
     />
   );
 }

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -138,7 +138,6 @@ function KnowledgeSearchComponent({
 
   return (
     <KnowledgeSlashSearch
-      excludeNonRemoteDatabaseTables
       onCancel={onCancel}
       onSelect={(node) => onSelect(knowledgeNodeToItem(node))}
       owner={owner}

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -35,7 +35,6 @@ describe("buildEditorExtensions", () => {
           selectedMCPServerViewIdsRef: { current: new Set<string>() },
           slashCommandsRef: { current: [] },
           includeAttachKnowledgeRef: { current: false },
-          includeContextFilesRef: { current: false },
         }),
       ],
     });

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -314,7 +314,6 @@ export interface CustomEditorProps {
     selectedMCPServerViewIdsRef: React.RefObject<Set<string>>;
     slashCommandsRef: React.RefObject<InputBarSlashCommand[]>;
     includeAttachKnowledgeRef: React.RefObject<boolean>;
-    includeContextFilesRef: React.RefObject<boolean>;
     attachedNodesRef: React.RefObject<DataSourceViewContentNode[]>;
     onNodeSelectRef: React.RefObject<
       ((node: DataSourceViewContentNode) => void) | undefined
@@ -465,7 +464,6 @@ export const buildEditorExtensions = ({
       InputBarContextSearchNode.configure({
         attachedNodesRef: slashSuggestion.attachedNodesRef,
         conversationIdRef: slashSuggestion.conversationIdRef,
-        includeFilesRef: slashSuggestion.includeContextFilesRef,
         onNodeSelectRef: slashSuggestion.onNodeSelectRef,
         owner,
         spaceIdRef: slashSuggestion.spaceIdRef,
@@ -479,7 +477,6 @@ export const buildEditorExtensions = ({
         onActiveChangeRef: onSuggestionActiveChangeRef,
         slashCommandsRef: slashSuggestion.slashCommandsRef,
         includeAttachKnowledgeRef: slashSuggestion.includeAttachKnowledgeRef,
-        includeContextFilesRef: slashSuggestion.includeContextFilesRef,
       })
     );
   }


### PR DESCRIPTION
## Description

Merged `KnowledgeSlashSearch` (~180 lines) into `ContextSlashSearch` by introducing a `useCase: ContextSlashSearchUseCase` prop (`"conversation-input"` | `"skill-builder"`). A `CONTEXT_SLASH_SEARCH_USE_CASES` config map drives `excludeNonRemoteDatabaseTables`, `includeDataSources`, and `includeFiles` per use case, replacing the ad-hoc `includeFilesRef` boolean that was threaded through `InputBarContainer` → `InputBarSlashSuggestionExtension` → `ContextSearchNodeView`. `KnowledgeSlashSearch` is now a thin wrapper delegating to `ContextSlashSearch` with `useCase="skill-builder"`. Also fixes `isDropdownOpen` to open on non-empty search query, not just when items are present.

## Tests

Updated `useCustomEditor.test.ts` to remove the `includeContextFilesRef` prop. Tested locally via the attach-knowledge slash command in both the input bar and skill builder.

## Risk

Low. Front-only refactor — no API changes, no persistence, no behavioral change for end users. The skill-builder path (`excludeNonRemoteDatabaseTables: true`, `includeDataSources: false`) matches what was previously passed explicitly as props.

## Deploy Plan

Deploy front.
