### PR TITLE
docs: add SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Support
+
+Thanks for using [Dust](https://dust.tt)! This page tells you where to go depending on what you need.
+
+**GitHub issues track bugs and feature requests only.** For usage questions, account help, and billing, use the channels below — you'll get a faster answer.
+
+## Documentation
+
+For "how do I…?" questions, API guidance, and developer documentation, start here:
+
+- **User guides & developer platform:** https://docs.dust.tt
+- **API reference:** https://docs.dust.tt/reference/developer-platform-overview
+
+## Account, billing & product help
+
+For account-specific, billing, or workspace issues, use the in-app support widget inside your Dust workspace, or email [support@dust.tt](mailto:support@dust.tt).
+
+## Bug reports
+
+Search [existing issues](https://github.com/dust-tt/dust/issues) (open and closed) before filing to avoid duplicates. Then open a new issue in the [issue tracker](https://github.com/dust-tt/dust/issues).
+
+Read [How to Write a Good Bug Report](.github/BUG_REPORT_GUIDELINES.md) before filing. Reports that include the exact error, your region (US or EU), and a URL to where the problem occurs get resolved significantly faster.
+
+## Feature requests
+
+Open an issue describing the problem you want to solve and the outcome you need. Search first — adding your use case to an existing request helps us prioritize.
+
+## Security
+
+**Do not report security vulnerabilities in public issues.** Follow [`SECURITY.md`](SECURITY.md) and use our vulnerability disclosure program at https://dust.tt/home/vulnerability.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,13 @@
 # Support
 
-Thanks for using [Dust](https://dust.tt)! This page tells you where to go depending on what you need.
-
-**GitHub issues track bugs and feature requests only.** For usage questions, account help, and billing, use the channels below — you'll get a faster answer.
+Thanks for using [Dust](https://dust.tt)! For any question or issue, email [support@dust.tt](mailto:support@dust.tt) — that's the fastest way to get help.
 
 ## Documentation
 
-For "how do I…?" questions, API guidance, and developer documentation, start here:
+For "how do I…?" questions, API guidance, and developer documentation:
 
 - **User guides & developer platform:** https://docs.dust.tt
 - **API reference:** https://docs.dust.tt/reference/developer-platform-overview
-
-## Account, billing & product help
-
-For account-specific, billing, or workspace issues, use the in-app support widget inside your Dust workspace, or email [support@dust.tt](mailto:support@dust.tt).
 
 ## Bug reports
 
@@ -27,4 +21,4 @@ Open an issue describing the problem you want to solve and the outcome you need.
 
 ## Security
 
-**Do not report security vulnerabilities in public issues.** Follow [`SECURITY.md`](SECURITY.md) and use our vulnerability disclosure program at https://dust.tt/home/vulnerability.
+**Do not report security vulnerabilities in public issues or by email.** Follow [`SECURITY.md`](SECURITY.md) and use our vulnerability disclosure program at https://dust.tt/home/vulnerability.


### PR DESCRIPTION
## Description

Adds `SUPPORT.md`, a GitHub-recognized support file that routes requests to the right channel:

- How-to / API questions → docs.dust.tt
- Account, billing, workspace → in-app support widget or support@dust.tt
- Bug reports → issue tracker + [BUG_REPORT_GUIDELINES.md](.github/BUG_REPORT_GUIDELINES.md) (already merged in #27761)
- Feature requests → issue tracker
- Security → SECURITY.md + vulnerability disclosure program

Follows patterns from Node.js and other well-maintained open-source projects: opens with an explicit directive ("GitHub issues track bugs and feature requests only"), uses imperative prose consistent with BUG_REPORT_GUIDELINES.md, no emoji headers.

## Tests

Docs-only — no code paths affected.

## Risk

None.

## Deploy Plan

Standard merge; no deployment steps required.