### PR TITLE
Start searching context / files after minimum query, show the popup immediately.

### DIFF
--- a/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/ContextFileSlashSearch.tsx
@@ -6,6 +6,7 @@ import { usePodFiles } from "@app/lib/swr/pods";
 import type { ProjectFileSearchResult } from "@app/lib/swr/search";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { FileAttachmentType } from "@app/types/api/assistant/conversation/attachments";
+import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useMemo } from "react";
@@ -58,10 +59,13 @@ export function useContextFileSlashSearchItems({
   owner: LightWorkspaceType;
   spaceId?: string | null;
 }) {
+  const shouldSearchFiles =
+    includeFiles && normalizedQuery.length >= MIN_SEARCH_QUERY_SIZE;
+
   const { spaces, isSpacesLoading } = useSpaces({
     workspaceId: owner.sId,
     kinds: ["global", "regular", "project"],
-    disabled: !includeFiles,
+    disabled: !shouldSearchFiles,
   });
 
   const spacesMap = useMemo(
@@ -77,18 +81,18 @@ export function useContextFileSlashSearchItems({
   const { files: podFiles, isPodFilesLoading } = usePodFiles({
     owner,
     podId: projectId ?? "",
-    disabled: !includeFiles || !projectId,
+    disabled: !shouldSearchFiles || !projectId,
   });
 
   const { attachments, isConversationAttachmentsLoading } =
     useConversationAttachments({
       conversationId,
       owner,
-      options: { disabled: !includeFiles || !conversationId },
+      options: { disabled: !shouldSearchFiles || !conversationId },
     });
 
   const fileItems = useMemo<ContextFileSlashSearchItem[]>(() => {
-    if (!includeFiles) {
+    if (!shouldSearchFiles) {
       return [];
     }
 
@@ -159,10 +163,10 @@ export function useContextFileSlashSearchItems({
       ...sortContextFileItemsByLabel(conversationFiles),
       ...sortContextFileItemsByLabel(podContextFiles),
     ];
-  }, [attachments, includeFiles, normalizedQuery, podFiles, projectName]);
+  }, [attachments, podFiles, projectName, shouldSearchFiles, normalizedQuery]);
 
   const isFileItemsLoading =
-    includeFiles &&
+    shouldSearchFiles &&
     (isSpacesLoading ||
       (Boolean(conversationId) && isConversationAttachmentsLoading) ||
       (Boolean(projectId) && isPodFilesLoading));

--- a/front/components/editor/extensions/shared/slash_suggestion/ContextSlashSearch.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/ContextSlashSearch.tsx
@@ -128,7 +128,7 @@ export function ContextSlashSearch({
     spaceId && spacesMap[spaceId]?.kind === "project" ? spaceId : undefined;
 
   const normalizedQuery = searchQuery.trim().toLowerCase();
-  const shouldSearchKnowledge = normalizedQuery.length >= MIN_SEARCH_QUERY_SIZE;
+  const hasMinimalQuery = normalizedQuery.length >= MIN_SEARCH_QUERY_SIZE;
 
   const { fileItems, isFileItemsLoading } = useContextFileSlashSearchItems({
     conversationId,
@@ -143,7 +143,7 @@ export function ContextSlashSearch({
       owner,
       query: searchQuery,
       pageSize: 10,
-      disabled: isSpacesLoading || !shouldSearchKnowledge,
+      disabled: isSpacesLoading || !hasMinimalQuery,
       spaceIds,
       projectId,
       viewType: "all",
@@ -221,12 +221,9 @@ export function ContextSlashSearch({
   const isLoading =
     isSpacesLoading ||
     isFileItemsLoading ||
-    (shouldSearchKnowledge && isSearchLoading);
+    (hasMinimalQuery && isSearchLoading);
 
-  const isDropdownOpen =
-    searchQuery.trim().length > 0 || items.length > 0 || isLoading;
-
-  const emptyMessage = !shouldSearchKnowledge
+  const emptyMessage = !hasMinimalQuery
     ? "Type at least 2 characters to search"
     : "No results found";
 
@@ -244,9 +241,7 @@ export function ContextSlashSearch({
       </div>
     ) : items.length === 0 ? (
       <div className="flex h-14 items-center justify-center text-center text-sm text-gray-500 dark:text-gray-500-night">
-        {!shouldSearchKnowledge && includeFiles && fileItems.length === 0
-          ? "No files found"
-          : emptyMessage}
+        {emptyMessage}
       </div>
     ) : (
       items.map((item, index) => (
@@ -299,7 +294,7 @@ export function ContextSlashSearch({
       deferDropdownUntilFocus
       dropdownContent={dropdownContent}
       highlightedItemId={items[selectedIndex]?.id}
-      isDropdownOpen={isDropdownOpen}
+      isDropdownOpen={true}
       itemCount={items.length}
       onCancel={onCancel}
       onSearchQueryChange={(text) => {


### PR DESCRIPTION
## Description

`ContextSlashSearch` now opens its dropdown immediately (`isDropdownOpen={true}`) instead of waiting for a non-empty query or results. File and knowledge search is still gated behind `MIN_SEARCH_QUERY_SIZE` (2 chars) — `useContextFileSlashSearchItems` introduces `shouldSearchFiles` to disable all three SWR hooks (`useSpaces`, `usePodFiles`, `useConversationAttachments`) until the threshold is met. The empty-state message is unified to "Type at least 2 characters to search" / "No results found", replacing the old conditional "No files found" branch.

## Tests

Tested locally — opened the context slash search with and without a query, confirmed the popup appears immediately, file/knowledge fetches only trigger after 2 characters.

## Risk

Low. Front-only change. The only behavioral delta is when the dropdown appears and when network requests fire — no data model or API changes.

## Deploy Plan

Deploy `front`.
