### PR TITLE
Fix markdown preview anchors

### DIFF
--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,3 +1,4 @@
+import { MarkdownFilePreview } from "@app/components/file_explorer/MarkdownFilePreview";
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import type { FileEntry } from "@app/components/file_explorer/types";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
@@ -243,7 +244,6 @@ function FilePreviewDialogContent({
       }
       return null;
 
-    case "markdown":
     case "text":
       if (processedContent) {
         return (
@@ -251,6 +251,12 @@ function FilePreviewDialogContent({
             <Markdown content={processedContent.text} isStreaming={false} />
           </div>
         );
+      }
+      return null;
+
+    case "markdown":
+      if (processedContent) {
+        return <MarkdownFilePreview content={processedContent.text} />;
       }
       return null;
 

--- a/front/components/file_explorer/MarkdownFilePreview.test.tsx
+++ b/front/components/file_explorer/MarkdownFilePreview.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MarkdownFilePreview } from "./MarkdownFilePreview";
+
+describe("MarkdownFilePreview", () => {
+  const scrollIntoView = vi.fn();
+  let originalScrollIntoView: Element["scrollIntoView"];
+
+  beforeEach(() => {
+    originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  afterEach(() => {
+    scrollIntoView.mockReset();
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it("renders heading ids from the markdown AST", () => {
+    render(
+      <MarkdownFilePreview
+        content={
+          "# Overview\n\nKey Concepts\n============\n\n## Résumé Café\n\n## Overview"
+        }
+      />
+    );
+
+    const overviewHeadings = screen.getAllByRole("heading", {
+      name: "Overview",
+    });
+    expect(overviewHeadings[0]).toHaveAttribute("id", "overview");
+    expect(
+      screen.getByRole("heading", { name: "Key Concepts" })
+    ).toHaveAttribute("id", "key-concepts");
+    expect(
+      screen.getByRole("heading", { name: "Résumé Café" })
+    ).toHaveAttribute("id", "résumé-café");
+    expect(overviewHeadings[1]).toHaveAttribute("id", "overview-1");
+  });
+
+  it("scrolls preview-local anchors", () => {
+    render(
+      <MarkdownFilePreview
+        content={"[Résumé Café](#r%C3%A9sum%C3%A9-caf%C3%A9)\n\n## Résumé Café"}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Résumé Café" })
+    ).toHaveAttribute("id", "résumé-café");
+    const link = screen.getByRole("link", { name: "Résumé Café" });
+    expect(link).toHaveAttribute("target", "_self");
+
+    fireEvent.click(link);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+  });
+
+  it("keeps external links opening in a new tab", () => {
+    render(<MarkdownFilePreview content={"[Dust](https://www.dust.tt)"} />);
+
+    const link = screen.getByRole("link", { name: "Dust" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/front/components/file_explorer/MarkdownFilePreview.tsx
+++ b/front/components/file_explorer/MarkdownFilePreview.tsx
@@ -1,0 +1,164 @@
+import { LinkBlock, Markdown } from "@dust-tt/sparkle";
+import type React from "react";
+import { useMemo, useRef } from "react";
+import type { Components } from "react-markdown";
+import type { PluggableList } from "react-markdown/lib/react-markdown";
+import { visit } from "unist-util-visit";
+
+interface MarkdownFilePreviewProps {
+  content: string;
+}
+
+interface LinkProps {
+  children: React.ReactNode;
+  href?: string;
+}
+
+interface MarkdownNode {
+  children?: MarkdownNode[];
+  data?: {
+    hProperties?: Record<string, string>;
+  };
+  value?: unknown;
+}
+
+function getMarkdownNodeText(node: MarkdownNode): string {
+  if (typeof node.value === "string") {
+    return node.value;
+  }
+
+  return node.children?.map(getMarkdownNodeText).join("") ?? "";
+}
+
+function getSlugBase(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N} _-]/gu, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+function getMarkdownHeadingAnchorPlugin() {
+  const slugCounts = new Map<string, number>();
+  return (tree: any) => {
+    visit(tree, "heading", (node: MarkdownNode) => {
+      const baseSlug = getSlugBase(getMarkdownNodeText(node));
+
+      if (!baseSlug) {
+        return;
+      }
+
+      const count = slugCounts.get(baseSlug) ?? 0;
+      slugCounts.set(baseSlug, count + 1);
+      const id = count === 0 ? baseSlug : `${baseSlug}-${count}`;
+
+      const data = node.data ?? (node.data = {});
+      data.hProperties = {
+        ...data.hProperties,
+        id,
+      };
+    });
+  };
+}
+
+function getElementByIdWithin(
+  root: HTMLElement,
+  id: string
+): HTMLElement | null {
+  for (const element of root.querySelectorAll<HTMLElement>("[id]")) {
+    if (element.id === id) {
+      return element;
+    }
+  }
+
+  return null;
+}
+
+function getLocalAnchorId(href: string): string | null {
+  const getDecodedHash = (hash: string) => {
+    const rawHash = hash.startsWith("#") ? hash.slice(1) : hash;
+
+    try {
+      return decodeURIComponent(rawHash);
+    } catch {
+      return rawHash;
+    }
+  };
+
+  if (href.startsWith("#")) {
+    return getDecodedHash(href);
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const url = new URL(href, window.location.href);
+    const currentUrl = new URL(window.location.href);
+
+    if (
+      url.origin === currentUrl.origin &&
+      url.pathname === currentUrl.pathname &&
+      url.search === currentUrl.search &&
+      url.hash
+    ) {
+      return getDecodedHash(url.hash);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function MarkdownFilePreview({ content }: MarkdownFilePreviewProps) {
+  const previewRef = useRef<HTMLDivElement>(null);
+  const markdownPlugins = useMemo<PluggableList>(
+    () => [() => getMarkdownHeadingAnchorPlugin()],
+    []
+  );
+
+  const markdownComponents = useMemo<Components>(
+    () => ({
+      a: ({ children, href }: LinkProps) => {
+        const anchorId = href ? getLocalAnchorId(href) : null;
+        const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+          if (!anchorId || !previewRef.current) {
+            return;
+          }
+
+          event.preventDefault();
+          getElementByIdWithin(previewRef.current, anchorId)?.scrollIntoView({
+            block: "start",
+          });
+        };
+
+        return (
+          <LinkBlock
+            href={href}
+            target={anchorId ? "_self" : undefined}
+            onClick={onClick}
+          >
+            {children}
+          </LinkBlock>
+        );
+      },
+    }),
+    []
+  );
+
+  return (
+    <div
+      ref={previewRef}
+      className="rounded-lg bg-muted-background p-4 dark:bg-muted-background-night"
+    >
+      <Markdown
+        content={content}
+        isStreaming={false}
+        additionalMarkdownComponents={markdownComponents}
+        additionalMarkdownPlugins={markdownPlugins}
+      />
+    </div>
+  );
+}

--- a/sparkle/src/components/markdown/HeadingBlock.tsx
+++ b/sparkle/src/components/markdown/HeadingBlock.tsx
@@ -18,14 +18,16 @@ const headingSpacing: Record<number, string> = {
 
 interface HeadingBlockProps {
   children?: React.ReactNode;
+  id?: string;
   node?: MarkdownNode;
 }
 
 export const H1Block = memo(
-  ({ children }: HeadingBlockProps) => {
+  ({ children, id }: HeadingBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     return (
       <h1
+        id={id}
         className={cn(
           headingSpacing[1],
           forcedTextSize ?? markdownHeaderClasses.h1,
@@ -36,15 +38,16 @@ export const H1Block = memo(
       </h1>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) => sameNodePosition(prev.node, next.node) && prev.id === next.id
 );
 H1Block.displayName = "H1Block";
 
 export const H2Block = memo(
-  ({ children }: HeadingBlockProps) => {
+  ({ children, id }: HeadingBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     return (
       <h2
+        id={id}
         className={cn(
           headingSpacing[2],
           forcedTextSize ?? markdownHeaderClasses.h2,
@@ -55,15 +58,16 @@ export const H2Block = memo(
       </h2>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) => sameNodePosition(prev.node, next.node) && prev.id === next.id
 );
 H2Block.displayName = "H2Block";
 
 export const H3Block = memo(
-  ({ children }: HeadingBlockProps) => {
+  ({ children, id }: HeadingBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     return (
       <h3
+        id={id}
         className={cn(
           headingSpacing[3],
           forcedTextSize ?? markdownHeaderClasses.h3,
@@ -74,15 +78,16 @@ export const H3Block = memo(
       </h3>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) => sameNodePosition(prev.node, next.node) && prev.id === next.id
 );
 H3Block.displayName = "H3Block";
 
 export const H4Block = memo(
-  ({ children }: HeadingBlockProps) => {
+  ({ children, id }: HeadingBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     return (
       <h4
+        id={id}
         className={cn(
           headingSpacing[4],
           forcedTextSize ?? markdownHeaderClasses.h4,
@@ -93,15 +98,16 @@ export const H4Block = memo(
       </h4>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) => sameNodePosition(prev.node, next.node) && prev.id === next.id
 );
 H4Block.displayName = "H4Block";
 
 export const H5Block = memo(
-  ({ children }: HeadingBlockProps) => {
+  ({ children, id }: HeadingBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     return (
       <h5
+        id={id}
         className={cn(
           headingSpacing[5],
           forcedTextSize ?? markdownHeaderClasses.h5,
@@ -112,15 +118,16 @@ export const H5Block = memo(
       </h5>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) => sameNodePosition(prev.node, next.node) && prev.id === next.id
 );
 H5Block.displayName = "H5Block";
 
 export const H6Block = memo(
-  ({ children }: HeadingBlockProps) => {
+  ({ children, id }: HeadingBlockProps) => {
     const { textColor, forcedTextSize } = useMarkdownStyle();
     return (
       <h6
+        id={id}
         className={cn(
           headingSpacing[6],
           forcedTextSize ?? markdownHeaderClasses.h6,
@@ -131,6 +138,6 @@ export const H6Block = memo(
       </h6>
     );
   },
-  (prev, next) => sameNodePosition(prev.node, next.node)
+  (prev, next) => sameNodePosition(prev.node, next.node) && prev.id === next.id
 );
 H6Block.displayName = "H6Block";

--- a/sparkle/src/components/markdown/LinkBlock.tsx
+++ b/sparkle/src/components/markdown/LinkBlock.tsx
@@ -8,27 +8,54 @@ import React, { memo } from "react";
 interface LinkBlockProps {
   href?: string;
   children: React.ReactNode;
+  className?: string;
   node?: MarkdownNode;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  rel?: string;
+  target?: React.HTMLAttributeAnchorTarget;
+  title?: string;
 }
 
 export const LinkBlock = memo(
-  ({ href, children }: LinkBlockProps) => (
-    <a
-      href={href}
-      title={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={cn(
-        "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
-        "s-text-highlight dark:s-text-highlight-night",
-        "hover:s-text-highlight-400 dark:hover:s-text-highlight-400-night",
-        "active:s-text-highlight-dark dark:active:s-text-highlight-dark-night"
-      )}
-    >
-      {children}
-    </a>
-  ),
+  ({
+    href,
+    children,
+    className,
+    onClick,
+    rel: providedRel,
+    target: providedTarget,
+    title,
+  }: LinkBlockProps) => {
+    const target = providedTarget ?? "_blank";
+    const rel =
+      providedRel ?? (target === "_blank" ? "noopener noreferrer" : undefined);
+
+    return (
+      <a
+        href={href}
+        title={title ?? href}
+        target={target}
+        rel={rel}
+        onClick={onClick}
+        className={cn(
+          "s-break-all s-font-semibold s-transition-all s-duration-200 s-ease-in-out hover:s-underline",
+          "s-text-highlight dark:s-text-highlight-night",
+          "hover:s-text-highlight-400 dark:hover:s-text-highlight-400-night",
+          "active:s-text-highlight-dark dark:active:s-text-highlight-dark-night",
+          className
+        )}
+      >
+        {children}
+      </a>
+    );
+  },
   (prev, next) =>
-    sameNodePosition(prev.node, next.node) && prev.href === next.href
+    sameNodePosition(prev.node, next.node) &&
+    prev.href === next.href &&
+    prev.rel === next.rel &&
+    prev.target === next.target &&
+    prev.title === next.title &&
+    prev.className === next.className &&
+    prev.onClick === next.onClick
 );
 LinkBlock.displayName = "LinkBlock";

--- a/sparkle/src/components/markdown/index.ts
+++ b/sparkle/src/components/markdown/index.ts
@@ -2,6 +2,7 @@ export * from "./ActionCardBlock";
 export * from "./CodeBlock";
 export * from "./CodeBlockWithExtendedSupport";
 export * from "./ContentBlockWrapper";
+export * from "./LinkBlock";
 export * from "./Markdown";
 export * from "./MarkdownContentContext";
 export * from "./MarkdownStyleContext";


### PR DESCRIPTION
## Description

Markdown file previews now add heading anchors from the markdown AST and intercept same-document links so table of contents links scroll inside the preview instead of changing the conversation URL hash.

This also makes Sparkle markdown headings accept an optional id and lets the Sparkle link block receive explicit anchor props while preserving the default external-link behavior.

## Tests

Added `MarkdownFilePreview` coverage for AST heading anchors, setext headings, duplicate headings, encoded local anchor scrolling, and external links.

Locally ran the focused test, Biome on touched files, front typecheck, and Sparkle typecheck.

No screenshot: the behavior change is scroll position and URL hash handling, covered by the component test.

## Risk

Low. The local anchor behavior is only wired into markdown file previews. Sparkle defaults remain unchanged when no extra props are passed.

## Deploy Plan

Standard deploy.