### PR TITLE
[front] enh: unify the sandbox-raw upload decision

### DIFF
--- a/front/lib/api/files/processing/index.ts
+++ b/front/lib/api/files/processing/index.ts
@@ -1,6 +1,5 @@
 import config from "@app/lib/api/config";
 import { processImage } from "@app/lib/api/files/processing/images";
-import { isSandboxRawDelimitedConversationFile } from "@app/lib/api/files/sandbox_raw";
 import { isSupportedForAvatar } from "@app/lib/api/files/use_cases/avatar";
 import { isSupportedForConversation } from "@app/lib/api/files/use_cases/conversation";
 import { isSupportedForFoldersDocument } from "@app/lib/api/files/use_cases/folders_document";
@@ -434,7 +433,10 @@ const maybeApplyProcessing = async (
   auth: Authenticator,
   file: FileResource
 ): Promise<Result<undefined, Error>> => {
-  if (isSandboxRawDelimitedConversationFile(file)) {
+  // Files mounted raw in the sandbox (stamped with skipFileProcessing at upload) are used as-is: no
+  // extraction/resize. The flag is only ever set server-side by buildEffectiveUseCaseMetadata, so it
+  // is safe to trust here. Covers large delimited conversation files.
+  if (file.useCaseMetadata?.skipFileProcessing === true) {
     return new Ok(undefined);
   }
 

--- a/front/lib/api/files/sandbox_raw.ts
+++ b/front/lib/api/files/sandbox_raw.ts
@@ -1,8 +1,4 @@
 import type { FileResource } from "@app/lib/resources/file_resource";
-import type {
-  AllSupportedFileContentType,
-  FileUseCase,
-} from "@app/types/files";
 import { isSupportedDelimitedTextContentType } from "@app/types/files";
 
 export function isSandboxRawDelimitedConversationFile(
@@ -12,21 +8,5 @@ export function isSandboxRawDelimitedConversationFile(
     file.useCase === "conversation" &&
     file.useCaseMetadata?.skipFileProcessing === true &&
     isSupportedDelimitedTextContentType(file.contentType)
-  );
-}
-
-export function shouldStampSandboxRawDelimited({
-  contentType,
-  flags,
-  useCase,
-}: {
-  contentType: AllSupportedFileContentType;
-  flags: { hasSandboxTools: boolean };
-  useCase: FileUseCase;
-}): boolean {
-  return (
-    flags.hasSandboxTools &&
-    useCase === "conversation" &&
-    isSupportedDelimitedTextContentType(contentType)
   );
 }

--- a/front/lib/api/files/upload_metadata.ts
+++ b/front/lib/api/files/upload_metadata.ts
@@ -1,9 +1,12 @@
-import { shouldStampSandboxRawDelimited } from "@app/lib/api/files/sandbox_raw";
 import { shouldSkipDataSourceIndexing } from "@app/lib/api/files/should_skip_indexing";
 import type {
   AllSupportedFileContentType,
   FileUseCase,
   FileUseCaseMetadata,
+} from "@app/types/files";
+import {
+  allowsSandboxRawUpload,
+  getFileFormatCategory,
 } from "@app/types/files";
 
 export function buildEffectiveUseCaseMetadata({
@@ -23,20 +26,23 @@ export function buildEffectiveUseCaseMetadata({
     contentType,
     fileName,
   });
-  const isSandboxRawDelimited = shouldStampSandboxRawDelimited({
-    contentType,
-    flags,
-    useCase,
-  });
+  const category = getFileFormatCategory(contentType);
+  const isSandboxRaw =
+    category !== null &&
+    allowsSandboxRawUpload({
+      category,
+      hasSandboxTools: flags.hasSandboxTools,
+      useCase,
+    });
 
-  if (!skipDataSourceIndexing && !isSandboxRawDelimited) {
+  if (!skipDataSourceIndexing && !isSandboxRaw) {
     return providedMetadata;
   }
 
   return {
     ...(providedMetadata ?? {}),
     ...(skipDataSourceIndexing ? { skipDataSourceIndexing: true } : {}),
-    ...(isSandboxRawDelimited
+    ...(isSandboxRaw
       ? {
           skipDataSourceIndexing: true,
           skipFileProcessing: true,

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -1,4 +1,5 @@
 import {
+  allowsSandboxRawUpload,
   authorizedFileAccessEntrySchema,
   ensureFileSize,
   getAuthorizedFileRefLabel,
@@ -7,6 +8,50 @@ import {
   resolveMaxFileSizes,
 } from "@app/types/files";
 import { describe, expect, it } from "vitest";
+
+describe("allowsSandboxRawUpload", () => {
+  it("allows delimited conversation files only when sandbox tools are present", () => {
+    expect(
+      allowsSandboxRawUpload({
+        category: "delimited",
+        hasSandboxTools: true,
+        useCase: "conversation",
+      })
+    ).toBe(true);
+
+    expect(
+      allowsSandboxRawUpload({
+        category: "delimited",
+        hasSandboxTools: false,
+        useCase: "conversation",
+      })
+    ).toBe(false);
+  });
+
+  it("does not apply to non-delimited categories in sandbox conversations", () => {
+    for (const category of ["image", "data", "code", "audio"] as const) {
+      expect(
+        allowsSandboxRawUpload({
+          category,
+          hasSandboxTools: true,
+          useCase: "conversation",
+        })
+      ).toBe(false);
+    }
+  });
+
+  it("does not apply outside of conversations", () => {
+    for (const useCase of ["upsert_table", "skill_attachment"] as const) {
+      expect(
+        allowsSandboxRawUpload({
+          category: "delimited",
+          hasSandboxTools: true,
+          useCase,
+        })
+      ).toBe(false);
+    }
+  });
+});
 
 describe("resolveMaxFileSizes", () => {
   it("raises the delimited limit only for sandbox conversations", () => {
@@ -29,6 +74,14 @@ describe("resolveMaxFileSizes", () => {
         hasSandboxTools: true,
         useCase: "upsert_table",
       }).delimited
+    ).toBe(50 * 1024 * 1024);
+
+    // Only delimited is raised: other categories keep the default even in a sandbox conversation.
+    expect(
+      resolveMaxFileSizes({
+        hasSandboxTools: true,
+        useCase: "conversation",
+      }).code
     ).toBe(50 * 1024 * 1024);
   });
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -293,6 +293,10 @@ export const MAX_FILE_SIZES_DEFAULT: Record<FileFormatCategory, number> = {
   audio: 100 * 1024 * 1024, // 100 MB, audio files can be large, ex transcript of meetings
 };
 
+export const MAX_FILE_SIZES = MAX_FILE_SIZES_DEFAULT;
+
+// Large delimited files (CSV/XLSX) are mounted into the sandbox and read as-is by the agent's code
+// rather than loaded into its context, so they can be much larger than regular uploads.
 export const MAX_FILE_SIZES_LARGE_DELIMITED: Record<
   FileFormatCategory,
   number
@@ -301,7 +305,38 @@ export const MAX_FILE_SIZES_LARGE_DELIMITED: Record<
   delimited: 350 * 1024 * 1024,
 };
 
-export const MAX_FILE_SIZES = MAX_FILE_SIZES_DEFAULT;
+// Whether an upload is stored as a raw sandbox file: kept as-is with no upload-time processing
+// (no Tika extraction / image resize) and not indexed. Always requires sandbox tools.
+//  - conversation: large delimited files are served raw to the sandbox instead of indexed as tables.
+export function allowsSandboxRawUpload({
+  category,
+  hasSandboxTools,
+  useCase,
+}: {
+  category: FileFormatCategory;
+  hasSandboxTools: boolean;
+  useCase: FileUseCase;
+}): boolean {
+  if (!hasSandboxTools) {
+    return false;
+  }
+
+  switch (useCase) {
+    case "conversation":
+      return category === "delimited";
+    case "avatar":
+    case "tool_output":
+    case "upsert_document":
+    case "folders_document":
+    case "upsert_table":
+    case "project_context":
+    case "skill_attachment":
+    case "workspace_branding":
+      return false;
+    default:
+      assertNever(useCase);
+  }
+}
 
 export function resolveMaxFileSizes({
   hasSandboxTools,


### PR DESCRIPTION
## Description

This stack of PRs is about increasing the size of attached files in skills, to be the same as sandbox large files (350MB).

The first PR is about a small refacto to make the changes more future proof, it's supposed to be 0 behavior change.

The second PR introduces the actual changes.

## Tests

Unit tests


## Risk

Low
Blast radius: large, file uploads 🥲 

## Deploy Plan

- [ ] Deploy front