### PR TITLE
feat(front): polish notification settings UX (save toast, gated customize, sparkle typography)

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -12,6 +12,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
@@ -101,11 +102,11 @@ function SectionContent({
     <div className="relative flex flex-1 flex-col overflow-hidden">
       <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-8">
         <header className="flex flex-col gap-1">
-          <h2 className="min-h-9 text-2xl font-semibold leading-9 text-foreground dark:text-foreground-night">
+          <h2 className="heading-2xl text-foreground dark:text-foreground-night">
             {title}
           </h2>
           {description && (
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
               {description}
             </p>
           )}
@@ -569,6 +570,7 @@ function CustomizationSection() {
 function NotificationsSection({ owner }: { owner: WorkspaceType }) {
   const { user } = useUser();
   const { hasFeature } = useFeatureFlags();
+  const sendNotification = useSendNotification();
   const notificationPreferencesRef =
     useRef<NotificationPreferencesRefProps>(null);
   const sound = useSoundNotificationPreferencesForm();
@@ -579,11 +581,17 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
   const handleSave = async () => {
     setIsSubmitting(true);
     try {
-      await Promise.all([
+      const [soundSaved, notifResult] = await Promise.all([
         sound.save(),
         notificationPreferencesRef.current?.savePreferences(),
       ]);
       setNotifDirty(notificationPreferencesRef.current?.isDirty() ?? false);
+      if (soundSaved && notifResult !== false) {
+        sendNotification({
+          type: "success",
+          title: "Notification preferences saved",
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -621,7 +621,7 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
         {hasFeature("sound_notification") && (
           <SoundNotificationPreferences
             control={sound.control}
-            disabled={sound.isLoading || isSubmitting}
+            disabled={sound.isLoading}
           />
         )}
       </SectionContent>

--- a/front/components/me/SoundNotificationPreferences.tsx
+++ b/front/components/me/SoundNotificationPreferences.tsx
@@ -10,6 +10,7 @@ import {
 import {
   Button,
   Check,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -65,32 +66,37 @@ export function useSoundNotificationPreferencesForm() {
     });
   }, [enabledMetadata, soundMetadata, form]);
 
-  const save = form.handleSubmit(async (data) => {
-    try {
-      const { dirtyFields } = form.formState;
-      if (dirtyFields.enabled) {
-        await setUserMetadataFromClient({
-          key: SOUND_NOTIFICATION_METADATA_KEYS.enabled,
-          value: String(data.enabled),
+  const save = async (): Promise<boolean> => {
+    let succeeded = false;
+    await form.handleSubmit(async (data) => {
+      try {
+        const { dirtyFields } = form.formState;
+        if (dirtyFields.enabled) {
+          await setUserMetadataFromClient({
+            key: SOUND_NOTIFICATION_METADATA_KEYS.enabled,
+            value: String(data.enabled),
+          });
+          await mutateEnabled();
+        }
+        if (dirtyFields.sound) {
+          await setUserMetadataFromClient({
+            key: SOUND_NOTIFICATION_METADATA_KEYS.sound,
+            value: data.sound,
+          });
+          await mutateSound();
+        }
+        form.reset(data);
+        succeeded = true;
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Error updating sound notification preferences",
+          description: error instanceof Error ? error.message : String(error),
         });
-        await mutateEnabled();
       }
-      if (dirtyFields.sound) {
-        await setUserMetadataFromClient({
-          key: SOUND_NOTIFICATION_METADATA_KEYS.sound,
-          value: data.sound,
-        });
-        await mutateSound();
-      }
-      form.reset(data);
-    } catch (error) {
-      sendNotification({
-        type: "error",
-        title: "Error updating sound notification preferences",
-        description: error instanceof Error ? error.message : String(error),
-      });
-    }
-  });
+    })();
+    return succeeded;
+  };
 
   return {
     control: form.control,
@@ -122,11 +128,11 @@ export function SoundNotificationPreferences({
   return (
     <div className="rounded-xl border border-border dark:border-border-night">
       <div className="flex items-center p-4">
-        <div className="flex flex-1 flex-col gap-1">
-          <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+        <div className="flex flex-1 flex-col">
+          <span className="heading-sm text-foreground dark:text-foreground-night">
             Manual actions sound notification
           </span>
-          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <span className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
             Play a sound when a manual action is required
           </span>
         </div>
@@ -150,11 +156,25 @@ export function SoundNotificationPreferences({
       <div className="border-t border-border dark:border-border-night" />
 
       <div className="flex items-center p-4">
-        <div className="flex flex-1 flex-col gap-1">
-          <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+        <div className="flex flex-1 flex-col">
+          <span
+            className={cn(
+              "heading-sm",
+              enabledField.value
+                ? "text-foreground dark:text-foreground-night"
+                : "text-faint dark:text-faint-night"
+            )}
+          >
             Customize sound notification
           </span>
-          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <span
+            className={cn(
+              "copy-sm",
+              enabledField.value
+                ? "text-muted-foreground dark:text-muted-foreground-night"
+                : "text-faint dark:text-faint-night"
+            )}
+          >
             Choose the sound you prefer
           </span>
         </div>
@@ -166,7 +186,7 @@ export function SoundNotificationPreferences({
                 size="xs"
                 label={soundField.value}
                 isSelect
-                disabled={disabled}
+                disabled={disabled || !enabledField.value}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent mountPortal={false}>
@@ -194,7 +214,7 @@ export function SoundNotificationPreferences({
             label="Play"
             className="text-highlight-500 dark:text-highlight-500-night"
             onClick={handlePlay}
-            disabled={disabled}
+            disabled={disabled || !enabledField.value}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description
Stacked on top of `sound-notification-settings` (PR 1). UX polish for the sound notification settings panel:

- **Save confirmation** — shows a success toast ("Notification preferences saved") when the save succeeds.
- **Gate "Customize" on the toggle** — the sound picker and Play button are disabled when the toggle is off, and the "Customize" row dims to `faint` to signal you must toggle on first.
- **Typography** — use the Sparkle tokens from Figma: rows use `heading-sm`/`copy-sm`, and the section header uses `heading-2xl`/`copy-sm` (shared `SectionContent`, so this also applies to the other settings section headers).

## Tests

Tested locally:
- Toggle off → picker + Play disabled, "Customize" row greyed (`faint`).
- Toggle on → controls enabled, row at normal colors.
- Change a value + Save → success toast, Save disables. Failed save → no success toast, Save stays enabled.

## Risk

Low. Frontend-only, behind the `sound_notification` flag from PR 1

## Deploy Plan

Merge after PR 1
