### PR TITLE
refactor(front): move file_system entry types into types/api

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,9 +1,9 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import { ensureIsSystemKey } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/files/index.ts
@@ -1,9 +1,4 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type {
-  FileSystemEntry,
-  GetSpaceFilesResponseBody,
-  PostSpaceFolderResponseBody,
-} from "@app/lib/api/file_system/types";
 import {
   isDustFileSystemError,
   SCOPED_PREFIX_POD,
@@ -11,6 +6,11 @@ import {
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { createProjectFolder } from "@app/lib/api/projects/context";
 import { PostPodFolderRequestBodySchema } from "@app/lib/api/projects/pod_mount_schemas";
+import type {
+  FileSystemEntry,
+  GetSpaceFilesResponseBody,
+  PostSpaceFolderResponseBody,
+} from "@app/types/api/file_system/types";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -11,8 +11,8 @@ import { useConversationAttachments } from "@app/hooks/conversations/useConversa
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import type { FileSystemFileEntry } from "@app/lib/api/file_system/types";
 import { downloadFile } from "@app/lib/swr/files";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isInteractiveContentType } from "@app/types/files";
 import type { LightWorkspaceType } from "@app/types/user";

--- a/front/components/assistant/conversation/files_panel/SandboxTab.tsx
+++ b/front/components/assistant/conversation/files_panel/SandboxTab.tsx
@@ -6,8 +6,8 @@ import {
 } from "@app/components/file_explorer/utils";
 import { useConversationSandboxFiles } from "@app/hooks/conversations/useConversationSandboxFiles";
 import { useDebounce } from "@app/hooks/useDebounce";
-import type { FileSystemFileEntry } from "@app/lib/api/file_system/types";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Card,

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -25,7 +25,7 @@ import {
   getScopedRelativePath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
 import { cn, Edit04, FolderOpen, Trash01 } from "@dust-tt/sparkle";

--- a/front/components/file_explorer/FileExplorerItem.tsx
+++ b/front/components/file_explorer/FileExplorerItem.tsx
@@ -15,9 +15,9 @@ import {
   getSingularFileCategoryLabelForContentType,
 } from "@app/components/file_explorer/utils";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
-import type { FileSystemFileEntry } from "@app/lib/api/file_system/types";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import {
   Button,
   CloudArrowLeftRight,

--- a/front/components/file_explorer/fileExplorerPipeline.ts
+++ b/front/components/file_explorer/fileExplorerPipeline.ts
@@ -11,8 +11,8 @@ import {
   getChildrenAtFolderPath,
   getFileExplorerBucket,
 } from "@app/components/file_explorer/utils";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
 import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 export interface FileExplorerPipeline {
   /** Tree nodes at the current folder level, filtered + sorted. */

--- a/front/components/file_explorer/types.ts
+++ b/front/components/file_explorer/types.ts
@@ -1,4 +1,4 @@
-import type { FileSystemFileEntry } from "@app/lib/api/file_system/types";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type React from "react";
 

--- a/front/components/file_explorer/utils.test.ts
+++ b/front/components/file_explorer/utils.test.ts
@@ -9,7 +9,7 @@ import {
   getChildrenAtFolderPath,
   isFileExplorerMovableFile,
 } from "@app/components/file_explorer/utils";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import { frameContentType, frameSlideshowContentType } from "@app/types/files";
 import { describe, expect, it } from "vitest";
 

--- a/front/components/file_explorer/utils.ts
+++ b/front/components/file_explorer/utils.ts
@@ -1,4 +1,4 @@
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import {
   frameSlideshowContentType,
   getFileFormatCategory,

--- a/front/hooks/conversations/useConversationSandboxFiles.ts
+++ b/front/hooks/conversations/useConversationSandboxFiles.ts
@@ -1,6 +1,6 @@
 import type { GetConversationFilesResponseBody } from "@app/lib/api/assistant/conversation/files";
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 

--- a/front/lib/api/assistant/conversation/files.ts
+++ b/front/lib/api/assistant/conversation/files.ts
@@ -1,4 +1,4 @@
-import type { FileSystemEntry } from "@app/lib/api/file_system/types";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 export type GetConversationFilesResponseBody = {
   files: FileSystemEntry[];

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -1,14 +1,16 @@
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
 import type {
   DustFileSystemError,
-  FileSystemDirectoryEntry,
-  FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
+import type {
+  FileSystemDirectoryEntry,
+  FileSystemEntry,
+} from "@app/types/api/file_system/types";
 import type { Result } from "@app/types/shared/result";
 import type { Readable } from "stream";
 
-export type { FileSystemEntry } from "@app/lib/api/file_system/types";
+export type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 /**
  * Backend-agnostic file system interface.

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -1,11 +1,7 @@
 import type { GCSMountTarget } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import { GCSSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/gcs_sandbox_mount_adapter";
 import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
-import type {
-  FileSystemDirectoryEntry,
-  FileSystemEntry,
-  FileSystemMount,
-} from "@app/lib/api/file_system/types";
+import type { FileSystemMount } from "@app/lib/api/file_system/types";
 import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
@@ -15,6 +11,10 @@ import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/lib/api/files/mount_path";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import fileStorageConfig from "@app/lib/file_storage/config";
 import logger from "@app/logger/logger";
+import type {
+  FileSystemDirectoryEntry,
+  FileSystemEntry,
+} from "@app/types/api/file_system/types";
 import { stripMimeParameters } from "@app/types/files";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -17,12 +17,7 @@
 import config from "@app/lib/api/config";
 import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
-import type {
-  FileSystemDirectoryEntry,
-  FileSystemEntry,
-  FileSystemFileEntry,
-  FileSystemMount,
-} from "@app/lib/api/file_system/types";
+import type { FileSystemMount } from "@app/lib/api/file_system/types";
 import {
   DustFileSystemError,
   LEGACY_PREFIX_CONVERSATION,
@@ -37,6 +32,11 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import type {
+  FileSystemDirectoryEntry,
+  FileSystemEntry,
+  FileSystemFileEntry,
+} from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import { isSupportedImageContentType } from "@app/types/files";
@@ -45,11 +45,9 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import * as path from "path";
 import type { Readable } from "stream";
 
-export type {
-  FileSystemEntry,
-  FileSystemMount,
-} from "@app/lib/api/file_system/types";
+export type { FileSystemMount } from "@app/lib/api/file_system/types";
 export { DustFileSystemError } from "@app/lib/api/file_system/types";
+export type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_RE = /[\x00-\x1F\x7F-\x9F]/g;

--- a/front/lib/api/file_system/index.ts
+++ b/front/lib/api/file_system/index.ts
@@ -6,7 +6,6 @@ export {
 } from "@app/lib/api/file_system/dust_file_system";
 export type {
   DustFileSystemErrorCode,
-  FileSystemEntry,
   FileSystemMount,
 } from "@app/lib/api/file_system/types";
 export {
@@ -15,3 +14,4 @@ export {
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system/types";
+export type { FileSystemEntry } from "@app/types/api/file_system/types";

--- a/front/lib/api/file_system/types.ts
+++ b/front/lib/api/file_system/types.ts
@@ -50,30 +50,6 @@ export type FileSystemMount = {
   };
 };
 
-type FileSystemEntryBase = {
-  fileName: string;
-  /** Full scoped path, e.g. `conversation-{cId}/folder/report.pdf`. Always canonical. */
-  path: string;
-  sizeBytes: number;
-  lastModifiedMs: number;
-};
-
-export type FileSystemDirectoryEntry = FileSystemEntryBase & {
-  isDirectory: true;
-};
-
-export type FileSystemFileEntry = FileSystemEntryBase & {
-  isDirectory: false;
-  contentType: string;
-  /** sId of the corresponding FileResource record, or null when none exists. */
-  fileId: string | null;
-  thumbnailUrl: string | null;
-  /** Present when the caller requested signed URLs. */
-  signedDownloadUrl?: string | null;
-};
-
-export type FileSystemEntry = FileSystemDirectoryEntry | FileSystemFileEntry;
-
 export type DustFileSystemErrorCode =
   | "unauthorized"
   | "not_found"
@@ -117,11 +93,3 @@ export function conversationScopedPath({
 export function podScopedPath(spaceId: string, rel: string): string {
   return `${SCOPED_PREFIX_POD}${spaceId}/${rel}`;
 }
-
-export type GetSpaceFilesResponseBody = {
-  files: FileSystemEntry[];
-};
-
-export type PostSpaceFolderResponseBody = {
-  folder: FileSystemDirectoryEntry;
-};

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -7,7 +7,6 @@
 import type { DustFileSystem } from "@app/lib/api/file_system";
 import {
   DustFileSystemError,
-  type FileSystemEntry,
   SCOPED_PREFIX_CONVERSATION,
   SCOPED_PREFIX_POD,
 } from "@app/lib/api/file_system/types";
@@ -15,6 +14,7 @@ import { decodeBuffer } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import type { FileUseCase, FileUseCaseMetadata } from "@app/types/files";
 import {
   contentTypeFromFileName,

--- a/front/lib/api/mcp_server/tools/files/list_output.ts
+++ b/front/lib/api/mcp_server/tools/files/list_output.ts
@@ -1,11 +1,11 @@
 import type { DustFileSystem } from "@app/lib/api/file_system";
-import type {
-  FileSystemEntry,
-  FileSystemFileEntry,
-} from "@app/lib/api/file_system/types";
 import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { parseProcessedFilename } from "@app/lib/api/files/mount_path";
 import type { Authenticator } from "@app/lib/auth";
+import type {
+  FileSystemEntry,
+  FileSystemFileEntry,
+} from "@app/types/api/file_system/types";
 import {
   isInteractiveContentType,
   stripMimeParameters,

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -5,7 +5,6 @@ import {
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
 import { DustFileSystem } from "@app/lib/api/file_system";
-import type { FileSystemDirectoryEntry } from "@app/lib/api/file_system/types";
 import {
   DustFileSystemError,
   podScopedPath,
@@ -37,6 +36,7 @@ import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/assistant";
 import type { ConversationAttachmentType } from "@app/types/api/assistant/conversation/attachments";
+import type { FileSystemDirectoryEntry } from "@app/types/api/file_system/types";
 import type { ContentNodeType } from "@app/types/core/content_node";
 import type { ConnectorProvider } from "@app/types/data_source";
 import type { Result } from "@app/types/shared/result";

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -7,10 +7,6 @@ import { usePodConversationsSummary } from "@app/hooks/conversations";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type {
-  FileSystemEntry,
-  GetSpaceFilesResponseBody,
-} from "@app/lib/api/file_system/types";
-import type {
   GetProjectContextResponseBody,
   PostProjectContextContentNodeResponseBody as PostPodContextContentNodeResponseBody,
 } from "@app/lib/api/projects/context";
@@ -25,6 +21,10 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type { ContentFragmentInputWithContentNode } from "@app/types/api/assistant";
+import type {
+  FileSystemEntry,
+  GetSpaceFilesResponseBody,
+} from "@app/types/api/file_system/types";
 import type {
   GetPodMetadataResponseBody,
   PatchPodMetadataResponseBody,

--- a/front/temporal/agent_loop/lib/compaction.ts
+++ b/front/temporal/agent_loop/lib/compaction.ts
@@ -8,14 +8,12 @@ import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conver
 import { isProviderWhitelisted } from "@app/lib/api/assistant/models";
 import { publishConversationEvent } from "@app/lib/api/assistant/streaming/events";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
-import type {
-  DustFileSystemError,
-  FileSystemFileEntry,
-} from "@app/lib/api/file_system/types";
+import type { DustFileSystemError } from "@app/lib/api/file_system/types";
 import { conversationScopedPath } from "@app/lib/api/file_system/types";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type {
   CompactionMessageType,

--- a/front/types/api/file_system/types.ts
+++ b/front/types/api/file_system/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared file-system entry types and the file-listing transport DTOs.
+ *
+ * Scoped path: the agent/API-visible path format, e.g. `conversation-{cId}/report.pdf`
+ * or `pod-{pId}/data.csv`. Entries always carry canonical scoped paths.
+ */
+
+type FileSystemEntryBase = {
+  fileName: string;
+  /** Full scoped path, e.g. `conversation-{cId}/folder/report.pdf`. Always canonical. */
+  path: string;
+  sizeBytes: number;
+  lastModifiedMs: number;
+};
+
+export type FileSystemDirectoryEntry = FileSystemEntryBase & {
+  isDirectory: true;
+};
+
+export type FileSystemFileEntry = FileSystemEntryBase & {
+  isDirectory: false;
+  contentType: string;
+  /** sId of the corresponding FileResource record, or null when none exists. */
+  fileId: string | null;
+  thumbnailUrl: string | null;
+  /** Present when the caller requested signed URLs. */
+  signedDownloadUrl?: string | null;
+};
+
+export type FileSystemEntry = FileSystemDirectoryEntry | FileSystemFileEntry;
+
+export type GetSpaceFilesResponseBody = {
+  files: FileSystemEntry[];
+};
+
+export type PostSpaceFolderResponseBody = {
+  folder: FileSystemDirectoryEntry;
+};


### PR DESCRIPTION
Part of the migration to move HTTP request/response DTO types out of `front/lib/api` and into `front/types/api/*`. Design doc: https://app.notion.com/p/38128599d94180848990e566ae472970

Stacked on #27858. The `file_system/types.ts` module mixes pure file-system entry types + their DTOs with runtime exports (a class, error guard, consts, helpers). This moves only the pure type tree to `types/api`; all runtime stays in lib.

- Moved → `types/api/file_system/types.ts`: `FileSystemEntryBase`, `FileSystemEntry`, `FileSystemFileEntry`, `FileSystemDirectoryEntry`, `GetSpaceFilesResponseBody`, `PostSpaceFolderResponseBody`.
- Kept in lib: `FileSystemMount`(+`Kind`), `DustFileSystemError`(+code+guard), `SCOPED_`/`LEGACY_PREFIX` consts, `conversationScopedPath`/`podScopedPath`.
- 20 consumers + the barrel updated (split-aware: types → `@app/types`, runtime → `@app/lib`). Also resolves the deferred Pass B file `conversation/files.ts`.

Verified: `npm run tsgo` clean in both `front` and `front-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)