### PR TITLE
[front] enh: allow large CSV/XLSX/PPTX skill attachments

### DIFF
--- a/front/components/skill_builder/SkillBuilderFilesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderFilesSection.tsx
@@ -3,6 +3,8 @@ import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBu
 import { useSkillVersionComparisonContext } from "@app/components/skill_builder/SkillBuilderVersionContext";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import {
   Button,
   ContextItem,
@@ -26,6 +28,7 @@ export function SkillBuilderFilesSection({
 }: SkillBuilderFilesSectionProps) {
   const { owner, skillId } = useSkillBuilderContext();
   const sendNotification = useSendNotification();
+  const { featureFlags } = useFeatureFlags();
   const { setValue } = useFormContext<SkillBuilderFormData>();
   const { compareVersion, isDiffMode } = useSkillVersionComparisonContext();
   const [canScrollFilesDown, setCanScrollFilesDown] = useState(false);
@@ -43,7 +46,7 @@ export function SkillBuilderFilesSection({
   const fileListBottomSentinelRef = useRef<HTMLDivElement>(null);
 
   const { handleFilesUpload, isProcessingFiles } = useFileUploaderService({
-    hasSandboxTools: false,
+    hasSandboxTools: isComputerFeatureEnabled(featureFlags),
     owner,
     useCase: "skill_attachment",
     useCaseMetadata: skillId ? { skillId } : undefined,

--- a/front/lib/api/files/processing/index.test.ts
+++ b/front/lib/api/files/processing/index.test.ts
@@ -294,6 +294,49 @@ describe("conversation use case", () => {
   });
 });
 
+// Skill attachments are mounted into the sandbox and read as-is. They are stamped with
+// skipFileProcessing, so even binary documents (PPTX/XLSX) that would normally be Tika-extracted
+// are stored as the original only — which is what lets large skill files upload without failing on
+// extraction.
+describe("skill_attachment use case", () => {
+  describe("processAndStoreFile", () => {
+    it("PPTX skips text extraction and is stored as original only", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const contentType =
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+      const file = await FileFactory.create(auth, null, {
+        contentType,
+        fileName: "template.pptx",
+        fileSize: 100,
+        status: "created",
+        useCase: "skill_attachment",
+        useCaseMetadata: {
+          skillId: "skl-test",
+          skipDataSourceIndexing: true,
+          skipFileProcessing: true,
+        },
+      });
+
+      const result = await processAndStoreFile(auth, {
+        file,
+        content: { type: "string", value: "fake pptx bytes" },
+      });
+
+      assert(
+        result.isOk(),
+        `Expected Ok, got: ${result.isErr() ? JSON.stringify(result.error) : ""}`
+      );
+
+      const writes = fileStorageMock.writeStreamCalls;
+      expect(writes).toHaveLength(1);
+      expect(writes[0].contentType).toBe(contentType);
+    });
+  });
+});
+
 // For non-conversation use cases (upsert_document, folders_document, etc.), binary documents
 // are text-extracted via Tika and their processed version is text/plain.
 describe("upsert_document / folders_document use cases", () => {

--- a/front/lib/api/files/processing/index.ts
+++ b/front/lib/api/files/processing/index.ts
@@ -434,8 +434,10 @@ const maybeApplyProcessing = async (
   file: FileResource
 ): Promise<Result<undefined, Error>> => {
   // Files mounted raw in the sandbox (stamped with skipFileProcessing at upload) are used as-is: no
-  // extraction/resize. The flag is only ever set server-side by buildEffectiveUseCaseMetadata, so it
-  // is safe to trust here. Covers large delimited conversation files.
+  // extraction/resize. The flag is only ever set server-side by buildEffectiveUseCaseMetadata (which
+  // owns the allowsSandboxRawUpload decision and never trusts client-provided metadata for it), so it
+  // is safe to trust here. Covers large delimited conversation files and large skill attachments
+  // (delimited/data documents).
   if (file.useCaseMetadata?.skipFileProcessing === true) {
     return new Ok(undefined);
   }

--- a/front/lib/api/files/upload_metadata.test.ts
+++ b/front/lib/api/files/upload_metadata.test.ts
@@ -1,0 +1,87 @@
+import { buildEffectiveUseCaseMetadata } from "@app/lib/api/files/upload_metadata";
+import { describe, expect, it } from "vitest";
+
+const SANDBOX = { hasSandboxTools: true };
+const NO_SANDBOX = { hasSandboxTools: false };
+
+const XLSX =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" as const;
+const PPTX =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation" as const;
+
+describe("buildEffectiveUseCaseMetadata", () => {
+  it("stamps skipFileProcessing for skill delimited/data files with sandbox tools", () => {
+    // XLSX is delimited; PPTX is data — both are read raw in the sandbox for skills.
+    expect(
+      buildEffectiveUseCaseMetadata({
+        contentType: XLSX,
+        fileName: "data.xlsx",
+        flags: SANDBOX,
+        providedMetadata: { skillId: "skl_1" },
+        useCase: "skill_attachment",
+      })
+    ).toMatchObject({
+      skillId: "skl_1",
+      skipFileProcessing: true,
+      skipDataSourceIndexing: true,
+    });
+
+    expect(
+      buildEffectiveUseCaseMetadata({
+        contentType: PPTX,
+        fileName: "deck.pptx",
+        flags: SANDBOX,
+        providedMetadata: { skillId: "skl_1" },
+        useCase: "skill_attachment",
+      })
+    ).toMatchObject({ skipFileProcessing: true });
+  });
+
+  it("does not stamp skill images (not a raw category)", () => {
+    const metadata = buildEffectiveUseCaseMetadata({
+      contentType: "image/png",
+      fileName: "logo.png",
+      flags: SANDBOX,
+      providedMetadata: { skillId: "skl_1" },
+      useCase: "skill_attachment",
+    });
+
+    expect(metadata?.skipFileProcessing).toBeUndefined();
+  });
+
+  it("does not stamp skill files without sandbox tools", () => {
+    const metadata = buildEffectiveUseCaseMetadata({
+      contentType: XLSX,
+      fileName: "data.xlsx",
+      flags: NO_SANDBOX,
+      providedMetadata: { skillId: "skl_1" },
+      useCase: "skill_attachment",
+    });
+
+    expect(metadata?.skipFileProcessing).toBeUndefined();
+  });
+
+  it("stamps sandbox delimited conversation files (regression)", () => {
+    expect(
+      buildEffectiveUseCaseMetadata({
+        contentType: "text/csv",
+        fileName: "data.csv",
+        flags: SANDBOX,
+        providedMetadata: { conversationId: "conv_1" },
+        useCase: "conversation",
+      })
+    ).toMatchObject({ skipFileProcessing: true });
+  });
+
+  it("does not stamp conversation documents (data stays normal)", () => {
+    const metadata = buildEffectiveUseCaseMetadata({
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      flags: SANDBOX,
+      providedMetadata: { conversationId: "conv_1" },
+      useCase: "conversation",
+    });
+
+    expect(metadata?.skipFileProcessing).toBeUndefined();
+  });
+});

--- a/front/types/files.test.ts
+++ b/front/types/files.test.ts
@@ -44,16 +44,46 @@ describe("allowsSandboxRawUpload", () => {
     }
   });
 
-  it("does not apply outside of conversations", () => {
-    for (const useCase of ["upsert_table", "skill_attachment"] as const) {
+  it("allows delimited and data skill attachments only when sandbox tools are present", () => {
+    for (const category of ["delimited", "data"] as const) {
       expect(
         allowsSandboxRawUpload({
-          category: "delimited",
+          category,
           hasSandboxTools: true,
-          useCase,
+          useCase: "skill_attachment",
+        })
+      ).toBe(true);
+
+      expect(
+        allowsSandboxRawUpload({
+          category,
+          hasSandboxTools: false,
+          useCase: "skill_attachment",
         })
       ).toBe(false);
     }
+  });
+
+  it("does not apply to image/code/audio skill attachments", () => {
+    for (const category of ["image", "code", "audio"] as const) {
+      expect(
+        allowsSandboxRawUpload({
+          category,
+          hasSandboxTools: true,
+          useCase: "skill_attachment",
+        })
+      ).toBe(false);
+    }
+  });
+
+  it("does not apply to other use cases (e.g. upsert_table)", () => {
+    expect(
+      allowsSandboxRawUpload({
+        category: "delimited",
+        hasSandboxTools: true,
+        useCase: "upsert_table",
+      })
+    ).toBe(false);
   });
 });
 
@@ -87,6 +117,29 @@ describe("resolveMaxFileSizes", () => {
         useCase: "conversation",
       }).code
     ).toBe(50 * 1024 * 1024);
+  });
+
+  it("raises delimited and data limits for skill attachments with sandbox tools", () => {
+    const sizes = resolveMaxFileSizes({
+      hasSandboxTools: true,
+      useCase: "skill_attachment",
+    });
+
+    // CSV/XLSX (delimited) and PPTX/PDF/DOCX (data) can be large for skills.
+    expect(sizes.delimited).toBe(350 * 1024 * 1024);
+    expect(sizes.data).toBe(350 * 1024 * 1024);
+    // Images stay at the default limit.
+    expect(sizes.image).toBe(20 * 1024 * 1024);
+  });
+
+  it("keeps skill attachments at the default limit without sandbox tools", () => {
+    const sizes = resolveMaxFileSizes({
+      hasSandboxTools: false,
+      useCase: "skill_attachment",
+    });
+
+    expect(sizes.delimited).toBe(50 * 1024 * 1024);
+    expect(sizes.data).toBe(50 * 1024 * 1024);
   });
 
   it("enforces the resolved per-file limit", () => {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -284,8 +284,9 @@ export const MAX_FILE_SIZES_DEFAULT: Record<FileFormatCategory, number> = {
 
 export const MAX_FILE_SIZES = MAX_FILE_SIZES_DEFAULT;
 
-// Large delimited files (CSV/XLSX) are mounted into the sandbox and read as-is by the agent's code
-// rather than loaded into its context, so they can be much larger than regular uploads.
+// Conversations: large delimited files (CSV/XLSX) are mounted into the sandbox and read as-is by
+// the agent's code rather than loaded into its context, so they can be much larger than regular
+// uploads.
 export const MAX_FILE_SIZES_LARGE_DELIMITED: Record<
   FileFormatCategory,
   number
@@ -294,9 +295,19 @@ export const MAX_FILE_SIZES_LARGE_DELIMITED: Record<
   delimited: 350 * 1024 * 1024,
 };
 
+// Skill attachments: tabular files (CSV/XLSX -> delimited) AND documents (PDF/DOCX/PPTX -> data)
+// are mounted into the sandbox and read as-is, so both categories can be much larger than regular
+// uploads.
+export const MAX_FILE_SIZES_LARGE_SKILL: Record<FileFormatCategory, number> = {
+  ...MAX_FILE_SIZES_DEFAULT,
+  delimited: 350 * 1024 * 1024,
+  data: 350 * 1024 * 1024,
+};
+
 // Whether an upload is stored as a raw sandbox file: kept as-is with no upload-time processing
 // (no Tika extraction / image resize) and not indexed. Always requires sandbox tools.
-//  - conversation: large delimited files are served raw to the sandbox instead of indexed as tables.
+//  - conversation: large delimited files are served raw to the sandbox instead of indexed as tables;
+//  - skill_attachment: delimited tables and data documents (PDF/DOCX/PPTX) are mounted raw.
 export function allowsSandboxRawUpload({
   category,
   hasSandboxTools,
@@ -313,13 +324,14 @@ export function allowsSandboxRawUpload({
   switch (useCase) {
     case "conversation":
       return category === "delimited";
+    case "skill_attachment":
+      return category === "delimited" || category === "data";
     case "avatar":
     case "tool_output":
     case "upsert_document":
     case "folders_document":
     case "upsert_table":
     case "project_context":
-    case "skill_attachment":
     case "workspace_branding":
       return false;
     default:
@@ -334,9 +346,26 @@ export function resolveMaxFileSizes({
   hasSandboxTools: boolean;
   useCase: FileUseCase;
 }): Record<FileFormatCategory, number> {
-  const eligible = hasSandboxTools && useCase === "conversation";
+  if (!hasSandboxTools) {
+    return MAX_FILE_SIZES_DEFAULT;
+  }
 
-  return eligible ? MAX_FILE_SIZES_LARGE_DELIMITED : MAX_FILE_SIZES_DEFAULT;
+  switch (useCase) {
+    case "conversation":
+      return MAX_FILE_SIZES_LARGE_DELIMITED;
+    case "skill_attachment":
+      return MAX_FILE_SIZES_LARGE_SKILL;
+    case "avatar":
+    case "tool_output":
+    case "upsert_document":
+    case "folders_document":
+    case "upsert_table":
+    case "project_context":
+    case "workspace_branding":
+      return MAX_FILE_SIZES_DEFAULT;
+    default:
+      return assertNever(useCase);
+  }
 }
 
 export function fileSizeToHumanReadable(size: number, decimals = 0) {


### PR DESCRIPTION
## Description

Make it possible to upload large data/delimited files for skills attachments.

Checked everywhere and except for a grep edge case (single-lined huge files) we should be good on the "don't leak 350MB of data in the context window".

Added some tests too

## Tests

Unit tests.

## Risk

Low

## Deploy Plan

- Deploy front