### PR TITLE
feat(poke): ES-backed credit usage chart to Poke workspace analytics

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/analytics/awu-usage-analytics.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/awu-usage-analytics.test.ts
@@ -1,0 +1,95 @@
+import { getAwuUsageFromAnalytics } from "@app/lib/api/analytics/awu_usage_analytics";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+// devModeConstants reads localStorage at module load. jsdom does not always
+// have localStorage initialized when mock factories evaluate, which crashes
+// any test whose mocked lib transitively imports AuthContext. Stub it here.
+vi.mock("@app/components/dev/devModeConstants", () => ({
+  DEV_MODE_STORAGE_KEY: "dust_dev_mode",
+  DEV_MODE_ACTIVE: false,
+}));
+
+vi.mock(import("@app/lib/api/analytics/awu_usage_analytics"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    getAwuUsageFromAnalytics: vi.fn(),
+  };
+});
+
+function getAwuUsageAnalyticsRequest(
+  wId: string,
+  query: Record<string, string> = {}
+) {
+  const qs = new URLSearchParams(query).toString();
+  return honoApp.request(
+    `/api/poke/workspaces/${wId}/analytics/awu-usage-analytics${qs ? `?${qs}` : ""}`
+  );
+}
+
+describe("GET /api/poke/workspaces/:wId/analytics/awu-usage-analytics", () => {
+  it("returns 401 for non-super-users", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: false,
+      role: "admin",
+    });
+
+    const response = await getAwuUsageAnalyticsRequest(workspace.sId);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: { type: "not_authenticated" },
+    });
+    expect(vi.mocked(getAwuUsageFromAnalytics)).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with usage data for super-users", async () => {
+    vi.mocked(getAwuUsageFromAnalytics).mockResolvedValue(
+      new Ok({
+        granularity: "day",
+        groups: [{ groupKey: "total", name: "Total usage" }],
+        points: [{ timestamp: 0, values: { total: 42 } }],
+      })
+    );
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await getAwuUsageAnalyticsRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      granularity: "day",
+      groups: [{ groupKey: "total", name: "Total usage" }],
+      points: [{ timestamp: 0, values: { total: 42 } }],
+    });
+  });
+
+  it("returns a CSV attachment when format=csv", async () => {
+    vi.mocked(getAwuUsageFromAnalytics).mockResolvedValue(
+      new Ok({
+        granularity: "day",
+        groups: [{ groupKey: "total", name: "Total usage" }],
+        points: [{ timestamp: 0, values: { total: 42 } }],
+      })
+    );
+    const { workspace } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await getAwuUsageAnalyticsRequest(workspace.sId, {
+      format: "csv",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/csv");
+    const body = await response.text();
+    expect(body).toContain("date,granularity,series,credits");
+    expect(body).toContain("Total usage");
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/analytics/awu-usage-analytics.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/awu-usage-analytics.ts
@@ -4,19 +4,18 @@ import {
   awuUsageAnalyticsToCsv,
   getAwuUsageFromAnalytics,
 } from "@app/lib/api/analytics/awu_usage_analytics";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 export type { AwuUsageAnalyticsResponse };
 
-const app = workspaceApp();
+// Mounted at /api/poke/workspaces/:wId/analytics/awu-usage-analytics.
+const app = pokeApp();
 
 /** @ignoreswagger */
 app.get(
   "/",
-  ensureIsAdmin(),
   validate("query", AwuUsageAnalyticsExportQuerySchema),
   async (ctx) => {
     const auth = ctx.get("auth");

--- a/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
@@ -2,6 +2,7 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 
 import activeUsers from "./active-users";
 import awuUsage from "./awu-usage";
+import awuUsageAnalytics from "./awu-usage-analytics";
 import metronomeUsage from "./metronome-usage";
 import programmaticCost from "./programmatic-cost";
 import usageMetrics from "./usage-metrics";
@@ -10,6 +11,7 @@ const app = pokeApp();
 
 app.route("/active-users", activeUsers);
 app.route("/awu-usage", awuUsage);
+app.route("/awu-usage-analytics", awuUsageAnalytics);
 app.route("/metronome-usage", metronomeUsage);
 app.route("/programmatic-cost", programmaticCost);
 app.route("/usage-metrics", usageMetrics);

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -95,7 +95,10 @@ export function AnalyticsPage() {
       />
       <div className="flex flex-col pb-8 gap-8">
         <SafeSuspense fallback={<ChartFallback />}>
-          <AwuUsageFromAnalyticsChart workspaceId={owner.sId} period={period} />
+          <AwuUsageFromAnalyticsChart
+            endpoint={`/api/w/${owner.sId}/analytics/awu-usage-analytics`}
+            period={period}
+          />
         </SafeSuspense>
         <WorkspaceUserCreditsTable workspaceId={owner.sId} period={period} />
         <WorkspaceAgentCreditsTable workspaceId={owner.sId} period={period} />

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -25,6 +25,7 @@ import {
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
 import { WebhookSourceDataTable } from "@app/components/poke/webhook_sources/table";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
+import { AwuUsageFromAnalyticsChart } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -369,6 +370,10 @@ export function WorkspacePage() {
             )}
             <TabsContent value="analytics">
               <div className="flex flex-col gap-6">
+                <AwuUsageFromAnalyticsChart
+                  endpoint={`/api/poke/workspaces/${owner.sId}/analytics/awu-usage-analytics`}
+                  period={30}
+                />
                 <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />
                 <WorkspaceDatasourceRetrievalTreemapPluginChart
                   workspaceId={owner.sId}

--- a/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
+++ b/front/components/workspace/AwuUsageFromAnalyticsChart.tsx
@@ -28,7 +28,9 @@ import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 
 interface AwuUsageFromAnalyticsChartProps {
-  workspaceId: string;
+  // Base path to the awu-usage-analytics endpoint, allowing the same chart to
+  // back both the workspace admin page and Poke (different API namespaces).
+  endpoint: string;
   period: ObservabilityTimeRangeType;
 }
 
@@ -81,7 +83,7 @@ function formatTimestamp(timestamp: number, granularity: Granularity): string {
 }
 
 export function AwuUsageFromAnalyticsChart({
-  workspaceId,
+  endpoint,
   period,
 }: AwuUsageFromAnalyticsChartProps) {
   const [granularity, setGranularity] = useState<Granularity>("day");
@@ -115,7 +117,7 @@ export function AwuUsageFromAnalyticsChart({
 
   const { awuUsageData, isAwuUsageLoading, isAwuUsageError } =
     useAwuUsageFromAnalytics({
-      workspaceId,
+      endpoint,
       groupBy,
       groupByCount,
       granularity,
@@ -189,7 +191,7 @@ export function AwuUsageFromAnalyticsChart({
     exportParams.set("series", effectiveEnabledKeys.join(","));
   }
   const csvDownload = useDownloadCsv({
-    url: `/api/w/${workspaceId}/analytics/awu-usage-analytics?${exportParams.toString()}`,
+    url: `${endpoint}?${exportParams.toString()}`,
     filename: `dust_credit_usage_last_${period}_days.csv`,
     disabled: isAwuUsageLoading || !!isAwuUsageError || chartData.length === 0,
   });

--- a/front/lib/api/analytics/awu_usage_analytics.ts
+++ b/front/lib/api/analytics/awu_usage_analytics.ts
@@ -1,3 +1,4 @@
+import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import type { CreditBreakdownBy } from "@app/lib/api/assistant/observability/credit_usage";
 import {
   fetchCreditTimeseries,
@@ -31,6 +32,17 @@ export const AwuUsageAnalyticsQuerySchema = z.object({
 export type AwuUsageAnalyticsQuery = z.infer<
   typeof AwuUsageAnalyticsQuerySchema
 >;
+
+// HTTP query schema for the JSON/CSV export endpoints (both /api/w/... and
+// /api/poke/...). The `format` and `series` fields are transport concerns; the
+// remaining fields are forwarded to getAwuUsageFromAnalytics.
+export const AwuUsageAnalyticsExportQuerySchema =
+  AwuUsageAnalyticsQuerySchema.extend({
+    format: z.enum(["json", "csv"]).optional().default("json"),
+    // Comma-separated group keys to restrict the export to, mirroring the
+    // chart's legend drilldown. Absent means all returned series.
+    series: z.string().optional(),
+  });
 
 export type AwuUsageAnalyticsGroup = { groupKey: string; name: string };
 
@@ -155,4 +167,42 @@ export async function getAwuUsageFromAnalytics(
   }
 
   return new Ok({ granularity, groups: mappedGroups, points: mappedPoints });
+}
+
+const AWU_USAGE_CSV_HEADERS = [
+  "date",
+  "granularity",
+  "series",
+  "credits",
+] as const;
+
+// Flatten an AWU usage analytics response into a downloadable CSV, optionally
+// restricting to a subset of series (mirrors the chart's legend drilldown).
+export function awuUsageAnalyticsToCsv({
+  response,
+  series,
+  days,
+}: {
+  response: AwuUsageAnalyticsResponse;
+  series?: string;
+  days: number;
+}): { csv: string; filename: string } {
+  const { granularity, groups, points } = response;
+  const seriesFilter = series ? new Set(series.split(",")) : null;
+  const visibleGroups = seriesFilter
+    ? groups.filter((group) => seriesFilter.has(group.groupKey))
+    : groups;
+  const rows = points.flatMap((point) => {
+    const date = new Date(point.timestamp).toISOString().slice(0, 10);
+    return visibleGroups.map((group) => ({
+      date,
+      granularity,
+      series: group.name,
+      credits: point.values[group.groupKey] ?? 0,
+    }));
+  });
+  return {
+    csv: rowsToCsv(AWU_USAGE_CSV_HEADERS, rows),
+    filename: `dust_credit_usage_last_${days}_days.csv`,
+  };
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -704,14 +704,17 @@ export function useAwuUsage({
 }
 
 export function useAwuUsageFromAnalytics({
-  workspaceId,
+  endpoint,
   groupBy,
   groupByCount,
   granularity,
   days,
   disabled,
 }: {
-  workspaceId: string;
+  // Base path to the awu-usage-analytics endpoint, e.g.
+  // `/api/w/${wId}/analytics/awu-usage-analytics` (workspace admin) or
+  // `/api/poke/workspaces/${wId}/analytics/awu-usage-analytics` (Poke).
+  endpoint: string;
   groupBy?: "usage_type" | "agent" | "user" | "origin";
   groupByCount?: number;
   granularity?: "day" | "week" | "month";
@@ -735,7 +738,7 @@ export function useAwuUsageFromAnalytics({
     queryParams.set("days", days.toString());
   }
   const queryString = queryParams.toString();
-  const key = `/api/w/${workspaceId}/analytics/awu-usage-analytics?${queryString}`;
+  const key = `${endpoint}?${queryString}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,


### PR DESCRIPTION
## Description

Surfaces the "Credit usage" analytics chart (AwuUsageFromAnalyticsChart) in Poke's workspace Analytics tab so Dust employees can view credit consumption for any workspace.
## Tests

Local

## Risk

Low
## Deploy Plan

Front