### PR TITLE
Add workspace opt-out for Computer features

### DIFF
--- a/front-api/middlewares/sandbox_auth.ts
+++ b/front-api/middlewares/sandbox_auth.ts
@@ -5,6 +5,7 @@ import {
   getFeatureFlags,
 } from "@app/lib/auth";
 import { getClientIp } from "@app/lib/utils/request";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { SandboxCtx } from "@front-api/middlewares/ctx";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
@@ -77,7 +78,7 @@ export const sandboxAuth = createMiddleware<SandboxCtx>(async (ctx, next) => {
   const auth = authRes.value;
 
   const featureFlags = await getFeatureFlags(auth);
-  if (!featureFlags.includes("sandbox_dsbx_tools")) {
+  if (!isComputerFeatureEnabled(featureFlags, "sandbox_dsbx_tools")) {
     return apiError(ctx, {
       status_code: 403,
       api_error: {

--- a/front-api/routes/v1/w/[wId]/files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/files/index.test.ts
@@ -113,6 +113,23 @@ describe("POST /api/v1/w/[wId]/files", () => {
     expect(file?.useCaseMetadata?.skipDataSourceIndexing).toBe(true);
   });
 
+  it("keeps the 50 MB CSV limit when disable_computer_feature is enabled", async () => {
+    const { workspace, key, auth } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "disable_computer_feature");
+
+    const response = await postFile(workspace, key, {
+      contentType: "text/csv",
+      fileName: "large.csv",
+      fileSize: 60 * 1024 * 1024,
+      useCase: "conversation",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it("keeps the 50 MB CSV limit when sandbox_tools is not enabled", async () => {
     const { workspace, key } = await createPublicApiMockRequest({
       method: "POST",

--- a/front-api/routes/v1/w/[wId]/files/index.ts
+++ b/front-api/routes/v1/w/[wId]/files/index.ts
@@ -9,6 +9,7 @@ import {
   isPubliclySupportedUseCase,
   isSupportedFileContentType,
 } from "@app/types/files";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { FileUploadRequestResponseType } from "@dust-tt/client";
 import { FileUploadUrlRequestSchema } from "@dust-tt/client";
 import { publicApiApp } from "@front-api/middlewares/ctx";
@@ -154,7 +155,7 @@ app.post(
     }
 
     const flags = await getFeatureFlags(auth);
-    const hasSandboxTools = flags.includes("sandbox_tools");
+    const hasSandboxTools = isComputerFeatureEnabled(flags, "sandbox_tools");
 
     if (
       !ensureFileSize(contentType, fileSize, {

--- a/front-api/routes/w/[wId]/files/index.ts
+++ b/front-api/routes/w/[wId]/files/index.ts
@@ -5,6 +5,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { ensureFileSize, isSupportedFileContentType } from "@app/types/files";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -191,7 +192,7 @@ app.post("/", validate("json", FileUploadUrlRequestSchema), async (ctx) => {
   }
 
   const flags = await getFeatureFlags(auth);
-  const hasSandboxTools = flags.includes("sandbox_tools");
+  const hasSandboxTools = isComputerFeatureEnabled(flags, "sandbox_tools");
 
   if (
     !ensureFileSize(contentType, fileSize, {

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -60,7 +60,7 @@ export const NavigationSidebar = React.forwardRef<
     return "";
   }, [router.isReady, router.pathname]);
 
-  const { featureFlags } = useFeatureFlags();
+  const { hasFeature } = useFeatureFlags();
 
   const { spaceMenuButtonRef } = useWelcomeTourGuide();
 
@@ -130,8 +130,7 @@ export const NavigationSidebar = React.forwardRef<
                         {nav.menus
                           .filter(
                             (menu) =>
-                              !menu.featureFlag ||
-                              featureFlags.includes(menu.featureFlag)
+                              !menu.featureFlag || hasFeature(menu.featureFlag)
                           )
                           .map((menu) => (
                             <NavigationListItem

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,14 +1,15 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { ContentMessage, Globe01, InfoCircle, Page } from "@dust-tt/sparkle";
 
 export function SandboxPage() {
   const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags();
   const hasSandboxAdmin =
-    featureFlags.includes("sandbox_tools") &&
-    featureFlags.includes("sandbox_workspace_admin");
+    isComputerFeatureEnabled(featureFlags, "sandbox_tools") &&
+    isComputerFeatureEnabled(featureFlags, "sandbox_workspace_admin");
 
   const renderBody = () => {
     if (!isAdmin) {

--- a/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
+++ b/front/components/pages/workspace/developers/sections/EnvironmentSection.tsx
@@ -23,6 +23,7 @@ import {
   type WorkspaceSandboxEnvVarKind,
   type WorkspaceSandboxEnvVarType,
 } from "@app/types/sandbox/env_var";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Button,
@@ -176,8 +177,8 @@ export function EnvironmentSection() {
   const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags();
   const hasSandboxAdmin =
-    featureFlags.includes("sandbox_tools") &&
-    featureFlags.includes("sandbox_workspace_admin");
+    isComputerFeatureEnabled(featureFlags, "sandbox_tools") &&
+    isComputerFeatureEnabled(featureFlags, "sandbox_workspace_admin");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isNameLocked, setIsNameLocked] = useState(false);
   const [envVarToReplace, setEnvVarToReplace] =

--- a/front/components/pages/workspace/developers/sections/NetworkSection.tsx
+++ b/front/components/pages/workspace/developers/sections/NetworkSection.tsx
@@ -9,6 +9,7 @@ import {
   useWorkspaceEgressPolicy,
 } from "@app/lib/swr/sandbox";
 import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import {
   Button,
   ContentMessage,
@@ -33,8 +34,8 @@ export function NetworkSection() {
   const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags();
   const hasSandboxAdmin =
-    featureFlags.includes("sandbox_tools") &&
-    featureFlags.includes("sandbox_workspace_admin");
+    isComputerFeatureEnabled(featureFlags, "sandbox_tools") &&
+    isComputerFeatureEnabled(featureFlags, "sandbox_workspace_admin");
   const [domainInput, setDomainInput] = useState("");
   const [isEnableAgentRequestsDialogOpen, setIsEnableAgentRequestsDialogOpen] =
     useState(false);

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -97,7 +97,10 @@ import type {
 } from "@app/lib/api/mcp";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type { PlanType } from "@app/types/plan";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import {
+  isComputerFeatureEnabled,
+  type WhitelistableFeature,
+} from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -1053,7 +1056,7 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: false,
     isPreview: true,
     isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("sandbox_tools");
+      return !isComputerFeatureEnabled(featureFlags, "sandbox_tools");
     },
     metadata: SANDBOX_SERVER,
     tools_arguments_requiring_approval: undefined,

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -45,6 +45,7 @@ import { WorkspaceSandboxEnvVarResource } from "@app/lib/resources/workspace_san
 import logger from "@app/logger/logger";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
 import { isDevelopment } from "@app/types/shared/env";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { Err, Ok, type Result } from "@app/types/shared/result";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { z } from "zod";
@@ -240,7 +241,7 @@ export async function createSandboxTools(
   // per-workspace setting that admins toggle on top of it.
   const flags = await getFeatureFlags(auth);
   if (
-    flags.includes("sandbox_workspace_admin") &&
+    isComputerFeatureEnabled(flags, "sandbox_workspace_admin") &&
     isSandboxAgentEgressRequestsAllowed(auth)
   ) {
     return tools;
@@ -256,7 +257,7 @@ export async function buildDescribeToolsetOutput(
 ): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
   const flags = await getFeatureFlags(auth);
   const toolsResult = getToolsForProvider(auth, providerId, {
-    includeDsbxTools: flags.includes("sandbox_dsbx_tools"),
+    includeDsbxTools: isComputerFeatureEnabled(flags, "sandbox_dsbx_tools"),
   });
   if (toolsResult.isErr()) {
     return new Err(new MCPError(toolsResult.error.message));

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -123,7 +123,10 @@ import {
 } from "@app/types/assistant/assistant";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import {
+  isComputerFeatureEnabled,
+  type WhitelistableFeature,
+} from "@app/types/shared/feature_flags";
 
 // Exhaustive map of flags for each global agent. This is used to control which agents inject
 // per-user dynamic content (like memories) into the prompt context. This approach is not ideal but
@@ -1646,7 +1649,7 @@ export async function getGlobalAgents(
       mcpServerViews,
       sidekickContext,
       hasDeepDive: !isDeepDiveDisabled,
-      hasSandbox: flags.includes("sandbox_tools"),
+      hasSandbox: isComputerFeatureEnabled(flags, "sandbox_tools"),
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
       preferGpt55DefaultModel: flags.includes("dust_agent_gpt_5_5_default"),

--- a/front/lib/auth.global_feature_flags.test.ts
+++ b/front/lib/auth.global_feature_flags.test.ts
@@ -111,6 +111,50 @@ describe("getFeatureFlags with global flags", () => {
     expect(flags).toContain("deepseek_feature");
     expect(flags).toContain("labs_transcripts");
   });
+
+  it("disable_computer_feature disables workspace sandbox flags", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await FeatureFlagResource.enableMany(workspace, [
+      "disable_computer_feature",
+      "sandbox_tools",
+      "sandbox_dsbx_tools",
+      "sandbox_workspace_admin",
+      "deepseek_feature",
+    ]);
+    invalidateAllCaches(auth);
+
+    const flags = await getFeatureFlags(auth);
+    expect(flags).toContain("disable_computer_feature");
+    expect(flags).toContain("deepseek_feature");
+    expect(flags).not.toContain("sandbox_tools");
+    expect(flags).not.toContain("sandbox_dsbx_tools");
+    expect(flags).not.toContain("sandbox_workspace_admin");
+  });
+
+  it("disable_computer_feature disables globally rolled out sandbox flags", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await FeatureFlagResource.enable(workspace, "disable_computer_feature");
+    await GlobalFeatureFlagResource.setRolloutPercentage("sandbox_tools", 100);
+    await GlobalFeatureFlagResource.setRolloutPercentage(
+      "sandbox_dsbx_tools",
+      100
+    );
+    await GlobalFeatureFlagResource.setRolloutPercentage(
+      "sandbox_workspace_admin",
+      100
+    );
+    invalidateAllCaches(auth);
+
+    const flags = await getFeatureFlags(auth);
+    expect(flags).toContain("disable_computer_feature");
+    expect(flags).not.toContain("sandbox_tools");
+    expect(flags).not.toContain("sandbox_dsbx_tools");
+    expect(flags).not.toContain("sandbox_workspace_admin");
+  });
 });
 
 describe("GlobalFeatureFlagResource.isInRollout", () => {

--- a/front/lib/auth.global_feature_flags.test.ts
+++ b/front/lib/auth.global_feature_flags.test.ts
@@ -1,6 +1,7 @@
 import {
   Authenticator,
   getFeatureFlags,
+  hasFeatureFlag,
   invalidateFeatureFlagsCache,
   invalidateGlobalFeatureFlagsCache,
 } from "@app/lib/auth";
@@ -112,7 +113,7 @@ describe("getFeatureFlags with global flags", () => {
     expect(flags).toContain("labs_transcripts");
   });
 
-  it("disable_computer_feature disables workspace sandbox flags", async () => {
+  it("returns disable_computer_feature alongside workspace sandbox flags", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
@@ -128,12 +129,35 @@ describe("getFeatureFlags with global flags", () => {
     const flags = await getFeatureFlags(auth);
     expect(flags).toContain("disable_computer_feature");
     expect(flags).toContain("deepseek_feature");
-    expect(flags).not.toContain("sandbox_tools");
-    expect(flags).not.toContain("sandbox_dsbx_tools");
-    expect(flags).not.toContain("sandbox_workspace_admin");
+    expect(flags).toContain("sandbox_tools");
+    expect(flags).toContain("sandbox_dsbx_tools");
+    expect(flags).toContain("sandbox_workspace_admin");
   });
 
-  it("disable_computer_feature disables globally rolled out sandbox flags", async () => {
+  it("disable_computer_feature takes precedence over workspace sandbox flags", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    await FeatureFlagResource.enableMany(workspace, [
+      "disable_computer_feature",
+      "sandbox_tools",
+      "sandbox_dsbx_tools",
+      "sandbox_workspace_admin",
+      "deepseek_feature",
+    ]);
+    invalidateAllCaches(auth);
+
+    await expect(hasFeatureFlag(auth, "sandbox_tools")).resolves.toBe(false);
+    await expect(hasFeatureFlag(auth, "sandbox_dsbx_tools")).resolves.toBe(
+      false
+    );
+    await expect(hasFeatureFlag(auth, "sandbox_workspace_admin")).resolves.toBe(
+      false
+    );
+    await expect(hasFeatureFlag(auth, "deepseek_feature")).resolves.toBe(true);
+  });
+
+  it("disable_computer_feature takes precedence over globally rolled out sandbox flags", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
@@ -151,9 +175,16 @@ describe("getFeatureFlags with global flags", () => {
 
     const flags = await getFeatureFlags(auth);
     expect(flags).toContain("disable_computer_feature");
-    expect(flags).not.toContain("sandbox_tools");
-    expect(flags).not.toContain("sandbox_dsbx_tools");
-    expect(flags).not.toContain("sandbox_workspace_admin");
+    expect(flags).toContain("sandbox_tools");
+    expect(flags).toContain("sandbox_dsbx_tools");
+    expect(flags).toContain("sandbox_workspace_admin");
+    await expect(hasFeatureFlag(auth, "sandbox_tools")).resolves.toBe(false);
+    await expect(hasFeatureFlag(auth, "sandbox_dsbx_tools")).resolves.toBe(
+      false
+    );
+    await expect(hasFeatureFlag(auth, "sandbox_workspace_admin")).resolves.toBe(
+      false
+    );
   });
 });
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -38,7 +38,11 @@ import type {
 import { hasRolePermissions } from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import { WHITELISTABLE_FEATURES } from "@app/types/shared/feature_flags";
+import {
+  DISABLE_COMPUTER_FEATURE,
+  isComputerFeatureFlag,
+  WHITELISTABLE_FEATURES,
+} from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -1583,10 +1587,24 @@ function getGlobalFeatureFlags(): Promise<GlobalFeatureFlagResource[]> {
   });
 }
 
+const ACTIVATE_ALL_DEV_FEATURES = WHITELISTABLE_FEATURES.filter(
+  (flag) => flag !== DISABLE_COMPUTER_FEATURE
+);
+
+function applyFeatureFlagOverrides(
+  flags: WhitelistableFeature[]
+): WhitelistableFeature[] {
+  if (!flags.includes(DISABLE_COMPUTER_FEATURE)) {
+    return flags;
+  }
+
+  return flags.filter((flag) => !isComputerFeatureFlag(flag));
+}
+
 const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
   load: (workspace, callback) => {
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
-      callback(null, [...WHITELISTABLE_FEATURES]);
+      callback(null, [...ACTIVATE_ALL_DEV_FEATURES]);
       return;
     }
 
@@ -1615,7 +1633,7 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
           }
         }
 
-        callback(null, effectiveFlags);
+        callback(null, applyFeatureFlagOverrides(effectiveFlags));
       })
       .catch((err: Error) => callback(err));
   },

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -39,7 +39,7 @@ import { hasRolePermissions } from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import {
-  DISABLE_COMPUTER_FEATURE,
+  isComputerFeatureEnabled,
   isComputerFeatureFlag,
   WHITELISTABLE_FEATURES,
 } from "@app/types/shared/feature_flags";
@@ -1587,24 +1587,10 @@ function getGlobalFeatureFlags(): Promise<GlobalFeatureFlagResource[]> {
   });
 }
 
-const ACTIVATE_ALL_DEV_FEATURES = WHITELISTABLE_FEATURES.filter(
-  (flag) => flag !== DISABLE_COMPUTER_FEATURE
-);
-
-function applyFeatureFlagOverrides(
-  flags: WhitelistableFeature[]
-): WhitelistableFeature[] {
-  if (!flags.includes(DISABLE_COMPUTER_FEATURE)) {
-    return flags;
-  }
-
-  return flags.filter((flag) => !isComputerFeatureFlag(flag));
-}
-
 const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
   load: (workspace, callback) => {
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
-      callback(null, [...ACTIVATE_ALL_DEV_FEATURES]);
+      callback(null, [...WHITELISTABLE_FEATURES]);
       return;
     }
 
@@ -1633,7 +1619,7 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
           }
         }
 
-        callback(null, applyFeatureFlagOverrides(effectiveFlags));
+        callback(null, effectiveFlags);
       })
       .catch((err: Error) => callback(err));
   },
@@ -1665,6 +1651,10 @@ export async function hasFeatureFlag(
   flag: WhitelistableFeature
 ): Promise<boolean> {
   const flags = await getFeatureFlags(auth);
+  if (isComputerFeatureFlag(flag)) {
+    return isComputerFeatureEnabled(flags, flag);
+  }
+
   return flags.includes(flag);
 }
 

--- a/front/lib/auth/AuthContext.tsx
+++ b/front/lib/auth/AuthContext.tsx
@@ -6,7 +6,11 @@ import {
 import { DEV_MODE_ACTIVE } from "@app/components/dev/devModeConstants";
 import type { SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import {
+  isComputerFeatureEnabled,
+  isComputerFeatureFlag,
+  type WhitelistableFeature,
+} from "@app/types/shared/feature_flags";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
   createContext,
@@ -64,6 +68,10 @@ export function useFeatureFlags() {
       if (!flag) {
         return true;
       }
+      if (isComputerFeatureFlag(flag)) {
+        return isComputerFeatureEnabled(featureFlags, flag);
+      }
+
       return featureFlags.includes(flag);
     },
     [featureFlags]

--- a/front/lib/resources/skill/code_defined/docx.ts
+++ b/front/lib/resources/skill/code_defined/docx.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 
 const DOCX_SKILL_INSTRUCTIONS = `# Documents (.docx, .doc)
 
@@ -135,6 +136,6 @@ export const docxSkill = {
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 
-    return !flags.includes("sandbox_tools");
+    return !isComputerFeatureEnabled(flags, "sandbox_tools");
   },
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/go_deep.ts
+++ b/front/lib/resources/skill/code_defined/go_deep.ts
@@ -5,6 +5,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 
 export const goDeepSkill = {
   sId: "go-deep",
@@ -24,7 +25,7 @@ export const goDeepSkill = {
     _params: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
   ) => {
     const flags = await getFeatureFlags(auth);
-    const hasSandbox = flags.includes("sandbox_tools");
+    const hasSandbox = isComputerFeatureEnabled(flags, "sandbox_tools");
     return getDeepDiveInstructions({
       includeToolsetsPrompt: false,
       hasSandbox,

--- a/front/lib/resources/skill/code_defined/pptx.ts
+++ b/front/lib/resources/skill/code_defined/pptx.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 
 const PPTX_SKILL_INSTRUCTIONS = `# Slide decks (.pptx)
 
@@ -347,6 +348,6 @@ export const pptxSkill = {
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 
-    return !flags.includes("sandbox_tools");
+    return !isComputerFeatureEnabled(flags, "sandbox_tools");
   },
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/code_defined/sandbox.ts
+++ b/front/lib/resources/skill/code_defined/sandbox.ts
@@ -14,6 +14,7 @@ import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { Ok } from "@app/types/shared/result";
 
 function buildSandboxInstructionProse({
@@ -126,7 +127,10 @@ function formatWorkspaceAllowlist(domains: string[]): string {
 
 async function buildNetworkAccessSection(auth: Authenticator): Promise<string> {
   const flags = await getFeatureFlags(auth);
-  const hasWorkspaceAdmin = flags.includes("sandbox_workspace_admin");
+  const hasWorkspaceAdmin = isComputerFeatureEnabled(
+    flags,
+    "sandbox_workspace_admin"
+  );
   const allowAgentRequests =
     hasWorkspaceAdmin &&
     auth.getNonNullableWorkspace().metadata?.sandboxAllowAgentEgressRequests ===
@@ -369,7 +373,7 @@ export const sandboxSkill = {
   ) => {
     const providerId = agentLoopData?.agentConfiguration?.model.providerId;
     const flags = await getFeatureFlags(auth);
-    const hasDsbxTools = flags.includes("sandbox_dsbx_tools");
+    const hasDsbxTools = isComputerFeatureEnabled(flags, "sandbox_dsbx_tools");
     const isProject = agentLoopData?.conversation
       ? isPodConversation(agentLoopData.conversation)
       : false;
@@ -388,6 +392,6 @@ export const sandboxSkill = {
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 
-    return !flags.includes("sandbox_tools");
+    return !isComputerFeatureEnabled(flags, "sandbox_tools");
   },
 } as const satisfies SystemSkillDefinition;

--- a/front/lib/resources/skill/code_defined/xlsx.ts
+++ b/front/lib/resources/skill/code_defined/xlsx.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 
 const XLSX_SKILL_INSTRUCTIONS = `# Spreadsheets (.xlsx, .xlsm, .csv, .tsv)
 
@@ -137,6 +138,6 @@ export const xlsxSkill = {
   isRestricted: async (auth: Authenticator) => {
     const flags = await getFeatureFlags(auth);
 
-    return !flags.includes("sandbox_tools");
+    return !isComputerFeatureEnabled(flags, "sandbox_tools");
   },
 } as const satisfies GlobalSkillDefinition;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -82,6 +82,7 @@ import type {
 } from "@app/types/assistant/conversation";
 import { isTextContent } from "@app/types/assistant/generation";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -392,7 +393,10 @@ export async function runModel(
 
   const isNewFileExplorer = conversation.metadata?.useFileSystem === true;
   const featureFlags = await getFeatureFlags(auth);
-  const hasSandboxTools = featureFlags.includes("sandbox_tools");
+  const hasSandboxTools = isComputerFeatureEnabled(
+    featureFlags,
+    "sandbox_tools"
+  );
   const disableFormattingPrompt = featureFlags.includes(
     "disable_formatting_prompt"
   );

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -385,12 +385,24 @@ export const COMPUTER_FEATURE_FLAGS = [
   "sandbox_workspace_admin",
 ] as const satisfies readonly WhitelistableFeature[];
 
-const COMPUTER_FEATURE_FLAG_SET = new Set<WhitelistableFeature>(
-  COMPUTER_FEATURE_FLAGS
-);
+export type ComputerFeatureFlag = (typeof COMPUTER_FEATURE_FLAGS)[number];
 
-export function isComputerFeatureFlag(feature: WhitelistableFeature): boolean {
-  return COMPUTER_FEATURE_FLAG_SET.has(feature);
+export function isComputerFeatureFlag(
+  feature: WhitelistableFeature
+): feature is ComputerFeatureFlag {
+  return COMPUTER_FEATURE_FLAGS.some(
+    (computerFeature) => computerFeature === feature
+  );
+}
+
+export function isComputerFeatureEnabled(
+  featureFlags: WhitelistableFeature[],
+  feature: ComputerFeatureFlag
+): boolean {
+  return (
+    featureFlags.includes(feature) &&
+    !featureFlags.includes(DISABLE_COMPUTER_FEATURE)
+  );
 }
 
 export function isWhitelistableFeature(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -84,6 +84,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Disable logging of agent runs",
     stage: "dust_only",
   },
+  disable_computer_feature: {
+    description:
+      "Disable all Computer (sandbox) features for this workspace, overriding sandbox opt-in flags",
+    stage: "on_demand",
+  },
   disallow_agent_creation_to_users: {
     description:
       "Prevent users from creating agents, allowing only admins and builders",
@@ -370,6 +375,23 @@ export type WhitelistableFeature = keyof typeof WHITELISTABLE_FEATURES_CONFIG;
 export const WHITELISTABLE_FEATURES = Object.keys(
   WHITELISTABLE_FEATURES_CONFIG
 ) as WhitelistableFeature[];
+
+export const DISABLE_COMPUTER_FEATURE =
+  "disable_computer_feature" as const satisfies WhitelistableFeature;
+
+export const COMPUTER_FEATURE_FLAGS = [
+  "sandbox_tools",
+  "sandbox_dsbx_tools",
+  "sandbox_workspace_admin",
+] as const satisfies readonly WhitelistableFeature[];
+
+const COMPUTER_FEATURE_FLAG_SET = new Set<WhitelistableFeature>(
+  COMPUTER_FEATURE_FLAGS
+);
+
+export function isComputerFeatureFlag(feature: WhitelistableFeature): boolean {
+  return COMPUTER_FEATURE_FLAG_SET.has(feature);
+}
 
 export function isWhitelistableFeature(
   feature: unknown

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -711,6 +711,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "deepseek_feature"
   | "dev_mcp_actions"
   | "exa_people_and_company"
+  | "disable_computer_feature"
   | "disable_formatting_prompt"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"


### PR DESCRIPTION
## Description

Computer is moving toward a broader sandbox rollout, but some customers still need workspace-level opt-out while the regular sandbox flags may be enabled globally or per workspace.

This adds `disable_computer_feature`, an on-demand workspace flag that leaves the opt-out visible while making Computer feature gates treat `sandbox_tools`, `sandbox_dsbx_tools`, and `sandbox_workspace_admin` as disabled. The JS SDK feature flag union is updated too.

## Tests

Added auth tests covering workspace-level sandbox flags and globally rolled-out sandbox flags under `disable_computer_feature`, plus a front-api upload test for the sandbox CSV limit opt-out.

## Risk

Worst case, a workspace with the disable flag loses Computer access until the flag is removed. Safe to rollback.

## Deploy Plan

Standard deploy. Enable `disable_computer_feature` only for workspaces that need the opt-out.