### PR TITLE
[front] fix: keep showing Skill Builder instructions resize handle

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -223,8 +223,10 @@ function sanitizeSkillInstructionsHtml(html: string): string {
 }
 
 const INSTRUCTIONS_EDITOR_SIZE = "min-h-60 max-h-[50vh]";
+const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_CONTAINER_SIZE =
+  "h-80 min-h-80 max-h-[50vh]";
 const INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_SIZE =
-  "min-h-80 rounded-b-none border-b-0 pb-44";
+  "h-full min-h-0 max-h-none resize-none rounded-b-none border-b-0 pb-44";
 
 interface SkillBuilderInstructionsEditorProps {
   onAddKnowledge?: (addKnowledge: () => void) => void;
@@ -777,8 +779,16 @@ export function SkillBuilderInstructionsEditor({
   return (
     <>
       <div className="space-y-1 p-px">
-        <div className="group relative overflow-hidden rounded-xl">
+        <div
+          className={cn(
+            "group relative overflow-hidden rounded-xl",
+            hasInstructionReferenceSummary &&
+              INSTRUCTIONS_EDITOR_REFERENCE_SUMMARY_CONTAINER_SIZE,
+            hasInstructionReferenceSummary && !isDiffMode && "resize-y"
+          )}
+        >
           <SkillInstructionsEditorContent
+            className={hasInstructionReferenceSummary ? "h-full" : undefined}
             editor={editor}
             isReadOnly={hasSuggestions}
           />


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/9158

This PR fixes the Skill Builder instructions editor when the capabilities and knowledge summary is displayed at the bottom of the editor. The summary previously covered the native resize handle, making the instructions block hard to expand.
The editor wrapper now owns the vertical resize behavior when the summary is present, while the ProseMirror editor fills that resized container. This keeps the summary full-width with its existing background and avoids special-casing the resize corner.

<img width="1028" height="639" alt="image" src="https://github.com/user-attachments/assets/3ec421b6-5789-4a04-8f49-04fb3f3f9260" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
