### PR TITLE
refactor(mcp): move google_calendar meeting defaults from server instructions to create_event description

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -106,7 +106,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_event: {
-    description: "Create a new event in a Google Calendar.",
+    description:
+      "Create a new event in a Google Calendar. By default: (1) add the calling user as both organizer and attendee, (2) call check_availability to verify attendee availability beforehand, (3) call get_user_timezones first to determine attendee timezones for accurate scheduling.",
     schema: {
       calendarId: z
         .string()
@@ -294,7 +295,6 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
 });
 
 export const GOOGLE_CALENDAR_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "google_calendar",
     version: "1.0.0",
@@ -307,8 +307,7 @@ export const GOOGLE_CALENDAR_SERVER = {
     },
     icon: "GcalLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-calendar",
-    instructions:
-      "By default when creating a meeting, (1) set the calling user as the organizer and an attendee (2) check availability for attendees using the check_availability tool (3) use get_user_timezones to check attendee timezones for better scheduling.",
+    instructions: null,
   },
   tools: Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,


### PR DESCRIPTION
## Description

Move the three meeting-creation defaults out of `GOOGLE_CALENDAR_SERVER.serverInfo.instructions` and into the `create_event` tool description directly.

**Why:** `serverInfo.instructions` is injected into the system prompt on every agent loop turn (via `generation.ts`), which bloats the prompt prefix and busts Anthropic's stable cache block. With BM25 tool search, server instructions are also not indexed — only tool names, descriptions, and input schemas are — so the guidance was invisible to tool search. Putting the defaults on the tool description means they are cache-stable, BM25-searchable, and only surfaced when the model considers calling `create_event`.

## Tests

No logic changes — description string and null instructions only.
