### PR TITLE
fix(gmail): stop garbling HTML thread history in reply quotes

### DIFF
--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -1,4 +1,5 @@
 import { escape } from "html-escaper";
+import sanitizeHtml from "sanitize-html";
 
 export interface GmailHeader {
   name: string;
@@ -73,23 +74,30 @@ export function isGmailMessage(data: unknown): data is GmailMessage {
   return typeof obj.id === "string";
 }
 
+export interface DecodedMessageBody {
+  body: string;
+  mimeType: "text/plain" | "text/html";
+}
+
 /**
  * Decode the message body from base64 (recursive for multi-part messages)
  */
 export function decodeMessageBody(
   payload: GmailMessagePayload | undefined
-): string {
+): DecodedMessageBody | null {
   if (!payload) {
-    return "";
+    return null;
   }
 
-  if (payload.mimeType === "text/plain" && payload.body?.data) {
+  if (
+    (payload.mimeType === "text/plain" || payload.mimeType === "text/html") &&
+    payload.body?.data
+  ) {
     const base64 = payload.body.data.replace(/-/g, "+").replace(/_/g, "/");
-    return Buffer.from(base64, "base64").toString("utf-8");
-  }
-  if (payload.mimeType == "text/html" && payload.body?.data) {
-    const base64 = payload.body.data.replace(/-/g, "+").replace(/_/g, "/");
-    return Buffer.from(base64, "base64").toString("utf-8");
+    return {
+      body: Buffer.from(base64, "base64").toString("utf-8"),
+      mimeType: payload.mimeType,
+    };
   }
 
   if (payload.parts) {
@@ -101,7 +109,7 @@ export function decodeMessageBody(
     }
   }
 
-  return "";
+  return null;
 }
 
 /**
@@ -197,6 +205,7 @@ export function findAttachmentIdByPartId(
  */
 export function createQuoteSection(
   originalBody: string,
+  originalMimeType: "text/plain" | "text/html",
   originalDate: string | undefined,
   originalFrom: string | undefined
 ): string {
@@ -210,7 +219,14 @@ export function createQuoteSection(
       : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         `${escape(originalFrom || "Original sender")} wrote:`;
 
-  const quotedOriginal = `<blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex">${escape(originalBody).replace(/\n/g, "<br>")}</blockquote>`;
+  const quotedContent =
+    originalMimeType === "text/html"
+      ? sanitizeHtml(originalBody, {
+          allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+        })
+      : escape(originalBody).replace(/\n/g, "<br>");
+
+  const quotedOriginal = `<blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex">${quotedContent}</blockquote>`;
 
   return `<br><br><div class="gmail_quote">${separator}<br>${quotedOriginal}</div>`;
 }
@@ -222,11 +238,13 @@ export function buildReplyBody(
   userBody: string,
   contentType: "text/plain" | "text/html",
   originalBody: string,
+  originalMimeType: "text/plain" | "text/html",
   originalDate: string | undefined,
   originalFrom: string | undefined
 ): string {
   const quoteSection = createQuoteSection(
     originalBody,
+    originalMimeType,
     originalDate,
     originalFrom
   );

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -1,6 +1,6 @@
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { escape } from "html-escaper";
 import sanitizeHtml from "sanitize-html";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export interface GmailHeader {
   name: string;

--- a/front/lib/api/actions/servers/gmail/helpers.ts
+++ b/front/lib/api/actions/servers/gmail/helpers.ts
@@ -1,5 +1,6 @@
 import { escape } from "html-escaper";
 import sanitizeHtml from "sanitize-html";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export interface GmailHeader {
   name: string;
@@ -219,12 +220,19 @@ export function createQuoteSection(
       : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         `${escape(originalFrom || "Original sender")} wrote:`;
 
-  const quotedContent =
-    originalMimeType === "text/html"
-      ? sanitizeHtml(originalBody, {
-          allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
-        })
-      : escape(originalBody).replace(/\n/g, "<br>");
+  let quotedContent: string;
+  switch (originalMimeType) {
+    case "text/html":
+      quotedContent = sanitizeHtml(originalBody, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+      });
+      break;
+    case "text/plain":
+      quotedContent = escape(originalBody).replace(/\n/g, "<br>");
+      break;
+    default:
+      assertNever(originalMimeType);
+  }
 
   const quotedOriginal = `<blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex">${quotedContent}</blockquote>`;
 

--- a/front/lib/api/actions/servers/gmail/tools/index.ts
+++ b/front/lib/api/actions/servers/gmail/tools/index.ts
@@ -204,11 +204,7 @@ async function buildReplyContext(params: {
   const headers = originalMessage.payload?.headers || [];
   const originalFrom = getHeaderValue(headers, "From");
   const originalDate = getHeaderValue(headers, "Date");
-  const rawBody = decodeMessageBody(originalMessage.payload);
-  const originalBody = unescape(rawBody)
-    .replace(/<[^>]*>/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  const decodedBody = decodeMessageBody(originalMessage.payload);
   const originalCc = getHeaderValue(headers, "Cc");
   const originalBcc = getHeaderValue(headers, "Bcc");
   const originalSubject = getHeaderValue(headers, "Subject") ?? null;
@@ -224,7 +220,8 @@ async function buildReplyContext(params: {
   const fullBody = buildReplyBody(
     params.body,
     "text/html",
-    originalBody,
+    decodedBody?.body ?? "",
+    decodedBody?.mimeType ?? "text/plain",
     originalDate,
     originalFrom
   );
@@ -623,7 +620,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         const date = getHeaderValue(headers, "Date");
         const subject = getHeaderValue(headers, "Subject");
         const body = unescape(
-          decodeMessageBody(message.payload)
+          (decodeMessageBody(message.payload)?.body ?? "")
             .replace(/<[^>]*>/g, " ")
             .replace(/\s+/g, " ")
             .trim()
@@ -779,7 +776,7 @@ const handlers: ToolHandlers<typeof GMAIL_TOOLS_METADATA> = {
         const date = getHeaderValue(headers, "Date");
 
         // Decode the full email body
-        const body = decodeMessageBody(messageData.payload);
+        const body = decodeMessageBody(messageData.payload)?.body ?? "";
 
         // Extract attachment metadata
         const attachments = includeAttachments


### PR DESCRIPTION
## Description

Fixes garbled quoted thread history in Gmail reply drafts. When replying to an email with an HTML body (HTML-only messages), create_draft / send_mail flattened the body with a naive regex and ran it through escape(), which entity-encoded the markup (raw tags shown), leaked <style> CSS and left tag fragments.

decodeMessageBody now returns the decoded body with its mimeType. createQuoteSection branches on it: plain-text is escaped (as before), HTML is embedded as-is after sanitization (sanitize-html). The regex strip is removed.

Fixes: [link](https://github.com/dust-tt/tasks/issues/9095)

**Note:** multipart emails carry both a plain-text and an HTML copy of the body. We quote the plain-text copy, which has no formatting (bold/italic don't exist in plain text), so the quote shows content (links, symbols) but not rich formatting. Only HTML-only emails produce a formatted quote. Quoting the HTML copy everywhere is a possible follow-up.

## Tests

Manual. Replied (draft and direct send) to an HTML-only email: formatting rendered, links and < > & preserved, no entity-encoded tags. Replied to a multipart email: plain-text quote rendered correctly.

## Risk

Low, scoped to Gmail reply-quote construction. sanitize-html is already a dependency. Safe to roll back by revert.

## Deploy Plan