### PR TITLE
refactor(mcp): move snowflake server instructions to query tool description

### DIFF
--- a/front/lib/api/actions/servers/schedules_management/metadata.ts
+++ b/front/lib/api/actions/servers/schedules_management/metadata.ts
@@ -6,7 +6,8 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const SCHEDULES_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
   create_schedule: {
-    description: "Create a schedule that runs this agent at specified times.",
+    description:
+      "Create a schedule that runs this agent at specified times. Schedules are user-specific: each user can only view and manage their own schedules. When the schedule triggers, it runs this agent with the specified prompt. Limit: 20 schedule creations per user per day.",
     schema: {
       name: z
         .string()
@@ -66,7 +67,6 @@ type SchedulesManagementToolKey =
   keyof typeof SCHEDULES_MANAGEMENT_TOOLS_METADATA;
 
 export const SCHEDULES_MANAGEMENT_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "schedules_management" as const,
     version: "1.0.0",
@@ -74,10 +74,7 @@ export const SCHEDULES_MANAGEMENT_SERVER = {
     authorization: null,
     icon: "ActionTimeIcon" as const,
     documentationUrl: null,
-    instructions:
-      "Schedules are user-specific: each user can only view and manage their own schedules. " +
-      "When a schedule triggers, it runs this agent with the specified prompt. " +
-      "Limit: 20 schedule creations per user per day.",
+    instructions: null,
   },
   tools: (
     Object.keys(

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -17,7 +17,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting. Do NOT use Slack-specific markup."
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
         .string()
@@ -63,7 +63,7 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The new message content, using standard Markdown formatting. Do NOT use Slack-specific markup."
+          "The new message content, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. To mention a user, use <@USER_ID>. To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
     },
     stake: "low",
@@ -216,7 +216,6 @@ The search_all parameter should only be set to true if the user explicitly reque
 });
 
 export const SLACK_BOT_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "slack_bot",
     version: "1.0.0",
@@ -228,13 +227,7 @@ export const SLACK_BOT_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: null,
-    instructions:
-      "The Slack bot must be explicitly added to a channel before it can post messages or read history. " +
-      "Direct messages and search operations are not supported. " +
-      "When posting or editing a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*). " +
-      "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
-      "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
-      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
+    instructions: null,
   },
   tools: Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -100,9 +100,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting. Do NOT use Slack-specific markup. " +
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
             "To mention a user, use <@user_id> (use the user's id field, not name). " +
-            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle)."
+            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle). " +
+            "To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       threadTs: z
         .string()
@@ -148,9 +149,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       message: z
         .string()
         .describe(
-          "The message to post, using standard Markdown formatting. Do NOT use Slack-specific markup. " +
+          "The message to post, using standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
             "To mention a user, use <@user_id> (use the user's id field, not name). " +
-            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle)."
+            "To mention a user group, use <!subteam^user_group_id> (use the user group's id field, not handle). " +
+            "To reference a channel, use #CHANNEL or <#CHANNEL_ID>."
         ),
       post_at: z
         .union([z.number().int().positive(), z.string()])
@@ -495,7 +497,6 @@ Set search_all=true only if the user explicitly requests to search all public wo
 
 // Server metadata for external consumption (e.g., by SDK).
 export const SLACK_PERSONAL_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "slack",
     version: "1.0.0",
@@ -507,11 +508,7 @@ export const SLACK_PERSONAL_SERVER = {
     },
     icon: "SlackLogo",
     documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
-    instructions:
-      "When posting a message on Slack, you MUST use standard Markdown formatting (e.g., [text](url) for links, **bold**, *italic*, `code`). " +
-      "Do NOT use Slack-specific markup like <url|text> for links — the system converts Markdown to Slack format automatically. " +
-      "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the Slack ID (e.g., 'U01234ABCD') of the user you want to mention.\n" +
-      "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
+    instructions: null,
   },
   tools: Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -6,8 +6,16 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const MAX_QUERY_ROWS = 1000;
 
+export const SNOWFLAKE_LIST_DATABASES_TOOL_NAME = "list_databases" as const;
+export const SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME = "list_schemas" as const;
+export const SNOWFLAKE_LIST_TABLES_TOOL_NAME = "list_tables" as const;
+export const SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME = "describe_table" as const;
+export const SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME =
+  "describe_semantic_view" as const;
+export const SNOWFLAKE_QUERY_TOOL_NAME = "query" as const;
+
 export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
-  list_databases: {
+  [SNOWFLAKE_LIST_DATABASES_TOOL_NAME]: {
     description:
       "List all databases accessible to the authenticated Snowflake user.",
     schema: {},
@@ -17,7 +25,7 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       done: "List Snowflake databases",
     },
   },
-  list_schemas: {
+  [SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME]: {
     description: "List all schemas within a specified Snowflake database.",
     schema: {
       database: z
@@ -30,7 +38,7 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       done: "List Snowflake schemas",
     },
   },
-  list_tables: {
+  [SNOWFLAKE_LIST_TABLES_TOOL_NAME]: {
     description:
       "List all tables, views, and semantic views within a specified Snowflake schema.",
     schema: {
@@ -45,7 +53,7 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       done: "List Snowflake tables",
     },
   },
-  describe_table: {
+  [SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME]: {
     description:
       "Get the schema (column names, types, and constraints) of a Snowflake table.",
     schema: {
@@ -59,9 +67,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       done: "Describe Snowflake table",
     },
   },
-  describe_semantic_view: {
-    description:
-      "Get the structure (dimensions and metrics) of a Snowflake semantic view. Use this instead of describe_table when the object kind is SEMANTIC_VIEW.",
+  [SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME]: {
+    description: `Get the structure (dimensions and metrics) of a Snowflake semantic view. Use this instead of ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} when the object kind is SEMANTIC_VIEW.`,
     schema: {
       database: z.string().describe("The name of the database."),
       schema: z.string().describe("The name of the schema."),
@@ -75,9 +82,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       done: "Describe Snowflake semantic view",
     },
   },
-  query: {
-    description:
-      "Execute a read-only SQL query against Snowflake. Write operations are not allowed. Use the dedicated tools for listing databases, schemas, tables, and describing table structure.",
+  [SNOWFLAKE_QUERY_TOOL_NAME]: {
+    description: `Execute a read-only SQL query against Snowflake. Only SELECT queries are allowed; write operations are not permitted. Before writing a query, use ${SNOWFLAKE_LIST_DATABASES_TOOL_NAME}, ${SNOWFLAKE_LIST_SCHEMAS_TOOL_NAME}, ${SNOWFLAKE_LIST_TABLES_TOOL_NAME}, and ${SNOWFLAKE_DESCRIBE_TABLE_TOOL_NAME} (or ${SNOWFLAKE_DESCRIBE_SEMANTIC_VIEW_TOOL_NAME} for semantic views) to explore the schema.`,
     schema: {
       sql: z
         .string()
@@ -113,7 +119,6 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
 });
 
 export const SNOWFLAKE_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "snowflake",
     version: "1.0.0",
@@ -125,8 +130,7 @@ export const SNOWFLAKE_SERVER = {
     },
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
-    instructions:
-      "Use list_databases, list_schemas, list_tables, and describe_table (or describe_semantic_view for semantic views) to explore the schema before writing queries. Only SELECT queries are allowed.",
+    instructions: null,
   },
   tools: Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => ({
     name: t.name,


### PR DESCRIPTION
## Description

Move the two constraints from `snowflake` `serverInfo.instructions` into the `query` tool description:
- schema-exploration precondition ("use list_databases, list_schemas, list_tables, describe_table / describe_semantic_view before writing queries")
- SELECT-only restriction ("only SELECT queries are allowed")

The `query` description already said "read-only" and "use dedicated tools" — the server instructions added the specific tool names and the SELECT framing. The merged description avoids duplication while preserving all guidance.

Same motivation as the prior Slack, Google Calendar, and schedules_management PRs: server instructions inject into the system prompt on every turn, busting the stable cache block and staying invisible to BM25 tool search.
