### PR TITLE
fix(front-api): avoid setting reporters to undefined in vitest config

### DIFF
--- a/front-api/vite.config.mjs
+++ b/front-api/vite.config.mjs
@@ -26,9 +26,9 @@ export default defineConfig({
     // annotation action resolves the right source file. Without file=, the
     // action guesses from the classname, which ends in ".ts" and matches
     // node_modules/thread-stream/test/ts.test.ts instead of the actual file.
-    reporters: process.env.CI
-      ? [["junit", { addFileAttribute: true }]]
-      : undefined,
+    ...(process.env.CI
+      ? { reporters: [["junit", { addFileAttribute: true }]] }
+      : {}),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Setting `reporters: undefined` explicitly in the vitest config caused a startup crash: vitest's coverage resolver calls `.length` on `resolved.reporters` before checking if it's defined, throwing `TypeError: Cannot read properties of undefined (reading 'length')`.
- Fixed by conditionally spreading the `reporters` key so it is simply absent when not in CI, letting vitest apply its default reporter instead.

## Test plan

- [ ] Run `NODE_ENV=test npm run test` from `front-api/` — should no longer crash at startup.