### PR TITLE
Gate conversation sandbox status behind Computer feature

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.test.ts
@@ -60,3 +60,20 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/sandbox", () => {
     });
   });
 });
+
+describe("Method support /api/w/:wId/assistant/conversations/:cId/sandbox", () => {
+  it("returns 404 for unsupported methods", async () => {
+    const { workspace, auth, conversation } = await setup();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    for (const method of ["DELETE", "POST", "PUT", "PATCH"] as const) {
+      const response = await honoApp.request(
+        `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}/sandbox`,
+        { method }
+      );
+
+      // Hono returns 404 for unregistered methods (no route matched).
+      expect(response.status).toBe(404);
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.test.ts
@@ -1,0 +1,62 @@
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function setup() {
+  const { workspace, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const conversation = await createConversation(auth, {
+    title: null,
+    visibility: "unlisted",
+    spaceId: null,
+  });
+
+  return { workspace, auth, conversation };
+}
+
+function getSandboxStatus(workspace: { sId: string }, cId: string) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${cId}/sandbox`
+  );
+}
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/sandbox", () => {
+  it("returns the sandbox status when Computer is enabled", async () => {
+    const { workspace, auth, conversation } = await setup();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await SandboxFactory.create(auth, conversation, { status: "running" });
+
+    const response = await getSandboxStatus(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ sandboxStatus: "running" });
+  });
+
+  it("returns null when Computer is enabled and no sandbox exists", async () => {
+    const { workspace, auth, conversation } = await setup();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+
+    const response = await getSandboxStatus(workspace, conversation.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ sandboxStatus: null });
+  });
+
+  it("rejects requests when Computer is disabled", async () => {
+    const { workspace, auth, conversation } = await setup();
+    await FeatureFlagFactory.basic(auth, "sandbox_tools");
+    await FeatureFlagFactory.basic(auth, "disable_computer_feature");
+    await SandboxFactory.create(auth, conversation, { status: "running" });
+
+    const response = await getSandboxStatus(workspace, conversation.sId);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "feature_flag_not_found" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.test.ts
@@ -18,9 +18,9 @@ async function setup() {
   return { workspace, auth, conversation };
 }
 
-function getSandboxStatus(workspace: { sId: string }, cId: string) {
+function getSandboxStatus(workspace: { sId: string }, conversationId: string) {
   return honoApp.request(
-    `/api/w/${workspace.sId}/assistant/conversations/${cId}/sandbox`
+    `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/sandbox`
   );
 }
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/sandbox/index.ts
@@ -5,6 +5,7 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { withComputerFeature } from "@front-api/middlewares/with_computer_feature";
 import { z } from "zod";
 
 const ParamsSchema = z.object({
@@ -13,6 +14,8 @@ const ParamsSchema = z.object({
 
 // Mounted at /api/w/:wId/assistant/conversations/:cId/sandbox.
 const app = workspaceApp();
+
+app.use("*", withComputerFeature());
 
 /** @ignoreswagger */
 app.get(

--- a/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFilesPanel.tsx
@@ -11,10 +11,12 @@ import { useConversationAttachments } from "@app/hooks/conversations/useConversa
 import { useConversationSandboxStatus } from "@app/hooks/conversations/useConversationSandboxStatus";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { downloadFile } from "@app/lib/swr/files";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isInteractiveContentType } from "@app/types/files";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -43,6 +45,8 @@ export function ConversationFilesPanel({
   const blobUrlRef = useRef<string | null>(null);
   const { openPanel, closePanel } = useConversationSidePanelContext();
   const sendNotification = useSendNotification();
+  const { featureFlags } = useFeatureFlags();
+  const isComputerEnabled = isComputerFeatureEnabled(featureFlags);
 
   const { attachments, isConversationAttachmentsLoading } =
     useConversationAttachments({
@@ -54,7 +58,7 @@ export function ConversationFilesPanel({
   const { sandboxStatus } = useConversationSandboxStatus({
     conversationId: conversation.sId,
     owner,
-    options: { disabled: isNewFileExplorer },
+    options: { disabled: isNewFileExplorer || !isComputerEnabled },
   });
 
   const openFile = useCallback(


### PR DESCRIPTION
## Description

Gate the conversation sandbox status endpoint behind the Computer feature middleware, so workspaces without Computer enabled cannot access sandbox state. Also stop the files panel from polling sandbox status when Computer is disabled, and add route coverage for enabled, disabled, missing sandbox, and unsupported method cases.

## Tests

- Added `front-api` route tests for enabled, no sandbox, disabled Computer, and unsupported methods.
- Ran the focused `front-api` sandbox route test in the Hive environment.
- Ran `npm run lint:swagger-annotations` in `front-api`.
- Ran `npm run tsgo -- --noEmit` in `front` and `front-api`.

## Risk

Low. The API change only gates the sandbox status endpoint with the existing Computer feature middleware. The UI change avoids a fetch that would be rejected when Computer is disabled.

## Deploy Plan

Standard deploy.