### PR TITLE
fix: preserve null reasoningEffort overwrites

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -80,7 +80,9 @@ export abstract class LLM<TPayload = unknown> {
     this.modelConfig = modelConfig;
     this.temperature = temperature;
     this.reasoningEffort =
-      reasoningEffort ?? modelConfig.defaultReasoningEffort;
+      reasoningEffort !== undefined
+        ? reasoningEffort
+        : modelConfig.defaultReasoningEffort;
     this.responseFormat = responseFormat;
     this.bypassFeatureFlag = bypassFeatureFlag;
     this.metadata = {


### PR DESCRIPTION
## Description

`reasoning_effort` was being sent to `mistral-large-latest` even though the model doesn't support it, causing a 400 (`reasoning_effort is not enabled for this model`). Example log [here](https://app.datadoghq.eu/logs?query=host%3Afront-agent-loop-worker-deployment-75ff5bdf47-q9n54%20service%3Afront-agent-loop-worker%20container_id%3A753f2af3af7b7e63d05a05cb60d3329fb7efa58624cdf186b61cd78b15632760%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&context_event=AZ74ybCSAAADklWfaqm4kwAw&event=AwAAAZ74yaeT35mzggAAABhBWjc0eWJDU0FBQURrbFdmYXFtNGt3QXQAAAAkMDE5ZWY4ZDItMGZlZC00Nzk3LWIyZmItNDJkNDFhNzM4OTZlAAL0tQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZ74yaeU35mzjwAAABhBWjc0eWJDU0FBQURrbFdmYXFtNGt3QTYAAAAkMDE5ZWY4ZDItMGZlZC00Nzk3LWIyZmItNDJkNDFhNzM4OTZlAAM3pg&viz=&from_ts=1782290125747&to_ts=1782290425749&live=false)

Root cause: `NON_REASONING_OVERWRITES` sets `reasoningEffort: null` to suppress the field for non-reasoning Mistral models, but the LLM base constructor used `??` which treats `null` as "no value" and fell back to `defaultReasoningEffort = "none"`. Then `"none"` and was sent to the Mistral API which rejected the request with an error.

Fix: replace `??` with `!== undefined` in `front/lib/api/llm/llm.ts` so an explicit `null` overwrite is preserved through the constructor.

## Tests
Manually.

## Risk

Low. Safe to rollback.

## Deploy Plan

Standard deployment.