### PR TITLE
Limit poke queue concurrency

### DIFF
--- a/front/poke/temporal/worker.ts
+++ b/front/poke/temporal/worker.ts
@@ -21,6 +21,7 @@ export async function runPokeWorker() {
     }),
     activities,
     taskQueue: "poke-queue",
+    maxConcurrentActivityTaskExecutions: 5,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     namespace,


### PR DESCRIPTION
## Description

The poke worker has no maxConcurrentActivityTaskExecutions cap , launchDeleteWorkspaceWorkflow m was flooding the db pool.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
