### PR TITLE
fix: throw error if workspace deletion fails

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -789,7 +789,10 @@ export async function deleteWorkspaceActivity({
 
   const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
   if (workspaceResource) {
-    await workspaceResource.delete(auth, {});
+    const deleteResult = await workspaceResource.delete(auth, {});
+    if (deleteResult.isErr()) {
+      throw deleteResult.error;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR fixes the `deleteWorkspaceActivity` temporal activity to properly surface errors when workspace deletion fails, instead of silently ignoring them.

- Captures the result of `workspaceResource.delete()` and throws the error if it returns an `Err` result.

## Tests

Manually.

## Risks
Low.

## Deploy Plan
Standard deployment.