### PR TITLE
Relax schema validation for MCP servers (as does MCP Inspector)

### DIFF
--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -32,6 +32,34 @@ import {
   asDisplayToolName,
 } from "@app/types/shared/utils/string_utils";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  JsonSchemaType,
+  JsonSchemaValidator,
+  jsonSchemaValidator,
+} from "@modelcontextprotocol/sdk/validation/types.js";
+
+/**
+ * Disables MCP SDK output-schema validation.
+ *
+ * Since SDK 1.22, `Client.listTools()` pre-compiles AJV validators for each tool's
+ * `outputSchema`. Some remote servers (e.g. Google Stitch) declare `$ref`s in
+ * `outputSchema` without in-document `$defs`, which makes `listTools()` throw even
+ * though the RPC response is valid. Dust only consumes `inputSchema` from
+ * `tools/list` and does not validate structured tool output, so we skip
+ * output-schema compilation entirely (same intent as MCP Inspector's try/catch
+ * around `ajv.compile`).
+ */
+class NoOpJsonSchemaValidator implements jsonSchemaValidator {
+  getValidator<T>(_schema: JsonSchemaType): JsonSchemaValidator<T> {
+    return (input) => ({
+      valid: true,
+      data: input as T,
+      errorMessage: undefined,
+    });
+  }
+}
+
+export const NO_OP_MCP_JSON_SCHEMA_VALIDATOR = new NoOpJsonSchemaValidator();
 
 /**
  * JSON-RPC error code for request timeout (MCP RequestTimeout).

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -20,6 +20,7 @@ import {
 import {
   getServerTypeAndIdFromSId,
   isMcpTimeoutError,
+  NO_OP_MCP_JSON_SCHEMA_VALIDATOR,
 } from "@app/lib/actions/mcp_helper";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
 import {
@@ -364,10 +365,13 @@ export async function connectToMCPServer(
   Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>
 > {
   // This is where we route the MCP client to the right server.
-  const mcpClient = new Client({
-    name: "dust-mcp-client",
-    version: "1.0.0",
-  });
+  const mcpClient = new Client(
+    {
+      name: "dust-mcp-client",
+      version: "1.0.0",
+    },
+    { jsonSchemaValidator: NO_OP_MCP_JSON_SCHEMA_VALIDATOR }
+  );
   const connectionType = params.type;
   switch (connectionType) {
     case "mcpServerId": {


### PR DESCRIPTION
## Description

Since MCP SDK 1.22, `Client.listTools()` pre-compiles AJV validators for each tool's `outputSchema`. Remote servers like Google Stitch declare `$ref`s in `outputSchema` without in-document `$defs`, which causes `listTools()` to throw — even though the RPC response is valid and the data is usable.

Introduces `NoOpJsonSchemaValidator` (implementing the `jsonSchemaValidator` interface) and passes it via `{ jsonSchemaValidator: NO_OP_MCP_JSON_SCHEMA_VALIDATOR }` to the `Client` constructor in `connectToMCPServer`. Dust only consumes `inputSchema` from `tools/list` and never validates structured tool output, so skipping output-schema compilation has no functional impact. This mirrors MCP Inspector's `try/catch` around `ajv.compile`.

This fixes google stitch MCP sever ([we are not alone](https://www.google.com/search?client=firefox-b-d&q=%22can%27t+resolve+reference+%23%2F%24defs%2FScreenInstance+from+id+%23%22)).


## Tests

Tested manually against a Google Stitch MCP server that was previously failing on `listTools()`.

## Risk

Low. No change to tool execution or input handling — only output-schema compilation is bypassed. The `NoOpJsonSchemaValidator` always returns `valid: true`, matching the behavior Dust already relies on (output schema was never enforced before SDK 1.22).

## Deploy Plan

Deploy front.
