### PR TITLE
feat: improve BM25 discoverability for gmail, google_calendar, outlook, outlook_calendar tools

### DIFF
--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -282,7 +282,8 @@ export const GMAIL_SERVER = {
   serverInfo: {
     name: "gmail",
     version: "1.0.0",
-    description: "Access messages and email drafts.",
+    description:
+      "Read and send Gmail emails: manage inbox messages, threads, drafts, labels, and attachments.",
     authorization: {
       provider: "google_drive",
       supported_use_cases: ["personal_actions", "platform_actions"],

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -44,7 +44,7 @@ const sharedEventFields = {
 export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   list_calendars: {
     description:
-      "List all calendars accessible by the user. Supports pagination via pageToken.",
+      "List all Google Calendars accessible by the user. Supports pagination via pageToken.",
     schema: {
       pageToken: z.string().optional().describe("Page token for pagination."),
       maxResults: z
@@ -212,7 +212,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   check_availability: {
     description:
-      "Compute combined availability across multiple participants within a date range.",
+      "Compute combined free/busy availability across multiple participants within a date range using Google Calendar.",
     schema: {
       participants: z
         .array(
@@ -279,7 +279,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   get_user_timezones: {
     description:
-      "Get timezone information for multiple users by attempting to access their calendars. Only works for calendars shared with you.",
+      "Get timezone settings for multiple users from their Google Calendar configuration. Only works for calendars shared with you.",
     schema: {
       emails: z
         .array(z.string())
@@ -298,7 +298,8 @@ export const GOOGLE_CALENDAR_SERVER = {
   serverInfo: {
     name: "google_calendar",
     version: "1.0.0",
-    description: "Access calendar schedules and appointments.",
+    description:
+      "Manage Google Calendar: list calendars, create and update meeting events, check free/busy availability, and look up attendee timezones.",
     authorization: {
       provider: "google_drive",
       supported_use_cases: ["personal_actions", "platform_actions"],

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -280,8 +280,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
   },
   check_self_availability: {
     description:
-      "Check if the current user is available during a specific time period by analyzing " +
-      "their calendar events. An event is considered blocking if its showAs status is 'busy', " +
+      "Check if the authenticated user is available during a specific time slot in Outlook Calendar. " +
+      "An event is considered blocking if its showAs status is 'busy', " +
       "'tentative', 'oof' (out of office), or 'workingElsewhere'.",
     schema: {
       calendarId: z
@@ -319,7 +319,8 @@ export const OUTLOOK_CALENDAR_SERVER = {
   serverInfo: {
     name: "outlook_calendar",
     version: "1.0.0",
-    description: "Tools for managing Outlook calendars and events.",
+    description:
+      "Manage Outlook Calendar (Microsoft 365): list calendars, create and update meeting events, check free/busy availability.",
     authorization: {
       provider: "microsoft_tools",
       supported_use_cases: ["personal_actions"],

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -485,7 +485,8 @@ export const OUTLOOK_MAIL_SERVER = {
   serverInfo: {
     name: "outlook",
     version: "1.0.0",
-    description: "Read emails, manage drafts and contacts.",
+    description:
+      "Read and send Outlook emails (Microsoft 365): manage inbox messages, drafts, mail folders, contacts, and shared mailboxes.",
     authorization: {
       provider: "microsoft_tools",
       supported_use_cases: ["personal_actions", "platform_actions"],


### PR DESCRIPTION
## Description

These four MCP servers will be deferred (not injected in the system prompt) once BM25 tool search is enabled. BM25 indexes tool name, description, and input schema only — server `instructions` are not indexed. For deferred tools to surface at all, names and descriptions must be precise enough to match user intent without the model having seen them in the system prompt.

**Server descriptions** were too terse and, in most cases, omitted the product name entirely:
- Gmail: `"Access messages and email drafts."` → `"Read and send Gmail emails: manage inbox messages, threads, drafts, labels, and attachments."`
- Google Calendar: `"Access calendar schedules and appointments."` → `"Manage Google Calendar: list calendars, create and update meeting events, check free/busy availability, and look up attendee timezones."`
- Outlook: `"Read emails, manage drafts and contacts."` → `"Read and send Outlook emails (Microsoft 365): manage inbox messages, drafts, mail folders, contacts, and shared mailboxes."`
- Outlook Calendar: `"Tools for managing Outlook calendars and events."` → `"Manage Outlook Calendar (Microsoft 365): list calendars, create and update meeting events, check free/busy availability."`

**Individual tools** that couldn't be distinguished from their counterpart on the other platform:
- `google_calendar.list_calendars`: added "Google"
- `google_calendar.check_availability`: was identical in intent to the Outlook Calendar tool — added "using Google Calendar"
- `google_calendar.get_user_timezones`: added "from their Google Calendar configuration"
- `outlook_calendar.check_self_availability`: had zero product identification — added "in Outlook Calendar"

## Tests

No functional changes — description strings only.

## Risk

Low. Metadata-only change, no logic affected.
