### PR TITLE
fix(extension): load PCM AudioWorklet from static file to comply with Chrome MV3 CSP

### DIFF
--- a/extension/platforms/chrome/manifests/manifest.development.json
+++ b/extension/platforms/chrome/manifests/manifest.development.json
@@ -6,7 +6,7 @@
     "128": "images/dust32green.png"
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu ws://localhost:* http://localhost:* https://*.novu.co wss://*.novu.co data:; frame-src http://localhost:*"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu ws://localhost:* http://localhost:* https://*.novu.co wss://*.novu.co wss://api.elevenlabs.io data:; frame-src http://localhost:*"
   },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu2kn2r/3emY/9AwPzAH0qb1KskhZCqLp4PE3o1PqD1hyLTf9fJ+VC0CPyy3F6bep/6mjVZaN+Ufw7bTn3XFoj3TW+Xg5e/KLg+qUn2pUS973j68IyhyIamydfx90ZZajCU1XwB666+8dFwgB6sy4sGe86WNKu0Be+EDhhVFCFVI2D7CyJjlmQXUXTYDr6U41MsdI1DlDK6jrv6N9IkHKhvq1o06GN0W8CpoPJ554iBHWcw5UYNHi6ySxA+u7OoV58tDkTyVOS9sQ8WGIge3hDmhc2jcUhsJTzkeAS3ijShKVdYC0i+5n5g6SnQ4N7y2xehEYsms0ARqkUkF/QPwmTQIDAQAB"
 }

--- a/extension/platforms/chrome/manifests/manifest.production.json
+++ b/extension/platforms/chrome/manifests/manifest.production.json
@@ -1,6 +1,6 @@
 {
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co wss://api.elevenlabs.io data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
   },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu2kn2r/3emY/9AwPzAH0qb1KskhZCqLp4PE3o1PqD1hyLTf9fJ+VC0CPyy3F6bep/6mjVZaN+Ufw7bTn3XFoj3TW+Xg5e/KLg+qUn2pUS973j68IyhyIamydfx90ZZajCU1XwB666+8dFwgB6sy4sGe86WNKu0Be+EDhhVFCFVI2D7CyJjlmQXUXTYDr6U41MsdI1DlDK6jrv6N9IkHKhvq1o06GN0W8CpoPJ554iBHWcw5UYNHi6ySxA+u7OoV58tDkTyVOS9sQ8WGIge3hDmhc2jcUhsJTzkeAS3ijShKVdYC0i+5n5g6SnQ4N7y2xehEYsms0ARqkUkF/QPwmTQIDAQAB"
 }

--- a/extension/platforms/chrome/manifests/manifest.release.json
+++ b/extension/platforms/chrome/manifests/manifest.release.json
@@ -1,5 +1,5 @@
 {
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co wss://api.elevenlabs.io data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
   }
 }

--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -243,6 +243,10 @@ export const getConfig = async ({
             to: path.join(buildDirPath, "request-mic.js"),
           },
           {
+            from: resolvePath("../../ui/pcm-processor.js"),
+            to: path.join(buildDirPath, "pcm-processor.js"),
+          },
+          {
             context: resolvePath("../../ui/images"),
             from: "**/*.png",
             to: path.resolve(buildDirPath, "images"),

--- a/extension/platforms/firefox/manifests/manifest.development.json
+++ b/extension/platforms/firefox/manifests/manifest.development.json
@@ -21,6 +21,6 @@
     }
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu ws://localhost:* http://localhost:* https://*.novu.co wss://*.novu.co data:; frame-src http://localhost:*"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu ws://localhost:* http://localhost:* https://*.novu.co wss://*.novu.co wss://api.elevenlabs.io data:; frame-src http://localhost:*"
   }
 }

--- a/extension/platforms/firefox/manifests/manifest.production.json
+++ b/extension/platforms/firefox/manifests/manifest.production.json
@@ -16,6 +16,6 @@
     }
   },
  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co wss://api.elevenlabs.io data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
   }
 }

--- a/extension/platforms/firefox/manifests/manifest.release.json
+++ b/extension/platforms/firefox/manifests/manifest.release.json
@@ -16,6 +16,6 @@
     }
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/ https://*.novu.co wss://*.novu.co wss://api.elevenlabs.io data:; frame-src https://viz.dust.tt https://eu.viz.dust.tt"
   }
 }

--- a/extension/platforms/firefox/webpack.config.ts
+++ b/extension/platforms/firefox/webpack.config.ts
@@ -255,6 +255,10 @@ export const getConfig = async ({
             to: path.join(buildDirPath, "request-mic.js"),
           },
           {
+            from: resolvePath("../../ui/pcm-processor.js"),
+            to: path.join(buildDirPath, "pcm-processor.js"),
+          },
+          {
             context: resolvePath("../../ui/images"),
             from: "**/*.png",
             to: path.resolve(buildDirPath, "images"),

--- a/extension/ui/pcm-processor.js
+++ b/extension/ui/pcm-processor.js
@@ -1,0 +1,16 @@
+class PCMProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      const float32 = input[0];
+      const int16 = new Int16Array(float32.length);
+      for (let i = 0; i < float32.length; i++) {
+        const s = Math.max(-1, Math.min(1, float32[i]));
+        int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      this.port.postMessage(int16.buffer, [int16.buffer]);
+    }
+    return true;
+  }
+}
+registerProcessor("pcm-processor", PCMProcessor);

--- a/front/hooks/useVoiceLiveTranscriberService.ts
+++ b/front/hooks/useVoiceLiveTranscriberService.ts
@@ -50,6 +50,13 @@ registerProcessor('pcm-processor', PCMProcessor);
 `;
 
 function createPCMWorkletURL(): string {
+  // Chrome extensions block blob: URLs in script-src CSP. Use the pre-bundled static file instead.
+  if (
+    typeof chrome !== "undefined" &&
+    typeof chrome.runtime?.getURL === "function"
+  ) {
+    return chrome.runtime.getURL("pcm-processor.js");
+  }
   const blob = new Blob([PCM_WORKLET_CODE], { type: "application/javascript" });
   return URL.createObjectURL(blob);
 }

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -141,10 +141,16 @@ procs:
       npm run dev
     autostart: false
 
-  extension:
+  extension-chrome:
     cwd: "<CONFIG_DIR>/../extension"
     shell: |
       npm run dev:chrome
+    autostart: false
+
+  extension-firefox:
+    cwd: "<CONFIG_DIR>/../extension"
+    shell: |
+      npm run dev:firefox
     autostart: false
 
   ngrok:

--- a/tools/process-compose.yaml
+++ b/tools/process-compose.yaml
@@ -188,8 +188,14 @@ processes:
     namespace: optional
     disabled: true
 
-  extension:
+  extension-chrome:
     command: "npm run dev:chrome"
+    working_dir: "${DUST_DEV_ROOT}/extension"
+    namespace: optional
+    disabled: true
+
+  extension-firefox:
+    command: "npm run dev:firefox"
     working_dir: "${DUST_DEV_ROOT}/extension"
     namespace: optional
     disabled: true


### PR DESCRIPTION
## Description

Fixes live STT in both Chrome and Firefox extensions. Several MV3 CSP constraints had to be worked around:

**AudioWorklet (both browsers)**
- The PCM processor worklet was loaded via a `blob:` URL — blocked by MV3 `script-src` CSP in both Chrome and Firefox (Chrome refuses to load the manifest if `blob:` is declared; Firefox rejects the connection)
- Added `pcm-processor.js` as a static asset copied to the extension build dir, and updated `useVoiceLiveTranscriberService` to detect `chrome.runtime.getURL` and load it from the extension origin instead of a blob URL

**ElevenLabs WebSocket**
- Added `wss://api.elevenlabs.io` to `connect-src` in all Chrome and Firefox manifests (dev/production/release)

## Tests

