### PR TITLE
refactor(mcp): move schedules_management server instructions to create_schedule description

### DIFF
--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -6,7 +6,8 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   create_schedule: {
-    description: "Create a schedule that runs this agent at specified times.",
+    description:
+      "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. Limit: 20 schedule creations per user per day.",
     schema: {
       name: z
         .string()
@@ -66,7 +67,6 @@ type SchedulesManagementToolKey =
   keyof typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA;
 
 export const SCHEDULES_MANAGEMENT_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "schedules_management" as const,
     version: "1.0.0",
@@ -74,10 +74,7 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon" as const,
     documentationUrl: null,
-    instructions:
-      "Schedules are user-specific: each user can only view and manage their own schedules. " +
-      "When a schedule triggers, it runs this agent with the specified prompt. " +
-      "Limit: 20 schedule creations per user per day.",
+    instructions: null,
   },
   tools: (
     Object.keys(

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -17,7 +17,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting. Do NOT use Slack-specific markup."
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
         .string()
@@ -63,7 +63,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The new message content, using standard Markdown formatting. Do NOT use Slack-specific markup."
+          "The new message content, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
     },
     stake: "low",
@@ -216,7 +216,6 @@ The search_all parameter should only be set to true if the user explicitly reque
 });
 
 export const SLACK_BOT_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "slack_bot",
     version: "1.0.0",
@@ -228,13 +227,7 @@ export const SLACK_BOT_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: null,
-    instructions:
-      "The Slack bot must be explicitly added to a channel before it can post messages or read history. " +
-      "Direct messages and search operations are not supported. " +
-      "When posting or editing a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). " +
-      "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
-      "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
-      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
+    instructions: null,
   },
   tools: Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -100,9 +100,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting. Do NOT use Slack-specific markup. " +
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
             "To mention a user, use <@user_id> (use the user's id field, not name). " +
-            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle)."
+            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle). " +
+            "To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
         .string()
@@ -148,9 +149,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting. Do NOT use Slack-specific markup. " +
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
             "To mention a user, use <@user_id> (use the user's id field, not name). " +
-            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle)."
+            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle). " +
+            "To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       post_at: z
         .union([z.number().int().positive(), z.string()])
@@ -495,7 +497,6 @@ Set search_all=true only if the user explicitly requests to search all public wo
 
 // Server metadata for external consumption (e.g., by SDK).
 export const SLACK_PERSONAL_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "slack",
     version: "1.0.0",
@@ -507,11 +508,7 @@ export const SLACK_PERSONAL_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
-    instructions:
-      "When posting a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). " +
-      "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
-      "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the Slack ID (e.g., 'U01234ABCD') of the user you want to mention.\n" +
-      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
+    instructions: null,
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,


### PR DESCRIPTION
## Description

Move the three constraints from `schedules_management` `serverInfo.instructions` onto the `create_schedule` tool description:
- user-scoping ("each user can only view and manage their own schedules")
- trigger behavior ("runs this agent with the specified prompt")
- rate limit ("20 schedule creations per user per day")

Same motivation as the prior Slack and Google Calendar PRs: server instructions are injected into the system prompt on every turn, bloating the prompt prefix and busting the stable cache block. They are also not indexed by BM25 tool search. Moving them to the tool description makes them cache-stable, searchable, and only surfaced when the model is considering `create_schedule`.
