### PR TITLE
[Agent Builder] Block save while data is loading

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -564,7 +564,11 @@ export default function AgentBuilder({
   const { isDirty, isSubmitting } = form.formState;
 
   const isSaveDisabled =
-    isSubmitting || isActionsLoading || isSkillsLoading || isTriggersLoading;
+    isSubmitting ||
+    isActionsLoading ||
+    isSkillsLoading ||
+    isTriggersLoading ||
+    isEditorsLoading;
 
   const handleSave = async () => {
     if (isSaving || isSaveDisabled) {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -561,8 +561,15 @@ export default function AgentBuilder({
     });
   };
 
+  const { isDirty, isSubmitting } = form.formState;
+
+  const isSaveDisabled =
+    isSubmitting ||
+    isSkillsLoading ||
+    (!duplicateAgentId && (isActionsLoading || isTriggersLoading));
+
   const handleSave = async () => {
-    if (isSaving) {
+    if (isSaving || isSaveDisabled) {
       return;
     }
 
@@ -587,14 +594,8 @@ export default function AgentBuilder({
     }
   };
 
-  const { isDirty, isSubmitting } = form.formState;
-
   // Disable navigation lock during save process for new agents
   useNavigationLock((isDirty || !!duplicateAgentId) && !isSaving);
-
-  const isSaveDisabled = duplicateAgentId
-    ? false
-    : isSubmitting || isActionsLoading || isTriggersLoading;
 
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -564,9 +564,7 @@ export default function AgentBuilder({
   const { isDirty, isSubmitting } = form.formState;
 
   const isSaveDisabled =
-    isSubmitting ||
-    isSkillsLoading ||
-    (!duplicateAgentId && (isActionsLoading || isTriggersLoading));
+    isSubmitting || isActionsLoading || isSkillsLoading || isTriggersLoading;
 
   const handleSave = async () => {
     if (isSaving || isSaveDisabled) {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/8990

Agent Builder loads parts of an existing agent form asynchronously. This blocks saving while that data is still loading, so an edit cannot persist an incomplete payload before the current skills/tools/triggers/editors have hydrated.

This is frontend-only and does not change API behavior.

## Risks
Blast radius: Agent Builder save button state while editing or duplicating agents.
Risk: low

## Deploy Plan
- pmrr
- deploy front