### PR TITLE
 Gate whitelabel frames behind a feature flag instead of the plan

### DIFF
--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -87,7 +87,6 @@ const EXTENSION_SUBSCRIPTION: SubscriptionType = {
     },
     trialPeriodDays: 0,
     isByok: false,
-    isBrandedFramesAllowed: false,
     isAuditLogsAllowed: false,
   },
   requestCancelAt: null,

--- a/front-api/routes/poke/plans.ts
+++ b/front-api/routes/poke/plans.ts
@@ -66,7 +66,6 @@ app.post(
       isSSOAllowed: body.limits.users.isSSOAllowed,
       isSCIMAllowed: body.limits.users.isSCIMAllowed,
       isAuditLogsAllowed: body.isAuditLogsAllowed,
-      isBrandedFramesAllowed: body.isBrandedFramesAllowed,
       maxDataSourcesCount: body.limits.dataSources.count,
       maxDataSourcesDocumentsCount: body.limits.dataSources.documents.count,
       maxDataSourcesDocumentsSizeMb: body.limits.dataSources.documents.sizeMb,

--- a/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/switch_contract.test.ts
@@ -126,7 +126,6 @@ async function ensureEnterprisePlan(): Promise<void> {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   });
 }
 

--- a/front-api/routes/v1/public/branding/index.test.ts
+++ b/front-api/routes/v1/public/branding/index.test.ts
@@ -44,7 +44,7 @@ describe("GET /api/v1/public/branding/:wId/:asset", () => {
   });
 
   it("redirects to the default asset when no custom asset is uploaded", async () => {
-    const workspace = await WorkspaceFactory.withBrandedFrames();
+    const workspace = await WorkspaceFactory.withWhitelabelFrames();
     mockGetFileContentType.mockResolvedValue(new Err(new Error("not found")));
 
     const res = await getBrandingAsset(workspace.sId, "logo");
@@ -54,7 +54,7 @@ describe("GET /api/v1/public/branding/:wId/:asset", () => {
   });
 
   it("serves the asset bytes with correct headers when a custom asset exists", async () => {
-    const workspace = await WorkspaceFactory.withBrandedFrames();
+    const workspace = await WorkspaceFactory.withWhitelabelFrames();
     mockGetFileContentType.mockResolvedValue(new Ok("image/png"));
     mockFetchFileBuffer.mockResolvedValue(new Uint8Array([137, 80, 78, 71]));
 

--- a/front-api/routes/v1/public/branding/index.ts
+++ b/front-api/routes/v1/public/branding/index.ts
@@ -6,10 +6,11 @@ import {
   buildBrandingAssetStoragePath,
   isBrandingAssetName,
 } from "@app/lib/api/workspace_branding";
+import { getFeatureFlagsForWorkspace } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
@@ -81,10 +82,10 @@ app.get("/:wId/:asset", validate("param", ParamsSchema), async (ctx) => {
     return redirectToDefaultAsset(ctx, asset);
   }
 
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
+  const featureFlags = await getFeatureFlagsForWorkspace(
+    renderLightWorkspaceType({ workspace })
   );
-  if (!subscription?.getPlan().isBrandedFramesAllowed) {
+  if (!featureFlags.includes("whitelabel_frames")) {
     return redirectToDefaultAsset(ctx, asset);
   }
 

--- a/front-api/routes/w/[wId]/branding/index.test.ts
+++ b/front-api/routes/w/[wId]/branding/index.test.ts
@@ -73,7 +73,7 @@ describe("PATCH /api/w/:wId/branding", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns 403 when workspace is not entitled to branded frames", async () => {
+  it("returns 403 when workspace is not entitled to whitelabel frames", async () => {
     const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
 
     const res = await honoApp.request(`/api/w/${workspace.sId}/branding`, {
@@ -86,7 +86,7 @@ describe("PATCH /api/w/:wId/branding", () => {
   });
 
   it("returns 204 and deletes the asset when fileId is null", async () => {
-    const workspace = await WorkspaceFactory.withBrandedFrames();
+    const workspace = await WorkspaceFactory.withWhitelabelFrames();
     await createPrivateApiMockRequest({ role: "admin", workspace });
 
     const res = await honoApp.request(`/api/w/${workspace.sId}/branding`, {
@@ -103,7 +103,7 @@ describe("PATCH /api/w/:wId/branding", () => {
   });
 
   it("returns 204 and copies the file when a valid fileId is given", async () => {
-    const workspace = await WorkspaceFactory.withBrandedFrames();
+    const workspace = await WorkspaceFactory.withWhitelabelFrames();
     const { auth, user } = await createPrivateApiMockRequest({
       role: "admin",
       workspace,
@@ -132,7 +132,7 @@ describe("PATCH /api/w/:wId/branding", () => {
   });
 
   it("returns 404 when the fileId does not exist", async () => {
-    const workspace = await WorkspaceFactory.withBrandedFrames();
+    const workspace = await WorkspaceFactory.withWhitelabelFrames();
     await createPrivateApiMockRequest({ role: "admin", workspace });
 
     const res = await honoApp.request(`/api/w/${workspace.sId}/branding`, {

--- a/front-api/routes/w/[wId]/branding/index.ts
+++ b/front-api/routes/w/[wId]/branding/index.ts
@@ -17,6 +17,7 @@ import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { z } from "zod";
 
 const BrandingPromoteBodySchema = z.object({
@@ -75,20 +76,12 @@ app.get(
 app.patch(
   "/",
   ensureIsAdmin(),
+  withFeatureFlag("whitelabel_frames", {
+    message: "Whitelabel frames are not enabled for this workspace.",
+  }),
   validate("json", BrandingPromoteBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const plan = auth.subscription()?.plan;
-    if (!plan?.isBrandedFramesAllowed) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "plan_limit_error",
-          message: "Branded frames are not available on your current plan.",
-        },
-      });
-    }
-
     const { asset, fileId } = ctx.req.valid("json");
 
     if (fileId === null) {

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -290,7 +290,7 @@ export const subNavigationAdmin = ({
         current: isCurrent("workspace"),
         disabled: !hasWorkspaceAdminPermission,
       },
-      ...(subscription.plan.isBrandedFramesAllowed
+      ...(featureFlags.includes("whitelabel_frames")
         ? [
             {
               id: "workspace_branding" as const,

--- a/front/components/pages/workspace/WorkspaceBrandingPage.tsx
+++ b/front/components/pages/workspace/WorkspaceBrandingPage.tsx
@@ -1,16 +1,16 @@
 import { BrandingSection } from "@app/components/workspace/settings/BrandingSection";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { cn, Page, Palette } from "@dust-tt/sparkle";
 
 export function WorkspaceBrandingPage() {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
-  const isBrandedFramesAllowed = subscription.plan.isBrandedFramesAllowed;
+  const { hasFeature } = useFeatureFlags();
+  const isWhitelabelFramesAllowed = hasFeature("whitelabel_frames");
 
   return (
     <Page.Vertical align="stretch" gap="xl">
       <Page.Header title="Branding" icon={Palette} />
-      {isBrandedFramesAllowed ? (
+      {isWhitelabelFramesAllowed ? (
         <BrandingSection owner={owner} />
       ) : (
         <div
@@ -23,9 +23,8 @@ export function WorkspaceBrandingPage() {
             Workspace branding
           </p>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Workspace branding is not available on the current plan. Upgrade to
-            a plan that includes branded frames to customize your workspace
-            logo.
+            Workspace branding is not available for this workspace. Whitelabel
+            frames must be enabled to customize your workspace logo.
           </p>
         </div>
       )}

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -40,7 +40,6 @@ export type EditingPlanType = {
   isSCIMAllowed: boolean;
   isByok: boolean;
   isAuditLogsAllowed: boolean;
-  isBrandedFramesAllowed: boolean;
   maxImagesPerWeek: string | number;
   maxMessages: string | number;
   maxMessagesTimeframe: string;
@@ -72,7 +71,6 @@ export const fromPlanType = (plan: PlanType): EditingPlanType => {
     isSCIMAllowed: plan.limits.users.isSCIMAllowed,
     isByok: plan.isByok,
     isAuditLogsAllowed: plan.isAuditLogsAllowed,
-    isBrandedFramesAllowed: plan.isBrandedFramesAllowed,
     maxMessages: plan.limits.assistant.maxMessages,
     maxMessagesTimeframe: plan.limits.assistant.maxMessagesTimeframe,
     maxAwuCredits: plan.limits.assistant.maxAwuCredits,
@@ -155,7 +153,6 @@ export const toPlanType = (editingPlan: EditingPlanType): PlanType => {
     trialPeriodDays: parseMaybeNumber(editingPlan.trialPeriodDays),
     isByok: editingPlan.isByok,
     isAuditLogsAllowed: editingPlan.isAuditLogsAllowed,
-    isBrandedFramesAllowed: editingPlan.isBrandedFramesAllowed,
   };
 };
 
@@ -178,7 +175,6 @@ const getEmptyPlan = (): EditingPlanType => ({
   isSCIMAllowed: false,
   isByok: false,
   isAuditLogsAllowed: false,
-  isBrandedFramesAllowed: false,
   maxImagesPerWeek: "",
   maxMessages: "",
   maxMessagesTimeframe: "day",
@@ -372,11 +368,6 @@ export const PLAN_FIELDS = {
     type: "boolean",
     width: "tiny",
     title: "Audit",
-  },
-  isBrandedFramesAllowed: {
-    type: "boolean",
-    width: "tiny",
-    title: "Branded Frames",
   },
   maxVaults: {
     type: "number",

--- a/front/components/workspace/settings/BrandingSection.tsx
+++ b/front/components/workspace/settings/BrandingSection.tsx
@@ -187,7 +187,7 @@ export function BrandingSection({ owner }: BrandingSectionProps) {
       <BrandingAssetUploader
         asset="favicon"
         currentVersion={branding?.assets.favicon?.version ?? null}
-        description="A compact version of your logo. Used as the favicon when someone opens a branded Frame. Must be square (1:1 ratio)."
+        description="A compact version of your logo. Used as the favicon when someone opens a whitelabel Frame. Must be square (1:1 ratio)."
         onSaved={handleSaved}
         owner={owner}
         title="Icon"

--- a/front/lib/api/workspace_branding/index.ts
+++ b/front/lib/api/workspace_branding/index.ts
@@ -9,12 +9,12 @@
  * Keys are extensionless, content type lives in GCS object metadata.
  */
 
-import type { Authenticator } from "@app/lib/auth";
+import { type Authenticator, getFeatureFlagsForWorkspace } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import type { FileResource } from "@app/lib/resources/file_resource";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -75,10 +75,10 @@ export async function getWorkspaceBrandingPublicUrls(
   logoUrl: string | null;
   ogImageUrl: string | null;
 }> {
-  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
-    workspace.id
+  const featureFlags = await getFeatureFlagsForWorkspace(
+    renderLightWorkspaceType({ workspace })
   );
-  if (!subscription?.getPlan().isBrandedFramesAllowed) {
+  if (!featureFlags.includes("whitelabel_frames")) {
     return { faviconUrl: null, logoUrl: null, ogImageUrl: null };
   }
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -79,7 +79,6 @@ function createMockPlan(code: string): PlanType {
     },
     isByok: false,
     isAuditLogsAllowed: false,
-    isBrandedFramesAllowed: false,
   };
 }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1626,11 +1626,9 @@ const _getFeatureFlags = memoizer<LightWorkspaceType, WhitelistableFeature[]>({
   ttl: 3000,
 });
 
-export function getFeatureFlags(
-  auth: Authenticator
+export function getFeatureFlagsForWorkspace(
+  workspace: LightWorkspaceType
 ): Promise<WhitelistableFeature[]> {
-  const workspace = auth.getNonNullableWorkspace();
-
   return new Promise((resolve, reject) => {
     _getFeatureFlags(workspace, (err, result) => {
       if (err) {
@@ -1640,6 +1638,12 @@ export function getFeatureFlags(
       }
     });
   });
+}
+
+export function getFeatureFlags(
+  auth: Authenticator
+): Promise<WhitelistableFeature[]> {
+  return getFeatureFlagsForWorkspace(auth.getNonNullableWorkspace());
 }
 
 export async function hasFeatureFlag(

--- a/front/lib/models/plan.ts
+++ b/front/lib/models/plan.ts
@@ -56,7 +56,6 @@ export class PlanModel extends BaseModel<PlanModel> {
   declare isSSOAllowed: boolean;
   declare isSCIMAllowed: boolean;
   declare isAuditLogsAllowed: boolean;
-  declare isBrandedFramesAllowed: boolean;
   declare isByok: boolean;
   declare maxDataSourcesCount: number;
   declare maxDataSourcesDocumentsCount: number;
@@ -187,10 +186,6 @@ PlanModel.init(
       defaultValue: false,
     },
     isAuditLogsAllowed: {
-      type: DataTypes.BOOLEAN,
-      defaultValue: false,
-    },
-    isBrandedFramesAllowed: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     },

--- a/front/lib/plans/credit_priced_plans.ts
+++ b/front/lib/plans/credit_priced_plans.ts
@@ -56,7 +56,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   });
   CREDIT_PRICED_PLANS_DATA.push({
     code: CREDIT_PRICED_FREE_PLAN_CODE,
@@ -89,7 +88,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   });
   CREDIT_PRICED_PLANS_DATA.push({
     code: CREDIT_PRICED_ENTERPRISE_DEFAULT_PLAN_CODE,
@@ -122,7 +120,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   });
 }
 

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -58,7 +58,6 @@ export const FREE_NO_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: false,
   isByok: false,
-  isBrandedFramesAllowed: false,
 };
 
 /**
@@ -97,7 +96,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: false,
     isByok: false,
-    isBrandedFramesAllowed: false,
   },
   {
     code: FREE_UPGRADED_PLAN_CODE,
@@ -130,7 +128,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   },
   {
     code: FREE_TRIAL_PHONE_PLAN_CODE,
@@ -163,7 +160,6 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   },
 ];
 

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -62,7 +62,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   });
   PRO_PLANS_DATA.push({
     code: PRO_PLAN_SEAT_39_CODE,
@@ -95,7 +94,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 14,
     canUseProduct: true,
     isByok: false,
-    isBrandedFramesAllowed: false,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_PLAN_CODE,
@@ -128,7 +126,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
-    isBrandedFramesAllowed: false,
   });
   PRO_PLANS_DATA.push({
     code: FREE_BYOK_TRANSITIONING_PLAN_CODE,
@@ -161,7 +158,6 @@ if (isDevelopment() || isTest()) {
     trialPeriodDays: 0,
     canUseProduct: true,
     isByok: true,
-    isBrandedFramesAllowed: false,
   });
 }
 

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -57,7 +57,6 @@ export function renderPlanFromModel({
     trialPeriodDays: plan.trialPeriodDays,
     isByok: plan.isByok,
     isAuditLogsAllowed: plan.isAuditLogsAllowed,
-    isBrandedFramesAllowed: plan.isBrandedFramesAllowed,
   };
 }
 

--- a/front/migrations/post-deploy/20260624104958_drop_branded_frames_from_plans.sql
+++ b/front/migrations/post-deploy/20260624104958_drop_branded_frames_from_plans.sql
@@ -1,0 +1,9 @@
+/*
+Post-deploy: drop the plans.isBrandedFramesAllowed column.
+
+Whitelabel frames are now gated by the `whitelabel_frames` feature flag instead
+of this per-plan column, so the column is no longer read by any code. Run after
+the code that stops referencing it is live.
+ */
+ALTER TABLE "public"."plans"
+    DROP COLUMN "isBrandedFramesAllowed";

--- a/front/scripts/seed/byok/seed.ts
+++ b/front/scripts/seed/byok/seed.ts
@@ -39,7 +39,6 @@ const FREE_BYOK_PLAN_DATA: PlanAttributes = {
   trialPeriodDays: 0,
   canUseProduct: true,
   isByok: true,
-  isBrandedFramesAllowed: false,
 };
 
 makeScript({}, async ({ execute }, logger) => {

--- a/front/tests/utils/PlanFactory.ts
+++ b/front/tests/utils/PlanFactory.ts
@@ -41,7 +41,6 @@ export class PlanFactory {
       trialPeriodDays: 0,
       canUseProduct: true,
       isByok: false,
-      isBrandedFramesAllowed: false,
       ...overrides,
     });
     return plan;

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -8,6 +8,7 @@ import {
   PRO_PLAN_SEAT_29_CODE,
 } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -80,14 +81,14 @@ export class WorkspaceFactory {
     );
   }
 
-  static async withBrandedFrames(
+  // Whitelabel frames are gated by the `whitelabel_frames` feature flag.
+  static async withWhitelabelFrames(
     overrides?: WorkspaceOverrides
   ): Promise<WorkspaceType> {
-    const plan = await PlanFactory.enterprise("ENT_BRANDED_FRAMES_TEST", {
-      isBrandedFramesAllowed: true,
-    });
+    const workspace = await this.basic(overrides);
+    await FeatureFlagResource.enable(workspace, "whitelabel_frames");
 
-    return this.createWithPlan(plan, overrides);
+    return workspace;
   }
 
   // Plans are seeded by the DB init script (admin/db.ts) to avoid deadlocks

--- a/front/types/api/poke/plans.ts
+++ b/front/types/api/poke/plans.ts
@@ -53,7 +53,6 @@ export const PlanTypeSchema = z.object({
   }),
   trialPeriodDays: z.number(),
   isByok: z.boolean(),
-  isBrandedFramesAllowed: z.boolean(),
   isAuditLogsAllowed: z.boolean(),
 });
 

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -89,7 +89,6 @@ export type PlanType = {
   trialPeriodDays: number;
   isByok: boolean;
   isAuditLogsAllowed: boolean;
-  isBrandedFramesAllowed: boolean;
 };
 
 export type SubscriptionType = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -350,6 +350,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Workspace default agent: admins can pre-select a workspace-wide default agent for new conversations.",
     stage: "on_demand",
   },
+  whitelabel_frames: {
+    description:
+      "Whitelabel frames: customize the workspace logo, favicon and OG image shown on shared Frames.",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -782,6 +782,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "live_speech_to_text"
   | "force_us_api_url"
   | "workspace_default_agent"
+  | "whitelabel_frames"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Whitelabel frames were gated on a dedicated plan entitlement column. That made every enablement an operational chore: the GTM team had to get a plan edited in Poke to turn the feature on for a workspace, which is heavier than it should be for what is effectively a toggle. This moves the gate to a workspace feature flag so it can be flipped on demand without touching plans, and drops the now-unused entitlement column from the plan. We also settled on the name "whitelabel frames" over "branded frames", so the concept is renamed across the gate, the test factory, and user-facing copy. The broader workspace branding surface keeps its existing name and routes, since branding is wider than just this feature.

💡 One thing worth being explicit about: a feature flag is not where this should live long term. Flags are meant for rollout and experimentation, not for permanent entitlement, and using one as a durable commercial gate is a smell. We are doing it deliberately because we do not yet have an add-on mechanism to attach this to, and a flag is the lowest-friction option available today that unblocks GTM. When add-ons exist, this should migrate onto a proper entitlement and the flag should be retired.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Deploy front
- [ ] Confirm no workspaces were granted the feature
- [ ] Run migration