### PR TITLE
Add: edit mode for markdown in file preview.

### DIFF
--- a/front/components/assistant/conversation/FilePreviewContext.tsx
+++ b/front/components/assistant/conversation/FilePreviewContext.tsx
@@ -69,7 +69,7 @@ export function FilePreviewProvider({
           kind: "file",
           isDirectory: false,
           fileName: file.title,
-          path: file.title,
+          path: file.filePath ?? file.title,
           contentType: file.contentType,
           fileId: file.fileId ?? null,
           thumbnailUrl: null,
@@ -104,6 +104,7 @@ export function FilePreviewProvider({
           }
         }}
         onDownload={handleDownload}
+        owner={owner}
       />
     </FilePreviewContext.Provider>
   );

--- a/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
+++ b/front/components/assistant/conversation/files_panel/ConversationFileExplorer.tsx
@@ -107,6 +107,7 @@ export function ConversationFileExplorer({
             getFileUrl={getFileUrl}
             onFileDownload={onFileDownload}
             onOpenInteractive={onOpenInteractive}
+            owner={owner}
           />
         </div>
 
@@ -125,6 +126,7 @@ export function ConversationFileExplorer({
               getFileUrl={getFileUrl}
               onFileDownload={onFileDownload}
               onOpenInteractive={onOpenInteractive}
+              owner={owner}
             />
           </div>
         )}

--- a/front/components/editor/RawMarkdownEditor.tsx
+++ b/front/components/editor/RawMarkdownEditor.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@dust-tt/sparkle";
+import { forwardRef, type UIEventHandler } from "react";
+
+interface RawMarkdownEditorProps {
+  value: string;
+  className?: string;
+  placeholder?: string;
+  readOnly?: boolean;
+  onChange?: (value: string) => void;
+  onScroll?: UIEventHandler<HTMLTextAreaElement>;
+}
+
+export const RawMarkdownEditor = forwardRef<
+  HTMLTextAreaElement,
+  RawMarkdownEditorProps
+>(function RawMarkdownEditor(
+  { value, onChange, onScroll, readOnly = false, placeholder, className },
+  ref
+) {
+  return (
+    <textarea
+      ref={ref}
+      aria-label={placeholder ?? "Markdown source"}
+      className={cn(
+        "block h-full min-h-0 w-full resize-none overflow-y-auto overflow-x-hidden",
+        "border-0 bg-transparent p-0 shadow-none",
+        "font-mono text-sm leading-relaxed",
+        "text-foreground dark:text-foreground-night",
+        "focus:outline-none focus:ring-0",
+        "placeholder:text-muted-foreground dark:placeholder:text-muted-foreground-night",
+        className
+      )}
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+      onScroll={onScroll}
+      readOnly={readOnly}
+      placeholder={placeholder}
+      spellCheck={false}
+    />
+  );
+});
+
+RawMarkdownEditor.displayName = "RawMarkdownEditor";

--- a/front/components/file_explorer/FileExplorer.tsx
+++ b/front/components/file_explorer/FileExplorer.tsx
@@ -28,6 +28,7 @@ import {
 import type { FileSystemEntry } from "@app/types/api/file_system/types";
 import { isInteractiveContentType } from "@app/types/files";
 import { Err, type Result } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
 import { cn, Edit04, FolderOpen, Trash01 } from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -52,6 +53,7 @@ interface FileExplorerProps {
   ) => Promise<Result<void, Error>>;
   onOpenInteractive?: (entry: FileEntryWithId) => void;
   onRename?: (entry: FileEntry | FolderEntry) => void;
+  owner?: LightWorkspaceType;
   getExtraFileMenuItems?: (
     entry: FileExplorerEntry
   ) => FileExplorerMenuAction[];
@@ -74,6 +76,7 @@ export function FileExplorer({
   onMoveFile,
   onOpenInteractive,
   onRename,
+  owner,
   getExtraFileMenuItems,
 }: FileExplorerProps) {
   const [currentFolderPath, setCurrentFolderPath] = useState("");
@@ -337,6 +340,7 @@ export function FileExplorer({
         onDownload={onFileDownload}
         onPrev={handlePreviewPrev}
         onNext={handlePreviewNext}
+        owner={owner}
       />
 
       {onMoveFile && (

--- a/front/components/file_explorer/FilePreviewDialog.tsx
+++ b/front/components/file_explorer/FilePreviewDialog.tsx
@@ -1,13 +1,23 @@
-import { MarkdownFilePreview } from "@app/components/file_explorer/MarkdownFilePreview";
+import {
+  MarkdownFilePreview,
+  type MarkdownFilePreviewViewMode,
+  MarkdownFilePreviewViewModeSwitch,
+} from "@app/components/file_explorer/MarkdownFilePreview";
 import { PDFViewer } from "@app/components/file_explorer/PDFViewer";
 import type { FileEntry } from "@app/components/file_explorer/types";
 import { getFilePreviewConfig } from "@app/components/file_explorer/utils";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { parseCanonicalScopedPath } from "@app/lib/api/files/mount_path";
 import type { ProcessedContent } from "@app/lib/file_content_utils";
 import { processFileContent } from "@app/lib/file_content_utils";
 import { getFileTypeIcon } from "@app/lib/file_icon_utils";
-import { useFileContentByUrl } from "@app/lib/swr/files";
+import {
+  useFileContentByUrl,
+  writeFileContentByPath,
+} from "@app/lib/swr/files";
 import { stripMimeParameters } from "@app/types/files";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   ChevronLeft,
@@ -27,7 +37,8 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useSWRConfig } from "swr";
 
 const MAX_CSV_ROWS = 200;
 const MAX_TEXT_CHARS = 100_000;
@@ -182,6 +193,11 @@ interface FilePreviewDialogContentProps {
   fileContent: string | null;
   fileUrl: string;
   isContentLoading: boolean;
+  markdownCanEdit?: boolean;
+  markdownContent?: string;
+  markdownViewMode?: MarkdownFilePreviewViewMode;
+  onMarkdownContentChange?: (content: string) => void;
+  onMarkdownViewModeChange?: (mode: MarkdownFilePreviewViewMode) => void;
   processedContent: ProcessedContent | null;
 }
 
@@ -191,11 +207,21 @@ function FilePreviewDialogContent({
   fileContent,
   fileUrl,
   isContentLoading,
+  markdownCanEdit,
+  markdownContent,
+  markdownViewMode,
+  onMarkdownContentChange,
+  onMarkdownViewModeChange,
   processedContent,
 }: FilePreviewDialogContentProps) {
   if (isContentLoading) {
     return (
-      <div className="flex h-48 items-center justify-center">
+      <div
+        className={cn(
+          "flex items-center justify-center",
+          category === "markdown" ? "min-h-0 flex-1" : "h-48"
+        )}
+      >
         <Spinner />
       </div>
     );
@@ -255,8 +281,21 @@ function FilePreviewDialogContent({
       return null;
 
     case "markdown":
-      if (processedContent) {
-        return <MarkdownFilePreview content={processedContent.text} />;
+      if (
+        processedContent &&
+        markdownContent !== undefined &&
+        markdownViewMode
+      ) {
+        return (
+          <MarkdownFilePreview
+            content={markdownContent}
+            canEdit={markdownCanEdit}
+            showToolbar={false}
+            viewMode={markdownViewMode}
+            onContentChange={onMarkdownContentChange}
+            onViewModeChange={onMarkdownViewModeChange}
+          />
+        );
       }
       return null;
 
@@ -290,6 +329,7 @@ interface FilePreviewDialogProps {
   entry: FileEntry | null;
   fileUrl: string | null;
   isOpen: boolean;
+  owner?: LightWorkspaceType;
   onDownload: (entry: FileEntry) => Promise<void>;
   onNext?: () => void;
   onOpenChange: (open: boolean) => void;
@@ -304,8 +344,25 @@ export function FilePreviewDialog({
   onDownload,
   onPrev,
   onNext,
+  owner,
 }: FilePreviewDialogProps) {
   const [isDownloading, setIsDownloading] = useState(false);
+  const [markdownViewMode, setMarkdownViewMode] =
+    useState<MarkdownFilePreviewViewMode>("preview");
+  const [markdownDraft, setMarkdownDraft] = useState("");
+  const [markdownSavedContent, setMarkdownSavedContent] = useState("");
+  const [markdownSourcePath, setMarkdownSourcePath] = useState<string | null>(
+    null
+  );
+  const [isMarkdownSaving, setIsMarkdownSaving] = useState(false);
+  const [markdownDialogKey, setMarkdownDialogKey] = useState({
+    isOpen,
+    path: entry?.path,
+  });
+  const markdownInitKeyRef = useRef<string | null>(null);
+
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
 
   const handleDownload = async () => {
     if (!entry) {
@@ -379,6 +436,104 @@ export function FilePreviewDialog({
       ? getDelimitedRecordCount({ content: truncatedContent })
       : null;
 
+  const editableMarkdownFilePath =
+    entry && owner && parseCanonicalScopedPath(entry.path) ? entry.path : null;
+  const canEditMarkdown = category === "markdown" && !!editableMarkdownFilePath;
+
+  if (
+    isOpen !== markdownDialogKey.isOpen ||
+    entry?.path !== markdownDialogKey.path
+  ) {
+    setMarkdownDialogKey({ isOpen, path: entry?.path });
+    setMarkdownViewMode("preview");
+    setMarkdownSourcePath(null);
+    setMarkdownDraft("");
+    setMarkdownSavedContent("");
+    markdownInitKeyRef.current = null;
+  }
+
+  const isMarkdownDirty = markdownDraft !== markdownSavedContent;
+
+  useEffect(() => {
+    if (
+      !isOpen ||
+      !canEditMarkdown ||
+      !entry?.path ||
+      isContentLoading ||
+      !processedContent
+    ) {
+      return;
+    }
+
+    const initKey = `${entry.path}:${processedContent.text}`;
+    if (markdownInitKeyRef.current === initKey) {
+      return;
+    }
+
+    const hadInitializedForPath = markdownInitKeyRef.current?.startsWith(
+      `${entry.path}:`
+    );
+    if (hadInitializedForPath && isMarkdownDirty) {
+      return;
+    }
+
+    setMarkdownSourcePath(entry.path);
+    setMarkdownDraft(processedContent.text);
+    setMarkdownSavedContent(processedContent.text);
+    markdownInitKeyRef.current = initKey;
+  }, [
+    canEditMarkdown,
+    entry?.path,
+    isContentLoading,
+    isMarkdownDirty,
+    isOpen,
+    processedContent?.text,
+    processedContent,
+  ]);
+
+  const handleMarkdownSave = async () => {
+    if (
+      !owner ||
+      !editableMarkdownFilePath ||
+      !isMarkdownDirty ||
+      isMarkdownSaving
+    ) {
+      return;
+    }
+
+    setIsMarkdownSaving(true);
+    try {
+      await writeFileContentByPath({
+        owner,
+        canonicalPath: editableMarkdownFilePath,
+        content: markdownDraft,
+        contentType: "text/markdown",
+      });
+      await mutate(
+        fileUrl,
+        { kind: "loaded", content: markdownDraft },
+        { revalidate: false }
+      );
+      setMarkdownSavedContent(markdownDraft);
+      if (entry?.path) {
+        markdownInitKeyRef.current = `${entry.path}:${markdownDraft}`;
+      }
+      sendNotification({ type: "success", title: "File saved" });
+    } catch (e) {
+      sendNotification({
+        type: "error",
+        title: "Failed to save file",
+        description: e instanceof Error ? e.message : "Unknown error",
+      });
+    } finally {
+      setIsMarkdownSaving(false);
+    }
+  };
+
+  const handleMarkdownRevert = () => {
+    setMarkdownDraft(markdownSavedContent);
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent size="2xl" height="2xl" className="gap-4 px-4">
@@ -416,6 +571,15 @@ export function FilePreviewDialog({
             )}
           </div>
         </DialogHeader>
+        {canEditMarkdown && (
+          <div className="flex shrink-0 justify-end px-4">
+            <MarkdownFilePreviewViewModeSwitch
+              key={`${entry?.path ?? "none"}:${isOpen}`}
+              viewMode={markdownViewMode}
+              onViewModeChange={setMarkdownViewMode}
+            />
+          </div>
+        )}
         {hasError ? (
           <div className="flex h-48 items-center justify-center px-4">
             <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
@@ -431,12 +595,36 @@ export function FilePreviewDialog({
                 fileContent={truncatedContent}
                 fileUrl={fileUrl ?? ""}
                 isContentLoading={isContentLoading}
+                markdownCanEdit={canEditMarkdown}
+                markdownContent={
+                  canEditMarkdown
+                    ? markdownSourcePath === entry.path
+                      ? markdownDraft
+                      : processedContent?.text
+                    : processedContent?.text
+                }
+                markdownViewMode={
+                  canEditMarkdown ? markdownViewMode : "preview"
+                }
+                onMarkdownContentChange={
+                  canEditMarkdown ? setMarkdownDraft : undefined
+                }
+                onMarkdownViewModeChange={
+                  canEditMarkdown ? setMarkdownViewMode : undefined
+                }
                 processedContent={processedContent}
               />
             )}
           </div>
         ) : (
-          <div className="min-h-0 flex-1 overflow-y-auto px-4">
+          <div
+            className={cn(
+              "min-h-0 flex-1 px-4",
+              category === "markdown"
+                ? "flex flex-col overflow-hidden"
+                : "overflow-y-auto"
+            )}
+          >
             {entry && (
               <FilePreviewDialogContent
                 category={category}
@@ -444,6 +632,23 @@ export function FilePreviewDialog({
                 fileContent={truncatedContent}
                 fileUrl={fileUrl ?? ""}
                 isContentLoading={isContentLoading}
+                markdownCanEdit={canEditMarkdown}
+                markdownContent={
+                  canEditMarkdown
+                    ? markdownSourcePath === entry.path
+                      ? markdownDraft
+                      : processedContent?.text
+                    : processedContent?.text
+                }
+                markdownViewMode={
+                  canEditMarkdown ? markdownViewMode : "preview"
+                }
+                onMarkdownContentChange={
+                  canEditMarkdown ? setMarkdownDraft : undefined
+                }
+                onMarkdownViewModeChange={
+                  canEditMarkdown ? setMarkdownViewMode : undefined
+                }
                 processedContent={processedContent}
               />
             )}
@@ -469,14 +674,42 @@ export function FilePreviewDialog({
                 tooltip="Next"
               />
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              icon={Download01}
-              label={isDownloading ? "Downloading…" : "Download"}
-              onClick={handleDownload}
-              disabled={!entry || isDownloading}
-            />
+            {canEditMarkdown ? (
+              <div className="flex items-center gap-2">
+                <Button
+                  label="Save"
+                  variant="highlight"
+                  size="sm"
+                  isLoading={isMarkdownSaving}
+                  disabled={!isMarkdownDirty || isMarkdownSaving}
+                  onClick={() => void handleMarkdownSave()}
+                />
+                <Button
+                  label="Revert"
+                  variant="outline"
+                  size="sm"
+                  disabled={!isMarkdownDirty || isMarkdownSaving}
+                  onClick={handleMarkdownRevert}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  icon={Download01}
+                  label={isDownloading ? "Downloading…" : "Download"}
+                  onClick={handleDownload}
+                  disabled={!entry || isDownloading || isMarkdownDirty}
+                />
+              </div>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                icon={Download01}
+                label={isDownloading ? "Downloading…" : "Download"}
+                onClick={handleDownload}
+                disabled={!entry || isDownloading}
+              />
+            )}
           </div>
         </DialogFooter>
       </DialogContent>

--- a/front/components/file_explorer/MarkdownFilePreview.test.tsx
+++ b/front/components/file_explorer/MarkdownFilePreview.test.tsx
@@ -23,6 +23,7 @@ describe("MarkdownFilePreview", () => {
         content={
           "# Overview\n\nKey Concepts\n============\n\n## Résumé Café\n\n## Overview"
         }
+        viewMode="preview"
       />
     );
 
@@ -43,6 +44,7 @@ describe("MarkdownFilePreview", () => {
     render(
       <MarkdownFilePreview
         content={"[Résumé Café](#r%C3%A9sum%C3%A9-caf%C3%A9)\n\n## Résumé Café"}
+        viewMode="preview"
       />
     );
 
@@ -58,10 +60,70 @@ describe("MarkdownFilePreview", () => {
   });
 
   it("keeps external links opening in a new tab", () => {
-    render(<MarkdownFilePreview content={"[Dust](https://www.dust.tt)"} />);
+    render(
+      <MarkdownFilePreview
+        content={"[Dust](https://www.dust.tt)"}
+        viewMode="preview"
+      />
+    );
 
     const link = screen.getByRole("link", { name: "Dust" });
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("switches to edit mode when clicking preview content", () => {
+    const onViewModeChange = vi.fn();
+
+    render(
+      <MarkdownFilePreview
+        canEdit
+        content={"# Hello\n\nClick me"}
+        viewMode="preview"
+        onViewModeChange={onViewModeChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("heading", { name: "Hello" }));
+
+    expect(onViewModeChange).toHaveBeenCalledWith("edit");
+  });
+
+  it("does not switch to edit mode when clicking a link", () => {
+    const onViewModeChange = vi.fn();
+
+    render(
+      <MarkdownFilePreview
+        canEdit
+        content={"[Dust](https://www.dust.tt)"}
+        viewMode="preview"
+        onViewModeChange={onViewModeChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Dust" }));
+
+    expect(onViewModeChange).not.toHaveBeenCalled();
+  });
+
+  it("updates nested list content in preview without remounting", () => {
+    const { rerender } = render(
+      <MarkdownFilePreview
+        content={"- item one\n- item two"}
+        viewMode="preview"
+      />
+    );
+
+    expect(screen.getByText("item two")).toBeInTheDocument();
+
+    rerender(
+      <MarkdownFilePreview
+        content={"- item one\n- updated item two"}
+        viewMode="preview"
+      />
+    );
+
+    expect(screen.getByText("updated item two")).toBeInTheDocument();
+    expect(screen.queryByText("item two")).not.toBeInTheDocument();
   });
 });

--- a/front/components/file_explorer/MarkdownFilePreview.tsx
+++ b/front/components/file_explorer/MarkdownFilePreview.tsx
@@ -1,12 +1,58 @@
-import { LinkBlock, Markdown } from "@dust-tt/sparkle";
+import { RawMarkdownEditor } from "@app/components/editor/RawMarkdownEditor";
+import {
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  cn,
+  Edit04,
+  Eye,
+  LinkBlock,
+  Markdown,
+} from "@dust-tt/sparkle";
 import type React from "react";
-import { useMemo, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { visit } from "unist-util-visit";
 
+export type MarkdownFilePreviewViewMode = "preview" | "edit";
+
 interface MarkdownFilePreviewProps {
   content: string;
+  canEdit?: boolean;
+  showToolbar?: boolean;
+  viewMode: MarkdownFilePreviewViewMode;
+  onContentChange?: (content: string) => void;
+  onViewModeChange?: (mode: MarkdownFilePreviewViewMode) => void;
+}
+
+interface MarkdownFilePreviewViewModeSwitchProps {
+  viewMode: MarkdownFilePreviewViewMode;
+  onViewModeChange: (mode: MarkdownFilePreviewViewMode) => void;
+}
+
+export function MarkdownFilePreviewViewModeSwitch({
+  viewMode,
+  onViewModeChange,
+}: MarkdownFilePreviewViewModeSwitchProps) {
+  return (
+    <ButtonsSwitchList
+      key={viewMode}
+      defaultValue={viewMode}
+      size="xs"
+      onValueChange={(value) => {
+        if (isViewMode(value)) {
+          onViewModeChange(value);
+        }
+      }}
+    >
+      <ButtonsSwitch value="preview" label="Preview" icon={Eye} />
+      <ButtonsSwitch value="edit" label="Edit" icon={Edit04} />
+    </ButtonsSwitchList>
+  );
+}
+
+function isViewMode(value: string): value is MarkdownFilePreviewViewMode {
+  return value === "preview" || value === "edit";
 }
 
 interface LinkProps {
@@ -112,8 +158,53 @@ function getLocalAnchorId(href: string): string | null {
   return null;
 }
 
-export function MarkdownFilePreview({ content }: MarkdownFilePreviewProps) {
+function isPreviewInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target.closest(
+      "a, button, input, textarea, select, [role='link'], [role='button']"
+    ) !== null
+  );
+}
+
+export function MarkdownFilePreview({
+  content,
+  canEdit = false,
+  showToolbar = true,
+  viewMode,
+  onContentChange,
+  onViewModeChange,
+}: MarkdownFilePreviewProps) {
   const previewRef = useRef<HTMLDivElement>(null);
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const previewContentRef = useRef(content);
+
+  if (viewMode === "preview") {
+    previewContentRef.current = content;
+  }
+
+  useLayoutEffect(() => {
+    if (viewMode === "edit") {
+      editTextareaRef.current?.focus({ preventScroll: true });
+    }
+  }, [viewMode]);
+
+  const handlePreviewClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      !canEdit ||
+      !onViewModeChange ||
+      viewMode !== "preview" ||
+      isPreviewInteractiveTarget(event.target)
+    ) {
+      return;
+    }
+
+    onViewModeChange("edit");
+  };
+
   const markdownPlugins = useMemo<PluggableList>(
     () => [() => getMarkdownHeadingAnchorPlugin()],
     []
@@ -148,17 +239,58 @@ export function MarkdownFilePreview({ content }: MarkdownFilePreviewProps) {
     []
   );
 
+  const markdownContent = canEdit ? previewContentRef.current : content;
+
   return (
-    <div
-      ref={previewRef}
-      className="rounded-lg bg-muted-background p-4 dark:bg-muted-background-night"
-    >
-      <Markdown
-        content={content}
-        isStreaming={false}
-        additionalMarkdownComponents={markdownComponents}
-        additionalMarkdownPlugins={markdownPlugins}
-      />
+    <div className="flex h-full min-h-0 flex-1 flex-col gap-2">
+      {canEdit && showToolbar && onViewModeChange && (
+        <div className="flex shrink-0 justify-end">
+          <MarkdownFilePreviewViewModeSwitch
+            viewMode={viewMode}
+            onViewModeChange={onViewModeChange}
+          />
+        </div>
+      )}
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-muted-background dark:bg-muted-background-night">
+        <div
+          className={cn(
+            "flex min-h-0 flex-1 flex-col p-4",
+            viewMode !== "preview" && "hidden"
+          )}
+        >
+          <div
+            className={cn(
+              "min-h-0 flex-1 overflow-y-auto overflow-x-hidden",
+              canEdit && "cursor-text"
+            )}
+            onClick={handlePreviewClick}
+          >
+            <div ref={previewRef}>
+              <Markdown
+                content={markdownContent}
+                isStreaming={false}
+                optimizeForStreaming={false}
+                additionalMarkdownComponents={markdownComponents}
+                additionalMarkdownPlugins={markdownPlugins}
+              />
+            </div>
+          </div>
+        </div>
+        {canEdit ? (
+          <div
+            className={cn(
+              "flex min-h-0 flex-1 flex-col p-4",
+              viewMode !== "edit" && "hidden"
+            )}
+          >
+            <RawMarkdownEditor
+              ref={editTextareaRef}
+              value={content}
+              onChange={onContentChange}
+            />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/front/components/pod/files/PodFileExplorer.tsx
+++ b/front/components/pod/files/PodFileExplorer.tsx
@@ -790,6 +790,7 @@ function PodFileExplorerContent({ owner, pod }: PodFileExplorerProps) {
         getExtraFileMenuItems={getExtraFileMenuItems}
         toolbarExtraActions={addButton}
         isLoading={isLoading}
+        owner={owner}
       />
     </>
   );

--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -1,31 +1,8 @@
 import { Chip } from "@sparkle/components/Chip";
-import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
-import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
-import {
-  H1Block,
-  H2Block,
-  H3Block,
-  H4Block,
-  H5Block,
-  H6Block,
-} from "@sparkle/components/markdown/HeadingBlock";
-import { HrBlock } from "@sparkle/components/markdown/HrBlock";
-import { InputBlock } from "@sparkle/components/markdown/InputBlock";
-import { LinkBlock } from "@sparkle/components/markdown/LinkBlock";
-import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
+import { createBaseMarkdownComponents } from "@sparkle/components/markdown/createBaseMarkdownComponents";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
 import { MarkdownStyleContext } from "@sparkle/components/markdown/MarkdownStyleContext";
-import { ParagraphBlock } from "@sparkle/components/markdown/ParagraphBlock";
-import { PreBlock } from "@sparkle/components/markdown/PreBlock";
-import { StrongBlock } from "@sparkle/components/markdown/StrongBlock";
 import { safeRehypeKatex } from "@sparkle/components/markdown/safeRehypeKatex";
-import {
-  TableBlock,
-  TableBodyBlock,
-  TableDataBlock,
-  TableHeadBlock,
-  TableHeaderBlock,
-} from "@sparkle/components/markdown/TableBlock";
 import {
   type StreamingState,
   useAnimatedText,
@@ -74,6 +51,8 @@ export interface MarkdownProps {
   enableAnimation?: boolean;
   animationDurationSeconds?: number;
   delimiter?: string;
+  /** When true (default), skip re-rendering blocks whose AST position is unchanged. */
+  optimizeForStreaming?: boolean;
 }
 
 export const Markdown: React.FC<MarkdownProps> = ({
@@ -90,6 +69,7 @@ export const Markdown: React.FC<MarkdownProps> = ({
   enableAnimation = false,
   animationDurationSeconds = DEFAULT_ANIMATION_DURATION_SECONDS,
   delimiter = DEFAULT_DELIMITER,
+  optimizeForStreaming = true,
 }) => {
   // Derive streaming state: explicit prop takes priority, otherwise derive from isStreaming boolean.
   // @TODO: remove isStreaming prop and use streamingState prop only
@@ -132,34 +112,12 @@ export const Markdown: React.FC<MarkdownProps> = ({
   // Minimal test whenever editing this code: ensure that code block content of a streaming message
   // can be selected without blinking.
 
-  // All base components are memo'd and read style props from MarkdownStyleContext,
-  // so this object never needs to be recreated.
+  // When optimizeForStreaming is false, plain (non-memo) block components are used so
+  // content edits at unchanged AST positions still re-render (e.g. file preview).
+
   const baseMarkdownComponents: Components = useMemo(
-    () => ({
-      pre: PreBlock,
-      a: LinkBlock,
-      ul: UlBlock,
-      ol: OlBlock,
-      li: LiBlock,
-      p: ParagraphBlock,
-      h1: H1Block,
-      h2: H2Block,
-      h3: H3Block,
-      h4: H4Block,
-      h5: H5Block,
-      h6: H6Block,
-      table: TableBlock,
-      thead: TableHeadBlock,
-      tbody: TableBodyBlock,
-      th: TableHeaderBlock,
-      td: TableDataBlock,
-      strong: StrongBlock,
-      input: InputBlock,
-      blockquote: BlockquoteBlock,
-      hr: HrBlock,
-      code: CodeBlockWithExtendedSupport,
-    }),
-    []
+    () => createBaseMarkdownComponents(optimizeForStreaming),
+    [optimizeForStreaming]
   );
 
   // Merge base components with additional directive components.

--- a/sparkle/src/components/markdown/createBaseMarkdownComponents.ts
+++ b/sparkle/src/components/markdown/createBaseMarkdownComponents.ts
@@ -1,0 +1,59 @@
+import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
+import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
+import {
+  H1Block,
+  H2Block,
+  H3Block,
+  H4Block,
+  H5Block,
+  H6Block,
+} from "@sparkle/components/markdown/HeadingBlock";
+import { HrBlock } from "@sparkle/components/markdown/HrBlock";
+import { InputBlock } from "@sparkle/components/markdown/InputBlock";
+import { LinkBlock } from "@sparkle/components/markdown/LinkBlock";
+import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
+import { ParagraphBlock } from "@sparkle/components/markdown/ParagraphBlock";
+import { PreBlock } from "@sparkle/components/markdown/PreBlock";
+import { StrongBlock } from "@sparkle/components/markdown/StrongBlock";
+import {
+  TableBlock,
+  TableBodyBlock,
+  TableDataBlock,
+  TableHeadBlock,
+  TableHeaderBlock,
+} from "@sparkle/components/markdown/TableBlock";
+import { pickMarkdownBlock } from "@sparkle/components/markdown/utils";
+import type { ComponentType, MemoExoticComponent } from "react";
+import type { Components } from "react-markdown";
+
+export function createBaseMarkdownComponents(
+  optimizeForStreaming: boolean
+): Components {
+  const pick = (optimizedBlock: MemoExoticComponent<ComponentType<any>>) =>
+    pickMarkdownBlock(optimizedBlock, optimizeForStreaming);
+
+  return {
+    pre: pick(PreBlock),
+    a: pick(LinkBlock),
+    ul: pick(UlBlock),
+    ol: pick(OlBlock),
+    li: pick(LiBlock),
+    p: pick(ParagraphBlock),
+    h1: pick(H1Block),
+    h2: pick(H2Block),
+    h3: pick(H3Block),
+    h4: pick(H4Block),
+    h5: pick(H5Block),
+    h6: pick(H6Block),
+    table: pick(TableBlock),
+    thead: pick(TableHeadBlock),
+    tbody: pick(TableBodyBlock),
+    th: pick(TableHeaderBlock),
+    td: pick(TableDataBlock),
+    strong: pick(StrongBlock),
+    input: pick(InputBlock),
+    blockquote: pick(BlockquoteBlock),
+    hr: pick(HrBlock),
+    code: pick(CodeBlockWithExtendedSupport),
+  };
+}

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -1,6 +1,30 @@
 import type { Element } from "hast";
+import type { ComponentType, MemoExoticComponent } from "react";
 
 export type MarkdownNode = Element;
+
+export function getPlainMarkdownBlock<P>(
+  optimizedBlock: MemoExoticComponent<ComponentType<P>>
+): ComponentType<P> {
+  const plain = (
+    optimizedBlock as MemoExoticComponent<ComponentType<P>> & {
+      type?: ComponentType<P>;
+    }
+  ).type;
+
+  return plain ?? optimizedBlock;
+}
+
+export function pickMarkdownBlock<P>(
+  optimizedBlock: MemoExoticComponent<ComponentType<P>>,
+  optimizeForStreaming: boolean
+): ComponentType<P> {
+  if (optimizeForStreaming) {
+    return optimizedBlock as unknown as ComponentType<P>;
+  }
+
+  return getPlainMarkdownBlock(optimizedBlock);
+}
 
 export function sameNodePosition(
   prev?: MarkdownNode,


### PR DESCRIPTION
## Summary

Adds preview/edit for markdown files in `FilePreviewDialog` when the file has a canonical scoped path and `owner` is provided.

- **Preview** — sparkle `Markdown` renderer (unchanged styling)
- **Edit** — raw markdown `textarea` via `RawMarkdownEditor`
- **State** — content loads once when the dialog opens; draft is shared between preview and edit
- **Footer** — Save, Revert, and Download always visible for editable files; Download disabled while dirty

Also fixes `FilePreviewContext` to use `file.filePath ?? file.title` for the preview path.

## Tests

- `MarkdownFilePreview.test.tsx` (heading anchors, local links)
- Tested locally in file explorer and pod file explorer

## Risk

Low. Frontend-only; edit is gated on `owner` + canonical scoped path. Existing read-only previews unchanged. Pod settings still uses `MarkdownFileEditor` (WYSIWYG) unchanged.

## Deploy Plan

Deploy front.