### PR TITLE
feat: improve deferred tool definitions for BM25 discoverability

### DIFF
--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -242,7 +242,8 @@ export const ASHBY_SERVER = {
   serverInfo: {
     name: "ashby",
     version: "1.0.0",
-    description: "Access and manage Ashby ATS data.",
+    description:
+      "Access and manage Ashby ATS (applicant tracking system) data for recruiting: candidates, job postings, interview feedback, referrals, and hiring.",
     authorization: null,
     icon: "AshbyLogo",
     documentationUrl: "https://docs.dust.tt/docs/ashby-mcp",

--- a/front/lib/api/actions/servers/fathom/metadata.ts
+++ b/front/lib/api/actions/servers/fathom/metadata.ts
@@ -6,7 +6,8 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const FATHOM_TOOLS_METADATA = createToolsRecord({
   list_meetings: {
-    description: "List Fathom meetings",
+    description:
+      "List Fathom video meeting recordings with optional filters for date range, team, attendee domain, recorded-by email, and CRM data. Returns summaries, action items, and metadata.",
     schema: {
       cursor: z
         .string()

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -1,4 +1,3 @@
-import { FRESHSERVICE_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/instructions";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { FreshserviceTicketSchema } from "@app/lib/api/actions/servers/freshservice/types";
@@ -693,18 +692,18 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
 });
 
 export const FRESHSERVICE_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "freshservice",
     version: "1.0.0",
-    description: "Connect to tickets, schedules and service catalog.",
+    description:
+      "Manage Freshservice IT service desk tickets, service requests, knowledge base articles, and service catalog items. An ITSM (IT Service Management) helpdesk platform.",
     authorization: {
       provider: "freshservice" as const,
       supported_use_cases: ["platform_actions", "personal_actions"] as const,
     },
     icon: "FreshserviceLogo",
     documentationUrl: "https://docs.dust.tt/docs/freshservice",
-    instructions: FRESHSERVICE_SERVER_INSTRUCTIONS,
+    instructions: null,
   },
   tools: Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/gong/metadata.ts
+++ b/front/lib/api/actions/servers/gong/metadata.ts
@@ -72,7 +72,8 @@ export const GONG_SERVER = {
   serverInfo: {
     name: "gong",
     version: "1.0.0",
-    description: "Access sales calls, transcripts, and conversation analytics.",
+    description:
+      "Access Gong sales calls, transcripts, conversation analytics, and revenue intelligence for deal coaching and pipeline review.",
     authorization: {
       provider: "gong" as const,
       supported_use_cases: ["personal_actions", "platform_actions"] as const,

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -127,7 +127,8 @@ export const OPENAI_USAGE_SERVER = {
   serverInfo: {
     name: "openai_usage",
     version: "1.0.0",
-    description: "Track API consumption and costs.",
+    description:
+      "Track OpenAI API consumption (token usage, model requests) and organization costs by project, API key, user, and model.",
     authorization: null,
     icon: "OpenaiLogo",
     documentationUrl: null,

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -369,162 +369,19 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
   },
 });
 
-export const PRODUCTBOARD_SERVER_INSTRUCTIONS = `
-**ALWAYS call \`get_configuration\` BEFORE creating or updating any entity or note.** Productboard has a flexible, workspace-specific data model where available fields, types, requirements, and allowed operations vary by workspace.
-
-Productboard uses a configuration-driven API. Always start by calling get_configuration to understand available fields.
-
-### Entity Types Reference
-
-**Notes:** Use \`entity_type='textNote'\` or \`entity_type='conversationNote'\`
-**Entities:** Use \`entity_type='product'\`, \`'component'\`, \`'feature'\`, \`'subfeature'\`, \`'initiative'\`, \`'objective'\`, \`'keyResult'\`, \`'release'\`, \`'releaseGroup'\`, \`'company'\`, or \`'user'\`
-
-### Required Workflow for Creating
-
-1. Call \`get_configuration\` with the appropriate \`entity_type\`
-2. Review the configuration response to identify:
-   - Required fields (marked with \`required: true\`)
-   - Optional fields you want to include
-   - Field types and formats (see Field Value Types section)
-   - Allowed operations for each field
-3. Build the \`fields\` object using exact field names and types from the configuration
-4. Optionally build the \`relationships\` array to link to other entities/customers
-5. Call \`create_note\` or \`create_entity\` with the properly formatted data
-
-### Required Workflow for Updating
-
-1. Call \`get_configuration\` with the appropriate \`entity_type\`
-2. Review the configuration response to identify:
-   - Which fields can be updated (check \`lifecycle.update\` and \`lifecycle.patch\` properties)
-   - Allowed operations for each field (set, clear, addItems, removeItems)
-   - Field types and formats for values
-3. Choose your update method:
-   - **Field updates:** Use \`fields\` object to replace entire field values
-   - **Patch operations:** Use \`patch\` array for granular updates with operations: \`set\` (replace value), \`clear\` (erase value), \`addItems\` (add to list), \`removeItems\` (remove from list)
-   - **Operation rules:** Cannot combine set/clear with addItems/removeItems on same field; cannot combine set and clear on same field; can combine addItems and removeItems together
-4. Build your update payload using exact field names and types from the configuration
-5. Call \`update_note\` or \`update_entity\` with the properly formatted data
-
-**Note:** The specific fields that support patch operations vary by workspace. Always check the configuration response for available operations.
-
----
-
-## Pagination
-
-The API uses cursor-based pagination for list endpoints. To fetch multiple pages:
-
-1. Call the tool (e.g., \`query_notes\`) without \`page_cursor\` for the first page
-2. If the response shows "More results available" with a \`pageCursor\`, call the tool again with \`page_cursor\` set to that value
-3. Repeat until no \`pageCursor\` is returned
-
-**Important:** Treat the \`pageCursor\` as an opaque string - do not parse or modify it.
-
----
-
-The Productboard REST API v2 uses types to represent structured data in a more organized way. Understanding these types is essential for effectively working with the API since they are frequently used in the configuration endpoints.
-
-## Field Value Types
-
-Types are referenced from the configuration endpoints. After calling these endpoints, a response will include a \`data\` object that contains many \`fields\`. Each of these \`fields\` will contain a \`schema\` key and value (e.g., \`RichTextFieldValue\`, \`TextFieldValue\`, \`StatusFieldValue\`).
-
-For detailed information about field value types, see: https://developer.productboard.com/v2.0.0/reference/field-value-types
-
-### Basic Types
-
-The following map to strings:
-- \`UUIDFieldValue\`
-- \`TextFieldValue\`
-- \`RichTextFieldValue\` - HTML content (e.g., \`"<p>This is <b>rich</b> text.</p>"\`)
-- \`DateFieldValue\` - ISO 8601 format without time (e.g., "2023-10-01")
-- \`DateTimeFieldValue\` - ISO 8601 format (e.g., "2023-10-01T12:00:00Z")
-- \`URLFieldValue\`
-- \`NameFieldValue\`
-
-The following map to numbers:
-- \`NumberFieldValue\` - integers or floats, including negative numbers
-
-The following map to booleans:
-- \`BooleanFieldValue\`
-
-The following map to enumerations:
-- \`GranularityFieldValue\` - year, quarter, month, day
-
-### Complex Types
-
-**Status Fields:**
-- \`StatusFieldValue\` - has \`id\` (UUID) and \`name\` (NameFieldValue)
-- \`StatusFieldAssign\` - can be \`StatusFieldAssignById\` (with \`id\`) or \`StatusFieldAssignByName\` (with \`name\`)
-
-**Member Fields:**
-- \`MemberFieldValue\` - has \`id\` (UUID) and \`email\` (NameFieldValue)
-- \`MemberFieldAssign\` - can be \`MemberAssignById\` (with \`id\`) or \`MemberAssignByEmail\` (with \`email\`)
-
-**Teams Fields:**
-- \`TeamFieldValue\` - has \`id\` (UUID) and \`name\` (NameFieldValue)
-- \`TeamsFieldValue\` - array of \`TeamFieldValue\` objects
-- \`TeamFieldAssign\` - can be \`TeamAssignById\` (with \`id\`) or \`TeamAssignByName\` (with \`name\`)
-- \`TeamsFieldAssign\` - array of \`TeamFieldAssign\` objects
-
-**Choice Fields:**
-- \`SingleSelectFieldValue\` - has \`id\`, \`name\`, and \`color\`
-- \`SingleSelectFieldAssign\` - can be \`SingleSelectFieldAssignById\` (with \`id\`) or \`SingleSelectFieldAssignByName\` (with \`name\`)
-- \`MultiSelectFieldValue\` - array of \`SingleSelectFieldValue\` objects
-- \`MultiSelectFieldAssign\` - array of \`SingleSelectFieldAssign\` objects
-
-**Time Fields:**
-- \`TimeframeFieldValue\` - has \`startDate\` (DateFieldValue), \`endDate\` (DateFieldValue), and \`granularity\` (GranularityFieldValue)
-
-**Health Fields:**
-- \`HealthFieldValue\` - has \`id\`, \`mode\` (manual/calculated), \`status\` (notSet/onTrack/atRisk/offTrack), \`previousStatus\`, \`lastUpdatedAt\`, \`comment\`, \`createdBy\`
-- \`HealthUpdateFieldValue\` - has \`mode\`, \`status\`, \`comment\`, \`createdBy\`
-
-**Progress Fields:**
-- \`ProgressFieldValue\` - has \`startValue\`, \`targetValue\`, \`currentValue\` (all floats)
-- \`WorkProgressFieldValue\` - has \`value\` (integer 0-100) and \`mode\` (manual/statusBased/calculated)
-
-### FieldValue vs FieldAssign
-
-- **FieldValue** types are used when retrieving data from the API (representing current field values)
-- **FieldAssign** types are used when sending data to the API (representing how to set/update field values)
-
-When a field has a \`FieldAssign\` type, you can often specify the value by \`id\` or by \`name\`. We recommend using IDs when possible, as names can change over time.
-
-### ConversationNotePart
-
-For conversation-type notes, the \`content\` field uses an array of \`ConversationNotePart\` objects:
-
-\`\`\`typescript
-interface ConversationNotePart {
-  externalId: string;        // REQUIRED - External identifier for this message
-  authorType: string;        // REQUIRED - Type of author (e.g., "customer", "agent")
-  content: string;           // REQUIRED - HTML content of the message
-  timestamp: string;         // REQUIRED - ISO 8601 timestamp (e.g., "2026-01-12T10:00:00Z")
-  authorName?: string;       // OPTIONAL - Name of the message author
-  id?: string;               // OPTIONAL - Internal Productboard ID (read-only, assigned by API)
-}
-\`\`\`
-
-
-**Update Examples:**
-- Field update: \`{fields: {name: "New name", tags: [{name: "tag1"}]}}\`
-- Patch set: \`{patch: [{op: "set", path: "name", value: "New name"}]}\`
-- Patch addItems: \`{patch: [{op: "addItems", path: "tags", value: [{name: "new-tag"}]}]}\`
-- Patch clear: \`{patch: [{op: "clear", path: "owner"}]}\`
-`;
-
 export const PRODUCTBOARD_SERVER = {
-  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "productboard",
     version: "1.0.0",
-    description: "Manage productboard entities and notes.",
+    description:
+      "Manage Productboard product management data: features, initiatives, roadmaps, OKRs, customer feedback notes, companies, and product hierarchy entities.",
     authorization: {
       provider: "productboard",
       supported_use_cases: ["platform_actions", "personal_actions"],
     },
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
-    instructions: PRODUCTBOARD_SERVER_INSTRUCTIONS,
+    instructions: null,
   },
   tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -369,7 +369,151 @@ export const PRODUCTBOARD_TOOLS_METADATA = createToolsRecord({
   },
 });
 
+export const PRODUCTBOARD_SERVER_INSTRUCTIONS = `
+**ALWAYS call \`get_configuration\` BEFORE creating or updating any entity or note.** Productboard has a flexible, workspace-specific data model where available fields, types, requirements, and allowed operations vary by workspace.
+
+Productboard uses a configuration-driven API. Always start by calling get_configuration to understand available fields.
+
+### Entity Types Reference
+
+**Notes:** Use \`entity_type='textNote'\` or \`entity_type='conversationNote'\`
+**Entities:** Use \`entity_type='product'\`, \`'component'\`, \`'feature'\`, \`'subfeature'\`, \`'initiative'\`, \`'objective'\`, \`'keyResult'\`, \`'release'\`, \`'releaseGroup'\`, \`'company'\`, or \`'user'\`
+
+### Required Workflow for Creating
+
+1. Call \`get_configuration\` with the appropriate \`entity_type\`
+2. Review the configuration response to identify:
+   - Required fields (marked with \`required: true\`)
+   - Optional fields you want to include
+   - Field types and formats (see Field Value Types section)
+   - Allowed operations for each field
+3. Build the \`fields\` object using exact field names and types from the configuration
+4. Optionally build the \`relationships\` array to link to other entities/customers
+5. Call \`create_note\` or \`create_entity\` with the properly formatted data
+
+### Required Workflow for Updating
+
+1. Call \`get_configuration\` with the appropriate \`entity_type\`
+2. Review the configuration response to identify:
+   - Which fields can be updated (check \`lifecycle.update\` and \`lifecycle.patch\` properties)
+   - Allowed operations for each field (set, clear, addItems, removeItems)
+   - Field types and formats for values
+3. Choose your update method:
+   - **Field updates:** Use \`fields\` object to replace entire field values
+   - **Patch operations:** Use \`patch\` array for granular updates with operations: \`set\` (replace value), \`clear\` (erase value), \`addItems\` (add to list), \`removeItems\` (remove from list)
+   - **Operation rules:** Cannot combine set/clear with addItems/removeItems on same field; cannot combine set and clear on same field; can combine addItems and removeItems together
+4. Build your update payload using exact field names and types from the configuration
+5. Call \`update_note\` or \`update_entity\` with the properly formatted data
+
+**Note:** The specific fields that support patch operations vary by workspace. Always check the configuration response for available operations.
+
+---
+
+## Pagination
+
+The API uses cursor-based pagination for list endpoints. To fetch multiple pages:
+
+1. Call the tool (e.g., \`query_notes\`) without \`page_cursor\` for the first page
+2. If the response shows "More results available" with a \`pageCursor\`, call the tool again with \`page_cursor\` set to that value
+3. Repeat until no \`pageCursor\` is returned
+
+**Important:** Treat the \`pageCursor\` as an opaque string - do not parse or modify it.
+
+---
+
+The Productboard REST API v2 uses types to represent structured data in a more organized way. Understanding these types is essential for effectively working with the API since they are frequently used in the configuration endpoints.
+
+## Field Value Types
+
+Types are referenced from the configuration endpoints. After calling these endpoints, a response will include a \`data\` object that contains many \`fields\`. Each of these \`fields\` will contain a \`schema\` key and value (e.g., \`RichTextFieldValue\`, \`TextFieldValue\`, \`StatusFieldValue\`).
+
+For detailed information about field value types, see: https://developer.productboard.com/v2.0.0/reference/field-value-types
+
+### Basic Types
+
+The following map to strings:
+- \`UUIDFieldValue\`
+- \`TextFieldValue\`
+- \`RichTextFieldValue\` - HTML content (e.g., \`"<p>This is <b>rich</b> text.</p>"\`)
+- \`DateFieldValue\` - ISO 8601 format without time (e.g., "2023-10-01")
+- \`DateTimeFieldValue\` - ISO 8601 format (e.g., "2023-10-01T12:00:00Z")
+- \`URLFieldValue\`
+- \`NameFieldValue\`
+
+The following map to numbers:
+- \`NumberFieldValue\` - integers or floats, including negative numbers
+
+The following map to booleans:
+- \`BooleanFieldValue\`
+
+The following map to enumerations:
+- \`GranularityFieldValue\` - year, quarter, month, day
+
+### Complex Types
+
+**Status Fields:**
+- \`StatusFieldValue\` - has \`id\` (UUID) and \`name\` (NameFieldValue)
+- \`StatusFieldAssign\` - can be \`StatusFieldAssignById\` (with \`id\`) or \`StatusFieldAssignByName\` (with \`name\`)
+
+**Member Fields:**
+- \`MemberFieldValue\` - has \`id\` (UUID) and \`email\` (NameFieldValue)
+- \`MemberFieldAssign\` - can be \`MemberAssignById\` (with \`id\`) or \`MemberAssignByEmail\` (with \`email\`)
+
+**Teams Fields:**
+- \`TeamFieldValue\` - has \`id\` (UUID) and \`name\` (NameFieldValue)
+- \`TeamsFieldValue\` - array of \`TeamFieldValue\` objects
+- \`TeamFieldAssign\` - can be \`TeamAssignById\` (with \`id\`) or \`TeamAssignByName\` (with \`name\`)
+- \`TeamsFieldAssign\` - array of \`TeamFieldAssign\` objects
+
+**Choice Fields:**
+- \`SingleSelectFieldValue\` - has \`id\`, \`name\`, and \`color\`
+- \`SingleSelectFieldAssign\` - can be \`SingleSelectFieldAssignById\` (with \`id\`) or \`SingleSelectFieldAssignByName\` (with \`name\`)
+- \`MultiSelectFieldValue\` - array of \`SingleSelectFieldValue\` objects
+- \`MultiSelectFieldAssign\` - array of \`SingleSelectFieldAssign\` objects
+
+**Time Fields:**
+- \`TimeframeFieldValue\` - has \`startDate\` (DateFieldValue), \`endDate\` (DateFieldValue), and \`granularity\` (GranularityFieldValue)
+
+**Health Fields:**
+- \`HealthFieldValue\` - has \`id\`, \`mode\` (manual/calculated), \`status\` (notSet/onTrack/atRisk/offTrack), \`previousStatus\`, \`lastUpdatedAt\`, \`comment\`, \`createdBy\`
+- \`HealthUpdateFieldValue\` - has \`mode\`, \`status\`, \`comment\`, \`createdBy\`
+
+**Progress Fields:**
+- \`ProgressFieldValue\` - has \`startValue\`, \`targetValue\`, \`currentValue\` (all floats)
+- \`WorkProgressFieldValue\` - has \`value\` (integer 0-100) and \`mode\` (manual/statusBased/calculated)
+
+### FieldValue vs FieldAssign
+
+- **FieldValue** types are used when retrieving data from the API (representing current field values)
+- **FieldAssign** types are used when sending data to the API (representing how to set/update field values)
+
+When a field has a \`FieldAssign\` type, you can often specify the value by \`id\` or by \`name\`. We recommend using IDs when possible, as names can change over time.
+
+### ConversationNotePart
+
+For conversation-type notes, the \`content\` field uses an array of \`ConversationNotePart\` objects:
+
+\`\`\`typescript
+interface ConversationNotePart {
+  externalId: string;        // REQUIRED - External identifier for this message
+  authorType: string;        // REQUIRED - Type of author (e.g., "customer", "agent")
+  content: string;           // REQUIRED - HTML content of the message
+  timestamp: string;         // REQUIRED - ISO 8601 timestamp (e.g., "2026-01-12T10:00:00Z")
+  authorName?: string;       // OPTIONAL - Name of the message author
+  id?: string;               // OPTIONAL - Internal Productboard ID (read-only, assigned by API)
+}
+\`\`\`
+
+
+**Update Examples:**
+- Field update: \`{fields: {name: "New name", tags: [{name: "tag1"}]}}\`
+- Patch set: \`{patch: [{op: "set", path: "name", value: "New name"}]}\`
+- Patch addItems: \`{patch: [{op: "addItems", path: "tags", value: [{name: "new-tag"}]}]}\`
+- Patch clear: \`{patch: [{op: "clear", path: "owner"}]}\`
+`;
+
 export const PRODUCTBOARD_SERVER = {
+  // biome-ignore lint/plugin/noMcpServerInstructions: existing usage
   serverInfo: {
     name: "productboard",
     version: "1.0.0",
@@ -381,7 +525,7 @@ export const PRODUCTBOARD_SERVER = {
     },
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
-    instructions: null,
+    instructions: PRODUCTBOARD_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -35,7 +35,8 @@ export const SALESLOFT_SERVER = {
   serverInfo: {
     name: "salesloft",
     version: "1.0.0",
-    description: "Access Salesloft cadences, tasks, and actions.",
+    description:
+      "Access Salesloft sales cadences (outreach sequences), tasks, and due actions for sales engagement and pipeline outreach.",
     authorization: null,
     icon: "SalesloftLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesloft-mcp",

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   create_val: {
     description:
-      "Creates a new val (project) in Val Town — a serverless TypeScript/JavaScript container that can hold HTTP endpoints, scripts, email handlers, or scheduled tasks. Use create_file to add files to the val.",
+      "Creates a new val (project) in Val Town: a serverless TypeScript/JavaScript container that can hold HTTP endpoints, scripts, email handlers, or scheduled tasks. Use create_file to add files to the val.",
     schema: {
       name: z
         .string()
@@ -42,7 +42,7 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   },
   get_val: {
     description:
-      "Gets a specific Val Town val (serverless script/project) by its ID, including its files and metadata.",
+      "Gets a specific Val Town val (serverless script or project) by its ID, including its files and metadata.",
     schema: {
       valId: z.string().describe("The ID of the val to retrieve"),
     },

--- a/front/lib/api/actions/servers/val_town/metadata.ts
+++ b/front/lib/api/actions/servers/val_town/metadata.ts
@@ -7,7 +7,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
   create_val: {
     description:
-      "Creates a new val in Val Town. Use create_file to add files to the val.",
+      "Creates a new val (project) in Val Town — a serverless TypeScript/JavaScript container that can hold HTTP endpoints, scripts, email handlers, or scheduled tasks. Use create_file to add files to the val.",
     schema: {
       name: z
         .string()
@@ -41,7 +41,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     },
   },
   get_val: {
-    description: "Gets a specific val by its ID",
+    description:
+      "Gets a specific Val Town val (serverless script/project) by its ID, including its files and metadata.",
     schema: {
       valId: z.string().describe("The ID of the val to retrieve"),
     },
@@ -52,7 +53,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     },
   },
   list_vals: {
-    description: "Lists vals available to the user's account",
+    description:
+      "Lists Val Town vals (serverless TypeScript/JavaScript functions and projects) available to the user's account.",
     schema: {
       limit: z
         .number()
@@ -81,7 +83,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     },
   },
   search_vals: {
-    description: "Searches for vals by name, description, or content",
+    description:
+      "Searches for Val Town vals (serverless scripts and projects) by name, description, or code content.",
     schema: {
       query: z.string().describe("Search query to find vals"),
       limit: z
@@ -107,7 +110,8 @@ export const VAL_TOWN_TOOLS_METADATA = createToolsRecord({
     },
   },
   list_val_files: {
-    description: "Lists all files in a specific val",
+    description:
+      "Lists all files in a specific Val Town val (serverless project).",
     schema: {
       valId: z.string().describe("The ID of the val to list files for"),
       path: z
@@ -259,7 +263,8 @@ export const VAL_TOWN_SERVER = {
   serverInfo: {
     name: "val_town",
     version: "1.0.0",
-    description: "Create and execute vals in Val Town.",
+    description:
+      "Create and manage Val Town vals: serverless TypeScript/JavaScript functions, HTTP endpoints, email handlers, and scheduled scripts.",
     authorization: null,
     icon: "ValTownLogo",
     documentationUrl: "https://docs.dust.tt/docs/val-town",


### PR DESCRIPTION
## Summary

- **Remove server-level instructions** from `freshservice`
- **Enrich server descriptions** with intent-matching keywords so BM25 can surface the right server when users describe their intent:
  - `ashby`: adds "applicant tracking system (ATS) … recruiting, candidates, job postings, interview feedback, referrals, and hiring"
  - `val_town`: adds "serverless TypeScript/JavaScript functions, HTTP endpoints, email handlers, and scheduled scripts"
  - `openai_usage`: adds "OpenAI API consumption (token usage, model requests) … costs by project, API key, user, and model"
  - `salesloft`: adds "outreach sequences … sales engagement and pipeline outreach"
  - `gong`: adds "revenue intelligence … deal coaching and pipeline review"
  - `freshservice`: adds "ITSM (IT Service Management) helpdesk platform"
  - `productboard`: adds "features, initiatives, roadmaps, OKRs, customer feedback notes … product hierarchy"
- **Fix terse/jargon tool descriptions**:
  - `fathom.list_meetings`: was "List Fathom meetings" — now describes filters and what it returns
  - `val_town` tools: `create_val`, `get_val`, `list_vals`, `search_vals`, `list_val_files` now explain what a "val" is (serverless TypeScript/JavaScript project)

## Test plan

