### PR TITLE
feat(files): downscale large images more reliably via imgproxy

### DIFF
--- a/front/lib/api/files/processing/image_converter/imgproxy.ts
+++ b/front/lib/api/files/processing/image_converter/imgproxy.ts
@@ -27,7 +27,10 @@ function buildImgproxyUrl({
   const salt = Buffer.from(config.getImgproxySalt(), "hex");
 
   const encodedSource = Buffer.from(sourceUrl).toString("base64url");
-  const path = `/rs:fit:${maxSizePixels}:${maxSizePixels}:0/${encodedSource}.${extension}`;
+  // q:75 re-encodes below imgproxy's default (80) to shrink file size while
+  // keeping text and detail legible to vision models. Lossy-format only (JPEG);
+  // a no-op for PNG/GIF.
+  const path = `/rs:fit:${maxSizePixels}:${maxSizePixels}:0/q:75/${encodedSource}.${extension}`;
 
   const signature = crypto
     .createHmac("sha256", key)

--- a/front/lib/api/files/processing/images.ts
+++ b/front/lib/api/files/processing/images.ts
@@ -16,6 +16,11 @@ const AVATAR_IMG_MAX_SIZE_PIXELS = 256;
 const BRANDING_LOGO_MAX_SIZE_PIXELS = 512;
 const BRANDING_FAVICON_MAX_SIZE_PIXELS = 256;
 
+// Images within the pixel limit are kept as-is below this byte size; above it
+// we still re-encode (via the converter) to bring the file size down, since a
+// small-dimension image can still be several MB.
+const IMG_REENCODE_THRESHOLD_BYTES = 1024 * 1024;
+
 function getMaxSizePixels(file: FileResource): number {
   if (file.useCase === "avatar") {
     return AVATAR_IMG_MAX_SIZE_PIXELS;
@@ -67,6 +72,11 @@ async function resizeRasterImage(
   file: FileResource,
   maxSizePixels: number
 ): Promise<Result<undefined, Error>> {
+  // Only imgproxy re-encodes at a lower quality (q:75); ConvertAPI can only
+  // rescale, so routing a within-dimension file through it is a paid no-op.
+  // Gate the byte-based re-encode on imgproxy being the active converter.
+  const useImgproxy = await hasFeatureFlag(auth, "imgproxy_image_resize");
+
   try {
     const readStreamForProbe = file.getReadStream({
       auth,
@@ -95,9 +105,13 @@ async function resizeRasterImage(
       throw new Error("Could not determine image dimensions");
     }
 
+    const withinByteBudget =
+      !useImgproxy || file.fileSize <= IMG_REENCODE_THRESHOLD_BYTES;
+
     if (
       dimensions.width <= maxSizePixels &&
-      dimensions.height <= maxSizePixels
+      dimensions.height <= maxSizePixels &&
+      withinByteBudget
     ) {
       const readStream = file.getReadStream({ auth, version: "original" });
       const writeStream = file.getWriteStream({ auth, version: "processed" });
@@ -106,6 +120,7 @@ async function resizeRasterImage(
         {
           dimensions: { width: dimensions.width, height: dimensions.height },
           maxSizePixels,
+          fileSize: file.fileSize,
         },
         "Image already within size limits, skipping resize"
       );
@@ -129,7 +144,7 @@ async function resizeRasterImage(
   const resizeOptions = { format, maxSizePixels };
 
   const converter = await getImageConverter(auth);
-  const resizeResult = (await hasFeatureFlag(auth, "imgproxy_image_resize"))
+  const resizeResult = useImgproxy
     ? await converter.resizeFromUrl(
         await file.getSignedUrlForInlineView(auth),
         resizeOptions


### PR DESCRIPTION
## Description

Image downscaling was inconsistent — a 3MB upload could pass through untouched while a 5MB one shrank to ~500KB. Root cause: the resize decision is driven **purely by pixel dimensions**. An image whose dimensions are already within the limit was copied through byte-for-byte, regardless of how many MB it weighed, and imgproxy re-encoded at its default quality (80) with no further byte control.

This PR makes file-size reduction predictable:

1. **Re-encode at `q:75`** in the imgproxy resize chain (`/rs:fit:.../q:75/...`) — below imgproxy's default of 80. Shrinks JPEGs meaningfully without degrading text/detail legibility for vision models.
2. **Byte-gate the skip path** — the "already within size limits, skip resize" branch now also requires the file to be under a 1MB budget. Within-dimension-but-large files now fall through and get re-encoded instead of copied verbatim.

The byte gate only applies when **imgproxy** is the active converter (FF `imgproxy_image_resize`). ConvertAPI (the fallback) can only rescale, not re-encode at a target quality, so routing a within-dimension file through it would be a paid no-op — the legacy dimension-only behavior is preserved there.

> [!NOTE]
> `q:` is lossy-format only. JPEGs shrink; **PNG/GIF are unaffected** (no quality knob). Photographic PNGs would only shrink via format conversion (e.g. WebP), which we deliberately skipped since not every model accepts WebP.

## Tests

Manual: type-checks clean (`tsgo --noEmit` on the changed files). Behavior verified by reasoning through the two converter paths and the gate matrix (within/over dimensions × within/over byte budget × imgproxy on/off).

## Risk

Low. Gated behind the existing `imgproxy_image_resize` feature flag (`dust_only` stage) — the ConvertAPI path is untouched. Worst case, JPEGs come out slightly more compressed than before; safe to rollback (revert the commit, no data migration). Already-processed images are not reprocessed.

## Deploy Plan

Standard front deploy. No migration, no ordering constraints.