### PR TITLE
fix: normalize empty-string params in data warehouses MCP tools

### DIFF
--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -27,6 +27,9 @@ const MAX_LIMIT = 100;
 
 const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
   list: async ({ nodeId, limit, nextPageCursor, dataSources }, { auth }) => {
+    const effectiveNodeId = !!nodeId ? nodeId : null;
+    const effectiveCursor = !!nextPageCursor ? nextPageCursor : undefined;
+
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
 
@@ -46,15 +49,15 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
 
     const result =
-      nodeId === null
+      effectiveNodeId === null
         ? await getAvailableWarehouses(auth, agentDataSourceConfigurations, {
             limit: effectiveLimit,
-            nextPageCursor,
+            nextPageCursor: effectiveCursor,
           })
         : await getWarehouseNodes(auth, agentDataSourceConfigurations, {
-            nodeId,
+            nodeId: effectiveNodeId,
             limit: effectiveLimit,
-            nextPageCursor,
+            nextPageCursor: effectiveCursor,
           });
 
     if (result.isErr()) {
@@ -67,7 +70,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       {
         type: "resource" as const,
         resource: makeBrowseResource({
-          nodeId,
+          nodeId: effectiveNodeId,
           nodes,
           nextPageCursor: newCursor,
           resultCount: dataSources.length,
@@ -80,6 +83,9 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     { query, rootNodeId, limit, nextPageCursor, dataSources },
     { auth }
   ) => {
+    const effectiveRootNodeId = !!rootNodeId ? rootNodeId : null;
+    const effectiveCursor = !!nextPageCursor ? nextPageCursor : undefined;
+
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
 
@@ -102,10 +108,10 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       auth,
       agentDataSourceConfigurations,
       {
-        nodeId: rootNodeId ?? null,
+        nodeId: effectiveRootNodeId,
         query,
         limit: effectiveLimit,
-        nextPageCursor,
+        nextPageCursor: effectiveCursor,
       }
     );
 
@@ -119,7 +125,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       {
         type: "resource" as const,
         resource: makeBrowseResource({
-          nodeId: rootNodeId ?? null,
+          nodeId: effectiveRootNodeId,
           nodes,
           nextPageCursor: newCursor,
           resultCount: dataSources.length,


### PR DESCRIPTION
## Description

This PR fixes a bug in the data warehouses MCP tools where empty-string parameters were being used in downstream calls causing unhandled API errors like https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Adata_warehouses%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZ74k7z1RDe8KgAAABhBWjc0azhVT0FBQndmSi1MdzZqVTBBQXcAAAAkMDE5ZWY4OWMtMTBiNi00OWNlLWE1M2EtYzU5YTE4ZGQxMDU1AAPA7g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1782285919000&to_ts=1782287119000&live=false

- In the `list` handler, `nodeId` and `nextPageCursor` are normalized: `""` → `null`/`undefined` via `effectiveNodeId` and `effectiveCursor`.
- In the `search` handler, `rootNodeId` and `nextPageCursor` are similarly normalized before being forwarded to `getAvailableWarehouses`, `getWarehouseNodes`, and `searchWarehouseNodes`.

## Tests

## Risks

Low.

## Deploy Plan

Standard deployment.

